### PR TITLE
Optional token auth, opt-in autonomy/gate controls, and a security test suite

### DIFF
--- a/README.md
+++ b/README.md
@@ -283,23 +283,35 @@ write to your repos and control Docker. It ships safe for its intended home —
 **your own single-user machine** — and you should know exactly where the lines
 are:
 
-- **It only listens on your own machine.** The server binds `127.0.0.1` — 
-  nothing on your network can reach it. There is **no authentication**, because
-  on a single-user machine "can reach localhost" already means "is you".
+- **It only listens on your own machine.** The server binds `127.0.0.1` —
+  nothing on your network can reach it. By default there is **no authentication**,
+  because on a single-user machine "can reach localhost" already means "is you".
+- **Optional shared-secret token.** Set `AGENTGLASS_TOKEN` and every route but
+  the append-only telemetry sinks (`/ingest`, the OTLP receivers) requires it —
+  `Authorization: Bearer <token>` for the API, `?token=<token>` on the dashboard
+  URL (it's stored and stripped from the address bar). This is what makes a
+  shared machine or a network bind safe, and it stops *other local processes*
+  from opening the shell. Binding a non-loopback address **without** a token
+  refuses to run unauthenticated: it mints one, prints it, and saves it
+  `0600` under your config dir.
 - **Websites you visit can't touch it.** Every request is origin-checked, the
   shell and the live stream require a verified local origin, and a Host-header
   guard blocks DNS-rebinding tricks (browsers can't forge `Host`). Running it
   behind a reverse proxy? Allow its name via `AGENTGLASS_ALLOWED_HOSTS`.
-- **⚠️ Shared / multi-user machines are NOT the intended home.** `localhost`
+- **⚠️ Shared / multi-user machines are NOT the default home.** `localhost`
   belongs to the *machine*, not to your account — on a box where other people
   also have accounts, any of them could reach the server and its shell **as
-  your user**. If you must run it there, disable the capability surfaces:
-  `AGENTGLASS_TERMINAL_DISABLED=1`, `AGENTGLASS_CHAT_DISABLED=1`,
-  `AGENTGLASS_GIT_WRITE_DISABLED=1`, `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
-- **⚠️ Never set `AGENTGLASS_BIND=0.0.0.0` on a network you don't fully
-  trust.** It hands the shell, git write and Docker control to anyone on that
-  network, unauthenticated. It exists for trusted-LAN setups only, and turning
-  it on is a deliberate act.
+  your user**. Set `AGENTGLASS_TOKEN` to lock it to you, and/or disable the
+  capability surfaces: `AGENTGLASS_TERMINAL_DISABLED=1`,
+  `AGENTGLASS_CHAT_DISABLED=1`, `AGENTGLASS_GIT_WRITE_DISABLED=1`,
+  `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
+- **⚠️ Exposing it to a network is a three-part deliberate act.** `AGENTGLASS_BIND=0.0.0.0`
+  hands the shell, git write and Docker control to that network. Do it only with
+  a token set **and** `AGENTGLASS_TRUST_LAN=1` (off by default, LAN browsers are
+  refused as cross-origin without it), and only on a network you fully trust.
+- **⚠️ Browser-driven autonomy is opt-in.** The Chat panel's `bypassPermissions`
+  mode (`claude --dangerously-skip-permissions`) is honored only when
+  `AGENTGLASS_CHAT_BYPASS=1`; otherwise it's downgraded to a prompting default.
 - **Your data stays local.** Events live in a local SQLite file (owner-only
   permissions). The only outbound call is the optional Anthropic plan-usage
   meter (`api.anthropic.com`, using your own credentials) and anything *you*
@@ -329,6 +341,11 @@ Safe by design — it **never blocks your agents by accident**:
 
 Scope it with the `matcher` (e.g. `Bash` only, or a specific tool) so you're not
 gating every call. Denying returns a `PreToolUse` deny with your reason.
+
+Want the opposite trade-off? Set `AGENTGLASS_GATE_FAILCLOSED=1` and a timeout or
+an unreachable control plane **denies** instead of allows — the fleet stops
+until you decide. Off by default; turn it on only when blocking is safer than
+proceeding, and remember agentglass being down then blocks every gated call.
 
 ---
 
@@ -390,7 +407,9 @@ inference, prompt) to an event the same way.
 | Var | Default | Meaning |
 |---|---|---|
 | `AGENTGLASS_PORT` | `4000` | Server HTTP/WS port. |
-| `AGENTGLASS_BIND` | `127.0.0.1` | Address the server binds to. Loopback-only by default. Setting `0.0.0.0` exposes the terminal / git-write / Docker control to your network **unauthenticated** — only on a trusted LAN. See [Security model](#security-model--read-this-before-installing). |
+| `AGENTGLASS_BIND` | `127.0.0.1` | Address the server binds to. Loopback-only by default. Exposing (`0.0.0.0`) requires `AGENTGLASS_TOKEN` **and** `AGENTGLASS_TRUST_LAN=1`, and only on a trusted network. See [Security model](#security-model--read-this-before-installing). |
+| `AGENTGLASS_TOKEN` | — | Shared secret required on every route but the telemetry intake sinks. Pass as `Authorization: Bearer <t>` or `?token=<t>`. Locks the server to you on a shared machine and makes a network bind safe. Exposing without one auto-mints + prints a token (saved `0600` in the config dir). |
+| `AGENTGLASS_TRUST_LAN` | — | `1` → also trust RFC1918 (private-LAN) addresses as origins/hosts, not just loopback. Required for LAN browsers to reach an exposed instance. Off by default: a shell-granting server trusts only `localhost` unless told otherwise. |
 | `AGENTGLASS_ALLOWED_HOSTS` | — | Comma-separated extra hostnames accepted by the DNS-rebinding guard (requests must arrive under a localhost/private `Host`). Only needed behind a reverse proxy. |
 | `AGENTGLASS_DB` | `agentglass.db` | SQLite file path. |
 | `AGENTGLASS_ROOT` | — | Scope the whole cockpit to one project (repo + worktrees) or a folder of projects. Unset = every project on the machine. Also set by passing a directory to the desktop app; the in-app **project picker** sets/clears the same scope at runtime and persists it as `root` in the config file (note: the env var, when set, wins again on the next launch). |
@@ -408,8 +427,12 @@ inference, prompt) to an event the same way.
 | `AGENTGLASS_DOCKER_WRITE_DISABLED` | — | `1` → make the **Docker** panel read-only (no start / stop / restart / rm). |
 | `AGENTGLASS_TERMINAL_DISABLED` | — | `1` → disable the in-browser **Terminal** entirely (no PTY shells are spawned). |
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
+| `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's `bypassPermissions` mode (`claude --dangerously-skip-permissions`). Off by default: the mode is downgraded to a prompting default unless you opt in. |
 | `AGENTGLASS_COMMIT_DISABLED` | — | `1` → disable the diff viewer's **Commit…** composer. |
 | `AGENTGLASS_GATE_TIMEOUT` | `60` | Seconds the `PreToolUse` gate hook waits for an approve/deny before auto-allowing. |
+| `AGENTGLASS_GATE_FAILCLOSED` | — | `1` → a gate timeout (server) or an unreachable control plane (hook) **denies** the tool call instead of allowing it. Off by default (fail-open — never block agents by accident). |
+| `AGENTGLASS_RATE_MAX` | `300` | Max intake requests (`/ingest`, OTLP receivers) per source-address+route within the window, before `429`. |
+| `AGENTGLASS_RATE_WINDOW_MS` | `10000` | Rate-limit window in ms for the intake sinks. |
 | `AGENTGLASS_CODE_DIR` | `~/code` | Where the skills explorer scans for per-project `.claude` skills/commands. |
 | `AGENTGLASS_WALKTHROUGH_MODEL` | `claude-haiku-4-5` | Model for the AI **Explain** walkthrough (uses a local `claude` CLI, else `ANTHROPIC_API_KEY`). |
 | `CLAUDE_CREDENTIALS` | `~/.claude/.credentials.json` | OAuth token for the Anthropic plan-usage meters (never leaves your machine except to `api.anthropic.com`). |

--- a/hooks/gate_event.py
+++ b/hooks/gate_event.py
@@ -42,6 +42,10 @@ def _agentglass_local_only(url):
         sys.exit(0)
 
 TIMEOUT = int(os.environ.get("AGENTGLASS_GATE_TIMEOUT", "60"))
+# Default is fail-open: if agentglass is unreachable, allow (never block agents
+# by accident). Set this to invert it — an unreachable control plane DENIES the
+# tool call. Opt-in, because with agentglass down every gated call is blocked.
+FAIL_CLOSED = os.environ.get("AGENTGLASS_GATE_FAILCLOSED") == "1"
 
 
 def allow_silently():
@@ -96,7 +100,9 @@ def main():
         with urllib.request.urlopen(req, timeout=TIMEOUT + 5) as resp:
             out = json.loads(resp.read())
     except Exception:
-        allow_silently()  # unreachable / error → never block
+        if FAIL_CLOSED:
+            emit("deny", "agentglass unreachable (fail-closed)")
+        allow_silently()  # unreachable / error → never block (default)
 
     decision = out.get("decision", "allow")
     reason = out.get("reason", "")

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -1,0 +1,91 @@
+// Optional shared-secret auth for the capability surface (a shell, git/docker
+// writes, the fleet feed). The whole model is otherwise "loopback + same-origin",
+// which is enough for a single-user localhost box but nothing more: any other
+// local process can reach the port, and binding a non-loopback address exposes
+// unauthenticated RCE. A token closes both — a local process without it can't
+// open the shell, and exposure becomes safe.
+//
+// Trust model:
+//   * AGENTGLASS_TOKEN set        → that token is required.
+//   * unset AND loopback-only     → no token (zero-config local UX, unchanged).
+//   * unset AND exposed (non-lo)  → refuse to run unauthenticated: mint a stable
+//                                   token (persisted 0600) and print it.
+//
+// Intake routes stay tokenless on purpose (see INTAKE): local hooks and OTel
+// exporters have no way to carry a secret, and they can only *append* events.
+import { timingSafeEqual, randomBytes } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { homedir } from "node:os";
+import { join, dirname } from "node:path";
+
+const TOKEN_PATH = join(
+  process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+  "agentglass",
+  "token"
+);
+
+// Append-only telemetry sinks + health. Everything else — reads, shell,
+// git/docker writes, gate decisions — is behind the token when one is set.
+const INTAKE = new Set([
+  "/health",
+  "/ingest",
+  "/gate",
+  "/v1/traces",
+  "/otlp/v1/traces",
+  "/v1/logs",
+  "/otlp/v1/logs",
+]);
+
+export const isIntake = (pathname: string) => INTAKE.has(pathname);
+
+export interface Auth {
+  token: string | null;
+  source: "env" | "file" | "generated" | "none";
+  path: string;
+}
+
+export function resolveToken(loopbackOnly: boolean): Auth {
+  const fromEnv = process.env.AGENTGLASS_TOKEN?.trim();
+  if (fromEnv) return { token: fromEnv, source: "env", path: TOKEN_PATH };
+  if (loopbackOnly) return { token: null, source: "none", path: TOKEN_PATH };
+  const existing = readPersisted();
+  if (existing) return { token: existing, source: "file", path: TOKEN_PATH };
+  const t = randomBytes(24).toString("base64url");
+  persist(t);
+  return { token: t, source: "generated", path: TOKEN_PATH };
+}
+
+function readPersisted(): string | null {
+  try {
+    return existsSync(TOKEN_PATH) ? readFileSync(TOKEN_PATH, "utf8").trim() || null : null;
+  } catch {
+    return null;
+  }
+}
+
+function persist(t: string): void {
+  try {
+    mkdirSync(dirname(TOKEN_PATH), { recursive: true });
+    writeFileSync(TOKEN_PATH, t + "\n", { mode: 0o600 });
+    chmodSync(TOKEN_PATH, 0o600); // enforce even if the file pre-existed with looser perms
+  } catch {
+    /* best effort — the token still works for this run */
+  }
+}
+
+function eq(a: string, b: string): boolean {
+  const ba = Buffer.from(a);
+  const bb = Buffer.from(b);
+  if (ba.length !== bb.length) return false; // length is not secret
+  return timingSafeEqual(ba, bb);
+}
+
+/** True when the request carries the token — `Authorization: Bearer <t>` for
+ *  fetch, or `?token=<t>` for the URLs a browser can't attach a header to
+ *  (WebSocket upgrades, download navigations). */
+export function tokenOk(req: Request, url: URL, token: string): boolean {
+  const auth = req.headers.get("authorization") || "";
+  const bearer = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
+  const provided = bearer || url.searchParams.get("token") || "";
+  return !!provided && eq(provided, token);
+}

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -17,6 +17,11 @@ const CORS = {
   "Access-Control-Allow-Headers": "content-type",
 };
 const MODES = new Set(["default", "plan", "acceptEdits", "bypassPermissions"]);
+// `bypassPermissions` launches `claude --dangerously-skip-permissions`: full
+// unattended autonomy driven straight from a browser request. That is too much
+// to hand out on the same-origin check alone, so it is off unless the operator
+// explicitly opts in; otherwise the mode is downgraded to a prompting default.
+const BYPASS_ALLOWED = process.env.AGENTGLASS_CHAT_BYPASS === "1";
 const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}$/;
 const SESSION_RE = /^[A-Za-z0-9][A-Za-z0-9-]{7,64}$/;
 const err = (msg: string, status = 400) => new Response(msg + "\n", { status, headers: CORS });
@@ -29,7 +34,8 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   if (!dir || !repoRootOf(dir)) return err("invalid or non-repo directory");
   if (typeof message !== "string" || !message.trim() || message.length > 100_000) return err("invalid message");
   const m = typeof model === "string" && MODEL_RE.test(model) ? model : "claude-opus-4-8";
-  const pm = typeof mode === "string" && MODES.has(mode) ? mode : "default";
+  let pm = typeof mode === "string" && MODES.has(mode) ? mode : "default";
+  if (pm === "bypassPermissions" && !BYPASS_ALLOWED) pm = "default"; // opt-in only
   const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";
 
   const args = [bin, "-p", "--output-format", "stream-json", "--verbose", "--model", m];

--- a/server/src/gate.ts
+++ b/server/src/gate.ts
@@ -13,6 +13,12 @@ interface Waiter extends PendingGate {
   timer: ReturnType<typeof setTimeout>;
 }
 
+// The gate is fail-open by design: a timeout (or an unreachable server) never
+// blocks an agent. Set this to invert that — a tool call that no human decides
+// within the timeout is DENIED. Opt-in, because it means a slow or absent human
+// stops the fleet; that is the point for security-sensitive use.
+const FAIL_CLOSED = process.env.AGENTGLASS_GATE_FAILCLOSED === "1";
+
 const waiters = new Map<string, Waiter>();
 let onChange: () => void = () => {};
 export function onGateChange(fn: () => void) { onChange = fn; }
@@ -31,6 +37,10 @@ export function submitGate(
     const timer = setTimeout(() => {
       waiters.delete(id);
       onChange();
+      if (FAIL_CLOSED) {
+        resolve({ decision: "deny", reason: "gate timeout — no decision (fail-closed)" });
+        return;
+      }
       // Empty reason so the hook falls through to Claude Code's own permission
       // prompt instead of force-allowing — an auto-allow shouldn't silently
       // skip the human it was meant to ask.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,4 +1,3 @@
-import { isIP } from "node:net";
 import type { ServerWebSocket } from "bun";
 import type { IngestBody, WsFrame } from "../../shared/types.ts";
 import { normalize, detectError } from "./ingest.ts";
@@ -43,6 +42,9 @@ import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERM
 import { chatStream, CHAT_ENABLED } from "./chat.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, CONFIG_PATH } from "./config.ts";
+import { privateHost } from "./net.ts";
+import { resolveToken, tokenOk, isIntake } from "./auth.ts";
+import { rateOk } from "./ratelimit.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 /**
@@ -55,20 +57,32 @@ const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
  */
 const BIND = process.env.AGENTGLASS_BIND || "127.0.0.1";
 const LOOPBACK_ONLY = BIND === "127.0.0.1" || BIND === "::1" || BIND === "localhost";
+// RFC1918 addresses are trusted as origins/hosts only when this is set. Off by
+// default: a shell-granting server should trust loopback alone unless exposing
+// it to a LAN is a deliberate choice (paired with a token — see below).
+const TRUST_LAN = process.env.AGENTGLASS_TRUST_LAN === "1";
+// Optional shared-secret auth. Null on a loopback-only box with no token set
+// (unchanged zero-config UX); required otherwise. Exposing without a token
+// mints and prints one rather than running unauthenticated.
+const AUTH = resolveToken(LOOPBACK_ONLY);
+const AUTH_TOKEN = AUTH.token;
 /** One socket, two roles: the live event stream and PTY terminal shells. */
 type WsData = { kind: "events" } | PtyWsData;
 const clients = new Set<ServerWebSocket<WsData>>();
 
-const CORS = {
-  "Access-Control-Allow-Origin": "*",
-  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
-  "Access-Control-Allow-Headers": "content-type",
-};
-const json = (data: unknown, status = 200) =>
-  new Response(JSON.stringify(data), {
-    status,
-    headers: { "content-type": "application/json", ...CORS },
-  });
+// Reflect the caller's Origin instead of a blanket `*`. Foreign origins are
+// already turned away by localOrigin() before any body is served, so the old
+// wildcard leaked nothing — but reflecting is honest, pairs with `Vary: Origin`,
+// and permits the Authorization header the token flow now sends.
+function corsFor(req: Request): Record<string, string> {
+  const origin = req.headers.get("origin");
+  return {
+    "Access-Control-Allow-Origin": origin || "*",
+    Vary: "Origin",
+    "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+    "Access-Control-Allow-Headers": "content-type, authorization",
+  };
+}
 
 /**
  * Is this request's Origin a machine we're willing to be driven by?
@@ -80,17 +94,7 @@ const json = (data: unknown, status = 200) =>
  * when it is literally localhost; everything else has to *be* an address in a
  * private range, not merely look like one.
  */
-function privateHost(hRaw: string): boolean {
-  const h = hRaw.replace(/^\[|\]$/g, ""); // URL keeps IPv6 brackets
-  if (h === "localhost" || h === "127.0.0.1" || h === "::1" || h.endsWith(".localhost")) return true;
-  const v = isIP(h);
-  if (v === 4) {
-    const [a, b] = h.split(".").map(Number);
-    return a === 127 || a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
-  }
-  if (v === 6) return h === "::1" || /^f[cd]/i.test(h); // loopback / unique-local
-  return false; // a name that isn't localhost resolves wherever its owner says
-}
+const isPrivate = (h: string): boolean => privateHost(h, TRUST_LAN);
 
 // Block drive-by cross-site writes: a request carrying an Origin from a real
 // website is rejected. A request with NO Origin is not a browser, so it can't
@@ -100,7 +104,7 @@ function localOrigin(req: Request): boolean {
   const o = req.headers.get("origin");
   if (!o) return true;
   try {
-    return privateHost(new URL(o).hostname);
+    return isPrivate(new URL(o).hostname);
   } catch { return false; }
 }
 
@@ -118,10 +122,9 @@ function trustedCaller(req: Request): boolean {
   const o = req.headers.get("origin");
   if (!o) return LOOPBACK_ONLY; // no origin is only safe when nobody remote can connect
   try {
-    return privateHost(new URL(o).hostname);
+    return isPrivate(new URL(o).hostname);
   } catch { return false; }
 }
-const csrfBlocked = () => json({ ok: false, error: "cross-origin write blocked" }, 403);
 
 /**
  * DNS-rebinding guard: the Host header must name an address that is plausibly
@@ -138,9 +141,7 @@ const csrfBlocked = () => json({ ok: false, error: "cross-origin write blocked" 
 const ALLOWED_HOSTS = new Set(
   (process.env.AGENTGLASS_ALLOWED_HOSTS || "").split(",").map((h) => h.trim().toLowerCase()).filter(Boolean)
 );
-const trustedHost = (url: URL) => privateHost(url.hostname) || ALLOWED_HOSTS.has(url.hostname.toLowerCase());
-const rebindBlocked = () =>
-  json({ ok: false, error: "request Host is not a local or private address (DNS-rebinding guard — set AGENTGLASS_ALLOWED_HOSTS for a reverse-proxy name)" }, 403);
+const trustedHost = (url: URL) => isPrivate(url.hostname) || ALLOWED_HOSTS.has(url.hostname.toLowerCase());
 
 function broadcast(frame: WsFrame) {
   const msg = JSON.stringify(frame);
@@ -168,7 +169,7 @@ function csvEscape(v: unknown): string {
   return /[",\n]/.test(s) ? `"${s.replace(/"/g, '""')}"` : s;
 }
 
-const server = Bun.serve({
+const server = Bun.serve<WsData>({
   port: PORT,
   hostname: BIND,
   // A frame is a control message or a keystroke; nothing legitimate is large.
@@ -178,17 +179,41 @@ const server = Bun.serve({
     const url = new URL(req.url);
     const { pathname } = url;
 
+    // Per-request response helpers: `cors` reflects this caller's Origin, so it
+    // has to be built here rather than shared as a module constant.
+    const cors = corsFor(req);
+    const json = (data: unknown, status = 200) =>
+      new Response(JSON.stringify(data), { status, headers: { "content-type": "application/json", ...cors } });
+    const csrfBlocked = () => json({ ok: false, error: "cross-origin write blocked" }, 403);
+    const rebindBlocked = () =>
+      json({ ok: false, error: "request Host is not a local or private address (DNS-rebinding guard — set AGENTGLASS_ALLOWED_HOSTS for a reverse-proxy name)" }, 403);
+
     // Before anything else — including OPTIONS and WS upgrades: a request that
     // arrived under a foreign Host is a rebinding attempt, whatever it asks.
     if (!trustedHost(url)) return rebindBlocked();
 
-    if (req.method === "OPTIONS") return new Response(null, { headers: CORS });
+    if (req.method === "OPTIONS") return new Response(null, { headers: cors });
 
-    // One gate for the whole surface — reads included. Without it, CORS `*` let
-    // any site the user visited read /export, /search and the rest from
-    // loopback. A missing Origin is a non-browser caller (curl, the hooks), not
-    // a drive-by, so it's allowed; a foreign website is turned away here.
+    // One gate for the whole surface — reads included. Without it, CORS let any
+    // site the user visited read /export, /search and the rest from loopback. A
+    // missing Origin is a non-browser caller (curl, the hooks), not a drive-by,
+    // so it's allowed; a foreign website is turned away here.
     if (!localOrigin(req)) return csrfBlocked();
+
+    // Shared-secret gate. When a token is configured, every route but the
+    // append-only intake sinks needs it — this is what closes the door on other
+    // local processes and makes a non-loopback bind safe. WS upgrades carry it
+    // as ?token= (a browser can't set a header on them); fetch uses Bearer.
+    if (AUTH_TOKEN && !isIntake(pathname) && !tokenOk(req, url, AUTH_TOKEN)) {
+      return json({ ok: false, error: "unauthorized — pass ?token= or Authorization: Bearer" }, 401);
+    }
+
+    // Throttle the unauthenticated intake sinks so a runaway client can't flood
+    // the DB and the broadcast fan-out. Keyed by source address + route.
+    if (req.method === "POST" && isIntake(pathname)) {
+      const ip = srv.requestIP(req)?.address || "local";
+      if (!rateOk(`${ip} ${pathname}`)) return json({ ok: false, error: "rate limited" }, 429);
+    }
 
     // --- WebSocket upgrade ---
     // Origin-checked like the mutating routes. WebSockets are exempt from CORS,
@@ -469,7 +494,7 @@ const server = Bun.serve({
       const fmt = url.searchParams.get("format") || "md";
       const dl = (body: string, type: string, name: string) =>
         new Response(body, {
-          headers: { "content-type": type, "content-disposition": `attachment; filename="${name}"`, ...CORS },
+          headers: { "content-type": type, "content-disposition": `attachment; filename="${name}"`, ...cors },
         });
       if (fmt === "json") return dl(JSON.stringify(getSkills(), null, 2), "application/json", "skills-catalog.json");
       if (fmt === "csv") return dl(catalogCsv(), "text/csv", "skills-catalog.csv");
@@ -501,7 +526,7 @@ const server = Bun.serve({
           headers: {
             "content-type": "text/csv",
             "content-disposition": 'attachment; filename="agentglass-events.csv"',
-            ...CORS,
+            ...cors,
           },
         });
       }
@@ -509,7 +534,7 @@ const server = Bun.serve({
         headers: {
           "content-type": "application/json",
           "content-disposition": 'attachment; filename="agentglass-events.json"',
-          ...CORS,
+          ...cors,
         },
       });
     }
@@ -636,7 +661,20 @@ for (const sig of ["SIGINT", "SIGTERM"] as const) {
 
 console.log(`🛰  agentglass server on http://${LOOPBACK_ONLY ? "localhost" : BIND}:${server.port}`);
 if (!LOOPBACK_ONLY) {
-  console.warn(`⚠  bound to ${BIND} — this exposes a shell, git write access and docker control to the network, unauthenticated`);
+  const posture = AUTH_TOKEN ? "token-protected" : "UNAUTHENTICATED";
+  console.warn(`⚠  bound to ${BIND} — this exposes a shell, git write access and docker control to the network (${posture})`);
+  if (!TRUST_LAN) console.warn(`⚠  AGENTGLASS_TRUST_LAN is not set — LAN browsers will be refused as cross-origin; set it to allow them`);
+}
+if (AUTH_TOKEN) {
+  if (AUTH.source === "generated") {
+    console.log(`🔑 auth token (generated, saved ${AUTH.path} — keep it):`);
+    console.log(`     ${AUTH_TOKEN}`);
+    console.log(`     open the dashboard as  <url>/?token=${AUTH_TOKEN}`);
+  } else if (AUTH.source === "file") {
+    console.log(`🔑 auth token loaded from ${AUTH.path} — clients must pass ?token= or Authorization: Bearer`);
+  } else {
+    console.log(`🔑 AGENTGLASS_TOKEN set — clients must pass ?token= or Authorization: Bearer`);
+  }
 }
 console.log(`   POST events → http://localhost:${server.port}/ingest`);
 console.log(`   WebSocket   → ws://localhost:${server.port}/stream`);

--- a/server/src/net.ts
+++ b/server/src/net.ts
@@ -1,0 +1,30 @@
+// Address classification for the origin/rebinding guards — pure and testable.
+//
+// The host is parsed as a real IP (not string-matched), so `10.evil.com` — a
+// name anyone can register and point at 127.0.0.1 — is NOT treated as private:
+// matching `/^10\./` against a hostname would turn "private network" into "any
+// website", with a shell on the other end. A name is trusted only when it is
+// literally localhost; everything else must *be* an address in a private range.
+//
+// `trustLan` gates the non-loopback private ranges. Off (the default) only
+// loopback/localhost is trusted, so exposing the server to a LAN is a deliberate
+// act — AGENTGLASS_TRUST_LAN=1 on top of a token — rather than something a
+// browser on a colleague's machine gets for free.
+import { isIP } from "node:net";
+
+export function privateHost(hRaw: string, trustLan: boolean): boolean {
+  const h = hRaw.replace(/^\[|\]$/g, ""); // a URL keeps IPv6 brackets
+  if (h === "localhost" || h === "127.0.0.1" || h === "::1" || h.endsWith(".localhost")) return true;
+  const v = isIP(h);
+  if (v === 4) {
+    const [a, b] = h.split(".").map(Number);
+    if (a === 127) return true; // loopback is always local
+    if (!trustLan) return false; // RFC1918 only when opted in
+    return a === 10 || (a === 192 && b === 168) || (a === 172 && b >= 16 && b <= 31);
+  }
+  if (v === 6) {
+    if (h === "::1") return true;
+    return trustLan && /^f[cd]/i.test(h); // fc00::/7 unique-local
+  }
+  return false; // a name that isn't localhost resolves wherever its owner says
+}

--- a/server/src/ratelimit.ts
+++ b/server/src/ratelimit.ts
@@ -1,0 +1,29 @@
+// Fixed-window rate limiter for the unauthenticated intake routes, so a runaway
+// or hostile local client can't flood the DB and the broadcast fan-out. The
+// window is generous — normal hook/OTel traffic never approaches it — and both
+// knobs are env-tunable.
+const WINDOW_MS = Math.max(1000, Number(process.env.AGENTGLASS_RATE_WINDOW_MS) || 10_000);
+const MAX = Math.max(10, Number(process.env.AGENTGLASS_RATE_MAX) || 300);
+
+const buckets = new Map<string, { n: number; reset: number }>();
+
+/** Count one hit for `key`; false once it exceeds MAX within the window. */
+export function rateOk(key: string): boolean {
+  const now = Date.now();
+  const b = buckets.get(key);
+  if (!b || now >= b.reset) {
+    buckets.set(key, { n: 1, reset: now + WINDOW_MS });
+    return true;
+  }
+  if (b.n >= MAX) return false;
+  b.n++;
+  return true;
+}
+
+// Evict expired buckets so a churn of distinct keys can't grow the map without
+// bound. unref so this timer never keeps the process alive on its own.
+const sweep = setInterval(() => {
+  const now = Date.now();
+  for (const [k, b] of buckets) if (now >= b.reset) buckets.delete(k);
+}, WINDOW_MS);
+(sweep as { unref?: () => void }).unref?.();

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -235,7 +235,7 @@ export function shutdownTerminals() {
 /** Parse Makefile text into named targets WITH their descriptions. A
  * description is taken from the `target: ## comment` convention, or from the
  * `# comment` line(s) directly above the target. */
-function parseMakeTargets(text: string): { name: string; desc: string }[] {
+export function parseMakeTargets(text: string): { name: string; desc: string }[] {
   const out: { name: string; desc: string }[] = [];
   const seen = new Set<string>();
   let pendingComment: string[] = [];
@@ -276,7 +276,7 @@ const CMD_SKIP = new Set([...SKIP_DIRS, "out", "coverage"]);
 // These strings end up verbatim in `make -C <dir>` / `--cwd <dir>` lines typed
 // into the user's shell, so only plain path characters are allowed — a folder
 // named `; rm -rf ~` (or just one with spaces) is skipped, not quoted.
-const shellSafeRel = (rel: string) => /^[A-Za-z0-9][A-Za-z0-9._@\/-]*$/.test(rel);
+export const shellSafeRel = (rel: string) => /^[A-Za-z0-9][A-Za-z0-9._@\/-]*$/.test(rel);
 
 type CommandDir = { rel: string; makefile: string | null; pkg: boolean };
 

--- a/server/test/security.test.ts
+++ b/server/test/security.test.ts
@@ -1,0 +1,115 @@
+// Guards on the functions where a regression = RCE or a path escape: the
+// origin/rebinding address parser, the repo-path boundary, the shell-safe
+// relative-path filter, the Makefile-target parser, and the token check.
+import { describe, expect, test } from "bun:test";
+import { privateHost } from "../src/net.ts";
+import { safeAbs } from "../src/git.ts";
+import { shellSafeRel, parseMakeTargets } from "../src/terminal.ts";
+import { tokenOk } from "../src/auth.ts";
+
+describe("privateHost", () => {
+  test("loopback is always trusted, regardless of trustLan", () => {
+    for (const h of ["localhost", "127.0.0.1", "::1", "[::1]", "foo.localhost", "127.9.9.9"]) {
+      expect(privateHost(h, false)).toBe(true);
+      expect(privateHost(h, true)).toBe(true);
+    }
+  });
+
+  test("a name that merely looks private is NOT trusted (rebinding defense)", () => {
+    // These are hostnames an attacker can register and point at 127.0.0.1.
+    for (const h of ["10.evil.com", "192.168.1.1.nip.io", "notlocalhost", "evil.com"]) {
+      expect(privateHost(h, true)).toBe(false);
+    }
+  });
+
+  test("RFC1918 ranges are gated by trustLan", () => {
+    for (const h of ["10.0.0.5", "192.168.1.10", "172.16.0.1", "172.31.255.255"]) {
+      expect(privateHost(h, false)).toBe(false); // loopback-only by default
+      expect(privateHost(h, true)).toBe(true); // opted into LAN
+    }
+  });
+
+  test("public and near-miss addresses are never private", () => {
+    for (const h of ["8.8.8.8", "1.1.1.1", "172.15.0.1", "172.32.0.1", "93.184.216.34"]) {
+      expect(privateHost(h, true)).toBe(false);
+    }
+  });
+
+  test("IPv6 unique-local gated by trustLan; ::1 always", () => {
+    expect(privateHost("fc00::1", false)).toBe(false);
+    expect(privateHost("fd12:3456::1", true)).toBe(true);
+    expect(privateHost("2001:4860:4860::8888", true)).toBe(false);
+  });
+});
+
+describe("safeAbs", () => {
+  test("rejects non-strings, empties, and NUL-injected paths", () => {
+    for (const p of [null, undefined, 123, {}, "", "\0", "a\0b"]) {
+      expect(safeAbs(p as unknown)).toBeNull();
+    }
+  });
+
+  test("normalizes to an absolute path", () => {
+    expect(safeAbs("/a/b/../c")).toBe("/a/c");
+    expect(safeAbs("relative/x")?.startsWith("/")).toBe(true);
+  });
+});
+
+describe("shellSafeRel", () => {
+  test("accepts plain relative paths", () => {
+    for (const p of ["web", "packages/api", "a_b-c.d", "x/y/z", "svc@1"]) {
+      expect(shellSafeRel(p)).toBe(true);
+    }
+  });
+
+  test("rejects metacharacters, spaces, and leading dot/dash", () => {
+    for (const p of ["; rm -rf ~", "a b", "$(x)", "-flag", ".hidden", "a;b", "a|b", "a`b`", "../up", "a&&b", ""]) {
+      expect(shellSafeRel(p)).toBe(false);
+    }
+  });
+});
+
+describe("parseMakeTargets", () => {
+  test("extracts targets with their ## descriptions", () => {
+    const mk = "build: ## build it\n\tcc main.c\n\ntest: deps ## run tests\n\tgo test\n";
+    const t = parseMakeTargets(mk);
+    expect(t.find((x) => x.name === "build")?.desc).toBe("build it");
+    expect(t.find((x) => x.name === "test")?.desc).toBe("run tests");
+  });
+
+  test("ignores variable assignments (:= and ::=)", () => {
+    const t = parseMakeTargets("CC := gcc\nFLAGS ::= -O2\nall: build\n\techo hi\n").map((x) => x.name);
+    expect(t).toContain("all");
+    expect(t).not.toContain("CC");
+    expect(t).not.toContain("FLAGS");
+  });
+
+  test("drops a co-target that would become a make flag (-f injection)", () => {
+    const t = parseMakeTargets("all -flib/evil.mk: deps ## d\n\techo\n").map((x) => x.name);
+    expect(t).toContain("all");
+    expect(t).not.toContain("-flib/evil.mk");
+  });
+
+  test("skips $ and % (variable/pattern) targets", () => {
+    expect(parseMakeTargets("$(OBJ): x\n\tcc\n%.o: %.c\n\tcc\n").length).toBe(0);
+  });
+});
+
+describe("tokenOk", () => {
+  const at = "http://localhost:4000/x";
+  const reqWith = (h: Record<string, string>) => new Request(at, { headers: h });
+
+  test("accepts a matching Bearer header", () => {
+    expect(tokenOk(reqWith({ authorization: "Bearer secret" }), new URL(at), "secret")).toBe(true);
+  });
+
+  test("accepts a matching ?token= (for WS / downloads)", () => {
+    expect(tokenOk(new Request(at), new URL(at + "?token=secret"), "secret")).toBe(true);
+  });
+
+  test("rejects wrong, missing, or length-mismatched tokens", () => {
+    expect(tokenOk(reqWith({ authorization: "Bearer nope" }), new URL(at), "secret")).toBe(false);
+    expect(tokenOk(reqWith({}), new URL(at), "secret")).toBe(false);
+    expect(tokenOk(reqWith({ authorization: "Bearer s" }), new URL(at), "secret")).toBe(false);
+  });
+});

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -27,9 +27,7 @@
   },
   "bundle": {
     "active": true,
-    "targets": [
-      "deb"
-    ],
+    "targets": "all",
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/web/src/components/SkillsModal.tsx
+++ b/web/src/components/SkillsModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { SkillInfo } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
-import { api, SERVER } from "../lib/api.ts";
+import { api } from "../lib/api.ts";
 import { fmtAgo, fmtUsd } from "../lib/format.ts";
 
 type Kind = "all" | "skill" | "command";
@@ -217,9 +217,9 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
                   )}
                 </div>
                 <div className="flex items-center gap-2">
-                  <a href={`${SERVER}/skills/export?format=md`} className="chip" style={{ color: "var(--text3)" }} onClick={(e) => e.stopPropagation()}>↓ md</a>
-                  <a href={`${SERVER}/skills/export?format=csv`} className="chip" style={{ color: "var(--text3)" }} onClick={(e) => e.stopPropagation()}>↓ csv</a>
-                  <a href={`${SERVER}/skills/export?format=json`} className="chip" style={{ color: "var(--text3)" }} onClick={(e) => e.stopPropagation()}>↓ json</a>
+                  <a href={api.skillsExportUrl("md")} className="chip" style={{ color: "var(--text3)" }} onClick={(e) => e.stopPropagation()}>↓ md</a>
+                  <a href={api.skillsExportUrl("csv")} className="chip" style={{ color: "var(--text3)" }} onClick={(e) => e.stopPropagation()}>↓ csv</a>
+                  <a href={api.skillsExportUrl("json")} className="chip" style={{ color: "var(--text3)" }} onClick={(e) => e.stopPropagation()}>↓ json</a>
                   <button onClick={onClose} className="text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
                 </div>
               </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -7,20 +7,47 @@ export const SERVER: string =
   (import.meta.env.VITE_CW_SERVER as string | undefined)?.replace(/\/$/, "") ||
   `http://${location.hostname}:4000`;
 
-export const WS_URL = SERVER.replace(/^http/, "ws") + "/stream";
+/** Auth token for a server that requires one (exposed / multi-user box). Read
+ *  once from `?token=` — then stripped from the URL bar so it isn't shoulder-
+ *  surfed or copied around — or from a prior localStorage save. Empty on the
+ *  usual local box, where every call below is a no-op passthrough. */
+const TOKEN: string = (() => {
+  try {
+    const u = new URL(location.href);
+    const fromUrl = u.searchParams.get("token");
+    if (fromUrl) {
+      try { localStorage.setItem("agentglass_token", fromUrl); } catch { /* private mode */ }
+      u.searchParams.delete("token");
+      history.replaceState(null, "", u.pathname + u.search + u.hash);
+      return fromUrl;
+    }
+    return localStorage.getItem("agentglass_token") || "";
+  } catch { return ""; }
+})();
+
+/** Attach the bearer token to fetch headers when one is configured. */
+const authHeaders = (h: Record<string, string> = {}): Record<string, string> =>
+  TOKEN ? { ...h, authorization: `Bearer ${TOKEN}` } : h;
+
+/** Append ?token= to URLs a browser can't put a header on: WS upgrades and the
+ *  download navigations (export links). */
+const withToken = (url: string): string =>
+  TOKEN ? url + (url.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(TOKEN) : url;
+
+export const WS_URL = withToken(SERVER.replace(/^http/, "ws") + "/stream");
 
 /** WebSocket URL for a real PTY shell in `root` (the in-browser terminal). */
 export const ptyWsUrl = (root: string, cols: number, rows: number) =>
-  `${SERVER.replace(/^http/, "ws")}/terminal/pty?root=${encodeURIComponent(root)}&cols=${cols}&rows=${rows}`;
+  withToken(`${SERVER.replace(/^http/, "ws")}/terminal/pty?root=${encodeURIComponent(root)}&cols=${cols}&rows=${rows}`);
 
 async function get<T>(path: string): Promise<T> {
-  const r = await fetch(SERVER + path);
+  const r = await fetch(SERVER + path, { headers: authHeaders() });
   if (!r.ok) throw new Error(`${path} → ${r.status}`);
   return r.json() as Promise<T>;
 }
 
 async function post<T>(path: string, body: unknown): Promise<T> {
-  const r = await fetch(SERVER + path, { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body) });
+  const r = await fetch(SERVER + path, { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(body) });
   return r.json() as Promise<T>;
 }
 
@@ -39,8 +66,8 @@ const realApi = {
     get<{ source_apps: string[]; hook_event_types: string[]; models: string[] }>(
       `/events/filter-options`
     ),
-  exportUrl: (fmt: "csv" | "json") => `${SERVER}/export?format=${fmt}`,
-  skillsExportUrl: () => `${SERVER}/skills/export?format=md`,
+  exportUrl: (fmt: "csv" | "json") => withToken(`${SERVER}/export?format=${fmt}`),
+  skillsExportUrl: (fmt: "md" | "csv" | "json" = "md") => withToken(`${SERVER}/skills/export?format=${fmt}`),
   usage: () => get<UsagePayload>(`/usage`),
   skills: () => get<{ skills: SkillInfo[]; generated_at: number }>(`/skills`),
   changes: (limit = 200) => get<{ changes: FileChange[] }>(`/changes?limit=${limit}`),
@@ -51,25 +78,25 @@ const realApi = {
   gateDecide: (id: string, decision: "allow" | "deny", reason = "") =>
     fetch(SERVER + "/gate/decide", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: authHeaders({ "content-type": "application/json" }),
       body: JSON.stringify({ id, decision, reason }),
     }).then((r) => r.json()),
   gitStatus: (paths: string[]) =>
     fetch(SERVER + "/git/status", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: authHeaders({ "content-type": "application/json" }),
       body: JSON.stringify({ paths }),
     }).then((r) => r.json() as Promise<GitStatusResponse>),
   gitCommit: (payload: { root: string; files: string[]; title: string; body: string }) =>
     fetch(SERVER + "/git/commit", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: authHeaders({ "content-type": "application/json" }),
       body: JSON.stringify(payload),
     }).then((r) => r.json() as Promise<CommitResult>),
   walkthrough: (files: WalkthroughInputFile[]) =>
     fetch(SERVER + "/walkthrough", {
       method: "POST",
-      headers: { "content-type": "application/json" },
+      headers: authHeaders({ "content-type": "application/json" }),
       body: JSON.stringify({ files }),
     }).then((r) => r.json() as Promise<WalkthroughResult>),
   /** Scope this instance to one project dir (null → whole machine). */
@@ -117,7 +144,7 @@ const realApi = {
   // --- multi-chat: drive a claude session from the browser ---
   chatEnabled: () => get<{ enabled: boolean }>("/chat/enabled"),
   chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
-    const res = await fetch(SERVER + "/chat/send", { method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(payload), signal });
+    const res = await fetch(SERVER + "/chat/send", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
     if (!res.body) { try { onEvent(JSON.parse(await res.text())); } catch { /* non-json */ } return; }
     const reader = res.body.getReader();
     const dec = new TextDecoder();


### PR DESCRIPTION
## What

Defense-in-depth for the server's capability surface (shell / git write / docker / chat), plus a test suite for the security-critical parsers. **Zero new dependencies** (stdlib Python / Bun / node built-ins only), and the **default local single-user experience is unchanged** — every new control is opt-in via env.

The server today rests entirely on *loopback + same-origin*, which is documented and fine for a single-user box but leaves two gaps: any other local process can reach the port (and the shell), and a non-loopback bind is unauthenticated RCE. This adds a way to close both without changing the zero-config path.

## Changes

| Env / area | Behavior |
|---|---|
| `AGENTGLASS_TOKEN` | Shared secret required on every route **except** the append-only telemetry sinks (`/ingest`, OTLP). `Authorization: Bearer` or `?token=` (WS/downloads). Binding a non-loopback address **without** a token now refuses to run unauthenticated: it mints, prints, and `0600`-saves one. |
| `AGENTGLASS_CHAT_BYPASS` | `bypassPermissions` (`claude --dangerously-skip-permissions`) honored only when opted in; otherwise downgraded to a prompting default. |
| `AGENTGLASS_GATE_FAILCLOSED` | Gate timeout (server) / unreachable control plane (hook) **denies** instead of allows. Off by default. |
| `AGENTGLASS_RATE_MAX` / `_WINDOW_MS` | Fixed-window limiter on the unauthenticated intake sinks (flood protection). |
| CORS | Reflects the caller's `Origin` (+ `Vary: Origin`) instead of a blanket `*`; permits the `Authorization` header. |
| Tests | `server/test/security.test.ts` — 16 cases over `privateHost` (incl. the `10.evil.com` rebinding case), `safeAbs`, `shellSafeRel`, `parseMakeTargets` (incl. the `-flib/*.mk` make-flag injection), and the token check. |
| Typecheck | `Bun.serve<WsData>` resolves the WS-data generic — `server/src` now passes `tsc --noEmit` clean (was 11 errors), so it could join a typecheck gate. |

Web side: the token is read once from `?token=` (then stripped from the address bar) or `localStorage` and attached to every fetch/WS/download.

## Verification

- `bun test` → 16/16 pass
- `bunx tsc --noEmit` → clean in both `web/` **and** `server/`
- `bunx vite build` → ok
- Boot-tested: default (loopback, no token), `AGENTGLASS_TOKEN` (401 without / 200 with, intake ungated), and `AGENTGLASS_BIND=0.0.0.0` with no token (auto-mints + prints).

## Two items I'd like your call on (kept separate in the diff so they're easy to drop)

1. **`AGENTGLASS_TRUST_LAN` default = off** (commit 1). Today RFC1918 addresses are trusted as origins/hosts; this makes the default loopback-only, so a machine currently accessed from a LAN browser would need `AGENTGLASS_TRUST_LAN=1`. It's the one **behavior change** here. Happy to flip the default to on (preserving today's behavior) and let the token be the real gate — your call, since the RFC1918 trust was a deliberate design choice.
2. **`tauri.conf.json` `targets: "all"`** (commit 3). This contradicts the "Linux only, `.deb`" note in `CONTRIBUTING.md` and could change `make desktop` on a minimal Linux box (now also attempts rpm/appimage). Easy to revert to `["deb"]` if you'd rather add other platforms yourself.

Everything else is additive and default-off. Glad to split, trim, or reshape to fit.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
