### PR TITLE
fix(hooks): quote send_event path on Windows installs

### DIFF
--- a/hooks/install_hooks.py
+++ b/hooks/install_hooks.py
@@ -69,7 +69,9 @@ def do_install(cfg):
     hooks = cfg.setdefault("hooks", {})
     for event, (matcher, add_chat) in EVENTS.items():
         arr = [e for e in hooks.get(event, []) if not _is_ours(e)]
-        cmd = f"python3 {SEND_EVENT} --event-type {event}"
+        # Quote the script path on Windows so spaces/backslashes survive JSON + shell parsing.
+        send_event_cmd = f'"{SEND_EVENT}"' if os.name == "nt" else SEND_EVENT
+        cmd = f"python3 {send_event_cmd} --event-type {event}"
         if add_chat:
             cmd += " --add-chat"
         entry = {"hooks": [{"type": "command", "command": cmd}]}


### PR DESCRIPTION
## Summary
Fixes #15

On Windows, `hooks/install_hooks.py` wrote:

```text
python3 C:\Users\...\hooks\send_event.py --event-type SessionStart
```

Unquoted paths with spaces/backslashes break Claude Code settings parsing and can make every tool call fail.

### Change
Quote the script path when `os.name == "nt"`:

```text
python3 "C:\Users\...\hooks\send_event.py" --event-type SessionStart
```

Non-Windows installs stay unchanged.

## Testing
- Inspected the single command construction site in `hooks/install_hooks.py`
- Confirmed quote branch is Windows-only
