### PR TITLE
fix(hooks): pick Windows python launcher for hook commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -330,6 +330,8 @@ with Approve / Deny buttons — decide from any device and the agent unblocks.
 "PreToolUse": [
   { "matcher": "Bash", "hooks": [{ "type": "command",
     "command": "python3 ~/code/agentglass/hooks/gate_event.py --source-app my-project" }] }
+
+On Windows, use `py` (or `python`) instead of `python3` in hand-written hook commands; `hooks/install_hooks.py` picks this automatically.
 ]
 ```
 

--- a/README.md
+++ b/README.md
@@ -330,10 +330,10 @@ with Approve / Deny buttons — decide from any device and the agent unblocks.
 "PreToolUse": [
   { "matcher": "Bash", "hooks": [{ "type": "command",
     "command": "python3 ~/code/agentglass/hooks/gate_event.py --source-app my-project" }] }
-
-On Windows, use `py` (or `python`) instead of `python3` in hand-written hook commands; `hooks/install_hooks.py` picks this automatically.
 ]
 ```
+
+On Windows, use `py` (or `python`) instead of `python3` in hand-written hook commands; `hooks/install_hooks.py` picks this automatically.
 
 Safe by design — it **never blocks your agents by accident**:
 

--- a/hooks/install_hooks.py
+++ b/hooks/install_hooks.py
@@ -63,16 +63,32 @@ def load(path):
     return json.loads(raw) if raw else {}
 
 
+def _hook_python():
+    """Interpreter name written into Claude Code hook commands.
+
+    On Windows most installs expose `py` (launcher) and/or `python`, not
+    `python3`. Prefer those at install time. Deliberately avoid
+    `sys.executable` so a later-deleted venv does not break every hook.
+    """
+    if os.name != "nt":
+        return "python3"
+    for candidate in ("py", "python"):
+        if shutil.which(candidate):
+            return candidate
+    return "py"
+
+
 def do_install(cfg):
     """Append our forwarder to each event, first stripping any prior agentglass
     entry (so a moved clone re-points cleanly). All other hooks are preserved."""
     hooks = cfg.setdefault("hooks", {})
+    python = _hook_python()
     for event, (matcher, add_chat) in EVENTS.items():
         arr = [e for e in hooks.get(event, []) if not _is_ours(e)]
         # Quote the script path unconditionally: a clone living under a spaced
         # path ("/Users/x/My Projects/…", "C:\Users\…") breaks the hook command
         # on every platform, not just Windows.
-        cmd = f'python3 "{SEND_EVENT}" --event-type {event}'
+        cmd = f'{python} "{SEND_EVENT}" --event-type {event}'
         if add_chat:
             cmd += " --add-chat"
         entry = {"hooks": [{"type": "command", "command": cmd}]}

--- a/hooks/settings.example.json
+++ b/hooks/settings.example.json
@@ -1,5 +1,5 @@
 {
-  "//": "MANUAL FALLBACK. `bun install` (or `bun run setup`) wires these globally for you via hooks/install_hooks.py. Only copy by hand if you want to customize.",
+  "//": "MANUAL FALLBACK. `bun install` (or `bun run setup`) wires these globally for you via hooks/install_hooks.py. Only copy by hand if you want to customize. On Windows use `py` (or `python`) instead of `python3`.",
   "//copy": "Copy these hooks into your project's .claude/settings.json (or ~/.claude/settings.json).",
   "//source-app": "Change --source-app to name this project/agent in the dashboard (the installer omits it so each project auto-labels by folder name).",
   "//path": "Adjust the absolute path to send_event.py.",


### PR DESCRIPTION
## Summary
On Windows, Claude Code hook commands generated by `hooks/install_hooks.py` used `python3`, which is usually missing (Microsoft Store shim / not installed). Prefer `py` then `python` on Windows; keep `python3` elsewhere.

Also notes the same Windows launcher choice in `settings.example.json` and the README gate example. Path quoting remains unconditional on all platforms (already merged via #23).

Fixes #24

## Notes
- Avoids `sys.executable` so a deleted venv cannot brick every hook
- Re-running the installer rewrites existing agentglass hook commands in place (idempotent strip+append)

## Testing
- `python3 -m py_compile hooks/install_hooks.py`
- Manual inspection of `_hook_python()` branch selection
