### PR TITLE
fix(auth): require token on /gate control plane (#21)

### DIFF
--- a/hooks/gate_event.py
+++ b/hooks/gate_event.py
@@ -89,10 +89,19 @@ def main():
         "timeout_ms": TIMEOUT * 1000,
     }).encode("utf-8")
 
+    # Carry the shared secret when the server has one. /gate is the control plane
+    # (a POST raises an operator-facing approval prompt), so a token-protected
+    # server requires auth here — otherwise any local process could inject spoofed
+    # approval prompts. The hook runs on the same machine and reads it from env.
+    headers = {"Content-Type": "application/json"}
+    token = os.environ.get("AGENTGLASS_TOKEN", "").strip()
+    if token:
+        headers["Authorization"] = "Bearer " + token
+
     req = urllib.request.Request(
         args.server.rstrip("/") + "/gate",
         data=body,
-        headers={"Content-Type": "application/json"},
+        headers=headers,
         method="POST",
     )
     try:

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -24,17 +24,31 @@ const TOKEN_PATH = join(
   "token"
 );
 
-// Append-only telemetry sinks + health. Everything else — reads, shell,
-// git/docker writes, gate decisions — is behind the token when one is set.
-const INTAKE = new Set([
+// Routes that never require the token: append-only telemetry sinks + health.
+// A local hook or OTel exporter has no way to carry a secret and can only
+// *append* events, so these stay open even when a token is configured.
+//
+// Note: /gate is deliberately NOT here. It's the control plane — a POST creates
+// an operator-facing approval prompt with caller-controlled text — so when a
+// token is set the gate hook must authenticate (it runs on the same machine and
+// can read AGENTGLASS_TOKEN from the env). With no token configured the whole
+// auth check is skipped anyway, so /gate keeps its zero-config tokenless UX.
+const AUTH_EXEMPT = new Set([
   "/health",
   "/ingest",
-  "/gate",
   "/v1/traces",
   "/otlp/v1/traces",
   "/v1/logs",
   "/otlp/v1/logs",
 ]);
+
+/** True for routes that bypass the shared-secret gate even when a token is set. */
+export const isAuthExempt = (pathname: string) => AUTH_EXEMPT.has(pathname);
+
+// Rate-limited intake sinks (flood protection). /gate is included: even though
+// it authenticates when a token is set, a burst of gate posts shouldn't be
+// unbounded. This set governs throttling only, not auth exemption.
+const INTAKE = new Set([...AUTH_EXEMPT, "/gate"]);
 
 export const isIntake = (pathname: string) => INTAKE.has(pathname);
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -43,7 +43,7 @@ import { chatStream, CHAT_ENABLED, CHAT_BYPASS_ALLOWED } from "./chat.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, CONFIG_PATH } from "./config.ts";
 import { privateHost } from "./net.ts";
-import { resolveToken, tokenOk, isIntake } from "./auth.ts";
+import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { rateOk } from "./ratelimit.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
@@ -204,7 +204,9 @@ const server = Bun.serve<WsData>({
     // append-only intake sinks needs it — this is what closes the door on other
     // local processes and makes a non-loopback bind safe. WS upgrades carry it
     // as ?token= (a browser can't set a header on them); fetch uses Bearer.
-    if (AUTH_TOKEN && !isIntake(pathname) && !tokenOk(req, url, AUTH_TOKEN)) {
+    // /gate is NOT exempt here: it's the control plane, and its hook carries the
+    // token when one is set (see auth.ts / gate_event.py).
+    if (AUTH_TOKEN && !isAuthExempt(pathname) && !tokenOk(req, url, AUTH_TOKEN)) {
       return json({ ok: false, error: "unauthorized — pass ?token= or Authorization: Bearer" }, 401);
     }
 

--- a/server/test/security.test.ts
+++ b/server/test/security.test.ts
@@ -5,7 +5,7 @@ import { describe, expect, test } from "bun:test";
 import { privateHost } from "../src/net.ts";
 import { safeAbs } from "../src/git.ts";
 import { shellSafeRel, parseMakeTargets } from "../src/terminal.ts";
-import { tokenOk } from "../src/auth.ts";
+import { tokenOk, isAuthExempt, isIntake } from "../src/auth.ts";
 
 describe("privateHost", () => {
   test("loopback is always trusted, regardless of trustLan", () => {
@@ -111,5 +111,30 @@ describe("tokenOk", () => {
     expect(tokenOk(reqWith({ authorization: "Bearer nope" }), new URL(at), "secret")).toBe(false);
     expect(tokenOk(reqWith({}), new URL(at), "secret")).toBe(false);
     expect(tokenOk(reqWith({ authorization: "Bearer s" }), new URL(at), "secret")).toBe(false);
+  });
+});
+
+describe("auth exemption vs intake", () => {
+  test("append-only telemetry sinks are always tokenless", () => {
+    for (const p of ["/health", "/ingest", "/v1/traces", "/otlp/v1/traces", "/v1/logs", "/otlp/v1/logs"]) {
+      expect(isAuthExempt(p)).toBe(true);
+    }
+  });
+
+  test("/gate is the control plane — NOT auth-exempt, so a configured token guards it", () => {
+    // Regression guard for the spoofed-approval-queue injection: /gate must sit
+    // behind the token when one is set, not alongside the telemetry sinks.
+    expect(isAuthExempt("/gate")).toBe(false);
+  });
+
+  test("/gate stays rate-limited as intake even though it authenticates", () => {
+    expect(isIntake("/gate")).toBe(true);
+  });
+
+  test("reads and writes are neither exempt nor intake", () => {
+    for (const p of ["/events/recent", "/gate/decide", "/workspace", "/terminal/pty"]) {
+      expect(isAuthExempt(p)).toBe(false);
+      expect(isIntake(p)).toBe(false);
+    }
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes #21. `/gate` was in the tokenless `INTAKE` set alongside the append-only telemetry sinks — but it's the **control plane**: a POST creates an operator-facing "What needs you" approval prompt with caller-controlled `source_app`/`tool_name`/summary, and pins a held connection per request. On a token-protected box, any unprivileged local process (the exact caller the token is meant to lock out) could inject spoofed "prod" approval prompts and phish an Approve click.

The fix splits the two things `INTAKE` was overloading:

- **`AUTH_EXEMPT`** (health + append-only telemetry sinks) now drives the token gate. `/gate` is **not** exempt, so a configured token guards it.
- **`INTAKE`** (`AUTH_EXEMPT` + `/gate`) still drives flood throttling, so `/gate` stays rate-limited.
- **`hooks/gate_event.py`** sends `Authorization: Bearer $AGENTGLASS_TOKEN` when set — it runs on the same machine and reads the secret from env.

**Zero-config is unchanged:** with no token set the whole auth check is skipped, so `/gate` keeps its tokenless UX. This also makes the code match the README's stated contract ("every route but the append-only telemetry sinks needs the token").

## How was it tested?

- `bun test` in `server/` → 42/42 pass, including 4 new cases in `security.test.ts` asserting `/gate` is **not** auth-exempt but **is** intake (rate-limited), and that reads/writes are neither.
- `bunx tsc --noEmit` clean in `server/` and `web/`.
- `python3 -m py_compile hooks/gate_event.py` OK.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`) — no web surface touched
- [x] Stays dependency-light (no new deps — stdlib only)
- [x] `shared/types.ts` updated if the server↔web contract changed (no contract change)
- [x] Docs updated if behavior/config changed (code now matches the documented token contract; no doc change needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_