### PR TITLE
fix(web): keyboard shortcuts stop leaking after clicks; free the chat Escape (#17)

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -56,6 +56,16 @@ export default function App() {
   const [projectOpen, setProjectOpen] = useState(false);
   const mountedAt = useRef(Date.now());
 
+  // A live snapshot of "is any panel/overlay open", read by the global key
+  // handler so single-letter shortcuts can't stack a second panel on top of an
+  // open one. Kept in a ref so the handler needn't re-subscribe on every toggle.
+  const anyPanelOpen =
+    paletteOpen || helpOpen || statsOpen || skillsOpen || changesOpen ||
+    gitOpen || dockerOpen || terminalOpen || chatOpen || searchOpen ||
+    projectOpen || sessionView !== null || selected !== null;
+  const anyPanelOpenRef = useRef(anyPanelOpen);
+  anyPanelOpenRef.current = anyPanelOpen;
+
   // Which folder is this cockpit about? Ask once on first open when nothing is
   // scoped yet — picking a project up front is what gives the terminal, git
   // panel and command list their directory. Answering "whole machine" (or just
@@ -129,40 +139,21 @@ export default function App() {
 
   const clearFilters = useCallback(() => setFilter({ app: "", type: "", provider: "" }), []);
 
-  // Keyboard shortcuts: ⌘K / Ctrl-K palette, ? help, Esc closes
+  // Keyboard shortcuts: ⌘K / Ctrl-K palette, ? help, single-letter panels, Esc closes
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      // ⌘K / Ctrl-K palette — always available, even inside a field or panel.
       if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "k") {
         e.preventDefault();
         setPaletteOpen((o) => !o);
-      } else if (e.key === "?" && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        setHelpOpen((o) => !o);
-      } else if (e.key === "s" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault(); // don't let the key leak into the modal's autofocused input
-        setStatsOpen((o) => !o);
-      } else if (e.key === "k" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setSkillsOpen((o) => !o);
-      } else if (e.key === "d" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setChangesOpen((o) => !o);
-      } else if (e.key === "g" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setGitOpen((o) => !o);
-      } else if (e.key === "o" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setDockerOpen((o) => !o);
-      } else if (e.key === "t" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setTerminalOpen((o) => !o);
-      } else if (e.key === "c" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setChatOpen((o) => !o);
-      } else if (e.key === "/" && !e.metaKey && !e.ctrlKey && !/input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "")) {
-        e.preventDefault();
-        setSearchOpen((o) => !o);
-      } else if (e.key === "Escape") {
-        // the real terminal owns Escape while focused (vim, fzf, Ctrl+R…)
+        return;
+      }
+
+      // Escape closes open panels, regardless of where focus rests. The real
+      // terminal owns Escape while its shell is focused (vim, fzf, Ctrl+R…), so
+      // leave xterm alone. Chat handles its own Escape locally (see ChatPanel)
+      // because a focused textarea can swallow it before it reaches here.
+      if (e.key === "Escape") {
         if ((e.target as HTMLElement)?.closest?.(".xterm")) return;
         setSelected(null);
         setPaletteOpen(false);
@@ -176,6 +167,30 @@ export default function App() {
         setChatOpen(false);
         setSearchOpen(false);
         setSessionView(null);
+        return;
+      }
+
+      // Single-letter globals below. Two guards, both required:
+      //  * focus must rest on nothing (the <body>) — never a button (a mouse
+      //    click parks focus there), an input, or a textarea. Without this a
+      //    letter fires right after any click, and leaks into a field's draft.
+      //  * no panel may already be open — otherwise a letter stacks a second
+      //    panel on top of the first. Close with Escape, then open with a letter.
+      if (e.metaKey || e.ctrlKey || e.altKey) return;
+      const a = document.activeElement;
+      const focusFree = !a || a === document.body || a === document.documentElement;
+      if (!focusFree || anyPanelOpenRef.current) return;
+
+      switch (e.key) {
+        case "?": setHelpOpen((o) => !o); break;
+        case "s": e.preventDefault(); setStatsOpen((o) => !o); break;
+        case "k": e.preventDefault(); setSkillsOpen((o) => !o); break;
+        case "d": e.preventDefault(); setChangesOpen((o) => !o); break;
+        case "g": e.preventDefault(); setGitOpen((o) => !o); break;
+        case "o": e.preventDefault(); setDockerOpen((o) => !o); break;
+        case "t": e.preventDefault(); setTerminalOpen((o) => !o); break;
+        case "c": e.preventDefault(); setChatOpen((o) => !o); break;
+        case "/": e.preventDefault(); setSearchOpen((o) => !o); break;
       }
     };
     window.addEventListener("keydown", onKey);

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -153,6 +153,9 @@ export function ChatPanel({ open, onClose }: { open: boolean; onClose: () => voi
   };
   const [hint, setHint] = useState("");
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    // A focused textarea can swallow Escape before it reaches the global
+    // handler, stranding the panel open. Close it here instead.
+    if (e.key === "Escape") { e.preventDefault(); onClose(); return; }
     if (e.key !== "Enter" || e.shiftKey) return;
     e.preventDefault();
     // send() returns early in both these cases; without saying so, Enter just


### PR DESCRIPTION
## What does this PR do?

Fixes #17. The global keydown handler only excluded `input`/`textarea`, so a focused **`<button>`** (where a mouse click parks focus) still fired the single-letter panel shortcuts. The results, all reproducible in the first five minutes:

- click any button → press a letter → a panel opens unexpectedly;
- with a panel already open, a letter **stacks a second panel** on top;
- letters **leak into the chat draft**;
- a focused chat textarea could **swallow Escape**, so the panel couldn't be closed from the keyboard.

The fix:

- **Gate the single-letter globals** (`?`, `s`, `k`, `d`, `g`, `o`, `t`, `c`, `/`) on two guards: focus must rest on `<body>` (never a button/input/textarea), **and** no panel may already be open. This kills both the click-then-type trigger and the stacking. `⌘K`/`Ctrl-K` and `Escape` stay global.
- A live `anyPanelOpen` snapshot (kept in a ref) feeds the handler without re-subscribing on every toggle.
- **ChatPanel handles Escape locally** (`→ onClose`), so a focused textarea can never strand the panel open.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/` and `server/`; `bunx vite build` builds clean.
- Drove the demo build with headless Chromium:
  - letter opens a panel **only** when focus is free (`c` → chat opens) ✅
  - parked button focus blocks the letter (`c` with a `<button>` focused → chat stays closed) ✅
  - a second letter no longer stacks (`c` open, then `g` → git does not open over it) ✅
  - Escape closes the chat ✅
  - no console errors.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps)
- [x] `shared/types.ts` updated if the server↔web contract changed (no contract change)
- [x] Docs updated if behavior/config changed (interaction fix; no config/docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_