### PR TITLE
fix(web): surface auth failures, stop the endless silent WS reconnect (#19)

### DIFF
--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useLayoutEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { ConnState } from "../lib/useLive.ts";
-import { api, IS_DEMO } from "../lib/api.ts";
+import { api, IS_DEMO, reauthPrompt } from "../lib/api.ts";
 import { MOD_KEY } from "../lib/format.ts";
 import { ThemeSwitcher } from "./ThemeSwitcher.tsx";
 import { UsageWidget } from "./UsageWidget.tsx";
@@ -211,6 +211,8 @@ export function Header({
   onOpenProject: () => void;
 }) {
   const live = conn === "open";
+  const unauth = conn === "unauthorized";
+  const pillColor = live ? "var(--success)" : unauth ? "var(--error)" : "var(--warning)";
   const hasFilter = filter.app || filter.type || filter.provider;
 
   return (
@@ -230,13 +232,15 @@ export function Header({
             <span className="t-dim2">▾</span>
           </button>
         </div>
-        <span className="flex items-center gap-1.5 ml-1 px-2 py-0.5 rounded-full text-[10px] font-semibold"
-          style={{ color: live ? "var(--success)" : "var(--warning)", background: `color-mix(in srgb, ${live ? "var(--success)" : "var(--warning)"} 14%, transparent)` }}>
+        <span onClick={unauth ? reauthPrompt : undefined}
+          title={unauth ? "This server needs an access token — click to enter it" : undefined}
+          className={`flex items-center gap-1.5 ml-1 px-2 py-0.5 rounded-full text-[10px] font-semibold ${unauth ? "cursor-pointer" : ""}`}
+          style={{ color: pillColor, background: `color-mix(in srgb, ${pillColor} 14%, transparent)` }}>
           <span className="relative flex h-1.5 w-1.5">
             {live && <span className="absolute inline-flex h-full w-full rounded-full opacity-70" style={{ background: "var(--success)", animation: "ping-ring 1.6s ease-out infinite" }} />}
-            <span className="relative inline-flex rounded-full h-1.5 w-1.5" style={{ background: live ? "var(--success)" : "var(--warning)" }} />
+            <span className="relative inline-flex rounded-full h-1.5 w-1.5" style={{ background: pillColor }} />
           </span>
-          {live ? "LIVE" : conn.toUpperCase()}
+          {live ? "LIVE" : unauth ? "UNAUTHORIZED ⚿" : conn.toUpperCase()}
         </span>
         {IS_DEMO && (
           <a

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -11,7 +11,7 @@ import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import type { GitRepoRef, ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
-import { api, IS_DEMO, ptyWsUrl } from "../lib/api.ts";
+import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 
 const ROOT_KEY = "agentglass.terminalRoot";
@@ -40,7 +40,7 @@ function themeFromCss() {
 const TERM_FONT = '"JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "JetBrains Mono", "SF Mono", ui-monospace, "Cascadia Code", "Fira Code", Menlo, Monaco, "Roboto Mono", Consolas, "Liberation Mono", monospace';
 
 // --- persistent per-repo shell sessions (outlive the panel) ------------------
-type SessStatus = "idle" | "connecting" | "live" | "exited" | "error";
+type SessStatus = "idle" | "connecting" | "live" | "exited" | "error" | "unauthorized";
 type Sess = {
   id: string;             // many shells can share a repo, so the id is the key
   root: string;
@@ -123,6 +123,7 @@ function connect(s: Sess) {
   };
   ws.onclose = () => {
     if (s.ws !== ws) return; // stale socket — the session already moved on
+    const wasLive = s.status === "live";
     s.ws = null;
     if (s.status === "connecting" || s.status === "live") {
       s.status = "error";
@@ -132,7 +133,7 @@ function connect(s: Sess) {
       // Making the user press Enter to come back is asking them to do the
       // computer's job; retry on our own and say so, with the manual path
       // still there if the retries give up.
-      scheduleReconnect(s);
+      maybeReconnect(s, wasLive);
     }
   };
 }
@@ -140,9 +141,40 @@ function connect(s: Sess) {
 /** Reconnect delay, backing off so a server that's down for a while isn't
  *  hammered, but a quick restart is picked up almost immediately. */
 const RETRY_MS = [400, 800, 1500, 3000, 5000, 8000];
+// Stop after ~2 minutes of failed reconnects (the backoff tops out at 8s). Left
+// unbounded, a wrong/rotated token — which rejects every upgrade with a 401 a
+// browser WS can't read — printed a reconnect dot forever (~450/hour).
+const MAX_RETRIES = 15;
+
+/** Decide whether to keep reconnecting after a socket dropped. A close before
+ *  the shell ever went live, on a token-protected server, is almost always the
+ *  401 that rejects the WS upgrade — unreadable off a browser WebSocket — so we
+ *  probe an authenticated endpoint to tell an auth wall from a plain outage and
+ *  stop retrying (with a way back) instead of spinning forever. */
+async function maybeReconnect(s: Sess, wasLive: boolean) {
+  if (!wasLive && hasToken()) {
+    const state = await probeAuth();
+    if (s.ws) return; // a manual reconnect (Enter / ⟲) beat us to it
+    if (state === "unauthorized") {
+      if (s.retryTimer) { clearTimeout(s.retryTimer); s.retryTimer = null; }
+      s.retries = 0;
+      s.status = "unauthorized";
+      s.term.write("\r\n\x1b[31m— unauthorized: this server needs an access token —\x1b[0m\r\n\x1b[2m  reopen the dashboard with ?token=… (or click the ⚿ status) to re-enter it\x1b[0m\r\n");
+      notify(s);
+      return;
+    }
+  }
+  scheduleReconnect(s);
+}
 
 function scheduleReconnect(s: Sess) {
   if (s.retryTimer) return;
+  if (s.retries >= MAX_RETRIES) {
+    s.status = "error";
+    s.term.write("\r\n\x1b[2m— still no server after many tries · press Enter to retry —\x1b[0m\r\n");
+    notify(s);
+    return;
+  }
   const wait = RETRY_MS[Math.min(s.retries, RETRY_MS.length - 1)];
   s.retries++;
   if (s.retries === 1) s.term.write("\r\n\x1b[2m— disconnected · reconnecting…\x1b[0m");
@@ -188,7 +220,8 @@ function createSession(root: string): Sess {
     sess.lastUsed = Date.now();
     if (sess.status === "live" && sess.ws?.readyState === WebSocket.OPEN) sess.ws.send(JSON.stringify({ t: "in", d }));
     else if (sess.status === "connecting") sess.pending.push(d); // don't drop keys typed before the shell is up
-    else if ((sess.status === "exited" || sess.status === "error") && d.includes("\r")) connect(sess); // Enter → new shell, scrollback kept
+    else if (sess.status === "unauthorized" && d.includes("\r")) reauthPrompt(); // Enter → re-enter the token
+    else if ((sess.status === "exited" || sess.status === "error") && d.includes("\r")) { sess.retries = 0; connect(sess); } // Enter → new shell, scrollback kept
   });
   term.onResize(({ cols, rows }) => {
     if (sess.ws?.readyState === WebSocket.OPEN) sess.ws.send(JSON.stringify({ t: "resize", cols, rows }));
@@ -364,6 +397,7 @@ export function TerminalPanel({ open, onClose }: { open: boolean; onClose: () =>
     live: { color: "var(--success, #98c379)", label: sess ? `${sess.shell} · ${sess.mode === "pipe" ? "pipe" : "pty"}${sess.mode !== "pipe" && !sess.canResize ? " · fixed size" : ""}` : "live" },
     exited: { color: "var(--text2)", label: "exited" },
     error: { color: "var(--error)", label: "disconnected" },
+    unauthorized: { color: "var(--error)", label: "unauthorized ⚿" },
   };
 
   return (
@@ -445,7 +479,9 @@ export function TerminalPanel({ open, onClose }: { open: boolean; onClose: () =>
                   </div>
 
                   <div className="ml-auto flex items-center gap-1.5 shrink-0">
-                    <span className="flex items-center gap-1.5 text-[10px] t-dim2 mr-1" title="shell status">
+                    <span onClick={status === "unauthorized" ? reauthPrompt : undefined}
+                      className={`flex items-center gap-1.5 text-[10px] t-dim2 mr-1 ${status === "unauthorized" ? "cursor-pointer" : ""}`}
+                      title={status === "unauthorized" ? "this server needs an access token — click to enter it" : "shell status"}>
                       <span style={{ color: statusDot[status].color }}>●</span>{statusDot[status].label}
                     </span>
                     <button onClick={splitPane} disabled={!root || IS_DEMO || disabled || paneIds.length >= 4} title="show another shell beside this one" className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", opacity: paneIds.length >= 4 ? 0.45 : 1 }}>⊞ split</button>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -34,6 +34,36 @@ const authHeaders = (h: Record<string, string> = {}): Record<string, string> =>
 const withToken = (url: string): string =>
   TOKEN ? url + (url.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(TOKEN) : url;
 
+/** Whether this client has a shared-secret token configured. */
+export const hasToken = (): boolean => !!TOKEN;
+
+/** Tell an auth failure apart from a plain outage. A browser WebSocket can't
+ *  read the 401 that rejects its upgrade, so a socket that closes before it ever
+ *  opens looks identical to the server being down. Probing an authenticated HTTP
+ *  endpoint (which *can* read the status) disambiguates: 401 → the token is
+ *  wrong/rotated/missing; any other answer → the server is up; a thrown fetch →
+ *  it's unreachable. */
+export async function probeAuth(): Promise<"ok" | "unauthorized" | "offline"> {
+  try {
+    const r = await fetch(SERVER + "/events/filter-options", { headers: authHeaders() });
+    return r.status === 401 ? "unauthorized" : "ok";
+  } catch {
+    return "offline";
+  }
+}
+
+/** Ask for a token, persist it, and reload so every fetch/WS picks it up. The
+ *  recovery path when a server starts requiring a token, or rotates it, after
+ *  this tab was loaded. */
+export function reauthPrompt(): void {
+  if (typeof window === "undefined") return;
+  const t = window.prompt("This server needs an access token.\nPaste it to reconnect:");
+  if (t && t.trim()) {
+    try { localStorage.setItem("agentglass_token", t.trim()); } catch { /* private mode */ }
+    location.reload();
+  }
+}
+
 export const WS_URL = withToken(SERVER.replace(/^http/, "ws") + "/stream");
 
 /** WebSocket URL for a real PTY shell in `root` (the in-browser terminal). */

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -1,12 +1,16 @@
 import { useEffect, useRef, useState, useCallback } from "react";
 import type { WatchEvent, WsFrame } from "../../../shared/types.ts";
-import { WS_URL, IS_DEMO } from "./api.ts";
+import { WS_URL, IS_DEMO, hasToken, probeAuth } from "./api.ts";
 import * as demo from "./demo.ts";
 
 const MAX_EVENTS = 2000;
 const FLUSH_MS = 220; // coalesce bursts into ~5 renders/sec
+// Stop hammering a server that won't come back. ~2 minutes of failed reconnects
+// (the backoff tops out at 8s) is long enough to ride out a restart but short
+// enough not to loop forever; becoming visible again resets and retries.
+const GIVE_UP_MS = 120_000;
 
-export type ConnState = "connecting" | "open" | "closed";
+export type ConnState = "connecting" | "open" | "closed" | "unauthorized";
 
 export interface LiveData {
   events: WatchEvent[];
@@ -23,10 +27,15 @@ export function useLive(): LiveData {
   const [events, setEvents] = useState<WatchEvent[]>([]);
   const [conn, setConn] = useState<ConnState>("connecting");
   const [lastEvent, setLastEvent] = useState<WatchEvent | null>(null);
+  const connRef = useRef(conn);
+  connRef.current = conn;
   const wsRef = useRef<WebSocket | null>(null);
   const retry = useRef(0);
   const timer = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   const disposed = useRef(false);
+  const opened = useRef(false);       // did the current socket ever reach open?
+  const firstFailAt = useRef(0);      // when the current run of failures started
 
   // Buffered incoming events + a set of ids already in the buffer (dedupe).
   const pending = useRef<WatchEvent[]>([]);
@@ -71,17 +80,35 @@ export function useLive(): LiveData {
   const connect = useCallback(() => {
     if (disposed.current) return;
     setConn("connecting");
+    opened.current = false;
     const ws = new WebSocket(WS_URL);
     wsRef.current = ws;
 
     ws.onopen = () => {
       retry.current = 0;
+      firstFailAt.current = 0;
+      opened.current = true;
       setConn("open");
     };
-    ws.onclose = () => {
+    ws.onclose = async () => {
       if (disposed.current || wsRef.current !== ws) return;
+      const everOpened = opened.current;
+      opened.current = false;
+
+      // A close before the socket ever opened, on a token-protected server, is
+      // almost always the 401 that rejects the WS upgrade — which a browser can't
+      // read off the socket. Probe an authenticated endpoint to be sure, and if
+      // it's an auth wall, stop: retrying forever just spams and never recovers.
+      if (!everOpened && hasToken()) {
+        const state = await probeAuth();
+        if (disposed.current || wsRef.current !== ws) return;
+        if (state === "unauthorized") { setConn("unauthorized"); return; }
+      }
+
       setConn("closed");
-      setTimeout(connect, Math.min(8000, 500 * 2 ** retry.current++));
+      if (!firstFailAt.current) firstFailAt.current = Date.now();
+      if (Date.now() - firstFailAt.current > GIVE_UP_MS) return; // gave up — see visibility reset
+      reconnectTimer.current = setTimeout(connect, Math.min(8000, 500 * 2 ** retry.current++));
     };
     ws.onerror = () => ws.close();
     ws.onmessage = (msg) => {
@@ -138,13 +165,29 @@ export function useLive(): LiveData {
     }
 
     connect();
-    // Catch up the moment the tab becomes visible again.
-    const onVis = () => { if (!document.hidden) flush(); };
+    // Catch up the moment the tab becomes visible again — and, if the stream
+    // died or gave up while we were away, reconnect right now instead of waiting
+    // out a backoff. An auth wall is left alone: the token is still wrong until
+    // the user re-enters it, so we don't spin on it.
+    const onVis = () => {
+      if (document.hidden) return;
+      flush();
+      if (connRef.current === "unauthorized") return;
+      const ws = wsRef.current;
+      const dead = !ws || ws.readyState === WebSocket.CLOSED || ws.readyState === WebSocket.CLOSING;
+      if (dead && connRef.current !== "open") {
+        if (reconnectTimer.current) { clearTimeout(reconnectTimer.current); reconnectTimer.current = null; }
+        retry.current = 0;
+        firstFailAt.current = 0;
+        connect();
+      }
+    };
     document.addEventListener("visibilitychange", onVis);
     return () => {
       disposed.current = true;
       document.removeEventListener("visibilitychange", onVis);
       if (timer.current) clearTimeout(timer.current);
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
       wsRef.current?.close();
     };
   }, [connect, flush]);


### PR DESCRIPTION
## What does this PR do?

Fixes #19. A wrong or rotated token rejects every WebSocket upgrade with a **401 the browser can't read off the socket**, so both the event stream (`useLive`) and the terminal PTY reconnected **forever** — backing off to 8s and never giving up, the word *unauthorized* appearing nowhere, the terminal printing a dot per attempt (~450/hour of scrollback). The stored token was read once at load, so the only recovery was knowing to revisit with `?token=`.

The fix distinguishes an **auth wall** from a **real outage** by probing an authenticated HTTP endpoint (which *can* read the 401):

- **`api.ts`** — `probeAuth()` returns `ok | unauthorized | offline`; `reauthPrompt()` re-enters and persists a token, then reloads; `hasToken()` exposes whether one is configured.
- **`useLive.ts`** — on a close *before the socket ever opened*, probe; a 401 → a new `"unauthorized"` `ConnState` and **retries stop**. Generic failures now give up after ~2 min instead of looping forever, and becoming visible again resets and reconnects so a long sleep still recovers. Also fixed a latent bug where the reconnect timer shared the flush timer's ref (a reconnect could cancel a pending flush).
- **`TerminalPanel.tsx`** — the same probe on drop-before-live → an `"unauthorized"` status that stops retrying; a `MAX_RETRIES` ceiling ends the dot-spam for generic outages (Enter retries). Enter re-auths from the unauthorized state.
- **Header + terminal status pills** show `unauthorized` and are **clickable to re-enter the token**.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/` and `server/`; `bunx vite build` builds clean.
- Booted a **real token-protected server** (`AGENTGLASS_TOKEN=…`) and confirmed the assumptions: `/events/filter-options` returns **401** without/with a wrong token and **200** with the right one; the `/stream` WS **closes before opening** on a bad token and **opens** on the right one.
- Drove the real (non-demo) build with headless Chromium:
  - `?token=wrong` → pill settles to **UNAUTHORIZED ⚿**, WS attempted **exactly once** (no loop) ✅
  - `?token=<correct>` → pill goes **LIVE** ✅

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps)
- [x] `shared/types.ts` updated if the server↔web contract changed (no contract change)
- [x] Docs updated if behavior/config changed (client-side reconnect UX; no config/docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_