### PR TITLE
fix: keep a long-running tool "running" when its PreToolUse ages out (#22)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -12,6 +12,7 @@ import type {
   SkillUsage,
   AppUsage,
   TypeCount,
+  OpenToolCall,
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
 import { costUsd, modelLabel } from "./pricing.ts";
@@ -380,6 +381,46 @@ export function getRecent(limit = 300, provider?: string): WatchEvent[] {
     .all(provider, limit)
     .map(parseEventRow)
     .reverse();
+}
+
+// A tool call is "open" while its PreToolUse has no matching Post. The client
+// derives this from its live buffer, but a long tool emits nothing while it runs,
+// so on a busy fleet (or after a reload) the Pre can age out of the buffer and
+// the session wrongly flips to idle — or vanishes — mid-run. This is the server's
+// authoritative view, sent on the initial frame so the client doesn't depend on
+// the Pre still being in memory. Bounded to the last 30 min (past that a stuck
+// pair is a lost session, not a long build — matching the client's ceiling) and
+// to sessions with no Stop/SessionEnd after the Pre.
+const OPEN_TOOL_MAX_MS = 30 * 60_000;
+const openToolStmt = db.query<OpenToolCall, [number]>(
+  `SELECT p.session_id AS session_id, p.source_app AS source_app,
+          COALESCE(p.tool_name, 'tool') AS tool_name, p.timestamp AS since
+     FROM events p
+    WHERE p.hook_event_type = 'PreToolUse'
+      AND p.timestamp >= ?
+      AND NOT EXISTS (
+        SELECT 1 FROM events q
+         WHERE q.hook_event_type IN ('PostToolUse','PostToolUseFailure')
+           AND (
+             (p.tool_use_id IS NOT NULL AND q.tool_use_id = p.tool_use_id)
+             OR (p.tool_use_id IS NULL AND q.session_id = p.session_id
+                 AND q.tool_name = p.tool_name AND q.timestamp >= p.timestamp)
+           )
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM events s
+         WHERE s.session_id = p.session_id
+           AND s.hook_event_type IN ('Stop','SessionEnd')
+           AND s.timestamp >= p.timestamp
+      )
+    ORDER BY p.timestamp ASC
+    LIMIT 200`
+);
+
+/** Currently-running tool calls across the fleet (open Pre, unpaired, session
+ *  still alive) — the seed for the client's per-agent "running" state. */
+export function openToolCalls(): OpenToolCall[] {
+  return openToolStmt.all(Date.now() - OPEN_TOOL_MAX_MS);
 }
 
 export function getFilterOptions() {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import { db } from "./db.ts";
 import {
   insertEvent,
   getRecent,
+  openToolCalls,
   getFilterOptions,
   getSessions,
   statsSummary,
@@ -550,7 +551,10 @@ const server = Bun.serve<WsData>({
     open(ws: ServerWebSocket<WsData>) {
       if (ws.data?.kind === "pty") { ptyOpen(ws); return; }
       clients.add(ws);
-      const frame: WsFrame = { type: "initial", data: getRecent(300) };
+      // openTools seeds the client's "running" state for tools whose PreToolUse
+      // predates the 300-event initial slice — otherwise a long job in flight
+      // when the page loads shows as idle (or missing) until its Post arrives.
+      const frame: WsFrame = { type: "initial", data: getRecent(300), openTools: openToolCalls() };
       ws.send(JSON.stringify(frame));
     },
     close(ws: ServerWebSocket<WsData>) {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -243,9 +243,20 @@ export interface FileChange {
   hunks: DiffHunk[];
 }
 
+/** A tool call the server sees as still running: a PreToolUse with no matching
+ *  Post yet, in a session that hasn't stopped. This is the authoritative "what's
+ *  open right now" — independent of whether the Pre still lives in the client's
+ *  bounded event buffer, which it may not on a busy fleet or after a reload. */
+export interface OpenToolCall {
+  session_id: string;
+  source_app: string;
+  tool_name: string;
+  since: number; // ms — the PreToolUse timestamp
+}
+
 /** WebSocket frames. */
 export type WsFrame =
-  | { type: "initial"; data: WatchEvent[] }
+  | { type: "initial"; data: WatchEvent[]; openTools?: OpenToolCall[] }
   | { type: "event"; data: WatchEvent }
   | { type: "session"; data: SessionRollup };
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,7 +34,7 @@ import { SessionModal } from "./components/SessionModal.tsx";
 import { ProjectPicker, PICKER_ANSWERED_KEY } from "./components/ProjectPicker.tsx";
 
 export default function App() {
-  const { events, conn, lastEvent } = useLive();
+  const { events, conn, lastEvent, openTools } = useLive();
   const [windowMs, setWindowMs] = useState(3_600_000);
   const [filter, setFilter] = useState({ app: "", type: "", provider: "" });
   const [theme, setTheme] = useState(initialTheme());
@@ -110,7 +110,7 @@ export default function App() {
   // Every session's provider, from the FULL buffer (so the list is stable and
   // never collapses when one provider is selected).
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  const agentsAll = useMemo(() => deriveAgents(events), [events, tick]);
+  const agentsAll = useMemo(() => deriveAgents(events, openTools), [events, openTools, tick]);
   const sessionProvider = useMemo(() => {
     const map = new Map<string, string>();
     for (const a of agentsAll) if (a.model_name) map.set(a.session_id, providerOf(a.model_name));
@@ -131,8 +131,11 @@ export default function App() {
     [events, filter.provider, sessionProvider]
   );
   const agents = useMemo(
-    () => (filter.provider ? deriveAgents(visibleEvents) : agentsAll),
-    [filter.provider, visibleEvents, agentsAll]
+    () =>
+      filter.provider
+        ? deriveAgents(visibleEvents, openTools.filter((s) => sessionProvider.get(s.session_id) === filter.provider))
+        : agentsAll,
+    [filter.provider, visibleEvents, agentsAll, openTools, sessionProvider]
   );
   const alerts = useMemo(() => deriveAlerts(agents), [agents]);
   useAlertSound(alerts.length, sound);

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent } from "../../../shared/types.ts";
+import type { WatchEvent, OpenToolCall } from "../../../shared/types.ts";
 import { agentKey, fmtMs } from "./format.ts";
 
 export type AgentStatus = "working" | "waiting" | "errored" | "idle";
@@ -53,8 +53,38 @@ const TOOL_RUN_MAX_MS = 30 * 60_000;
 // possibly a hang — either way the user wants to know it's still open.
 const TOOL_RUN_WARN_MS = 5 * 60_000;
 
-/** Roll the live event buffer up into per-agent cards. */
-export function deriveAgents(events: WatchEvent[]): AgentCard[] {
+function blankCard(key: string, source_app: string, session_id: string, model_name: string | null): AgentCard {
+  return {
+    key,
+    source_app,
+    session_id,
+    model_name,
+    status: "idle",
+    lastAction: "",
+    lastType: "",
+    events: 0,
+    tools: 0,
+    errors: 0,
+    cost: 0,
+    tokens: 0,
+    lastSeen: 0,
+    lastErrorTs: 0,
+    spark: new Array(20).fill(0),
+    subagents: 0,
+    subagentTypes: [],
+    runningTool: null,
+    runningSince: 0,
+    ctxTokens: 0,
+    ctxTs: 0,
+    ctxLimit: 200_000,
+  };
+}
+
+/** Roll the live event buffer up into per-agent cards. `openTools` is the
+ *  server's authoritative list of still-running tool calls, used to keep (or
+ *  restore) a session's "running" state when the originating PreToolUse has aged
+ *  out of `events` — otherwise a long job in flight reads as idle or vanishes. */
+export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = []): AgentCard[] {
   const now = Date.now();
   const map = new Map<string, AgentCard>();
   // Subagents fold into their parent session_id but carry agent_id/agent_type,
@@ -82,30 +112,7 @@ export function deriveAgents(events: WatchEvent[]): AgentCard[] {
     const key = agentKey(e);
     let a = map.get(key);
     if (!a) {
-      a = {
-        key,
-        source_app: e.source_app,
-        session_id: e.session_id,
-        model_name: e.model_name,
-        status: "idle",
-        lastAction: "",
-        lastType: "",
-        events: 0,
-        tools: 0,
-        errors: 0,
-        cost: 0,
-        tokens: 0,
-        lastSeen: 0,
-        lastErrorTs: 0,
-        spark: new Array(20).fill(0),
-        subagents: 0,
-        subagentTypes: [],
-        runningTool: null,
-        runningSince: 0,
-        ctxTokens: 0,
-        ctxTs: 0,
-        ctxLimit: 200_000,
-      };
+      a = blankCard(key, e.source_app, e.session_id, e.model_name);
       map.set(key, a);
     }
     // Context estimate from the newest MAIN-session turn. Subagent turns are
@@ -141,6 +148,26 @@ export function deriveAgents(events: WatchEvent[]): AgentCard[] {
         ? `${e.hook_event_type} · ${e.tool_name}`
         : e.hook_event_type;
     }
+  }
+
+  // Seed "running" state from the server's authoritative open-tool list, for
+  // tool calls whose PreToolUse isn't in the buffer (aged out on a busy fleet,
+  // or never loaded after a reload). A session with ALL its events evicted gets
+  // its card recreated here so it doesn't vanish from Fleet/Radar mid-run.
+  for (const s of openTools) {
+    // A Post already in the buffer means the tool finished after the seed was
+    // taken — don't resurrect it as running.
+    const closed = (postBySessTool.get(`${s.session_id}|${s.tool_name}`) ?? []).some((t) => t >= s.since);
+    if (closed) continue;
+    const key = `${s.source_app}:${s.session_id}`;
+    let a = map.get(key);
+    if (!a) {
+      a = blankCard(key, s.source_app, s.session_id, null);
+      a.lastSeen = s.since;
+      a.lastType = "PreToolUse";
+      map.set(key, a);
+    }
+    if (s.since >= a.runningSince) { a.runningTool = s.tool_name; a.runningSince = s.since; }
   }
 
   // Spark buckets over the last 20 * 3s = 60s window.

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -1,5 +1,5 @@
 import { useEffect, useRef, useState, useCallback } from "react";
-import type { WatchEvent, WsFrame } from "../../../shared/types.ts";
+import type { WatchEvent, WsFrame, OpenToolCall } from "../../../shared/types.ts";
 import { WS_URL, IS_DEMO, hasToken, probeAuth } from "./api.ts";
 import * as demo from "./demo.ts";
 
@@ -16,6 +16,9 @@ export interface LiveData {
   events: WatchEvent[];
   conn: ConnState;
   lastEvent: WatchEvent | null;
+  /** Server's authoritative list of tool calls still running — seeds the
+   *  per-agent "running" state for Pres that have aged out of `events`. */
+  openTools: OpenToolCall[];
 }
 
 /**
@@ -27,6 +30,7 @@ export function useLive(): LiveData {
   const [events, setEvents] = useState<WatchEvent[]>([]);
   const [conn, setConn] = useState<ConnState>("connecting");
   const [lastEvent, setLastEvent] = useState<WatchEvent | null>(null);
+  const [openTools, setOpenTools] = useState<OpenToolCall[]>([]);
   const connRef = useRef(conn);
   connRef.current = conn;
   const wsRef = useRef<WebSocket | null>(null);
@@ -124,11 +128,22 @@ export function useLive(): LiveData {
         pending.current = [];
         setEvents(initial);
         setLastEvent(initial[initial.length - 1] ?? null);
+        setOpenTools(frame.openTools ?? []);
       } else if (frame.type === "event") {
         if (seen.current.has(frame.data.id)) return; // duplicate delivery
         seen.current.add(frame.data.id);
         pending.current.push(frame.data);
         scheduleFlush();
+        // A Post closes its tool: drop the matching seed so it can't keep a
+        // finished tool marked "running" after its Post later evicts the buffer.
+        const ev = frame.data;
+        if (ev.hook_event_type === "PostToolUse" || ev.hook_event_type === "PostToolUseFailure") {
+          setOpenTools((cur) =>
+            cur.length && cur.some((s) => s.session_id === ev.session_id && (!ev.tool_name || s.tool_name === ev.tool_name) && ev.timestamp >= s.since)
+              ? cur.filter((s) => !(s.session_id === ev.session_id && (!ev.tool_name || s.tool_name === ev.tool_name) && ev.timestamp >= s.since))
+              : cur
+          );
+        }
       }
       // "session" frames are ignored — the Sessions panel fetches its own roll-ups.
     };
@@ -192,5 +207,5 @@ export function useLive(): LiveData {
     };
   }, [connect, flush]);
 
-  return { events, conn, lastEvent };
+  return { events, conn, lastEvent, openTools };
 }


### PR DESCRIPTION
## What does this PR do?

Fixes #22. The open-tool status (`running Bash · 8m`, plus the long-job alert) was derived purely from the client's live buffer (last 2000 events; 300 on the initial frame). A long tool emits nothing while it runs, so on a busy fleet — or simply after a reload past 300 fleet events — its `PreToolUse` falls out of the buffer, `deriveAgents` never sees the open pair, and the card flips to **idle** (or the session **vanishes** from Fleet/Radar) while the tool is still executing. That's precisely the slow-vs-hung false signal the open-pair tracking was built to prevent, resurfacing at fleet scale.

The fix is the issue's most-robust direction — **server-side truth**. The server already pairs Pre/Post for latency, so it can report what's open authoritatively, independent of the client's buffer:

- **`shared/types.ts`** — `OpenToolCall`; the `initial` WS frame gains an optional `openTools`.
- **`db.ts`** — `openToolCalls()`: a `PreToolUse` with no matching Post (by `tool_use_id`, or session+tool for id-less sources) in a session with no later `Stop`/`SessionEnd`, bounded to the last 30 min (matching the client's lost-pair ceiling).
- **`index.ts`** — send `openTools` on the initial frame.
- **`useLive.ts`** — capture the seed; drop a seed when its Post later arrives, so a finished tool can't stay "running" after its Post evicts the buffer.
- **`derive.ts`** — `deriveAgents(events, openTools)` seeds `runningTool`/`runningSince` for Pres not in the buffer, and **recreates a card** for a session whose events all evicted — without resurrecting one a buffered Post already closed, or one past the 30-min ceiling.
- **`App.tsx`** — thread `openTools` through (the provider filter scopes the seeds too).

Backwards-compatible: `openTools` is optional, so old clients ignore it and an old server simply doesn't send it.

## How was it tested?

- `bunx tsc --noEmit` clean in `server/` and `web/`; `bunx vite build` builds clean.
- **`deriveAgents` seed logic** — 8 assertions: a seed recreates a vanished card as `working` with the running tool and a live-duration label; an in-buffer Pre still works (regression); a buffered Post closes the seed; a newer in-buffer Pre wins over an older seed; a seed past the 30-min ceiling is nulled.
- **Server `openToolCalls` path, end-to-end** — booted a real server on a temp DB, ingested an open tool (Pre only), a closed one (Pre+Post), and an ended session (Pre+Stop), then read the initial WS frame: `openTools` contained **only** the open tool; the paired and ended sessions were correctly excluded.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps)
- [x] `shared/types.ts` updated if the server↔web contract changed (added `OpenToolCall` + optional `openTools` on the initial frame)
- [x] Docs updated if behavior/config changed (internal derivation; no config/docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_