### PR TITLE
fix(scan): don't drop sessions running in a scoped project's own worktrees (#20)

### DIFF
--- a/server/src/transcripts.ts
+++ b/server/src/transcripts.ts
@@ -99,14 +99,21 @@ function str(v: unknown): string | null {
 // Resolving a project root shells out to git, so memoize per cwd — a scan walks
 // hundreds of transcripts that share a handful of directories.
 const rootCache = new Map<string, string>();
-/** Label a session by the project it belongs to, folding worktrees and nested
- *  subdirectories into the repo that owns them. */
-function projectOf(cwd: string): { source_app: string; project_path: string } {
+/** The repo a cwd belongs to, folding linked worktrees and nested subdirectories
+ *  up to the owning repo (via `git --git-common-dir`). Falls back to the cwd
+ *  itself for a non-repo path. Memoized. */
+function resolvedRoot(cwd: string): string {
   let root = rootCache.get(cwd);
   if (root === undefined) {
     root = projectRootOf(cwd) ?? cwd;
     rootCache.set(cwd, root);
   }
+  return root;
+}
+/** Label a session by the project it belongs to, folding worktrees and nested
+ *  subdirectories into the repo that owns them. */
+function projectOf(cwd: string): { source_app: string; project_path: string } {
+  const root = resolvedRoot(cwd);
   return { source_app: basename(root), project_path: root };
 }
 
@@ -341,8 +348,18 @@ async function ingestFile(
   // the project list despite contributing no events. The scope is pinned per
   // sweep (passed in), so a workspace switched mid-sweep can't suddenly widen
   // a *live* sweep into broadcasting months of backfill.
-  if (scope && cwd && cwd !== scope && !cwd.startsWith(scope + "/")) {
-    return { lines: 0, ingested: 0, source_app: "", project_path: "", session_id, skipped: true };
+  //
+  // Match on the *resolved repo root*, not just the raw cwd: a session running
+  // in a project's own linked worktree (e.g. ~/code/app-wt, outside the scope
+  // path) belongs to the scoped repo — `--git-common-dir` folds it back — and
+  // the git panel already lists such worktrees as part of the project. We still
+  // accept a raw-cwd match first, so scoping to a monorepo subdir (whose git
+  // root sits *above* the scope) keeps working.
+  if (scope && cwd) {
+    const inScope = (p: string) => p === scope || p.startsWith(scope + "/");
+    if (!inScope(cwd) && !inScope(resolvedRoot(cwd))) {
+      return { lines: 0, ingested: 0, source_app: "", project_path: "", session_id, skipped: true };
+    }
   }
 
   let source_app: string;


### PR DESCRIPTION
## What does this PR do?

Fixes #20. A cockpit scoped to a project (picker or `AGENTGLASS_ROOT`) showed **zero** events, sessions, or alerts for agents working in that project's linked worktrees. The scanner's scope check compared the transcript's **raw cwd** against the scope with `startsWith(scope + "/")` — a normal worktree like `~/code/app-wt` lives *outside* the scope path and failed the prefix test, so the file was skipped **before** `projectOf()`/`projectRootOf()` could fold it back into the owning repo. Meanwhile `discoverRepos` deliberately lists those worktrees as part of the project, so the git panel and terminal showed `app-wt` while the dashboard stayed blank — worktree-per-task being a common pattern for exactly this audience.

The fix matches on the **resolved repo root** as well as the raw cwd: include a transcript when its cwd is in scope **OR** its `--git-common-dir` root is in scope. The raw-cwd check stays first, so scoping to a **monorepo subdir** (whose git root sits *above* the scope) is unaffected and never widens to sibling packages. It reuses the existing per-cwd root cache (extracted as `resolvedRoot`), so it costs no extra git calls.

## How was it tested?

- `bunx tsc --noEmit` clean in `server/`.
- Against **real git worktrees** (a repo + a `git worktree add ../app-wt`, not under `/.worktrees/`):
  - `projectRootOf` folds the linked worktree to its main repo root ✅
  - a scoped instance (`scope = repo`) now **includes** the worktree's sessions (the bug: previously excluded) and still **excludes** an outsider path ✅
  - **subdir scoping** (`scope = repo/packages/a`) includes only that package's sessions, and does **not** widen to the sibling `packages/b` or the repo root ✅

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`) — server touched; web unaffected
- [x] Production build passes (`bunx vite build` in `web/`) — no web change
- [x] Stays dependency-light (no new deps)
- [x] `shared/types.ts` updated if the server↔web contract changed (no contract change)
- [x] Docs updated if behavior/config changed (bug fix to scope matching; no config/docs change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_