### PR TITLE
feat(brand): theme-reactive loupe-radar logo, replacing the 🛰 emoji

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -8,7 +8,7 @@
 <meta property="og:title" content="agentglass — every agent, one tower" />
 <meta property="og:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, then act — without leaving the glass." />
 <meta property="og:type" content="website" />
-<link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%9B%B0%3C/text%3E%3C/svg%3E" />
+<link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2032%2032%22%3E%3Cline%20x1=%2220.2%22%20y1=%2220.2%22%20x2=%2227%22%20y2=%2227%22%20stroke=%22%237c3aed%22%20stroke-width=%223.4%22%20stroke-linecap=%22round%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%229%22%20fill=%22%23a78bfa%22%20fill-opacity=%220.14%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%225.6%22%20fill=%22none%22%20stroke=%22%23a78bfa%22%20stroke-opacity=%220.35%22%20stroke-width=%221%22/%3E%3Cpath%20d=%22M13.5%2013.5%20L13.5%204.6%20A8.9%208.9%200%200%201%2019.7%207%20Z%22%20fill=%22%23a78bfa%22%20fill-opacity=%220.28%22/%3E%3Cline%20x1=%2213.5%22%20y1=%2213.5%22%20x2=%2219.7%22%20y2=%227%22%20stroke=%22%23c4b5fd%22%20stroke-width=%221%22/%3E%3Ccircle%20cx=%229%22%20cy=%2216.4%22%20r=%221.9%22%20fill=%22%2334d399%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%229.6%22%20fill=%22none%22%20stroke=%22%237c3aed%22%20stroke-width=%222.5%22/%3E%3C/svg%3E" />
 <style>
   /* ═══════════════════════════════════════════════════════════════
      agentglass · landing ("Flight Ops")
@@ -473,7 +473,7 @@
 <!-- ══════════ NAV ══════════ -->
 <nav class="nav">
   <div class="in">
-    <span class="logo"><span class="sat">🛰</span><span>agentglass<small>a loupe for your agents</small></span></span>
+    <span class="logo"><span class="sat" aria-hidden="true"><svg viewBox="0 0 32 32" width="24" height="24" style="display:block; color:var(--primary)"><line x1="20.2" y1="20.2" x2="27" y2="27" stroke="currentColor" stroke-width="3.1" stroke-linecap="round"/><circle cx="13.5" cy="13.5" r="9" fill="currentColor" fill-opacity="0.1"/><circle cx="13.5" cy="13.5" r="5.6" fill="none" stroke="currentColor" stroke-opacity="0.28" stroke-width="1"/><path d="M13.5 5.6 V21.4 M5.6 13.5 H21.4" stroke="currentColor" stroke-opacity="0.16" stroke-width="1"/><path d="M13.5 13.5 L13.5 4.6 A8.9 8.9 0 0 1 19.7 7 Z" fill="currentColor" fill-opacity="0.2"/><line x1="13.5" y1="13.5" x2="19.7" y2="7" stroke="currentColor" stroke-width="1" stroke-opacity="0.8"/><circle cx="9" cy="16.4" r="3" fill="none" stroke="var(--success)" stroke-opacity="0.5" stroke-width="1"/><circle cx="9" cy="16.4" r="1.7" fill="var(--success)"/><circle cx="16.4" cy="16" r="1.1" fill="currentColor" fill-opacity="0.75"/><circle cx="13.5" cy="13.5" r="9.6" fill="none" stroke="currentColor" stroke-width="2.3"/></svg></span><span>agentglass<small>a loupe for your agents</small></span></span>
     <span class="lamp"></span>
     <span class="links"><a href="#workspace">Workspace</a><a href="#fleet">Fleet</a><a href="#quickstart">Quickstart</a></span>
     <span class="sp"></span>

--- a/web/index.html
+++ b/web/index.html
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>agentglass</title>
     <meta name="description" content="Real-time observability for AI agent workflows — any provider." />
-    <link rel="icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 100 100'%3E%3Ctext y='.9em' font-size='90'%3E%F0%9F%9B%B0%3C/text%3E%3C/svg%3E" />
+    <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
   </head>
   <body>
     <div id="root"></div>

--- a/web/public/favicon.svg
+++ b/web/public/favicon.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 32 32">
+  <line x1="20.2" y1="20.2" x2="27" y2="27" stroke="#7c3aed" stroke-width="3.4" stroke-linecap="round"/>
+  <circle cx="13.5" cy="13.5" r="9" fill="#a78bfa" fill-opacity="0.14"/>
+  <circle cx="13.5" cy="13.5" r="5.6" fill="none" stroke="#a78bfa" stroke-opacity="0.35" stroke-width="1"/>
+  <path d="M13.5 13.5 L13.5 4.6 A8.9 8.9 0 0 1 19.7 7 Z" fill="#a78bfa" fill-opacity="0.28"/>
+  <line x1="13.5" y1="13.5" x2="19.7" y2="7" stroke="#c4b5fd" stroke-width="1"/>
+  <circle cx="9" cy="16.4" r="1.9" fill="#34d399"/>
+  <circle cx="13.5" cy="13.5" r="9.6" fill="none" stroke="#7c3aed" stroke-width="2.5"/>
+</svg>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -6,6 +6,7 @@ import { MOD_KEY } from "../lib/format.ts";
 import { ThemeSwitcher } from "./ThemeSwitcher.tsx";
 import { UsageWidget } from "./UsageWidget.tsx";
 import { Portal } from "./Portal.tsx";
+import { Logo } from "./Logo.tsx";
 import { Select } from "./Select.tsx";
 import { autostartEnabled, setAutostart } from "../lib/desktop.ts";
 
@@ -219,9 +220,11 @@ export function Header({
     <header className="flex items-center gap-x-3 gap-y-2 px-3 sm:px-4 py-2.5 shrink-0 relative z-20 flex-wrap sm:flex-nowrap"
       style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", background: "color-mix(in srgb, var(--bg2) 94%, var(--bg))" }}>
       <div className="flex items-center gap-2.5 shrink-0">
-        <motion.span initial={{ rotate: -20, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} transition={{ type: "spring", stiffness: 200 }} className="text-xl">🛰</motion.span>
+        <motion.span initial={{ rotate: -20, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} transition={{ type: "spring", stiffness: 200 }} className="flex">
+          <Logo size={26} title="agentglass" />
+        </motion.span>
         <div className="leading-none">
-          <div className="text-[16px] font-bold tracking-tight" style={{ color: "var(--text)" }}>agentglass</div>
+          <div className="text-[16px] font-bold tracking-tight" style={{ color: "var(--text)" }}>agent<span style={{ color: "var(--primary)" }}>glass</span></div>
           {/* Scoped to one project → say which — and make it the way to switch:
               the name IS the project picker. */}
           <button onClick={onOpenProject} className="hidden sm:flex items-center gap-1 text-[10px] hover:opacity-80"

--- a/web/src/components/Logo.tsx
+++ b/web/src/components/Logo.tsx
@@ -1,0 +1,45 @@
+// The agentglass mark: a loupe whose lens is a mission-control radar — the
+// product folded into one glyph (the loupe = "glass"/inspect, the sweep =
+// real-time, the blips = your fleet, the bright one = the session that needs
+// you). It is deliberately THEME-REACTIVE: the structure inherits the active
+// theme's --primary via `currentColor`, and the live blip uses --success, so
+// the logo turns violet / green / amber / blue with the palette instead of
+// being locked to one "AI purple". Pure vector, scales from 16px to a hero.
+export function Logo({ size = 22, className, style, title }: {
+  size?: number;
+  className?: string;
+  style?: React.CSSProperties;
+  title?: string;
+}) {
+  return (
+    <svg
+      width={size}
+      height={size}
+      viewBox="0 0 32 32"
+      role="img"
+      aria-label={title ?? "agentglass"}
+      className={className}
+      style={{ color: "var(--primary)", display: "block", ...style }}
+    >
+      {title ? <title>{title}</title> : null}
+      {/* handle (drawn first so the rim sits on top of it) */}
+      <line x1="20.2" y1="20.2" x2="27" y2="27" stroke="currentColor" strokeWidth="3.1" strokeLinecap="round" />
+      {/* glass */}
+      <circle cx="13.5" cy="13.5" r="9" fill="currentColor" fillOpacity="0.1" />
+      {/* scope rings + crosshair */}
+      <g stroke="currentColor" fill="none">
+        <circle cx="13.5" cy="13.5" r="5.6" strokeOpacity="0.28" strokeWidth="1" />
+        <path d="M13.5 5.6 V21.4 M5.6 13.5 H21.4" strokeOpacity="0.16" strokeWidth="1" />
+      </g>
+      {/* radar sweep */}
+      <path d="M13.5 13.5 L13.5 4.6 A8.9 8.9 0 0 1 19.7 7 Z" fill="currentColor" fillOpacity="0.2" />
+      <line x1="13.5" y1="13.5" x2="19.7" y2="7" stroke="currentColor" strokeWidth="1" strokeOpacity="0.8" />
+      {/* blips — the bright one is the session that needs you (semantic --success) */}
+      <circle cx="9" cy="16.4" r="3" fill="none" stroke="var(--success)" strokeOpacity="0.5" strokeWidth="1" />
+      <circle cx="9" cy="16.4" r="1.7" fill="var(--success)" />
+      <circle cx="16.4" cy="16" r="1.1" fill="currentColor" fillOpacity="0.75" />
+      {/* rim */}
+      <circle cx="13.5" cy="13.5" r="9.6" fill="none" stroke="currentColor" strokeWidth="2.3" />
+    </svg>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

Gives agentglass a real mark: **a loupe whose lens is a mission-control radar** — the loupe is the "glass" (inspect the fleet up close), the sweep is real-time, the blips are your agents, and the bright one is the session that needs you.

Crucially it's **theme-reactive**, not locked to one "AI purple." The structure inherits the active theme's `--primary` via `currentColor` and the live blip uses `--success`, so the logo turns violet / green / amber / blue with the palette — one glyph, 22 skins.

| Theme | Logo |
|-------|------|
| Midnight Purple | violet |
| Forest | green |
| Ember | orange (mint blip) |
| Dark Blue / Deep Sea | blue / teal |

- **`Logo.tsx`** — the reusable mark (`currentColor` + `--success`), scales from 16px to a hero.
- **Header** — replaces the `🛰` span with `<Logo size={26}>` and tints "glass" in the wordmark with `--primary` to tie it together.
- **Favicon** — `web/public/favicon.svg` (static, flagship colors that read on both light and dark browser tabs), wired into `web/index.html`.
- **Landing** — the nav `🛰` becomes the same theme-reactive inline mark (recolors with the landing's rolled theme), and its favicon becomes the mark too.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/`; `bunx vite build` builds clean.
- Drove the demo build headless and screenshotted the header across **midnight-purple, forest, ember, dark-blue, rosewood, deep-sea** — the loupe-radar recolors to each theme's primary and the wordmark accent follows.
- Rendered the landing headless — nav mark renders, layout intact, no console errors.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`) — web touched
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps — pure inline SVG)
- [x] `shared/types.ts` updated if the server↔web contract changed (no contract change)
- [x] Docs updated if behavior/config changed (brand asset; no config change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_