### PR TITLE
docs(readme): replace the 🛰 title emoji with the new loupe-radar logo

### DIFF
--- a/.github/assets/logo.svg
+++ b/.github/assets/logo.svg
@@ -1,0 +1,30 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" width="88" height="88" role="img" aria-label="agentglass">
+  <defs>
+    <linearGradient id="rim" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#c4b5fd"/><stop offset="0.5" stop-color="#a78bfa"/><stop offset="1" stop-color="#7c3aed"/>
+    </linearGradient>
+    <linearGradient id="handle" x1="0" y1="0" x2="1" y2="1">
+      <stop offset="0" stop-color="#a78bfa"/><stop offset="1" stop-color="#6d28d9"/>
+    </linearGradient>
+    <linearGradient id="sweep" x1="0" y1="1" x2="1" y2="0">
+      <stop offset="0" stop-color="#c4b5fd" stop-opacity="0"/><stop offset="1" stop-color="#c4b5fd" stop-opacity="0.55"/>
+    </linearGradient>
+    <radialGradient id="glass" cx="0.38" cy="0.32" r="0.72">
+      <stop offset="0" stop-color="#a78bfa" stop-opacity="0.28"/><stop offset="1" stop-color="#a78bfa" stop-opacity="0"/>
+    </radialGradient>
+  </defs>
+  <line x1="39.5" y1="39.5" x2="55" y2="55" stroke="url(#handle)" stroke-width="6" stroke-linecap="round"/>
+  <circle cx="27" cy="27" r="17.4" fill="url(#glass)"/>
+  <g stroke="#a78bfa" fill="none">
+    <circle cx="27" cy="27" r="12" stroke-opacity="0.24" stroke-width="1"/>
+    <circle cx="27" cy="27" r="6.4" stroke-opacity="0.32" stroke-width="1"/>
+    <path d="M27 11.5 V42.5 M11.5 27 H42.5" stroke-opacity="0.15" stroke-width="1"/>
+  </g>
+  <path d="M27 27 L27 10 A17 17 0 0 1 40.9 17.2 Z" fill="url(#sweep)"/>
+  <line x1="27" y1="27" x2="40.9" y2="17.2" stroke="#c4b5fd" stroke-width="1" stroke-opacity="0.85"/>
+  <circle cx="18.6" cy="32.4" r="3.9" fill="none" stroke="#34d399" stroke-opacity="0.5" stroke-width="1"/>
+  <circle cx="18.6" cy="32.4" r="2.1" fill="#34d399"/>
+  <circle cx="33.6" cy="34.6" r="1.7" fill="#c4b5fd"/>
+  <circle cx="31" cy="20.4" r="1.4" fill="#a78bfa" fill-opacity="0.9"/>
+  <circle cx="27" cy="27" r="19" fill="none" stroke="url(#rim)" stroke-width="3.4"/>
+</svg>

--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 <div align="center">
 
-# 🛰 agentglass
+<img src=".github/assets/logo.svg" alt="agentglass" width="88" height="88" />
+
+# agentglass
 
 **A loupe for your agents** — a real-time Mission-Control **dashboard _and_ workspace** for AI coding agents, across every provider and every project on your machine.
 


### PR DESCRIPTION
## What does this PR do?

The README H1 still opened with the old `🛰` satellite emoji. This swaps it for the real mark — `.github/assets/logo.svg`, the loupe-radar in flagship violet with the mint "needs you" blip — placed centered above the title.

- **`.github/assets/logo.svg`** — the full-colour mark (gradient rim + glass + sweep + blips), a static asset (README has no theme context), tuned to read on both README grounds.
- **`README.md`** — `# 🛰 agentglass` → centered `<img>` logo + `# agentglass`.

The `🛰` in the feature table is intentionally left: it's a decorative bullet for the "Mission-Control cockpit" radar row (one of a per-feature emoji set 🛰🗂🖥🔬🌿🐳▶💬), not the brand icon. Happy to swap it too if you'd rather.

## How was it tested?

Rendered `logo.svg` headless on both a white (GitHub light) and `#0d1117` (GitHub dark) background — the mark reads on both (deep-violet rim + mint blip give it definition on white; it glows on dark). No parse errors.

## Checklist

- [x] Typechecks pass — no code change (docs + asset only)
- [x] Production build passes — n/a
- [x] Stays dependency-light (no new deps)
- [x] `shared/types.ts` updated if the server↔web contract changed (no contract change)
- [x] Docs updated if behavior/config changed (this *is* the docs update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_