### PR TITLE
fix(scope): make an open project actually scope the dashboard

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
 import { costUsd, modelLabel } from "./pricing.ts";
+import { workspaceRoot } from "./config.ts";
 
 /**
  * Where the database lives.
@@ -114,6 +115,33 @@ CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(text);
 // it is prepared. Harmless (throws "duplicate column") once it already exists.
 try { db.exec("ALTER TABLE sessions ADD COLUMN provider TEXT"); } catch { /* already present */ }
 
+// Where a row came from, promoted out of `payload` so scope can be a WHERE
+// clause instead of a JSON re-parse per query. Both are VIRTUAL generated
+// columns: they cost no storage and apply to rows written *before* this
+// migration, so a cockpit scoped today correctly hides a machine-wide history
+// collected yesterday — no backfill pass over a multi-GB events table.
+//
+// `project_path` is the resolved repo root; `cwd` is only present when the turn
+// ran somewhere else inside it (a linked worktree, a monorepo subdir). Scope has
+// to consult both, mirroring the scanner's own test in transcripts.ts.
+for (const [col, path] of [["project_path", "$.project_path"], ["cwd_path", "$.cwd"]]) {
+  try {
+    db.exec(`ALTER TABLE events ADD COLUMN ${col} TEXT GENERATED ALWAYS AS (json_extract(payload, '${path}')) VIRTUAL`);
+  } catch { /* already present */ }
+}
+db.exec("CREATE INDEX IF NOT EXISTS idx_events_project ON events(project_path)");
+
+// Sessions have no payload of their own, so this one is a real column, written
+// at upsert and backfilled from the session's events for rows that predate it.
+try { db.exec("ALTER TABLE sessions ADD COLUMN project_path TEXT"); } catch { /* already present */ }
+db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_path)");
+db.exec(`
+  UPDATE sessions SET project_path = (
+    SELECT e.project_path FROM events e
+     WHERE e.session_id = sessions.session_id AND e.project_path IS NOT NULL
+     ORDER BY e.id DESC LIMIT 1
+  ) WHERE project_path IS NULL`);
+
 /** Coarse vendor for a model name — the provider dimension. Returns null for an
  *  unknown/absent model so a session's known provider is never overwritten.
  *  Kept in sync with the web's providerOf() in web/src/lib/format.ts. */
@@ -136,6 +164,32 @@ export function providerOf(model: string | null | undefined): string | null {
 function providerScope(provider?: string | null): { clause: string; args: string[] } {
   return provider
     ? { clause: " AND session_id IN (SELECT session_id FROM sessions WHERE provider = ?)", args: [provider] }
+    : { clause: "", args: [] };
+}
+
+/** SQL fragment + args restricting an events query to one project. A scoped
+ *  cockpit is *about* that project, so rows from anywhere else stay hidden even
+ *  though they remain in the DB — an earlier machine-wide run, or hooks fired by
+ *  a sibling repo. Matches the root and everything under it, against both the
+ *  resolved repo root and the raw cwd, so linked worktrees and monorepo subdirs
+ *  are in scope either way (the same test the scanner applies at ingest).
+ *
+ *  Rows with no recorded path (pre-scanner events) are treated as out of scope:
+ *  a project view that quietly includes "unknown" is worse than one that's
+ *  honestly narrow. Empty clause when unscoped — the whole-machine view. */
+export function scopeClause(scope: string | null = workspaceRoot()): { clause: string; args: string[] } {
+  if (!scope) return { clause: "", args: [] };
+  const under = scope + "/%";
+  return {
+    clause: " AND (project_path = ? OR project_path LIKE ? OR cwd_path = ? OR cwd_path LIKE ?)",
+    args: [scope, under, scope, under],
+  };
+}
+
+/** Same restriction for the `sessions` table, which carries its own column. */
+function sessionScopeClause(scope: string | null = workspaceRoot()): { clause: string; args: string[] } {
+  return scope
+    ? { clause: " AND (project_path = ? OR project_path LIKE ?)", args: [scope, scope + "/%"] }
     : { clause: "", args: [] };
 }
 
@@ -307,11 +361,11 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
 
 const upsertStmt = db.query(`
   INSERT INTO sessions (
-    session_id, source_app, model_name, provider, started_at, ended_at, last_seen,
+    session_id, source_app, model_name, provider, project_path, started_at, ended_at, last_seen,
     event_count, tool_count, error_count,
     input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_usd
   ) VALUES (
-    $sid, $src, $model, $provider, $ts, $ended, $ts,
+    $sid, $src, $model, $provider, $project, $ts, $ended, $ts,
     1, $tool, $err,
     $in, $out, $cw, $cr, $cost
   )
@@ -319,6 +373,7 @@ const upsertStmt = db.query(`
     source_app = excluded.source_app,
     model_name = COALESCE(excluded.model_name, sessions.model_name),
     provider = COALESCE(excluded.provider, sessions.provider),
+    project_path = COALESCE(excluded.project_path, sessions.project_path),
     ended_at = COALESCE(excluded.ended_at, sessions.ended_at),
     last_seen = excluded.last_seen,
     event_count = sessions.event_count + 1,
@@ -348,6 +403,9 @@ function upsertSession(
     $src: n.source_app,
     $model: n.model_name,
     $provider: providerOf(n.model_name),
+    // Carried in the payload by both the scanner and the hooks; null for an
+    // event that never recorded where it ran, which COALESCE leaves alone.
+    $project: typeof n.payload?.project_path === "string" ? n.payload.project_path : null,
     $ts: n.timestamp,
     $ended: isTerminal(n.hook_event_type) ? n.timestamp : null,
     $tool: isToolPost(n.hook_event_type) ? 1 : 0,
@@ -373,12 +431,14 @@ const recentStmt = db.query<any, [number]>(
   `SELECT * FROM events ORDER BY timestamp DESC, id DESC LIMIT ?`
 );
 export function getRecent(limit = 300, provider?: string): WatchEvent[] {
-  if (!provider) return recentStmt.all(limit).map(parseEventRow).reverse();
+  const scope = scopeClause();
+  const prov = providerScope(provider);
+  if (!scope.clause && !prov.clause) return recentStmt.all(limit).map(parseEventRow).reverse();
   return db
     .query<any, any[]>(
-      `SELECT * FROM events WHERE session_id IN (SELECT session_id FROM sessions WHERE provider = ?) ORDER BY timestamp DESC, id DESC LIMIT ?`
+      `SELECT * FROM events WHERE 1=1${prov.clause}${scope.clause} ORDER BY timestamp DESC, id DESC LIMIT ?`
     )
-    .all(provider, limit)
+    .all(...prov.args, ...scope.args, limit)
     .map(parseEventRow)
     .reverse();
 }
@@ -392,7 +452,7 @@ export function getRecent(limit = 300, provider?: string): WatchEvent[] {
 // pair is a lost session, not a long build — matching the client's ceiling) and
 // to sessions with no Stop/SessionEnd after the Pre.
 const OPEN_TOOL_MAX_MS = 30 * 60_000;
-const openToolStmt = db.query<OpenToolCall, [number]>(
+const openToolSql = (scoped: string) =>
   `SELECT p.session_id AS session_id, p.source_app AS source_app,
           COALESCE(p.tool_name, 'tool') AS tool_name, p.timestamp AS since
      FROM events p
@@ -413,42 +473,48 @@ const openToolStmt = db.query<OpenToolCall, [number]>(
            AND s.hook_event_type IN ('Stop','SessionEnd')
            AND s.timestamp >= p.timestamp
       )
+      ${scoped}
     ORDER BY p.timestamp ASC
-    LIMIT 200`
-);
+    LIMIT 200`;
 
 /** Currently-running tool calls across the fleet (open Pre, unpaired, session
  *  still alive) — the seed for the client's per-agent "running" state. */
 export function openToolCalls(): OpenToolCall[] {
-  return openToolStmt.all(Date.now() - OPEN_TOOL_MAX_MS);
+  // Aliased to `p`, so the shared clause needs qualifying to stay unambiguous
+  // against the correlated subqueries above.
+  const s = scopeClause();
+  const scoped = s.clause.replace(/\b(project_path|cwd_path)\b/g, "p.$1");
+  return db
+    .query<OpenToolCall, any[]>(openToolSql(scoped))
+    .all(Date.now() - OPEN_TOOL_MAX_MS, ...s.args);
 }
 
 export function getFilterOptions() {
-  const apps = db
-    .query<{ source_app: string }, []>(`SELECT DISTINCT source_app FROM events ORDER BY 1`)
-    .all()
-    .map((r) => r.source_app);
-  const types = db
-    .query<{ hook_event_type: string }, []>(
-      `SELECT DISTINCT hook_event_type FROM events ORDER BY 1`
-    )
-    .all()
-    .map((r) => r.hook_event_type);
-  const models = db
-    .query<{ model_name: string }, []>(
-      `SELECT DISTINCT model_name FROM events WHERE model_name IS NOT NULL ORDER BY 1`
-    )
-    .all()
-    .map((r) => r.model_name);
-  return { source_apps: apps, hook_event_types: types, models };
+  // Scoped too, or the dropdowns keep offering apps and models that the feed
+  // behind them can no longer show — picking one would just empty the panel.
+  const s = scopeClause();
+  const distinct = <T,>(col: string, extra = "") =>
+    db
+      .query<Record<string, T>, string[]>(
+        `SELECT DISTINCT ${col} FROM events WHERE 1=1${extra}${s.clause} ORDER BY 1`
+      )
+      .all(...s.args)
+      .map((r) => r[col] as T);
+  return {
+    source_apps: distinct<string>("source_app"),
+    hook_event_types: distinct<string>("hook_event_type"),
+    models: distinct<string>("model_name", " AND model_name IS NOT NULL"),
+  };
 }
 
 export function getSessions(limit = 100, provider?: string): SessionRollup[] {
-  const where = provider ? " WHERE provider = ?" : "";
-  const args = provider ? [provider, limit] : [limit];
+  const s = sessionScopeClause();
+  const prov = provider ? { clause: " AND provider = ?", args: [provider] } : { clause: "", args: [] };
   return db
-    .query<SessionRollup, any[]>(`SELECT * FROM sessions${where} ORDER BY last_seen DESC LIMIT ?`)
-    .all(...args);
+    .query<SessionRollup, any[]>(
+      `SELECT * FROM sessions WHERE 1=1${prov.clause}${s.clause} ORDER BY last_seen DESC LIMIT ?`
+    )
+    .all(...prov.args, ...s.args, limit);
 }
 
 function percentile(sorted: number[], p: number): number {
@@ -458,11 +524,16 @@ function percentile(sorted: number[], p: number): number {
 }
 
 /** Full analytics summary over a rolling window (default 24h), optionally scoped
- *  to a single provider (Anthropic / OpenAI / Google / …). */
+ *  to a single provider (Anthropic / OpenAI / Google / …). Always scoped to the
+ *  open project, so spend, tool mix and the radar describe that project alone. */
 export function statsSummary(windowMs = 24 * 3600 * 1000, provider?: string): StatsSummary {
   const since = Date.now() - windowMs;
-  const { clause: pf, args: pa } = providerScope(provider);
-  const A = [since, ...pa]; // bind order: timestamp first, then provider (if any)
+  const { clause: prov, args: pa } = providerScope(provider);
+  const { clause: sc, args: sa } = scopeClause();
+  // Every query below appends `pf` and binds `A` in this order, so folding the
+  // project filter in here reaches all of them at once.
+  const pf = prov + sc;
+  const A = [since, ...pa, ...sa]; // bind order: timestamp, provider (if any), project (if any)
 
   // Totals come from the authoritative sessions table for cost/tokens,
   // and from events for counts/errors within the window.
@@ -766,15 +837,16 @@ function parseChange(r: ChangeRow): import("../../shared/types.ts").FileChange |
 /** Recent file changes (Edit/Write/MultiEdit) with their diff hunks, parsed
  *  from the tool_response.structuredPatch Claude Code already provides. */
 export function getChanges(limit = 200, sessionId?: string): import("../../shared/types.ts").FileChange[] {
+  const chg = scopeClause();
   const rows = sessionId
-    ? db.query<ChangeRow, [string, number]>(
+    ? db.query<ChangeRow, any[]>(
         `SELECT id, timestamp, source_app, session_id, tool_name, payload FROM events
-         WHERE hook_event_type='PostToolUse' AND tool_name IN ('Edit','Write','MultiEdit') AND session_id = ?
-         ORDER BY timestamp DESC, id DESC LIMIT ?`).all(sessionId, limit)
-    : db.query<ChangeRow, [number]>(
+         WHERE hook_event_type='PostToolUse' AND tool_name IN ('Edit','Write','MultiEdit') AND session_id = ?${chg.clause}
+         ORDER BY timestamp DESC, id DESC LIMIT ?`).all(sessionId, ...chg.args, limit)
+    : db.query<ChangeRow, any[]>(
         `SELECT id, timestamp, source_app, session_id, tool_name, payload FROM events
-         WHERE hook_event_type='PostToolUse' AND tool_name IN ('Edit','Write','MultiEdit')
-         ORDER BY timestamp DESC, id DESC LIMIT ?`).all(limit);
+         WHERE hook_event_type='PostToolUse' AND tool_name IN ('Edit','Write','MultiEdit')${chg.clause}
+         ORDER BY timestamp DESC, id DESC LIMIT ?`).all(...chg.args, limit);
   return rows.map(parseChange).filter((c): c is import("../../shared/types.ts").FileChange => c !== null);
 }
 
@@ -842,26 +914,30 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
 export function searchEvents(q: string, limit = 60): import("../../shared/types.ts").SearchHit[] {
   const match = q.trim().split(/\s+/).map((t) => t.replace(/[^a-zA-Z0-9_]/g, "")).filter(Boolean).map((t) => t + "*").join(" ");
   if (!match) return [];
+  const s = scopeClause();
+  const scoped = s.clause.replace(/\b(project_path|cwd_path)\b/g, "e.$1");
   try {
     return db
-      .query<any, [string, number]>(
+      .query<any, any[]>(
         `SELECT e.id, e.timestamp, e.source_app, e.session_id, e.hook_event_type, e.tool_name,
                 e.cost_usd, e.duration_ms,
                 snippet(events_fts, 0, char(1), char(2), ' … ', 14) AS snippet
          FROM events_fts f JOIN events e ON e.id = f.rowid
-         WHERE events_fts MATCH ? ORDER BY rank LIMIT ?`
+         WHERE events_fts MATCH ?${scoped} ORDER BY rank LIMIT ?`
       )
-      .all(match, limit);
+      .all(match, ...s.args, limit);
   } catch {
     return [];
   }
 }
 
-/** Stream rows for export (bounded). */
+/** Stream rows for export (bounded). Scoped like everything else — an export
+ *  from a project cockpit is that project's data, not the whole machine's. */
 export function exportRows(limit = 100_000): WatchEvent[] {
+  const s = scopeClause();
   return db
-    .query<any, [number]>(`SELECT * FROM events ORDER BY id ASC LIMIT ?`)
-    .all(limit)
+    .query<any, any[]>(`SELECT * FROM events WHERE 1=1${s.clause} ORDER BY id ASC LIMIT ?`)
+    .all(...s.args, limit)
     .map(parseEventRow);
 }
 

--- a/server/test/scope-off.test.ts
+++ b/server/test/scope-off.test.ts
@@ -1,0 +1,54 @@
+// The other half of the scoping contract: with no project open, the cockpit is
+// machine-wide and must show *everything*.
+//
+// This is a unit test on the clause builder rather than an integration test on
+// the query layer, because `bun test` runs every file in one process: db.ts and
+// config.ts each read their scope once at module load, so a second file that
+// imported them with a different AGENTGLASS_ROOT would just inherit whichever
+// scope loaded first and assert nothing. scope.test.ts owns the integration
+// side; this owns the shape of the filter itself.
+import { describe, expect, test } from "bun:test";
+import { scopeClause } from "../src/db.ts";
+
+describe("scopeClause", () => {
+  test("unscoped produces no filter at all", () => {
+    // The whole-machine view must not narrow anything — an empty clause is the
+    // difference between "every project" and "silently only the ones with a
+    // recorded path".
+    const { clause, args } = scopeClause(null);
+    expect(clause).toBe("");
+    expect(args).toEqual([]);
+  });
+
+  test("scoped matches the root and everything under it", () => {
+    const { clause, args } = scopeClause("/home/dev/proj");
+    expect(clause).toContain("project_path = ?");
+    expect(clause).toContain("project_path LIKE ?");
+    expect(args).toEqual([
+      "/home/dev/proj",
+      "/home/dev/proj/%",
+      "/home/dev/proj",
+      "/home/dev/proj/%",
+    ]);
+  });
+
+  test("consults cwd as well as the resolved repo root", () => {
+    // A turn in a linked worktree or a monorepo subdir records a project_path
+    // that can sit outside the scope while the cwd is inside it.
+    expect(scopeClause("/x").clause).toContain("cwd_path");
+  });
+
+  test("the LIKE prefix cannot match a sibling with a shared name", () => {
+    // "/code/app" must not drag in "/code/app-backup" — hence the trailing "/".
+    const [, like] = scopeClause("/code/app").args;
+    expect(like).toBe("/code/app/%");
+    expect("/code/app-backup/file".startsWith("/code/app/")).toBe(false);
+  });
+
+  test("binds parameters instead of interpolating the path", () => {
+    // A project path is user input (typed into the picker); it never reaches
+    // SQL as text.
+    const { clause } = scopeClause("'; DROP TABLE events; --");
+    expect(clause).not.toContain("DROP");
+  });
+});

--- a/server/test/scope.test.ts
+++ b/server/test/scope.test.ts
@@ -1,0 +1,102 @@
+// Project scoping is a *read* filter, not just an ingest filter.
+//
+// The bug this guards: scope used to be applied only when the scanner decided
+// what to ingest, so a cockpit opened for one project still served every other
+// project's events, sessions, spend and search hits from history collected
+// earlier. Nothing failed loudly — the numbers were simply someone else's.
+//
+// These tests drive the real query layer against a throwaway DB, because the
+// regression is "the WHERE clause isn't there at all": asserting on a SQL
+// fragment would happily pass while the rows stayed unfiltered.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+// Both are read once at module load inside db.ts / config.ts, so they have to
+// be set before the dynamic import below — not at the top of a normal import.
+const dir = mkdtempSync(join(tmpdir(), "agx-scope-"));
+
+// Real directories: config.ts resolves a scope against the filesystem and
+// discards one that doesn't exist, so string-only paths would silently leave
+// the instance unscoped and every assertion below would test nothing.
+const SCOPED = join(dir, "scoped");
+const OTHER = join(dir, "other");
+// A repo whose root sits outside the scope while the turn itself ran *inside*
+// it — the monorepo-subdir / linked-worktree case. Given its own name so the
+// assertions can tell "in scope via cwd" apart from "out of scope entirely".
+const MONO = join(dir, "mono");
+for (const p of [SCOPED, OTHER, MONO]) mkdirSync(p, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "scope.db");
+process.env.AGENTGLASS_ROOT = SCOPED;
+// Keep config.json out of it — the scope under test must come from this file,
+// not from the developer's own open project.
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const event = (project: string, session: string, over: Record<string, unknown> = {}) => ({
+  source_app: project.split("/").pop()!,
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 20, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "did a thing",
+  timestamp: Date.now(),
+  payload: { project_path: project, ...over },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  db.insertEvent(event(SCOPED, "s-in-1") as any);
+  db.insertEvent(event(SCOPED, "s-in-2") as any);
+  db.insertEvent(event(OTHER, "s-out-1") as any);
+  db.insertEvent(event(OTHER, "s-out-2") as any);
+  // project_path is outside the scope, but the turn ran inside it — must count.
+  db.insertEvent(event(MONO, "s-worktree", { cwd: SCOPED + "/wt/feature" }) as any);
+});
+
+describe("scoped reads", () => {
+  test("getRecent returns only the scoped project", () => {
+    const apps = new Set(db.getRecent(500).map((e) => e.source_app));
+    expect(apps.has("scoped")).toBe(true);
+    expect(apps.has("other")).toBe(false);
+  });
+
+  test("getSessions excludes other projects", () => {
+    const ids = db.getSessions(100).map((s) => s.session_id);
+    expect(ids).toContain("s-in-1");
+    expect(ids).not.toContain("s-out-1");
+  });
+
+  test("filter options only offer apps the feed can actually show", () => {
+    // The dropdown and the feed must agree, or picking an app empties the panel.
+    // mono earns its place: its turn ran inside the scope.
+    expect(db.getFilterOptions().source_apps.sort()).toEqual(["mono", "scoped"]);
+  });
+
+  test("stats count the scoped project alone", () => {
+    const s = db.statsSummary(24 * 3600 * 1000) as any;
+    // 2 scoped events + the worktree turn; the two out-of-scope ones are gone.
+    expect(s.totals.events).toBe(3);
+  });
+
+  test("a worktree of the scoped repo is in scope via cwd", () => {
+    expect(db.getRecent(500).some((e) => e.session_id === "s-worktree")).toBe(true);
+  });
+
+  test("export carries the scope too", () => {
+    const rows = db.exportRows(1000);
+    expect(rows.length).toBe(3);
+    expect(rows.every((r) => r.source_app !== "other")).toBe(true);
+    expect(rows.some((r) => r.source_app === "mono")).toBe(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Opening a project scoped the *scanner* and the *git panel*, but no read path — so the dashboard kept showing every other project's events, sessions, spend, changes, search hits and exports from history already in the DB. Picking a project appeared to do nothing.

Scope is now a read filter as well.

- `events.project_path` / `events.cwd_path` — VIRTUAL generated columns over the JSON the scanner and hooks already write. No storage cost and **no backfill**: they apply to rows written before the migration, so scoping is retroactive on an existing large DB.
- `sessions.project_path` — a real column (sessions carry no payload), written at upsert and backfilled once from each session's events.
- Promoted out of `payload` into indexed columns per CONTRIBUTING.

**Design note:** the filter lives in `db.ts` and defaults to `workspaceRoot()` rather than being threaded through each route. The original bug was that every endpoint had to *remember* to scope and nine of them didn't; applying it at the query layer means a new endpoint can't reintroduce the gap by omission.

Scope matches the root and everything beneath it, against both the resolved repo root and the raw `cwd` — the same test `transcripts.ts` applies at ingest — so linked worktrees and monorepo subdirs stay in scope. Rows with no recorded path are out of scope for a project view and still visible machine-wide.

Covers `/events/recent`, `/events/filter-options`, `/sessions`, `/stats`, `/changes`, `/search`, `/export` and `openToolCalls`.

## How was it tested?

- `bun test` — 53 pass, including two new files:
  - `scope.test.ts` — integration against the real query layer on a throwaway DB (the regression is "the WHERE clause isn't there at all", which a test on a SQL string would miss), covering the worktree/monorepo-via-`cwd` case.
  - `scope-off.test.ts` — unit tests on the clause builder, including that unscoped produces an empty clause, that `/code/app` can't drag in `/code/app-backup`, and that paths are bound rather than interpolated.
- `bunx tsc --noEmit` in `web/` and `server/` — clean.
- `bunx vite build` — clean.
- Exercised against a copy of a real 114 MB database, scoped to one project: filter-options 15 apps → 1, stats `$4.43` → `$0.031`, sessions/events/search/export all narrowed; unscoped unchanged.

Note: the two scope test files can't both be integration tests — `bun test` runs files in one process and `db.ts`/`config.ts` read their scope once at module load. Hence one integration file plus one unit file. The tests also pin `XDG_CONFIG_HOME`, without which the suite silently inherits whatever project the developer has open.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps)
- [ ] `shared/types.ts` updated if the server↔web contract changed — not needed, no contract change
- [ ] Docs updated — follow-up: README describes scoping as narrowing "the dashboard", which only becomes true with this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)