### PR TITLE
feat(chat): resume a finished session instead of only reading it

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -854,7 +854,8 @@ export function getChanges(limit = 200, sessionId?: string): import("../../share
 export function getSession(sessionId: string): import("../../shared/types.ts").SessionDetail | null {
   const roll = db.query<any, [string]>(`SELECT * FROM sessions WHERE session_id = ?`).get(sessionId);
   const agg = db.query<any, [string]>(
-    `SELECT source_app, MAX(model_name) model_name, MIN(timestamp) started_at, MAX(timestamp) last_seen,
+    `SELECT source_app, MAX(model_name) model_name, MAX(project_path) project_path,
+            MIN(timestamp) started_at, MAX(timestamp) last_seen,
             COUNT(*) events,
             SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) tools,
             SUM(is_error) errors, SUM(cost_usd) cost_usd,
@@ -893,6 +894,9 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     session_id: sessionId,
     source_app: agg.source_app,
     model_name: agg.model_name ?? roll?.model_name ?? null,
+    // Prefer the session row; fall back to the events for one that predates the
+    // column. Without a directory the UI can't offer to resume the session.
+    project_path: roll?.project_path ?? agg.project_path ?? null,
     started_at: agg.started_at,
     ended_at: roll?.ended_at ?? null,
     last_seen: agg.last_seen,

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -56,6 +56,9 @@ export interface SessionRollup {
   session_id: string;
   source_app: string;
   model_name: string | null;
+  /** Directory the session ran in — what a resume needs to run in the right
+   *  place. Null for rows recorded before the column existed. */
+  project_path?: string | null;
   started_at: number;
   ended_at: number | null;
   last_seen: number;
@@ -215,6 +218,8 @@ export interface SessionDetail {
   session_id: string;
   source_app: string;
   model_name: string | null;
+  /** Where it ran — a resume has to start in the same directory. */
+  project_path?: string | null;
   started_at: number;
   ended_at: number | null;
   last_seen: number;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import { GitPanel } from "./components/GitPanel.tsx";
 import { DockerPanel } from "./components/DockerPanel.tsx";
 import { TerminalPanel } from "./components/TerminalPanel.tsx";
 import { ChatPanel } from "./components/ChatPanel.tsx";
+import { newChat, chatResuming } from "./lib/chatStore.ts";
 import { SearchModal } from "./components/SearchModal.tsx";
 import { SessionModal } from "./components/SessionModal.tsx";
 import { ProjectPicker, PICKER_ANSWERED_KEY } from "./components/ProjectPicker.tsx";
@@ -49,6 +50,7 @@ export default function App() {
   const [dockerOpen, setDockerOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+  const [chatFocus, setChatFocus] = useState<string | undefined>(undefined);
   const [searchOpen, setSearchOpen] = useState(false);
   const [sessionView, setSessionView] = useState<{ id: string; app: string } | null>(null);
   const [sound, setSound] = useState(false);
@@ -290,9 +292,26 @@ export default function App() {
       <GitPanel open={gitOpen} onClose={() => setGitOpen(false)} />
       <DockerPanel open={dockerOpen} onClose={() => setDockerOpen(false)} />
       <TerminalPanel open={terminalOpen} onClose={() => setTerminalOpen(false)} />
-      <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} />
+      <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} focusId={chatFocus} />
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} onSelectApp={(app) => setFilter((f) => ({ ...f, app }))} />
-      <SessionModal sessionId={sessionView?.id ?? null} sourceApp={sessionView?.app} onClose={() => setSessionView(null)} onFilter={(app) => setFilter((f) => ({ ...f, app }))} />
+      <SessionModal
+        sessionId={sessionView?.id ?? null}
+        sourceApp={sessionView?.app}
+        onClose={() => setSessionView(null)}
+        onFilter={(app) => setFilter((f) => ({ ...f, app }))}
+        onResume={(s) => {
+          if (!s.project_path) return;
+          // Reuse an open tab for the same session rather than starting a
+          // second one: two chats resuming one id would both write to it.
+          const existing = chatResuming(s.session_id);
+          const chat = existing ?? newChat(s.project_path, s.model_name || undefined, undefined, {
+            sessionId: s.session_id,
+            title: s.summary?.slice(0, 40) || `${s.source_app}:${s.session_id.slice(0, 8)}`,
+          });
+          setChatFocus(chat.id);
+          setChatOpen(true);
+        }}
+      />
       <CommandPalette
         open={paletteOpen}
         onClose={() => setPaletteOpen(false)}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -68,7 +68,7 @@ function ChatRow({ chat, active, onPick, onClose }: { chat: Chat; active: boolea
   );
 }
 
-export function ChatPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: () => void; focusId?: string }) {
   const chats = useSyncExternalStore(subscribe, listChats, listChats);
   const [activeId, setActiveId] = useState("");
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
@@ -117,6 +117,10 @@ export function ChatPanel({ open, onClose }: { open: boolean; onClose: () => voi
     }
     if (!getChat(activeId) && chats.length) setActiveId(chats[chats.length - 1].id);
   }, [open, chats, defaultCwd, activeId]);
+
+  // Opened to continue a specific session (from the fleet view): show that tab
+  // rather than whichever was last active, or the request looks ignored.
+  useEffect(() => { if (focusId && getChat(focusId)) setActiveId(focusId); }, [focusId]);
 
   useEffect(() => { if (defaultCwd) { try { localStorage.setItem(CWD_KEY, defaultCwd); } catch { /* ignore */ } } }, [defaultCwd]);
 

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -18,7 +18,7 @@ function Stat({ k, v, color }: { k: string; v: string; color?: string }) {
   );
 }
 
-export function SessionModal({ sessionId, sourceApp, onClose, onFilter }: { sessionId: string | null; sourceApp?: string; onClose: () => void; onFilter?: (app: string) => void }) {
+export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume }: { sessionId: string | null; sourceApp?: string; onClose: () => void; onFilter?: (app: string) => void; onResume?: (s: SessionDetail) => void }) {
   const [d, setD] = useState<SessionDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [diffOpen, setDiffOpen] = useState(false);
@@ -35,6 +35,10 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter }: { sess
   const dur = d ? Math.max(0, d.last_seen - d.started_at) : 0;
   const durLabel = dur > 3_600_000 ? `${(dur / 3_600_000).toFixed(1)}h` : dur > 60_000 ? `${Math.round(dur / 60_000)}m` : `${Math.round(dur / 1000)}s`;
   const toolMax = Math.max(1, ...(d?.tool_mix.map((t) => t.n) ?? [1]));
+  // Still owned by a running claude: no end recorded and it spoke recently.
+  // Erring towards "live" is the safe side — refusing to resume a dead session
+  // is an annoyance, resuming a live one forks its transcript.
+  const live = !!d && !d.ended_at && Date.now() - d.last_seen < 120_000;
 
   return (
     <Portal>
@@ -58,6 +62,27 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter }: { sess
                     {d && <span className="text-[10px] t-dim2">{durLabel} · last {fmtAgo(d.last_seen)} ago</span>}
                   </div>
                   <div className="ml-auto flex items-center gap-2 shrink-0">
+                    {d && onResume && (
+                      live ? (
+                        // A claude session has one owner. Resuming one that's
+                        // still running would put a second writer on the same
+                        // transcript, so say why rather than offer a button
+                        // that corrupts the history.
+                        <span className="chip t-dim2" title="This session is still running — resume it once it stops, or watch it live below.">
+                          ● running
+                        </span>
+                      ) : d.project_path ? (
+                        <button onClick={() => { onResume(d); onClose(); }} className="chip cursor-pointer"
+                          title={`Continue this conversation in ${d.project_path} — claude keeps the full context`}
+                          style={{ color: "var(--ok, #34d399)", background: "color-mix(in srgb, #34d399 15%, transparent)", borderColor: "color-mix(in srgb, #34d399 45%, transparent)" }}>
+                          ↩ resume in chat
+                        </button>
+                      ) : (
+                        <span className="chip t-dim2" title="No directory recorded for this session, so there's nowhere to resume it.">
+                          ↩ resume unavailable
+                        </span>
+                      )
+                    )}
                     {d && onFilter && (
                       <button onClick={() => { onFilter(d.source_app); onClose(); }} className="chip cursor-pointer" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", borderColor: "color-mix(in srgb, var(--primary) 45%, transparent)" }}>
                         ⧉ watch in live feed

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -47,16 +47,34 @@ export const listChats = (): Chat[] => snapshot;
 export const getChat = (id: string): Chat | undefined => chats.get(id);
 export const chatCount = () => chats.size;
 
-export function newChat(cwd: string, model = DEFAULT_MODEL, mode = DEFAULT_MODE): Chat {
+/** Open a chat. `resume` adopts an existing claude session instead of starting
+ *  a fresh one: the next message goes out with `--resume <id>`, so the model
+ *  still has the whole conversation even though this panel has no transcript of
+ *  it. That's what turns a finished session in the fleet view into something you
+ *  can pick back up, rather than only read. */
+export function newChat(
+  cwd: string,
+  model = DEFAULT_MODEL,
+  mode = DEFAULT_MODE,
+  resume?: { sessionId: string; title?: string },
+): Chat {
   const id = `c${++seq}-${Date.now().toString(36)}`;
   const chat: Chat = {
-    id, cwd, model, mode, title: "new chat", messages: [], sessionId: "",
+    id, cwd, model, mode,
+    title: resume?.title || "new chat",
+    messages: [], sessionId: resume?.sessionId ?? "",
     sending: false, draft: "", createdAt: Date.now(), abort: null, unread: false,
   };
   chats.set(id, chat);
   emit();
   return chat;
 }
+
+/** An existing chat already resuming this claude session, if any — so asking to
+ *  resume twice focuses the open tab instead of forking a second writer onto
+ *  the same transcript. */
+export const chatResuming = (sessionId: string): Chat | undefined =>
+  [...chats.values()].find((c) => c.sessionId === sessionId);
 
 export function closeChat(id: string) {
   const c = chats.get(id);


### PR DESCRIPTION
> **Stacked on #48** — targets `fix/scope-read-filter`, since it needs the `project_path` column that PR adds. Review/merge #48 first; this rebases onto `main` automatically once it lands.

## What does this PR do?

The fleet view could show what a session did, but not let you pick it back up — continuing meant leaving the app, finding the directory, and running `claude --resume` by hand.

The machinery already existed: `/chat/send` accepts `resumeId` and `chat.ts:45` passes it to `claude --resume`, used today for follow-ups inside one chat. The only missing piece was a way to point a *new* chat at an *existing* session. So this is wiring, not new capability.

- expose the session's directory (`project_path`) on `SessionRollup` / `SessionDetail` — a resume has to start where it ran
- `newChat()` takes an optional `resume`, seeding claude's session id so the first message goes out with `--resume` and the model still has the whole conversation this panel never saw
- **"↩ resume in chat"** in the session modal, opening the chat panel focused on that tab

### The one real constraint

A claude session has a single owner. A session that is **still running** is deliberately *not* resumable — a second writer on the same transcript corrupts its history. Those render `● running` with an explanation, and "watch in live feed" stays the way to follow them.

The liveness test errs towards *live* (no recorded end + spoke within 2 min): refusing to resume a dead session is an annoyance, resuming a live one loses work.

Asking to resume a session that already has an open tab focuses it instead of opening a second chat onto the same id.

## How was it tested?

- `bun test` — 53 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean
- Traced the full path: `SessionModal.onResume` → `newChat(..., {sessionId})` → `chatStore.send` → `api.chatStream({resumeId: chat.sessionId})` → `chatStream(...)` → `args.push("--resume", rid)`

**Not verified end-to-end against a live `claude` process** — that spawns a real billed session, so I stopped at the request shape. The `--resume` path itself is unchanged and already exercised by existing follow-ups.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps)
- [x] `shared/types.ts` updated — `project_path` added to `SessionRollup` and `SessionDetail`, both optional so older rows type cleanly
- [ ] Docs — worth a README line once the header work lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)