### PR TITLE
fix(chat): let a chat pre-approve tools, and stop the mode selector lying

### DIFF
--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -25,9 +25,28 @@ export const CHAT_BYPASS_ALLOWED = process.env.AGENTGLASS_CHAT_BYPASS === "1";
 const BYPASS_ALLOWED = CHAT_BYPASS_ALLOWED;
 const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}$/;
 const SESSION_RE = /^[A-Za-z0-9][A-Za-z0-9-]{7,64}$/;
+
+// A pre-approved tool spec, e.g. `Read`, `Edit`, `Bash(git status)`,
+// `Bash(gh pr view:*)`. Deliberately narrow: letters for the tool name, and an
+// optional parenthesised argument pattern built from the characters those specs
+// actually use. Anything else is dropped rather than passed through, since this
+// string ends up shaping what the agent may run unattended.
+const TOOL_RE = /^[A-Za-z_][A-Za-z0-9_]{0,31}(\([^()\n]{1,120}\))?$/;
+const MAX_ALLOWED = 40;
+
+/** Tool specs the user has pre-approved for this chat.
+ *
+ *  `claude -p` has no terminal to prompt from, so a tool that would normally
+ *  raise a permission dialog is simply refused — the chat reports "requires
+ *  approval" and there is no way to grant it from inside. This is the way out:
+ *  the caller says up front what may run without asking. */
+export function allowList(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  return v.filter((t): t is string => typeof t === "string" && TOOL_RE.test(t.trim())).map((t) => t.trim()).slice(0, MAX_ALLOWED);
+}
 const err = (msg: string, status = 400) => new Response(msg + "\n", { status, headers: CORS });
 
-export function chatStream(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown): Response {
+export function chatStream(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, allowedTools?: unknown): Response {
   const bin = claudeBin();
   if (!bin) return err("no local `claude` CLI — install Claude Code to chat", 403);
   if (process.env.AGENTGLASS_CHAT_DISABLED === "1") return err("chat is disabled (AGENTGLASS_CHAT_DISABLED=1)", 403);
@@ -42,6 +61,9 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   const args = [bin, "-p", "--output-format", "stream-json", "--verbose", "--model", m];
   if (pm === "bypassPermissions") args.push("--dangerously-skip-permissions");
   else args.push("--permission-mode", pm);
+  // Only meaningful for the prompting modes — bypass already allows everything.
+  const allow = pm === "bypassPermissions" ? [] : allowList(allowedTools);
+  if (allow.length) args.push("--allowedTools", ...allow);
   if (rid) args.push("--resume", rid);
 
   // Its own process group, so stopping a turn reaches the whole job tree.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -473,7 +473,7 @@ const server = Bun.serve<WsData>({
       if (!localOrigin(req)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
-      return chatStream(b.cwd, b.message, b.model, b.resumeId, b.mode);
+      return chatStream(b.cwd, b.message, b.model, b.resumeId, b.mode, b.allowedTools);
     }
 
     // --- LLM walkthrough: AI-authored review itinerary for the changes ---

--- a/server/test/chat-allowlist.test.ts
+++ b/server/test/chat-allowlist.test.ts
@@ -1,0 +1,48 @@
+// The chat allowlist decides what a browser request may run unattended, so it
+// is worth pinning precisely.
+//
+// Context: `claude -p` has no terminal to prompt from, so a tool that would
+// normally raise a permission dialog is refused and there is no way to grant it
+// mid-chat. --allowedTools is the way out — which makes this list the thing
+// standing between a chat message and arbitrary local execution.
+import { describe, expect, test } from "bun:test";
+import { allowList } from "../src/chat.ts";
+
+describe("allowList", () => {
+  test("accepts plain tool names and argument patterns", () => {
+    expect(allowList(["Read", "Edit", "Bash(git status)", "Bash(gh pr view:*)"])).toEqual([
+      "Read", "Edit", "Bash(git status)", "Bash(gh pr view:*)",
+    ]);
+  });
+
+  test("drops anything that isn't a tool spec", () => {
+    // Non-strings, shell metacharacters and newlines never reach the arg array.
+    expect(allowList(["Read", 42, null, {}, "", "  "])).toEqual(["Read"]);
+    expect(allowList(["Bash(git status)\nBash(rm -rf /)"])).toEqual([]);
+    expect(allowList(["--dangerously-skip-permissions"])).toEqual([]);
+  });
+
+  test("rejects an unbalanced or nested parenthesis spec", () => {
+    expect(allowList(["Bash(git"])).toEqual([]);
+    expect(allowList(["Bash(a(b))"])).toEqual([]);
+  });
+
+  test("ignores a non-array payload entirely", () => {
+    // The field is attacker-shaped input from a JSON body; a bare string must
+    // not be treated as a one-element list.
+    expect(allowList("Bash(rm -rf /)")).toEqual([]);
+    expect(allowList(undefined)).toEqual([]);
+    expect(allowList({ 0: "Read", length: 1 })).toEqual([]);
+  });
+
+  test("trims and caps the list", () => {
+    expect(allowList([" Read "])).toEqual(["Read"]);
+    expect(allowList(Array.from({ length: 100 }, () => "Read")).length).toBe(40);
+  });
+
+  test("a tool name cannot smuggle a second flag", () => {
+    // Each entry becomes its own argv element, but a spec containing a space
+    // outside parentheses would still be misleading — reject it.
+    expect(allowList(["Read --allowedTools"])).toEqual([]);
+  });
+});

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -25,13 +25,22 @@ const MODELS = [
   { id: "claude-sonnet-5", label: "Sonnet 5" },
   { id: "claude-haiku-4-5", label: "Haiku 4.5" },
 ];
+// These run through `claude -p`, which has no terminal to prompt from: a tool
+// that would raise a permission dialog is refused outright, and there is no
+// way to grant it mid-chat. "Ask" therefore does not ask — it declines. The
+// labels say so, because a mode that silently denies while claiming to prompt
+// is what sends you hunting for a bug that isn't there.
 const MODES = [
-  { id: "default", label: "Ask" },
+  { id: "default", label: "Ask (denies un-allowed)" },
   { id: "plan", label: "Plan (no edits)" },
   { id: "acceptEdits", label: "Auto-accept edits" },
   { id: "bypassPermissions", label: "⚡ Bypass (runs all)" },
 ];
 const CWD_KEY = "agentglass.chatCwd";
+const ALLOW_KEY = "agentglass.chatAllowedTools";
+// A starting point that covers the reading and inspection an assistant reaches
+// for constantly, without granting anything that writes or leaves the machine.
+const ALLOW_DEFAULT = "Read Glob Grep Bash(git status) Bash(git log:*) Bash(git diff:*) Bash(gh pr view:*)";
 const repoName = (p: string) => p.split("/").pop() || p;
 
 const selCls = "text-[10.5px] px-2 py-1 rounded-md outline-none";
@@ -76,6 +85,12 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
   // The server silently downgrades bypassPermissions unless the operator opted
   // in (AGENTGLASS_CHAT_BYPASS=1) — don't offer a mode that wouldn't stick.
   const [bypassAllowed, setBypassAllowed] = useState(false);
+  // Shared by every chat and remembered across launches: the set of tools you
+  // trust is a property of how you work, not of one conversation.
+  const [allowed, setAllowed] = useState(() => {
+    try { return localStorage.getItem(ALLOW_KEY) ?? ALLOW_DEFAULT; } catch { return ALLOW_DEFAULT; }
+  });
+  useEffect(() => { try { localStorage.setItem(ALLOW_KEY, allowed); } catch { /* private mode */ } }, [allowed]);
   const [query, setQuery] = useState("");
   const [defaultCwd, setDefaultCwd] = useState<string>(() => { try { return localStorage.getItem(CWD_KEY) || ""; } catch { return ""; } });
   const scrollRef = useRef<HTMLDivElement>(null);
@@ -153,7 +168,7 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
   const submit = () => {
     if (!active) return;
     const text = active.draft;
-    send(active.id, text, () => openRef.current && activeIdRef.current === active.id);
+    send(active.id, text, () => openRef.current && activeIdRef.current === active.id, allowed.split(/\s+/).filter(Boolean));
   };
   const [hint, setHint] = useState("");
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
@@ -227,6 +242,16 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                         <Select value={active.mode} onChange={(v) => update(active.id, (c) => { c.mode = v; })}
                           className={selCls} style={selStyle} title="Permission mode for tool use"
                           options={MODES.filter((m) => bypassAllowed || m.id !== "bypassPermissions").map((m) => ({ value: m.id, label: m.label }))} />
+                        {active.mode !== "bypassPermissions" && (
+                          <input
+                            value={allowed}
+                            onChange={(e) => setAllowed(e.target.value)}
+                            placeholder="allowed tools…"
+                            title={"Tools that may run without asking — space-separated.\n\nExamples: Read  Edit  Bash(git status)  Bash(gh pr view:*)\n\nWithout this, `claude -p` refuses anything that would normally prompt, because there is no terminal to prompt from."}
+                            className="text-[10px] px-2 py-1 rounded-md outline-none min-w-0 flex-1 max-w-[280px]"
+                            style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
+                          />
+                        )}
                         {active.sessionId && <span className="text-[9.5px] t-dim2 tabular-nums" title="resuming this session">↻ {active.sessionId.slice(0, 8)}</span>}
                       </>
                     ) : <span className="text-[12px] t-dim2">no chat selected</span>}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -173,7 +173,7 @@ const realApi = {
   terminalCommands: (root: string) => get<TerminalCommands>(`/terminal/commands?root=${encodeURIComponent(root)}`),
   // --- multi-chat: drive a claude session from the browser ---
   chatEnabled: () => get<{ enabled: boolean; bypass?: boolean }>("/chat/enabled"),
-  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
+  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[] }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
     const res = await fetch(SERVER + "/chat/send", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
     if (!res.body) { try { onEvent(JSON.parse(await res.text())); } catch { /* non-json */ } return; }
     const reader = res.body.getReader();
@@ -248,7 +248,7 @@ const demoApi: typeof realApi = {
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),
   terminalCommands: (_root: string) => D({ enabled: false, make: [], scripts: [] } as TerminalCommands),
   chatEnabled: () => D({ enabled: false }),
-  chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void) => {
+  chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[] }, onEvent: (o: Record<string, unknown>) => void) => {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });
     onEvent({ type: "result", result: "" });

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -104,7 +104,7 @@ const titleOf = (s: string) => {
  * `activeId` decides whether the reply counts as unread — a chat answering in
  * the background should say so, and the one on screen shouldn't.
  */
-export async function send(id: string, text: string, isActive: () => boolean) {
+export async function send(id: string, text: string, isActive: () => boolean, allowedTools: string[] = []) {
   const chat = chats.get(id);
   const msg = text.trim();
   if (!chat || !msg || chat.sending || !chat.cwd) return;
@@ -151,7 +151,7 @@ export async function send(id: string, text: string, isActive: () => boolean) {
   };
 
   try {
-    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId }, onEvent, ac.signal);
+    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools }, onEvent, ac.signal);
   } catch (e) {
     if (!(e instanceof DOMException && e.name === "AbortError")) {
       update(id, (c) => {


### PR DESCRIPTION
## What does this PR do?

A chat that asked for anything needing approval simply failed — `requires approval`, `permission not granted`, and `/permissions` replying *"isn't available in this environment"*. Nothing was misconfigured: chats run `claude -p`, which has **no terminal to prompt from**, so any tool that would raise a permission dialog is refused outright and there's no way to grant it mid-conversation.

The mode selector made it worse by offering **"Ask"** as the default. It doesn't ask — it declines. That sends you hunting for a bug that doesn't exist.

- **`--allowedTools`** — a chat can now declare up front which tools may run without asking, in the shape claude already understands (`Read`, `Edit`, `Bash(git status)`, `Bash(gh pr view:*)`). Shared across chats and persisted: the set of tools you trust is a property of how you work, not of one conversation. The default grants reading and inspection only — nothing that writes or leaves the machine.
- **Honest labels** — `Ask (denies un-allowed)`, so the behaviour is legible before you spend a turn discovering it.

### Security

This list decides what a browser request may run unattended, so it's validated rather than forwarded:

- entries must match a narrow tool-spec pattern
- a non-array payload is ignored (a bare string must **not** be read as a one-element list)
- unbalanced/nested parentheses rejected; newlines can't smuggle a second spec
- flag-shaped entries (`--dangerously-skip-permissions`) dropped
- list capped at 40

`bypassPermissions` skips the allowlist entirely — it already allows everything — and stays behind `AGENTGLASS_CHAT_BYPASS=1`.

### Deliberately not included

The CLI's newer `dontAsk` / `auto` modes: I couldn't establish their exact semantics from `--help`, and guessing wrong here means exposing something more permissive than intended.

This version also ships **no `--permission-prompt-tool`**, so routing approvals into the existing gate UI (`gate.ts`, `/gate/decide`) isn't possible yet — that would be the elegant fix. An explicit allowlist is the honest option available today.

## How was it tested?

- `bun test` — 59 pass, including 6 new tests pinning the allowlist validator
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean

Not exercised against a live `claude` process (real billed session); verified at the argv-construction and validation layer.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change needed (`allowedTools` is a chat-request field, typed in `api.ts`)
- [ ] Docs — README's chat section deserves a note on the allowlist; happy to fold in

🤖 Generated with [Claude Code](https://claude.com/claude-code)