### PR TITLE
feat(settings): replace the "⋯" dropdown with a real settings modal

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,6 +31,7 @@ import { TerminalPanel } from "./components/TerminalPanel.tsx";
 import { ChatPanel } from "./components/ChatPanel.tsx";
 import { newChat, chatResuming } from "./lib/chatStore.ts";
 import { SearchModal } from "./components/SearchModal.tsx";
+import { SettingsModal } from "./components/SettingsModal.tsx";
 import { SessionModal } from "./components/SessionModal.tsx";
 import { ProjectPicker, PICKER_ANSWERED_KEY } from "./components/ProjectPicker.tsx";
 
@@ -50,6 +51,7 @@ export default function App() {
   const [dockerOpen, setDockerOpen] = useState(false);
   const [terminalOpen, setTerminalOpen] = useState(false);
   const [chatOpen, setChatOpen] = useState(false);
+  const [settingsOpen, setSettingsOpen] = useState(false);
   const [chatFocus, setChatFocus] = useState<string | undefined>(undefined);
   const [searchOpen, setSearchOpen] = useState(false);
   const [sessionView, setSessionView] = useState<{ id: string; app: string } | null>(null);
@@ -241,6 +243,7 @@ export default function App() {
         onOpenDocker={() => setDockerOpen(true)}
         onOpenTerminal={() => setTerminalOpen(true)}
         onOpenChat={() => setChatOpen(true)}
+        onOpenSettings={() => setSettingsOpen(true)}
         onClear={clearFilters}
         showUsage={showUsage}
         workspace={workspace}
@@ -299,6 +302,14 @@ export default function App() {
       <TerminalPanel open={terminalOpen} onClose={() => setTerminalOpen(false)} />
       <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} focusId={chatFocus} />
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} onSelectApp={(app) => setFilter((f) => ({ ...f, app }))} />
+      <SettingsModal
+        open={settingsOpen}
+        onClose={() => setSettingsOpen(false)}
+        sound={sound}
+        onSound={() => setSound((s) => !s)}
+        onOpenStats={() => setStatsOpen(true)}
+        onOpenHelp={() => setHelpOpen(true)}
+      />
       <SessionModal
         sessionId={sessionView?.id ?? null}
         sourceApp={sessionView?.app}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -1,14 +1,12 @@
-import { useEffect, useLayoutEffect, useRef, useState, useSyncExternalStore } from "react";
-import { motion, AnimatePresence } from "motion/react";
+import { useEffect, useState, useSyncExternalStore } from "react";
+import { motion } from "motion/react";
 import type { ConnState } from "../lib/useLive.ts";
-import { api, IS_DEMO, reauthPrompt } from "../lib/api.ts";
+import { IS_DEMO, reauthPrompt } from "../lib/api.ts";
 import { MOD_KEY } from "../lib/format.ts";
 import { ThemeSwitcher } from "./ThemeSwitcher.tsx";
 import { UsageWidget } from "./UsageWidget.tsx";
-import { Portal } from "./Portal.tsx";
 import { Logo } from "./Logo.tsx";
 import { Select } from "./Select.tsx";
-import { autostartEnabled, setAutostart } from "../lib/desktop.ts";
 import { subscribe as subscribeChats, attentionCount } from "../lib/chatStore.ts";
 
 // The long windows matter once history isn't pruned: the transcript scan can
@@ -95,95 +93,26 @@ function ChatIcon() {
   );
 }
 
-/** Overflow menu: secondary actions nested behind one "⋯" button. */
-function MoreMenu({ sound, onSound, onOpenStats, onOpenHelp }: { sound: boolean; onSound: () => void; onOpenStats: () => void; onOpenHelp: () => void }) {
-  const [open, setOpen] = useState(false);
-  const btnRef = useRef<HTMLButtonElement>(null);
-  const [pos, setPos] = useState({ top: 0, right: 0 });
-
-  useLayoutEffect(() => {
-    if (open && btnRef.current) {
-      const r = btnRef.current.getBoundingClientRect();
-      setPos({ top: r.bottom + 8, right: window.innerWidth - r.right });
-    }
-  }, [open]);
-
-  // Launch-at-login is a property of the installed app, so the entry only
-  // exists in the desktop window — and only once the shell has confirmed the
-  // current state, rather than showing a toggle that might be lying.
-  const [autostart, setAutostartState] = useState<boolean | null>(null);
-  useEffect(() => { autostartEnabled().then(setAutostartState); }, []);
-  const toggleAutostart = async () => {
-    const next = await setAutostart(!autostart);
-    if (next !== null) setAutostartState(next);
-  };
-
-  const items: { label: string; hint?: string; onClick?: () => void; href?: string; download?: string }[] = [
-    { label: "📊 Statistics", hint: "s", onClick: onOpenStats },
-    { label: "❔ Legend & shortcuts", hint: "?", onClick: onOpenHelp },
-    { label: sound ? "🔊 Alert sounds — on" : "🔇 Alert sounds — off", onClick: onSound },
-    ...(autostart === null
-      ? []
-      : [{ label: autostart ? "🚀 Start at login — on" : "🚀 Start at login — off", onClick: toggleAutostart }]),
-    { label: "↓ Events CSV", href: api.exportUrl("csv"), download: "agentglass-events.csv" },
-    { label: "↓ Events JSON", href: api.exportUrl("json"), download: "agentglass-events.json" },
-    { label: "↓ Skills catalog (md)", href: api.skillsExportUrl(), download: "agentglass-skills.md" },
-  ];
-
+/** Settings button — the overflow menu became a real modal (SettingsModal),
+ *  because a flat list of one-liners could not show a toggle's state without
+ *  spelling it out in the label. */
+function MoreMenu({ onOpen }: { onOpen: () => void }) {
   return (
-    <>
-      <button ref={btnRef} title="More — stats, help, sounds, exports" onClick={() => setOpen((o) => !o)}
-        className="h-8 w-8 grid place-items-center rounded-lg text-[15px]"
-        style={{
-          border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)",
-          background: open ? "color-mix(in srgb, var(--primary) 20%, transparent)" : "color-mix(in srgb, var(--bg3) 30%, transparent)",
-          color: open ? "var(--primary-hover)" : "var(--text3)",
-        }}>
-        ⋯
-      </button>
-      <Portal>
-        <AnimatePresence>
-          {open && (
-            <>
-              <div className="fixed inset-0" style={{ zIndex: 9998 }} onClick={() => setOpen(false)} />
-              <motion.div
-                initial={{ opacity: 0, y: -8, scale: 0.96 }} animate={{ opacity: 1, y: 0, scale: 1 }} exit={{ opacity: 0, y: -8, scale: 0.96 }}
-                transition={{ type: "spring", stiffness: 420, damping: 32 }}
-                className="fixed w-56 p-1.5 rounded-xl flex flex-col gap-0.5"
-                style={{
-                  top: pos.top, right: pos.right, zIndex: 9999,
-                  background: "color-mix(in srgb, var(--bg2) 97%, black)",
-                  border: "1px solid color-mix(in srgb, var(--border) 70%, transparent)",
-                  boxShadow: "0 24px 60px -18px rgba(0,0,0,0.7)",
-                  backdropFilter: "blur(18px)",
-                }}
-              >
-                {items.map((it) =>
-                  it.href ? (
-                    <a key={it.label} href={it.href} download={it.download} onClick={() => setOpen(false)}
-                      className="flex items-center justify-between px-2.5 py-1.5 rounded-lg text-[11.5px] t-dim hover:bg-white/5">
-                      {it.label}
-                    </a>
-                  ) : (
-                    <button key={it.label} onClick={() => { it.onClick?.(); setOpen(false); }}
-                      className="flex items-center justify-between px-2.5 py-1.5 rounded-lg text-[11.5px] t-dim text-left hover:bg-white/5">
-                      <span>{it.label}</span>
-                      {it.hint && <kbd className="chip text-[9px] t-dim2">{it.hint}</kbd>}
-                    </button>
-                  )
-                )}
-              </motion.div>
-            </>
-          )}
-        </AnimatePresence>
-      </Portal>
-    </>
+    <button title="Settings — preferences, exports, shortcuts" onClick={onOpen}
+      className="h-8 w-8 grid place-items-center rounded-lg text-[15px]"
+      style={{
+        border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)",
+        background: "color-mix(in srgb, var(--bg3) 30%, transparent)",
+        color: "var(--text3)",
+      }}>
+      ⋯
+    </button>
   );
 }
 
 export function Header({
   conn, windowMs, onWindow, apps, types, providers, filter, onFilter, theme, onTheme,
-  sound, onSound, onOpenPalette, onOpenHelp, onOpenStats, onOpenSkills, onOpenChanges, onOpenGit, onOpenDocker, onOpenTerminal, onOpenChat, onClear, showUsage,
+  sound, onSound, onOpenPalette, onOpenHelp, onOpenStats, onOpenSkills, onOpenChanges, onOpenGit, onOpenDocker, onOpenTerminal, onOpenChat, onOpenSettings, onClear, showUsage,
   workspace, onOpenProject,
 }: {
   conn: ConnState;
@@ -207,6 +136,7 @@ export function Header({
   onOpenDocker: () => void;
   onOpenTerminal: () => void;
   onOpenChat: () => void;
+  onOpenSettings: () => void;
   onClear: () => void;
   showUsage: boolean;
   workspace: string | null;
@@ -392,7 +322,7 @@ export function Header({
         </button>
         {/* Skills demoted to a plain icon */}
         <IconBtn title="Skills explorer — browse every available skill (k)" onClick={onOpenSkills}><SkillsIcon /></IconBtn>
-        <MoreMenu sound={sound} onSound={onSound} onOpenStats={onOpenStats} onOpenHelp={onOpenHelp} />
+        <MoreMenu onOpen={onOpenSettings} />
         <ThemeSwitcher current={theme} onChange={onTheme} />
       </div>
     </header>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -1,0 +1,144 @@
+// Settings — what used to be the "⋯" dropdown.
+//
+// That menu mixed three unrelated things in one flat list of one-liners:
+// preferences you toggle, panels you open, and files you download. Worse, the
+// toggles were rendered as their own label ("🔇 Alert sounds — off"), so the
+// only way to learn what a click would do was to read the current state and
+// invert it in your head — and a stale label read as a broken switch.
+//
+// Here each kind gets its own section, toggles look like toggles and say what
+// they control, and downloads say what you actually get.
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Portal } from "./Portal.tsx";
+import { api } from "../lib/api.ts";
+import { autostartEnabled, setAutostart } from "../lib/desktop.ts";
+import { MOD_KEY } from "../lib/format.ts";
+
+function Toggle({ on, onClick, label, hint }: { on: boolean; onClick: () => void; label: string; hint: string }) {
+  return (
+    <button onClick={onClick} role="switch" aria-checked={on}
+      className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left hover:bg-white/5">
+      <span className="min-w-0 flex-1">
+        <span className="block text-[12.5px]" style={{ color: "var(--text)" }}>{label}</span>
+        <span className="block text-[10.5px] t-dim2 mt-0.5">{hint}</span>
+      </span>
+      {/* A real switch: position carries the state, so it reads at a glance
+          instead of having to be parsed. */}
+      <span className="shrink-0 relative rounded-full transition-colors" style={{
+        width: 34, height: 19,
+        background: on ? "color-mix(in srgb, var(--primary) 55%, transparent)" : "color-mix(in srgb, var(--border) 55%, transparent)",
+      }}>
+        <span className="absolute rounded-full transition-transform" style={{
+          width: 15, height: 15, top: 2, left: 2,
+          transform: on ? "translateX(15px)" : "translateX(0)",
+          background: on ? "var(--primary-hover)" : "var(--text3)",
+        }} />
+      </span>
+    </button>
+  );
+}
+
+function Row({ label, hint, kbd, href, download, onClick }: { label: string; hint: string; kbd?: string; href?: string; download?: string; onClick?: () => void }) {
+  const body = (
+    <>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[12.5px]" style={{ color: "var(--text)" }}>{label}</span>
+        <span className="block text-[10.5px] t-dim2 mt-0.5">{hint}</span>
+      </span>
+      {kbd && <kbd className="chip text-[9.5px] t-dim2 shrink-0">{kbd}</kbd>}
+    </>
+  );
+  const cls = "w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left hover:bg-white/5";
+  return href
+    ? <a href={href} download={download} className={cls}>{body}</a>
+    : <button onClick={onClick} className={cls}>{body}</button>;
+}
+
+function Section({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <div className="px-2 py-2">
+      <div className="panel-eyebrow px-3 pb-1">{title}</div>
+      {children}
+    </div>
+  );
+}
+
+export function SettingsModal({ open, onClose, sound, onSound, onOpenStats, onOpenHelp }: {
+  open: boolean; onClose: () => void; sound: boolean; onSound: () => void; onOpenStats: () => void; onOpenHelp: () => void;
+}) {
+  // Launch-at-login belongs to the installed app, so the row exists only in the
+  // desktop window — and only once the shell has confirmed the current state,
+  // rather than showing a switch that might be lying about it.
+  const [autostart, setAutostartState] = useState<boolean | null>(null);
+  useEffect(() => { if (open) autostartEnabled().then(setAutostartState); }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, [open, onClose]);
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+            <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none" style={{ zIndex: 10001 }}>
+              <motion.div
+                initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}
+                transition={{ type: "spring", stiffness: 340, damping: 30 }}
+                className="w-[460px] max-w-[95vw] max-h-[85vh] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
+                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+
+                <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                  <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>Settings</span>
+                  <button onClick={onClose} className="ml-auto text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
+                </div>
+
+                <div className="overflow-y-auto flex-1 divide-y" style={{ borderColor: "color-mix(in srgb, var(--border) 20%, transparent)" }}>
+                  <Section title="Preferences">
+                    <Toggle on={sound} onClick={onSound}
+                      label="Alert sounds"
+                      hint="A chime when a session errors or needs you" />
+                    {autostart !== null && (
+                      <Toggle on={autostart} onClick={async () => {
+                        const next = await setAutostart(!autostart);
+                        if (next !== null) setAutostartState(next);
+                      }}
+                        label="Start at login"
+                        hint="Open agentglass automatically when you log in" />
+                    )}
+                  </Section>
+
+                  <Section title="Open">
+                    <Row label="Statistics" hint="Totals, tool latency and cost breakdowns" kbd="s"
+                      onClick={() => { onOpenStats(); onClose(); }} />
+                    <Row label="Legend & shortcuts" hint="What the colours mean, and every key binding" kbd="?"
+                      onClick={() => { onOpenHelp(); onClose(); }} />
+                    <Row label="Command palette" hint="Jump to any panel, filter or session" kbd={`${MOD_KEY}K`}
+                      onClick={onClose} />
+                  </Section>
+
+                  <Section title="Export">
+                    {/* Scoped like everything else: with a project open these
+                        carry that project's rows, not the whole machine's. */}
+                    <Row label="Events — CSV" hint="One row per event, for a spreadsheet"
+                      href={api.exportUrl("csv")} download="agentglass-events.csv" />
+                    <Row label="Events — JSON" hint="Full payloads, for scripting"
+                      href={api.exportUrl("json")} download="agentglass-events.json" />
+                    <Row label="Skills catalog — Markdown" hint="Every skill the fleet has available"
+                      href={api.skillsExportUrl()} download="agentglass-skills.md" />
+                  </Section>
+                </div>
+              </motion.div>
+            </div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

The overflow menu mixed three unrelated kinds of thing in one flat list of one-liners — preferences you toggle, panels you open, files you download — with nothing distinguishing them.

The toggles were the worst of it. State was encoded in the **label**: `🔇 Alert sounds — off`. The only way to know what a click would do was to read the current state and invert it in your head, and a label that was momentarily stale read as a switch that was broken.

Now:

- **One section per kind** — Preferences / Open / Export
- **Real switches** whose position carries the state, so it reads at a glance instead of having to be parsed
- **A line under each row** saying what it actually controls (`Alert sounds` → *"A chime when a session errors or needs you"*)
- **Downloads say what you get**, not just the format

Start-at-login keeps its existing rule: desktop only, and only once the shell has confirmed the current state — the switch is never shown lying about it.

Also removes the imports the dropdown left behind in `Header.tsx` (`Portal`, `AnimatePresence`, `useLayoutEffect`, `useRef`, `api`, the autostart helpers), all verified unused before deletion.

## Note

The export rows are scoped like everything else after #48 — with a project open they carry that project's rows, not the whole machine's. Worth knowing if you expected a full dump.

## How was it tested?

- `bunx tsc --noEmit` in `web/` — clean
- `bunx vite build` — clean
- `bun test` — 59 pass (no server change)

Visual change; worth opening once to check the switches and Escape-to-close.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)