### PR TITLE
fix(panels): keep the git, diff and session views live instead of frozen on open

### DIFF
--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -4,6 +4,7 @@ import type { FileChange, DiffHunk, WalkthroughResult, WalkthroughFile } from ".
 import { Portal } from "./Portal.tsx";
 import { CommitModal } from "./CommitModal.tsx";
 import { api } from "../lib/api.ts";
+import { usePoll } from "../lib/usePoll.ts";
 import { fmtTime, agentKey } from "../lib/format.ts";
 import { THEMES } from "../lib/highlight.ts";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
@@ -580,6 +581,25 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
     // focus the frame so j/k nav works immediately (filter is opt-in via click)
     requestAnimationFrame(() => frameRef.current?.focus());
   }, [open]);
+
+  // The fleet keeps editing while this is open, so a list loaded once goes
+  // stale within a turn. Refreshed in place rather than through the effect
+  // above: that one resets the filter, the collapsed groups and the selection,
+  // which would yank the file out from under you mid-read every few seconds.
+  //
+  // Not polled for a preset changeset — those are one session's changes, handed
+  // in already resolved, and re-fetching would replace them with the fleet's.
+  usePoll(open && !presetChanges, () => {
+    api.changes(200).then((r) => {
+      setChanges((prev) => {
+        // Same ids in the same order → keep the old array so nothing downstream
+        // re-renders or re-highlights on an unchanged poll.
+        if (prev && prev.length === r.changes.length && prev.every((c, i) => c.id === r.changes[i].id)) return prev;
+        return r.changes;
+      });
+      setSelId((cur) => (cur && r.changes.some((c) => c.id === cur) ? cur : r.changes[0]?.id ?? null));
+    }).catch(() => { /* keep showing what we have */ });
+  }, 4000);
 
   // prune stored "reviewed" ids to those still present; persist the group-by pref
   useEffect(() => {

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -8,6 +8,7 @@ import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitStash, GitGr
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
+import { usePoll } from "../lib/usePoll.ts";
 import { UnifiedDiff, SplitDiff, ThemePicker, Toggle, SCROLLBAR_CSS, ChangesModal, changesetSig, readWalkCache, writeWalkCache } from "./ChangesModal.tsx";
 
 const unifiedText = (c: GitFileChange) => c.hunks.map((h) => `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@\n${h.lines.join("\n")}`).join("\n");
@@ -154,13 +155,21 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
   useEffect(() => { if (open && root) loadTree(root); }, [root, open, loadTree]);
 
   // load the data a non-Changes view needs when it (or the repo) becomes active
-  useEffect(() => {
+  const loadView = useCallback(() => {
     if (!open || !root) return;
     if (view === "branches") api.gitBranches(root).then(setBranchData).catch(() => {});
     else if (view === "log") api.gitGraph(root, 500).then((r) => setGraph(r.lines)).catch(() => {});
     else if (view === "stashes") api.gitStashes(root).then((r) => setStashes(r.stashes)).catch(() => {});
     else if (view === "worktrees") api.gitWorktrees(root).then((r) => setWorktrees(r.worktrees)).catch(() => {});
   }, [open, root, view]);
+  useEffect(() => { loadView(); }, [loadView]);
+
+  // The working tree changes from outside this app — a commit in a terminal, a
+  // branch switch, an agent editing files — and none of that emits an event we
+  // could listen for, so an open panel would otherwise sit on whatever it read
+  // when it opened. Not while a write is in flight: refreshing mid-stage would
+  // fight the optimistic selection the action is about to set.
+  usePoll(open && !!root && !busy, () => { loadTree(root); loadView(); });
 
   const act = async (fn: () => Promise<{ ok: boolean; error?: string; output?: string }>, okMsg?: string) => {
     if (busy) return false;

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -4,6 +4,7 @@ import type { SessionDetail } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
 import { ChangesModal } from "./ChangesModal.tsx";
 import { api } from "../lib/api.ts";
+import { usePoll } from "../lib/usePoll.ts";
 import { fmtUsd, fmtTokens, fmtAgo, fmtTime, modelLabelOf, modelColor } from "../lib/format.ts";
 
 const TOOL_RAMP = ["#a78bfa", "#f472b6", "#34d399", "#60a5fa", "#fbbf24", "#22d3ee", "#a3e635", "#fb923c"];
@@ -29,6 +30,20 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
     setLoading(true);
     api.session(sessionId).then((s) => { setD(s); setLoading(false); }).catch(() => { setD(null); setLoading(false); });
   }, [sessionId]);
+
+  // A session you are reading is very often one that is still working, so this
+  // is the last place that should be a snapshot: the conversation, the cost and
+  // the file list all keep moving while the modal sits open. Refreshed in place
+  // — no `loading` flag, no clearing `d` — so a running session updates under
+  // you instead of flickering through an empty state every few seconds.
+  usePoll(!!sessionId, () => {
+    if (!sessionId) return;
+    api.session(sessionId).then((s) => {
+      // last_seen advances on every new event, so it is the cheap way to tell a
+      // genuinely changed session from an idle poll and skip the re-render.
+      setD((prev) => (prev && s && prev.last_seen === s.last_seen && prev.events === s.events ? prev : s));
+    }).catch(() => { /* keep showing what we have */ });
+  }, 3000);
 
   const open = !!sessionId;
   const key = d ? `${d.source_app}:${d.session_id.slice(0, 8)}` : sourceApp ? `${sourceApp}:${sessionId?.slice(0, 8)}` : sessionId?.slice(0, 8) ?? "";

--- a/web/src/lib/usePoll.ts
+++ b/web/src/lib/usePoll.ts
@@ -1,0 +1,44 @@
+// Keep an open panel current.
+//
+// The git and diff panels loaded once, when they opened, and then went stale:
+// commit from a terminal, switch branch, let the fleet edit a file, and the
+// panel kept showing the world as it was minutes ago — with no sign it was out
+// of date. The only fix was to close and reopen it, which is a workaround the
+// user has to invent and then remember.
+//
+// The live event feed doesn't have this problem because it's pushed over the
+// WebSocket. Git state isn't pushed: it changes from outside the app entirely
+// (a terminal, an editor, another agent), so nothing emits an event for it.
+// Polling is the honest answer for state we can't be notified about.
+import { useEffect, useRef } from "react";
+
+/**
+ * Run `fn` on an interval while `active`, and immediately whenever the window
+ * regains focus.
+ *
+ * Paused while the document is hidden: each tick shells out to `git`, and a
+ * panel left open on a background desktop should not keep spawning processes
+ * for output nobody is looking at. Coming back to the window refreshes at once,
+ * so the pause is invisible — that is also the moment the state is most likely
+ * to have changed underneath you.
+ */
+export function usePoll(active: boolean, fn: () => void, ms = 2500) {
+  // Held in a ref so a caller can pass an inline closure without the interval
+  // being torn down and rebuilt on every render.
+  const saved = useRef(fn);
+  saved.current = fn;
+
+  useEffect(() => {
+    if (!active) return;
+    const tick = () => { if (!document.hidden) saved.current(); };
+    const id = setInterval(tick, ms);
+    const onVisible = () => { if (!document.hidden) saved.current(); };
+    window.addEventListener("focus", onVisible);
+    document.addEventListener("visibilitychange", onVisible);
+    return () => {
+      clearInterval(id);
+      window.removeEventListener("focus", onVisible);
+      document.removeEventListener("visibilitychange", onVisible);
+    };
+  }, [active, ms]);
+}


### PR DESCRIPTION
## What does this PR do?

Both panels loaded once, on open, then went stale. Commit from a terminal, switch branch, or let the fleet edit a file and the panel kept showing the world as it was when you opened it — with nothing on screen admitting it was out of date.

Reported case: Source Control showing branch `feat/settings-modal` with 2 uncommitted files, minutes after that branch had been merged and deleted and those files were in `main`. The only fix was to close and reopen — a workaround the user has to invent, then remember.

## Why polling

The live event feed doesn't have this problem because it's **pushed** over the WebSocket. Git state isn't pushed: it changes from outside the app entirely — a terminal, an editor, another agent — so nothing emits an event we could subscribe to. Polling is the honest answer for state we can't be notified about.

It's also already the pattern here: `DockerPanel` has polled every 5s all along (`DockerPanel.tsx:104,113,123`). Git and the diff were the outliers, not the precedent.

`usePoll()` runs while the panel is open, **pauses while the document is hidden** — each tick shells out to `git`, and a panel left open on a background desktop shouldn't keep spawning processes for output nobody is reading — and refreshes **immediately on focus**, which is exactly when the state is most likely to have moved underneath you.

## The details that make it usable rather than annoying

- **Git doesn't poll while a write is in flight** (`!busy`) — refreshing mid-stage would fight the optimistic selection the action is about to set.
- **The diff refreshes in place**, not through the open-effect, which resets filter / collapsed groups / selection.
- **Unchanged polls are free**: if the ids come back identical, the previous array is kept, so no re-render and no re-highlight.
- **Selection is preserved** if the file is still present, instead of jumping to the top every 4s.
- **A preset changeset is not polled** — one session's changes, handed in already resolved; re-fetching would replace them with the fleet's.

## How was it tested?

- `bunx tsc --noEmit` in `web/` — clean
- `bunx vite build` — clean
- `bun test` — 59 pass (no server change)

Behavioural change best judged live: open the git panel, commit from a terminal, and it should catch up within ~2.5s without you touching it.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light (a 40-line hook, no library)
- [x] `shared/types.ts` — no contract change
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)