### PR TITLE
feat(session): show what the agent did, not only what it said

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -918,6 +918,50 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     spent += c.text.length;
   }
 
+  // Timeline: the messages above, plus every tool the session ran, in order.
+  //
+  // Without the tool runs the panel shows what was said and hides what was
+  // done — an agent that spent an hour editing files looks like it produced
+  // two paragraphs. What identifies a run differs per tool, so each one is
+  // reduced to the single thing worth reading in a list: the path it touched,
+  // the command it ran, the URL it fetched.
+  const target = (tool: string, ti: Record<string, unknown>): string | null => {
+    const s = (v: unknown) => (typeof v === "string" && v ? v : null);
+    switch (tool) {
+      case "Bash": return s(ti.command);
+      case "WebFetch": case "WebSearch": return s(ti.url) ?? s(ti.query);
+      case "ToolSearch": return s(ti.query);
+      case "Task": case "Agent": return s(ti.description);
+      default: return s(ti.file_path) ?? s(ti.path) ?? s(ti.pattern) ?? s(ti.query) ?? s(ti.command);
+    }
+  };
+
+  const timeline: import("../../shared/types.ts").TimelineEntry[] =
+    kept.map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text }));
+
+  // Bounded to the same window the messages cover, so the timeline can't be
+  // dominated by tool noise from turns whose text was already dropped.
+  const oldest = kept.length ? Math.min(...kept.map((c) => c.ts)) : 0;
+  for (const r of db.query<{ timestamp: number; tool_name: string | null; is_error: number; duration_ms: number | null; tool_use_id: string | null; payload: string }, [string, number]>(
+    `SELECT timestamp, tool_name, is_error, duration_ms, tool_use_id, payload FROM events
+      WHERE session_id = ? AND hook_event_type IN ('PostToolUse','PostToolUseFailure')
+        AND timestamp >= ?
+      ORDER BY timestamp DESC LIMIT 400`).all(sessionId, oldest)) {
+    const tool = r.tool_name || "tool";
+    let ti: Record<string, unknown> = {};
+    try { ti = (JSON.parse(r.payload).tool_input ?? {}) as Record<string, unknown>; } catch { /* keep empty */ }
+    const note = typeof ti.description === "string" ? ti.description : null;
+    timeline.push({
+      kind: "tool", ts: r.timestamp, tool,
+      target: target(tool, ti),
+      note: note && note !== target(tool, ti) ? note : null,
+      is_error: !!r.is_error,
+      duration_ms: r.duration_ms,
+      tool_use_id: r.tool_use_id,
+    });
+  }
+  timeline.sort((a, b) => b.ts - a.ts);
+
   return {
     session_id: sessionId,
     source_app: agg.source_app,
@@ -938,6 +982,7 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     tool_mix: toolMix,
     subagents: subRows.map((s) => ({ agent_id: s.agent_id, agent_type: s.agent_type || "subagent", events: s.n })),
     conversation: kept,
+    timeline,
     changes: getChanges(40, sessionId),
   };
 }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -214,6 +214,31 @@ export interface DiffHunk {
   newLines: number;
   lines: string[]; // each begins with " ", "+" or "-"
 }
+/** One thing that happened in a session, in order — a message or a tool run.
+ *
+ *  The conversation used to be prompts and assistant replies only, which left
+ *  out everything the agent actually *did*: the file it edited, the command it
+ *  ran, the search it made. That is most of the work, and without it the panel
+ *  can't replace the terminal you'd otherwise read it in. */
+export interface TimelineEntry {
+  kind: "message" | "tool";
+  ts: number;
+  /** kind === "message" */
+  role?: "user" | "assistant";
+  text?: string;
+  /** kind === "tool" */
+  tool?: string;
+  /** What it acted on: a file path, a command, a URL, a query. */
+  target?: string | null;
+  /** A Bash tool's own description of its intent, when it gave one. */
+  note?: string | null;
+  is_error?: boolean;
+  duration_ms?: number | null;
+  /** Links a tool run to its diff in `changes`, so an edit can show what it
+   *  changed rather than only that it happened. */
+  tool_use_id?: string | null;
+}
+
 export interface SessionDetail {
   session_id: string;
   source_app: string;
@@ -233,6 +258,8 @@ export interface SessionDetail {
   tool_mix: { tool: string; n: number }[];
   subagents: { agent_id: string; agent_type: string; events: number }[];
   conversation: { role: "user" | "assistant"; text: string; ts: number }[];
+  /** Messages and tool runs interleaved in time — what actually happened. */
+  timeline: TimelineEntry[];
   changes: FileChange[];
 }
 

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import type { SessionDetail } from "../../../shared/types.ts";
+import type { SessionDetail, TimelineEntry } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
 import { ChangesModal } from "./ChangesModal.tsx";
 import { api } from "../lib/api.ts";
@@ -10,6 +10,41 @@ import { fmtUsd, fmtTokens, fmtAgo, fmtTime, modelLabelOf, modelColor } from "..
 
 const TOOL_RAMP = ["#a78bfa", "#f472b6", "#34d399", "#60a5fa", "#fbbf24", "#22d3ee", "#a3e635", "#fb923c"];
 const shortType = (t: string) => t.replace(/^workflow-subagent$/, "workflow").replace(/^general-purpose$/, "general");
+
+// A tool run in the thread. Deliberately one dense line rather than a bubble:
+// a session runs hundreds of these, and giving each the weight of a message
+// would bury the conversation it is supposed to sit alongside.
+function ToolRow({ e }: { e: TimelineEntry }) {
+  const [open, setOpen] = useState(false);
+  const target = e.target ?? "";
+  // A command can be a whole script; show its first line and let the rest be
+  // opened, rather than either truncating it away or pasting 40 lines inline.
+  const firstLine = target.split("\n")[0];
+  const hasMore = target.length > firstLine.length || firstLine.length > 110;
+  const tint = e.is_error ? "var(--error)" : "var(--info)";
+  return (
+    <div className="flex items-start gap-2 text-[10.5px] leading-relaxed pl-1">
+      <span className="shrink-0 tabular-nums t-dim2 pt-px" style={{ minWidth: 52 }}>{fmtTime(e.ts)}</span>
+      <span className="shrink-0 px-1.5 rounded font-medium"
+        style={{ color: tint, background: `color-mix(in srgb, ${tint} 13%, transparent)` }}>
+        {e.is_error ? "✕" : "⚙"} {e.tool}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span
+          onClick={hasMore ? () => setOpen((o) => !o) : undefined}
+          className={`block break-all ${hasMore ? "cursor-pointer" : ""} ${open ? "whitespace-pre-wrap" : "truncate"}`}
+          style={{ color: "var(--text3)", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}
+          title={hasMore && !open ? "click to expand" : undefined}>
+          {open ? target : firstLine}
+        </span>
+        {e.note && <span className="block t-dim2 truncate">{e.note}</span>}
+      </span>
+      {e.duration_ms != null && e.duration_ms >= 1000 && (
+        <span className="shrink-0 tabular-nums t-dim2">{(e.duration_ms / 1000).toFixed(1)}s</span>
+      )}
+    </div>
+  );
+}
 
 function Stat({ k, v, color }: { k: string; v: string; color?: string }) {
   return (
@@ -25,6 +60,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
   const [loading, setLoading] = useState(false);
   const [diffOpen, setDiffOpen] = useState(false);
   const [diffPath, setDiffPath] = useState<string | undefined>(undefined);
+  const [showTools, setShowTools] = useState(true);
 
   useEffect(() => {
     if (!sessionId) { setD(null); setDiffOpen(false); return; }
@@ -55,6 +91,14 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
   // Erring towards "live" is the safe side — refusing to resume a dead session
   // is an annoyance, resuming a live one forks its transcript.
   const live = !!d && !d.ended_at && Date.now() - d.last_seen < 120_000;
+
+  // Oldest-first, so it reads as a story rather than in reverse. Falls back to
+  // the plain conversation for a server that predates the timeline field.
+  const entries: TimelineEntry[] = d?.timeline?.length
+    ? d.timeline
+    : (d?.conversation ?? []).map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text }));
+  const toolCount = entries.reduce((n, e) => n + (e.kind === "tool" ? 1 : 0), 0);
+  const timeline = [...entries].reverse().filter((e) => showTools || e.kind !== "tool");
 
   return (
     <Portal>
@@ -185,10 +229,27 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
 
                       {/* right: conversation — scrolls independently */}
                       <div className="agx-scroll min-h-0 overflow-y-auto px-5 py-4">
-                        <div className="panel-eyebrow mb-2.5">Conversation</div>
+                        <div className="flex items-center gap-2 mb-2.5">
+                          <span className="panel-eyebrow">Conversation</span>
+                          {/* Tool runs are most of what a session does, but they
+                              are also the bulk of the rows — so they can be
+                              hidden when you want to read the thread alone. */}
+                          <button onClick={() => setShowTools((s) => !s)}
+                            className="ml-auto text-[9.5px] px-1.5 py-0.5 rounded-full"
+                            title={showTools ? "Hide tool runs" : "Show tool runs"}
+                            style={{
+                              color: showTools ? "var(--primary-hover)" : "var(--text3)",
+                              background: `color-mix(in srgb, var(--primary) ${showTools ? 15 : 6}%, transparent)`,
+                              border: `1px solid color-mix(in srgb, var(--primary) ${showTools ? 40 : 18}%, transparent)`,
+                            }}>
+                            ⚙ tools {toolCount > 0 && <span className="tabular-nums">{toolCount}</span>}
+                          </button>
+                        </div>
                         <div className="space-y-2.5">
-                          {d.conversation.length === 0 && <div className="t-dim2 text-[11px]">no prompts or messages captured</div>}
-                          {[...d.conversation].reverse().map((c, i) => (
+                          {timeline.length === 0 && <div className="t-dim2 text-[11px]">no prompts or messages captured</div>}
+                          {timeline.map((c, i) => c.kind === "tool" ? (
+                            <ToolRow key={i} e={c} />
+                          ) : (
                             <div key={i} className={`flex ${c.role === "user" ? "justify-end" : "justify-start"}`}>
                               <div
                                 className="max-w-[85%] min-w-0 rounded-xl px-3 py-2 text-[11.5px] leading-relaxed break-words"
@@ -199,7 +260,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                                 }
                               >
                                 <div className="text-[9px] uppercase tracking-wider mb-1" style={{ color: c.role === "user" ? "var(--primary-hover)" : "var(--text4)" }}>{c.role} · {fmtTime(c.ts)}</div>
-                                <Markdown text={c.text} />
+                                <Markdown text={c.text ?? ""} />
                               </div>
                             </div>
                           ))}

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -477,6 +477,22 @@ export function session(id: string): SessionDetail {
       { role: "user", text: "add a retry to the checkout webhook too", ts: now - 40 * 60_000 },
       { role: "assistant", text: "Done. Wrapped the webhook call in the standard retry policy (3 attempts, exponential backoff) and opened PR #482.", ts: now - 12 * 60_000 },
     ],
+    // The demo's timeline shows what the real one is for: the tool runs between
+    // the messages, which is where the work actually happens.
+    timeline: [
+      { kind: "message", role: "user", text: "the cart total is applying the discount twice at checkout, fix it", ts: now - 90 * 60_000 },
+      { kind: "tool", tool: "Grep", target: "calculateTotal", ts: now - 89 * 60_000, duration_ms: 120 },
+      { kind: "tool", tool: "Read", target: "src/cart/total.ts", ts: now - 88 * 60_000, duration_ms: 90 },
+      { kind: "tool", tool: "Edit", target: "src/cart/total.ts", ts: now - 80 * 60_000, duration_ms: 210 },
+      { kind: "tool", tool: "Bash", target: "npm test -- cart", note: "run the cart suite", ts: now - 79 * 60_000, duration_ms: 8400 },
+      { kind: "message", role: "assistant", text: "Found it — `calculateTotal` applied the coupon and `checkout()` applied it again. Consolidating it into one place and clamping the total at zero.", ts: now - 78 * 60_000 },
+      { kind: "message", role: "user", text: "add a retry to the checkout webhook too", ts: now - 40 * 60_000 },
+      { kind: "tool", tool: "Edit", target: "src/checkout/webhook.ts", ts: now - 30 * 60_000, duration_ms: 180 },
+      { kind: "tool", tool: "Bash", target: "npm test -- checkout", ts: now - 26 * 60_000, is_error: true, duration_ms: 6100 },
+      { kind: "tool", tool: "Edit", target: "src/checkout/webhook.ts", ts: now - 22 * 60_000, duration_ms: 160 },
+      { kind: "tool", tool: "Bash", target: "gh pr create --fill", ts: now - 13 * 60_000, duration_ms: 2400 },
+      { kind: "message", role: "assistant", text: "Done. Wrapped the webhook call in the standard retry policy (3 attempts, exponential backoff) and opened PR #482.", ts: now - 12 * 60_000 },
+    ],
     changes: changes().changes.slice(0, 6),
   };
 }


### PR DESCRIPTION
## What does this PR do?

The session view built its conversation from `UserPromptSubmit` + `last_assistant_message` **only**. So it showed what was *said* and hid everything that was *done*: every file edited, command run, search made — the actual work — sat in the `events` table and never reached the panel.

An agent that spent an hour editing files looked like it produced two paragraphs. And the file list on the left was disconnected from the thread: you could see *what* changed, never *when* or *why*.

That gap is the reason the terminal stayed necessary.

## What's in it

`SessionDetail` now carries a `timeline`: messages and tool runs interleaved in time.

Each run is reduced to the one thing worth reading in a list — the path it touched, the command it ran, the URL it fetched, the query it searched. What identifies a run differs per tool (`Bash`→`command`, `Edit`/`Read`→`file_path`, `WebFetch`→`url`, `ToolSearch`→`query`), and dumping raw `tool_input` would be noise.

**Rendered as one dense line, not a bubble.** A session runs hundreds of these; giving each the weight of a message would bury the conversation it's meant to sit alongside.

- Long commands show their first line, expand on click — a 40-line script is neither truncated away nor pasted inline
- Failures tinted and marked `✕`
- Durations shown only when worth noticing (≥1s)
- A `⚙ tools` toggle hides them to read the thread alone

## Bounds

Tool rows are limited to the same time window the messages cover, so the timeline can't be swamped by tool noise from turns whose text the budget already dropped. Capped at 400 rows.

Falls back to the plain `conversation` when the server has no `timeline` field, so a web build talking to an older server still renders.

## How was it tested?

- `bun test` — 67 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean
- Verified the real payload shapes against a live server first (`Bash`→`command`+`description`, `Edit`/`Write`/`Read`→`file_path`, `WebFetch`→`url`, `ToolSearch`→`query`) rather than guessing them
- Demo data updated so the showcase demonstrates the interleaving

Visual change — worth opening a busy session to judge the density.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` updated — new `TimelineEntry`, `timeline` on `SessionDetail`
- [ ] Docs — README screenshots show the old session view; worth regenerating once the header/session work settles

🤖 Generated with [Claude Code](https://claude.com/claude-code)