### PR TITLE
fix(docker): scope the Docker panel to the open project

### DIFF
--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -4,10 +4,12 @@
 // AGENTGLASS_DOCKER_WRITE_DISABLED=1. Container ids/names are validated before
 // they reach the CLI.
 
+import { basename } from "node:path";
 import type {
   DockerContainer, DockerStat, DockerImage, DockerVolume, DockerNetwork,
-  DockerOverview, DockerActionResult,
+  DockerOverview, DockerScope, DockerActionResult,
 } from "../../shared/types.ts";
+import { workspaceRoot } from "./config.ts";
 
 export const DOCKER_WRITE_ENABLED = process.env.AGENTGLASS_DOCKER_WRITE_DISABLED !== "1";
 // Container id (hex) or name (compose names: letters/digits . _ -).
@@ -89,7 +91,78 @@ const PS_FIELDS = ["ID", "Names", "Image", "State", "Status", "Ports", "Labels",
 // labels do this (a cloudflared image here embeds a JSON blob in one).
 const PS_FORMAT = PS_FIELDS.map((f) => `{{.${f}}}`).join("\t");
 
-async function containers(): Promise<DockerContainer[]> {
+// --- project scope ----------------------------------------------------------
+// The rest of the cockpit (events, sessions, git, diffs) narrows to the open
+// project; the docker panel used to be the one surface that still showed the
+// whole machine, which made "my containers" a hunt through everything else
+// running on the host.
+//
+// Compose is the only thing that records which directory a container came from,
+// so its labels are the key. `working_dir` is the strong signal — it is the
+// absolute path of the compose file's directory — but it is only set by
+// reasonably recent compose versions, so the project name is kept as a fallback
+// for containers that carry just that.
+const WORKING_DIR_LABEL = "com.docker.compose.project.working_dir";
+
+// Compose lowercases the project name and drops everything outside [a-z0-9_-],
+// so a checkout at ~/code/My.App runs as project "myapp". Comparing the raw
+// basename would miss exactly those repos, which is the confusing half of the
+// bug rather than the obvious half.
+const normalizeProject = (s: string) => s.toLowerCase().replace(/[^a-z0-9_-]/g, "");
+
+export interface DockerScopeKey { dir: string; project: string }
+const trimSlash = (p: string) => p.replace(/\/+$/, "");
+
+/** The open project expressed the way container labels express it, or null when
+ *  this instance is machine-wide. */
+export function dockerScopeKey(root: string | null): DockerScopeKey | null {
+  if (!root) return null;
+  const dir = trimSlash(root);
+  return { dir, project: normalizeProject(basename(dir)) };
+}
+
+/**
+ * Whether a container belongs to the open project.
+ *
+ * Either signal is enough. A directory match is authoritative — that stack was
+ * literally launched from inside this checkout, whatever it named itself. A
+ * name match is looser (two checkouts of the same repo in different directories
+ * both answer to "myapp") but it is the only thing older compose versions give
+ * us, and showing a sibling checkout's container is a far smaller failure than
+ * showing none of them.
+ */
+export function containerInScope(c: { project: string | null; workingDir: string | null }, s: DockerScopeKey): boolean {
+  const wd = trimSlash(c.workingDir || "");
+  if (wd && (wd === s.dir || wd.startsWith(s.dir + "/"))) return true;
+  return !!s.project && normalizeProject(c.project || "") === s.project;
+}
+
+// Carries the working-dir label alongside the wire shape; it is a matching
+// input, not something the panel renders, so it is stripped before serving.
+type ScopedContainer = DockerContainer & { workingDir: string | null };
+const strip = (c: ScopedContainer): DockerContainer => {
+  const { workingDir: _wd, ...rest } = c;
+  return rest;
+};
+
+/**
+ * Apply the scope to a container list.
+ *
+ * When a scope is set but nothing matches, the full list is returned with
+ * `showingAll` set rather than an empty one. An empty panel is indistinguishable
+ * from a broken daemon, and plenty of perfectly normal containers carry no
+ * compose labels at all (`docker run`, Podman, k3d) — silently hiding them would
+ * teach people the panel is unreliable. Degrading to the host view *and saying
+ * so* keeps the panel honest in both directions.
+ */
+export function applyScope(all: ScopedContainer[], key: DockerScopeKey | null): { containers: DockerContainer[]; scope?: DockerScope } {
+  if (!key) return { containers: all.map(strip) };
+  const mine = all.filter((c) => containerInScope(c, key));
+  const scope: DockerScope = { workspace: key.dir, project: key.project, matched: mine.length, showingAll: mine.length === 0 };
+  return { containers: (mine.length ? mine : all).map(strip), scope };
+}
+
+async function containers(): Promise<ScopedContainer[]> {
   const r = await dockerAsync(["ps", "--all", "--no-trunc", "--format", PS_FORMAT]);
   if (r.code !== 0) return [];
   const rows: Record<string, string>[] = [];
@@ -111,6 +184,7 @@ async function containers(): Promise<DockerContainer[]> {
       ports: c.Ports || "",
       project: labels["com.docker.compose.project"] || null,
       service: labels["com.docker.compose.service"] || null,
+      workingDir: labels[WORKING_DIR_LABEL] || null,
       runningFor: c.RunningFor || "",
       size: c.Size || "",
     };
@@ -148,19 +222,28 @@ async function networks(): Promise<DockerNetwork[]> {
 // never idle — it just queued. They're independent, so they go together, and
 // the result is held long enough to absorb a second viewer or a panel reopen.
 const OVERVIEW_CACHE_MS = 2_000;
-let overviewCache: { at: number; data: DockerOverview } | null = null;
+// The scope is part of the cache identity: the project picker can switch
+// workspaces mid-poll, and serving the previous project's containers for the
+// next two seconds looks like the switch didn't take.
+let overviewCache: { at: number; root: string | null; data: DockerOverview } | null = null;
 
 export async function overview(): Promise<DockerOverview> {
-  if (overviewCache && Date.now() - overviewCache.at < OVERVIEW_CACHE_MS) return overviewCache.data;
+  const root = workspaceRoot();
+  if (overviewCache && overviewCache.root === root && Date.now() - overviewCache.at < OVERVIEW_CACHE_MS) return overviewCache.data;
   const version = await dockerVersion();
   if (!version) {
     const down: DockerOverview = { available: false, writeEnabled: DOCKER_WRITE_ENABLED, version: null, containers: [], images: [], volumes: [], networks: [], error: "docker not available (is the daemon running?)" };
-    overviewCache = { at: Date.now(), data: down };
+    overviewCache = { at: Date.now(), root, data: down };
     return down;
   }
   const [c, i, v, n] = await Promise.all([containers(), images(), volumes(), networks()]);
-  const data: DockerOverview = { available: true, writeEnabled: DOCKER_WRITE_ENABLED, version, containers: c, images: i, volumes: v, networks: n };
-  overviewCache = { at: Date.now(), data };
+  // Only containers are scoped. Images, volumes and networks are host-global
+  // resources shared between projects — an image layer isn't "owned" by the
+  // checkout that happened to build it — so filtering them would hide things
+  // the user can legitimately act on without telling them anything true.
+  const { containers: scoped, scope } = applyScope(c, dockerScopeKey(root));
+  const data: DockerOverview = { available: true, writeEnabled: DOCKER_WRITE_ENABLED, version, containers: scoped, images: i, volumes: v, networks: n, ...(scope ? { scope } : {}) };
+  overviewCache = { at: Date.now(), root, data };
   return data;
 }
 

--- a/server/test/docker-scope.test.ts
+++ b/server/test/docker-scope.test.ts
@@ -1,0 +1,104 @@
+// The docker panel is scoped to the open project the same way events, sessions
+// and diffs are — a cockpit opened for one repo shouldn't list every container
+// on the machine.
+//
+// The two things worth pinning are the matching rule (compose normalizes
+// project names, so a raw basename comparison quietly misses real repos) and
+// the no-match fallback: showing nothing is indistinguishable from a dead
+// daemon, so the full list comes back with a flag instead.
+import { describe, expect, test } from "bun:test";
+import { dockerScopeKey, containerInScope, applyScope } from "../src/docker.ts";
+
+const c = (over: Partial<{ id: string; project: string | null; workingDir: string | null }> = {}) => ({
+  id: over.id ?? "abc123",
+  name: "svc-1",
+  image: "nginx",
+  state: "running",
+  status: "Up 2 hours",
+  ports: "",
+  project: over.project ?? null,
+  service: null,
+  workingDir: over.workingDir ?? null,
+  runningFor: "2 hours",
+  size: "",
+});
+
+describe("dockerScopeKey", () => {
+  test("derives the compose project name from the directory", () => {
+    expect(dockerScopeKey("/home/x/code/myapp")).toEqual({ dir: "/home/x/code/myapp", project: "myapp" });
+  });
+
+  test("normalizes like compose does — lowercase, [a-z0-9_-] only", () => {
+    expect(dockerScopeKey("/home/x/code/My.App")?.project).toBe("myapp");
+    expect(dockerScopeKey("/home/x/code/Agent Glass")?.project).toBe("agentglass");
+    expect(dockerScopeKey("/home/x/code/my_app-2")?.project).toBe("my_app-2");
+  });
+
+  test("trims a trailing slash so the prefix test can't be fooled", () => {
+    expect(dockerScopeKey("/home/x/code/myapp/")?.dir).toBe("/home/x/code/myapp");
+  });
+
+  test("is null when the instance is machine-wide", () => {
+    expect(dockerScopeKey(null)).toBeNull();
+  });
+});
+
+describe("containerInScope", () => {
+  const key = dockerScopeKey("/home/x/code/myapp")!;
+
+  test("matches on the compose project name", () => {
+    expect(containerInScope(c({ project: "myapp" }), key)).toBe(true);
+    expect(containerInScope(c({ project: "MyApp" }), key)).toBe(true);
+    expect(containerInScope(c({ project: "otherapp" }), key)).toBe(false);
+  });
+
+  test("matches on a working dir inside the workspace", () => {
+    expect(containerInScope(c({ project: "renamed", workingDir: "/home/x/code/myapp" }), key)).toBe(true);
+    expect(containerInScope(c({ project: "renamed", workingDir: "/home/x/code/myapp/deploy" }), key)).toBe(true);
+  });
+
+  test("a sibling directory sharing the prefix is not inside it", () => {
+    // "/home/x/code/myapp-staging" starts with the scope string but is a
+    // different project; the separator has to be part of the comparison.
+    expect(containerInScope(c({ project: null, workingDir: "/home/x/code/myapp-staging" }), key)).toBe(false);
+  });
+
+  test("an unlabelled container never matches", () => {
+    // A plain `docker run` has no compose labels at all. Empty must not read as
+    // "same project" just because both sides normalize to "".
+    expect(containerInScope(c(), key)).toBe(false);
+    expect(containerInScope(c(), { dir: "/", project: "" })).toBe(false);
+  });
+});
+
+describe("applyScope", () => {
+  const key = dockerScopeKey("/home/x/code/myapp")!;
+  const mine = c({ id: "aaa", project: "myapp" });
+  const theirs = c({ id: "bbb", project: "otherapp" });
+
+  test("unscoped leaves the host list untouched and reports no scope", () => {
+    const r = applyScope([mine, theirs], null);
+    expect(r.containers.map((x) => x.id)).toEqual(["aaa", "bbb"]);
+    expect(r.scope).toBeUndefined();
+  });
+
+  test("scoped keeps only this project's containers", () => {
+    const r = applyScope([mine, theirs], key);
+    expect(r.containers.map((x) => x.id)).toEqual(["aaa"]);
+    expect(r.scope).toEqual({ workspace: "/home/x/code/myapp", project: "myapp", matched: 1, showingAll: false });
+  });
+
+  test("no match falls back to the full list with showingAll set", () => {
+    // The deliberate choice: an empty panel looks like a broken daemon, so the
+    // host view comes back and the flag lets the UI explain why.
+    const r = applyScope([theirs], key);
+    expect(r.containers.map((x) => x.id)).toEqual(["bbb"]);
+    expect(r.scope).toMatchObject({ matched: 0, showingAll: true });
+  });
+
+  test("the working-dir label never reaches the wire shape", () => {
+    // It's a matching input, not something the panel renders.
+    const [only] = applyScope([c({ workingDir: "/home/x/code/myapp" })], key).containers;
+    expect(only).not.toHaveProperty("workingDir");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -429,6 +429,15 @@ export interface DockerImage {
 }
 export interface DockerVolume { name: string; driver: string; }
 export interface DockerNetwork { id: string; name: string; driver: string; scope: string; }
+/** Present only when the cockpit is open for one project, so the panel can say
+ *  which slice of the host it is showing — and admit when the filter found
+ *  nothing and fell back to the whole machine. */
+export interface DockerScope {
+  workspace: string;   // the open project's directory
+  project: string;     // compose project name derived from it
+  matched: number;     // containers that belong to it
+  showingAll: boolean; // nothing matched, so every container is listed instead
+}
 export interface DockerOverview {
   available: boolean;
   writeEnabled: boolean;
@@ -437,6 +446,7 @@ export interface DockerOverview {
   images: DockerImage[];
   volumes: DockerVolume[];
   networks: DockerNetwork[];
+  scope?: DockerScope;
   error?: string;
 }
 export interface DockerActionResult { ok: boolean; error?: string; output?: string; }

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -189,6 +189,19 @@ export function DockerPanel({ open, onClose }: { open: boolean; onClose: () => v
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>🐳 Docker</span>
                   {ov?.version && <span className="text-[10px] t-dim2">engine {ov.version}</span>}
+                  {/* Scoped to the open project. The fallback case is spelled out
+                      rather than shown as an empty list, so an unlabelled stack
+                      doesn't read as "docker is broken". */}
+                  {ov?.scope && (
+                    <span className="text-[9.5px] px-1.5 py-0.5 rounded shrink-0" title={ov.scope.showingAll
+                      ? `no container is labelled for ${ov.scope.project} (${ov.scope.workspace}) — showing every container on this host`
+                      : `showing containers for ${ov.scope.workspace}`}
+                      style={ov.scope.showingAll
+                        ? { background: "color-mix(in srgb, var(--warning) 16%, transparent)", color: "var(--warning)" }
+                        : { background: "color-mix(in srgb, var(--primary) 14%, transparent)", color: "var(--text2)" }}>
+                      {ov.scope.showingAll ? `no ${ov.scope.project} containers · showing all` : ov.scope.project}
+                    </span>
+                  )}
                   <div className="flex items-center gap-1 ml-2">
                     <TabBtn id="containers" label="Containers" n={containers.length} />
                     <TabBtn id="images" label="Images" n={ov?.images.length ?? 0} />


### PR DESCRIPTION
## What does this PR do?

Scopes the Docker panel to the open project, the way events/sessions/git/diffs already are since #48. Previously `docker.ts` had no scoping at all — a cockpit opened for one repo still listed every container on the host.

Containers are matched against the workspace using the compose labels the parser was already reading but never using:

- `com.docker.compose.project.working_dir` — authoritative when present (the stack was launched from inside this checkout; also covers subdirectories like `<repo>/deploy`).
- `com.docker.compose.project` — fallback for older compose, compared with compose's own normalization (lowercase, `[a-z0-9_-]` only) so a checkout at `~/code/My.App` matches project `myapp`.

**No-match behaviour:** if a scope is set but nothing matches, the full host list is returned with `scope.showingAll = true` and the panel shows a warning chip (`no <project> containers · showing all`). An empty panel is indistinguishable from a dead daemon, and plenty of legitimate containers carry no compose labels at all (`docker run`, Podman, k3d) — degrading to the host view *and saying so* is the honest failure mode.

Images, volumes and networks stay unfiltered: they are host-global resources shared between projects, and hiding them would not communicate anything true. The overview cache is now keyed on the scope so switching projects in the picker takes effect immediately.

Unscoped (machine-wide) instances are unchanged — no `scope` field, identical list.

## How was it tested?

- `bun test` from the repo root — 87 pass, incl. new `server/test/docker-scope.test.ts` covering the matching predicate as a pure function (normalization, working-dir prefix, the `myapp` vs `myapp-staging` sibling-prefix trap, unlabelled containers, and the fallback).
- `bunx tsc --noEmit` in both `server/` and `web/`; `bunx vite build` in `web/`.
- Exercised against a live daemon: scoped to a real compose checkout (15/15 matched, `showingAll: false`), scoped to a directory with no stack (full list returned, `showingAll: true`), and unscoped (`scope` absent, list unchanged).

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new deps; `node:path` only)
- [x] `shared/types.ts` updated if the server↔web contract changed (new optional `DockerScope`)
- [ ] Docs updated — no config/behaviour surface to document beyond the existing `AGENTGLASS_ROOT` scoping

🤖 Generated with [Claude Code](https://claude.com/claude-code)