### PR TITLE
fix(diff): keep the theme dropdown above the sticky hunk headers

### DIFF
--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -480,10 +480,14 @@ export function ThemePicker({ value, onChange }: { value: string; onChange: (v: 
         <span className="truncate" style={{ maxWidth: 92 }}>{label}</span>
         <span style={{ opacity: 0.6, fontSize: 8 }}>▼</span>
       </button>
+      {/* zIndex must beat the diff's sticky hunk headers, which are also z-20:
+          on a tie the later-painted element wins, so those headers were
+          striping grey bars across this list wherever a `@@ … @@` line sat
+          behind it. */}
       {open && (
         <div
           className="agx-scroll absolute right-0 mt-1 rounded-lg py-1 text-[10.5px] shadow-2xl"
-          style={{ zIndex: 20, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 178, maxHeight: 340, overflowY: "auto" }}
+          style={{ zIndex: 40, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 178, maxHeight: 340, overflowY: "auto" }}
         >
           <Row id="auto" name="Auto (app theme)" />
           <div className="px-2.5 pt-1.5 pb-0.5 text-[8.5px] uppercase tracking-wider t-dim2">Dark</div>


### PR DESCRIPTION
## What does this PR do?

The syntax-theme dropdown rendered at `zIndex: 20` — **exactly the same layer** as the diff's sticky `@@ … @@` hunk headers (`ChangesModal.tsx:155,233,256`). On a tie the later-painted element wins, so every hunk header sitting behind the open list punched a grey bar straight across it. The menu looked corrupted rather than merely overlapped, and the theme names under those bars were unreadable.

Raised the dropdown rather than lowering the headers: those have to stay pinned over the diff body while it scrolls, which is the entire reason they're sticky.

## How was it tested?

- `bunx tsc --noEmit` in `web/` — clean
- `bunx vite build` — clean

Visual fix; verify by opening the diff, scrolling so a hunk header is mid-pane, then opening the theme picker over it.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)