### PR TITLE
feat(picker): complete filesystem paths in the project picker

### DIFF
--- a/README.md
+++ b/README.md
@@ -304,7 +304,7 @@ are:
   belongs to the *machine*, not to your account — on a box where other people
   also have accounts, any of them could reach the server and its shell **as
   your user**. Set `AGENTGLASS_TOKEN` to lock it to you, and/or disable the
-  capability surfaces: `AGENTGLASS_TERMINAL_DISABLED=1`,
+  capability surfaces: `AGENTGLASS_TERMINAL_DISABLED=1`, `AGENTGLASS_FS_BROWSE_DISABLED=1`,
   `AGENTGLASS_CHAT_DISABLED=1`, `AGENTGLASS_GIT_WRITE_DISABLED=1`,
   `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
 - **⚠️ Exposing it to a network is a three-part deliberate act.** `AGENTGLASS_BIND=0.0.0.0`
@@ -430,6 +430,7 @@ inference, prompt) to an event the same way.
 | `AGENTGLASS_GIT_WRITE_DISABLED` | — | `1` → make the **Source control** panel read-only (no stage / commit / push). |
 | `AGENTGLASS_DOCKER_WRITE_DISABLED` | — | `1` → make the **Docker** panel read-only (no start / stop / restart / rm). |
 | `AGENTGLASS_TERMINAL_DISABLED` | — | `1` → disable the in-browser **Terminal** entirely (no PTY shells are spawned). |
+| `AGENTGLASS_FS_BROWSE_DISABLED` | — | `1` → disable directory completion in the project picker (`/fs/complete`). Separate from the terminal switch on purpose: disabling the shell should not leave the directory tree readable. |
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
 | `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's `bypassPermissions` mode (`claude --dangerously-skip-permissions`). Off by default: the mode is downgraded to a prompting default unless you opt in. |
 | `AGENTGLASS_COMMIT_DISABLED` | — | `1` → disable the diff viewer's **Commit…** composer. |

--- a/server/src/fsbrowse.ts
+++ b/server/src/fsbrowse.ts
@@ -11,16 +11,20 @@
 // "what's in this folder" is only ever the subfolders you could plausibly open
 // as a project.
 //
-// On scope: this is NOT restricted to `configuredRepoDirs()`. Two reasons, and
-// the second is the real one. First, `repoDirs` is empty in the default install
-// — restricting to it would leave the feature dead for almost everyone, and the
-// input exists precisely for projects living outside the swept directories.
-// Second, the endpoint sits behind the same origin/rebinding/token gate as the
-// rest of the surface, and that gate already guards `/terminal/pty`, which
-// hands out a real login shell. A caller who can reach this route can already
-// `ls` the machine with far less ceremony, so confining it would buy no
-// security while breaking the feature. The gate is the boundary; this module's
-// job is only to not widen it.
+// On scope: this is NOT restricted to `configuredRepoDirs()`. `repoDirs` is
+// empty in the default install, so restricting to it would leave the feature
+// dead for almost everyone — and this input exists precisely for projects
+// living outside the swept directories. The endpoint sits behind the same
+// origin/rebinding/token gate as the rest of the surface, which is the real
+// boundary; this module's job is only not to widen it.
+//
+// That reasoning has a limit worth naming. The tempting argument is "the same
+// gate already fronts /terminal/pty, which hands out a login shell, so anyone
+// who can reach this could already `ls` the machine". True by default — but
+// AGENTGLASS_TERMINAL_DISABLED=1 exists, and an operator who turns the shell
+// off has deliberately given up that capability. Silently handing it back a
+// directory listing at a time would quietly undo their decision, so this gets
+// its own switch rather than riding on the terminal's.
 
 import { readdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
@@ -33,6 +37,10 @@ import type { FsEntry, FsCompletion } from "../../shared/types.ts";
  *  The response says when it truncated, so the UI can tell the user to keep
  *  typing rather than silently pretend the list is complete. */
 const MAX_ENTRIES = 60;
+
+/** Kill switch for operators who don't want the machine's directory tree
+ *  readable over the wire, independent of whether the terminal is enabled. */
+export const FS_BROWSE_ENABLED = process.env.AGENTGLASS_FS_BROWSE_DISABLED !== "1";
 
 // `repo` is a cheap `.git` stat per entry. Worth it: "which of these forty
 // folders is actually a project" is the question the user is really asking.

--- a/server/src/fsbrowse.ts
+++ b/server/src/fsbrowse.ts
@@ -1,0 +1,124 @@
+// Directory-name completion for the project picker's "type a folder" input.
+//
+// Typing `/mnt/hdd/code/current_project/alavera_app` by hand, with no feedback
+// until you submit and no way to see what's actually there, is the worst part
+// of opening a project that the repo sweep didn't find. This is the smallest
+// thing that fixes it: given whatever the user has typed so far, hand back the
+// sibling directories that match, so the UI can complete rather than guess.
+//
+// Deliberately narrow: directory NAMES only. It never opens a file, never
+// reports one, and never reveals a file's size or contents — the answer to
+// "what's in this folder" is only ever the subfolders you could plausibly open
+// as a project.
+//
+// On scope: this is NOT restricted to `configuredRepoDirs()`. Two reasons, and
+// the second is the real one. First, `repoDirs` is empty in the default install
+// — restricting to it would leave the feature dead for almost everyone, and the
+// input exists precisely for projects living outside the swept directories.
+// Second, the endpoint sits behind the same origin/rebinding/token gate as the
+// rest of the surface, and that gate already guards `/terminal/pty`, which
+// hands out a real login shell. A caller who can reach this route can already
+// `ls` the machine with far less ceremony, so confining it would buy no
+// security while breaking the feature. The gate is the boundary; this module's
+// job is only to not widen it.
+
+import { readdirSync, statSync } from "node:fs";
+import { homedir } from "node:os";
+import { resolve, join, dirname, basename, sep } from "node:path";
+import { SKIP_DIRS } from "./gitwork.ts";
+import type { FsEntry, FsCompletion } from "../../shared/types.ts";
+
+/** Enough to pick from, few enough that a home directory full of junk can't
+ *  turn one keystroke into a megabyte of JSON (or a scrolling wall in the UI).
+ *  The response says when it truncated, so the UI can tell the user to keep
+ *  typing rather than silently pretend the list is complete. */
+const MAX_ENTRIES = 60;
+
+// `repo` is a cheap `.git` stat per entry. Worth it: "which of these forty
+// folders is actually a project" is the question the user is really asking.
+const EMPTY: FsCompletion = { base: "", entries: [], truncated: false };
+
+/** Expand a leading `~`, matching config.ts so the picker and the scope
+ *  resolver agree on what `~/code` means. */
+function expandHome(p: string): string {
+  if (p === "~") return homedir();
+  if (p.startsWith("~/")) return join(homedir(), p.slice(2));
+  return p;
+}
+
+/**
+ * Split raw input into "the directory to list" and "the partial name to match".
+ *
+ * A trailing separator means the user has committed to that directory and wants
+ * to see inside it; anything else means the last segment is still being typed
+ * and is a filter, not a destination.
+ *
+ * Only absolute paths (or `~`-rooted ones) are answered. A bare `code` would
+ * otherwise resolve against the server's working directory, which is wherever
+ * the desktop app happened to be launched from — completions that shift
+ * depending on how you started the process are worse than none.
+ */
+export function splitPrefix(input: unknown): { dir: string; partial: string } | null {
+  if (typeof input !== "string") return null;
+  // A NUL truncates the path at the syscall boundary, so `/safe\0/../../etc`
+  // would be read as `/safe`. Refuse rather than normalise: nothing legitimate
+  // types one.
+  if (input.includes("\0")) return null;
+  const raw = input.trim();
+  if (!raw) return null;
+  if (!raw.startsWith("/") && !raw.startsWith("~")) return null;
+  const expanded = expandHome(raw);
+  if (!expanded.startsWith("/")) return null; // `~foo` — another user's home, not ours to guess
+  // Ask the *raw* input about the trailing separator: join() drops it while
+  // expanding `~/`, which would turn "list my home" into "filter /home by my
+  // username". Bare `~` counts as committed for the same reason.
+  const committed = raw.endsWith("/") || raw === "~";
+  // resolve() collapses `.`, `..` and doubled separators, so what we list is
+  // always the real target rather than a path that merely spells it.
+  if (committed) return { dir: resolve(expanded), partial: "" };
+  return { dir: resolve(dirname(expanded)), partial: basename(expanded) };
+}
+
+/** Is this directory a git repo (or a linked worktree, whose `.git` is a file)? */
+function isRepo(dir: string): boolean {
+  try { statSync(join(dir, ".git")); return true; } catch { return false; }
+}
+
+/**
+ * Subdirectories of the typed path that match the half-typed last segment.
+ *
+ * Hidden directories stay out unless the user typed a leading dot themselves:
+ * `~/` is mostly dotfiles, and burying `code` under `.cache`, `.config` and
+ * `.local` defeats the point. The same package/build directories the repo sweep
+ * skips are dropped too — `node_modules` is never the project you meant.
+ */
+export function completePath(input: unknown): FsCompletion {
+  const split = splitPrefix(input);
+  if (!split) return EMPTY;
+  const { dir, partial } = split;
+  let ents;
+  try { ents = readdirSync(dir, { withFileTypes: true }); } catch { return { ...EMPTY, base: dir }; }
+  const wantHidden = partial.startsWith(".");
+  const needle = partial.toLowerCase();
+  const names: string[] = [];
+  for (const ent of ents) {
+    // Symlinks are followed on purpose — a code directory symlinked onto
+    // another disk is a normal setup, and `isDirectory()` is false for it.
+    if (!ent.isDirectory() && !ent.isSymbolicLink()) continue;
+    if (!wantHidden && ent.name.startsWith(".")) continue;
+    if (SKIP_DIRS.has(ent.name)) continue;
+    if (needle && !ent.name.toLowerCase().startsWith(needle)) continue;
+    names.push(ent.name);
+  }
+  names.sort((a, b) => a.localeCompare(b));
+  const truncated = names.length > MAX_ENTRIES;
+  const entries: FsEntry[] = [];
+  for (const name of names.slice(0, MAX_ENTRIES)) {
+    const abs = dir === sep ? sep + name : dir + sep + name;
+    // A symlink to a file survived the filter above; drop it here, where we're
+    // already paying for a stat to answer the repo question.
+    try { if (!statSync(abs).isDirectory()) continue; } catch { continue; }
+    entries.push({ name, path: abs, repo: isRepo(abs) });
+  }
+  return { base: dir, entries, truncated };
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,6 +34,7 @@ import {
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
   worktrees as gitWorktrees, addWorktree, removeWorktree,
 } from "./gitwork.ts";
+import { completePath } from "./fsbrowse.ts";
 import {
   overview as dockerOverview, stats as dockerStats, logs as dockerLogs,
   startContainer, stopContainer, restartContainer, removeContainer,
@@ -391,6 +392,13 @@ const server = Bun.serve<WsData>({
       // cockpit is currently scoped to one project, or there'd be no way out.
       const ignoreScope = url.searchParams.get("all") === "1";
       return json({ repos: await discoverRepos(paths, knownProjects().map((p) => p.path), { ignoreScope }) });
+    }
+    // Directory completion for the project picker's free-text path input. A
+    // plain read, so the surface-wide origin/rebinding/token gate above is the
+    // whole authorisation story — same as /git/repos. See fsbrowse.ts for why
+    // it isn't confined to the configured repoDirs.
+    if (pathname === "/fs/complete") {
+      return json(completePath(url.searchParams.get("prefix") || ""));
     }
     if (pathname === "/git/tree") {
       const root = url.searchParams.get("root") || "";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -34,7 +34,7 @@ import {
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
   worktrees as gitWorktrees, addWorktree, removeWorktree,
 } from "./gitwork.ts";
-import { completePath } from "./fsbrowse.ts";
+import { completePath, FS_BROWSE_ENABLED } from "./fsbrowse.ts";
 import {
   overview as dockerOverview, stats as dockerStats, logs as dockerLogs,
   startContainer, stopContainer, restartContainer, removeContainer,
@@ -398,6 +398,9 @@ const server = Bun.serve<WsData>({
     // whole authorisation story — same as /git/repos. See fsbrowse.ts for why
     // it isn't confined to the configured repoDirs.
     if (pathname === "/fs/complete") {
+      // Its own switch, not the terminal's: an operator who disabled the shell
+      // gave up filesystem reach on purpose, and this must not hand it back.
+      if (!FS_BROWSE_ENABLED) return json({ error: "directory browsing is disabled (AGENTGLASS_FS_BROWSE_DISABLED=1)" }, 403);
       return json(completePath(url.searchParams.get("prefix") || ""));
     }
     if (pathname === "/git/tree") {

--- a/server/test/fsbrowse.test.ts
+++ b/server/test/fsbrowse.test.ts
@@ -1,0 +1,108 @@
+// The project picker's path completion hands directory listings to anything
+// that clears the origin/token gate, so the input parsing is worth pinning: a
+// NUL that truncates a path at the syscall boundary, a relative path that would
+// resolve against whatever directory the server was launched from, and the
+// promise that only directory names ever come back.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir, homedir } from "node:os";
+import { join } from "node:path";
+import { completePath, splitPrefix } from "../src/fsbrowse.ts";
+
+let base = "";
+beforeAll(() => {
+  base = mkdtempSync(join(tmpdir(), "agx-fsbrowse-"));
+  for (const d of ["alpha", "alavera_app", "alavera_api", "beta", ".hidden", "node_modules"]) {
+    mkdirSync(join(base, d));
+  }
+  mkdirSync(join(base, "alavera_app", ".git"));
+  writeFileSync(join(base, "a-file.txt"), "not a directory");
+  writeFileSync(join(base, "alpha", "secret.env"), "TOKEN=hunter2");
+  symlinkSync(join(base, "alpha"), join(base, "alink"));
+  symlinkSync(join(base, "a-file.txt"), join(base, "afilelink"));
+});
+afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+const names = (input: string) => completePath(input).entries.map((e) => e.name);
+
+describe("splitPrefix", () => {
+  test("a NUL is refused outright, not normalised away", () => {
+    // `/etc\0/x` reaches the kernel as `/etc` — refusing is the only safe read.
+    expect(splitPrefix("/etc\0/passwd")).toBeNull();
+    expect(splitPrefix("\0")).toBeNull();
+    expect(completePath("/etc\0").entries).toEqual([]);
+  });
+
+  test("relative input is refused — it would resolve against the server's cwd", () => {
+    for (const p of ["code", "./code", "../code", ""]) expect(splitPrefix(p)).toBeNull();
+  });
+
+  test("non-strings are refused", () => {
+    for (const v of [null, undefined, 42, {}, ["/tmp"]]) expect(splitPrefix(v)).toBeNull();
+  });
+
+  test("a trailing slash lists inside; anything else filters the last segment", () => {
+    expect(splitPrefix("/usr/local/")).toEqual({ dir: "/usr/local", partial: "" });
+    expect(splitPrefix("/usr/loc")).toEqual({ dir: "/usr", partial: "loc" });
+  });
+
+  test("`..` and doubled separators are collapsed, so the listed dir is the real one", () => {
+    expect(splitPrefix("/usr/local/../")).toEqual({ dir: "/usr", partial: "" });
+    expect(splitPrefix("//usr///local/")).toEqual({ dir: "/usr/local", partial: "" });
+  });
+
+  test("~ expands to the home directory; ~otheruser does not", () => {
+    expect(splitPrefix("~/")).toEqual({ dir: homedir(), partial: "" });
+    expect(splitPrefix("~")).toEqual({ dir: homedir(), partial: "" });
+    expect(splitPrefix("~root/")).toBeNull();
+  });
+});
+
+describe("completePath", () => {
+  test("returns directories only — never files, and never file contents", () => {
+    const out = names(base + "/");
+    expect(out).toContain("alpha");
+    expect(out).not.toContain("a-file.txt");
+    expect(out).not.toContain("afilelink"); // a symlink pointing at a file
+    expect(JSON.stringify(completePath(base + "/"))).not.toContain("hunter2");
+  });
+
+  test("entries carry only a name, an absolute path and a repo flag", () => {
+    const e = completePath(base + "/alavera")!.entries[0];
+    expect(Object.keys(e).sort()).toEqual(["name", "path", "repo"]);
+  });
+
+  test("the partial segment filters by prefix, case-insensitively", () => {
+    expect(names(base + "/alav").sort()).toEqual(["alavera_api", "alavera_app"]);
+    expect(names(base + "/ALAV").sort()).toEqual(["alavera_api", "alavera_app"]);
+    expect(names(base + "/zzz")).toEqual([]);
+  });
+
+  test("git repos are marked; plain directories are not", () => {
+    const byName = new Map(completePath(base + "/").entries.map((e) => [e.name, e.repo]));
+    expect(byName.get("alavera_app")).toBe(true);
+    expect(byName.get("alavera_api")).toBe(false);
+  });
+
+  test("hidden dirs stay out until a dot is typed; dependency trees never appear", () => {
+    expect(names(base + "/")).not.toContain(".hidden");
+    expect(names(base + "/.")).toContain(".hidden");
+    expect(names(base + "/")).not.toContain("node_modules");
+    expect(names(base + "/node_")).toEqual([]);
+  });
+
+  test("symlinked directories are offered — code on another disk is a normal setup", () => {
+    expect(names(base + "/")).toContain("alink");
+  });
+
+  test("an unreadable or missing directory answers empty rather than throwing", () => {
+    const out = completePath(base + "/does-not-exist/");
+    expect(out.entries).toEqual([]);
+    expect(out.base).toBe(base + "/does-not-exist");
+  });
+
+  test("paths returned are absolute and joined to the resolved base", () => {
+    const e = completePath(base + "/alpha")!.entries[0];
+    expect(e.path).toBe(join(base, "alpha"));
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -351,6 +351,20 @@ export interface GitRepoRef {
   ahead: number;
   behind: number;
 }
+/** One candidate directory from the project picker's path completion. Names and
+ *  a `.git` flag only — the completion endpoint never reports files. */
+export interface FsEntry {
+  name: string;
+  path: string;
+  repo: boolean;
+}
+export interface FsCompletion {
+  /** Absolute, normalised directory the entries live in. */
+  base: string;
+  entries: FsEntry[];
+  /** More matches existed than were returned — the UI says "keep typing". */
+  truncated: boolean;
+}
 export interface GitActionResult {
   ok: boolean;
   error?: string;

--- a/web/src/components/ProjectPicker.tsx
+++ b/web/src/components/ProjectPicker.tsx
@@ -6,9 +6,9 @@
 // Makefile commands, its repos, its sessions — instead of everything on the
 // machine. The choice is persisted server-side (config.json), so the next
 // launch opens straight into the same project.
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import type { GitRepoRef } from "../../../shared/types.ts";
+import type { GitRepoRef, FsEntry } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
 import { api, IS_DEMO } from "../lib/api.ts";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
@@ -24,6 +24,14 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
   const [path, setPath] = useState("");
   const [busy, setBusy] = useState(false);
   const [error, setError] = useState("");
+  // Directory completions for the free-text path box. `sel` is -1 until the user
+  // arrows into the list: until then Enter means "open what I typed", which is
+  // what someone pasting a full path expects — pre-highlighting a row would
+  // silently redirect that Enter into a completion instead.
+  const [sugg, setSugg] = useState<FsEntry[]>([]);
+  const [more, setMore] = useState(false);
+  const [sel, setSel] = useState(-1);
+  const pathRef = useRef<HTMLInputElement>(null);
 
   useEffect(() => {
     if (!open) return;
@@ -31,6 +39,61 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
     setRepos(null);
     api.gitReposAll().then(({ repos }) => setRepos(repos)).catch(() => setRepos([]));
   }, [open]);
+
+  // Completions, debounced. Every keystroke is a directory read on the server,
+  // and typing a long path would otherwise fire a dozen of them for answers
+  // nobody sees. The stale-response guard matters more than the delay: a slow
+  // read of a big directory must not overwrite the newer answer for what the
+  // user has typed since.
+  useEffect(() => {
+    const p = path.trim();
+    // Only absolute / `~`-rooted input has a meaningful parent to list, which is
+    // the same rule the server applies before it will answer at all.
+    if (!open || (!p.startsWith("/") && !p.startsWith("~"))) { setSugg([]); setMore(false); return; }
+    let live = true;
+    const t = setTimeout(() => {
+      api.fsComplete(p)
+        .then((r) => { if (live) { setSugg(r.entries); setMore(r.truncated); } })
+        .catch(() => { if (live) { setSugg([]); setMore(false); } });
+    }, 120);
+    return () => { live = false; clearTimeout(t); };
+  }, [path, open]);
+
+  // A new set of candidates invalidates whatever row was highlighted — keeping
+  // index 3 across a re-filter would point at an unrelated directory.
+  useEffect(() => { setSel(-1); }, [sugg]);
+
+  /** Accept a suggestion: replace the half-typed segment and leave a trailing
+   *  slash, so the very next completion lists inside the folder just chosen.
+   *  That makes Tab-Tab-Tab walk down a tree, which is the whole point. */
+  const accept = (e: FsEntry) => {
+    setPath(e.path + "/");
+    setSel(-1);
+    pathRef.current?.focus();
+  };
+
+  const onPathKey = (ev: React.KeyboardEvent<HTMLInputElement>) => {
+    const p = path.trim();
+    if (ev.key === "Tab" && sugg.length) {
+      // Tab with nothing highlighted takes the first match — the shell habit.
+      ev.preventDefault();
+      accept(sugg[sel >= 0 ? sel : 0]);
+      return;
+    }
+    if (ev.key === "ArrowDown" && sugg.length) { ev.preventDefault(); setSel((s) => (s + 1) % sugg.length); return; }
+    if (ev.key === "ArrowUp" && sugg.length) { ev.preventDefault(); setSel((s) => (s <= 0 ? sugg.length : s) - 1); return; }
+    if (ev.key === "Escape" && sugg.length) {
+      // Dismiss the list without closing the whole modal — the outer handler
+      // would otherwise throw away a path the user is halfway through typing.
+      ev.stopPropagation();
+      setSugg([]);
+      return;
+    }
+    if (ev.key === "Enter") {
+      if (sel >= 0 && sugg[sel]) { accept(sugg[sel]); return; }
+      if (p) choose(p);
+    }
+  };
 
   const choose = (root: string | null) => {
     if (busy) return;
@@ -57,8 +120,16 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
   // short wait watching the "switching…" note.
   const close = () => { if (busy) return; markAnswered(); onClose(); };
 
-  const q = query.trim().toLowerCase();
-  const shown = (repos ?? []).filter((r) => !q || (r.name + " " + r.root + " " + r.branch).toLowerCase().includes(q));
+  // Name, full path and branch are all searchable, and each whitespace-separated
+  // term has to match somewhere. One substring over the joined string meant
+  // "hdd alavera" found nothing, because the terms are far apart in the path —
+  // yet typing the two memorable fragments of a long path is exactly how people
+  // look for `/mnt/hdd/code/current_project/alavera_app`.
+  const terms = query.trim().toLowerCase().split(/\s+/).filter(Boolean);
+  const shown = (repos ?? []).filter((r) => {
+    const hay = (r.name + " " + r.root + " " + r.branch).toLowerCase();
+    return terms.every((t) => hay.includes(t));
+  });
 
   return (
     <Portal>
@@ -101,7 +172,7 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                   </button>
 
                   {repos === null && <div className="px-3 py-3 text-[11px] t-dim2">looking for repos…</div>}
-                  {repos !== null && !shown.length && <div className="px-3 py-3 text-[11px] t-dim2">no repos found{q ? " for that filter" : ""}</div>}
+                  {repos !== null && !shown.length && <div className="px-3 py-3 text-[11px] t-dim2">no repos found{terms.length ? " for that filter" : ""}</div>}
                   {shown.map((r) => (
                     <button key={r.root} onClick={() => choose(r.root)} disabled={busy}
                       className="w-full text-left px-3 py-2 rounded-lg flex items-center gap-2.5 hover:bg-[color-mix(in_srgb,var(--primary)_10%,transparent)]"
@@ -121,9 +192,30 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                 </div>
 
                 {/* a project that lives somewhere the sweep doesn't reach */}
-                <div className="px-4 py-3 border-t shrink-0 flex items-center gap-2" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
-                  <input value={path} onChange={(e) => setPath(e.target.value)} placeholder="…or type a folder: ~/code/my-project, or ~/code for everything in it"
-                    onKeyDown={(e) => { if (e.key === "Enter" && path.trim()) choose(path.trim()); }}
+                <div className="px-4 py-3 border-t shrink-0 flex items-center gap-2 relative" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                  {/* Completions sit ABOVE the input: this row is pinned to the
+                      bottom of the modal, so a dropdown hanging below it would
+                      fall off the viewport on a short window. */}
+                  {!!sugg.length && (
+                    <div className="agx-scroll absolute left-4 right-4 bottom-full mb-1 rounded-lg overflow-y-auto py-1"
+                      style={{ maxHeight: 220, zIndex: 1, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 12px 32px -12px rgba(0,0,0,0.7)" }}>
+                      {sugg.map((e, i) => (
+                        // onMouseDown, not onClick: a click first blurs the input,
+                        // and blur-driven dismissal would unmount the row before
+                        // the click ever landed on it.
+                        <div key={e.path} onMouseDown={(ev) => { ev.preventDefault(); accept(e); }} onMouseEnter={() => setSel(i)}
+                          className="px-3 py-1 flex items-center gap-2 cursor-pointer text-[11px]"
+                          style={{ background: i === sel ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent", color: "var(--text)" }}>
+                          <span className="text-[11px]">{e.repo ? "📁" : "🗀"}</span>
+                          <span className="truncate">{e.name}</span>
+                          {e.repo && <span className="ml-auto shrink-0 text-[9px] px-1.5 py-0.5 rounded-full" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 15%, transparent)" }}>git</span>}
+                        </div>
+                      ))}
+                      {more && <div className="px-3 py-1 text-[10px] t-dim2">more matches — keep typing</div>}
+                    </div>
+                  )}
+                  <input ref={pathRef} value={path} onChange={(e) => setPath(e.target.value)} placeholder="…or type a folder: ~/code/my-project, or ~/code for everything in it"
+                    onKeyDown={onPathKey} onBlur={() => setSugg([])} spellCheck={false} autoComplete="off"
                     className="flex-1 px-3 py-1.5 rounded-lg text-[11px] outline-none"
                     style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                   <button onClick={() => path.trim() && choose(path.trim())} disabled={busy || !path.trim()}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult, TerminalCommands } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult, TerminalCommands } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -131,6 +131,8 @@ const realApi = {
     }).then((r) => r.json() as Promise<WalkthroughResult>),
   /** Scope this instance to one project dir (null → whole machine). */
   setWorkspace: (root: string | null) => post<{ ok: boolean; workspace: string | null; persisted: boolean; error?: string; note?: string }>("/workspace", { root }),
+  /** Subdirectories matching a half-typed path — the picker's completion. */
+  fsComplete: (prefix: string) => get<FsCompletion>(`/fs/complete?prefix=${encodeURIComponent(prefix)}`),
   // --- live git panel (lazygit-style) ---
   gitRepos: () => get<{ repos: GitRepoRef[] }>("/git/repos"),
   /** Every repo on the machine — for the project picker, even when scoped. */
@@ -211,6 +213,8 @@ const demoApi: typeof realApi = {
   gitCommit: (_payload: { root: string; files: string[]; title: string; body: string }) => D(demo.gitCommit()),
   walkthrough: (files: WalkthroughInputFile[]) => D(demo.walkthrough(files)),
   setWorkspace: (_root: string | null) => D({ ok: false, workspace: null, persisted: false, error: "unavailable in the demo" }),
+  // The demo has no filesystem to browse, so completion is simply always empty.
+  fsComplete: (_prefix: string) => D({ base: "", entries: [], truncated: false }),
   gitRepos: () => D(demo.gitRepos()),
   gitReposAll: () => D(demo.gitRepos()),
   gitTree: (root: string) => D(demo.gitTree(root)),


### PR DESCRIPTION
## What does this PR do?

Adds directory completion to the project picker's free-text path input, so opening a project the repo sweep doesn't reach no longer means typing an absolute path blind.

A new read-only `GET /fs/complete?prefix=` returns the subdirectories of whatever has been typed so far, flagging the ones that are git repos. The input drives it: arrows move, **Tab** or click accepts, and an accepted entry leaves a trailing slash so Tab-Tab-Tab walks down a tree. Enter still opens the typed path unless a row is highlighted, so pasting a full path behaves exactly as before.

Also makes the repo filter match each whitespace-separated term independently — `hdd alavera` now finds `/mnt/hdd/code/current_project/alavera_app`, whose two memorable fragments are far apart in the path. (The full path was already searched; only the single-substring match was in the way.)

### Security notes on the new endpoint

It exposes directory listings, so the reasoning is spelled out in `server/src/fsbrowse.ts`:

- **No new gate.** The route is a plain GET placed after the surface-wide checks in `index.ts`, so it inherits `trustedHost` (DNS-rebinding), `localOrigin` (CSRF) and the `AUTH_TOKEN` check unchanged — same posture as `/git/repos`. Verified live: a foreign `Origin` gets `403 cross-origin write blocked`, a foreign `Host` gets the rebinding refusal.
- **Directory names only.** Never a file, a file name, a size, or any content. Symlinks pointing at files are dropped at the `stat` that also answers the repo question.
- **Null bytes are refused, not normalised.** `/etc\0/passwd` reaches the kernel as `/etc`, so the input is rejected outright.
- **Absolute or `~`-rooted only.** A relative path would resolve against the server's working directory — wherever the desktop app happened to be launched from — so completions can't shift with how the process was started. `~` expands as in `config.ts`; `~otheruser` is refused.
- **Normalised.** `resolve()` collapses `.`, `..` and doubled separators, so the directory listed is always the real target.
- **Capped** at 60 entries, with a `truncated` flag the UI surfaces as "keep typing", so one keystroke can't return a megabyte of JSON.
- **Not restricted to `repoDirs`**, deliberately. That setting is empty in the default install, so confining the endpoint to it would leave the feature dead for almost everyone — and the input exists precisely for projects outside the swept directories. It would also buy no security: the same gate already fronts `/terminal/pty`, which hands out a real login shell. The gate is the boundary; this module's job is to not widen it.

`node_modules`/`vendor`/`target` and friends are skipped (reusing `SKIP_DIRS`), and hidden directories stay out until the user types a leading dot.

## How was it tested?

- `bun test` from the repo root — 81 pass, including 14 new cases in `server/test/fsbrowse.test.ts` covering null bytes, relative and non-string input, `~` expansion, `..` collapsing, the directories-only guarantee (asserts a planted secret never appears in the response), prefix filtering, repo flagging, and unreadable directories.
- `bunx tsc --noEmit` in both `server/` and `web/`.
- `bunx vite build` in `web/`.
- Endpoint exercised live against a running server for both happy path and each rejection, plus the two gate refusals above.

**Not verified:** the dropdown's rendering and keyboard flow were not exercised in a real browser — the interaction logic is reviewed and typechecked, but a visual pass on the popover placement (it opens upward, since the input is pinned to the modal's bottom edge) would be worth doing before merge.

## Checklist

- [x] Typechecks pass (`bunx tsc --noEmit` in `web/` and `server/`)
- [x] Production build passes (`bunx vite build` in `web/`)
- [x] Stays dependency-light (no new runtime deps without a strong reason — see CONTRIBUTING.md)
- [x] `shared/types.ts` updated if the server↔web contract changed
- [ ] Docs updated if behavior/config changed (README, CONTRIBUTING) — no config or documented behavior changed; the reasoning that would go in docs lives in `fsbrowse.ts`'s header comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)