### PR TITLE
feat(session): read one subagent's thread on its own

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ src-tauri/target/
 src-tauri/bin/
 src-tauri/icon-*.png
 src-tauri/gen/schemas/
+.claude/

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -892,17 +892,17 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     return head.slice(0, at > MSG_MAX * 0.8 ? at : MSG_MAX) + "\n\n…[truncated]";
   };
 
-  const convo: { role: "user" | "assistant"; text: string; ts: number }[] = [];
+  const convo: { role: "user" | "assistant"; text: string; ts: number; agent_id?: string | null; agent_type?: string | null }[] = [];
   for (const r of db.query<{ timestamp: number; payload: string }, [string]>(
     `SELECT timestamp, payload FROM events WHERE session_id = ? AND hook_event_type='UserPromptSubmit' ORDER BY timestamp DESC LIMIT 40`).all(sessionId)) {
     try { const p = JSON.parse(r.payload); if (p.prompt) convo.push({ role: "user", text: clip(String(p.prompt)), ts: r.timestamp }); } catch { /* skip */ }
   }
   let lastMsg = "";
-  for (const r of db.query<{ timestamp: number; payload: string }, [string]>(
-    `SELECT timestamp, payload FROM events WHERE session_id = ? AND payload LIKE '%last_assistant_message%' ORDER BY timestamp DESC LIMIT 60`).all(sessionId)) {
+  for (const r of db.query<{ timestamp: number; payload: string; agent_id: string | null; agent_type: string | null }, [string]>(
+    `SELECT timestamp, payload, agent_id, agent_type FROM events WHERE session_id = ? AND payload LIKE '%last_assistant_message%' ORDER BY timestamp DESC LIMIT 60`).all(sessionId)) {
     try {
       const m = JSON.parse(r.payload).last_assistant_message;
-      if (m && m !== lastMsg) { convo.push({ role: "assistant", text: clip(String(m)), ts: r.timestamp }); lastMsg = m; }
+      if (m && m !== lastMsg) { convo.push({ role: "assistant", text: clip(String(m)), ts: r.timestamp, agent_id: r.agent_id, agent_type: r.agent_type }); lastMsg = m; }
     } catch { /* skip */ }
   }
   convo.sort((a, b) => b.ts - a.ts);
@@ -937,13 +937,13 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
   };
 
   const timeline: import("../../shared/types.ts").TimelineEntry[] =
-    kept.map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text }));
+    kept.map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text, agent_id: c.agent_id, agent_type: c.agent_type }));
 
   // Bounded to the same window the messages cover, so the timeline can't be
   // dominated by tool noise from turns whose text was already dropped.
   const oldest = kept.length ? Math.min(...kept.map((c) => c.ts)) : 0;
-  for (const r of db.query<{ timestamp: number; tool_name: string | null; is_error: number; duration_ms: number | null; tool_use_id: string | null; payload: string }, [string, number]>(
-    `SELECT timestamp, tool_name, is_error, duration_ms, tool_use_id, payload FROM events
+  for (const r of db.query<{ timestamp: number; tool_name: string | null; is_error: number; duration_ms: number | null; tool_use_id: string | null; agent_id: string | null; agent_type: string | null; payload: string }, [string, number]>(
+    `SELECT timestamp, tool_name, is_error, duration_ms, tool_use_id, agent_id, agent_type, payload FROM events
       WHERE session_id = ? AND hook_event_type IN ('PostToolUse','PostToolUseFailure')
         AND timestamp >= ?
       ORDER BY timestamp DESC LIMIT 400`).all(sessionId, oldest)) {
@@ -958,6 +958,8 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
       is_error: !!r.is_error,
       duration_ms: r.duration_ms,
       tool_use_id: r.tool_use_id,
+      agent_id: r.agent_id,
+      agent_type: r.agent_type,
     });
   }
   timeline.sort((a, b) => b.ts - a.ts);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -237,6 +237,14 @@ export interface TimelineEntry {
   /** Links a tool run to its diff in `changes`, so an edit can show what it
    *  changed rather than only that it happened. */
   tool_use_id?: string | null;
+  /** Which subagent produced this, when it wasn't the main thread.
+   *
+   *  Subagent turns report the *parent's* session id, so everything a fleet of
+   *  them does lands on one timeline. Without this tag those runs are
+   *  indistinguishable from the main thread's, and four agents working in
+   *  parallel read as one very busy one. */
+  agent_id?: string | null;
+  agent_type?: string | null;
 }
 
 export interface SessionDetail {

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -480,10 +480,14 @@ export function ThemePicker({ value, onChange }: { value: string; onChange: (v: 
         <span className="truncate" style={{ maxWidth: 92 }}>{label}</span>
         <span style={{ opacity: 0.6, fontSize: 8 }}>▼</span>
       </button>
+      {/* zIndex must beat the diff's sticky hunk headers, which are also z-20:
+          on a tie the later-painted element wins, so those headers were
+          striping grey bars across this list wherever a `@@ … @@` line sat
+          behind it. */}
       {open && (
         <div
           className="agx-scroll absolute right-0 mt-1 rounded-lg py-1 text-[10.5px] shadow-2xl"
-          style={{ zIndex: 20, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 178, maxHeight: 340, overflowY: "auto" }}
+          style={{ zIndex: 40, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 178, maxHeight: 340, overflowY: "auto" }}
         >
           <Row id="auto" name="Auto (app theme)" />
           <div className="px-2.5 pt-1.5 pb-0.5 text-[8.5px] uppercase tracking-wider t-dim2">Dark</div>

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -61,9 +61,10 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
   const [diffOpen, setDiffOpen] = useState(false);
   const [diffPath, setDiffPath] = useState<string | undefined>(undefined);
   const [showTools, setShowTools] = useState(true);
+  const [focusAgent, setFocusAgent] = useState<string | null>(null);
 
   useEffect(() => {
-    if (!sessionId) { setD(null); setDiffOpen(false); return; }
+    if (!sessionId) { setD(null); setDiffOpen(false); setFocusAgent(null); return; }
     setLoading(true);
     api.session(sessionId).then((s) => { setD(s); setLoading(false); }).catch(() => { setD(null); setLoading(false); });
   }, [sessionId]);
@@ -98,7 +99,12 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
     ? d.timeline
     : (d?.conversation ?? []).map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text }));
   const toolCount = entries.reduce((n, e) => n + (e.kind === "tool" ? 1 : 0), 0);
-  const timeline = [...entries].reverse().filter((e) => showTools || e.kind !== "tool");
+  // Subagents report the parent's session id, so a fleet of them lands on this
+  // one timeline. Focusing one is the only way to read what it actually did
+  // without its work being shuffled together with three siblings'.
+  const timeline = [...entries].reverse()
+    .filter((e) => showTools || e.kind !== "tool")
+    .filter((e) => !focusAgent || e.agent_id === focusAgent);
 
   return (
     <Portal>
@@ -196,14 +202,33 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                         </div>
                         <div>
                           <div className="panel-eyebrow mb-2">Subagents · {d.subagents.length}</div>
+                          {/* Clickable: a subagent's work is buried in the
+                              parent's timeline because it reports the parent's
+                              session id, so focusing one is the only way to read
+                              it as its own thread. */}
                           <div className="flex flex-wrap gap-1.5">
-                            {d.subagents.map((s) => (
-                              <span key={s.agent_id} className="chip" style={{ color: "var(--info)", background: "color-mix(in srgb, var(--info) 12%, transparent)" }} title={s.agent_id}>
-                                {shortType(s.agent_type)} · {s.events}
-                              </span>
-                            ))}
+                            {d.subagents.map((s) => {
+                              const on = focusAgent === s.agent_id;
+                              return (
+                                <button key={s.agent_id} onClick={() => setFocusAgent(on ? null : s.agent_id)}
+                                  className="chip cursor-pointer"
+                                  title={on ? `${s.agent_id}\nclick to show the whole session again` : `${s.agent_id}\nclick to read only this subagent's thread`}
+                                  style={{
+                                    color: on ? "var(--bg)" : "var(--info)",
+                                    background: on ? "var(--info)" : "color-mix(in srgb, var(--info) 12%, transparent)",
+                                    borderColor: `color-mix(in srgb, var(--info) ${on ? 80 : 30}%, transparent)`,
+                                  }}>
+                                  {shortType(s.agent_type)} · {s.events}
+                                </button>
+                              );
+                            })}
                             {d.subagents.length === 0 && <div className="t-dim2 text-[11px]">none</div>}
                           </div>
+                          {focusAgent && (
+                            <button onClick={() => setFocusAgent(null)} className="mt-2 text-[10px] t-dim2 hover:opacity-70">
+                              ← showing one subagent · back to the whole session
+                            </button>
+                          )}
                         </div>
                         <div>
                           <div className="panel-eyebrow mb-2 flex items-center gap-2">


### PR DESCRIPTION
## What does this PR do?

A subagent reports its **parent's** session id, so everything a fleet of them does lands on a single timeline. Four agents working in parallel read as one improbably busy agent — their edits, commands and replies shuffled together in timestamp order — and the dashboard counts them as one session, because that is what they are.

The events already carried `agent_id` and `agent_type`. Nothing exposed them.

They now ride on each `TimelineEntry`, and the subagent chips became buttons: click one to filter the thread to that agent alone, click again (or the explicit "back to the whole session" link) to widen out.

## Why filtering, not a separate view

The interleaved timeline is the honest picture of a session, and a subagent's work only makes sense against the parent that dispatched it. A separate view would imply an independence these agents don't have.

Focus resets when the modal moves to another session, so a filter can't silently follow you into a different thread.

## Verified against real data

Checked a live server before building: 268 events across 3 distinct `agent_id`s in one session, matching the three worktree agents actually running at the time. The data was fully present and simply unexposed.

## How was it tested?

- `bun test` — 67 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean

Visual change; worth opening a session that dispatched subagents.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` updated — `agent_id` / `agent_type` on `TimelineEntry`
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)