### PR TITLE
fix(chat): show the conversation you just resumed

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -436,9 +436,21 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                         </div>
                       )}
                       {active?.messages.map((m, i) => (
-                        <div key={i} className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
+                        <div key={i}>
+                          {/* The seam between what was said before this panel
+                              adopted the session and what is being said in it
+                              now — without it, replayed history reads as though
+                              you had typed it here. */}
+                          {m.historical && !active.messages[i + 1]?.historical && (
+                            <div className="flex items-center gap-2 my-3 text-[9.5px] uppercase tracking-wider t-dim2">
+                              <span className="flex-1 h-px" style={{ background: "color-mix(in srgb, var(--border) 45%, transparent)" }} />
+                              <span>resumed here</span>
+                              <span className="flex-1 h-px" style={{ background: "color-mix(in srgb, var(--border) 45%, transparent)" }} />
+                            </div>
+                          )}
+                          <div className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
                           <div className="max-w-[86%] min-w-0 rounded-xl px-3.5 py-2.5 text-[12px] leading-relaxed break-words"
-                            style={{ ...CODE_FONT_STYLE, fontFamily: undefined, background: m.role === "user" ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "color-mix(in srgb, var(--bg3) 45%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", color: "var(--text)" }}>
+                            style={{ ...CODE_FONT_STYLE, fontFamily: undefined, opacity: m.historical ? 0.72 : 1, background: m.role === "user" ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "color-mix(in srgb, var(--bg3) 45%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", color: "var(--text)" }}>
                             {m.tools.length > 0 && (
                               <div className="flex flex-wrap gap-1 mb-1.5">
                                 {m.tools.map((t, j) => <span key={j} className="text-[9.5px] px-1.5 py-0.5 rounded" style={{ ...CODE_FONT_STYLE, color: "var(--info)", background: "color-mix(in srgb, var(--info) 12%, transparent)" }}>⚙ {t}</span>)}
@@ -446,6 +458,7 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                             )}
                             {m.text ? <Markdown text={m.text} /> : (m.streaming ? <span className="t-dim2">▍</span> : "")}
                             {m.streaming && m.text && <span className="t-dim2">▍</span>}
+                          </div>
                           </div>
                         </div>
                       ))}

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -7,7 +7,16 @@
 
 import { api } from "./api.ts";
 
-export type ChatMsg = { role: "user" | "assistant"; text: string; tools: string[]; streaming?: boolean };
+export type ChatMsg = {
+  role: "user" | "assistant";
+  text: string;
+  tools: string[];
+  streaming?: boolean;
+  /** Replayed from the session's transcript when this chat adopted an existing
+   *  session, rather than said in this panel. Marked so the UI can draw the
+   *  seam — and so it's clear these were not sent from here. */
+  historical?: boolean;
+};
 
 export type Chat = {
   id: string;
@@ -67,7 +76,37 @@ export function newChat(
   };
   chats.set(id, chat);
   emit();
+  // Resuming leaves `claude` holding the whole conversation while this panel
+  // holds none of it, so an adopted session opened as a blank canvas — the
+  // model knew everything and the user could see nothing, which reads as the
+  // resume having silently failed. Replay the transcript we already store so
+  // the thread you are continuing is actually in front of you.
+  if (resume?.sessionId) void hydrate(id, resume.sessionId);
   return chat;
+}
+
+/** Fill a resumed chat with the session's existing conversation.
+ *
+ *  Best-effort and non-blocking: the chat is usable the moment it opens, and a
+ *  failure here costs history on screen, not the ability to continue — `claude`
+ *  still has the real context either way. */
+async function hydrate(chatId: string, sessionId: string) {
+  try {
+    const s = await api.session(sessionId);
+    if (!s) return;
+    // Oldest-first, matching how the panel reads. Tool runs are left out: this
+    // is the conversation view, and the session modal already renders the full
+    // interleaved timeline for anyone who wants the machinery.
+    const msgs: ChatMsg[] = [...(s.conversation ?? [])]
+      .sort((a, b) => a.ts - b.ts)
+      .map((c) => ({ role: c.role, text: c.text, tools: [], historical: true }));
+    if (!msgs.length) return;
+    update(chatId, (c) => {
+      // Anything typed while this was in flight stays last — the reply to a
+      // resumed thread must not end up above the thread it replies to.
+      c.messages = [...msgs, ...c.messages];
+    });
+  } catch { /* history is a nicety; the resume itself still works */ }
 }
 
 /** An existing chat already resuming this claude session, if any — so asking to


### PR DESCRIPTION
## What does this PR do?

Resuming an existing session opened a **blank panel**. `claude --resume` hands the model the entire history, so it answers as though it remembers everything — but the panel held none of it. An empty canvas with a session id in the corner reads as a resume that silently failed; you had to type into nothing and hope.

The transcript is already stored and already served by `/session`, so the chat now replays it on adopt.

- **Messages only.** This is the conversation view; the session modal already renders the full interleaved timeline (#57) for anyone who wants the tool runs.
- **Replayed turns are dimmed, with a `resumed here` divider.** Without that seam the history reads as though it had been typed in this panel — and it wasn't. Nothing above the line was sent from here.
- **Best-effort and non-blocking.** The chat is usable the moment it opens; a failure costs history on screen, not the ability to continue, since `claude` holds the real context either way. Anything typed while the fetch is in flight stays below the replayed turns.

## Context

Follows #50 (resume from the session modal) and #61 (resume from the Chats panel). Both shipped the mechanism; this makes the result legible. Found by actually clicking "resume in chat" — the wiring was correct and the experience was still wrong.

## How was it tested?

- `bun test` — 97 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean

Not exercised against a live `claude` process (real billed session). The hydration path itself only reads `/session`, which is unchanged.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)