### PR TITLE
fix(terminal): don't leak Python's ignored SIGPIPE into the panel's shell

### DIFF
--- a/server/src/pty_bridge.py
+++ b/server/src/pty_bridge.py
@@ -21,12 +21,35 @@ import sys
 import termios
 
 
+# Signals CPython sets to SIG_IGN for its own convenience at interpreter
+# startup. An ignored disposition is one of the few things that survives
+# execve, so without this the user's shell — and every command they run in the
+# panel — would start with SIGPIPE ignored, which a real terminal never does.
+# The visible symptom is a pipeline whose reader exits early (`history | sed
+# -n 1p`, `... | head`): instead of the writer dying quietly on SIGPIPE it gets
+# EPIPE back and prints "write error: Broken pipe".
+_INHERITED_IGNORES = ("SIGPIPE", "SIGXFSZ", "SIGXCPU", "SIGTTIN", "SIGTTOU")
+
+
+def reset_signals() -> None:
+    """Hand the shell the clean signal slate a terminal emulator would."""
+    for name in _INHERITED_IGNORES:
+        sig = getattr(signal, name, None)
+        if sig is None:
+            continue  # not on this platform
+        try:
+            signal.signal(sig, signal.SIG_DFL)
+        except (OSError, ValueError):
+            pass  # unresettable here — better a stray ignore than no shell
+
+
 def main() -> int:
     cmd = sys.argv[1:] or [os.environ.get("SHELL", "bash"), "-i"]
     size_file = os.environ.get("AGENTGLASS_PTY_SIZE_FILE", "")
 
     pid, fd = pty.fork()
     if pid == 0:  # child: become the shell, attached to the pty slave
+        reset_signals()
         try:
             os.execvp(cmd[0], cmd)
         except OSError as e:

--- a/server/test/pty-signals.test.ts
+++ b/server/test/pty-signals.test.ts
@@ -1,0 +1,27 @@
+// The shell the PTY bridge starts must get the same signal dispositions a
+// terminal emulator would give it. CPython ignores SIGPIPE (and friends) for
+// its own convenience, and an ignored disposition survives execve — so without
+// an explicit reset the panel's shell, and every command run in it, would see
+// EPIPE where a real terminal sees a quiet death on SIGPIPE.
+import { describe, expect, test } from "bun:test";
+import { join } from "node:path";
+
+const BRIDGE = join(import.meta.dir, "..", "src", "pty_bridge.py");
+const PYTHON = Bun.which("python3") || Bun.which("python");
+
+describe.if(!!PYTHON && process.platform === "linux")("pty bridge signal hygiene", () => {
+  test("the shell starts with no inherited ignored signals", async () => {
+    const proc = Bun.spawn([PYTHON!, BRIDGE, "sh", "-c", "grep SigIgn /proc/self/status"], {
+      stdin: "pipe",
+      stdout: "pipe",
+      stderr: "pipe",
+    });
+    const out = await new Response(proc.stdout).text();
+    proc.kill();
+    // The bridge relays the pty verbatim, so the grep line arrives with the
+    // terminal's CRLF; only the mask itself matters.
+    const mask = out.match(/SigIgn:\s*([0-9a-f]+)/)?.[1];
+    expect(mask).toBeDefined();
+    expect(BigInt(`0x${mask}`)).toBe(0n);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`pty_bridge.py` handed the user's shell a signal slate no real terminal would. CPython sets `SIGPIPE` (and `SIGXFSZ`) to `SIG_IGN` at interpreter startup, and an ignored disposition is one of the few things that survives `execve` — so the shell exec'd inside the pty, and every command run in the terminal panel, started with `SIGPIPE` ignored. Measured on the shell the bridge starts: `SigIgn: 0000000001001000`, where the `script` fallback and a real terminal emulator both give `0`.

The consequence is that any pipeline whose reader exits early gets `EPIPE` back instead of dying quietly on `SIGPIPE`, and complains. The report that led here was four `bash: history: write error: Broken pipe` lines after *every* prompt: [ble.sh](https://github.com/akinomyoga/ble.sh) reads the first history entry with `builtin history | sed -n '1{p;q;}'`, `sed` quits after line 1, and a 12k-line `~/.bash_history` is still being written when it does. It reproduced only under the `pty_bridge.py` path, never under the `script` fallback — which is what isolated the cause to the inherited disposition rather than to the pty, the controlling terminal, or the shell config.

The child now resets those ignores to `SIG_DFL` before `exec`.

## How was it tested?

- Reproduced end-to-end first, driving `ws://127.0.0.1:<port>/terminal/pty` against a server on a throwaway DB: `make help` printed the four `Broken pipe` lines per prompt before, zero after.
- Bisected the cause with an identical harness over both PTY backends — `pty_bridge.py` reproduced, util-linux `script` did not — then confirmed the mask difference directly via `/proc/self/status`.
- New `server/test/pty-signals.test.ts` asserts the shell's `SigIgn` mask is empty; verified it fails with the reset removed and passes with it.
- `bun test` (98 pass), `bunx tsc --noEmit` in both `server/` and `web/`.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)