### PR TITLE
fix(diff): recover visibly when a syntax theme fails to load

### DIFF
--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -446,7 +446,7 @@ function GroupBlock({ g, collapsed, selId, reviewed, descMap, onToggleCollapse, 
 // --- controls ----------------------------------------------------------------
 // Syntax-theme dropdown (Shiki). "auto" follows the app's light/dark; the rest
 // mirror the user's Neovim themes. Grouped dark/light, closes on outside click.
-export function ThemePicker({ value, onChange }: { value: string; onChange: (v: string) => void }) {
+export function ThemePicker({ value, onChange, error }: { value: string; onChange: (v: string) => void; error?: string | null }) {
   const [open, setOpen] = useState(false);
   const ref = useRef<HTMLDivElement>(null);
   useEffect(() => {
@@ -473,10 +473,18 @@ export function ThemePicker({ value, onChange }: { value: string; onChange: (v: 
     <div ref={ref} className="relative">
       <button
         onClick={() => setOpen((o) => !o)}
-        title="Syntax theme"
+        title={error || "Syntax theme"}
         className="px-2 py-0.5 rounded-md text-[10px] transition-colors flex items-center gap-1"
-        style={{ background: "color-mix(in srgb, var(--bg3) 45%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", color: "var(--text3)" }}
+        style={{
+          background: error ? "color-mix(in srgb, var(--warning) 16%, transparent)" : "color-mix(in srgb, var(--bg3) 45%, transparent)",
+          border: `1px solid color-mix(in srgb, var(--${error ? "warning" : "border"}) ${error ? 55 : 30}%, transparent)`,
+          color: error ? "var(--warning)" : "var(--text3)",
+        }}
       >
+        {/* The label names the theme the user picked, so when that theme could
+            not be loaded the button has to say so — otherwise it vouches for
+            colors that aren't on screen. */}
+        {error && <span aria-hidden>⚠</span>}
         <span className="truncate" style={{ maxWidth: 92 }}>{label}</span>
         <span style={{ opacity: 0.6, fontSize: 8 }}>▼</span>
       </button>
@@ -628,7 +636,7 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
   const commitPaths = useMemo(() => [...new Set(all.map((c) => c.file_path))], [all]);
   const walkSig = useMemo(() => changesetSig(all), [all]);
   // Shiki highlighter + theme/bold controls (shared with the git panel).
-  const { hilite, themePref, setThemePref, bold, setBold } = useDiffHighlight(selected?.file_path);
+  const { hilite, themePref, setThemePref, bold, setBold, themeError } = useDiffHighlight(selected?.file_path);
   // Restore a cached walkthrough for the current changeset (on open / when the
   // changeset changes) so it persists across close/reopen and never re-runs.
   useEffect(() => {
@@ -866,7 +874,7 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
                             <Toggle on={reviewed.has(selected.id)} onClick={() => toggleReviewed(selected.id)} title="Mark this file reviewed (x)">{reviewed.has(selected.id) ? "reviewed ✓" : "review"}</Toggle>
                             <Toggle on={split} onClick={() => setSplit((s) => !s)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
                             <Toggle on={wrap} onClick={() => setWrap((w) => !w)} title="Toggle line wrap (w)">wrap</Toggle>
-                            <ThemePicker value={themePref} onChange={setThemePref} />
+                            <ThemePicker value={themePref} onChange={setThemePref} error={themeError} />
                             <Toggle on={bold} onClick={() => setBold((b) => !b)} title="Bold keywords, functions & types (Neovim-style)">bold</Toggle>
                             <Toggle onClick={() => copy("path")} title="Copy file path (c)">{copied === "path" ? "copied ✓" : "path"}</Toggle>
                             <Toggle onClick={() => copy("diff")} title="Copy unified diff">{copied === "diff" ? "copied ✓" : "diff"}</Toggle>

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -113,7 +113,7 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
 
   const all = useMemo(() => [...(tree?.staged ?? []), ...(tree?.unstaged ?? [])], [tree]);
   const selected = useMemo(() => all.find((c) => keyOf(c) === selKey) ?? all[0] ?? null, [all, selKey]);
-  const { hilite, themePref, setThemePref, bold, setBold } = useDiffHighlight(selected?.file_path);
+  const { hilite, themePref, setThemePref, bold, setBold, themeError } = useDiffHighlight(selected?.file_path);
   const writeEnabled = tree?.writeEnabled ?? false;
   const flash = (ok: boolean, msg: string) => { setToast({ ok, msg }); setTimeout(() => setToast(null), 2600); };
 
@@ -373,7 +373,7 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
                               {writeEnabled && (selected.staged ? <Toggle onClick={() => unstage(selected)} title="Unstage this file">－ unstage</Toggle> : <Toggle onClick={() => stage(selected)} title="Stage this file">＋ stage</Toggle>)}
                               <Toggle on={split} onClick={() => setSplit((s) => !s)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
                               <Toggle on={wrap} onClick={() => setWrap((w) => !w)} title="Toggle line wrap">wrap</Toggle>
-                              <ThemePicker value={themePref} onChange={setThemePref} />
+                              <ThemePicker value={themePref} onChange={setThemePref} error={themeError} />
                               <Toggle on={bold} onClick={() => setBold((b) => !b)} title="Bold keywords, functions & types (Neovim-style)">bold</Toggle>
                             </div>
                           </div>

--- a/web/src/lib/diffHighlight.ts
+++ b/web/src/lib/diffHighlight.ts
@@ -4,7 +4,7 @@
 // value to drop into <HiliteCtx.Provider>.
 import { createContext, useEffect, useMemo, useState } from "react";
 import type { Highlighter } from "shiki";
-import { getHighlighter, langFromPath, shikiTheme, ensureTheme } from "./highlight.ts";
+import { getHighlighter, langFromPath, shikiTheme, ensureTheme, themeLabel } from "./highlight.ts";
 
 export type Hilite = { hl: Highlighter | null; lang: string | null; theme: string | null };
 export const HiliteCtx = createContext<Hilite>({ hl: null, lang: null, theme: null });
@@ -18,6 +18,7 @@ export function useDiffHighlight(filePath?: string) {
   const [themePref, setThemePref] = useState<string>(() => { try { return localStorage.getItem(THEME_KEY) || "auto"; } catch { return "auto"; } });
   const [bold, setBold] = useState<boolean>(() => { try { return localStorage.getItem(BOLD_KEY) !== "0"; } catch { return true; } });
   const [themeName, setThemeName] = useState<string | null>(null);
+  const [themeError, setThemeError] = useState<string | null>(null);
   const lang = useMemo(() => langFromPath(filePath), [filePath]);
 
   useEffect(() => {
@@ -41,12 +42,20 @@ export function useDiffHighlight(filePath?: string) {
   useEffect(() => {
     if (!hl) return;
     let alive = true;
-    ensureTheme(hl, resolvedTheme, bold).then((name) => { if (alive) setThemeName(name); }).catch(() => {});
+    // A theme that won't load is reported rather than swallowed: without this
+    // the diff just renders monochrome and the picker keeps claiming the theme
+    // the user chose is the one on screen.
+    ensureTheme(hl, resolvedTheme, bold).then(({ name, failed }) => {
+      if (!alive) return;
+      setThemeName(name);
+      setThemeError(!failed ? null
+        : `${themeLabel(failed)} couldn't be loaded — ${name ? `showing ${themeLabel(name)} instead` : "syntax highlighting is off"}.`);
+    }).catch(() => {});
     return () => { alive = false; };
   }, [hl, resolvedTheme, bold]);
 
   // Stable context object so <HiliteCtx.Provider> doesn't re-render every
   // memoized <Code> whenever an unrelated parent state changes.
   const hilite = useMemo<Hilite>(() => ({ hl, lang: lang && loadedLangs.has(lang) ? lang : null, theme: themeName }), [hl, lang, loadedLangs, themeName]);
-  return { hilite, themePref, setThemePref, bold, setBold };
+  return { hilite, themePref, setThemePref, bold, setBold, themeError };
 }

--- a/web/src/lib/highlight.ts
+++ b/web/src/lib/highlight.ts
@@ -68,29 +68,68 @@ function boldify(theme: ThemeRegistrationRaw, id: string): ThemeRegistrationRaw 
 }
 
 const loadedThemes = new Set<string>();
+
+/** Register one theme and return the name it was registered under. Rejects if
+ *  the theme cannot be loaded — including for an id shiki doesn't bundle, which
+ *  must not be papered over: recording a name that is not actually on the
+ *  highlighter is the failure mode this whole module has to avoid. */
+async function loadInto(hl: Highlighter, id: string, bold: boolean): Promise<string> {
+  const name = bold ? `${id}-bold` : id;
+  if (loadedThemes.has(name)) return name;
+  if (!bold) {
+    await hl.loadTheme(id as never); // shiki resolves the bundled id string
+  } else {
+    const m = await shiki();
+    const loader = (m.bundledThemes as Record<string, () => Promise<{ default: ThemeRegistrationRaw }>>)[id];
+    if (!loader) throw new Error(`"${id}" is not a bundled shiki theme`);
+    await hl.loadTheme(boldify((await loader()).default, id) as never);
+  }
+  loadedThemes.add(name);
+  return name;
+}
+
+/** Whichever theme a diff surface should actually tokenize with. `name` is
+ *  always a theme that is registered on the highlighter, or null when nothing
+ *  could be registered at all; `failed` carries the id we were asked for when
+ *  it isn't the one we got. */
+export type ResolvedTheme = { name: string | null; failed?: string };
+
+// Falling back within the same light/dark family keeps the diff legible against
+// the panel it sits on, rather than painting light-theme foregrounds onto a
+// dark surface.
+const FALLBACK = { dark: "github-dark", light: "github-light" } as const;
+
 /**
  * Ensure a theme is registered on the highlighter and return the theme *name*
  * to pass to codeToTokens. When `bold`, a boldified variant is registered under
  * `${id}-bold`. Idempotent; safe to call on every render.
+ *
+ * Loading a theme fetches a chunk at runtime, so it can fail for reasons that
+ * have nothing to do with the theme itself — offline, or a deploy whose hashed
+ * chunks moved out from under a long-lived tab. This used to answer such a
+ * failure by returning the requested name anyway, and `codeToTokens` then threw
+ * on every single line: the diff rendered as unstyled monochrome text with
+ * nothing logged, indistinguishable from "this language has no grammar". So a
+ * failed load now resolves to a theme we have genuinely registered and reports
+ * which id we could not honour, for the caller to put in front of the user.
  */
-export async function ensureTheme(hl: Highlighter, id: string, bold: boolean): Promise<string> {
-  const name = bold ? `${id}-bold` : id;
-  if (loadedThemes.has(name)) return name;
+export async function ensureTheme(hl: Highlighter, id: string, bold: boolean): Promise<ResolvedTheme> {
   try {
-    if (!bold) {
-      await hl.loadTheme(id as never); // shiki resolves the bundled id string
-    } else {
-      const m = await shiki();
-      const loader = (m.bundledThemes as Record<string, () => Promise<{ default: ThemeRegistrationRaw }>>)[id];
-      const mod = loader ? await loader() : null;
-      await hl.loadTheme((mod ? boldify(mod.default, id) : (id as never)) as never);
-    }
-    loadedThemes.add(name);
-    return name;
+    return { name: await loadInto(hl, id, bold) };
   } catch {
-    // Load failed — reuse any theme already registered so highlighting survives.
-    return loadedThemes.size ? [...loadedThemes][0] : name;
+    const fallback = FALLBACK[THEMES.find((t) => t.id === id)?.dark === false ? "light" : "dark"];
+    if (fallback !== id) {
+      try { return { name: await loadInto(hl, fallback, bold), failed: id }; } catch { /* both gone — plain text below */ }
+    }
+    return { name: null, failed: id };
   }
+}
+
+/** The picker label for a name `ensureTheme` resolved to (it may carry the
+ *  `-bold` suffix, which is an implementation detail users never chose). */
+export function themeLabel(name: string): string {
+  const id = name.endsWith("-bold") ? name.slice(0, -"-bold".length) : name;
+  return THEMES.find((t) => t.id === id)?.label ?? id;
 }
 
 const EXT: Record<string, string> = {

--- a/web/test/diff-theme.test.ts
+++ b/web/test/diff-theme.test.ts
@@ -1,0 +1,73 @@
+// The contract between the diff's theme picker and shiki.
+//
+// Worth testing on its own because breaking it is invisible. A theme that
+// cannot be registered used to leave `codeToTokens` throwing once per line,
+// which the renderer catches and answers with plain text — so the diff came out
+// as unstyled monochrome, looking exactly like a file whose language has no
+// grammar. Nothing was logged and nothing was shown, so the only way to notice
+// was to compare two themes side by side.
+import { expect, test } from "bun:test";
+import { bundledThemes } from "shiki";
+import { getHighlighter, ensureTheme, THEMES, themeLabel } from "../src/lib/highlight.ts";
+
+const CODE = 'const greeting = "hello"; // note';
+
+test("every theme the picker offers is a real shiki bundled id", () => {
+  // A typo, or an id shiki renames or drops in a future major, would otherwise
+  // only ever show up as one entry in the menu quietly doing nothing.
+  const unknown = THEMES.filter((t) => !(t.id in bundledThemes)).map((t) => t.id);
+  expect(unknown).toEqual([]);
+});
+
+test("the picker's light/dark grouping matches the theme's own type", async () => {
+  // The fallback picks a replacement from the same family, so a mislabelled
+  // theme would swap a dark diff onto a light background.
+  for (const t of THEMES) {
+    const raw = (await bundledThemes[t.id as keyof typeof bundledThemes]()).default;
+    expect(`${t.id}:${raw.type}`).toBe(`${t.id}:${t.dark ? "dark" : "light"}`);
+  }
+});
+
+test("every offered theme tokenizes, in both plain and bold mode", async () => {
+  const hl = await getHighlighter();
+  await hl.loadLanguage("typescript" as never);
+  for (const bold of [false, true]) {
+    for (const t of THEMES) {
+      const { name, failed } = await ensureTheme(hl, t.id, bold);
+      expect(`${t.id} bold=${bold} failed=${failed ?? "-"}`).toBe(`${t.id} bold=${bold} failed=-`);
+      // The real assertion: the name we hand back is registered, so this call
+      // does not throw and every token comes out with a colour.
+      const tokens = hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! }).tokens.flat();
+      expect(tokens.every((x) => !!x.color)).toBe(true);
+      expect(new Set(tokens.map((x) => x.color)).size).toBeGreaterThan(1);
+    }
+  }
+});
+
+test("bold mode bolds keywords the theme itself leaves plain", async () => {
+  const hl = await getHighlighter();
+  await hl.loadLanguage("typescript" as never);
+  const count = async (bold: boolean) => {
+    const { name } = await ensureTheme(hl, "github-dark", bold);
+    return hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! })
+      .tokens.flat().filter((x) => ((x.fontStyle ?? 0) & 2) > 0).length;
+  };
+  expect(await count(true)).toBeGreaterThan(await count(false));
+});
+
+test("a theme that cannot load falls back to one that is actually registered", async () => {
+  const hl = await getHighlighter();
+  await hl.loadLanguage("typescript" as never);
+  // An id shiki does not bundle stands in for the runtime failure we cannot
+  // stage here — a theme chunk that 404s or never arrives.
+  const { name, failed } = await ensureTheme(hl, "no-such-theme", true);
+  expect(failed).toBe("no-such-theme");
+  expect(name).toBe("github-dark-bold");
+  expect(() => hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! })).not.toThrow();
+});
+
+test("the failure is reported with the name the user chose, not the internal one", () => {
+  // The message goes on the picker button, where "-bold" would be noise.
+  expect(themeLabel("kanagawa-dragon-bold")).toBe("Kanagawa Dragon");
+  expect(themeLabel("kanagawa-dragon")).toBe("Kanagawa Dragon");
+});


### PR DESCRIPTION
## What does this PR do?

Some themes rendered the diff as uniform monochrome with nothing in the console. The cause was not a bad theme id — all 22 ids in the picker are valid `shiki` bundled themes, verified against `bundledThemes`.

The cause was `ensureTheme`'s catch-all. Loading a theme fetches a chunk at runtime, so it can fail for reasons unrelated to the theme (offline, a deploy whose hashed chunks moved under a long-lived tab). On failure it returned a name **without checking it was registered**:

```ts
return loadedThemes.size ? [...loadedThemes][0] : name;
```

Two bad outcomes, both silent:

- **Cold start on a theme that fails** — `loadedThemes` is empty, so the unregistered name comes straight back. `codeToTokens` throws on every line, `<Code>` catches and renders plain text, and the diff is monochrome *permanently* (the effect won't re-run). Exactly the reported screenshot.
- **After another theme has loaded** — you silently get *that* theme's colors while the picker still claims the one you chose.

Now a failed load resolves to a theme that is actually registered, picked from the same light/dark family so the diff stays legible against the panel, and the id that could not be honoured travels back to the picker, which marks itself `⚠` and explains the substitution. Loading an id `shiki` doesn't bundle fails into the same path instead of recording a name that was never registered — so a future renamed/dropped id degrades visibly rather than silently.

## How was it tested?

`bunx tsc --noEmit` in `web/` and `server/`, `bunx vite build` in `web/`, `bun test` from the root (103 pass).

Reproduced and verified in headless Chromium against the real render path — `useDiffHighlight` + `<HiliteCtx.Provider>` + `<UnifiedDiff>` — with one theme's `loadTheme` forced to reject, standing in for a chunk that never arrives:

| | before | after |
|---|---|---|
| cold start on the failing theme | `0` colored spans, **0 errors surfaced** | `45` spans / 7 distinct colors, button reads `⚠ Kanagawa Dragon`, title *"Kanagawa Dragon couldn't be loaded — showing GitHub Dark instead."* |
| same theme after another loaded | silently showed Tokyo Night's colors | falls back deterministically and says so |

New `web/test/diff-theme.test.ts` pins the contract: every offered id is a real bundled theme, the light/dark grouping matches each theme's own `type`, every theme tokenizes with colors in both plain and bold mode, bold mode really does bold keywords, and a theme that cannot load resolves to a registered fallback. Confirmed the fallback test fails when the old catch block is put back.

Exercised via the ChangesModal diff and the git panel, which share the hook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)