### PR TITLE
feat(chat): paste images into the chat composer

### DIFF
--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -6,7 +6,13 @@
 // plan (no execution) → default/acceptEdits → bypass (runs everything). Unlike
 // the walkthrough this is NOT marked internal: a chat you start SHOULD appear
 // in the fleet. Gated by AGENTGLASS_CHAT_DISABLED; cwd must be a git dir.
+//
+// A turn is normally written to stdin as plain text. When the user has pasted
+// images the turn goes out as `--input-format stream-json` instead — one JSON
+// line carrying text and image content blocks together, which is the only
+// channel structured content has into a `claude -p` run.
 import { safeAbs, repoRootOf } from "./git.ts";
+import type { ChatImage, ChatImageMediaType } from "../../shared/types.ts";
 
 const claudeBin = () => Bun.which("claude");
 export const CHAT_ENABLED = !!claudeBin();
@@ -44,21 +50,132 @@ export function allowList(v: unknown): string[] {
   if (!Array.isArray(v)) return [];
   return v.filter((t): t is string => typeof t === "string" && TOOL_RE.test(t.trim())).map((t) => t.trim()).slice(0, MAX_ALLOWED);
 }
+// --- pasted images ----------------------------------------------------------
+// These bounds exist because /chat/send accepts arbitrary binary from a browser
+// request, and every byte is held in memory twice (base64 in the JSON body, and
+// again in the stdin line handed to `claude`).
+//
+// Four images per turn covers what a person actually pastes — a screenshot, or
+// a before/after pair, with room to spare — while keeping a single turn's worth
+// of buffering bounded. Five megabytes per image matches the Anthropic API's own
+// per-image ceiling, so a larger one could not be answered anyway. Ten megabytes
+// total is the real backstop: it caps a turn at roughly 13MB of base64 regardless
+// of how the per-image budget is spent.
+const MAX_IMAGES = 4;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGES_TOTAL_BYTES = 10 * 1024 * 1024;
+
+// The media types `claude` accepts for an image block. A type outside this set
+// is refused here rather than passed through, since the client's label is the
+// only thing that would otherwise decide how the bytes get interpreted.
+const MEDIA_TYPES = new Set<string>(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+const BASE64_RE = /^[A-Za-z0-9+/]+={0,2}$/;
+
+/** Sniff the real media type from the leading bytes.
+ *
+ *  The client's declared type is a label, not evidence — a `image/png` claim
+ *  over a payload that is something else entirely would still be forwarded
+ *  verbatim to the model. These signatures are a few bytes each, so checking is
+ *  cheap enough to do unconditionally, and it is what makes the declared type
+ *  trustworthy rather than merely allowlisted. */
+export function sniffMediaType(b: Uint8Array): ChatImageMediaType | null {
+  const at = (i: number) => b[i];
+  if (b.length >= 8 && at(0) === 0x89 && at(1) === 0x50 && at(2) === 0x4e && at(3) === 0x47
+    && at(4) === 0x0d && at(5) === 0x0a && at(6) === 0x1a && at(7) === 0x0a) return "image/png";
+  if (b.length >= 3 && at(0) === 0xff && at(1) === 0xd8 && at(2) === 0xff) return "image/jpeg";
+  // "GIF87a" / "GIF89a" — the version digit differs, the rest does not.
+  if (b.length >= 6 && at(0) === 0x47 && at(1) === 0x49 && at(2) === 0x46 && at(3) === 0x38) return "image/gif";
+  // WebP is a RIFF container: "RIFF" <4-byte size> "WEBP".
+  if (b.length >= 12 && at(0) === 0x52 && at(1) === 0x49 && at(2) === 0x46 && at(3) === 0x46
+    && at(8) === 0x57 && at(9) === 0x45 && at(10) === 0x42 && at(11) === 0x50) return "image/webp";
+  return null;
+}
+
+/** Images attached to this turn, or `null` if the payload is unusable.
+ *
+ *  Returning `null` rather than silently dropping matters here: quietly sending
+ *  a turn without the screenshot it was written about produces a confusing
+ *  answer, which is worse than an error saying the attachment was rejected. */
+export function chatImages(v: unknown): ChatImage[] | null {
+  if (v === undefined || v === null) return [];
+  if (!Array.isArray(v)) return null;
+  if (v.length > MAX_IMAGES) return null;
+  const out: ChatImage[] = [];
+  let total = 0;
+  for (const raw of v) {
+    if (!raw || typeof raw !== "object") return null;
+    const { mediaType, data } = raw as Record<string, unknown>;
+    if (typeof mediaType !== "string" || !MEDIA_TYPES.has(mediaType)) return null;
+    if (typeof data !== "string" || !data) return null;
+    // Bound the encoded length before decoding — decoding first would mean
+    // materialising whatever size the client chose to send just to discover it
+    // was too big, which is the denial-of-service this cap exists to prevent.
+    if (data.length > Math.ceil(MAX_IMAGE_BYTES / 3) * 4 + 4) return null;
+    if (!BASE64_RE.test(data)) return null;
+    let bytes: Uint8Array;
+    try { bytes = Uint8Array.from(atob(data), (ch) => ch.charCodeAt(0)); } catch { return null; }
+    if (!bytes.length || bytes.length > MAX_IMAGE_BYTES) return null;
+    total += bytes.length;
+    if (total > MAX_IMAGES_TOTAL_BYTES) return null;
+    // The declared type has to match the bytes, not merely be allowlisted.
+    if (sniffMediaType(bytes) !== mediaType) return null;
+    out.push({ mediaType: mediaType as ChatImageMediaType, data });
+  }
+  return out;
+}
+
 const err = (msg: string, status = 400) => new Response(msg + "\n", { status, headers: CORS });
 
-export function chatStream(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, allowedTools?: unknown): Response {
+/** The stdin line for a turn that carries image blocks.
+ *
+ *  This envelope is not guesswork: it is the shape `claude` itself writes when
+ *  it injects a user message into its own structured-input stream, and the shape
+ *  its stdin reader validates on the way back in — the reader accepts a line
+ *  whose `type` is `user` and whose `message.role` is `user`, and rejects
+ *  anything else with "Expected message role 'user'". `content` is passed
+ *  through to the API untouched, which is what lets it be an array of blocks
+ *  rather than a bare string.
+ *
+ *  Exported for tests: this is the one part of the feature that cannot be
+ *  checked without spending money on a real turn, so it is pinned here instead. */
+export function turnEnvelope(text: string, images: ChatImage[]): string {
+  const content: Array<Record<string, unknown>> = [];
+  if (text) content.push({ type: "text", text });
+  for (const img of images) {
+    content.push({ type: "image", source: { type: "base64", media_type: img.mediaType, data: img.data } });
+  }
+  return JSON.stringify({
+    type: "user",
+    session_id: "",
+    message: { role: "user", content },
+    parent_tool_use_id: null,
+  }) + "\n";
+}
+
+export function chatStream(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, allowedTools?: unknown, images?: unknown): Response {
   const bin = claudeBin();
   if (!bin) return err("no local `claude` CLI — install Claude Code to chat", 403);
   if (process.env.AGENTGLASS_CHAT_DISABLED === "1") return err("chat is disabled (AGENTGLASS_CHAT_DISABLED=1)", 403);
   const dir = safeAbs(cwd);
   if (!dir || !repoRootOf(dir)) return err("invalid or non-repo directory");
-  if (typeof message !== "string" || !message.trim() || message.length > 100_000) return err("invalid message");
+  const imgs = chatImages(images);
+  if (!imgs) return err("invalid image attachment");
+  if (typeof message !== "string" || message.length > 100_000) return err("invalid message");
+  // An image on its own is a complete thought ("what's wrong with this?"), so a
+  // turn only needs text when it carries nothing else.
+  if (!message.trim() && !imgs.length) return err("invalid message");
   const m = typeof model === "string" && MODEL_RE.test(model) ? model : "claude-opus-4-8";
   let pm = typeof mode === "string" && MODES.has(mode) ? mode : "default";
   if (pm === "bypassPermissions" && !BYPASS_ALLOWED) pm = "default"; // opt-in only
   const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";
 
   const args = [bin, "-p", "--output-format", "stream-json", "--verbose", "--model", m];
+  // Structured input is only switched on for a turn that actually needs it.
+  // Plain text is the overwhelmingly common case and its path through `claude`
+  // is the well-trodden one; `--input-format stream-json` is comparatively
+  // undocumented, so a turn with nothing to gain from it keeps the old
+  // behaviour byte for byte rather than riding a newer code path for free.
+  if (imgs.length) args.push("--input-format", "stream-json");
   if (pm === "bypassPermissions") args.push("--dangerously-skip-permissions");
   else args.push("--permission-mode", pm);
   // Only meaningful for the prompting modes — bypass already allows everything.
@@ -72,7 +189,7 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   const setsid = Bun.which("setsid");
   const proc = Bun.spawn(setsid ? [setsid, ...args] : args, {
     cwd: dir,
-    stdin: new TextEncoder().encode(message),
+    stdin: new TextEncoder().encode(imgs.length ? turnEnvelope(message.trim(), imgs) : message),
     stdout: "pipe",
     stderr: "pipe",
     env: { ...process.env },

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -484,7 +484,7 @@ const server = Bun.serve<WsData>({
       if (!localOrigin(req)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
-      return chatStream(b.cwd, b.message, b.model, b.resumeId, b.mode, b.allowedTools);
+      return chatStream(b.cwd, b.message, b.model, b.resumeId, b.mode, b.allowedTools, b.images);
     }
 
     // --- LLM walkthrough: AI-authored review itinerary for the changes ---

--- a/server/test/chat-images.test.ts
+++ b/server/test/chat-images.test.ts
@@ -1,0 +1,136 @@
+// Pasted images arrive as arbitrary base64 in a browser request body, so this
+// is the boundary where a client's claims about them stop being taken on faith.
+// Two things are pinned here: the limits (a turn cannot be used to make the
+// server hold unbounded memory) and the stdin envelope (the one part of the
+// feature that a typecheck cannot catch — a wrong shape fails only at runtime,
+// inside a `claude` process that costs money to start).
+import { describe, expect, test } from "bun:test";
+import { chatImages, sniffMediaType, turnEnvelope } from "../src/chat.ts";
+
+const b64 = (bytes: number[]) => btoa(String.fromCharCode(...bytes));
+
+// Real signatures, padded out to the length each sniff needs.
+const PNG = [0x89, 0x50, 0x4e, 0x47, 0x0d, 0x0a, 0x1a, 0x0a, 0, 0, 0, 0];
+const JPEG = [0xff, 0xd8, 0xff, 0xe0, 0, 0, 0, 0];
+const GIF = [0x47, 0x49, 0x46, 0x38, 0x39, 0x61, 0, 0];
+const WEBP = [0x52, 0x49, 0x46, 0x46, 1, 2, 3, 4, 0x57, 0x45, 0x42, 0x50];
+
+const png = { mediaType: "image/png", data: b64(PNG) };
+
+describe("sniffMediaType", () => {
+  test("recognises each allowed format from its magic bytes", () => {
+    expect(sniffMediaType(new Uint8Array(PNG))).toBe("image/png");
+    expect(sniffMediaType(new Uint8Array(JPEG))).toBe("image/jpeg");
+    expect(sniffMediaType(new Uint8Array(GIF))).toBe("image/gif");
+    expect(sniffMediaType(new Uint8Array(WEBP))).toBe("image/webp");
+  });
+
+  test("returns null for anything else", () => {
+    expect(sniffMediaType(new Uint8Array([0x25, 0x50, 0x44, 0x46]))).toBeNull(); // %PDF
+    expect(sniffMediaType(new Uint8Array([0x7f, 0x45, 0x4c, 0x46]))).toBeNull(); // ELF
+    expect(sniffMediaType(new Uint8Array([]))).toBeNull();
+    // A RIFF container that is not WebP (e.g. a .wav) must not pass.
+    expect(sniffMediaType(new Uint8Array([0x52, 0x49, 0x46, 0x46, 1, 2, 3, 4, 0x57, 0x41, 0x56, 0x45]))).toBeNull();
+  });
+});
+
+describe("chatImages", () => {
+  test("absent or empty attachments are fine — this is the common case", () => {
+    expect(chatImages(undefined)).toEqual([]);
+    expect(chatImages(null)).toEqual([]);
+    expect(chatImages([])).toEqual([]);
+  });
+
+  test("accepts well-formed images of every allowed type", () => {
+    const ok = chatImages([png, { mediaType: "image/webp", data: b64(WEBP) }]);
+    expect(ok).toHaveLength(2);
+    expect(ok![0].mediaType).toBe("image/png");
+  });
+
+  test("rejects a media type outside the allowlist", () => {
+    expect(chatImages([{ mediaType: "image/svg+xml", data: b64(PNG) }])).toBeNull();
+    expect(chatImages([{ mediaType: "text/html", data: b64(PNG) }])).toBeNull();
+    expect(chatImages([{ mediaType: "application/octet-stream", data: b64(PNG) }])).toBeNull();
+  });
+
+  test("rejects bytes that do not match the declared type", () => {
+    // The whole point of sniffing: a truthful-looking label over other content.
+    expect(chatImages([{ mediaType: "image/png", data: b64(JPEG) }])).toBeNull();
+    expect(chatImages([{ mediaType: "image/png", data: b64([0x25, 0x50, 0x44, 0x46, 0, 0, 0, 0, 0, 0, 0, 0]) }])).toBeNull();
+  });
+
+  test("rejects a malformed payload rather than coercing it", () => {
+    expect(chatImages("not an array")).toBeNull();
+    expect(chatImages([null])).toBeNull();
+    expect(chatImages(["just a string"])).toBeNull();
+    expect(chatImages([{ mediaType: "image/png" }])).toBeNull();
+    expect(chatImages([{ mediaType: "image/png", data: "" }])).toBeNull();
+    // Not base64 — `atob` is lenient about some of this, so the charset is
+    // checked explicitly before decoding.
+    expect(chatImages([{ mediaType: "image/png", data: "!!!!not base64!!!!" }])).toBeNull();
+  });
+
+  test("caps the number of images per message", () => {
+    expect(chatImages([png, png, png, png])).toHaveLength(4);
+    expect(chatImages([png, png, png, png, png])).toBeNull();
+  });
+
+  test("caps a single image's size", () => {
+    // A valid PNG header followed by more than 5MB of payload.
+    const big = new Uint8Array(5 * 1024 * 1024 + 1024);
+    big.set(PNG.slice(0, 8));
+    let s = "";
+    for (let i = 0; i < big.length; i += 0x8000) s += String.fromCharCode(...big.subarray(i, i + 0x8000));
+    expect(chatImages([{ mediaType: "image/png", data: btoa(s) }])).toBeNull();
+  });
+
+  test("caps the total across images even when each one is legal", () => {
+    // Three images of 4MB each are individually fine but blow the 10MB budget.
+    const four = new Uint8Array(4 * 1024 * 1024);
+    four.set(PNG.slice(0, 8));
+    let s = "";
+    for (let i = 0; i < four.length; i += 0x8000) s += String.fromCharCode(...four.subarray(i, i + 0x8000));
+    const img = { mediaType: "image/png", data: btoa(s) };
+    expect(chatImages([img, img])).toHaveLength(2);
+    expect(chatImages([img, img, img])).toBeNull();
+  });
+});
+
+describe("turnEnvelope", () => {
+  // This shape is what `claude` itself writes into its own structured-input
+  // stream, and what its stdin reader validates coming back in. If any of these
+  // change, the turn is silently rejected by a subprocess at runtime.
+  test("is a single NDJSON line with the type and role claude checks for", () => {
+    const line = turnEnvelope("hello", []);
+    expect(line.endsWith("\n")).toBe(true);
+    expect(line.trimEnd()).not.toContain("\n"); // exactly one line
+    const o = JSON.parse(line);
+    expect(o.type).toBe("user");
+    expect(o.message.role).toBe("user");
+    expect(o.session_id).toBe("");
+    expect(o.parent_tool_use_id).toBeNull();
+  });
+
+  test("carries text and images as content blocks in the Anthropic shape", () => {
+    const o = JSON.parse(turnEnvelope("look at this", [{ mediaType: "image/png", data: b64(PNG) }]));
+    expect(o.message.content).toEqual([
+      { type: "text", text: "look at this" },
+      { type: "image", source: { type: "base64", media_type: "image/png", data: b64(PNG) } },
+    ]);
+  });
+
+  test("omits the text block entirely when the turn is images only", () => {
+    // An empty text block is rejected by the API, so it must not be emitted.
+    const o = JSON.parse(turnEnvelope("", [{ mediaType: "image/png", data: b64(PNG) }]));
+    expect(o.message.content).toHaveLength(1);
+    expect(o.message.content[0].type).toBe("image");
+  });
+
+  test("a newline in the message cannot break the line framing", () => {
+    // The envelope is newline-delimited, so an embedded newline has to survive
+    // as escaped JSON rather than terminating the line early.
+    const line = turnEnvelope("one\ntwo", []);
+    expect(line.trimEnd()).not.toContain("\n");
+    expect(JSON.parse(line).message.content[0].text).toBe("one\ntwo");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -493,6 +493,22 @@ export interface WalkthroughResult {
   error?: string;
 }
 
+// --- chat attachments (images pasted into the composer) ----------------------
+/** An image attached to a chat turn, carried inline as base64.
+ *
+ *  The browser has no path the server could read, so the bytes travel in the
+ *  JSON body rather than as a file reference. `data` is unpadded-or-padded
+ *  standard base64 with no `data:` URI prefix — the server strips the prefix on
+ *  the way in so the field holds only what a Claude image block wants. */
+export interface ChatImage {
+  mediaType: ChatImageMediaType;
+  data: string; // base64, no `data:image/png;base64,` prefix
+}
+/** The media types a chat attachment may declare. This mirrors the set the
+ *  `claude` CLI itself accepts for image blocks, so anything outside it would be
+ *  rejected downstream anyway. */
+export type ChatImageMediaType = "image/png" | "image/jpeg" | "image/gif" | "image/webp";
+
 // --- in-browser terminal (real PTY shell per repo/worktree) ------------------
 /** A ready-to-run project command surfaced in the terminal panel. */
 export interface ProjectCommand {

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -20,7 +20,7 @@ import { fmtAgo, fmtUsd, modelLabelOf, modelColor, providerOf } from "../lib/for
 import { sessionIsLive } from "../lib/derive.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, subscribe, chatResuming,
-  DEFAULT_MODEL, DEFAULT_MODE, type Chat,
+  DEFAULT_MODEL, DEFAULT_MODE, addAttachments, dropAttachment, type Chat,
 } from "../lib/chatStore.ts";
 
 const MODELS = [
@@ -324,6 +324,20 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
     send(active.id, text, () => openRef.current && activeIdRef.current === active.id, allowed.split(/\s+/).filter(Boolean));
   };
   const [hint, setHint] = useState("");
+  // A turn is sendable when there is text or at least one attachment.
+  const hasTurn = !!(active?.draft.trim() || active?.attachments.length);
+
+  // Screenshots arrive as clipboard *files*, not text, so the paste is only
+  // intercepted when there is at least one image among the items — a normal
+  // text paste has to fall through to the textarea untouched.
+  const onPaste = async (e: React.ClipboardEvent<HTMLTextAreaElement>) => {
+    if (!active) return;
+    const files = Array.from(e.clipboardData.files).filter((f) => f.type.startsWith("image/"));
+    if (!files.length) return;
+    e.preventDefault();
+    setHint(await addAttachments(active.id, files));
+  };
+
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // A focused textarea can swallow Escape before it reaches the global
     // handler, stranding the panel open. Close it here instead.
@@ -456,6 +470,15 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                                 {m.tools.map((t, j) => <span key={j} className="text-[9.5px] px-1.5 py-0.5 rounded" style={{ ...CODE_FONT_STYLE, color: "var(--info)", background: "color-mix(in srgb, var(--info) 12%, transparent)" }}>⚙ {t}</span>)}
                               </div>
                             )}
+                            {!!m.images?.length && (
+                              <div className="flex flex-wrap gap-1.5 mb-1.5">
+                                {m.images.map((img, j) => (
+                                  <img key={j} src={`data:${img.mediaType};base64,${img.data}`} alt="attached image"
+                                    className="block max-h-40 max-w-full rounded-lg"
+                                    style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }} />
+                                ))}
+                              </div>
+                            )}
                             {m.text ? <Markdown text={m.text} /> : (m.streaming ? <span className="t-dim2">▍</span> : "")}
                             {m.streaming && m.text && <span className="t-dim2">▍</span>}
                           </div>
@@ -466,15 +489,30 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                   </div>
 
                   <div className="shrink-0 border-t p-3" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                    {!!active?.attachments.length && (
+                      <div className="flex flex-wrap gap-2 mb-2">
+                        {active.attachments.map((a) => (
+                          <div key={a.id} className="relative group rounded-lg overflow-hidden shrink-0"
+                            style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}
+                            title={`${a.name} · ${(a.bytes / 1024).toFixed(0)}KB`}>
+                            <img src={a.url} alt={a.name} className="block h-14 w-14 object-cover" />
+                            <button onClick={() => dropAttachment(active.id, a.id)} aria-label={`remove ${a.name}`}
+                              className="absolute top-0.5 right-0.5 w-4 h-4 grid place-items-center rounded text-[10px] leading-none"
+                              style={{ color: "var(--text)", background: "rgba(0,0,0,0.65)" }}>✕</button>
+                          </div>
+                        ))}
+                      </div>
+                    )}
                     <div className="flex items-end gap-2">
                       <textarea ref={inputRef} value={active?.draft ?? ""} disabled={!enabled || !active} rows={2}
                         onChange={(e) => active && update(active.id, (c) => { c.draft = e.target.value; })}
                         onKeyDown={onKey}
-                        placeholder={!enabled ? "chat unavailable" : active?.sessionId ? "reply… (Enter to send, Shift+Enter newline)" : "message a new session… (Enter to send)"}
+                        onPaste={onPaste}
+                        placeholder={!enabled ? "chat unavailable" : active?.sessionId ? "reply… (Enter to send, Shift+Enter newline, paste to attach an image)" : "message a new session… (Enter to send, paste to attach an image)"}
                         className="agx-scroll flex-1 px-3 py-2 rounded-lg text-[12px] outline-none resize-none" style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }} />
                       {active?.sending
                         ? <button onClick={() => stop(active.id)} className="shrink-0 px-3.5 py-2 rounded-lg text-[11.5px] font-semibold" style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>■ stop</button>
-                        : <button onClick={submit} disabled={!active?.draft.trim() || !active?.cwd || !enabled} className="shrink-0 px-4 py-2 rounded-lg text-[11.5px] font-semibold" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!active?.draft.trim() || !active?.cwd) ? 0.45 : 1 }}>send ↵</button>}
+                        : <button onClick={submit} disabled={!hasTurn || !active?.cwd || !enabled} className="shrink-0 px-4 py-2 rounded-lg text-[11.5px] font-semibold" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!hasTurn || !active?.cwd) ? 0.45 : 1 }}>send ↵</button>}
                     </div>
                     <div className="mt-1.5 text-[9.5px] t-dim2">
                       {hint

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult, TerminalCommands } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -175,7 +175,7 @@ const realApi = {
   terminalCommands: (root: string) => get<TerminalCommands>(`/terminal/commands?root=${encodeURIComponent(root)}`),
   // --- multi-chat: drive a claude session from the browser ---
   chatEnabled: () => get<{ enabled: boolean; bypass?: boolean }>("/chat/enabled"),
-  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[] }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
+  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[] }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
     const res = await fetch(SERVER + "/chat/send", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
     if (!res.body) { try { onEvent(JSON.parse(await res.text())); } catch { /* non-json */ } return; }
     const reader = res.body.getReader();
@@ -252,7 +252,7 @@ const demoApi: typeof realApi = {
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),
   terminalCommands: (_root: string) => D({ enabled: false, make: [], scripts: [] } as TerminalCommands),
   chatEnabled: () => D({ enabled: false }),
-  chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[] }, onEvent: (o: Record<string, unknown>) => void) => {
+  chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[] }, onEvent: (o: Record<string, unknown>) => void) => {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });
     onEvent({ type: "result", result: "" });

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -6,12 +6,21 @@
 // owner. That's also what lets many exist at once instead of one at a time.
 
 import { api } from "./api.ts";
+import type { ChatImage } from "../../../shared/types.ts";
+
+/** A pasted image waiting in the composer. `url` is an object URL for the
+ *  thumbnail; it is revoked when the attachment is dropped or sent, since
+ *  otherwise every paste leaks a blob for the life of the tab. */
+export type Attachment = ChatImage & { id: string; name: string; bytes: number; url: string };
 
 export type ChatMsg = {
   role: "user" | "assistant";
   text: string;
   tools: string[];
   streaming?: boolean;
+  /** Images sent with this turn, shown back in the transcript so the message
+   *  reads the way it was written. */
+  images?: ChatImage[];
   /** Replayed from the session's transcript when this chat adopted an existing
    *  session, rather than said in this panel. Marked so the UI can draw the
    *  seam — and so it's clear these were not sent from here. */
@@ -28,6 +37,7 @@ export type Chat = {
   sessionId: string;    // claude's own id, for resuming
   sending: boolean;
   draft: string;        // per-chat, so switching tabs doesn't lose what you typed
+  attachments: Attachment[]; // pasted images, per-chat for the same reason as the draft
   createdAt: number;
   abort: AbortController | null;
   unread: boolean;      // replied while you were looking at another chat
@@ -72,7 +82,7 @@ export function newChat(
     id, cwd, model, mode,
     title: resume?.title || "new chat",
     messages: [], sessionId: resume?.sessionId ?? "",
-    sending: false, draft: "", createdAt: Date.now(), abort: null, unread: false,
+    sending: false, draft: "", attachments: [], createdAt: Date.now(), abort: null, unread: false,
   };
   chats.set(id, chat);
   emit();
@@ -126,6 +136,7 @@ export function closeChat(id: string) {
   const c = chats.get(id);
   if (!c) return;
   c.abort?.abort(); // a closed tab must not keep a stream running
+  for (const a of c.attachments) URL.revokeObjectURL(a.url);
   chats.delete(id);
   emit();
 }
@@ -153,14 +164,21 @@ const titleOf = (s: string) => {
 export async function send(id: string, text: string, isActive: () => boolean, allowedTools: string[] = []) {
   const chat = chats.get(id);
   const msg = text.trim();
-  if (!chat || !msg || chat.sending || !chat.cwd) return;
+  // An image alone is a complete turn, so the draft may be empty when something
+  // is attached.
+  const images: ChatImage[] = chat ? chat.attachments.map((a) => ({ mediaType: a.mediaType, data: a.data })) : [];
+  if (!chat || (!msg && !images.length) || chat.sending || !chat.cwd) return;
 
   update(id, (c) => {
-    if (c.messages.length === 0) c.title = titleOf(msg);
-    c.messages.push({ role: "user", text: msg, tools: [] });
+    if (c.messages.length === 0) c.title = titleOf(msg || `${images.length} image${images.length > 1 ? "s" : ""}`);
+    c.messages.push({ role: "user", text: msg, tools: [], images: images.length ? images : undefined });
     c.messages.push({ role: "assistant", text: "", tools: [], streaming: true });
     c.sending = true;
     c.draft = "";
+    // The thumbnails belong to the composer, not the sent message, so their
+    // object URLs are released as the attachments leave it.
+    for (const a of c.attachments) URL.revokeObjectURL(a.url);
+    c.attachments = [];
   });
 
   const ac = new AbortController();
@@ -197,7 +215,7 @@ export async function send(id: string, text: string, isActive: () => boolean, al
   };
 
   try {
-    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools }, onEvent, ac.signal);
+    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools, images }, onEvent, ac.signal);
   } catch (e) {
     if (!(e instanceof DOMException && e.name === "AbortError")) {
       update(id, (c) => {
@@ -218,4 +236,60 @@ export async function send(id: string, text: string, isActive: () => boolean, al
 
 export function stop(id: string) {
   chats.get(id)?.abort?.abort();
+}
+
+// Mirrors the server's caps in server/src/chat.ts. The server is what actually
+// enforces them — this copy exists only so an oversized paste is refused with a
+// message in the composer instead of a failed request after the upload.
+export const MAX_IMAGES = 4;
+const MAX_IMAGE_BYTES = 5 * 1024 * 1024;
+const MAX_IMAGES_TOTAL_BYTES = 10 * 1024 * 1024;
+const MEDIA_TYPES = new Set(["image/png", "image/jpeg", "image/gif", "image/webp"]);
+
+const toBase64 = (buf: ArrayBuffer) => {
+  // Chunked because String.fromCharCode(...bytes) on a multi-megabyte image
+  // blows the argument limit and throws.
+  const b = new Uint8Array(buf);
+  let s = "";
+  for (let i = 0; i < b.length; i += 0x8000) s += String.fromCharCode(...b.subarray(i, i + 0x8000));
+  return btoa(s);
+};
+
+/** Attach images to a chat's composer. Returns a message to show the user when
+ *  something was refused, or "" when everything was taken. */
+export async function addAttachments(id: string, files: File[]): Promise<string> {
+  const chat = chats.get(id);
+  if (!chat) return "";
+  let rejected = "";
+  for (const f of files) {
+    const c = chats.get(id);
+    if (!c) break;
+    if (!MEDIA_TYPES.has(f.type)) { rejected = "only png, jpeg, gif and webp images can be attached"; continue; }
+    if (c.attachments.length >= MAX_IMAGES) { rejected = `at most ${MAX_IMAGES} images per message`; continue; }
+    if (f.size > MAX_IMAGE_BYTES) { rejected = `each image must be under ${MAX_IMAGE_BYTES / 1024 / 1024}MB`; continue; }
+    if (c.attachments.reduce((n, a) => n + a.bytes, 0) + f.size > MAX_IMAGES_TOTAL_BYTES) {
+      rejected = `attachments must total under ${MAX_IMAGES_TOTAL_BYTES / 1024 / 1024}MB`;
+      continue;
+    }
+    const data = toBase64(await f.arrayBuffer());
+    update(id, (cc) => {
+      cc.attachments.push({
+        id: `a${++seq}-${Date.now().toString(36)}`,
+        name: f.name || "pasted image",
+        bytes: f.size,
+        mediaType: f.type as Attachment["mediaType"],
+        data,
+        url: URL.createObjectURL(f),
+      });
+    });
+  }
+  return rejected;
+}
+
+export function dropAttachment(id: string, attId: string) {
+  update(id, (c) => {
+    const a = c.attachments.find((x) => x.id === attId);
+    if (a) URL.revokeObjectURL(a.url);
+    c.attachments = c.attachments.filter((x) => x.id !== attId);
+  });
 }


### PR DESCRIPTION
## What does this PR do?

Lets you paste images into the chat composer, so a screenshot can go to the model instead of being described in prose. Pasted images show as removable thumbnail chips before sending, and appear in the transcript afterwards.

A turn carrying images is sent over `--input-format stream-json` as a single NDJSON line whose `content` is an array of text and image blocks — the only channel structured content has into a `claude -p` run. **Turns with no attachments keep the existing plain-text stdin path byte for byte.** That is the common case, and the structured-input path is comparatively undocumented, so a turn with nothing to gain from it does not ride the newer code path for free.

The envelope was established by reading the installed CLI's own stdin reader (v2.1.215) rather than guessed:

```json
{"type":"user","session_id":"","message":{"role":"user","content":[...]},"parent_tool_use_id":null}
```

That is both the shape the CLI writes when injecting a user message into its own structured-input stream, and the shape its reader validates coming back in (it accepts `type: "user"` with `message.role === "user"` and rejects anything else with `Expected message role 'user'`). The binary also confirms the hard constraints `--input-format=stream-json` requires `--print` and `--output-format=stream-json`, both of which the chat already passed.

`/chat/send` now accepts arbitrary binary from a browser request, so attachments are bounded and verified server-side:

- **at most 4 images per turn** — covers a screenshot or a before/after pair with room to spare
- **5MB per image** — matches the Anthropic API's own per-image ceiling, so a larger one could not be answered anyway
- **10MB total per turn** — the real backstop, capping a turn at roughly 13MB of base64 however the per-image budget is spent
- the encoded length is bounded *before* decoding, so an oversized paste is refused without being materialised
- the declared media type must **match the bytes' magic number** (png/jpeg/gif/webp), not merely sit in the allowlist — the same four types the CLI itself accepts
- nothing is written to disk, so no path derives from client input

`shared/types.ts` gains `ChatImage` / `ChatImageMediaType` for the new field on the `/chat/send` body.

## How was it tested?

- `bunx tsc --noEmit` in both `server/` and `web/`; `bunx vite build` in `web/`; `bun test` from the repo root (112 pass).
- New `server/test/chat-images.test.ts` pins the limits, the magic-byte sniffing (including a RIFF-but-not-WebP payload and a JPEG mislabelled as PNG), and the exact stdin envelope — the last of these being the one part a typecheck cannot catch.

**Not verified:** no real `claude` process was spawned, so the envelope is confirmed against the CLI's own reader and emitter by inspection, not by a live turn. The image blocks themselves use the standard Anthropic content-block shape and the CLI's own allowlisted media types, but an end-to-end paste against a live session is worth doing before relying on this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)