### PR TITLE
fix(stats): count uptime from the server process, not the oldest event

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -49,6 +49,9 @@ import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { rateOk } from "./ratelimit.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
+/** When this process came up. /stats ships it so the dashboard's uptime is
+ *  the server's, not the age of the oldest event in the database. */
+const STARTED_AT = Date.now() - Math.round(process.uptime() * 1000);
 /**
  * Loopback unless told otherwise.
  *
@@ -522,7 +525,7 @@ const server = Bun.serve<WsData>({
     }
     if (pathname === "/stats") {
       const windowMs = Math.min(3660 * 86_400_000, Math.max(60_000, Number(url.searchParams.get("window") || 24 * 3600 * 1000)));
-      return json(statsSummary(windowMs, url.searchParams.get("provider") || undefined));
+      return json({ ...statsSummary(windowMs, url.searchParams.get("provider") || undefined), server_started_at: STARTED_AT });
     }
 
     // --- export ---

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -172,6 +172,9 @@ export interface StatsSummary {
   /** Event counts by day-of-week × hour (length 168 = 7*24), local time. */
   heatmap: number[];
   window_ms: number;
+  /** Wall-clock ms when the server process started — what the header's
+   *  uptime counts from. Absent in demo mode, where nothing is "up". */
+  server_started_at?: number;
 }
 
 /** A tool call held at the gate, awaiting a remote approve/deny. */

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -209,7 +209,9 @@ export default function App() {
     return () => window.removeEventListener("keydown", onKey);
   }, []);
 
-  const startedAt = events.length ? Math.min(mountedAt.current, events[0].timestamp) : mountedAt.current;
+  // /stats carries the server's process start; fall back to page mount for
+  // demo mode and the beat before the first poll lands.
+  const startedAt = stats?.server_started_at ?? mountedAt.current;
   const epm = useMemo(() => {
     const cutoff = Date.now() - 60_000;
     return visibleEvents.filter((e) => e.timestamp >= cutoff).length;


### PR DESCRIPTION
## What does this PR do?

### Problem

The KPI footer showed `uptime 1589:55:40` on a server that had been up for a few minutes.

### Root cause

The stat is computed client-side, in `web/src/App.tsx`:

```ts
const startedAt = events.length ? Math.min(mountedAt.current, events[0].timestamp) : mountedAt.current;
```

"Uptime" counts from the oldest event in the client buffer. That heuristic works when history starts at boot, but with transcripts persisted in SQLite the oldest event is the top of the database, not the last restart — my install has ~66 days of backfilled history, hence 1589 hours of "uptime".

### Fix

Treat the stat as what the label says — server uptime:

- `/stats` now ships `server_started_at` (process start), typed as optional on `StatsSummary` so demo mode stays valid without fabricating one.
- The client prefers it, falling back to page mount for demo mode and the beat before the first poll lands.

I read the `Math.min(page mount, oldest event)` as an approximation of server start from before transcripts persisted, so I kept the label and fixed the number. If you'd rather the footer describe the data span instead ("tracking 66d of history"), happy to rework it that way — it's a small change on top of this.

## How was it tested?

- `bunx tsc --noEmit` clean in both `server/` and `web/`; `bun test` green (97 pass).
- On my live install: `/stats` carries `server_started_at`, and right after a service restart the header reads seconds/minutes instead of weeks.

Environment: WSL2 Ubuntu 24.04, scanning a Windows-side `~/.claude/projects` over `/mnt/c`.

---

This is one of three small PRs from the same install (with `fix/stats-window-all` and `feat/multi-root-projects-dir`); they're independent and any subset merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
