### PR TITLE
fix(stats): stop ?window=all zeroing every total

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,6 +47,7 @@ import { workspaceRoot, setWorkspaceRoot, CONFIG_PATH } from "./config.ts";
 import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { rateOk } from "./ratelimit.ts";
+import { parseWindowMs } from "./params.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 /**
@@ -521,7 +522,7 @@ const server = Bun.serve<WsData>({
       return json(getSessions(limit, url.searchParams.get("provider") || undefined));
     }
     if (pathname === "/stats") {
-      const windowMs = Math.min(3660 * 86_400_000, Math.max(60_000, Number(url.searchParams.get("window") || 24 * 3600 * 1000)));
+      const windowMs = parseWindowMs(url.searchParams.get("window"));
       return json(statsSummary(windowMs, url.searchParams.get("provider") || undefined));
     }
 

--- a/server/src/params.ts
+++ b/server/src/params.ts
@@ -1,0 +1,23 @@
+// Query-param parsing kept out of index.ts so tests can import it without
+// booting the server.
+
+/** Default /stats window: the last 24 hours. */
+export const DEFAULT_WINDOW_MS = 24 * 3600 * 1000;
+/** Widest window we compute over — same order of magnitude as the UI's "all"
+ *  chip (3650d), so both spellings of "everything" cover the whole database. */
+export const MAX_WINDOW_MS = 3660 * 86_400_000;
+
+/**
+ * Parse the /stats `window` query param.
+ *
+ * "all" means unbounded, served as the cap — no retention setting outlives a
+ * decade. A number is clamped to [1 minute, cap]. Anything else (absent,
+ * empty, garbage) falls back to the default rather than NaN: the window
+ * becomes a `timestamp > since` cutoff, and a NaN there matches no rows, so
+ * every total silently reads zero.
+ */
+export function parseWindowMs(raw: string | null): number {
+  if (raw && raw.toLowerCase() === "all") return MAX_WINDOW_MS;
+  const n = Number(raw || DEFAULT_WINDOW_MS);
+  return Number.isFinite(n) ? Math.min(MAX_WINDOW_MS, Math.max(60_000, n)) : DEFAULT_WINDOW_MS;
+}

--- a/server/test/params.test.ts
+++ b/server/test/params.test.ts
@@ -1,0 +1,31 @@
+// The /stats window reaches SQL as a timestamp cutoff — a NaN there zeroes
+// every total silently, so the parser must never produce one.
+import { describe, expect, test } from "bun:test";
+import { parseWindowMs, DEFAULT_WINDOW_MS, MAX_WINDOW_MS } from "../src/params.ts";
+
+describe("parseWindowMs", () => {
+  test("a numeric window passes through, clamped to [1 minute, cap]", () => {
+    expect(parseWindowMs("3600000")).toBe(3_600_000);
+    expect(parseWindowMs("1")).toBe(60_000);
+    expect(parseWindowMs("-5")).toBe(60_000);
+    expect(parseWindowMs(String(MAX_WINDOW_MS * 2))).toBe(MAX_WINDOW_MS);
+  });
+
+  test('"all" (any case) means the widest window, not NaN', () => {
+    expect(parseWindowMs("all")).toBe(MAX_WINDOW_MS);
+    expect(parseWindowMs("ALL")).toBe(MAX_WINDOW_MS);
+  });
+
+  test("absent or malformed falls back to the 24h default", () => {
+    expect(parseWindowMs(null)).toBe(DEFAULT_WINDOW_MS);
+    expect(parseWindowMs("")).toBe(DEFAULT_WINDOW_MS);
+    expect(parseWindowMs("yesterday")).toBe(DEFAULT_WINDOW_MS);
+    expect(parseWindowMs("12abc")).toBe(DEFAULT_WINDOW_MS);
+  });
+
+  test("every path returns a finite number", () => {
+    for (const raw of [null, "", "all", "NaN", "Infinity", "-Infinity", "1e999", "0", "86400000"]) {
+      expect(Number.isFinite(parseWindowMs(raw))).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

### Problem

`GET /stats?window=all` answers with all-zero totals:

```json
{"totals":{"events":0,"sessions":0,...},"window_ms":null}
```

### Root cause

In `server/src/index.ts`:

```ts
const windowMs = Math.min(3660 * 86_400_000, Math.max(60_000, Number(url.searchParams.get("window") || 24 * 3600 * 1000)));
```

`Number("all")` is `NaN`, and `Math.min`/`Math.max` pass NaN straight through, so `statsSummary` computes `since = Date.now() - NaN` and every `timestamp > since` comparison matches nothing — zero totals, `window_ms: null` in the JSON. The dashboard never trips over this because its "all" chip sends `3650 * 86_400_000` as a number; only direct API calls hit it.

### Fix

The param now parses through a small `parseWindowMs` helper (its own module, so tests can import it without booting the server):

- `"all"` (any case) → the existing 3660-day cap — same order of magnitude as the UI chip, so both spellings of "everything" cover the whole database;
- numbers → clamped to [1 minute, cap] exactly as before;
- absent → the 24h default, unchanged;
- anything malformed → the 24h default rather than NaN.

One judgment call: malformed input falls back to the default rather than to "all" — a typo silently returning months of data seemed more surprising than getting the default window. Easy to flip if you'd rather.

## How was it tested?

- New `server/test/params.test.ts` covers "all"/case, clamping, garbage, and that every path returns a finite number; `bun test` green (101 pass), `bunx tsc --noEmit` clean.
- Live before/after on my install (~27.5k events over 66 days):
  - before: `window=all` → `events: 0`, `window_ms: null`
  - after: `window=all` → `events: 27535, sessions: 351`, `window_ms: 316224000000`
  - numeric windows unchanged (`window=3600000` → 404 events); `window=banana` → 24h default.

Environment: WSL2 Ubuntu 24.04, scanning a Windows-side `~/.claude/projects` over `/mnt/c`.

---

This is one of three small PRs from the same install (with `fix/uptime-stat` and `feat/multi-root-projects-dir`); they're independent and any subset merges cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
