### PR TITLE
security(scope): hold chat to the project boundary too

### DIFF
--- a/README.md
+++ b/README.md
@@ -435,7 +435,7 @@ inference, prompt) to an event the same way.
 | `AGENTGLASS_GIT_WRITE_DISABLED` | — | `1` → make the **Source control** panel read-only (no stage / commit / push). |
 | `AGENTGLASS_DOCKER_WRITE_DISABLED` | — | `1` → make the **Docker** panel read-only (no start / stop / restart / rm). |
 **Scope is a boundary, not just a filter.** With a project open, git writes, the
-terminal and chat are refused outside it — the same rule that decides what the
+terminal and chat are all refused outside it — the same rule that decides what the
 dashboard shows. For genuinely multi-repo work, scope to the parent folder
 (`~/code`) rather than one repo: every repo beneath it is then in scope. An
 unscoped (whole-machine) instance is unaffected.

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -12,6 +12,7 @@
 // line carrying text and image content blocks together, which is the only
 // channel structured content has into a `claude -p` run.
 import { safeAbs, repoRootOf } from "./git.ts";
+import { inScope } from "./config.ts";
 import type { ChatImage, ChatImageMediaType } from "../../shared/types.ts";
 
 const claudeBin = () => Bun.which("claude");
@@ -158,6 +159,11 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   if (process.env.AGENTGLASS_CHAT_DISABLED === "1") return err("chat is disabled (AGENTGLASS_CHAT_DISABLED=1)", 403);
   const dir = safeAbs(cwd);
   if (!dir || !repoRootOf(dir)) return err("invalid or non-repo directory");
+  // The last write path still outside the scope boundary (#67 covered git and
+  // the terminal). A chat runs a real `claude` with tools in that directory, so
+  // it can change anything a shell could — leaving it machine-wide would have
+  // made the boundary decorative in exactly the place it matters most.
+  if (!inScope(dir)) return err("outside the open project — open the parent folder to work across repos", 403);
   const imgs = chatImages(images);
   if (!imgs) return err("invalid image attachment");
   if (typeof message !== "string" || message.length > 100_000) return err("invalid message");


### PR DESCRIPTION
## What does this PR do?

The last write path still outside the scope boundary.

#67 covered git mutations and the PTY but deliberately left `chat.ts` alone — the image-paste work (#68) was rewriting its transport at the time, and a second edit to the same file would only have produced a conflict. #68 has landed, so this closes the gap.

A chat runs a real `claude` **with tools** in the chosen directory, so it can change anything a shell could. Leaving it machine-wide would have made the boundary decorative in exactly the place it matters most: the one capability that edits files on its own initiative.

Same rule, same shared `inScope()`, same error naming the parent-folder escape hatch rather than just refusing:

> `outside the open project — open the parent folder to work across repos`

## How was it tested?

- `bun test` — 124 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- The `inScope` rule itself is covered by `server/test/scope-writes.test.ts` from #67, including the sibling-prefix and traversal cases

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change
- [x] Docs — README already described the boundary; wording updated to include chat

🤖 Generated with [Claude Code](https://claude.com/claude-code)