### PR TITLE
feat(session): show what each tool answered, not only what it ran

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -881,6 +881,13 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
   // is per-session rather than per-message: long messages get room, and a
   // session full of them still can't produce an unbounded response.
   const MSG_MAX = 20_000;
+  // Outputs are attached to the newest runs only. Every row carrying one would
+  // multiply this response by the size of a build log, and the rows you scroll
+  // back to are the ones you already read. Counted over tool rows specifically:
+  // counting whole timeline entries let the messages, which are added first,
+  // eat the budget before any tool reached it.
+  const OUTPUT_ROWS = 120;
+  const OUTPUT_MAX = 4_000;
   const CONVO_BUDGET = 400_000;
 
   /** Trim at a line, then a word, so a cut never lands mid-word — and say so,
@@ -942,6 +949,7 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
   // Bounded to the same window the messages cover, so the timeline can't be
   // dominated by tool noise from turns whose text was already dropped.
   const oldest = kept.length ? Math.min(...kept.map((c) => c.ts)) : 0;
+  let withOutput = 0;
   for (const r of db.query<{ timestamp: number; tool_name: string | null; is_error: number; duration_ms: number | null; tool_use_id: string | null; agent_id: string | null; agent_type: string | null; payload: string }, [string, number]>(
     `SELECT timestamp, tool_name, is_error, duration_ms, tool_use_id, agent_id, agent_type, payload FROM events
       WHERE session_id = ? AND hook_event_type IN ('PostToolUse','PostToolUseFailure')
@@ -951,6 +959,23 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     let ti: Record<string, unknown> = {};
     try { ti = (JSON.parse(r.payload).tool_input ?? {}) as Record<string, unknown>; } catch { /* keep empty */ }
     const note = typeof ti.description === "string" ? ti.description : null;
+    // What the tool answered. Capped per row and only for the newest runs: a
+    // session's outputs together dwarf everything else in this response, and a
+    // `bun test` or a `git log` alone can be hundreds of lines. The head is
+    // what tells you whether it worked, which is the question being asked.
+    let output: string | null = null;
+    let clipped = false;
+    if (withOutput < OUTPUT_ROWS) {
+      try {
+        const raw = JSON.parse(r.payload)?.tool_response?.content;
+        if (typeof raw === "string" && raw.trim()) {
+          const t = raw.trimEnd();
+          clipped = t.length > OUTPUT_MAX;
+          output = clipped ? t.slice(0, OUTPUT_MAX) : t;
+          withOutput++;
+        }
+      } catch { /* no parseable response — the row still stands on its own */ }
+    }
     timeline.push({
       kind: "tool", ts: r.timestamp, tool,
       target: target(tool, ti),
@@ -960,6 +985,8 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
       tool_use_id: r.tool_use_id,
       agent_id: r.agent_id,
       agent_type: r.agent_type,
+      output,
+      output_clipped: clipped,
     });
   }
   timeline.sort((a, b) => b.ts - a.ts);

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -248,6 +248,13 @@ export interface TimelineEntry {
    *  parallel read as one very busy one. */
   agent_id?: string | null;
   agent_type?: string | null;
+  /** What the tool answered, trimmed. Seeing only what an agent *ran* and never
+   *  what came back is what still sends you to the terminal — a failing test and
+   *  a passing one look identical without it. */
+  output?: string | null;
+  /** True when `output` is only the head of a longer result, so the UI can say
+   *  so instead of implying the command was that quiet. */
+  output_clipped?: boolean;
 }
 
 export interface SessionDetail {

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -21,7 +21,14 @@ function ToolRow({ e }: { e: TimelineEntry }) {
   // A command can be a whole script; show its first line and let the rest be
   // opened, rather than either truncating it away or pasting 40 lines inline.
   const firstLine = target.split("\n")[0];
-  const hasMore = target.length > firstLine.length || firstLine.length > 110;
+  const out = (e.output ?? "").trimEnd();
+  const outLines = out ? out.split("\n") : [];
+  // Two lines of result, always. It is usually the difference between "the
+  // tests ran" and "the tests passed", and expanding for that every time would
+  // make the timeline useless as something you skim.
+  const PREVIEW = 2;
+  const outMore = outLines.length > PREVIEW || !!e.output_clipped;
+  const hasMore = target.length > firstLine.length || firstLine.length > 110 || outMore;
   const tint = e.is_error ? "var(--error)" : "var(--info)";
   return (
     <div className="flex items-start gap-2 text-[10.5px] leading-relaxed pl-1">
@@ -39,6 +46,20 @@ function ToolRow({ e }: { e: TimelineEntry }) {
           {open ? target : firstLine}
         </span>
         {e.note && <span className="block t-dim2 truncate">{e.note}</span>}
+        {outLines.length > 0 && (
+          <span className="block mt-0.5 pl-2" style={{ borderLeft: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+            <span className={`block ${open ? "whitespace-pre-wrap break-all" : "truncate"}`}
+              style={{ color: e.is_error ? "var(--error)" : "var(--text4)", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>
+              {open ? out : outLines.slice(0, PREVIEW).join(" · ")}
+            </span>
+            {outMore && !open && (
+              <span className="block t-dim2 cursor-pointer" onClick={() => setOpen(true)}>
+                +{e.output_clipped ? "more" : `${outLines.length - PREVIEW} lines`}
+              </span>
+            )}
+            {open && e.output_clipped && <span className="block t-dim2">…output trimmed</span>}
+          </span>
+        )}
       </span>
       {e.duration_ms != null && e.duration_ms >= 1000 && (
         <span className="shrink-0 tabular-nums t-dim2">{(e.duration_ms / 1000).toFixed(1)}s</span>


### PR DESCRIPTION
## What does this PR do?

The timeline said an agent ran `bun test` and stopped there. **Whether the tests passed was invisible** — a failing run and a passing one rendered identically. So the one question you open a session to answer still sent you back to the terminal.

Tool rows now carry the response `claude` already records.

## The display choice

**Two lines inline, the rest a click away.**

Two lines is usually the difference between "the tests ran" and "the tests passed". Demanding an expand for that would make the timeline useless as something you skim; pasting a whole build log inline would do the same from the other direction. Errors are tinted, and a clipped row says so rather than letting a trimmed result read as a command that was simply quiet.

## Bounded on the server, not trimmed in the browser

Outputs attach to the **newest 120 tool rows at 4KB each**. A session's outputs together dwarf everything else in the response, and the rows you scroll back to are the ones you already read.

Measured against a real session: 400 tool rows, 120 with output, **509 KB** response.

## A bug I caught in my own first attempt

The budget counts **tool rows** specifically. Counting timeline *entries* — what I wrote first — let the messages, which are appended before the tools, eat the budget before any tool reached it: **24 of 400 rows carried output instead of 120**.

Found by querying the real endpoint against a copy of a live database, not by re-reading the diff. Worth saying because the typechecked, test-passing version was the broken one.

## How was it tested?

- `bun test` — 128 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean
- Endpoint exercised against a copy of a real 114 MB database, before and after the budget fix

Visual change — worth opening a busy session to judge the density.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` updated — `output` / `output_clipped` on `TimelineEntry`
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)