### PR TITLE
fix(chat): stop Bun's 10s idle timeout killing a thinking turn

### DIFF
--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -127,6 +127,33 @@ export function chatImages(v: unknown): ChatImage[] | null {
 
 const err = (msg: string, status = 400) => new Response(msg + "\n", { status, headers: CORS });
 
+// --- keepalive --------------------------------------------------------------
+// How often a turn that is producing nothing still writes something.
+//
+// A turn goes quiet for as long as the model thinks or a tool runs, and both the
+// server's own idleTimeout (255s, its ceiling) and any proxy in front of it drop
+// a connection that has been silent too long. A blank line is the cheapest thing
+// that resets those timers: the ndjson framing makes it a no-op, and both this
+// server's client and any other line reader skip an empty line already, so it
+// costs one byte and needs no handling on the far end.
+const KEEPALIVE_MS = 20_000;
+
+/** Write a blank ndjson line to `controller` every `ms` until the returned
+ *  function is called.
+ *
+ *  Exported for tests: the surrounding turn cannot be exercised without spawning
+ *  a real `claude`, so the keepalive is pinned on its own. `enqueue` throws once
+ *  the stream is closed or cancelled, which is a race the timer cannot avoid —
+ *  losing that race simply means the stream is over, so it stops rather than
+ *  surfacing an unhandled rejection. */
+export function startKeepalive(controller: { enqueue: (c: Uint8Array) => void }, ms = KEEPALIVE_MS): () => void {
+  const nl = new TextEncoder().encode("\n");
+  const timer = setInterval(() => {
+    try { controller.enqueue(nl); } catch { clearInterval(timer); }
+  }, ms);
+  return () => clearInterval(timer);
+}
+
 /** The stdin line for a turn that carries image blocks.
  *
  *  This envelope is not guesswork: it is the shape `claude` itself writes when
@@ -213,6 +240,7 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+      const stopKeepalive = startKeepalive(controller);
       try {
         for (;;) {
           const { done, value } = await reader.read();
@@ -220,6 +248,7 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
           if (value) controller.enqueue(value);
         }
       } catch { /* closed */ }
+      stopKeepalive();
       const code = await proc.exited;
       // The reader loop ends on cancel too, and a cancelled controller throws
       // on enqueue/close — which would surface as an unhandled rejection on

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -181,6 +181,14 @@ const server = Bun.serve<WsData>({
   // A frame is a control message or a keystroke; nothing legitimate is large.
   // Unset, Bun allows 16MB per frame, which is a cheap way to exhaust memory.
   maxRequestBodySize: 32 * 1024 * 1024,
+  // Bun closes a connection that has been quiet for `idleTimeout` seconds, and
+  // the default is 10 — which counts the gaps *inside* a streaming response, not
+  // just an idle socket. A chat turn is silent for as long as the model thinks
+  // or a tool runs, so the default cut `/chat/send` off mid-turn and the browser
+  // reported only a generic fetch failure. 255 is the maximum Bun accepts; it is
+  // still not long enough on its own for a slow turn, so `chat.ts` also sends a
+  // periodic keepalive to keep the gaps under it.
+  idleTimeout: 255,
   async fetch(req, srv) {
     const url = new URL(req.url);
     const { pathname } = url;

--- a/server/test/chat-keepalive.test.ts
+++ b/server/test/chat-keepalive.test.ts
@@ -1,0 +1,94 @@
+// A chat turn is silent for as long as the model thinks or a tool runs, and Bun
+// closes a connection whose gaps exceed `idleTimeout` — the default 10s cut real
+// turns off mid-answer, and the browser could only report a generic fetch
+// failure. The server now raises that ceiling to Bun's maximum and, because even
+// the maximum is shorter than a slow turn, writes a blank ndjson line while
+// nothing else is happening.
+//
+// Both halves are pinned here against a deliberately tiny timeout, so the test
+// proves the mechanism in a second rather than in four minutes — and without
+// spawning a real `claude`, which costs money.
+import { describe, expect, test } from "bun:test";
+import { startKeepalive } from "../src/chat.ts";
+
+/** Serve one silent-then-final ndjson response and read it back, standing in for
+ *  a turn whose model is still thinking. `idleTimeout` is left at Bun's default
+ *  — the 10 seconds that caused the bug — so this exercises the real thing; the
+ *  quiet gap is sized just past it, since a lower timeout is not honoured
+ *  precisely enough by Bun's timer wheel to test against. */
+async function silentTurn(opts: { keepalive: boolean; quietMs: number }) {
+  const server = Bun.serve({
+    port: 0,
+    fetch() {
+      const enc = new TextEncoder();
+      return new Response(new ReadableStream<Uint8Array>({
+        async start(c) {
+          c.enqueue(enc.encode(JSON.stringify({ type: "system", subtype: "init" }) + "\n"));
+          const stop = opts.keepalive ? startKeepalive(c, 2_000) : () => {};
+          await Bun.sleep(opts.quietMs);
+          stop();
+          c.enqueue(enc.encode(JSON.stringify({ type: "result" }) + "\n"));
+          c.close();
+        },
+      }), { headers: { "content-type": "application/x-ndjson" } });
+    },
+  });
+  try {
+    const res = await fetch(`http://127.0.0.1:${server.port}/`);
+    const reader = res.body!.getReader();
+    const dec = new TextDecoder();
+    let text = "";
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      text += dec.decode(value, { stream: true });
+    }
+    // What the web client does: parse the non-blank lines, ignore the rest.
+    return text.split("\n").map((l) => l.trim()).filter(Boolean).map((l) => JSON.parse(l));
+  } finally {
+    server.stop(true);
+  }
+}
+
+// Both halves share one 16-second wall clock by running together, rather than
+// costing the suite that long twice over.
+describe("streaming a quiet turn", () => {
+  test("only a keepalive survives a gap past the idle timeout", async () => {
+    const quietMs = 16_000;
+    const [without, with_] = await Promise.allSettled([
+      silentTurn({ keepalive: false, quietMs }),
+      silentTurn({ keepalive: true, quietMs }),
+    ]);
+    // The bug, reproduced: the turn is accepted, the first event arrives, and
+    // then the socket dies before the answer does.
+    expect(without.status).toBe("rejected");
+    // The fix: the same gap, carried through to the real final event.
+    expect(with_.status).toBe("fulfilled");
+    expect(with_.status === "fulfilled" && with_.value.map((e) => e.type)).toEqual(["system", "result"]);
+  }, 40_000);
+});
+
+describe("startKeepalive", () => {
+  test("writes blank lines until stopped, and not after", async () => {
+    const written: string[] = [];
+    const dec = new TextDecoder();
+    const stop = startKeepalive({ enqueue: (c) => { written.push(dec.decode(c)); } }, 20);
+    await Bun.sleep(120);
+    stop();
+    const atStop = written.length;
+    expect(atStop).toBeGreaterThan(1);
+    // Every write is a line the ndjson reader skips, never a parseable event.
+    expect(written.every((w) => w === "\n")).toBe(true);
+    await Bun.sleep(80);
+    expect(written.length).toBe(atStop);
+  });
+
+  test("stops itself when the stream is already gone", async () => {
+    // `enqueue` throws once the controller is closed or cancelled. The timer
+    // cannot win that race, so it has to survive losing it.
+    let calls = 0;
+    startKeepalive({ enqueue: () => { calls++; throw new Error("stream closed"); } }, 20);
+    await Bun.sleep(120);
+    expect(calls).toBe(1);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -37,6 +37,31 @@ const withToken = (url: string): string =>
 /** Whether this client has a shared-secret token configured. */
 export const hasToken = (): boolean => !!TOKEN;
 
+/** Why a chat turn ended early.
+ *
+ *  `refused` — the server answered and declined; `detail` is its reason.
+ *  `unreachable` — the request never got a response at all.
+ *  `dropped` — the turn was accepted and the connection died partway through.
+ *
+ *  The distinction is the whole point: a dropped turn may still be running in
+ *  the background, so the advice is to go look, whereas a refusal is over and
+ *  the reason is already known. Neither is recoverable from the raw fetch error,
+ *  which under WebKitGTK is the same opaque "TypeError: Load failed" either way. */
+export type ChatStreamFailure = "refused" | "unreachable" | "dropped";
+
+export class ChatStreamError extends Error {
+  constructor(readonly kind: ChatStreamFailure, readonly detail = "", readonly status = 0) {
+    super(
+      kind === "refused"
+        ? `the server refused this turn${status ? ` (${status})` : ""}${detail ? `: ${detail}` : ""}`
+        : kind === "unreachable"
+          ? `can't reach the agentglass server at ${SERVER} — it may not be running`
+          : "the connection to the agentglass server dropped mid-turn — it may have restarted (reinstalling replaces the running server). The turn itself may still be going; check the session in the fleet view before resending",
+    );
+    this.name = "ChatStreamError";
+  }
+}
+
 /** Tell an auth failure apart from a plain outage. A browser WebSocket can't
  *  read the 401 that rejects its upgrade, so a socket that closes before it ever
  *  opens looks identical to the server being down. Probing an authenticated HTTP
@@ -176,13 +201,36 @@ const realApi = {
   // --- multi-chat: drive a claude session from the browser ---
   chatEnabled: () => get<{ enabled: boolean; bypass?: boolean }>("/chat/enabled"),
   chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[] }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
-    const res = await fetch(SERVER + "/chat/send", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
+    let res: Response;
+    // A fetch that throws before a response has arrived never reached the
+    // server, which is a different problem from one that dies mid-turn — the
+    // turn has not started, so there is nothing running to go back to.
+    try {
+      res = await fetch(SERVER + "/chat/send", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
+    } catch (e) {
+      if (e instanceof DOMException && e.name === "AbortError") throw e;
+      throw new ChatStreamError("unreachable", "");
+    }
+    // A refusal — chat disabled, out of scope, a bad directory — comes back as
+    // plain text with a 4xx, not ndjson. Without this it fell into the reader
+    // below, failed to parse as JSON, and was skipped line by line, so the user
+    // was told nothing at all about why their turn did not run.
+    if (!res.ok) throw new ChatStreamError("refused", (await res.text().catch(() => "")).trim(), res.status);
     if (!res.body) { try { onEvent(JSON.parse(await res.text())); } catch { /* non-json */ } return; }
     const reader = res.body.getReader();
     const dec = new TextDecoder();
     let buf = "";
     const flush = (line: string) => { const t = line.trim(); if (t) { try { onEvent(JSON.parse(t)); } catch { /* skip */ } } };
-    for (;;) { const { done, value } = await reader.read(); if (done) break; buf += dec.decode(value, { stream: true }); let nl; while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); } }
+    try {
+      for (;;) { const { done, value } = await reader.read(); if (done) break; buf += dec.decode(value, { stream: true }); let nl; while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); } }
+    } catch (e) {
+      // The turn was accepted and then the connection died under it. WebKitGTK
+      // (the Tauri shell) reports every such failure as "TypeError: Load
+      // failed", so the raw error says nothing about what happened — the cause
+      // is named here instead, where it is known.
+      if (e instanceof DOMException && e.name === "AbortError") throw e;
+      throw new ChatStreamError("dropped", "");
+    }
     flush(buf);
   },
   dockerStart: (id: string) => post<DockerActionResult>("/docker/start", { id }),

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -5,7 +5,7 @@
 // as the terminal's session store: the panel is a *view* of these, not their
 // owner. That's also what lets many exist at once instead of one at a time.
 
-import { api } from "./api.ts";
+import { api, ChatStreamError } from "./api.ts";
 import type { ChatImage } from "../../../shared/types.ts";
 
 /** A pasted image waiting in the composer. `url` is an object URL for the
@@ -218,9 +218,12 @@ export async function send(id: string, text: string, isActive: () => boolean, al
     await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools, images }, onEvent, ac.signal);
   } catch (e) {
     if (!(e instanceof DOMException && e.name === "AbortError")) {
+      // A ChatStreamError already carries a sentence written for this spot;
+      // anything else is unexpected and its own text is the best there is.
+      const why = e instanceof ChatStreamError ? e.message : String(e);
       update(id, (c) => {
         const last = c.messages[c.messages.length - 1];
-        if (last?.role === "assistant") last.text += `\n[error] ${String(e)}`;
+        if (last?.role === "assistant") last.text += `\n[error] ${why}`;
       });
     }
   } finally {


### PR DESCRIPTION
## What does this PR do?

A chat turn died mid-answer with `[error] TypeError: Load failed` after two successful tool calls. The cause is `Bun.serve` in `server/src/index.ts` having no `idleTimeout`, so it ran on Bun's default of **10 seconds** — and that timeout counts the gaps *inside* a streaming response, not just an idle socket. Any turn whose model thought (or whose tool ran) for more than ten seconds had `/chat/send` closed from under it. The browser saw only a dead socket, which WebKitGTK — the Tauri shell's engine — reports as the generic `TypeError: Load failed` the chat panel appended to the message.

The fix is two-part, because `idleTimeout` alone is not enough:

- Set `idleTimeout: 255`, the maximum Bun accepts.
- Since even 255s is shorter than a genuinely slow turn, `chat.ts` now writes a blank ndjson line every 20s while the turn is otherwise quiet. A write resets the timer; a blank line is a no-op under ndjson framing and is already skipped by the client's line reader, so it costs one byte and needs no handling on the far end.

Two related things made the failure unreadable, fixed here too:

- `chatStream` never checked `res.ok`. A refusal (chat disabled, out of scope, bad directory) comes back as **plain text** with a 4xx, fell into the ndjson reader, failed `JSON.parse`, and was skipped line by line — so a refused turn died **silently, with no reason shown at all**.
- Every failure was rendered as `String(e)`. A dropped connection, an unreachable server and a refusal are now distinguished by a `ChatStreamError`, each carrying a sentence saying what happened and what to do — a dropped turn may still be running in the background, so it points at the fleet view rather than suggesting a blind resend.

No new dependencies.

## How was it tested?

**The root cause was reproduced directly**, without spawning a real `claude`: a `Bun.serve` streaming ndjson, silent for 25s, is cut off by the server at ~12s with `ECONNRESET`. Bun prints the confirming diagnostic itself — `[Bun.serve]: request timed out after 10 seconds. Pass idleTimeout to configure.`

New `server/test/chat-keepalive.test.ts` pins both halves against Bun's real default timeout: a quiet turn without a keepalive is dropped, the same gap with one is carried through to the final event, and `startKeepalive` is unit-tested for what it writes, that it stops, and that it survives `enqueue` throwing after the stream closes. Both scenarios run concurrently so the suite pays the 16s wall clock once.

- `bun test` from the repo root — 131 pass, 0 fail
- `bunx tsc --noEmit` in both `server/` and `web/` — clean
- `bunx vite build` in `web/` — builds
- Real server booted on a throwaway DB and a non-default port (`AGENTGLASS_DB=... AGENTGLASS_PORT=4519 AGENTGLASS_SCAN=0`) and serves normally with `idleTimeout: 255`.

**Ruled out** as causes, by reading: the `inScope` check from #72 cannot fire mid-turn (it runs synchronously before the spawn, so it can only ever produce a clean 403 up front), and the `AbortController` path is reached only from the two explicit user actions — closing a chat and pressing stop — both of which raise `AbortError`, which was already swallowed.

Not verified: whether a server restart (`make desktop-install` replacing the running binary) *also* contributed on the day. It would produce the same symptom, and the new "dropped" message names it as a possibility.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)