### PR TITLE
fix(diff): restore syntax highlighting in the desktop app

### DIFF
--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -636,7 +636,7 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
   const commitPaths = useMemo(() => [...new Set(all.map((c) => c.file_path))], [all]);
   const walkSig = useMemo(() => changesetSig(all), [all]);
   // Shiki highlighter + theme/bold controls (shared with the git panel).
-  const { hilite, themePref, setThemePref, bold, setBold, themeError } = useDiffHighlight(selected?.file_path);
+  const { hilite, themePref, setThemePref, bold, setBold, hiliteError } = useDiffHighlight(selected?.file_path);
   // Restore a cached walkthrough for the current changeset (on open / when the
   // changeset changes) so it persists across close/reopen and never re-runs.
   useEffect(() => {
@@ -874,7 +874,7 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
                             <Toggle on={reviewed.has(selected.id)} onClick={() => toggleReviewed(selected.id)} title="Mark this file reviewed (x)">{reviewed.has(selected.id) ? "reviewed ✓" : "review"}</Toggle>
                             <Toggle on={split} onClick={() => setSplit((s) => !s)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
                             <Toggle on={wrap} onClick={() => setWrap((w) => !w)} title="Toggle line wrap (w)">wrap</Toggle>
-                            <ThemePicker value={themePref} onChange={setThemePref} error={themeError} />
+                            <ThemePicker value={themePref} onChange={setThemePref} error={hiliteError} />
                             <Toggle on={bold} onClick={() => setBold((b) => !b)} title="Bold keywords, functions & types (Neovim-style)">bold</Toggle>
                             <Toggle onClick={() => copy("path")} title="Copy file path (c)">{copied === "path" ? "copied ✓" : "path"}</Toggle>
                             <Toggle onClick={() => copy("diff")} title="Copy unified diff">{copied === "diff" ? "copied ✓" : "diff"}</Toggle>

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -113,7 +113,7 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
 
   const all = useMemo(() => [...(tree?.staged ?? []), ...(tree?.unstaged ?? [])], [tree]);
   const selected = useMemo(() => all.find((c) => keyOf(c) === selKey) ?? all[0] ?? null, [all, selKey]);
-  const { hilite, themePref, setThemePref, bold, setBold, themeError } = useDiffHighlight(selected?.file_path);
+  const { hilite, themePref, setThemePref, bold, setBold, hiliteError } = useDiffHighlight(selected?.file_path);
   const writeEnabled = tree?.writeEnabled ?? false;
   const flash = (ok: boolean, msg: string) => { setToast({ ok, msg }); setTimeout(() => setToast(null), 2600); };
 
@@ -373,7 +373,7 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
                               {writeEnabled && (selected.staged ? <Toggle onClick={() => unstage(selected)} title="Unstage this file">－ unstage</Toggle> : <Toggle onClick={() => stage(selected)} title="Stage this file">＋ stage</Toggle>)}
                               <Toggle on={split} onClick={() => setSplit((s) => !s)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
                               <Toggle on={wrap} onClick={() => setWrap((w) => !w)} title="Toggle line wrap">wrap</Toggle>
-                              <ThemePicker value={themePref} onChange={setThemePref} error={themeError} />
+                              <ThemePicker value={themePref} onChange={setThemePref} error={hiliteError} />
                               <Toggle on={bold} onClick={() => setBold((b) => !b)} title="Bold keywords, functions & types (Neovim-style)">bold</Toggle>
                             </div>
                           </div>

--- a/web/src/lib/diffHighlight.ts
+++ b/web/src/lib/diffHighlight.ts
@@ -18,18 +18,28 @@ export function useDiffHighlight(filePath?: string) {
   const [themePref, setThemePref] = useState<string>(() => { try { return localStorage.getItem(THEME_KEY) || "auto"; } catch { return "auto"; } });
   const [bold, setBold] = useState<boolean>(() => { try { return localStorage.getItem(BOLD_KEY) !== "0"; } catch { return true; } });
   const [themeName, setThemeName] = useState<string | null>(null);
+  const [coreError, setCoreError] = useState<string | null>(null);
+  const [langError, setLangError] = useState<string | null>(null);
   const [themeError, setThemeError] = useState<string | null>(null);
   const lang = useMemo(() => langFromPath(filePath), [filePath]);
 
+  // Every stage below fetches a chunk at runtime, so every stage can fail for
+  // reasons the user cannot see — and each one fails into the *same* blank
+  // monochrome diff. Swallowing any of them is what made this bug take three
+  // separate reports to pin down, so all three now surface on the picker.
   useEffect(() => {
     let alive = true;
-    getHighlighter().then((h) => { if (alive) setHl(h); }).catch(() => {});
+    getHighlighter()
+      .then((h) => { if (alive) { setHl(h); setCoreError(null); } })
+      .catch(() => { if (alive) setCoreError("Syntax highlighting couldn't start — the highlighter failed to load."); });
     return () => { alive = false; };
   }, []);
   useEffect(() => {
     if (!hl || !lang || loadedLangs.has(lang)) return;
     let alive = true;
-    hl.loadLanguage(lang as never).then(() => { if (alive) setLoadedLangs((s) => new Set(s).add(lang)); }).catch(() => {});
+    hl.loadLanguage(lang as never)
+      .then(() => { if (alive) { setLoadedLangs((s) => new Set(s).add(lang)); setLangError(null); } })
+      .catch(() => { if (alive) setLangError(`The ${lang} grammar couldn't be loaded — this file is shown as plain text.`); });
     return () => { alive = false; };
   }, [hl, lang, loadedLangs]);
   // Resolve "auto" to the app's light/dark, then register the chosen theme
@@ -50,12 +60,15 @@ export function useDiffHighlight(filePath?: string) {
       setThemeName(name);
       setThemeError(!failed ? null
         : `${themeLabel(failed)} couldn't be loaded — ${name ? `showing ${themeLabel(name)} instead` : "syntax highlighting is off"}.`);
-    }).catch(() => {});
+    }).catch(() => { if (alive) setThemeError("The syntax theme couldn't be loaded."); });
     return () => { alive = false; };
   }, [hl, resolvedTheme, bold]);
 
   // Stable context object so <HiliteCtx.Provider> doesn't re-render every
   // memoized <Code> whenever an unrelated parent state changes.
   const hilite = useMemo<Hilite>(() => ({ hl, lang: lang && loadedLangs.has(lang) ? lang : null, theme: themeName }), [hl, lang, loadedLangs, themeName]);
-  return { hilite, themePref, setThemePref, bold, setBold, themeError };
+  // Reported worst-first: a highlighter that never started explains the theme
+  // and grammar being missing too, so leading with those would misdirect.
+  const hiliteError = coreError ?? themeError ?? langError;
+  return { hilite, themePref, setThemePref, bold, setBold, hiliteError };
 }

--- a/web/src/lib/highlight.ts
+++ b/web/src/lib/highlight.ts
@@ -8,6 +8,7 @@
 // `bold` is on we clone the chosen theme and append a rule that bolds them —
 // giving the same look on ANY theme. Themes' own italic/bold are always honored.
 import type { Highlighter, ThemeRegistrationRaw } from "shiki";
+import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 
 // Lazy handle to the shiki module — imported once, shared by every helper, so
 // the whole library is a single on-demand chunk.
@@ -15,8 +16,25 @@ let modP: Promise<typeof import("shiki")> | null = null;
 const shiki = () => (modP ??= import("shiki"));
 
 let hp: Promise<Highlighter> | null = null;
+/**
+ * The one shared highlighter, tokenizing with shiki's **JavaScript** RegExp
+ * engine rather than its default Oniguruma one.
+ *
+ * Oniguruma is WebAssembly, and the desktop shell serves the bundle under the
+ * CSP in `src-tauri/tauri.conf.json`, whose `script-src 'self'` omits
+ * `'wasm-unsafe-eval'` — so the webview refuses to instantiate the module and
+ * `createHighlighter` rejects before a theme or a language is ever requested.
+ * That is why the diff was monochrome in the app but coloured in a browser,
+ * and why the theme picker showed no complaint: the theme step never ran.
+ *
+ * The engine swap is preferred over widening the CSP because it keeps the
+ * desktop app's script policy as tight as it is today, and because relying on
+ * `'wasm-unsafe-eval'` would put us at the mercy of whether the host's
+ * WebKitGTK recognises that token — an unknown source expression is simply
+ * ignored, which would silently leave wasm blocked on older systems.
+ */
 export function getHighlighter(): Promise<Highlighter> {
-  if (!hp) hp = shiki().then((m) => m.createHighlighter({ themes: [], langs: [] }));
+  if (!hp) hp = shiki().then((m) => m.createHighlighter({ themes: [], langs: [], engine: createJavaScriptRegexEngine() }));
   return hp;
 }
 

--- a/web/test/diff-theme.test.ts
+++ b/web/test/diff-theme.test.ts
@@ -8,9 +8,33 @@
 // was to compare two themes side by side.
 import { expect, test } from "bun:test";
 import { bundledThemes } from "shiki";
-import { getHighlighter, ensureTheme, THEMES, themeLabel } from "../src/lib/highlight.ts";
+import { getHighlighter, ensureTheme, langFromPath, THEMES, themeLabel } from "../src/lib/highlight.ts";
 
 const CODE = 'const greeting = "hello"; // note';
+
+// Stand in for the desktop shell's CSP for this whole file.
+//
+// The regression: shiki's default Oniguruma engine is WebAssembly, and
+// `src-tauri/tauri.conf.json` sets `script-src 'self'` with no
+// `'wasm-unsafe-eval'`, so the webview refuses to instantiate it and
+// `createHighlighter` rejects before a theme or grammar is ever asked for —
+// every diff in the app came out monochrome while browsers were fine. The
+// guard is installed at import time rather than inside one test because the
+// highlighter is memoized: by the time any single test ran, an earlier one
+// would already have built it, wasm and all, and the check would pass
+// vacuously. With it here, *any* test in this file that reaches for wasm
+// fails.
+const usedWasm: string[] = [];
+for (const k of ["instantiate", "compile", "instantiateStreaming", "compileStreaming"] as const) {
+  const refuse = () => { usedWasm.push(k); throw new Error(`WebAssembly.${k} is blocked, as it is under the desktop CSP`); };
+  (WebAssembly as unknown as Record<string, unknown>)[k] = refuse;
+}
+for (const k of ["Instance", "Module"] as const) {
+  (WebAssembly as unknown as Record<string, unknown>)[k] = function () {
+    usedWasm.push(k);
+    throw new Error(`new WebAssembly.${k} is blocked, as it is under the desktop CSP`);
+  };
+}
 
 test("every theme the picker offers is a real shiki bundled id", () => {
   // A typo, or an id shiki renames or drops in a future major, would otherwise
@@ -64,6 +88,33 @@ test("a theme that cannot load falls back to one that is actually registered", a
   expect(failed).toBe("no-such-theme");
   expect(name).toBe("github-dark-bold");
   expect(() => hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! })).not.toThrow();
+});
+
+test("the highlighter tokenizes without instantiating any WebAssembly", async () => {
+  const hl = await getHighlighter();
+  await hl.loadLanguage("typescript" as never);
+  const { name, failed } = await ensureTheme(hl, "gruvbox-dark-medium", true);
+  expect(failed).toBeUndefined();
+  const tokens = hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! }).tokens.flat();
+  expect(new Set(tokens.map((x) => x.color)).size).toBeGreaterThan(1);
+  expect(usedWasm).toEqual([]);
+});
+
+test("every language the diff maps a file to actually has a grammar", async () => {
+  // A grammar that will not load leaves the file as plain text, which looks
+  // identical to a theme failure — so the extension table is checked against
+  // shiki directly rather than trusted.
+  const hl = await getHighlighter();
+  const langs = [...new Set(["a.ts", "a.tsx", "a.js", "a.jsx", "a.json", "a.py", "a.rb", "a.go", "a.rs",
+    "a.java", "a.kt", "a.swift", "a.scala", "a.dart", "a.c", "a.cpp", "a.cs", "a.php", "a.css", "a.scss",
+    "a.html", "a.xml", "a.vue", "a.svelte", "a.astro", "a.md", "a.mdx", "a.sh", "a.fish", "a.yml",
+    "a.toml", "a.ini", "a.sql", "a.graphql", "a.proto", "a.lua", "a.r", "a.ex", "a.clj", "a.hs",
+    "a.elm", "a.ml", "a.nim", "a.zig", "Dockerfile", "Makefile"].map((f) => langFromPath(f)!))];
+  const failed: string[] = [];
+  for (const l of langs) {
+    try { await hl.loadLanguage(l as never); } catch { failed.push(l); }
+  }
+  expect(failed).toEqual([]);
 });
 
 test("the failure is reported with the name the user chose, not the internal one", () => {


### PR DESCRIPTION
## What does this PR do?

Fixes the diff rendering as monochrome plain text **in the desktop app** (fine in a browser). Neither of the two earlier theories was the cause.

**The actual cause:** Shiki's default Oniguruma regex engine is WebAssembly. The desktop shell serves the bundle under the CSP in `src-tauri/tauri.conf.json`, whose `script-src 'self'` carries no `'wasm-unsafe-eval'`, so the webview refuses to instantiate the module and `createHighlighter()` **rejects outright** — before a theme or a grammar is ever requested. That also explains the missing ⚠ badge: #66's reporting hangs off the theme step, and the theme effect is guarded by `if (!hl) return`, so it never ran.

Proven by serving the `make desktop-web` bundle under the CSP taken verbatim from `tauri.conf.json` and loading it in headless Chromium:

```
WITHOUT CSP:  wasm=OK  createHighlighter=OK  loadTheme=OK  loadLanguage=OK
              codeToTokens=OK colors=["#FE8019","#EBDBB2","#83A598",...]

WITH the CSP: wasm=FAIL(WebAssembly.instantiate(): Compiling or instantiating
              WebAssembly module violates the following Content Security policy
              directive because 'unsafe-eval' is not an allowed source...)
              SHIKI_FAIL=<same>          <- createHighlighter never resolves
```

Nothing 404s and nothing else is CSP-blocked; the chunks all arrive.

**The fix:** tokenize with shiki's JavaScript RegExp engine (`shiki/engine/javascript`, already part of the `shiki` package — no new dependency). It needs no wasm, so the desktop app's script policy stays exactly as tight as it is today. Widening the CSP was the alternative, but it would have meant trusting the host's WebKitGTK to recognise `'wasm-unsafe-eval'` — an unknown source expression is silently ignored, which would leave wasm blocked on older systems for the same invisible symptom.

**And the recurring bug:** the silent `.catch(() => {})` on the load paths. The highlighter, the grammar and the theme all fail into the same blank monochrome diff, so every stage now surfaces on the picker the way #66 made the theme step surface, worst-first. (`themeError` becomes `hiliteError`; both call sites updated.)

## How was it tested?

- `bunx tsc --noEmit` in `web/` and `server/` — clean; `bunx vite build` — clean; `bun test` — 133 pass, 0 fail.
- Extended `web/test/diff-theme.test.ts` (from #66) rather than adding a file. The CSP is stood in for by blocking `WebAssembly.instantiate` / `compile` / `*Streaming` / `Instance` / `Module` at import time — it has to be import time, because the highlighter is memoized and an in-test guard would pass vacuously once an earlier test had already built it. **Confirmed the test fails on the pre-fix engine and passes after**, so it genuinely guards the regression. A second test checks every language the extension table maps to actually has a grammar.
- Under the real CSP in headless Chromium, with the fix: all **49 grammars** and all **22 offered themes** load, tokenization succeeds for every one, and the colours are identical to the wasm engine. End-to-end through the shipped module: `lang=typescript theme=gruvbox-dark-medium-bold failed=- distinctColors=7`.

Not verified: I could not run the built `.deb` in a real WebKitGTK window on this machine, so the WebKitGTK-side confirmation is by CSP equivalence (Chromium enforcing the identical policy), not by launching the app.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)