### PR TITLE
fix(chat): a paperclip that attaches any file, aligned with send

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -213,6 +213,17 @@ function ResumePicker({ onPick, onClose }: { onPick: (s: SessionRollup) => void;
   );
 }
 
+// A paperclip, not a plus: this attaches an existing file, it doesn't create
+// anything. Drawn rather than an emoji so it renders identically in WebKitGTK
+// and matches the stroke weight of the header's icons.
+function ClipIcon() {
+  return (
+    <svg width="15" height="15" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round" strokeLinejoin="round">
+      <path d="M21 11.5l-8.6 8.6a5 5 0 0 1-7-7l8.9-8.9a3.3 3.3 0 0 1 4.7 4.7l-8.9 8.9a1.7 1.7 0 0 1-2.3-2.3l8.2-8.2" />
+    </svg>
+  );
+}
+
 export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: () => void; focusId?: string }) {
   const chats = useSyncExternalStore(subscribe, listChats, listChats);
   const [activeId, setActiveId] = useState("");
@@ -360,7 +371,7 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
       // identical to the feature being broken.
       if (Array.from(e.clipboardData.items).some((i) => i.kind === "file")) {
         e.preventDefault();
-        setHint("that file isn't a PNG, JPEG, GIF or WebP");
+        setHint("that file isn't an image or a text file");
       }
       return;
     }
@@ -538,27 +549,28 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                           screenshot tools only put a file path on it, so the
                           picker is the path that always works — these tools
                           save a file as well as copying it. */}
-                      <input ref={fileRef} type="file" accept="image/png,image/jpeg,image/gif,image/webp" multiple hidden
+                      <input ref={fileRef} type="file" multiple hidden
                         onChange={async (ev) => {
                           const picked = Array.from(ev.target.files ?? []);
                           ev.target.value = ""; // re-picking the same file must still fire
                           if (active && picked.length) setHint(await addAttachments(active.id, picked));
                         }} />
                       <button onClick={() => fileRef.current?.click()} disabled={!enabled || !active}
-                        title="Attach an image (PNG, JPEG, GIF or WebP)"
-                        className="h-9 w-9 shrink-0 grid place-items-center rounded-lg text-[15px]"
+                        title="Attach a file — images are sent as images, text files are quoted into the message"
+                        aria-label="Attach a file"
+                        className="shrink-0 grid place-items-center rounded-lg px-3 self-stretch"
                         style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}>
-                        ⊕
+                        <ClipIcon />
                       </button>
                       <textarea ref={inputRef} value={active?.draft ?? ""} disabled={!enabled || !active} rows={2}
                         onChange={(e) => active && update(active.id, (c) => { c.draft = e.target.value; })}
                         onKeyDown={onKey}
                         onPaste={onPaste}
-                        placeholder={!enabled ? "chat unavailable" : active?.sessionId ? "reply… (Enter to send, Shift+Enter newline, ⊕ or paste to attach an image)" : "message a new session… (Enter to send, ⊕ or paste to attach an image)"}
+                        placeholder={!enabled ? "chat unavailable" : active?.sessionId ? "reply… (Enter to send, Shift+Enter newline)" : "message a new session… (Enter to send)"}
                         className="agx-scroll flex-1 px-3 py-2 rounded-lg text-[12px] outline-none resize-none" style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }} />
                       {active?.sending
-                        ? <button onClick={() => stop(active.id)} className="shrink-0 px-3.5 py-2 rounded-lg text-[11.5px] font-semibold" style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>■ stop</button>
-                        : <button onClick={submit} disabled={!hasTurn || !active?.cwd || !enabled} className="shrink-0 px-4 py-2 rounded-lg text-[11.5px] font-semibold" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!hasTurn || !active?.cwd) ? 0.45 : 1 }}>send ↵</button>}
+                        ? <button onClick={() => stop(active.id)} className="shrink-0 px-3.5 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>■ stop</button>
+                        : <button onClick={submit} disabled={!hasTurn || !active?.cwd || !enabled} className="shrink-0 px-4 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!hasTurn || !active?.cwd) ? 0.45 : 1 }}>send ↵</button>}
                     </div>
                     <div className="mt-1.5 text-[9.5px] t-dim2">
                       {hint

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -260,6 +260,22 @@ const toBase64 = (buf: ArrayBuffer) => {
 
 /** Attach images to a chat's composer. Returns a message to show the user when
  *  something was refused, or "" when everything was taken. */
+
+/** A non-image file, quoted into the draft so it reaches the conversation.
+ *
+ *  Bounded because this becomes part of the prompt: a 5MB log pasted whole
+ *  would be billed as tokens and drown the question being asked. Binary files
+ *  return null — inlining their bytes as text helps nobody. */
+const TEXT_FILE_MAX = 128 * 1024;
+async function quoteTextFile(f: File): Promise<string | null> {
+  if (f.size > TEXT_FILE_MAX) return null;
+  let text: string;
+  try { text = await f.text(); } catch { return null; }
+  // A NUL byte is the cheap, reliable tell that this isn't text.
+  if (!text || text.includes("\u0000")) return null;
+  return `${f.name}:\n\n\u0060\u0060\u0060\n${text.trimEnd()}\n\u0060\u0060\u0060`;
+}
+
 export async function addAttachments(id: string, files: File[]): Promise<string> {
   const chat = chats.get(id);
   if (!chat) return "";
@@ -267,7 +283,18 @@ export async function addAttachments(id: string, files: File[]): Promise<string>
   for (const f of files) {
     const c = chats.get(id);
     if (!c) break;
-    if (!MEDIA_TYPES.has(f.type)) { rejected = "only png, jpeg, gif and webp images can be attached"; continue; }
+    if (!MEDIA_TYPES.has(f.type)) {
+      // Anything that isn't an image claude can look at directly still has a
+      // useful path: quote it into the message. `claude` runs with tools in the
+      // project, so a file that lives there it can simply read — but a file
+      // picked from anywhere else (a download, another disk) it cannot, and the
+      // picker deliberately doesn't expose real paths. Inlining the text is the
+      // only way that file reaches the conversation at all.
+      const note = await quoteTextFile(f);
+      if (note) update(id, (cc) => { cc.draft = cc.draft ? `${cc.draft}\n\n${note}` : note; });
+      else rejected = `${f.name} isn't an image or a text file`;
+      continue;
+    }
     if (c.attachments.length >= MAX_IMAGES) { rejected = `at most ${MAX_IMAGES} images per message`; continue; }
     if (f.size > MAX_IMAGE_BYTES) { rejected = `each image must be under ${MAX_IMAGE_BYTES / 1024 / 1024}MB`; continue; }
     if (c.attachments.reduce((n, a) => n + a.bytes, 0) + f.size > MAX_IMAGES_TOTAL_BYTES) {


### PR DESCRIPTION
## What does this PR do?

Three things wrong with the attach control, all found by actually using it.

**The icon was ⊕** — "add", which isn't what the button does. It attaches an *existing* file; it doesn't create anything. Now a drawn paperclip — drawn rather than an emoji so it renders identically in WebKitGTK and matches the stroke weight of the header's icons.

**The buttons didn't line up.** Attach was a fixed 36px square while send sized itself from padding against a two-row textarea, so the strip read as three unrelated controls. Both now stretch to the row.

**It only accepted images, with no answer for anything else.** A file that isn't an image claude can look at directly is now quoted into the draft — bounded at 128KB and refused when it contains a NUL byte, since this becomes part of the prompt: inlining a binary, or a 5MB log, helps nobody and is billed as tokens either way.

### Why quote rather than pass a path

The file picker deliberately doesn't expose real paths, so for a file outside the project there's no path to hand over. `claude` can read what lives in the project on its own; inlining is the only route for everything else.

## Good news from the field

The image pipeline **works end to end** — the model received a pasted screenshot and described it correctly. That was the one link in #68 that nobody had verified with a live turn.

## Still not fixed: paste in the desktop app

`Ctrl+V` of an image still does nothing in the Tauri window. #75 made the handler read both `files` and `items`, which is correct, but WebKitGTK appears not to expose image data to the web clipboard API at all. The real fix is Tauri's clipboard plugin, which is a new Rust dependency and its own PR. The paperclip is the working path meanwhile.

## How was it tested?

- `bun test` — 131 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean

Visual change; the alignment is the point, so it's worth a look.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)