### PR TITLE
feat(chat): same detail as the session view, and legible in every theme

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -14,6 +14,8 @@ import type { GitRepoRef, SessionRollup } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
+import { ToolRow } from "./ToolRow.tsx";
+import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
 import { fmtAgo, fmtUsd, modelLabelOf, modelColor, providerOf } from "../lib/format.ts";
@@ -568,10 +570,33 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                           )}
                           <div className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
                           <div className="max-w-[86%] min-w-0 rounded-xl px-3.5 py-2.5 text-[12px] leading-relaxed break-words"
-                            style={{ ...CODE_FONT_STYLE, fontFamily: undefined, opacity: m.historical ? 0.72 : 1, background: m.role === "user" ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "color-mix(in srgb, var(--bg3) 45%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", color: "var(--text)" }}>
+                            style={{
+                              ...CODE_FONT_STYLE, fontFamily: undefined, opacity: m.historical ? 0.72 : 1,
+                              // Stronger than the old 16%/45% wash: at that
+                              // strength every bubble was the same violet as the
+                              // panel behind it, and on some themes the two roles
+                              // were indistinguishable. The left border is what
+                              // survives a theme that flattens the fills.
+                              background: m.role === "user"
+                                ? "color-mix(in srgb, var(--primary) 26%, var(--bg2))"
+                                : "color-mix(in srgb, var(--bg3) 85%, var(--bg))",
+                              border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)",
+                              borderLeft: `3px solid ${m.role === "user" ? "var(--primary)" : "color-mix(in srgb, var(--info) 70%, transparent)"}`,
+                              color: "var(--text)",
+                            }}>
+                            {/* Role and time, the way the session view has always
+                                shown them — their absence is most of why the two
+                                read as different products. */}
+                            <div className="text-[9px] uppercase tracking-wider mb-1 flex items-center gap-2"
+                              style={{ color: m.role === "user" ? "var(--primary-hover)" : "var(--info)" }}>
+                              <span>{m.role}</span>
+                              <span className="t-dim2 normal-case tracking-normal">{fmtTime(m.ts)}</span>
+                            </div>
                             {m.tools.length > 0 && (
-                              <div className="flex flex-wrap gap-1 mb-1.5">
-                                {m.tools.map((t, j) => <span key={j} className="text-[9.5px] px-1.5 py-0.5 rounded" style={{ ...CODE_FONT_STYLE, color: "var(--info)", background: "color-mix(in srgb, var(--info) 12%, transparent)" }}>⚙ {t}</span>)}
+                              <div className="flex flex-col gap-0.5 mb-1.5 pb-1.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                                {m.tools.map((t) => (
+                                  <ToolRow key={t.id} e={{ kind: "tool", ts: t.ts, tool: t.name, target: t.target, is_error: t.error, output: t.output }} />
+                                ))}
                               </div>
                             )}
                             {!!m.images?.length && (

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -7,66 +7,11 @@ import { api } from "../lib/api.ts";
 import { usePoll } from "../lib/usePoll.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { fmtUsd, fmtTokens, fmtAgo, fmtTime, modelLabelOf, modelColor } from "../lib/format.ts";
+import { ToolRow } from "./ToolRow.tsx";
 import { sessionIsLive } from "../lib/derive.ts";
 
 const TOOL_RAMP = ["#a78bfa", "#f472b6", "#34d399", "#60a5fa", "#fbbf24", "#22d3ee", "#a3e635", "#fb923c"];
 const shortType = (t: string) => t.replace(/^workflow-subagent$/, "workflow").replace(/^general-purpose$/, "general");
-
-// A tool run in the thread. Deliberately one dense line rather than a bubble:
-// a session runs hundreds of these, and giving each the weight of a message
-// would bury the conversation it is supposed to sit alongside.
-function ToolRow({ e }: { e: TimelineEntry }) {
-  const [open, setOpen] = useState(false);
-  const target = e.target ?? "";
-  // A command can be a whole script; show its first line and let the rest be
-  // opened, rather than either truncating it away or pasting 40 lines inline.
-  const firstLine = target.split("\n")[0];
-  const out = (e.output ?? "").trimEnd();
-  const outLines = out ? out.split("\n") : [];
-  // Two lines of result, always. It is usually the difference between "the
-  // tests ran" and "the tests passed", and expanding for that every time would
-  // make the timeline useless as something you skim.
-  const PREVIEW = 2;
-  const outMore = outLines.length > PREVIEW || !!e.output_clipped;
-  const hasMore = target.length > firstLine.length || firstLine.length > 110 || outMore;
-  const tint = e.is_error ? "var(--error)" : "var(--info)";
-  return (
-    <div className="flex items-start gap-2 text-[10.5px] leading-relaxed pl-1">
-      <span className="shrink-0 tabular-nums t-dim2 pt-px" style={{ minWidth: 52 }}>{fmtTime(e.ts)}</span>
-      <span className="shrink-0 px-1.5 rounded font-medium"
-        style={{ color: tint, background: `color-mix(in srgb, ${tint} 13%, transparent)` }}>
-        {e.is_error ? "✕" : "⚙"} {e.tool}
-      </span>
-      <span className="min-w-0 flex-1">
-        <span
-          onClick={hasMore ? () => setOpen((o) => !o) : undefined}
-          className={`block break-all ${hasMore ? "cursor-pointer" : ""} ${open ? "whitespace-pre-wrap" : "truncate"}`}
-          style={{ color: "var(--text3)", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}
-          title={hasMore && !open ? "click to expand" : undefined}>
-          {open ? target : firstLine}
-        </span>
-        {e.note && <span className="block t-dim2 truncate">{e.note}</span>}
-        {outLines.length > 0 && (
-          <span className="block mt-0.5 pl-2" style={{ borderLeft: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-            <span className={`block ${open ? "whitespace-pre-wrap break-all" : "truncate"}`}
-              style={{ color: e.is_error ? "var(--error)" : "var(--text4)", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>
-              {open ? out : outLines.slice(0, PREVIEW).join(" · ")}
-            </span>
-            {outMore && !open && (
-              <span className="block t-dim2 cursor-pointer" onClick={() => setOpen(true)}>
-                +{e.output_clipped ? "more" : `${outLines.length - PREVIEW} lines`}
-              </span>
-            )}
-            {open && e.output_clipped && <span className="block t-dim2">…output trimmed</span>}
-          </span>
-        )}
-      </span>
-      {e.duration_ms != null && e.duration_ms >= 1000 && (
-        <span className="shrink-0 tabular-nums t-dim2">{(e.duration_ms / 1000).toFixed(1)}s</span>
-      )}
-    </div>
-  );
-}
 
 function Stat({ k, v, color }: { k: string; v: string; color?: string }) {
   return (
@@ -345,13 +290,19 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                             <div key={i} className={`flex ${c.role === "user" ? "justify-end" : "justify-start"}`}>
                               <div
                                 className="max-w-[85%] min-w-0 rounded-xl px-3 py-2 text-[11.5px] leading-relaxed break-words"
+                                // Mixed against a solid base rather than
+                                // `transparent`: over the panel's own violet the
+                                // old wash left both roles nearly the same
+                                // colour, and some themes flattened them
+                                // completely. The left border carries the
+                                // distinction even where the fills don't.
                                 style={
                                   c.role === "user"
-                                    ? { background: "color-mix(in srgb, var(--primary) 16%, transparent)", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)" }
-                                    : { background: "color-mix(in srgb, var(--bg3) 40%, transparent)", color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }
+                                    ? { background: "color-mix(in srgb, var(--primary) 26%, var(--bg2))", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--primary) 55%, transparent)", borderLeft: "3px solid var(--primary)" }
+                                    : { background: "color-mix(in srgb, var(--bg3) 85%, var(--bg))", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", borderLeft: "3px solid color-mix(in srgb, var(--info) 70%, transparent)" }
                                 }
                               >
-                                <div className="text-[9px] uppercase tracking-wider mb-1" style={{ color: c.role === "user" ? "var(--primary-hover)" : "var(--text4)" }}>{c.role} · {fmtTime(c.ts)}</div>
+                                <div className="text-[9px] uppercase tracking-wider mb-1" style={{ color: c.role === "user" ? "var(--primary-hover)" : "var(--info)" }}>{c.role} · {fmtTime(c.ts)}</div>
                                 <Markdown text={c.text ?? ""} />
                               </div>
                             </div>

--- a/web/src/components/ToolRow.tsx
+++ b/web/src/components/ToolRow.tsx
@@ -1,0 +1,64 @@
+// One tool run, rendered the same way wherever a conversation is shown — the
+// session timeline and the live chat. They were drifting apart: the chat
+// reduced a tool call to a bare chip with its name, which threw away the
+// command, its output and whether it failed. Sharing the row is what keeps
+// "what the agent actually did" identical in both places.
+import { useState } from "react";
+import type { TimelineEntry } from "../../../shared/types.ts";
+import { fmtTime } from "../lib/format.ts";
+
+// A tool run in the thread. Deliberately one dense line rather than a bubble:
+// a session runs hundreds of these, and giving each the weight of a message
+// would bury the conversation it is supposed to sit alongside.
+export function ToolRow({ e }: { e: TimelineEntry }) {
+  const [open, setOpen] = useState(false);
+  const target = e.target ?? "";
+  // A command can be a whole script; show its first line and let the rest be
+  // opened, rather than either truncating it away or pasting 40 lines inline.
+  const firstLine = target.split("\n")[0];
+  const out = (e.output ?? "").trimEnd();
+  const outLines = out ? out.split("\n") : [];
+  // Two lines of result, always. It is usually the difference between "the
+  // tests ran" and "the tests passed", and expanding for that every time would
+  // make the timeline useless as something you skim.
+  const PREVIEW = 2;
+  const outMore = outLines.length > PREVIEW || !!e.output_clipped;
+  const hasMore = target.length > firstLine.length || firstLine.length > 110 || outMore;
+  const tint = e.is_error ? "var(--error)" : "var(--info)";
+  return (
+    <div className="flex items-start gap-2 text-[10.5px] leading-relaxed pl-1">
+      <span className="shrink-0 tabular-nums t-dim2 pt-px" style={{ minWidth: 52 }}>{fmtTime(e.ts)}</span>
+      <span className="shrink-0 px-1.5 rounded font-medium"
+        style={{ color: tint, background: `color-mix(in srgb, ${tint} 13%, transparent)` }}>
+        {e.is_error ? "✕" : "⚙"} {e.tool}
+      </span>
+      <span className="min-w-0 flex-1">
+        <span
+          onClick={hasMore ? () => setOpen((o) => !o) : undefined}
+          className={`block break-all ${hasMore ? "cursor-pointer" : ""} ${open ? "whitespace-pre-wrap" : "truncate"}`}
+          style={{ color: "var(--text3)", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}
+          title={hasMore && !open ? "click to expand" : undefined}>
+          {open ? target : firstLine}
+        </span>
+        {e.note && <span className="block t-dim2 truncate">{e.note}</span>}
+        {outLines.length > 0 && (
+          <span className="block mt-0.5 pl-2" style={{ borderLeft: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+            <span className={`block ${open ? "whitespace-pre-wrap break-all" : "truncate"}`}
+              style={{ color: e.is_error ? "var(--error)" : "var(--text4)", fontFamily: "var(--font-mono, ui-monospace, monospace)" }}>
+              {open ? out : outLines.slice(0, PREVIEW).join(" · ")}
+            </span>
+            {outMore && !open && (
+              <span className="block t-dim2 cursor-pointer" onClick={() => setOpen(true)}>
+                +{e.output_clipped ? "more" : `${outLines.length - PREVIEW} lines`}
+              </span>
+            )}
+            {open && e.output_clipped && <span className="block t-dim2">…output trimmed</span>}
+          </span>
+        )}
+      </span>
+      {e.duration_ms != null && e.duration_ms >= 1000 && (
+        <span className="shrink-0 tabular-nums t-dim2">{(e.duration_ms / 1000).toFixed(1)}s</span>
+      )}
+    </div>
+  );
+}

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -13,10 +13,25 @@ import type { ChatImage } from "../../../shared/types.ts";
  *  otherwise every paste leaks a blob for the life of the tab. */
 export type Attachment = ChatImage & { id: string; name: string; bytes: number; url: string };
 
+/** A tool the agent ran inside a turn. Shaped like the session timeline's rows
+ *  so both render through the same component — the chat used to keep only the
+ *  name, which lost the command, its output and whether it failed. */
+export type ChatTool = {
+  id: string;
+  name: string;
+  target: string | null;
+  output: string | null;
+  error: boolean;
+  ts: number;
+};
+
 export type ChatMsg = {
   role: "user" | "assistant";
   text: string;
-  tools: string[];
+  tools: ChatTool[];
+  /** When it was said — the session view has always shown this and the chat
+   *  hasn't, which is most of why they read as different products. */
+  ts: number;
   streaming?: boolean;
   /** Images sent with this turn, shown back in the transcript so the message
    *  reads the way it was written. */
@@ -111,7 +126,7 @@ async function hydrate(chatId: string, sessionId: string) {
     // interleaved timeline for anyone who wants the machinery.
     const msgs: ChatMsg[] = [...(s.conversation ?? [])]
       .sort((a, b) => a.ts - b.ts)
-      .map((c) => ({ role: c.role, text: c.text, tools: [], historical: true }));
+      .map((c) => ({ role: c.role, text: c.text, tools: [], ts: c.ts, historical: true }));
     if (!msgs.length) return;
     update(chatId, (c) => {
       // Anything typed while this was in flight stays last — the reply to a
@@ -182,8 +197,8 @@ export async function send(id: string, text: string, isActive: () => boolean, al
   update(id, (c) => {
     // A name you chose outranks one derived from the first message.
     if (c.messages.length === 0 && !c.renamed) c.title = titleOf(msg || `${images.length} image${images.length > 1 ? "s" : ""}`);
-    c.messages.push({ role: "user", text: msg, tools: [], images: images.length ? images : undefined });
-    c.messages.push({ role: "assistant", text: "", tools: [], streaming: true });
+    c.messages.push({ role: "user", text: msg, tools: [], ts: Date.now(), images: images.length ? images : undefined });
+    c.messages.push({ role: "assistant", text: "", tools: [], ts: Date.now(), streaming: true });
     c.sending = true;
     c.draft = "";
     // The thumbnails belong to the composer, not the sent message, so their
@@ -210,13 +225,23 @@ export async function send(id: string, text: string, isActive: () => boolean, al
         for (const b of blocks) {
           if (b.type === "text" && typeof b.text === "string") last.text += b.text;
           else if (b.type === "tool_use" && typeof b.name === "string") {
-            // The denial comes back later keyed only by id, so remember which
-            // tool it was — naming it is the whole point of the prompt below.
+            // The result comes back later keyed only by id, so remember which
+            // tool it was — both to name a refusal and to attach the output.
             if (typeof b.id === "string") toolNames.set(b.id, String(b.name));
             const inp = (b.input ?? {}) as Record<string, unknown>;
-            const hint = typeof inp.command === "string" ? `: ${inp.command.slice(0, 44)}`
-              : typeof inp.file_path === "string" ? `: ${String(inp.file_path).split("/").pop()}` : "";
-            last.tools.push(String(b.name) + hint);
+            const str = (v: unknown) => (typeof v === "string" && v ? v : null);
+            // Same per-tool notion of "what it acted on" the server uses for
+            // the session timeline, so the two views agree.
+            const target = String(b.name) === "Bash" ? str(inp.command)
+              : str(inp.file_path) ?? str(inp.url) ?? str(inp.query) ?? str(inp.pattern) ?? str(inp.description);
+            last.tools.push({
+              id: String(b.id ?? `${Date.now()}`),
+              name: String(b.name),
+              target,
+              output: null,
+              error: false,
+              ts: Date.now(),
+            });
           }
         }
         if (!isActive()) c.unread = true;
@@ -232,8 +257,20 @@ export async function send(id: string, text: string, isActive: () => boolean, al
         const text = typeof b.content === "string" ? b.content
           : Array.isArray(b.content) ? b.content.map((x: Record<string, unknown>) => (typeof x?.text === "string" ? x.text : "")).join(" ")
           : "";
+        const useId = String(b.tool_use_id ?? "");
+        // Attach the answer to the row that asked for it, so the chat shows
+        // what came back rather than only what was run.
+        update(id, (c) => {
+          for (const m of c.messages) {
+            const row = m.tools.find((t) => t.id === useId);
+            if (!row) continue;
+            row.output = text.trimEnd() || null;
+            row.error = b.is_error === true;
+            break;
+          }
+        });
         if (!/permission|requires approval|not allowed|denied/i.test(text)) continue;
-        const tool = toolNames.get(String(b.tool_use_id ?? ""));
+        const tool = toolNames.get(useId);
         if (tool) update(id, (c) => { c.blockedTool = tool; });
       }
     } else if (t === "agx_error") {


### PR DESCRIPTION
## What does this PR do?

The chat and the session timeline were drifting into **different products showing the same thing**.

The session view had roles, timestamps, and a full row per tool run — command, output, whether it failed. The chat had none of it: a tool call collapsed into a chip with just its name, so **the command, the result and the failure state were discarded on arrival**. That's precisely the information you open a conversation to read.

- **`ToolRow` is now shared** by both views, so "what the agent did" renders identically wherever a conversation appears — and the two can't drift again.
- **`ChatMsg` carries a timestamp**, and tool runs became rows with the same shape the server builds for the timeline, including the per-tool notion of what a run acted on (a `Bash` row shows its command, an `Edit` row its path) so both views agree.
- **`tool_result` events were already arriving and being dropped** except to detect a refusal. They now fill in the output on the row that asked for it.

## Contrast

Bubbles were mixed against `transparent`, so over the panel's own violet both roles landed on nearly the same colour — and some themes flattened them entirely.

They now mix against a **solid base**, and each role carries a **3px left border**. A fill can be washed out by a theme; an accent border can't. Role labels pick up the same accent.

## How was it tested?

- `bun test` — 133 pass
- `bunx tsc --noEmit` in `web/` and `server/` — clean
- `bunx vite build` — clean

Visual + streaming change. The tool rows populate from live `tool_use`/`tool_result` events, so it's worth watching a turn that runs a few commands — especially one that fails, since the error tint is new here.

## Checklist

- [x] Typechecks pass
- [x] Production build passes
- [x] Stays dependency-light
- [x] `shared/types.ts` — no contract change (reuses `TimelineEntry`)
- [ ] Docs — not needed

🤖 Generated with [Claude Code](https://claude.com/claude-code)