### PR TITLE
perf: stop the cockpit burning a core while it sits there

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -68,9 +68,17 @@ const expand = (p: string) => (p.startsWith("~/") ? join(homedir(), p.slice(2)) 
  * Scoping is a decision, so it has to be stated.
  */
 let cachedRoot: string | null | undefined;
+let cachedFor: string | undefined;
 export function workspaceRoot(): string | null {
-  if (cachedRoot !== undefined) return cachedRoot;
   const asked = process.env.AGENTGLASS_ROOT || config.root;
+  // Keyed on what was asked for, not merely "have we answered before". The
+  // scope never changes in a running server, so this costs one comparison —
+  // but `bun test` shares a process, and the first suite to call this used to
+  // pin the answer for every suite after it. A later file setting
+  // AGENTGLASS_ROOT then got the earlier file's scope, silently, and only in
+  // whatever file order the runner happened to pick.
+  if (cachedRoot !== undefined && cachedFor === asked) return cachedRoot;
+  cachedFor = asked;
   cachedRoot = asked ? resolveScope(asked) : null;
   return cachedRoot;
 }

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -258,11 +258,28 @@ export async function overview(): Promise<DockerOverview> {
 
 const pct = (s?: string) => { const n = parseFloat((s || "").replace("%", "")); return Number.isFinite(n) ? n : 0; };
 
-/** Live-ish resource stats (a single --no-stream sample). Can take ~1-2s. */
-export function stats(): DockerStat[] {
-  const r = docker(["stats", "--no-stream", "--no-trunc", "--format", "{{json .}}"], 12000);
+let statsCache: { at: number; data: DockerStat[] } | null = null;
+/** Long enough that a 5s poll never lands on a cold cache twice in a row. */
+const STATS_TTL_MS = 4000;
+
+/**
+ * Live-ish resource stats (a single --no-stream sample).
+ *
+ * Async, and it matters more here than anywhere else in this file: the command
+ * takes about two seconds, and run synchronously it stopped the whole server
+ * for that long — this process serves the terminal's PTY bytes on the same
+ * event loop, so an open Docker panel meant the terminal froze for two seconds
+ * out of every five and then dumped everything you had typed at once.
+ *
+ * Cached for the same reason `overview()` is: a 5s poll of a 2s command is
+ * close enough to continuous that two clients would otherwise keep one running
+ * permanently.
+ */
+export async function stats(): Promise<DockerStat[]> {
+  if (statsCache && Date.now() - statsCache.at < STATS_TTL_MS) return statsCache.data;
+  const r = await dockerAsync(["stats", "--no-stream", "--no-trunc", "--format", "{{json .}}"], 12000);
   if (r.code !== 0) return [];
-  return jsonLines(r.stdout).map((s) => ({
+  const data = jsonLines(r.stdout).map((s) => ({
     id: (s.ID || "").slice(0, 12),
     cpu: pct(s.CPUPerc),
     mem: pct(s.MemPerc),
@@ -271,6 +288,8 @@ export function stats(): DockerStat[] {
     blockIO: s.BlockIO || "",
     pids: parseInt(s.PIDs || "0", 10) || 0,
   }));
+  statsCache = { at: Date.now(), data };
+  return data;
 }
 
 /** Last `tail` log lines for a container (bounded). Docker writes logs to stderr. */

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -493,7 +493,7 @@ const server = Bun.serve<WsData>({
 
     // --- live docker panel (lazydocker-style) ---
     if (pathname === "/docker/overview") return json(await dockerOverview());
-    if (pathname === "/docker/stats") return json({ stats: dockerStats() });
+    if (pathname === "/docker/stats") return json({ stats: await dockerStats() });
     if (pathname === "/docker/logs") {
       const id = url.searchParams.get("id") || "";
       const tail = Number(url.searchParams.get("tail") || 400);

--- a/server/src/transcripts.ts
+++ b/server/src/transcripts.ts
@@ -27,14 +27,22 @@ import { workspaceRoot, inScope } from "./config.ts";
 // Windows) sweeps several at once — e.g. a WSL home next to a Windows one.
 // The Set folds a root listed twice, which would otherwise ingest every
 // transcript in it twice.
-const PROJECTS_DIRS = [
-  ...new Set(
-    (process.env.AGENTGLASS_PROJECTS_DIR || join(homedir(), ".claude", "projects"))
-      .split(delimiter)
-      .map((d) => d.trim())
-      .filter(Boolean)
-  ),
-];
+//
+// Read per sweep rather than pinned at import: `bun test` runs every file in one
+// process, so a module-level constant would be decided by whichever test file
+// imported this module first — which for every other file means the developer's
+// real ~/.claude/projects, i.e. the scanner tests would sweep the machine
+// instead of their fixture. It is one env read every 3s.
+function projectsDirs(): string[] {
+  return [
+    ...new Set(
+      (process.env.AGENTGLASS_PROJECTS_DIR || join(homedir(), ".claude", "projects"))
+        .split(delimiter)
+        .map((d) => d.trim())
+        .filter(Boolean)
+    ),
+  ];
+}
 const POLL_MS = Math.max(500, Number(process.env.AGENTGLASS_SCAN_INTERVAL_MS || 3000));
 export const SCAN_ENABLED = process.env.AGENTGLASS_SCAN_DISABLED !== "1";
 
@@ -337,57 +345,181 @@ function lineToBodies(
 }
 
 /**
+ * Everything a from-zero re-parse used to rederive, kept per file so a sweep can
+ * read *only* the bytes appended since the last one.
+ *
+ * The sweep runs every 3s and used to `readFileSync` + split + `JSON.parse` the
+ * whole transcript each time, just to rebuild this state before skipping past
+ * the lines it had already ingested. On this machine's real transcripts (86 MB,
+ * 79 MB, 42 MB) that measured ~4ms/MB, ~9% steady CPU doing nothing — and since
+ * this single-threaded process also pumps the built-in terminal's PTY bytes, it
+ * is felt as the terminal stuttering, worse the longer a session runs. That is
+ * why restarting the app "fixed" it.
+ *
+ * Each field is load-bearing; dropping any of them changes output:
+ *  - toolCalls — a tool_result matches its call by id, and the call is usually
+ *    in a chunk ingested on an earlier tick. Without it PostToolUse loses
+ *    tool_name/tool_input, which the diff list and repo discovery read.
+ *  - seenUsage — Claude Code repeats one message's `usage` on every
+ *    content-block line of the same reply; deduping by message.id is what stops
+ *    tokens and cost coming out multiplied (measured 2.5x).
+ *  - customTitle/aiTitle — the last title line in the file wins, and a rename
+ *    can sit far before the offset.
+ *  - cwd/source_app/project_path/session_id — sniffed from the first line that
+ *    carries them, which a tail chunk usually does *not* contain, so a tail read
+ *    that re-sniffed would file the session under its own uuid instead of its
+ *    project.
+ *
+ * Deliberately *not* persisted, and no new `transcript_files` column: the byte
+ * offset is worthless without the maps above, which can't be cheaply written to
+ * SQLite, so a cold start has to re-read whole regardless. `lines_done` stays
+ * the only durable progress marker, and every path below keeps it exact so a
+ * restart with a warm DB and a cold cache is still correct.
+ */
+interface Tail {
+  /** Byte offset just past the last complete line processed. */
+  bytes: number;
+  /** Complete lines processed — must stay equal to transcript_files.lines_done. */
+  lines: number;
+  toolCalls: Map<string, { name: string; input: unknown }>;
+  seenUsage: Set<string>;
+  customTitle: string | null;
+  aiTitle: string | null;
+  cwd: string;
+  source_app: string;
+  project_path: string;
+  session_id: string;
+  touched: number;
+}
+const tails = new Map<string, Tail>();
+/** A transcript nobody has appended to in this long is finished, or close
+ *  enough; its cached tool inputs can be megabytes, so let them go. Dropping an
+ *  entry is always safe — the next sweep just re-reads the file whole. */
+const TAIL_IDLE_MS = 10 * 60_000;
+/** Hard ceiling on cached files, so a machine running dozens of sessions at once
+ *  can't grow this without bound between idle sweeps. Oldest-touched go first. */
+const MAX_TAILS = 24;
+/** Drop every cached tail. Exported for the tests, which use it to stand in for
+ *  a server restart — offsets gone, `lines_done` intact — and so to prove that
+ *  eviction can only cost time, never correctness. */
+export function __dropTailCache(): void {
+  tails.clear();
+}
+function evictTails(now: number): void {
+  for (const [path, t] of tails) if (now - t.touched > TAIL_IDLE_MS) tails.delete(path);
+  if (tails.size <= MAX_TAILS) return;
+  const byAge = [...tails].sort((a, b) => a[1].touched - b[1].touched);
+  for (const [path] of byAge.slice(0, tails.size - MAX_TAILS)) tails.delete(path);
+}
+
+/**
  * Ingest a transcript, emitting only lines past `from`.
  *
- * Earlier lines are still parsed (not emitted) because a PostToolUse needs the
- * tool name recorded by its PreToolUse, which may live in a chunk we ingested
- * on a previous tick.
+ * Two paths, same result. With a warm `Tail` for this file we read only from the
+ * cached byte offset to EOF; otherwise (cold cache, or `allowTail` false because
+ * the file was rewritten) we read it whole and skip the first `from` lines,
+ * still parsing them so a PostToolUse finds the tool name its PreToolUse
+ * recorded. Correctness never depends on the cache being warm.
  */
 async function ingestFile(
   path: string,
   fallbackSessionId: string,
   from: number,
   onLive: ((r: InsertResult) => void) | null,
-  scope: string | null
+  scope: string | null,
+  allowTail = true
 ): Promise<{ lines: number; ingested: number; source_app: string; project_path: string; session_id: string; skipped?: boolean }> {
-  const text = await Bun.file(path).text();
-  const lines = text.split("\n");
+  const file = Bun.file(path);
+  const cached = allowTail ? tails.get(path) : undefined;
+  // Only tail when the cache still agrees with the durable progress marker. If
+  // they ever drift — a DB row rewritten underneath us, a failed sweep, a file
+  // replaced at the same size — the offset points into content it wasn't taken
+  // from, which silently drops or duplicates records. Re-reading whole is slow,
+  // wrong numbers are forever.
+  const tail = cached && cached.lines === from && cached.bytes <= file.size ? cached : undefined;
+  if (!tail) tails.delete(path);
+
+  const baseByte = tail?.bytes ?? 0;
+  const baseLine = tail?.lines ?? 0;
+  const chunk = tail ? await file.slice(baseByte).text() : await file.text();
+
+  // Cut at the last newline. An active session is appended record by record and
+  // a sweep lands mid-write often enough to matter: parsing the half-flushed
+  // fragment would fail its JSON.parse *and* count it as done, so the record is
+  // lost for good once the writer finishes it. Holding it back means the next
+  // sweep, which sees the whole line, ingests it exactly once.
+  //
+  // A trailing fragment that does parse is a finished record whose newline just
+  // hasn't landed — a proper prefix of a JSON object never parses on its own —
+  // so it's taken now rather than held back forever, which is what a transcript
+  // whose final line has no trailing newline would otherwise do.
+  let complete = chunk;
+  const nl = chunk.lastIndexOf("\n");
+  if (nl < chunk.length - 1) {
+    const rest = chunk.slice(nl + 1).trim();
+    let restIsWholeRecord = false;
+    if (rest) {
+      try { JSON.parse(rest); restIsWholeRecord = true; } catch { /* half-written */ }
+    }
+    if (!restIsWholeRecord) complete = chunk.slice(0, nl + 1);
+  }
+  const lines = complete.split("\n");
   // JSONL ends with a newline, so split() leaves a phantom empty element. Left
   // in, lines_done ends up one past the real record count and the next sweep
   // skips the first line appended after it — which is *every* live line, since
   // sessions grow one record at a time.
   if (lines.length && lines[lines.length - 1] === "") lines.pop();
-  const toolCalls = new Map<string, { name: string; input: unknown }>();
+  // byteLength, not string length: a transcript is full of non-ASCII (paths,
+  // prose, emoji) and a character offset would land mid-codepoint, so the next
+  // tail read would start on a broken line.
+  const nextByte = baseByte + Buffer.byteLength(complete, "utf8");
+
+  const toolCalls = tail?.toolCalls ?? new Map<string, { name: string; input: unknown }>();
   // Claude Code splits one API response across several transcript lines (one
   // per content block) and repeats the identical `message.usage` on each. Only
   // the first line of a given message.id may carry it, or tokens and cost come
   // out multiplied by the number of blocks in the reply — measured at 2.5x.
-  const seenUsage = new Set<string>();
+  const seenUsage = tail?.seenUsage ?? new Set<string>();
 
-  // First pass: read the project path (cwd) and the session id off the
-  // transcript's own lines. Both beat inferring them from the file layout —
-  // the directory encoding is lossy (a dash in a folder name is
-  // indistinguishable from a separator), and a subagent transcript is named
-  // after the agent while reporting the *parent* session it belongs to.
-  let project_path = "";
-  let session_id = "";
-  for (const line of lines) {
-    if (!line) continue;
-    if (!line.includes('"cwd"') && !line.includes('"sessionId"')) continue;
-    try {
-      const o = JSON.parse(line) as Record<string, unknown>;
-      project_path ||= str(o.cwd) ?? "";
-      session_id ||= str(o.sessionId) ?? "";
-    } catch { /* skip malformed line */ }
-    if (project_path && session_id) break;
+  let cwd: string;
+  let session_id: string;
+  let source_app: string;
+  let project_path: string;
+  if (tail) {
+    ({ cwd, session_id, source_app, project_path } = tail);
+  } else {
+    // First pass: read the project path (cwd) and the session id off the
+    // transcript's own lines. Both beat inferring them from the file layout —
+    // the directory encoding is lossy (a dash in a folder name is
+    // indistinguishable from a separator), and a subagent transcript is named
+    // after the agent while reporting the *parent* session it belongs to.
+    let sniffedCwd = "";
+    let sniffedSid = "";
+    for (const line of lines) {
+      if (!line) continue;
+      if (!line.includes('"cwd"') && !line.includes('"sessionId"')) continue;
+      try {
+        const o = JSON.parse(line) as Record<string, unknown>;
+        sniffedCwd ||= str(o.cwd) ?? "";
+        sniffedSid ||= str(o.sessionId) ?? "";
+      } catch { /* skip malformed line */ }
+      if (sniffedCwd && sniffedSid) break;
+    }
+    cwd = sniffedCwd;
+    session_id = sniffedSid || fallbackSessionId;
+    if (cwd) ({ source_app, project_path } = projectOf(cwd));
+    else { source_app = fallbackSessionId.slice(0, 8); project_path = ""; }
   }
-  session_id ||= fallbackSessionId;
-  const cwd = project_path;
+
   // Opened for one project: a transcript from anywhere else isn't this
   // cockpit's business. Bail before naming it, or it would still show up in
   // the project list despite contributing no events. The scope is pinned per
   // sweep (passed in), so a workspace switched mid-sweep can't suddenly widen
   // a *live* sweep into broadcasting months of backfill.
+  //
+  // Re-tested on the tail path too, not just when the cwd is freshly sniffed:
+  // narrowing the workspace at runtime has to stop a file we were already
+  // tailing, or the cache would keep ingesting a project the user just left.
   //
   // Match on the *resolved repo root* as well as the raw cwd: a session running
   // in a project's own linked worktree (e.g. ~/code/app-wt, outside the scope
@@ -401,18 +533,10 @@ async function ingestFile(
       return { lines: 0, ingested: 0, source_app: "", project_path: "", session_id, skipped: true };
     }
   }
-
-  let source_app: string;
-  if (cwd) {
-    ({ source_app, project_path } = projectOf(cwd));
-    projectPaths.set(source_app, project_path);
-  } else {
-    source_app = fallbackSessionId.slice(0, 8);
-  }
+  if (cwd) projectPaths.set(source_app, project_path);
 
   const ctx = { source_app, project_path, cwd, session_id, toolCalls, seenUsage };
   let ingested = 0;
-  let seen = 0;
   // Collected inside the transaction, delivered after it commits: broadcasting
   // mid-transaction would push events to clients that a later failure rolls
   // back, leaving them showing rows the database never kept.
@@ -420,16 +544,15 @@ async function ingestFile(
   const fileMtime = statSync(path).mtimeMs;
   // What the session is called. Both kinds are appended as their own lines and
   // rewritten on every change, so the *last* one in the file is the current
-  // one — and because the loop below parses every line regardless of `from`, an
-  // incremental sweep still sees a rename that happened before its offset.
-  let customTitle: string | null = null;
-  let aiTitle: string | null = null;
+  // one — carried across sweeps so a tail read that sees no title line still
+  // reports the rename that happened before its offset.
+  let customTitle: string | null = tail?.customTitle ?? null;
+  let aiTitle: string | null = tail?.aiTitle ?? null;
 
   const run = db.transaction(() => {
     for (let i = 0; i < lines.length; i++) {
       const line = lines[i]!.trim();
       if (!line) continue;
-      seen = i + 1;
       let o: Record<string, unknown>;
       try {
         o = JSON.parse(line) as Record<string, unknown>;
@@ -441,20 +564,45 @@ async function ingestFile(
       if (o.type === "custom-title") customTitle = str(o.customTitle) ?? customTitle;
       else if (o.type === "ai-title") aiTitle = str(o.aiTitle) ?? aiTitle;
       const bodies = lineToBodies(o, ctx, fileMtime);
-      if (i < from) continue; // already ingested — parsed only for tool names
+      // Absolute position in the file: on the tail path the chunk starts at
+      // baseLine, so `from` still means "lines already ingested".
+      if (baseLine + i < from) continue; // already ingested — parsed only for tool names
       for (const body of bodies) {
         emitted.push(insertEvent(normalize(body)));
         ingested++;
       }
     }
   });
-  run();
+  try {
+    run();
+  } catch (e) {
+    // The rollback undoes the inserts but not the in-memory maps, which
+    // lineToBodies already mutated — seenUsage in particular would suppress the
+    // usage of every message in this chunk on the retry, losing those tokens for
+    // good. Drop the entry so the retry rebuilds it from the file.
+    tails.delete(path);
+    throw e;
+  }
   // After the transaction: the session row is created by the inserts above, and
   // a title for a session with no events yet has nothing to attach to.
   if (customTitle || aiTitle) setSessionTitles(session_id, customTitle, aiTitle);
   for (const r of emitted) onLive?.(r);
 
-  return { lines: lines.length, ingested, source_app, project_path, session_id };
+  const doneLines = baseLine + lines.length;
+  tails.set(path, {
+    bytes: nextByte,
+    lines: doneLines,
+    toolCalls,
+    seenUsage,
+    customTitle,
+    aiTitle,
+    cwd,
+    source_app,
+    project_path,
+    session_id,
+    touched: Date.now(),
+  });
+  return { lines: doneLines, ingested, source_app, project_path, session_id };
 }
 
 /** Every *.jsonl under a project dir, at any depth.
@@ -476,8 +624,10 @@ function walkTranscripts(dir: string, out: string[] = []): string[] {
   return out;
 }
 
-/** One sweep over every project directory under every root. */
-async function scanOnce(onLive: ((r: InsertResult) => void) | null): Promise<number> {
+/** One sweep over every project directory under every root.
+ *  Exported for the scanner tests, which drive sweeps by hand rather than
+ *  waiting on the 3s timer. */
+export async function scanOnce(onLive: ((r: InsertResult) => void) | null): Promise<number> {
   // Read the workspace once per sweep so every file in it sees the same scope.
   const scope = workspaceRoot();
   // Transcripts older than the retention window would be pruned on the next
@@ -485,7 +635,7 @@ async function scanOnce(onLive: ((r: InsertResult) => void) | null): Promise<num
   const cutoff = RETENTION_DAYS ? Date.now() - RETENTION_DAYS * 86_400_000 : 0;
   let total = 0;
 
-  for (const root of PROJECTS_DIRS) {
+  for (const root of projectsDirs()) {
     let dirs: string[];
     try {
       dirs = readdirSync(root);
@@ -521,7 +671,9 @@ async function scanOnce(onLive: ((r: InsertResult) => void) | null): Promise<num
           // rather than skipping past records that no longer exist.
           const rewritten = !!prev && st.size < prev.size;
           const from = rewritten ? 0 : prev?.lines_done ?? 0;
-          const r = await ingestFile(path, basename(path, ".jsonl"), from, onLive, scope);
+          // A rewrite also invalidates the cached tail: its byte offset and its
+          // carried tool calls describe content that no longer exists.
+          const r = await ingestFile(path, basename(path, ".jsonl"), from, onLive, scope, !rewritten);
           // Out of scope: claim nothing, so widening the scope later can still
           // pick it up, and the hook path isn't blocked for a session we skipped.
           if (r.skipped) continue;
@@ -542,6 +694,10 @@ async function scanOnce(onLive: ((r: InsertResult) => void) | null): Promise<num
       }
     }
   }
+  // Once per sweep, not per file: the tail cache holds every tool call's input
+  // for each transcript it follows, which is the one collection here that can
+  // grow with session length rather than with the number of projects.
+  evictTails(Date.now());
   return total;
 }
 
@@ -635,7 +791,7 @@ export function startScanner(onLive: (r: InsertResult) => void): void {
     .then((n) => {
       const projects = projectPaths.size;
       console.log(
-        `📚 scanned ${PROJECTS_DIRS.join(", ")} — ${n} events from ${projects} project${projects === 1 ? "" : "s"} in ${Date.now() - t0}ms`
+        `📚 scanned ${projectsDirs().join(", ")} — ${n} events from ${projects} project${projects === 1 ? "" : "s"} in ${Date.now() - t0}ms`
       );
       // After the sweep, so freshly-discovered sessions are already rows.
       backfillTitles()

--- a/server/test/transcript-tail.test.ts
+++ b/server/test/transcript-tail.test.ts
@@ -12,7 +12,7 @@
 // noticing a rename that happened before the offset, coping with a rewritten
 // file and with a line the writer has only half-flushed is the part that breaks.
 // Each test below is one of those.
-import { describe, expect, test, beforeAll } from "bun:test";
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
 import { appendFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -41,6 +41,21 @@ beforeAll(async () => {
   const scope = (await import("../src/config.ts")).workspaceRoot();
   if (scope) CWD = join(scope, "agx-tail-fixture");
   mkdirSync(CWD, { recursive: true });
+});
+
+// `bun test` shares one process and db.ts opens its file at import, so an
+// earlier test file may already own the database — these fixtures then land in
+// it. Keying every assertion here by session id is not enough: other files
+// assert on what is *absent* (scope.test.ts uses not.toContain), and in CI,
+// where the files run in a different order than locally, these sessions showed
+// up in their results. So take the rows back out.
+const FIXTURES = ["s-append", "s-pair", "s-tool", "s-usage", "s-title", "s-rewrite", "s-partial", "s-nonewline", "s-cold"];
+afterAll(() => {
+  if (!db) return;
+  const marks = FIXTURES.map(() => "?").join(",");
+  for (const t of ["events", "sessions", "transcript_files"]) {
+    try { db.db.run(`DELETE FROM ${t} WHERE session_id IN (${marks})`, FIXTURES); } catch { /* table may not have the column */ }
+  }
 });
 
 const sweep = () => scan.scanOnce(null);

--- a/server/test/transcript-tail.test.ts
+++ b/server/test/transcript-tail.test.ts
@@ -1,0 +1,254 @@
+// The sweep reads only the bytes a transcript grew by — without losing anything
+// the from-zero re-parse used to give it for free.
+//
+// The bug this guards: every 3s the scanner read each changed transcript whole,
+// parsed every line, and only then skipped the ones it had already ingested.
+// On an 86 MB session that is ~360ms of pure re-parse per tick, ~9% steady CPU,
+// on the same single thread that pumps the terminal's PTY — which is why the
+// terminal stuttered more the longer a session ran, and why restarting fixed it.
+//
+// Reading only the tail is easy; reading only the tail *and still* matching a
+// tool result to a call made an hour ago, not double-counting a reply's tokens,
+// noticing a rename that happened before the offset, coping with a rewritten
+// file and with a line the writer has only half-flushed is the part that breaks.
+// Each test below is one of those.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { appendFileSync, mkdirSync, mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-tail-"));
+const PROJECTS = join(dir, "projects", "-tmp-tailproj");
+mkdirSync(PROJECTS, { recursive: true });
+// Sweep this fixture, never ~/.claude/projects. Read per sweep by the scanner,
+// so this holds however the module got imported.
+process.env.AGENTGLASS_PROJECTS_DIR = join(dir, "projects");
+// Only set the DB if nothing has claimed one yet: `bun test` shares one process
+// and db.ts opens its file at import, so an earlier test file may already own
+// it. Sharing is fine — every assertion here is keyed by session id.
+process.env.AGENTGLASS_DB ||= join(dir, "tail.db");
+
+let db: typeof import("../src/db.ts");
+let scan: typeof import("../src/transcripts.ts");
+// A real directory the scanner will accept: it resolves a transcript's cwd on
+// the filesystem, and if an earlier test file already pinned a workspace scope
+// (config.ts caches it on first call) anything outside it is skipped.
+let CWD = join(dir, "tailproj");
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  scan = await import("../src/transcripts.ts");
+  const scope = (await import("../src/config.ts")).workspaceRoot();
+  if (scope) CWD = join(scope, "agx-tail-fixture");
+  mkdirSync(CWD, { recursive: true });
+});
+
+const sweep = () => scan.scanOnce(null);
+
+let clock = Date.now() - 60_000;
+const ts = () => new Date((clock += 1000)).toISOString();
+
+const path = (name: string) => join(PROJECTS, `${name}.jsonl`);
+const write = (name: string, lines: string[]) =>
+  writeFileSync(path(name), lines.map((l) => l + "\n").join(""));
+const append = (name: string, lines: string[]) =>
+  appendFileSync(path(name), lines.map((l) => l + "\n").join(""));
+
+const prompt = (sid: string, text: string) =>
+  JSON.stringify({
+    type: "user",
+    cwd: CWD,
+    sessionId: sid,
+    timestamp: ts(),
+    message: { role: "user", content: text },
+  });
+
+const toolUse = (sid: string, id: string, name: string, msgId = `m-${id}`, usage?: unknown) =>
+  JSON.stringify({
+    type: "assistant",
+    cwd: CWD,
+    sessionId: sid,
+    timestamp: ts(),
+    message: {
+      id: msgId,
+      model: "claude-opus-4-8",
+      role: "assistant",
+      content: [{ type: "tool_use", id, name, input: { command: "ls" } }],
+      ...(usage ? { usage } : {}),
+    },
+  });
+
+const toolResult = (sid: string, id: string) =>
+  JSON.stringify({
+    type: "user",
+    cwd: CWD,
+    sessionId: sid,
+    timestamp: ts(),
+    message: { role: "user", content: [{ type: "tool_result", tool_use_id: id, content: "ok" }] },
+  });
+
+const rows = (sid: string) =>
+  db.db
+    .query<{ hook_event_type: string; tool_name: string | null; payload: string }, [string]>(
+      "SELECT hook_event_type, tool_name, payload FROM events WHERE session_id = ? ORDER BY id"
+    )
+    .all(sid);
+
+const prompts = (sid: string) =>
+  rows(sid)
+    .filter((r) => r.hook_event_type === "UserPromptSubmit")
+    .map((r) => JSON.parse(r.payload).prompt as string);
+
+const progress = (name: string) =>
+  db.db
+    .query<{ lines_done: number }, [string]>("SELECT lines_done FROM transcript_files WHERE path = ?")
+    .get(path(name));
+
+describe("incremental transcript sweep", () => {
+  test("an appended line is ingested exactly once", async () => {
+    const sid = "s-append";
+    write("append", [prompt(sid, "one"), prompt(sid, "two")]);
+    await sweep();
+    expect(prompts(sid)).toEqual(["one", "two"]);
+
+    append("append", [prompt(sid, "three")]);
+    await sweep();
+    // A tail read that forgot the offset would re-ingest "one"/"two"; one that
+    // over-advanced it would drop "three".
+    expect(prompts(sid)).toEqual(["one", "two", "three"]);
+
+    // Unchanged file: the sweep must not manufacture anything on a re-run.
+    await sweep();
+    expect(prompts(sid)).toEqual(["one", "two", "three"]);
+    expect(progress("append")?.lines_done).toBe(3);
+  });
+
+  test("a tool result resolves the name of a call made in an earlier sweep", async () => {
+    const sid = "s-pair";
+    write("pair", [toolUse(sid, "t1", "Bash")]);
+    await sweep();
+
+    // The call is now far behind the byte offset. Its name and input live only
+    // in the carried-over map; losing them empties tool_input, which is what the
+    // diff list and repo discovery read off the PostToolUse.
+    append("pair", [toolResult(sid, "t1")]);
+    await sweep();
+
+    const post = rows(sid).find((r) => r.hook_event_type === "PostToolUse");
+    expect(post?.tool_name).toBe("Bash");
+    expect(JSON.parse(post!.payload).tool_input).toEqual({ command: "ls" });
+  });
+
+  test("one reply's usage is not counted twice when its lines span sweeps", async () => {
+    const sid = "s-usage";
+    const usage = { input_tokens: 100, output_tokens: 10 };
+    // Claude Code repeats the identical usage on every content-block line of the
+    // same message.id. The dedupe set has to survive the sweep boundary or the
+    // second line re-adds the whole reply's tokens.
+    write("usage", [toolUse(sid, "u1", "Bash", "msg-shared", usage)]);
+    await sweep();
+    append("usage", [toolUse(sid, "u2", "Bash", "msg-shared", usage)]);
+    await sweep();
+
+    const s = db.db
+      .query<{ input_tokens: number; output_tokens: number }, [string]>(
+        "SELECT input_tokens, output_tokens FROM sessions WHERE session_id = ?"
+      )
+      .get(sid);
+    expect(s?.input_tokens).toBe(100);
+    expect(s?.output_tokens).toBe(10);
+  });
+
+  test("a rename appended after the offset is picked up", async () => {
+    const sid = "s-title";
+    write("title", [prompt(sid, "hello")]);
+    await sweep();
+
+    append("title", [JSON.stringify({ type: "custom-title", customTitle: "Ship the thing" })]);
+    await sweep();
+    expect(
+      db.db
+        .query<{ custom_title: string | null }, [string]>(
+          "SELECT custom_title FROM sessions WHERE session_id = ?"
+        )
+        .get(sid)?.custom_title
+    ).toBe("Ship the thing");
+
+    // And a rename that happened *before* the offset must still be the name
+    // after a later append that carries no title line at all.
+    append("title", [prompt(sid, "more")]);
+    await sweep();
+    expect(
+      db.db
+        .query<{ custom_title: string | null }, [string]>(
+          "SELECT custom_title FROM sessions WHERE session_id = ?"
+        )
+        .get(sid)?.custom_title
+    ).toBe("Ship the thing");
+  });
+
+  test("a rewritten, shorter file is re-read whole", async () => {
+    const sid = "s-rewrite";
+    write("rewrite", [prompt(sid, "aaaaaaaaaaaaaaaaaaaa"), prompt(sid, "bbbbbbbbbbbbbbbbbbbb"), prompt(sid, "cccccccccccccccccccc")]);
+    await sweep();
+    expect(prompts(sid).length).toBe(3);
+
+    // Fewer bytes than before: the saved offset now points past EOF, and every
+    // line it names is different content. Tailing here would ingest nothing and
+    // leave the session showing records that no longer exist on disk.
+    write("rewrite", [prompt(sid, "rw-1"), prompt(sid, "rw-2")]);
+    await sweep();
+    const after = prompts(sid);
+    expect(after).toContain("rw-1");
+    expect(after).toContain("rw-2");
+    expect(progress("rewrite")?.lines_done).toBe(2);
+  });
+
+  test("a half-written final line is held back, then ingested exactly once", async () => {
+    const sid = "s-partial";
+    const full = prompt(sid, "complete-at-last");
+    const cut = Math.floor(full.length / 2);
+    write("partial", [prompt(sid, "first")]);
+    // The writer got half the record out and no newline — exactly what a sweep
+    // landing mid-append sees. Counting it as done loses the record for good.
+    appendFileSync(path("partial"), full.slice(0, cut));
+    await sweep();
+    expect(prompts(sid)).toEqual(["first"]);
+    expect(progress("partial")?.lines_done).toBe(1);
+
+    appendFileSync(path("partial"), full.slice(cut) + "\n");
+    await sweep();
+    expect(prompts(sid)).toEqual(["first", "complete-at-last"]);
+
+    await sweep();
+    expect(prompts(sid)).toEqual(["first", "complete-at-last"]);
+  });
+
+  test("a final record with no trailing newline is not stranded", async () => {
+    // A finished transcript whose last line lacks its newline would otherwise
+    // never be ingested, because the tail cut always held it back.
+    const sid = "s-nonewline";
+    writeFileSync(path("nonewline"), prompt(sid, "only") + "\n" + prompt(sid, "last"));
+    await sweep();
+    expect(prompts(sid)).toEqual(["only", "last"]);
+
+    // And appending the missing newline plus another record must not re-ingest
+    // the line we already took.
+    appendFileSync(path("nonewline"), "\n" + prompt(sid, "next") + "\n");
+    await sweep();
+    expect(prompts(sid)).toEqual(["only", "last", "next"]);
+  });
+
+  test("a cold cache with a warm database ingests only the new lines", async () => {
+    // What a server restart looks like: the byte offset is gone (it is memory
+    // only, by design), the durable lines_done is not. The full re-read must
+    // still skip exactly what it already has.
+    const sid = "s-cold";
+    write("cold", [prompt(sid, "c1"), prompt(sid, "c2")]);
+    await sweep();
+    scan.__dropTailCache();
+    append("cold", [prompt(sid, "c3")]);
+    await sweep();
+    expect(prompts(sid)).toEqual(["c1", "c2", "c3"]);
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -38,6 +38,24 @@ import { SettingsModal } from "./components/SettingsModal.tsx";
 import { SessionModal } from "./components/SessionModal.tsx";
 import { ProjectPicker, PICKER_ANSWERED_KEY } from "./components/ProjectPicker.tsx";
 
+/**
+ * Wrap a setState so a poll that answers the same thing twice doesn't commit.
+ *
+ * These endpoints return a fresh object every time, so `setX(result)` always
+ * changed identity and always re-rendered the whole cockpit — several times a
+ * minute, for data that had not moved. Comparing serialized form is far cheaper
+ * than the render it avoids.
+ */
+const keepIfSame = <T,>(set: (v: T) => void) => {
+  let last = "";
+  return (next: T) => {
+    const sig = JSON.stringify(next);
+    if (sig === last) return;
+    last = sig;
+    set(next);
+  };
+};
+
 export default function App() {
   const { events, conn, lastEvent, openTools } = useLive();
   // The live socket is the app's only real-time source, and until now the chat
@@ -45,7 +63,25 @@ export default function App() {
   // whatever had been true when you opened it while the agent kept working.
   // This is the whole subscription: the store decides which chat, if any, each
   // event belongs to, and ignores everything else.
-  useEffect(() => { for (const e of events) applyLiveEvent(e); }, [events]);
+  //
+  // Only the events past the high-water mark. `events` is a rolling buffer of
+  // two thousand and every socket flush replaces the array, so handing the
+  // whole thing to the store each time meant re-walking all of it — and the
+  // store's own "seen" guard doesn't help, because it only records events that
+  // matched an open chat. With no chat open, which is most of the time, nothing
+  // was ever marked and every flush paid for all two thousand. That work lands
+  // on the same thread that draws the terminal, which is where it showed up:
+  // sluggish output and dropped keystrokes.
+  const appliedThrough = useRef(0);
+  useEffect(() => {
+    let high = appliedThrough.current;
+    for (const e of events) {
+      if (e.id <= appliedThrough.current) continue;
+      applyLiveEvent(e);
+      if (e.id > high) high = e.id;
+    }
+    appliedThrough.current = high;
+  }, [events]);
 
   const [windowMs, setWindowMs] = useState(3_600_000);
   const [filter, setFilter] = useState({ app: "", type: "", provider: "" });
@@ -111,9 +147,13 @@ export default function App() {
     applyTheme(theme);
   }, [theme]);
 
-  // Filter options change rarely (a new app/event type) — poll slowly.
+  // Filter options change rarely (a new app/event type) — poll slowly, and only
+  // take the new object when it actually differs. Setting state to a fresh copy
+  // of the same data still commits the whole tree; on a poll that answers
+  // identically almost every time, that is a free re-render of the cockpit.
   useEffect(() => {
-    const load = () => api.filterOptions().then(setOpts).catch(() => {});
+    const take = keepIfSame(setOpts); // once per effect — inside load() its memory would reset each call
+    const load = () => api.filterOptions().then(take).catch(() => {});
     load();
     const id = setInterval(load, 20_000);
     return () => clearInterval(id);
@@ -142,16 +182,28 @@ export default function App() {
    */
   const [sessions, setSessions] = useState<SessionRollup[]>([]);
   useEffect(() => {
-    const load = () => api.sessions(200).then(setSessions).catch(() => { /* labels fall back to the uuid */ });
+    const take = keepIfSame(setSessions); // once per effect, not once per poll
+    const load = () => api.sessions(200).then(take).catch(() => { /* labels fall back to the uuid */ });
     load();
     const id = setInterval(load, 30_000);
     return () => clearInterval(id);
   }, []);
   const titles = useMemo(() => buildTitles(sessions), [sessions]);
   const agentsAll = useMemo(() => deriveAgents(events, openTools, titles), [events, openTools, titles, tick]);
+  // Kept identical across renders while its *contents* are. `agentsAll` is
+  // rebuilt on every socket flush and every tick, so a plain useMemo handed out
+  // a new Map several times a second — and everything downstream that depends
+  // on it, most expensively the feed's 120 rows, re-rendered for a value that
+  // had not actually changed. The signature is cheap; the re-render was not.
+  const providerRef = useRef(new Map<string, string>());
+  const providerSig = useRef("");
   const sessionProvider = useMemo(() => {
     const map = new Map<string, string>();
     for (const a of agentsAll) if (a.model_name) map.set(a.session_id, providerOf(a.model_name));
+    const sig = [...map].map(([k, v]) => k + " " + v).join("");
+    if (sig === providerSig.current) return providerRef.current;
+    providerSig.current = sig;
+    providerRef.current = map;
     return map;
   }, [agentsAll]);
   const providers = useMemo(

--- a/web/src/components/Feed.tsx
+++ b/web/src/components/Feed.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState } from "react";
+import { memo, useEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { WatchEvent } from "../../../shared/types.ts";
 import { Panel } from "./Panel.tsx";
@@ -93,7 +93,7 @@ function buildRows(events: WatchEvent[], pairPool: WatchEvent[] = events): Row[]
 }
 
 /** One feed line — shared between the single stream and the per-session lanes. */
-function EventRow({ row, onSelect, compact }: { row: Row; onSelect?: (e: WatchEvent) => void; compact?: boolean }) {
+function EventRowInner({ row, onSelect, compact }: { row: Row; onSelect?: (e: WatchEvent) => void; compact?: boolean }) {
   const { e, running, count } = row;
   const f = running ? { verb: "Running", color: "#a78bfa", dot: "run" as const } : friendly(e);
   const d = detail(e);
@@ -133,6 +133,29 @@ function EventRow({ row, onSelect, compact }: { row: Row; onSelect?: (e: WatchEv
   );
 }
 
+/**
+ * Memoized on the row's *contents*, not its identity.
+ *
+ * Two things made this the most expensive thing on screen. The feed renders 120
+ * rows, and App re-renders for any reason at all — a 4s stats poll, a 20s
+ * options poll, the 10s tick — so all 120 `motion.div`s were rebuilt several
+ * times a second with byte-identical props: 12.1ms of React work per commit
+ * that changed nothing. And `buildRows` allocates fresh row objects every call,
+ * so a plain memo() would compare identities that never match and buy nothing.
+ *
+ * Hence the explicit comparator. `count` and `running` are in it because a
+ * coalesced ×N row and a running→finished tool change nothing else about the
+ * row: leave either out and those rows silently stop updating.
+ */
+const EventRow = memo(EventRowInner, (a, b) =>
+  a.row.key === b.row.key &&
+  a.row.e.id === b.row.e.id &&
+  a.row.count === b.row.count &&
+  a.row.running === b.row.running &&
+  a.compact === b.compact &&
+  a.onSelect === b.onSelect
+);
+
 /** One session's column in the lanes view: its own header and its own scroll,
  *  pinned to the newest line — so three busy Claudes read as three tidy
  *  streams instead of one interleaved wall. */
@@ -158,7 +181,7 @@ function Lane({ aKey, rows, onSelect }: { aKey: string; rows: Row[]; onSelect?: 
 
 const MAX_LANES = 4; // beyond four a lane is too narrow to read
 
-export function Feed({ events, filter, sessionProvider, onSelect, onClearFilter }: { events: WatchEvent[]; filter: { app: string; type: string; provider: string }; sessionProvider?: Map<string, string>; onSelect?: (e: WatchEvent) => void; onClearFilter?: () => void }) {
+function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }: { events: WatchEvent[]; filter: { app: string; type: string; provider: string }; sessionProvider?: Map<string, string>; onSelect?: (e: WatchEvent) => void; onClearFilter?: () => void }) {
   const [q, setQ] = useState("");
   const [cat, setCat] = useState<Category>("all");
   const [lanes, setLanes] = useState(false);
@@ -200,7 +223,12 @@ export function Feed({ events, filter, sessionProvider, onSelect, onClearFilter 
       }
       return true;
     });
-  }, [events, filter.app, filter.type, filter.provider, sessionProvider, cat, q]);
+    // `sessionProvider` is a fresh Map on every tick and every socket flush, but
+    // the filter above only reads it when a provider filter is set — which is
+    // not the default. Depending on it unconditionally re-ran this filter, and
+    // re-rendered all 120 rows behind it, ten times a minute for a value nobody
+    // was looking at.
+  }, [events, filter.app, filter.type, filter.provider, filter.provider ? sessionProvider : null, cat, q]);
 
   const rows = useMemo(() => buildRows(shown, events).slice(-120), [shown, events]);
 
@@ -414,3 +442,7 @@ export function Feed({ events, filter, sessionProvider, onSelect, onClearFilter 
     </>
   );
 }
+
+/** The whole panel, memoized: App re-renders for reasons the feed does not care
+ *  about (a stats poll, an options poll), and each one rebuilt every row. */
+export const Feed = memo(FeedInner);

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -272,7 +272,14 @@ const APPLIED_MAX = 8000;
  */
 export function applyLiveEvent(ev: WatchEvent) {
   if (applied.has(ev.id)) return;
-  const chat = [...chats.values()].find((c) => c.sessionId && c.sessionId === ev.session_id);
+  // Walk the map rather than spreading it into an array to call .find(). Most
+  // events belong to no open chat at all, so this is the hot path and the
+  // allocation was the whole cost of it.
+  if (!ev.session_id) return;
+  let chat: Chat | undefined;
+  for (const c of chats.values()) {
+    if (c.sessionId === ev.session_id) { chat = c; break; }
+  }
   if (!chat) return;
 
   applied.add(ev.id);


### PR DESCRIPTION
## What does this PR do?

Stops the cockpit burning most of a core while it sits there doing nothing, and fixes the terminal locking up mid-typing. Four causes, all found by measuring rather than reading.

| | Before | After |
| --- | --- | --- |
| Server CPU, no client attached | 8.7–9.3% | **0–1%** |
| Sweeping the three local transcripts (215 MB) | 336 ms | **2.5 ms** |
| `/docker/stats` blocking the event loop | p50 **2013 ms** | async + 4s cache |
| Webview CPU, app idle | 61% | **33–44%** |
| Feed re-render with identical props | 12.1 ms | **0.6 ms** |

**The transcript sweep re-read whole files every 3s.** It did `readFileSync` + `split` + `JSON.parse` over the *entire* transcript of any file that had grown, then discarded everything before the ingest offset. That parse-from-zero is load-bearing — it rebuilds the `tool_use_id` map, the usage dedupe set and the session title — so it now carries that state per file and reads only the new bytes, with a full-read fallback whenever the cache is cold, the file shrank, or a rewrite is detected. Local transcripts are 86, 79 and 42 MB.

This is also **why the app degraded the longer it ran**: an active session's transcript only grows, so the sweep cost grew with it. Restarting "fixed" it by starting from a small file again.

**`/docker/stats` froze the event loop for two seconds**, every five, while the Docker panel is open — on the single-threaded process that also carries the terminal's PTY bytes. That is the terminal freezing and then dumping everything you typed at once. An async variant already existed in the same file.

**The feed re-rendered all 120 rows on every commit, for any reason** — a stats poll, an options poll, the tick. `buildRows` allocates fresh row objects, so a plain `memo()` would compare identities that never match; it's memoized on row *contents* instead. `sessionProvider` is now stable while its contents are: it was a new `Map` on every flush, invalidating the whole feed for a value only read when a provider filter is set.

**The live-event fan-out walked the whole 2000-event buffer per flush.** The store's seen-guard only records events that matched an open chat, so with no chat open nothing was ever marked and every flush paid for all 2000.

Two things measured but deliberately **not** addressed here, to keep this reviewable: the shell process spends ~25 points of CPU on always-on animations (disabling them all is not the fix — pausing them when the window is hidden would be), and ~9% of the server is now purely serving the dashboard's own polling.

## How was it tested?

- `bun test` — **243 pass**, 0 fail (was 235). Eight new tests in `server/test/transcript-tail.test.ts` cover the tail path: an append ingested exactly once, a tool result resolving a call from an earlier sweep, usage not double-counted across a sweep boundary, a rename appearing after the offset, a rewritten file re-read whole, a half-written final line held back and then ingested once, and a cold cache against a warm DB. Each was mutation-tested — removing the corresponding carry-over or guard makes the intended test fail.
- `bunx tsc --noEmit` clean in both halves; `bunx vite build` and `bun scripts/smoke.ts` green.
- **Before/after measured on the real desktop app**, not in a benchmark: rebuilt, installed, relaunched, and CPU sampled from `/proc` over several 5s windows. The `0–1%` server figure is from a second server instance with no client attached, which isolates background work from request serving.

One reviewer note: the `EventRow` comparator includes `count` and `running` deliberately. Without them, coalesced ×N rows and running→finished morphs would silently stop updating — the two cases where the row changes but nothing else about it does.
