### PR TITLE
fix(desktop): macOS install and window controls

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ src-tauri/bin/
 src-tauri/icon-*.png
 src-tauri/gen/schemas/
 .claude/
+*.bun-build

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,8 +30,8 @@ python3 hooks/seed_demo.py   # populate with demo data
 - **`hooks/`** — stdlib-only Python; keep it dependency-free.
 - **`src-tauri/`** — the Tauri v2 desktop shell (Rust). `make desktop` compiles
   the Bun server to a standalone sidecar, builds the web bundle, and runs
-  `tauri build`; `make desktop-dev` runs against the live dev server. Linux only
-  for now (`.deb`).
+  `tauri build`; `make desktop-dev` runs against the live dev server. Linux
+  (`.deb`) and macOS (`.app`).
 
 ## Ground rules
 

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,7 @@ desktop: desktop-server desktop-web ## Build the desktop app (icon + native wind
 desktop-dev: desktop-server ## Run the desktop app against the live dev server
 	bunx tauri dev
 
-desktop-install: ## Install the built app for this user (~/.local, no root)
+desktop-install: ## Install the built app for this user (no root)
 	src-tauri/install-local.sh
 
 # Open the cockpit for ONE project: only that repo (and its worktrees) appear,

--- a/README.md
+++ b/README.md
@@ -256,7 +256,7 @@ the server goes with it.
 
 ```bash
 make desktop            # build: compiles the server sidecar + web, then `tauri build`
-make desktop-install    # install for this user under ~/.local (no root)
+make desktop-install    # install for this user (no root)
 ```
 
 Then launch **agentglass** from your desktop menu, or `agentglass` from a shell.
@@ -279,9 +279,7 @@ directory instead:
 make desktop-open DIR=~/code/my-project   # or: agentglass ~/code/my-project
 ```
 
-> Built for **Linux** today (`.deb` bundle, `x86_64`). The `src-tauri/` Tauri v2
-> shell + Bun sidecar is portable in principle, but only the Linux build is
-> wired up for now.
+> Works on **Linux** and **macOS**.
 
 ---
 

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -1,13 +1,14 @@
 {
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
-  "description": "What the cockpit window is allowed to ask the native shell for. The launch-at-login toggle, its own zoom level, and going fullscreen — everything else it needs comes from the server over HTTP.",
+  "description": "What the cockpit window is allowed to ask the native shell for. The launch-at-login toggle, its own zoom level, going fullscreen, and window-dragging — everything else it needs comes from the server over HTTP.",
   "windows": ["main"],
   "permissions": [
     "core:default",
     "core:webview:allow-set-webview-zoom",
     "core:window:allow-set-fullscreen",
     "core:window:allow-is-fullscreen",
+    "core:window:allow-start-dragging",
     "autostart:allow-enable",
     "autostart:allow-disable",
     "autostart:allow-is-enabled"

--- a/src-tauri/install-local.sh
+++ b/src-tauri/install-local.sh
@@ -1,16 +1,44 @@
 #!/usr/bin/env bash
 # Install the desktop app for the current user only — no root, no packaging.
 #
-# Everything lands under ~/.local, which is already on the standard search
-# paths, so the launcher picks it up without touching system directories.
+# Linux: everything lands under ~/.local, which is already on the standard
+# search paths, so the launcher picks it up without touching system dirs.
+# macOS: the .app bundle goes to ~/Applications, with CLI entry points
+# symlinked under ~/.local so `agentglass` and `make desktop-open` work.
 set -euo pipefail
 
 REPO="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
-BIN_SRC="$REPO/src-tauri/target/release/agentglass"
-SIDECAR="$REPO/src-tauri/bin/agentglass-server-x86_64-unknown-linux-gnu"
 
 BIN_DIR="$HOME/.local/bin"
 APP_DIR="$HOME/.local/share/agentglass"
+
+if [ "$(uname)" = Darwin ]; then
+  APP_SRC="$REPO/src-tauri/target/release/bundle/macos/agentglass.app"
+  [ -d "$APP_SRC" ] || { echo "missing $APP_SRC — run 'make desktop' first" >&2; exit 1; }
+  [ -x "$APP_SRC/Contents/MacOS/agentglass-server" ] || {
+    echo "no server sidecar inside $APP_SRC — run 'make desktop' first" >&2; exit 1; }
+
+  mkdir -p "$HOME/Applications" "$BIN_DIR" "$APP_DIR"
+  rm -rf "$HOME/Applications/agentglass.app"
+  ditto "$APP_SRC" "$HOME/Applications/agentglass.app"
+
+  BIN="$HOME/Applications/agentglass.app/Contents/MacOS/agentglass"
+  ln -sf "$BIN" "$BIN_DIR/agentglass"
+  ln -sf "$BIN" "$APP_DIR/agentglass"
+
+  echo "installed:"
+  echo "  app      ~/Applications/agentglass.app"
+  echo "  command  agentglass"
+  echo
+  echo "Find it in Spotlight as 'agentglass'. To start it at login, use the"
+  echo "autostart toggle in the app rather than editing files by hand."
+  exit 0
+fi
+
+BIN_SRC="$REPO/src-tauri/target/release/agentglass"
+SIDECAR="$(find "$REPO/src-tauri/bin" -name 'agentglass-server-*-linux-*' -type f 2>/dev/null | head -n1)"
+[ -n "$SIDECAR" ] || { echo "no Linux server sidecar in src-tauri/bin — run 'make desktop' first" >&2; exit 1; }
+
 DESKTOP_DIR="$HOME/.local/share/applications"
 ICON_DIR="$HOME/.local/share/icons/hicolor"
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -41,6 +41,7 @@ fn already_serving() -> bool {
 /// The bundled server binary, which ships next to the app executable.
 fn server_path() -> Option<PathBuf> {
     let exe = std::env::current_exe().ok()?;
+    let exe = std::fs::canonicalize(exe).ok()?;
     let path = exe.parent()?.join("agentglass-server");
     path.exists().then_some(path)
 }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "https://schema.tauri.app/config/2",
+  "app": {
+    "windows": [
+      {
+        "title": "agentglass",
+        "width": 1500,
+        "height": 950,
+        "minWidth": 900,
+        "minHeight": 600,
+        "resizable": true,
+        "center": true,
+        "decorations": true,
+        "titleBarStyle": "Overlay",
+        "hiddenTitle": true,
+        "theme": "Dark"
+      }
+    ]
+  },
+  "bundle": {
+    "targets": ["app"]
+  }
+}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import type { ConnState } from "../lib/useLive.ts";
 import { IS_DEMO, reauthPrompt } from "../lib/api.ts";
 import { MOD_KEY } from "../lib/format.ts";
+import { IS_MAC_DESKTOP } from "../lib/desktop.ts";
 import { ThemeSwitcher } from "./ThemeSwitcher.tsx";
 import { UsageWidget } from "./UsageWidget.tsx";
 import { Logo } from "./Logo.tsx";
@@ -151,13 +152,13 @@ export function Header({
   const hasFilter = filter.app || filter.type || filter.provider;
 
   return (
-    <header className="flex items-center gap-x-3 gap-y-2 px-3 sm:px-4 py-2.5 shrink-0 relative z-20 flex-wrap sm:flex-nowrap"
-      style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", background: "color-mix(in srgb, var(--bg2) 94%, var(--bg))" }}>
-      <div className="flex items-center gap-2.5 shrink-0">
-        <motion.span initial={{ rotate: -20, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} transition={{ type: "spring", stiffness: 200 }} className="flex">
+    <header data-tauri-drag-region="" className="flex items-center gap-x-3 gap-y-2 px-3 sm:px-4 py-2.5 shrink-0 relative z-20 flex-wrap sm:flex-nowrap"
+      style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", background: "color-mix(in srgb, var(--bg2) 94%, var(--bg))", paddingLeft: IS_MAC_DESKTOP ? 76 : undefined }}>
+      <div data-tauri-drag-region="" className="flex items-center gap-2.5 shrink-0">
+        <motion.span initial={{ rotate: -20, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} transition={{ type: "spring", stiffness: 200 }} className="flex pointer-events-none">
           <Logo size={26} title="agentglass" />
         </motion.span>
-        <div className="leading-none">
+        <div className="leading-none pointer-events-none">
           <div className="text-[16px] font-bold tracking-tight" style={{ color: "var(--text)" }}>agent<span style={{ color: "var(--primary)" }}>glass</span></div>
         </div>
         {/* The project defines what every other number on screen means, so it
@@ -204,7 +205,7 @@ export function Header({
           wrapping, so the header stays a single line at any width / zoom.
           On phones it drops to its own full-width second row — otherwise the
           right-side controls get pushed off-screen and become unreachable. */}
-      <div className="flex items-center gap-2 grow min-w-0 overflow-x-auto agw-noscrollbar order-3 basis-full sm:order-none sm:basis-0">
+      <div data-tauri-drag-region="" className="flex items-center gap-2 grow min-w-0 overflow-x-auto agw-noscrollbar order-3 basis-full sm:order-none sm:basis-0">
       <div className="flex items-center gap-0.5 p-0.5 rounded-lg shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 35%, transparent)" }}>
         {WINDOWS.map((w) => (
           <button key={w.label} onClick={() => onWindow(w.ms)} className="px-2 py-1 rounded-md text-[11px] transition-all"
@@ -235,7 +236,7 @@ export function Header({
       {hasFilter && <button onClick={onClear} className="text-[11px] px-2 py-1 rounded-lg shrink-0 whitespace-nowrap" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>clear ✕</button>}
       </div>{/* middle scroll zone */}
 
-      <div className="shrink-0 flex items-center gap-1.5 sm:gap-2 ml-auto sm:ml-0 max-w-full overflow-x-auto agw-noscrollbar">
+      <div data-tauri-drag-region="" className="shrink-0 flex items-center gap-1.5 sm:gap-2 ml-auto sm:ml-0 max-w-full overflow-x-auto agw-noscrollbar">
         {/* Anthropic plan meters — only shown when viewing Anthropic (it's the
             one provider with a usage API), and only where there's room. */}
         {showUsage && <div className="hidden 2xl:block"><UsageWidget /></div>}

--- a/web/src/lib/desktop.ts
+++ b/web/src/lib/desktop.ts
@@ -10,6 +10,8 @@
 export const IS_DESKTOP =
   typeof window !== "undefined" && "__TAURI_INTERNALS__" in window;
 
+export const IS_MAC_DESKTOP = IS_DESKTOP && /mac/i.test(navigator.platform ?? "");
+
 type AutostartApi = {
   isEnabled: () => Promise<boolean>;
   enable: () => Promise<void>;


### PR DESCRIPTION
## What does this PR do?

Makes the desktop app usable on macOS: `make desktop` now bundles an `.app` and `make desktop-install` installs it to `~/Applications` — the installer previously hardcoded the Linux x86_64 sidecar name, so it always failed with "run 'make desktop' first" on a Mac. The frameless window gains native traffic lights (`titleBarStyle: Overlay`) and can be moved by dragging its header: drag regions in the header plus the `core:window:allow-start-dragging` permission, which Tauri's defaults omit — so this also enables header-dragging on Linux, where WM modifier-drag had been masking its absence. The Linux install flow is otherwise unchanged, now triple-agnostic (works on ARM, no rustc needed at install time).

## How was it tested?

- `bunx tsc --noEmit` in `web/` and `server/`, `bun test` in both (170 + 65 green), `bunx vite build`, `bun run build:demo`, and `bun scripts/smoke.ts` (headless Chromium boots the production bundle, no console errors)
- Built and installed on an Apple Silicon Mac: launches from Spotlight and the CLI symlink, the bundled server starts, traffic lights work, the window drags by its header and resizes as before
- Linux install path regression-tested by running `install-local.sh` in a sandbox (stubbed `uname`, throwaway `$HOME`): file layout identical to the current release — binary + sidecar under `~/.local/share/agentglass`, `.desktop` launcher, icons
- Release CI unaffected: `desktop-binaries.yml` passes `--bundles dmg` explicitly, which overrides the new macOS config's `app` target