### PR TITLE
feat: one workspace overlay instead of five modals

### DIFF
--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -272,6 +272,66 @@ async function main() {
 
     if (mounted) await Bun.sleep(SETTLE_MS);
 
+    // The workspace is the app's main surface and all of it sits behind a
+    // keypress, so "the dashboard mounted" says nothing about it. Drive it the
+    // way a user does: open it, switch views, and check the views really are
+    // all mounted at once — the keep-state-alive property is the whole design,
+    // and it fails silently (you only notice a lost commit draft later).
+    if (mounted) {
+      const evaluate = async (expression: string) => {
+        const { result, exceptionDetails } = await cdp!.send(
+          "Runtime.evaluate",
+          { expression, returnByValue: true, awaitPromise: true },
+          sessionId
+        );
+        if (exceptionDetails) throw new Error(exceptionDetails.exception?.description ?? exceptionDetails.text);
+        return result.value;
+      };
+
+      // A real window-level keydown, which is where App.tsx listens.
+      const press = (key: string, mod = false) =>
+        evaluate(`(() => {
+          window.dispatchEvent(new KeyboardEvent("keydown", { key: ${JSON.stringify(key)}, ctrlKey: ${mod}, bubbles: true, cancelable: true }));
+          return new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+        })()`);
+
+      const railSel = '[role="tablist"][aria-label="Workspace views"]';
+      const selectedView = () =>
+        evaluate(`document.querySelector('${railSel} [aria-selected="true"]')?.getAttribute("data-view") ?? null`);
+
+      await press("\\", true); // ⌘\ / Ctrl-\ opens it
+      const railTabs = await evaluate(`document.querySelectorAll('${railSel} [role="tab"]').length`);
+      if (railTabs !== 5) failures.push(`[workspace] expected 5 rail tabs after Ctrl-\\, found ${railTabs}`);
+
+      // Every view mounts up front; only one is visible.
+      const panes = await evaluate(`document.querySelectorAll('${railSel}')[0]?.parentElement?.querySelectorAll(':scope > div > [aria-hidden]').length ?? 0`);
+      if (panes !== 5) failures.push(`[workspace] expected all 5 views mounted, found ${panes}`);
+
+      await press("d"); // bare letter switches while the frame holds focus
+      const afterD = await selectedView();
+      if (afterD !== "diff") failures.push(`[workspace] "d" should select diff, selected ${afterD}`);
+
+      await press("t");
+      const afterT = await selectedView();
+      if (afterT !== "term") failures.push(`[workspace] "t" should select term, selected ${afterT}`);
+
+      await press("1", true); // ⌘1 works even from inside a field
+      const after1 = await selectedView();
+      if (after1 !== "git") failures.push(`[workspace] Ctrl-1 should select git, selected ${after1}`);
+
+      // Poll rather than check once: closing runs an AnimatePresence exit
+      // animation, so the rail outlives the state change by a few hundred ms.
+      await press("Escape");
+      let closed = false;
+      for (let i = 0; i < 20 && !closed; i++) {
+        closed = (await evaluate(`!document.querySelector('${railSel}')`)) === true;
+        if (!closed) await Bun.sleep(100);
+      }
+      if (!closed) failures.push("[workspace] Escape did not close the workspace");
+
+      if (!failures.length) console.log("✓ smoke: workspace opens, all 5 views mount, keys switch and close");
+    }
+
     console.log(`smoke: served ${DIST} at ${url}`);
     if (!mounted) {
       console.error(

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -26,11 +26,8 @@ import { CommandPalette } from "./components/CommandPalette.tsx";
 import { HelpLegend } from "./components/HelpLegend.tsx";
 import { StatsModal } from "./components/StatsModal.tsx";
 import { SkillsModal } from "./components/SkillsModal.tsx";
-import { ChangesModal } from "./components/ChangesModal.tsx";
-import { GitPanel } from "./components/GitPanel.tsx";
-import { DockerPanel } from "./components/DockerPanel.tsx";
-import { TerminalPanel } from "./components/TerminalPanel.tsx";
-import { ChatPanel } from "./components/ChatPanel.tsx";
+import { Workspace } from "./components/workspace/Workspace.tsx";
+import { LETTER_TO_VIEW, VIEW_IDS, loadLastView, type ViewId } from "./components/workspace/views.ts";
 import { newChat, chatResuming, applyLiveEvent } from "./lib/chatStore.ts";
 import { sessionCwd } from "./lib/worktree.ts";
 import { SearchModal } from "./components/SearchModal.tsx";
@@ -92,11 +89,11 @@ export default function App() {
   const [helpOpen, setHelpOpen] = useState(false);
   const [statsOpen, setStatsOpen] = useState(false);
   const [skillsOpen, setSkillsOpen] = useState(false);
-  const [changesOpen, setChangesOpen] = useState(false);
-  const [gitOpen, setGitOpen] = useState(false);
-  const [dockerOpen, setDockerOpen] = useState(false);
-  const [terminalOpen, setTerminalOpen] = useState(false);
-  const [chatOpen, setChatOpen] = useState(false);
+  // One overlay replaced five modals. `wsView` is which view it shows, and it
+  // survives closing — reopening lands you where you left off, because
+  // switching views is the thing you do constantly.
+  const [wsOpen, setWsOpen] = useState(false);
+  const [wsView, setWsView] = useState<ViewId>(loadLastView);
   const [settingsOpen, setSettingsOpen] = useState(false);
   const [chatFocus, setChatFocus] = useState<string | undefined>(undefined);
   const [searchOpen, setSearchOpen] = useState(false);
@@ -112,12 +109,20 @@ export default function App() {
   // A live snapshot of "is any panel/overlay open", read by the global key
   // handler so single-letter shortcuts can't stack a second panel on top of an
   // open one. Kept in a ref so the handler needn't re-subscribe on every toggle.
+  // NB: the workspace is deliberately NOT in this list. It used to be, back
+  // when it was five separate panels, and that guard is exactly what made the
+  // app unusable: with git open, `d` did nothing, so reaching the diff meant
+  // Escape, then `d`, losing the git panel's state on the way. Inside the
+  // workspace the letters now *switch views* instead of being swallowed.
   const anyPanelOpen =
-    paletteOpen || helpOpen || statsOpen || skillsOpen || changesOpen ||
-    gitOpen || dockerOpen || terminalOpen || chatOpen || searchOpen ||
+    paletteOpen || helpOpen || statsOpen || skillsOpen || searchOpen ||
     projectOpen || sessionView !== null || selected !== null;
   const anyPanelOpenRef = useRef(anyPanelOpen);
   anyPanelOpenRef.current = anyPanelOpen;
+  const wsOpenRef = useRef(wsOpen);
+  wsOpenRef.current = wsOpen;
+  const wsViewRef = useRef(wsView);
+  wsViewRef.current = wsView;
 
   // Which folder is this cockpit about? Ask once on first open when nothing is
   // scoped yet — picking a project up front is what gives the terminal, git
@@ -261,6 +266,26 @@ export default function App() {
         if (k === "=" || k === "+") { e.preventDefault(); setScale(nudgeScale(1)); return; }
         if (k === "-" || k === "_") { e.preventDefault(); setScale(nudgeScale(-1)); return; }
         if (k === "0") { e.preventDefault(); setScale(resetScale()); return; }
+
+        // Workspace navigation, and the reason it carries a modifier: these
+        // have to work while the caret sits in the chat composer or a commit
+        // message, where a bare letter is just a letter.
+        if (k >= "1" && k <= String(VIEW_IDS.length)) {
+          e.preventDefault();
+          setWsView(VIEW_IDS[Number(k) - 1]);
+          setWsOpen(true);
+          return;
+        }
+        if (k === "[" || k === "]") {
+          e.preventDefault();
+          setWsView((cur) => {
+            const i = VIEW_IDS.indexOf(cur);
+            return VIEW_IDS[(i + (k === "]" ? 1 : VIEW_IDS.length - 1)) % VIEW_IDS.length];
+          });
+          setWsOpen(true);
+          return;
+        }
+        if (k === "\\") { e.preventDefault(); setWsOpen((o) => !o); return; }
       }
       // F11, the way every desktop app binds it. Outside the modifier block —
       // it carries none — and before the bailout below, which would otherwise
@@ -279,11 +304,7 @@ export default function App() {
         setHelpOpen(false);
         setStatsOpen(false);
         setSkillsOpen(false);
-        setChangesOpen(false);
-        setGitOpen(false);
-        setDockerOpen(false);
-        setTerminalOpen(false);
-        setChatOpen(false);
+        setWsOpen(false);
         setSearchOpen(false);
         setSessionView(null);
         return;
@@ -298,17 +319,39 @@ export default function App() {
       if (e.metaKey || e.ctrlKey || e.altKey) return;
       const a = document.activeElement;
       const focusFree = !a || a === document.body || a === document.documentElement;
-      if (!focusFree || anyPanelOpenRef.current) return;
 
+      // Inside the workspace the frame itself holds focus, so `focusFree` is
+      // false and the old guard would swallow every letter. What actually
+      // matters there is narrower: is the keystroke going into a field or a
+      // shell? If not, it's navigation.
+      const typing = !!a && (
+        /^(input|textarea|select)$/i.test(a.tagName) ||
+        (a as HTMLElement).isContentEditable ||
+        !!a.closest?.(".xterm")
+      );
+      const canNavigate = (focusFree && !anyPanelOpenRef.current) || (wsOpenRef.current && !typing);
+      if (!canNavigate) return;
+
+      // A workspace letter either opens the workspace on that view or, if it's
+      // already open, switches to it. Same five keys as before, except they no
+      // longer stop working the moment you're actually using one of them.
+      const view = LETTER_TO_VIEW[e.key];
+      if (view) {
+        e.preventDefault();
+        // Pressing the current view's own letter closes the workspace, so a
+        // key that opened something can also put it away.
+        if (wsOpenRef.current && view === wsViewRef.current) setWsOpen(false);
+        else { setWsView(view); setWsOpen(true); }
+        return;
+      }
+
+      // The remaining globals still open something *over* whatever you're in,
+      // so they keep the original strict guard: dashboard only.
+      if (!focusFree || anyPanelOpenRef.current || wsOpenRef.current) return;
       switch (e.key) {
         case "?": setHelpOpen((o) => !o); break;
         case "s": e.preventDefault(); setStatsOpen((o) => !o); break;
         case "k": e.preventDefault(); setSkillsOpen((o) => !o); break;
-        case "d": e.preventDefault(); setChangesOpen((o) => !o); break;
-        case "g": e.preventDefault(); setGitOpen((o) => !o); break;
-        case "o": e.preventDefault(); setDockerOpen((o) => !o); break;
-        case "t": e.preventDefault(); setTerminalOpen((o) => !o); break;
-        case "c": e.preventDefault(); setChatOpen((o) => !o); break;
         case "/": e.preventDefault(); setSearchOpen((o) => !o); break;
       }
     };
@@ -347,11 +390,7 @@ export default function App() {
         onOpenHelp={() => setHelpOpen(true)}
         onOpenStats={() => setStatsOpen(true)}
         onOpenSkills={() => setSkillsOpen(true)}
-        onOpenChanges={() => setChangesOpen(true)}
-        onOpenGit={() => setGitOpen(true)}
-        onOpenDocker={() => setDockerOpen(true)}
-        onOpenTerminal={() => setTerminalOpen(true)}
-        onOpenChat={() => setChatOpen(true)}
+        onOpenWorkspace={() => setWsOpen(true)}
         onOpenSettings={() => setSettingsOpen(true)}
         onClear={clearFilters}
         showUsage={showUsage}
@@ -405,11 +444,7 @@ export default function App() {
       <EventModal event={selected} onClose={() => setSelected(null)} />
       <StatsModal open={statsOpen} onClose={() => setStatsOpen(false)} stats={stats} windowMs={windowMs} />
       <SkillsModal open={skillsOpen} onClose={() => setSkillsOpen(false)} />
-      <ChangesModal open={changesOpen} onClose={() => setChangesOpen(false)} />
-      <GitPanel open={gitOpen} onClose={() => setGitOpen(false)} />
-      <DockerPanel open={dockerOpen} onClose={() => setDockerOpen(false)} />
-      <TerminalPanel open={terminalOpen} onClose={() => setTerminalOpen(false)} />
-      <ChatPanel open={chatOpen} onClose={() => setChatOpen(false)} focusId={chatFocus} />
+      <Workspace open={wsOpen} view={wsView} onView={setWsView} onClose={() => setWsOpen(false)} chatFocusId={chatFocus} />
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} onSelectApp={(app) => setFilter((f) => ({ ...f, app }))} />
       <SettingsModal
         open={settingsOpen}
@@ -439,7 +474,8 @@ export default function App() {
             title: s.summary?.slice(0, 40) || `${s.source_app}:${s.session_id.slice(0, 8)}`,
           });
           setChatFocus(chat.id);
-          setChatOpen(true);
+          setWsView("chat");
+          setWsOpen(true);
         }}
       />
       <CommandPalette
@@ -452,11 +488,11 @@ export default function App() {
         onTheme={setTheme}
         onStats={() => setStatsOpen(true)}
         onSkills={() => setSkillsOpen(true)}
-        onChanges={() => setChangesOpen(true)}
-        onGit={() => setGitOpen(true)}
-        onDocker={() => setDockerOpen(true)}
-        onTerminal={() => setTerminalOpen(true)}
-        onChat={() => setChatOpen(true)}
+        onChanges={() => { setWsView("diff"); setWsOpen(true); }}
+        onGit={() => { setWsView("git"); setWsOpen(true); }}
+        onDocker={() => { setWsView("docker"); setWsOpen(true); }}
+        onTerminal={() => { setWsView("term"); setWsOpen(true); }}
+        onChat={() => { setWsView("chat"); setWsOpen(true); }}
         onSearch={() => setSearchOpen(true)}
         onClear={clearFilters}
         onZoom={zoom}

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -572,7 +572,24 @@ export function writeWalkCache(sig: string, r: WalkthroughResult) {
   } catch { /* ignore */ }
 }
 
-export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, presetTitle, presetPath }: { open: boolean; onClose: () => void; onBack?: () => void; backLabel?: string; presetChanges?: FileChange[]; presetTitle?: string; presetPath?: string }) {
+type DiffViewProps = {
+  active: boolean;
+  onClose?: () => void;
+  onBack?: () => void;
+  backLabel?: string;
+  presetChanges?: FileChange[];
+  presetTitle?: string;
+  presetPath?: string;
+};
+
+/** The file-changes viewer, without a frame around it.
+ *
+ *  Two callers with two different shapes: the workspace mounts it as the
+ *  `diff` view (no chrome — the rail is the chrome), and GitPanel still opens
+ *  it as a modal to drill into one commit. Hence `DiffView` plus the
+ *  `ChangesModal` wrapper at the bottom of this file. */
+export function DiffView({ active, onClose, onBack, backLabel, presetChanges, presetTitle, presetPath }: DiffViewProps) {
+  const open = active;
   const [changes, setChanges] = useState<FileChange[] | null>(null);
   const [titles, setTitles] = useState<ReadonlyMap<string, string>>(new Map());
   const [q, setQ] = useState("");
@@ -772,22 +789,8 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
   };
 
   return (
-    <Portal>
-      <AnimatePresence>
-        {open && (
-          <>
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
-            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
-              <motion.div
-                ref={frameRef}
-                tabIndex={-1}
-                onKeyDown={onKey}
-                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
-                transition={{ type: "spring", stiffness: 330, damping: 30 }}
-                className="w-[95vw] h-[95vh] rounded-2xl flex flex-col pointer-events-auto outline-none overflow-hidden"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}
-              >
+    <div ref={frameRef} tabIndex={-1} onKeyDown={onKey}
+      className="flex-1 min-h-0 flex flex-col outline-none overflow-hidden relative">
                 <style>{SCROLLBAR_CSS}</style>
                 <div className="flex items-center justify-between px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <div className="flex items-baseline gap-2.5 flex-wrap">
@@ -824,7 +827,9 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
                         style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)" }}
                       >⎇ Commit…</button>
                     )}
-                    <button onClick={onClose} className="text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
+                    {/* only when framed as a modal — inside the workspace the
+                        rail owns closing */}
+                    {onClose && <button onClick={onClose} className="text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>}
                   </div>
                 </div>
 
@@ -925,9 +930,31 @@ export function ChangesModal({ open, onClose, onBack, backLabel, presetChanges, 
                     )}
                   </div>
                 </div>
+      <CommitModal open={commitOpen} onClose={() => setCommitOpen(false)} paths={commitPaths} />
+    </div>
+  );
+}
+
+/** The same viewer with a modal frame, for callers that drill into it rather
+ *  than navigate to it (GitPanel's commit log, the file-card deep link). */
+export function ChangesModal({ open, onClose, ...rest }: Omit<DiffViewProps, "active"> & { open: boolean; onClose: () => void }) {
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
+              <motion.div
+                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
+                transition={{ type: "spring", stiffness: 330, damping: 30 }}
+                className="w-[95vw] h-[95vh] rounded-2xl flex flex-col pointer-events-auto outline-none overflow-hidden"
+                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}
+              >
+                <DiffView active={open} onClose={onClose} {...rest} />
               </motion.div>
             </div>
-            <CommitModal open={commitOpen} onClose={() => setCommitOpen(false)} paths={commitPaths} />
           </>
         )}
       </AnimatePresence>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -11,7 +11,6 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { GitRepoRef, SessionRollup } from "../../../shared/types.ts";
-import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
@@ -385,7 +384,16 @@ function ClipIcon() {
   );
 }
 
-export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: () => void; focusId?: string }) {
+/** Chat as a workspace view.
+ *
+ *  The conversations themselves already live outside React in chatStore, so
+ *  they survived the old panel closing. What didn't survive was everything
+ *  around them — which chat was selected, the draft in the composer, the
+ *  scroll position. Staying mounted fixes that. */
+// `active` is destructured as `visible` because this component already has an
+// `active` of its own — the currently selected chat.
+export function ChatView({ active: visible, focusId, onClose = () => {} }: { active: boolean; focusId?: string | null; onClose?: () => void }) {
+  const open = visible;
   const chats = useSyncExternalStore(subscribe, listChats, listChats);
   const [activeId, setActiveId] = useState("");
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
@@ -613,17 +621,7 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
   );
 
   return (
-    <Portal>
-      <AnimatePresence>
-        {open && (
-          <>
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
-            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
-              <motion.div initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
-                transition={{ type: "spring", stiffness: 330, damping: 30 }}
-                className="relative w-[95vw] h-[95vh] rounded-2xl flex pointer-events-auto overflow-hidden"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+    <div className="relative flex-1 min-h-0 flex overflow-hidden">
                 <style>{SCROLLBAR_CSS}</style>
 
                 {/* Anchored inside the modal rather than portalled like Select:
@@ -904,11 +902,6 @@ export function ChatPanel({ open, onClose, focusId }: { open: boolean; onClose: 
                     </div>
                   </div>
                 </div>
-              </motion.div>
-            </div>
-          </>
-        )}
-      </AnimatePresence>
-    </Portal>
+    </div>
   );
 }

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -2,9 +2,7 @@
 // compose project with live CPU/mem, a streaming-ish log viewer, and start/
 // stop/restart/rm actions. Images / volumes / networks get their own tabs.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
 import type { DockerOverview, DockerContainer, DockerStat } from "../../../shared/types.ts";
-import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
@@ -61,7 +59,9 @@ function ContainerRow({ c, stat, active, writeEnabled, busy, onSelect, onAction 
   );
 }
 
-export function DockerPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+/** Docker as a workspace view. `active` means "visible right now" — the view
+ *  stays mounted while you're off in the diff, it just stops polling. */
+export function DockerView({ active }: { active: boolean }) {
   const [ov, setOv] = useState<DockerOverview | null>(null);
   const [stats, setStats] = useState<Record<string, DockerStat>>({});
   const [view, setView] = useState<View>("containers");
@@ -96,33 +96,34 @@ export function DockerPanel({ open, onClose }: { open: boolean; onClose: () => v
     catch (e) { if (seq === logSeq.current) setLogs(String(e)); }
   }, []);
 
-  // open → load overview (cheap), then poll every 5s.
+  // visible → load overview (cheap), then poll every 5s. Gated on `active`
+  // rather than on mount: hidden views keep their state but go quiet.
   useEffect(() => {
-    if (!open) return;
+    if (!active) return;
     setToast(null);
     loadOverview();
     const t = setInterval(loadOverview, 5000);
     requestAnimationFrame(() => frameRef.current?.focus());
     return () => clearInterval(t);
-  }, [open, loadOverview]);
+  }, [active, loadOverview]);
 
   // stats: only poll the (slow) `docker stats` sample while viewing containers.
   useEffect(() => {
-    if (!open || view !== "containers") return;
+    if (!active || view !== "containers") return;
     loadStats();
     const t = setInterval(loadStats, 5000);
     return () => clearInterval(t);
-  }, [open, view, loadStats]);
+  }, [active, view, loadStats]);
 
   // logs: poll every 3s while a container's log tab is visible. Keyed by id
   // (not the container object) so the 5s overview refresh doesn't restart it.
   useEffect(() => {
     const id = selected?.id;
-    if (!open || view !== "containers" || tab !== "logs" || !id) return;
+    if (!active || view !== "containers" || tab !== "logs" || !id) return;
     loadLogs(id, tail);
     const t = setInterval(() => loadLogs(id, tail), 3000);
     return () => clearInterval(t);
-  }, [open, view, tab, selected?.id, tail, loadLogs]);
+  }, [active, view, tab, selected?.id, tail, loadLogs]);
 
   // keep the log view pinned to the bottom.
   useEffect(() => { const el = logRef.current; if (el && stuckBottom.current) el.scrollTop = el.scrollHeight; }, [logs]);
@@ -173,18 +174,8 @@ export function DockerPanel({ open, onClose }: { open: boolean; onClose: () => v
   );
 
   return (
-    <Portal>
-      <AnimatePresence>
-        {open && (
-          <>
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
-            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
-              <motion.div ref={frameRef} tabIndex={-1} onKeyDown={onKey}
-                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
-                transition={{ type: "spring", stiffness: 330, damping: 30 }}
-                className="w-[95vw] h-[95vh] rounded-2xl flex flex-col pointer-events-auto outline-none overflow-hidden"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+    <div ref={frameRef} tabIndex={-1} onKeyDown={onKey}
+      className="flex-1 min-h-0 flex flex-col outline-none overflow-hidden relative">
                 <style>{SCROLLBAR_CSS}</style>
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>🐳 Docker</span>
@@ -211,7 +202,6 @@ export function DockerPanel({ open, onClose }: { open: boolean; onClose: () => v
                   <div className="ml-auto flex items-center gap-1.5">
                     {!writeEnabled && ov?.available && <span className="text-[9.5px] t-dim2">read-only</span>}
                     <button onClick={() => { loadOverview(); loadStats(); }} title="Refresh" className="text-[13px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>⟳</button>
-                    <button onClick={onClose} className="text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
                   </div>
                 </div>
 
@@ -303,11 +293,6 @@ export function DockerPanel({ open, onClose }: { open: boolean; onClose: () => v
                 {toast && (
                   <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3.5 py-2 rounded-lg text-[11px] shadow-xl" style={{ zIndex: 40, background: "var(--bg3)", border: `1px solid ${toast.ok ? "color-mix(in srgb, var(--success) 50%, transparent)" : "color-mix(in srgb, var(--error) 50%, transparent)"}`, color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</div>
                 )}
-              </motion.div>
-            </div>
-          </>
-        )}
-      </AnimatePresence>
-    </Portal>
+    </div>
   );
 }

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -3,9 +3,7 @@
 // (browse commits, view a commit's diff), and stash — all with the same diff
 // renderer as the telemetry view.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
-import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
 import { usePoll } from "../lib/usePoll.ts";
@@ -317,7 +315,13 @@ function Section({ title, count, tint, action, onAll, children }: { title: strin
   );
 }
 
-export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+/** Source control as a workspace view.
+ *
+ *  Staying mounted while hidden is worth more here than anywhere else: the
+ *  commit message drafts (`title`/`body`) used to be destroyed every time you
+ *  looked at something else, which is precisely what you do before committing. */
+export function GitView({ active }: { active: boolean }) {
+  const open = active;
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState<string>("");
   const [tree, setTree] = useState<WorkingTree | null>(null);
@@ -860,18 +864,8 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
   );
 
   return (
-    <Portal>
-      <AnimatePresence>
-        {open && (
-          <>
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
-            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
-              <motion.div ref={frameRef} tabIndex={-1} onKeyDown={onKey}
-                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
-                transition={{ type: "spring", stiffness: 330, damping: 30 }}
-                className="w-[95vw] h-[95vh] rounded-2xl flex flex-col pointer-events-auto outline-none overflow-hidden"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+    <div ref={frameRef} tabIndex={-1} onKeyDown={onKey}
+      className="flex-1 min-h-0 flex flex-col outline-none overflow-hidden relative">
                 <style>{SCROLLBAR_CSS}</style>
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>Source control</span>
@@ -934,7 +928,6 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
                       running={pending === "push"} disabled={!writeEnabled || busy} primary
                       onClick={() => act(() => api.gitPush(root), "pushed", "push")} />
                     <button onClick={() => loadTree(root)} title="Refresh" className="text-[13px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>⟳</button>
-                    <button onClick={onClose} className="text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
                   </div>
                 </div>
 
@@ -1203,13 +1196,10 @@ export function GitPanel({ open, onClose }: { open: boolean; onClose: () => void
                 <ShortcutBar view={view} logOpen={logOpen} onToggleLog={() => setLogOpen((v) => !v)} editorName={editor?.editor} />
                 {helpOpen && <HelpSheet view={view} onClose={() => setHelpOpen(false)} />}
                 {toast && <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3.5 py-2 rounded-lg text-[11px] shadow-xl" style={{ zIndex: 40, background: "var(--bg3)", border: `1px solid ${toast.ok ? "color-mix(in srgb, var(--success) 50%, transparent)" : "color-mix(in srgb, var(--error) 50%, transparent)"}`, color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</div>}
-              </motion.div>
-            </div>
-            {/* a commit's diff, reusing the full file-changes viewer */}
-            <ChangesModal open={!!commitView} onClose={() => setCommitView(null)} onBack={() => setCommitView(null)} backLabel="Log" presetChanges={commitView?.changes} presetTitle={commitView?.title} />
-          </>
-        )}
-      </AnimatePresence>
-    </Portal>
+      {/* A commit's diff, reusing the full file-changes viewer. Still a modal:
+          it's a drill-down from a row you clicked, not a place you navigate
+          to — the rail's views are the destinations, this is a detour. */}
+      <ChangesModal open={!!commitView} onClose={() => setCommitView(null)} onBack={() => setCommitView(null)} backLabel="Log" presetChanges={commitView?.changes} presetTitle={commitView?.title} />
+    </div>
   );
 }

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -8,6 +8,7 @@ import { UsageWidget } from "./UsageWidget.tsx";
 import { Logo } from "./Logo.tsx";
 import { Select } from "./Select.tsx";
 import { subscribe as subscribeChats, attentionCount } from "../lib/chatStore.ts";
+import { WorkspaceIcon } from "./workspace/icons.tsx";
 
 // The long windows matter once history isn't pruned: the transcript scan can
 // backfill months of sessions, and a 7d ceiling would hide most of the fleet.
@@ -52,46 +53,8 @@ function SkillsIcon() {
   );
 }
 
-function DiffIcon() {
-  return (
-    <svg {...svg}>
-      <path d="M6 3v12" /><circle cx="6" cy="18" r="2.2" /><path d="M6 15a6 6 0 0 0 6 6" />
-      <circle cx="18" cy="6" r="2.2" /><path d="M18 8v3a6 6 0 0 1-6 6" />
-    </svg>
-  );
-}
-
-function GitIcon() {
-  return (
-    <svg {...svg}>
-      <path d="M12 3v6M12 15v6" /><circle cx="12" cy="12" r="3" />
-    </svg>
-  );
-}
-
-function DockerIcon() {
-  return (
-    <svg {...svg}>
-      <path d="M3 9l9-5 9 5v6l-9 5-9-5z" /><path d="M3 9l9 5 9-5M12 14v6" />
-    </svg>
-  );
-}
-
-function TerminalIcon() {
-  return (
-    <svg {...svg}>
-      <path d="M6 8l3.5 4L6 16" /><path d="M12.5 16.5H18" />
-    </svg>
-  );
-}
-
-function ChatIcon() {
-  return (
-    <svg {...svg}>
-      <path d="M20 4H4v12h5v4l5-4h6z" />
-    </svg>
-  );
-}
+/* The git/diff/docker/terminal/chat glyphs moved to workspace/icons.tsx when
+   their five buttons became one — the rail needs them too. */
 
 /** Settings button — the overflow menu became a real modal (SettingsModal),
  *  because a flat list of one-liners could not show a toggle's state without
@@ -112,7 +75,7 @@ function MoreMenu({ onOpen }: { onOpen: () => void }) {
 
 export function Header({
   conn, windowMs, onWindow, apps, types, providers, filter, onFilter, theme, onTheme,
-  sound, onSound, onOpenPalette, onOpenHelp, onOpenStats, onOpenSkills, onOpenChanges, onOpenGit, onOpenDocker, onOpenTerminal, onOpenChat, onOpenSettings, onClear, showUsage,
+  sound, onSound, onOpenPalette, onOpenHelp, onOpenStats, onOpenSkills, onOpenWorkspace, onOpenSettings, onClear, showUsage,
   workspace, onOpenProject,
 }: {
   conn: ConnState;
@@ -131,11 +94,7 @@ export function Header({
   onOpenHelp: () => void;
   onOpenStats: () => void;
   onOpenSkills: () => void;
-  onOpenChanges: () => void;
-  onOpenGit: () => void;
-  onOpenDocker: () => void;
-  onOpenTerminal: () => void;
-  onOpenChat: () => void;
+  onOpenWorkspace: () => void;
   onOpenSettings: () => void;
   onClear: () => void;
   showUsage: boolean;
@@ -243,68 +202,20 @@ export function Header({
         <button onClick={onOpenPalette} className="h-8 hidden sm:flex items-center gap-1.5 px-2.5 rounded-lg text-[11px]" style={selStyle}>
           <span>{MOD_KEY}K</span><span className="hidden sm:inline t-dim2">search</span>
         </button>
-        {/* Git + Diff are the primary workspaces (replacing lazygit) — labeled + accented */}
+        {/* One button where there were five (git/diff/docker/term/chat).
+            They were the app's whole purpose and yet each one opened its own
+            modal, so moving between them meant closing and reopening — the
+            rail inside the workspace does that switching now, for free.
+            The letter keys still deep-link straight to a view, so this button
+            only serves the mouse.
+            It also inherits the chat button's attention state: a reply that
+            landed while you were elsewhere has to be visible from the
+            dashboard, and this is the only door left. */}
         <button
-          onClick={onOpenGit}
-          title="Source control — stage, commit, push/pull the working tree (g)"
-          className="h-8 flex items-center gap-1.5 px-2.5 rounded-lg text-[11px] font-semibold"
-          style={{
-            color: "var(--primary-hover)",
-            background: "color-mix(in srgb, var(--primary) 18%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--primary) 50%, transparent)",
-          }}
-        >
-          <GitIcon />
-          <span className="hidden sm:inline">git</span>
-        </button>
-        <button
-          onClick={onOpenChanges}
-          title="File changes — review & commit every diff the fleet made (d)"
-          className="h-8 flex items-center gap-1.5 px-2.5 rounded-lg text-[11px] font-semibold"
-          style={{
-            color: "var(--primary-hover)",
-            background: "color-mix(in srgb, var(--primary) 18%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--primary) 50%, transparent)",
-          }}
-        >
-          <DiffIcon />
-          <span className="hidden sm:inline">diff</span>
-        </button>
-        <button
-          onClick={onOpenDocker}
-          title="Docker — containers, logs, stats & actions (o)"
-          className="h-8 flex items-center gap-1.5 px-2.5 rounded-lg text-[11px] font-semibold"
-          style={{
-            color: "var(--primary-hover)",
-            background: "color-mix(in srgb, var(--primary) 18%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--primary) 50%, transparent)",
-          }}
-        >
-          <DockerIcon />
-          <span className="hidden md:inline">docker</span>
-        </button>
-        <button
-          onClick={onOpenTerminal}
-          title="Terminal — a real shell in any repo/worktree (t)"
-          className="h-8 flex items-center gap-1.5 px-2.5 rounded-lg text-[11px] font-semibold"
-          style={{
-            color: "var(--primary-hover)",
-            background: "color-mix(in srgb, var(--primary) 18%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--primary) 50%, transparent)",
-          }}
-        >
-          <TerminalIcon />
-          <span className="hidden lg:inline">term</span>
-        </button>
-        {/* A chat runs on its own clock: you send, move to the diff, and the
-            reply lands against a closed panel. Waiting replies pull the button
-            to the success colour and pulse it, so "is anything waiting for me?"
-            is answerable without opening anything. */}
-        <button
-          onClick={onOpenChat}
+          onClick={onOpenWorkspace}
           title={waiting
-            ? `${waiting} chat${waiting === 1 ? "" : "s"} replied while you were elsewhere (c)`
-            : "Chat — drive a Claude session in any repo/worktree (c)"}
+            ? `Workspace — ${waiting} chat${waiting === 1 ? "" : "s"} replied while you were elsewhere (${MOD_KEY}\\)`
+            : `Workspace — git, diff, docker, terminal, chat (${MOD_KEY}\\)`}
           className="h-8 flex items-center gap-1.5 px-2.5 rounded-lg text-[11px] font-semibold"
           style={{
             color: waiting ? "var(--success)" : "var(--primary-hover)",
@@ -313,8 +224,8 @@ export function Header({
             animation: waiting ? "agx-attention 1.8s ease-in-out infinite" : undefined,
           }}
         >
-          <ChatIcon />
-          <span className="hidden lg:inline">chat</span>
+          <WorkspaceIcon />
+          <span className="hidden sm:inline">workspace</span>
           {waiting > 0 && (
             <span className="tabular-nums px-1 rounded-full text-[9.5px]"
               style={{ background: "color-mix(in srgb, var(--success) 30%, transparent)" }}>{waiting}</span>

--- a/web/src/components/HelpLegend.tsx
+++ b/web/src/components/HelpLegend.tsx
@@ -64,17 +64,27 @@ export function HelpLegend({ open, onClose }: { open: boolean; onClose: () => vo
                   <span><kbd className="chip">?</kbd> this help</span>
                   <span><kbd className="chip">s</kbd> statistics</span>
                   <span><kbd className="chip">k</kbd> skills explorer</span>
-                  <span><kbd className="chip">d</kbd> file changes / diffs</span>
-                  <span><kbd className="chip">g</kbd> source control (git)</span>
-                  <span><kbd className="chip">o</kbd> docker (containers)</span>
-                  <span><kbd className="chip">t</kbd> terminal (a real shell)</span>
-                  <span><kbd className="chip">c</kbd> chat (drive a claude session)</span>
                   <span><kbd className="chip">/</kbd> search all history</span>
                   {IS_DESKTOP && (
                     <span><kbd className="chip">{MOD_KEY}+</kbd> <kbd className="chip">{MOD_KEY}−</kbd> display size</span>
                   )}
                   <span>Click an event → full details</span>
                   <span>Click an agent → filter to it</span>
+                </div>
+                <div className="panel-eyebrow mt-3 mb-2">workspace</div>
+                <div className="grid grid-cols-2 gap-y-1 text-[11px] t-dim">
+                  <span><kbd className="chip">{MOD_KEY}\</kbd> open / close</span>
+                  <span><kbd className="chip">{MOD_KEY}1</kbd>…<kbd className="chip">{MOD_KEY}5</kbd> jump to a view</span>
+                  <span><kbd className="chip">g</kbd> git</span>
+                  <span><kbd className="chip">d</kbd> diff</span>
+                  <span><kbd className="chip">o</kbd> docker</span>
+                  <span><kbd className="chip">t</kbd> terminal</span>
+                  <span><kbd className="chip">c</kbd> chat</span>
+                  <span><kbd className="chip">{MOD_KEY}[</kbd> <kbd className="chip">{MOD_KEY}]</kbd> cycle views</span>
+                  {/* The distinction that actually bites: bare letters are
+                      swallowed by the shell and the composer, the ⌘ pair never
+                      is. */}
+                  <span className="col-span-2 t-dim2">letters switch views unless you're typing; {MOD_KEY} shortcuts always work</span>
                 </div>
               </div>
             </motion.div>

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -5,12 +5,10 @@
 // module-level store, so closing the panel (or switching repos) never kills a
 // running job — reopening reattaches to the live session, scrollback intact.
 import { useCallback, useEffect, useReducer, useRef, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import type { GitRepoRef, ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
-import { Portal } from "./Portal.tsx";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
 import { worktreeTag } from "../lib/worktree.ts";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
@@ -70,7 +68,27 @@ const sessions = new Map<string, Sess>();
 let seq = 0;
 /** Shells for one repo, in creation order. */
 const sessionsFor = (root: string) => [...sessions.values()].filter((s) => s.root === root).sort((a, b) => a.createdAt - b.createdAt);
-const notify = (s: Sess) => s.subs.forEach((fn) => fn());
+const notify = (s: Sess) => { s.subs.forEach((fn) => fn()); rosterChanged(); };
+
+// --- roster: "is any shell alive?", for the workspace rail ---------------------
+// Per-session `subs` answer "did *this* shell change"; nothing could answer
+// "is anything running at all" without holding a session. The rail needs
+// exactly that, and needs it while the terminal view is hidden.
+const rosterSubs = new Set<() => void>();
+export function subscribeSessions(fn: () => void) {
+  rosterSubs.add(fn);
+  return () => { rosterSubs.delete(fn); };
+}
+let liveCount = 0;
+function recount() {
+  let n = 0;
+  for (const s of sessions.values()) if (s.status === "live" || s.status === "connecting") n++;
+  liveCount = n;
+}
+/** Cached so useSyncExternalStore sees a stable value between real changes —
+ *  recomputing per call would hand React a new number and loop. */
+export function liveSessionCount() { return liveCount; }
+const rosterChanged = () => { const before = liveCount; recount(); if (before !== liveCount) rosterSubs.forEach((fn) => fn()); };
 // Set by the mounted panel so the terminal itself can close it (Shift+Esc).
 let panelClose: () => void = () => {};
 
@@ -95,6 +113,7 @@ function evictLru(exceptRoot: string) {
   try { lru.term.dispose(); } catch { /* already disposed */ }
   lru.holder.remove();
   sessions.delete(lru.id);
+  rosterChanged();
 }
 
 /**
@@ -280,6 +299,7 @@ function killSession(s: Sess) {
   try { s.term.dispose(); } catch { /* already disposed */ }
   s.holder.remove();
   sessions.delete(s.id);
+  rosterChanged();
 }
 
 /** Type a command into the repo's shell (starting one if needed). */
@@ -292,7 +312,12 @@ function runInShell(s: Sess, cmd: string) {
 }
 
 // --- the panel ---------------------------------------------------------------
-export function TerminalPanel({ open, onClose }: { open: boolean; onClose: () => void }) {
+/** The terminal as a workspace view.
+ *
+ *  `onClose` is still needed here (unlike the other views) because the shell
+ *  itself can dismiss the workspace with Shift+Esc — see `panelClose`. */
+export function TermView({ active, onClose = () => {} }: { active: boolean; onClose?: () => void }) {
+  const open = active;
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState<string>(() => { try { return localStorage.getItem(ROOT_KEY) || ""; } catch { return ""; } });
   const [repoOpen, setRepoOpen] = useState(false);
@@ -449,23 +474,11 @@ export function TerminalPanel({ open, onClose }: { open: boolean; onClose: () =>
   };
 
   return (
-    <Portal>
-      <AnimatePresence>
-        {open && (
-          <>
-            <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
-            {/* Above the panel, not inside it. Sitting within the terminal it
-                covered the first line of output and read as part of the shell;
-                floating over the modal's top edge it belongs to the app, which
-                is what it actually reports on. */}
-            <UsageIsland />
-            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
-              <motion.div
-                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
-                transition={{ type: "spring", stiffness: 330, damping: 30 }}
-                className="w-[95vw] h-[95vh] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+    <div className="flex-1 min-h-0 flex flex-col overflow-hidden relative">
+                {/* Only while this view is the visible one — the island is
+                    fixed-positioned, so a hidden terminal would otherwise leave
+                    it floating over the git view. */}
+                {active && <UsageIsland />}
                 <style>{SCROLLBAR_CSS}</style>
                 {/* Pin xterm's own boxes flush. The stylesheet ships no padding
                     today, but it has before and it is one release away from
@@ -661,12 +674,7 @@ export function TerminalPanel({ open, onClose }: { open: boolean; onClose: () =>
                   )}
                   <span className="ml-auto">{sess ? `${sess.term.cols}×${sess.term.rows}` : ""}</span>
                 </div>
-              </motion.div>
-            </div>
-          </>
-        )}
-      </AnimatePresence>
-    </Portal>
+    </div>
   );
 }
 

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -1,0 +1,97 @@
+import { VIEWS, type ViewId } from "./views.ts";
+
+export type RailPip = { dot?: boolean; count?: number };
+
+/** Icon-only switcher down the side of the workspace.
+ *
+ *  Deliberately 52px and wordless: this is the frame around every view, so
+ *  every pixel it takes is taken from the thing you actually came to look at.
+ *  The name lives in a hover tooltip, and after a day nobody uses the rail
+ *  anyway — the letter keys are faster. Status (a live shell, a chat that
+ *  replied) rides as a corner pip so it costs no width at all.
+ */
+export function ViewRail({
+  view, onSelect, onClose, pips,
+}: {
+  view: ViewId;
+  onSelect: (v: ViewId) => void;
+  onClose: () => void;
+  pips?: Partial<Record<ViewId, RailPip>>;
+}) {
+  // Arrow keys move between tabs, matching the tablist pattern. Without this
+  // the rail is reachable by Tab but not traversable, which is the usual way
+  // an icon rail fails a keyboard user.
+  const onKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key !== "ArrowDown" && e.key !== "ArrowUp") return;
+    e.preventDefault();
+    const i = VIEWS.findIndex((v) => v.id === view);
+    const n = VIEWS[(i + (e.key === "ArrowDown" ? 1 : VIEWS.length - 1)) % VIEWS.length];
+    onSelect(n.id);
+    (e.currentTarget.querySelector(`[data-view="${n.id}"]`) as HTMLElement | null)?.focus();
+  };
+
+  return (
+    <nav
+      role="tablist"
+      aria-label="Workspace views"
+      onKeyDown={onKeyDown}
+      className="w-[52px] shrink-0 flex flex-col gap-[3px] p-2 overflow-visible"
+      style={{
+        borderRight: "1px solid color-mix(in srgb, var(--primary) 14%, transparent)",
+        background: "color-mix(in srgb, var(--bg) 55%, transparent)",
+      }}
+    >
+      {VIEWS.map((v) => {
+        const on = v.id === view;
+        const pip = pips?.[v.id];
+        const Icon = v.icon;
+        return (
+          <button
+            key={v.id}
+            data-view={v.id}
+            role="tab"
+            aria-selected={on}
+            aria-label={v.label}
+            tabIndex={on ? 0 : -1}
+            onClick={() => onSelect(v.id)}
+            className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+            data-tip={`${v.label} · ${v.key}`}
+            style={{
+              color: on ? "var(--primary-hover)" : "var(--text4)",
+              background: on ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
+            }}
+          >
+            <Icon size={17} />
+            {/* the 3px edge marker: reads as "you are here" from the far side
+                of the screen, where a background tint alone doesn't. */}
+            {on && (
+              <span className="absolute left-[-8px] top-[9px] bottom-[9px] w-[3px] rounded-r-[3px]"
+                style={{ background: "var(--primary)" }} />
+            )}
+            {pip?.count ? (
+              <span className="absolute top-[5px] right-[6px] min-w-[14px] h-[14px] px-[3px] grid place-items-center rounded-full text-[9px] font-bold tabular-nums"
+                style={{ background: "var(--success)", color: "#06281c" }}>{pip.count}</span>
+            ) : pip?.dot ? (
+              <span className="absolute top-[7px] right-[9px] w-[6px] h-[6px] rounded-full"
+                style={{ background: "var(--success)", boxShadow: "0 0 0 3px color-mix(in srgb, var(--success) 22%, transparent)" }} />
+            ) : null}
+          </button>
+        );
+      })}
+
+      <div className="mt-auto pt-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--primary) 10%, transparent)" }}>
+        <button
+          onClick={onClose}
+          aria-label="Close workspace"
+          data-tip="close · esc"
+          className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+          style={{ color: "var(--text4)" }}
+        >
+          <svg viewBox="0 0 24 24" width={16} height={16} fill="none" stroke="currentColor" strokeWidth={2} strokeLinecap="round">
+            <path d="M6 6l12 12M18 6L6 18" />
+          </svg>
+        </button>
+      </div>
+    </nav>
+  );
+}

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -1,0 +1,116 @@
+import { useEffect, useRef, useSyncExternalStore } from "react";
+import { AnimatePresence, motion } from "motion/react";
+import { Portal } from "../Portal.tsx";
+import { ViewRail, type RailPip } from "./ViewRail.tsx";
+import { VIEWS, saveLastView, type ViewId } from "./views.ts";
+import { subscribe as subscribeChats, attentionCount } from "../../lib/chatStore.ts";
+import { GitView } from "../GitPanel.tsx";
+import { DiffView } from "../ChangesModal.tsx";
+import { DockerView } from "../DockerPanel.tsx";
+import { TermView, subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
+import { ChatView } from "../ChatPanel.tsx";
+
+const BODY = {
+  git: GitView,
+  diff: DiffView,
+  docker: DockerView,
+  term: TermView,
+  chat: ChatView,
+} as const;
+
+/** One overlay, five views.
+ *
+ *  Every view mounts as soon as the workspace opens and stays mounted until it
+ *  closes — switching only flips visibility. That is the whole point: the old
+ *  five-separate-modals shape tore a panel down on every switch, so a commit
+ *  message half-written in git evaporated the moment you looked at the diff.
+ *  Polling is gated on `active` rather than on mount, so the four views you
+ *  aren't looking at keep their state without costing anything on the network.
+ */
+export function Workspace({
+  open, view, onView, onClose, chatFocusId,
+}: {
+  open: boolean;
+  view: ViewId;
+  onView: (v: ViewId) => void;
+  onClose: () => void;
+  chatFocusId?: string | null;
+}) {
+  const frameRef = useRef<HTMLDivElement>(null);
+
+  const chatWaiting = useSyncExternalStore(subscribeChats, attentionCount, attentionCount);
+  const shells = useSyncExternalStore(subscribeSessions, liveSessionCount, liveSessionCount);
+
+  const pips: Partial<Record<ViewId, RailPip>> = {
+    chat: chatWaiting > 0 ? { count: chatWaiting } : {},
+    term: shells > 0 ? { dot: true } : {},
+  };
+
+  useEffect(() => { if (open) saveLastView(view); }, [open, view]);
+
+  // Focus the frame on open so Escape and the rail's arrow keys work without
+  // needing a click first.
+  useEffect(() => {
+    if (!open) return;
+    const id = requestAnimationFrame(() => frameRef.current?.focus());
+    return () => cancelAnimationFrame(id);
+  }, [open]);
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+              onClick={onClose}
+            />
+            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
+              <motion.div
+                ref={frameRef}
+                tabIndex={-1}
+                role="dialog"
+                aria-label="Workspace"
+                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
+                transition={{ type: "spring", stiffness: 330, damping: 30 }}
+                className="w-[95vw] h-[95vh] rounded-2xl flex pointer-events-auto outline-none overflow-hidden"
+                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}
+              >
+                <ViewRail view={view} onSelect={onView} onClose={onClose} pips={pips} />
+
+                <div className="relative flex-1 min-w-0">
+                  {VIEWS.map((v) => {
+                    const View = BODY[v.id];
+                    const active = v.id === view;
+                    return (
+                      <div
+                        key={v.id}
+                        // `visibility`, not `display:none`: xterm's fit addon
+                        // measures its container, and a display:none parent
+                        // measures 0x0 — which is how a hidden terminal comes
+                        // back reflowed to a single column.
+                        className="absolute inset-0 flex flex-col min-h-0"
+                        style={{ visibility: active ? "visible" : "hidden" }}
+                        aria-hidden={!active}
+                      >
+                        {/* term and chat can dismiss the workspace from the
+                            inside — Shift+Esc in the shell, Escape in the
+                            composer — so they alone need onClose. */}
+                        <View
+                          active={active}
+                          {...(v.id === "chat" ? { focusId: chatFocusId, onClose } : {})}
+                          {...(v.id === "term" ? { onClose } : {})}
+                        />
+                      </div>
+                    );
+                  })}
+                </div>
+              </motion.div>
+            </div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  );
+}

--- a/web/src/components/workspace/icons.tsx
+++ b/web/src/components/workspace/icons.tsx
@@ -1,0 +1,47 @@
+/** The five workspace glyphs, shared by the rail and the header button.
+ *  They used to live in Header.tsx, where the rail couldn't reach them. */
+
+const svg = {
+  viewBox: "0 0 24 24",
+  fill: "none",
+  stroke: "currentColor",
+  strokeWidth: 2,
+  strokeLinecap: "round" as const,
+  strokeLinejoin: "round" as const,
+};
+
+type P = { size?: number };
+
+export function GitIcon({ size = 15 }: P) {
+  return <svg {...svg} width={size} height={size}><path d="M12 3v6M12 15v6" /><circle cx="12" cy="12" r="3" /></svg>;
+}
+
+export function DiffIcon({ size = 15 }: P) {
+  return (
+    <svg {...svg} width={size} height={size}>
+      <path d="M6 3v12" /><circle cx="6" cy="18" r="2.2" /><path d="M6 15a6 6 0 0 0 6 6" />
+      <circle cx="18" cy="6" r="2.2" /><path d="M18 8v3a6 6 0 0 1-6 6" />
+    </svg>
+  );
+}
+
+export function DockerIcon({ size = 15 }: P) {
+  return <svg {...svg} width={size} height={size}><path d="M3 9l9-5 9 5v6l-9 5-9-5z" /><path d="M3 9l9 5 9-5M12 14v6" /></svg>;
+}
+
+export function TerminalIcon({ size = 15 }: P) {
+  return <svg {...svg} width={size} height={size}><path d="M6 8l3.5 4L6 16" /><path d="M12.5 16.5H18" /></svg>;
+}
+
+export function ChatIcon({ size = 15 }: P) {
+  return <svg {...svg} width={size} height={size}><path d="M20 4H4v12h5v4l5-4h6z" /></svg>;
+}
+
+/** The single header button that replaced the five. A pane split off a frame. */
+export function WorkspaceIcon({ size = 15 }: P) {
+  return <svg {...svg} width={size} height={size}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M9 4v16" /></svg>;
+}
+
+export function CloseIcon({ size = 15 }: P) {
+  return <svg {...svg} width={size} height={size}><path d="M6 6l12 12M18 6L6 18" /></svg>;
+}

--- a/web/src/components/workspace/views.ts
+++ b/web/src/components/workspace/views.ts
@@ -1,0 +1,48 @@
+import type { ComponentType } from "react";
+import { GitIcon, DiffIcon, DockerIcon, TerminalIcon, ChatIcon } from "./icons.tsx";
+
+export type ViewId = "git" | "diff" | "docker" | "term" | "chat";
+
+export type ViewDef = {
+  id: ViewId;
+  label: string;
+  /** Bare letter that jumps here. Kept identical to the old per-panel hotkeys
+   *  so nobody has to relearn them. */
+  key: string;
+  icon: ComponentType<{ size?: number }>;
+  hint: string;
+};
+
+/** Order is the rail's order, and ⌘1..⌘5 index into it. */
+export const VIEWS: ViewDef[] = [
+  { id: "git", label: "git", key: "g", icon: GitIcon, hint: "stage, commit, push/pull the working tree" },
+  { id: "diff", label: "diff", key: "d", icon: DiffIcon, hint: "review & commit every diff the fleet made" },
+  { id: "docker", label: "docker", key: "o", icon: DockerIcon, hint: "containers, logs, stats & actions" },
+  { id: "term", label: "term", key: "t", icon: TerminalIcon, hint: "a real shell in any repo/worktree" },
+  { id: "chat", label: "chat", key: "c", icon: ChatIcon, hint: "drive a Claude session in any repo/worktree" },
+];
+
+export const VIEW_IDS = VIEWS.map((v) => v.id);
+
+/** "g" -> "git". Used by the global keydown handler. */
+export const LETTER_TO_VIEW: Record<string, ViewId> = Object.fromEntries(
+  VIEWS.map((v) => [v.key, v.id]),
+);
+
+export const isViewId = (v: unknown): v is ViewId => VIEW_IDS.includes(v as ViewId);
+
+const LAST_VIEW_KEY = "agentglass.workspace.view";
+
+/** The workspace reopens where you left it — switching views is the common
+ *  action, so the last one is a far better guess than a fixed default. */
+export function loadLastView(): ViewId {
+  try {
+    const v = localStorage.getItem(LAST_VIEW_KEY);
+    if (isViewId(v)) return v;
+  } catch { /* private mode / disabled storage */ }
+  return "git";
+}
+
+export function saveLastView(v: ViewId) {
+  try { localStorage.setItem(LAST_VIEW_KEY, v); } catch { /* non-fatal */ }
+}

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -247,6 +247,46 @@
   border-radius: 6px;
 }
 
+/* Workspace rail.
+ *
+ * The rail is icon-only, so the tooltip is not decoration — it is the only
+ * place the view's name exists. The delay keeps it from strobing as the
+ * pointer crosses the rail on its way somewhere else. */
+.agw-tip:hover {
+  background: color-mix(in srgb, var(--primary) 10%, transparent) !important;
+  color: var(--text2) !important;
+}
+.agw-tip[aria-selected="true"]:hover {
+  background: color-mix(in srgb, var(--primary) 22%, transparent) !important;
+  color: var(--primary-hover) !important;
+}
+.agw-tip::after {
+  content: attr(data-tip);
+  position: absolute;
+  left: calc(100% + 10px);
+  white-space: nowrap;
+  padding: 4px 8px;
+  border-radius: 7px;
+  font-size: 10.5px;
+  color: var(--text2);
+  background: color-mix(in srgb, var(--bg) 96%, var(--bg2));
+  border: 1px solid color-mix(in srgb, var(--primary) 30%, transparent);
+  box-shadow: 0 12px 30px -18px #000;
+  opacity: 0;
+  pointer-events: none;
+  transform: translateX(-3px);
+  transition: opacity 0.12s ease 0.25s, transform 0.12s ease 0.25s;
+  z-index: 5;
+}
+.agw-tip:hover::after,
+.agw-tip:focus-visible::after {
+  opacity: 1;
+  transform: translateX(0);
+}
+@media (prefers-reduced-motion: reduce) {
+  .agw-tip::after { transition: opacity 0.12s ease 0.25s; transform: none; }
+}
+
 /* A chat that replied while you were elsewhere. Deliberately a slow, low-
    contrast breath rather than a hard blink: it sits in a header you look at
    all day, and something that flashes urgently for a message that can wait


### PR DESCRIPTION
## What does this PR do?

Collapses the five separate `95vw` modals (git, diff, docker, term, chat) into a single **workspace** overlay with an icon rail, so switching between them stops being a close-then-reopen round trip through the header.

Two things made the old shape painful:

- Each panel unmounted on close, so a half-written commit message did not survive a look at the diff.
- The single-letter shortcuts were guarded by `anyPanelOpen`, so the moment you were *using* one of them the keyboard went dead.

Now all five views mount when the overlay opens and stay mounted — switching flips visibility. Polling moved from `open` to a new `active` prop, so hidden views keep their state without costing anything on the network. The letters switch views instead of being swallowed, and `⌘1..5` / `⌘[` `⌘]` / `⌘\` keep working with the caret in the chat composer or a shell.

The five header buttons become one, which inherits the chat button's attention pulse (it is the only remaining door to a waiting reply).

Notes for review:

- Views hide with `visibility`, not `display:none` — xterm's fit addon measures its container, and a `display:none` parent measures 0x0, which is how a hidden terminal comes back reflowed to one column.
- `ChangesModal` keeps a thin modal wrapper around the extracted `DiffView`, because `GitPanel` drills into it from a commit row. Drill-downs stay modals; the rail's views are destinations.
- `TerminalPanel` gains a small session roster (`subscribeSessions` / `liveSessionCount`) so the rail can show a live-shell pip while the terminal view is hidden.

## How was it tested?

- `tsc --noEmit` and `vite build` in `web/` — both clean.
- `bun scripts/smoke.ts` — extended in this PR to actually drive the overlay in the headless browser: opens it with `Ctrl-\`, asserts all five views are mounted at once, switches with `d` / `t` / `Ctrl-1`, and asserts Escape closes it. The previous mount-only check could not see any of this. (It caught one real bug while I wrote it, plus one flaw in the assertion itself — the close check needed to poll past the exit animation.)
- Exercised by hand against the real backend in a headless Chrome session: git view on a live repo, docker view listing 15 real containers with streaming logs, and a real PTY in the terminal view (fit correct at 185x41).

🤖 Generated with [Claude Code](https://claude.com/claude-code)