### PR TITLE
fix: measure context against the window that actually ran

### DIFF
--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -35,7 +35,12 @@ const BYPASS_ALLOWED = CHAT_BYPASS_ALLOWED;
 /** How long a turn may produce nothing at all before we assume the CLI is stuck
  *  on something it can't ask us for. Only ever armed before the first byte. */
 const STARTUP_TIMEOUT_MS = Number(process.env.AGENTGLASS_CHAT_STARTUP_TIMEOUT_MS ?? 20_000);
-const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}$/;
+// A model id, with the optional window suffix Claude Code uses to ask for a
+// non-default context size: `claude-opus-4-8[1m]`. The suffix has to be allowed
+// through rather than sanitised away — without it the request silently fell
+// back to the 200k default, so a chat asking for the 1M window got a fifth of
+// it and the UI still measured against whatever the name implied.
+const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}(\[[a-z0-9]{1,8}\])?$/;
 const SESSION_RE = /^[A-Za-z0-9][A-Za-z0-9-]{7,64}$/;
 
 // A pre-approved tool spec, e.g. `Read`, `Edit`, `Bash(git status)`,

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -20,6 +20,7 @@ import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
 import { fmtAgo, fmtUsd, fmtTokens, modelLabelOf, modelColor, providerOf } from "../lib/format.ts";
 import { sessionIsLive } from "../lib/derive.ts";
+import { ctxLimitOf } from "../lib/contextWindow.ts";
 import { worktreeTag, sessionWorktree, sessionCwd } from "../lib/worktree.ts";
 import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
@@ -27,8 +28,12 @@ import {
   DEFAULT_MODEL, DEFAULT_MODE, addAttachments, dropAttachment, renameChat, clearAttention, type Chat,
 } from "../lib/chatStore.ts";
 
+// Still hand-maintained, and still drifts every release — the runtime-sourced
+// list is its own job. The 1M entry is here because it is what this fix buys:
+// the suffix now survives the server, so the window is actually selectable.
 const MODELS = [
   { id: "claude-opus-4-8", label: "Opus 4.8" },
+  { id: "claude-opus-4-8[1m]", label: "Opus 4.8 · 1M" },
   { id: "claude-sonnet-5", label: "Sonnet 5" },
   { id: "claude-haiku-4-5", label: "Haiku 4.5" },
 ];
@@ -90,13 +95,10 @@ function Thinking({ text, streaming }: { text: string; streaming: boolean }) {
   );
 }
 
-/** Context ceiling by model — the same coarse table the radar uses. */
-function ctxLimitOf(model: string): number {
-  const m = model.toLowerCase();
-  if (m.includes("1m")) return 1_000_000;
-  if (m.includes("gemini")) return 1_000_000;
-  if (m.includes("gpt-5")) return 400_000;
-  return 200_000;
+/** What a chat's context is measured against: the model the CLI said it ran,
+ *  falling back to the one we asked for until the first turn reports back. */
+function chatLimit(chat: Chat, observed: number): number {
+  return ctxLimitOf(chat.resolvedModel ?? chat.model, observed);
 }
 
 /**
@@ -111,8 +113,8 @@ function ctxLimitOf(model: string): number {
 function Inspector({ chat }: { chat: Chat }) {
   const u = chat.usage;
   if (!u) return null;
-  const limit = ctxLimitOf(chat.model);
-  const pct = Math.min(100, (u.contextTokens / limit) * 100);
+  const limit = chatLimit(chat, u.contextTokens);
+  const pct = (u.contextTokens / limit) * 100;
   // Amber is "start thinking about wrapping up"; red is "the next turn may compact".
   const tone = pct >= 90 ? "var(--error)" : pct >= 70 ? "var(--warning)" : "var(--primary)";
   const Row = ({ k, v, c }: { k: string; v: string; c?: string }) => (
@@ -214,7 +216,7 @@ function ChatRow({ chat, active, onPick, onClose }: { chat: Chat; active: boolea
               the number that decides which one you go back to first — the one
               at 88% is about to lose its own history to a compaction. */}
           {chat.usage && chat.usage.contextTokens > 0 && (() => {
-            const pct = Math.min(100, (chat.usage.contextTokens / ctxLimitOf(chat.model)) * 100);
+            const pct = (chat.usage.contextTokens / chatLimit(chat, chat.usage.contextTokens)) * 100;
             if (pct < 1) return null;
             return (
               <span className="ml-auto shrink-0 text-[9px] tabular-nums" title={`${fmtTokens(chat.usage.contextTokens)} of context used`}

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -90,7 +90,14 @@ export type QueuedTurn = { id: string; text: string; images: ChatImage[] };
 export type Chat = {
   id: string;
   cwd: string;
+  /** What we ask for: the dropdown's pick, sent with every turn. */
   model: string;
+  /** What the CLI reported running, off the `init` frame. Differs from `model`
+   *  whenever an alias expands or a fallback takes over, and it is the only
+   *  place the window suffix (`[1m]`) is guaranteed to survive — so it, not
+   *  `model`, is what the context meter measures against. Absent until the
+   *  first turn has started. */
+  resolvedModel?: string;
   mode: string;
   title: string;        // derived from the first message; the tab label
   messages: ChatMsg[];
@@ -488,7 +495,16 @@ export async function send(id: string, text: string, isActive: () => boolean, al
       // `claude --resume` forks a new id, so this is usually a different session
       // from the one we adopted. Rebase the live watermark with it: nothing that
       // session did before this moment is ours to draw.
-      update(id, (c) => { c.sessionId = o.session_id as string; c.liveFrom = Date.now(); });
+      //
+      // The same frame reports the model the CLI actually resolved, which is not
+      // always the one we asked for — an alias (`opus`) expands, a fallback may
+      // have taken over, and the id carries the window suffix (`[1m]`) that
+      // decides how much context this chat really has.
+      update(id, (c) => {
+        c.sessionId = o.session_id as string;
+        c.liveFrom = Date.now();
+        if (typeof o.model === "string" && o.model) c.resolvedModel = o.model;
+      });
       return;
     }
     if (t === "assistant") {

--- a/web/src/lib/contextWindow.ts
+++ b/web/src/lib/contextWindow.ts
@@ -1,0 +1,50 @@
+/**
+ * How large a model's context window is.
+ *
+ * This used to be a hardcoded table per call site, which drifts on every model
+ * release and was silently wrong: a chat on `claude-opus-4-8[1m]` was measured
+ * against 200k and rendered "237.0k / 200.0k · 100%" — an impossible reading
+ * presented as a full bar. Three rules now decide the ceiling, in order, so a
+ * model nobody has taught this file about still gets a defensible number.
+ */
+
+/** Windows that actually ship, smallest first. Used to round an observation up
+ *  when the model turns out to be bigger than we assumed. */
+const LADDER = [128_000, 200_000, 400_000, 1_000_000, 2_000_000];
+
+/**
+ * Claude Code's own notation for a non-default window, e.g. `claude-opus-4-8[1m]`
+ * or `claude-sonnet-5[200k]`. Self-describing, so a future 1M variant needs no
+ * change here — which is the whole point of preferring it over a name table.
+ */
+function suffixWindow(m: string): number | null {
+  const hit = /\[(\d+)(k|m)\]/.exec(m);
+  if (!hit) return null;
+  const n = Number(hit[1]);
+  if (!Number.isFinite(n) || n <= 0) return null;
+  return hit[2] === "m" ? n * 1_000_000 : n * 1_000;
+}
+
+/** Ceiling by model family. Only consulted when the id doesn't say outright. */
+function familyWindow(m: string): number {
+  if (m.includes("gemini")) return 1_000_000;
+  if (m.includes("gpt-5")) return 400_000;
+  if (m.includes("gpt") || /\bo[134]\b/.test(m)) return 128_000;
+  return 200_000;  // every current Claude model, absent a suffix
+}
+
+/**
+ * The context ceiling to measure `observed` tokens against.
+ *
+ * `observed` is the current prompt size. If it exceeds what the name implies,
+ * the name is wrong — an alias we failed to resolve, a model newer than this
+ * file, a window we misread — and the measurement is the harder evidence of the
+ * two. Rather than clamp the bar to 100% and show a fraction greater than one,
+ * promote the ceiling to the smallest real window that fits what we just saw.
+ */
+export function ctxLimitOf(model: string | null | undefined, observed = 0): number {
+  const m = (model || "").toLowerCase();
+  const named = suffixWindow(m) ?? familyWindow(m);
+  if (observed <= named) return named;
+  return LADDER.find((w) => w >= observed) ?? observed;
+}

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -1,6 +1,7 @@
 import type { WatchEvent, OpenToolCall } from "../../../shared/types.ts";
 import { agentKey, fmtMs, sessionTitle } from "./format.ts";
 import { sessionWorktree } from "./worktree.ts";
+import { ctxLimitOf } from "./contextWindow.ts";
 
 export type AgentStatus = "working" | "waiting" | "errored" | "idle";
 
@@ -61,16 +62,6 @@ export interface AgentCard {
    *  agents on one project are otherwise indistinguishable in the fleet — which
    *  is the normal case for anyone who works a worktree per ticket. */
   worktree: string | null;
-}
-
-/** Context-window ceiling by model — coarse, for the radar's "how close to
- *  compaction" scale. Unknown models get Claude's 200k. */
-function ctxLimitOf(model: string | null): number {
-  const m = (model || "").toLowerCase();
-  if (m.includes("gemini")) return 1_000_000;
-  if (m.includes("gpt-5")) return 400_000;
-  if (m.includes("gpt") || /^o[134]/.test(m)) return 128_000;
-  return 200_000;
 }
 
 const STALL_MS = 20_000;
@@ -268,7 +259,7 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
     // thing the card can say — better than the stale "PreToolUse · Bash".
     if (a.status === "working" && running) a.lastAction = `running ${a.runningTool} · ${fmtMs(now - a.runningSince)}`;
 
-    a.ctxLimit = ctxLimitOf(a.model_name);
+    a.ctxLimit = ctxLimitOf(a.model_name, a.ctxTokens);
 
     const m = subs.get(a.key);
     if (m) {


### PR DESCRIPTION
## What

The context meter could render `237.0k / 200.0k · 100%` — a full red bar next to a fraction greater than one. Neither number was wrong; the ceiling between them was invented.

## Why it happened

Three separate defects stacked up:

- **`MODEL_RE` rejected the window suffix.** `/^[a-z0-9][a-z0-9.-]{2,48}$/` has no `[` or `]`, so `claude-opus-4-8[1m]` failed validation and silently fell back to `claude-opus-4-8`. A chat asking for the 1M window got a fifth of it, with nothing said.
- **The ceiling was guessed from the model string we sent**, by substring match, in two hardcoded tables (`ChatPanel.tsx` and `derive.ts`). The radar's copy had no `1m` case at all, so it was wrong the same way. And because of the defect above, the one marker `ctxLimitOf` looked for was stripped before the UI ever saw it.
- **The bar clamped to 100%**, which dressed an impossible reading up as a merely-full one.

## The fix

The `init` frame already reports the model the CLI resolved — aliases expanded, fallbacks applied, suffix intact:

```json
{"type":"system","subtype":"init","model":"claude-opus-4-8[1m]", ...}
```

That, not what we requested, is now what the meter measures against. Worth noting `/v1/models` would have been the weaker source: it returns id and display name, no context window.

One shared `ctxLimitOf` resolves the ceiling in three steps:

1. **The suffix, when the id states it** (`[1m]`, `[200k]`). Self-describing, so a future 1M variant needs no change here.
2. **A family table**, when it doesn't.
3. **The measurement.** A prompt larger than the assumed ceiling proves the assumption wrong, so the ceiling is promoted to the smallest real window that fits, rather than clamping the bar. A model this file has never heard of still gets a defensible number.

## Verification

The exact case from the bug report, plus the regex boundaries:

```
claude-opus-4-8[1m]      obs= 237000 -> limit=1000000  pct=24%   (was 100% of 200k)
claude-opus-4-8          obs= 150000 -> limit= 200000  pct=75%
claude-sonnet-5[200k]    obs=  10000 -> limit= 200000  pct=5%
some-model-from-2027     obs= 640000 -> limit=1000000  pct=64%   (promoted)
```

Injection attempts rejected by the widened regex: `claude-opus-4-8[1m];rm -rf /`, `x[1m][2m]`, `../../etc/passwd`, `a[`.

`make typecheck`, `make test` (178 pass), and `make smoke` all green.

## Not in scope

The model list is still hand-maintained and still drifts each release; sourcing it at runtime remains its own job, blocked on the OAuth-token question. The `Opus 4.8 · 1M` dropdown entry is included only because it is what this fix buys — the suffix now survives the server, so the window is actually selectable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)