### PR TITLE
feat(chat): keep chats across crashes and project switches

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,8 +39,20 @@ jobs:
       # instant a browser evaluates it — a use-before-declaration inside a
       # component already shipped a black screen that way. This is the only
       # step that actually runs the thing.
+      # On port 4000 because that is where the bundle looks. Without it the smoke
+      # run has no repos, so it cannot open a chat, so the chat-persistence check
+      # skips itself and the reload path goes uncovered.
       - name: Smoke (production bundle boots)
-        run: bun scripts/smoke.ts
+        run: |
+          cd server
+          AGENTGLASS_PORT=4000 AGENTGLASS_DB=/tmp/smoke.db AGENTGLASS_SCAN_DISABLED=1 bun run src/index.ts &
+          SVPID=$!
+          cd ..
+          for i in $(seq 1 30); do curl -sf http://localhost:4000/health >/dev/null && break; sleep 1; done
+          bun scripts/smoke.ts
+          STATUS=$?
+          kill $SVPID || true
+          exit $STATUS
         env:
           CHROME_PATH: ${{ steps.chrome.outputs.chrome-path }}
       - name: Server boots

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -330,6 +330,94 @@ async function main() {
       if (!closed) failures.push("[workspace] Escape did not close the workspace");
 
       if (!failures.length) console.log("✓ smoke: workspace opens, all 5 views mount, keys switch and close");
+
+      // Chats have to outlive the page, which is a property no unit test can
+      // reach: the store restores at module load, from real storage, in a real
+      // document. So drive it the way the accident does, by opening tabs, typing
+      // into one and then actually reloading, rather than hand-writing storage,
+      // which the running app would rightly overwrite on its way out.
+      //
+      // This is the crash and the project switch both: that switch deliberately
+      // calls location.reload() to rescope every view, and it used to take every
+      // open conversation with it.
+      if (!(await evaluate(`!!document.querySelector('${railSel}')`))) await press("\\", true);
+      await press("c");
+
+      const listSel = '[role="listbox"][aria-label="open chats"]';
+      const rows = () => evaluate(`document.querySelectorAll('${listSel} [role="option"]').length`);
+
+      // A chat needs a repo to sit in, and that comes from the server. With no
+      // server behind the bundle there is nothing to persist and nothing to check.
+      let haveChat = false;
+      for (let i = 0; i < 30 && !haveChat; i++) {
+        haveChat = (await rows()) > 0;
+        if (!haveChat) await Bun.sleep(100);
+      }
+
+      if (!haveChat) {
+        console.log("• smoke: chat persistence not checked, no server behind the bundle so no chat exists to persist");
+      } else {
+        // A second tab, so the check cannot be satisfied by the panel simply
+        // seeding one fresh blank chat the way it does on a cold start.
+        await evaluate(`(() => {
+          [...document.querySelectorAll("button")].find((b) => b.textContent.includes("+ new"))?.click();
+          return new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+        })()`);
+        await Bun.sleep(300);
+        const before = await rows();
+
+        // The draft is the part that exists nowhere else. Claude's own transcript
+        // has the conversation, but never what you had not sent yet.
+        const DRAFT = "a half typed thing";
+        await evaluate(`(() => {
+          const ta = document.querySelector('textarea[aria-label="chat composer"]');
+          Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype, "value").set.call(ta, ${JSON.stringify(DRAFT)});
+          ta.dispatchEvent(new Event("input", { bubbles: true }));
+          return new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+        })()`);
+        // Past the store's debounced write, so the reload is not racing it.
+        await Bun.sleep(900);
+
+        await cdp.send("Page.navigate", { url }, sessionId);
+        // Same wait as the first mount: the reload throws the whole tree away.
+        const reDeadline = Date.now() + MOUNT_TIMEOUT_MS;
+        let remounted = false;
+        while (Date.now() < reDeadline && !remounted) {
+          remounted = (await evaluate(`!!document.querySelector("#root") && document.querySelector("#root").childElementCount > 0`)) === true;
+          if (!remounted) await Bun.sleep(250);
+        }
+
+        if (!remounted) failures.push("[chat-persist] the app never came back after the reload");
+        else {
+          await Bun.sleep(SETTLE_MS);
+          // The workspace remembers whether it was open, so toggling blind would
+          // close it half the time. Ask first.
+          // A freshly reloaded page can take a moment to attach the window
+          // keydown handler, so the first ⌘\\ may land on nothing. Keep asking
+          // until the rail is actually up rather than assuming one press took.
+          for (let i = 0; i < 30; i++) {
+            if (await evaluate(`!!document.querySelector('${railSel}')`)) break;
+            await press("\\", true);
+            await Bun.sleep(200);
+          }
+          for (let i = 0; i < 30; i++) {
+            if (await evaluate(`!!document.querySelector('${listSel}')`)) break;
+            await press("c");
+            await Bun.sleep(200);
+          }
+          await Bun.sleep(500);
+
+          const after = await rows();
+          if (after !== before)
+            failures.push(`[chat-persist] ${before} tab(s) were open, ${after} came back`);
+
+          const draft = await evaluate(`document.querySelector('textarea[aria-label="chat composer"]')?.value ?? ""`);
+          if (draft !== DRAFT)
+            failures.push(`[chat-persist] the draft did not come back, found: ${JSON.stringify(draft)}`);
+
+          if (!failures.length) console.log(`✓ smoke: ${after} chats and the composer draft survive a reload`);
+        }
+      }
     }
 
     console.log(`smoke: served ${DIST} at ${url}`);

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -26,6 +26,7 @@ import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
   DEFAULT_MODEL, DEFAULT_MODE, addAttachments, dropAttachment, renameChat, clearAttention, type Chat,
+  restoredActiveId, setActiveChatId,
 } from "../lib/chatStore.ts";
 
 // Still hand-maintained, and still drifts every release — the runtime-sourced
@@ -396,8 +397,27 @@ function ClipIcon() {
 // `active` of its own — the currently selected chat.
 export function ChatView({ active: visible, focusId, onClose = () => {} }: { active: boolean; focusId?: string | null; onClose?: () => void }) {
   const open = visible;
-  const chats = useSyncExternalStore(subscribe, listChats, listChats);
-  const [activeId, setActiveId] = useState("");
+  const allChats = useSyncExternalStore(subscribe, listChats, listChats);
+  // `null` until we know, which is not the same as "unscoped". See the filter
+  // below, which must not run on a guess.
+  const [workspace, setWorkspace] = useState<string | null>(null);
+  const [scopeKnown, setScopeKnown] = useState(false);
+
+  // Chats outlive the page now, so the panel can be holding tabs from a project
+  // you are no longer in. They stay in the store, and stay saved, but a project
+  // is a scope: being in one repo and looking at another's conversations is the
+  // mixing this app exists to avoid. Switching back brings them straight back.
+  //
+  // An unscoped instance, the desktop app watching every project at once, has
+  // no scope to filter by, so it shows everything.
+  const chats = useMemo(() => {
+    if (!workspace) return allChats;
+    return allChats.filter((c) => c.cwd === workspace || c.cwd.startsWith(workspace.replace(/\/$/, "") + "/"));
+  }, [allChats, workspace]);
+  // Starts on whichever tab was open when the window last went away, so a crash
+  // or a project switch puts you back where you were instead of at the end of
+  // the tab strip.
+  const [activeId, setActiveId] = useState(restoredActiveId);
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [enabled, setEnabled] = useState(true);
   // The server silently downgrades bypassPermissions unless the operator opted
@@ -424,7 +444,10 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     api.skills().then((r) => setSkills(r.skills.map((k) => ({ name: k.name, description: k.when_to_use || k.description })))).catch(() => {});
   }, [open, skills.length]);
 
-  const active = getChat(activeId);
+  // Looked up in the scoped list, not the store, so a restored tab belonging to
+  // another project never renders even for the frame before the effect below
+  // moves selection off it.
+  const active = chats.find((c) => c.id === activeId);
 
   // Only while the draft is a bare `/word` on the first line: past the first
   // space it is prose, and a menu stealing Enter there would be maddening.
@@ -459,6 +482,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
       setDefaultCwd((c) => c || repos[0]?.root || "");
     }).catch(() => {});
     api.chatEnabled().then((r) => { setEnabled(r.enabled); setBypassAllowed(!!r.bypass); }).catch(() => {});
+    // Which project this instance is scoped to, if any. A failure here means we
+    // never learn of a scope, so nothing is hidden, which is the safe direction.
+    api.projects()
+      .then((r) => setWorkspace(r.workspace))
+      .catch(() => {})
+      .finally(() => setScopeKnown(true));
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [open]);
 
@@ -469,13 +498,23 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   const seeded = useRef(false);
   useEffect(() => {
     if (!open) { seeded.current = false; setResumeOpen(false); return; }
+    // Not before the scope is known. Restored chats are already in the store,
+    // but until we know which project we are in we cannot tell whether any of
+    // them belong here, and seeding on that guess drops a blank tab on top of
+    // the ones about to appear.
+    if (!scopeKnown) return;
     if (!seeded.current && !chats.length && defaultCwd) {
       seeded.current = true;
       setActiveId(newChat(defaultCwd).id);
       return;
     }
-    if (!getChat(activeId) && chats.length) setActiveId(chats[chats.length - 1].id);
-  }, [open, chats, defaultCwd, activeId]);
+    // Covers the restored tab having been closed, and the restored tab belonging
+    // to a project other than the one now open.
+    if (!chats.some((c) => c.id === activeId) && chats.length) setActiveId(chats[chats.length - 1].id);
+  }, [open, chats, defaultCwd, activeId, scopeKnown]);
+
+  // The store persists the tab set and needs to record which of them was up.
+  useEffect(() => { setActiveChatId(activeId); }, [activeId]);
 
   // Opened to continue a specific session (from the fleet view): show that tab
   // rather than whichever was last active, or the request looks ignored.
@@ -769,6 +808,11 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                                 ))}
                               </div>
                             )}
+                            {!!m.imagesDropped && (
+                              <div className="mb-1.5 text-[10px] t-dim2 italic">
+                                {m.imagesDropped} image{m.imagesDropped > 1 ? "s" : ""} sent with this turn, not kept when the chat was restored
+                              </div>
+                            )}
                             {m.text ? <Markdown text={m.text} /> : (m.streaming ? <span className="t-dim2">▍</span> : "")}
                             {m.streaming && m.text && <span className="t-dim2">▍</span>}
                           </div>
@@ -915,7 +959,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}>
                         <ClipIcon />
                       </button>
-                      <textarea ref={inputRef} value={active?.draft ?? ""} disabled={!enabled || !active} rows={2}
+                      <textarea ref={inputRef} aria-label="chat composer" value={active?.draft ?? ""} disabled={!enabled || !active} rows={2}
                         onChange={(e) => active && update(active.id, (c) => { c.draft = e.target.value; })}
                         onKeyDown={onKey}
                         onPaste={onPaste}

--- a/web/src/lib/chatPersist.ts
+++ b/web/src/lib/chatPersist.ts
@@ -1,0 +1,140 @@
+// Chats, written down so they outlive the page.
+//
+// The store's Map was the only copy of a conversation, which made it as durable
+// as the tab holding it. Two entirely ordinary things destroyed it: the app
+// crashing, and switching projects, since that path deliberately calls
+// `location.reload()` to rescope every view. Either way you came back to an
+// empty panel with no way to tell what had been open.
+//
+// localStorage rather than the server's sqlite, because what is being saved is
+// tab state: which conversations you had open, what you had half-typed in each,
+// what you had queued. That belongs to the window, the same way the tool
+// allowlist and the terminal's root already do. The conversations themselves are
+// also on disk in claude's own transcript, but the *set of open tabs* is known
+// nowhere but here.
+
+import type { Chat, ChatMsg, ChatTool } from "./chatStore.ts";
+
+const KEY = "agentglass.chats.v1";
+
+/** Per chat. Enough to scroll back through a conversation, not so much that a
+ *  handful of long tool-running sessions exhausts the 5MB quota. */
+const MAX_MESSAGES = 60;
+/** Tool output is the single largest thing in a chat: one `cat` of a big file
+ *  outweighs the entire conversation around it. */
+const MAX_OUTPUT = 2000;
+const MAX_TEXT = 20000;
+/** Well under the ~5MB localStorage quota, leaving room for the settings and
+ *  view state that share it. */
+const MAX_BYTES = 2_000_000;
+
+/** What actually gets written. Everything absent from here is either not
+ *  serializable or not true after a reload. */
+type StoredChat = Pick<Chat,
+  | "id" | "cwd" | "model" | "resolvedModel" | "mode" | "title" | "sessionId" | "draft"
+  | "queued" | "createdAt" | "unread" | "renamed" | "attention" | "usage" | "liveFrom">
+  & { messages: ChatMsg[] };
+
+type Stored = { v: 1; activeId: string; chats: StoredChat[] };
+
+const clip = (s: string, n: number) => (s.length > n ? s.slice(0, n) + "\n[trimmed]" : s);
+
+function packTool(t: ChatTool): ChatTool {
+  return { ...t, output: t.output === null ? null : clip(t.output, MAX_OUTPUT) };
+}
+
+function packMsg(m: ChatMsg): ChatMsg {
+  const { images, ...rest } = m;
+  return {
+    ...rest,
+    text: clip(m.text, MAX_TEXT),
+    thinking: m.thinking === undefined ? undefined : clip(m.thinking, MAX_TEXT),
+    // A streaming message is only streaming while the process writing it is
+    // alive, and by definition it is not.
+    streaming: undefined,
+    tools: m.tools.map(packTool),
+    // Images are base64 in memory. A couple of screenshots is megabytes, which
+    // is the whole quota, so the turn is kept and the pixels are not.
+    imagesDropped: images?.length || undefined,
+  };
+}
+
+function pack(c: Chat): StoredChat {
+  // A turn interrupted by the crash left a trailing empty assistant message
+  // waiting for text that will never arrive. Restoring it would show a reply
+  // that is permanently mid-thought.
+  let messages = c.messages;
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant" && !last.text && !last.tools.length) messages = messages.slice(0, -1);
+
+  return {
+    id: c.id, cwd: c.cwd, model: c.model,
+    // The window the CLI actually resolved, which is what the context meter
+    // measures against. Without it a restored chat measures a 1M session against
+    // the 200k default until its next turn re-reports one.
+    resolvedModel: c.resolvedModel,
+    mode: c.mode, title: c.title,
+    sessionId: c.sessionId, draft: c.draft, queued: c.queued, createdAt: c.createdAt,
+    unread: c.unread, renamed: c.renamed, attention: c.attention, usage: c.usage,
+    liveFrom: c.liveFrom,
+    messages: messages.slice(-MAX_MESSAGES).map(packMsg),
+  };
+}
+
+/** Rebuild a live chat from a stored one. The fields left out are the ones a
+ *  fresh page has no business inheriting: there is no stream in flight, no
+ *  AbortController to cancel, and no pasted attachment, since its object URL
+ *  died with the document that minted it. */
+function unpack(s: StoredChat): Chat {
+  return {
+    ...s,
+    messages: (s.messages ?? []).map((m) => ({ ...m, streaming: undefined })),
+    sending: false,
+    abort: null,
+    attachments: [],
+    queued: s.queued ?? [],
+  };
+}
+
+/**
+ * Write the open chats.
+ *
+ * Trims oldest-first when the payload is too large rather than failing the whole
+ * save: losing the chat you opened a week ago is a far better outcome than
+ * losing the one you are in the middle of.
+ */
+export function saveChats(chats: Chat[], activeId: string) {
+  try {
+    const packed = chats.map(pack).sort((a, b) => a.createdAt - b.createdAt);
+    let body: Stored = { v: 1, activeId, chats: packed };
+    let json = JSON.stringify(body);
+    while (json.length > MAX_BYTES && body.chats.length > 1) {
+      body = { ...body, chats: body.chats.slice(1) };
+      json = JSON.stringify(body);
+    }
+    localStorage.setItem(KEY, json);
+  } catch {
+    // Private mode, a full quota, or a value we could not serialize. Persistence
+    // is a convenience; nothing here is allowed to break the panel.
+  }
+}
+
+/** Read back what was open. Returns an empty list on anything unexpected, so a
+ *  corrupt or older payload costs the tabs, never the app. */
+export function loadChats(): { chats: Chat[]; activeId: string } {
+  const empty = { chats: [], activeId: "" };
+  try {
+    const raw = localStorage.getItem(KEY);
+    if (!raw) return empty;
+    const parsed = JSON.parse(raw) as Stored;
+    if (!parsed || parsed.v !== 1 || !Array.isArray(parsed.chats)) return empty;
+    const chats = parsed.chats.filter((c) => c && typeof c.id === "string" && typeof c.cwd === "string").map(unpack);
+    return { chats, activeId: typeof parsed.activeId === "string" ? parsed.activeId : "" };
+  } catch {
+    return empty;
+  }
+}
+
+export function clearChats() {
+  try { localStorage.removeItem(KEY); } catch { /* nothing to clear */ }
+}

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -6,6 +6,7 @@
 // owner. That's also what lets many exist at once instead of one at a time.
 
 import { api, ChatStreamError } from "./api.ts";
+import { loadChats, saveChats } from "./chatPersist.ts";
 import type { ChatImage, WatchEvent } from "../../../shared/types.ts";
 
 /** A pasted image waiting in the composer. `url` is an object URL for the
@@ -69,6 +70,10 @@ export type ChatMsg = {
    * longer than the answer, and it belongs behind a fold.
    */
   thinking?: string;
+  /** How many images this turn carried, when the turn was restored from storage
+   *  and the pixels themselves were not. Base64 image data is megabytes; the
+   *  quota buys the conversation or the screenshots, not both. */
+  imagesDropped?: number;
 };
 
 /** What a turn cost. Every field is already on the stream's `usage` object;
@@ -155,8 +160,61 @@ export const DEFAULT_MODE = "default";
 // when it can differ.
 let snapshot: Chat[] = [];
 function rebuild() { snapshot = [...chats.values()].sort((a, b) => a.createdAt - b.createdAt); }
-function emit() { rebuild(); subs.forEach((fn) => fn()); }
+function emit() { rebuild(); persistSoon(); subs.forEach((fn) => fn()); }
 export function subscribe(fn: () => void): () => void { subs.add(fn); return () => subs.delete(fn); }
+
+// Writing on every emit would mean serializing every open chat once per streamed
+// token, so the write is coalesced to the end of a quiet moment. The tradeoff is
+// a window in which a crash loses the last fraction of a second of a reply,
+// which `pagehide` closes for every exit the browser tells us about.
+let persistTimer: ReturnType<typeof setTimeout> | null = null;
+let activeChatId = "";
+// Whether this window has changed anything worth writing down.
+//
+// Without it, a window that merely *opened* still saves on the way out, and
+// what it saves is its own empty store. Open the app twice, close the one you
+// never used, and it overwrites the tabs belonging to the one you did. A page
+// that has not touched a chat has nothing to say about chats.
+let touched = false;
+function persistNow() {
+  if (persistTimer) { clearTimeout(persistTimer); persistTimer = null; }
+  if (touched) saveChats(snapshot, activeChatId);
+}
+function persistSoon() {
+  touched = true;
+  if (persistTimer) return;
+  persistTimer = setTimeout(() => { persistTimer = null; saveChats(snapshot, activeChatId); }, 500);
+}
+
+/** Which tab is on screen, remembered so a restored window comes back to the
+ *  conversation you were actually in rather than whichever sorts last. */
+export function setActiveChatId(id: string) {
+  if (id === activeChatId) return;
+  activeChatId = id;
+  persistSoon();
+}
+
+// Restored synchronously, at module load, on purpose. The panel seeds a blank
+// chat when it opens and finds none, so a restore that resolved a tick later
+// would race that and land behind an empty tab nobody asked for.
+const restored = loadChats();
+for (const c of restored.chats) chats.set(c.id, c);
+// Ids embed a counter. Resuming it below the highest restored one would mint a
+// second `c1-...` and quietly overwrite a conversation.
+seq = restored.chats.reduce((n, c) => Math.max(n, Number(/^c(\d+)-/.exec(c.id)?.[1] ?? 0)), 0);
+activeChatId = restored.activeId;
+rebuild();
+
+/** The tab that was selected when the window last went away, if it is still
+ *  around. The panel owns selection, so it asks for this rather than being told. */
+export const restoredActiveId = (): string => (chats.has(restored.activeId) ? restored.activeId : "");
+
+if (typeof window !== "undefined") {
+  // `pagehide` rather than `beforeunload`: it is the one that fires for a tab
+  // discarded on mobile and for bfcache, and it does not block the navigation.
+  window.addEventListener("pagehide", persistNow);
+  document.addEventListener("visibilitychange", () => { if (document.visibilityState === "hidden") persistNow(); });
+}
 
 export const listChats = (): Chat[] => snapshot;
 export const getChat = (id: string): Chat | undefined => chats.get(id);

--- a/web/test/chat-persist.test.ts
+++ b/web/test/chat-persist.test.ts
@@ -1,0 +1,148 @@
+import { test, expect, beforeEach, beforeAll } from "bun:test";
+
+// Chats used to live only in the store's Map, which made them exactly as durable
+// as the page. A crash lost them; so did switching projects, since that path
+// reloads on purpose to rescope every view. These pin the writing-down: that a
+// tab comes back with what you had typed and which session it was on, that a
+// reply cut off mid-sentence does not come back still pretending to stream, and
+// that the things which would blow the storage quota, pasted images and a tool
+// that printed half a megabyte, are shed rather than taking the save with them.
+
+const KEY = "agentglass.chats.v1";
+const cell = new Map<string, string>();
+
+let persist: typeof import("../src/lib/chatPersist.ts");
+beforeAll(async () => {
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  persist = await import("../src/lib/chatPersist.ts");
+});
+beforeEach(() => cell.clear());
+
+const stored = () => cell.get(KEY) ?? "";
+
+/** A chat as the store holds it, including the fields that cannot be written
+ *  down: the live AbortController, the attachments' object URLs. */
+const chat = (over: Record<string, unknown> = {}) => ({
+  id: "c1-abc", cwd: "/repo", model: "claude-opus-4-8", resolvedModel: "claude-opus-4-8[1m]", mode: "default",
+  title: "fix the parser", messages: [], sessionId: "sess-1", sending: false,
+  draft: "half typed", attachments: [], queued: [], createdAt: 1000,
+  abort: null, unread: false, attention: "none", ...over,
+}) as any;
+
+test("a tab comes back with the draft and the session it was on", () => {
+  persist.saveChats([chat()], "c1-abc");
+  const { chats, activeId } = persist.loadChats();
+
+  expect(chats).toHaveLength(1);
+  expect(chats[0].draft).toBe("half typed");
+  expect(chats[0].sessionId).toBe("sess-1");
+  expect(chats[0].title).toBe("fix the parser");
+  // The window the CLI resolved, not just the one the dropdown asked for: the
+  // context meter measures against it.
+  expect(chats[0].resolvedModel).toBe("claude-opus-4-8[1m]");
+  // Which tab was up, so a reload lands where you were rather than at the end
+  // of the strip.
+  expect(activeId).toBe("c1-abc");
+});
+
+test("nothing in flight is restored as if it still were", () => {
+  persist.saveChats([chat({ sending: true })], "c1-abc");
+  const [c] = persist.loadChats().chats;
+
+  // There is no subprocess on the far side of a reload, and no controller that
+  // could cancel one.
+  expect(c.sending).toBe(false);
+  expect(c.abort).toBeNull();
+  // The thumbnails' object URLs died with the document that minted them.
+  expect(c.attachments).toEqual([]);
+});
+
+test("a reply the crash cut off does not come back mid-thought", () => {
+  persist.saveChats([chat({
+    sending: true,
+    messages: [
+      { role: "user", text: "hi", tools: [], ts: 1 },
+      { role: "assistant", text: "", tools: [], ts: 2, streaming: true },
+    ],
+  })], "c1-abc");
+
+  // An empty assistant turn is a placeholder waiting on text that will never
+  // arrive, so it is dropped rather than restored as a permanent cursor.
+  expect(persist.loadChats().chats[0].messages).toHaveLength(1);
+});
+
+test("a reply that got partway through is kept, minus the cursor", () => {
+  persist.saveChats([chat({
+    messages: [
+      { role: "user", text: "hi", tools: [], ts: 1 },
+      { role: "assistant", text: "partial ans", tools: [], ts: 2, streaming: true },
+    ],
+  })], "c1-abc");
+  const msgs = persist.loadChats().chats[0].messages;
+
+  expect(msgs).toHaveLength(2);
+  expect(msgs[1].text).toBe("partial ans");
+  expect(msgs[1].streaming).toBeFalsy();
+});
+
+test("pasted images are shed but the turn says they were there", () => {
+  persist.saveChats([chat({
+    messages: [{
+      role: "user", text: "look at this", tools: [], ts: 1,
+      images: [{ mediaType: "image/png", data: "A".repeat(5_000_000) }],
+    }],
+  })], "c1-abc");
+  const [m] = persist.loadChats().chats[0].messages;
+
+  // Base64 image data is megabytes, which is the entire quota. The conversation
+  // is worth more than the pixels, and the turn admits what it lost.
+  expect(m.images).toBeUndefined();
+  expect(m.imagesDropped).toBe(1);
+  expect(stored().length).toBeLessThan(10_000);
+});
+
+test("a tool that printed half a megabyte is clipped, not fatal", () => {
+  persist.saveChats([chat({
+    messages: [{
+      role: "assistant", text: "ran it", ts: 1,
+      tools: [{ id: "t1", name: "Bash", target: "cat big", output: "X".repeat(500_000), error: false, ts: 1 }],
+    }],
+  })], "c1-abc");
+  const out = persist.loadChats().chats[0].messages[0].tools[0].output!;
+
+  expect(out.length).toBeLessThan(3_000);
+  expect(out.endsWith("[trimmed]")).toBe(true);
+});
+
+test("too much to store drops the oldest, never the one you are in", () => {
+  const many = Array.from({ length: 40 }, (_, i) => chat({
+    id: `c${i + 1}-x`, createdAt: 1000 + i, title: `chat ${i + 1}`,
+    messages: Array.from({ length: 60 }, (_, j) => ({ role: "assistant", text: "Y".repeat(19_000), tools: [], ts: j })),
+  }));
+  persist.saveChats(many, "c40-x");
+  const { chats } = persist.loadChats();
+
+  expect(chats.length).toBeGreaterThan(0);
+  expect(chats.length).toBeLessThan(40);
+  // Losing the chat you opened last week beats losing the one on screen.
+  expect(chats[chats.length - 1].title).toBe("chat 40");
+  expect(stored().length).toBeLessThanOrEqual(2_100_000);
+});
+
+test("a payload we cannot read costs the tabs, not the panel", () => {
+  cell.set(KEY, "{not json");
+  expect(persist.loadChats()).toEqual({ chats: [], activeId: "" });
+});
+
+test("a version we do not know is ignored rather than half-read", () => {
+  cell.set(KEY, JSON.stringify({ v: 99, activeId: "c1-abc", chats: [{ id: "c1-abc", cwd: "/repo" }] }));
+  expect(persist.loadChats().chats).toEqual([]);
+});
+
+test("a first run with nothing stored is simply empty", () => {
+  expect(persist.loadChats().chats).toEqual([]);
+});


### PR DESCRIPTION
## What does this PR do?

Chats lived only in the store's module-level `Map`, which made them exactly as durable as the page holding them. Two ordinary things destroyed every open conversation: the app crashing, and switching projects, since `ProjectPicker` calls `location.reload()` on purpose to rescope every view. Either way you came back to an empty panel with no record that anything had been open.

The tab set is now written to `localStorage` and restored **synchronously at module load**, ahead of the effect that seeds a blank chat when it finds none. What comes back is the part that exists nowhere else on disk: which conversations were open, which one you were in, the per-tab draft you had half-typed, the queued turns, the running usage. `sessionId` and `resolvedModel` come back too, so the next message still resumes the real claude session and the context meter still measures against the right window.

Tabs are scoped to the open project, so switching away hides that project's chats and switching back restores them. An unscoped instance (the desktop app watching every project at once) shows everything.

Bounded on purpose, since localStorage is ~5MB:
- pasted images are shed (base64 is megabytes, which is the whole quota) with a note left on the turn
- tool output is clipped, message history capped per chat
- an over-large payload drops the oldest chats rather than failing the save
- a window that never touched a chat does not write on exit, so opening the app twice and closing the unused one cannot wipe the other's tabs

`localStorage` rather than the server's sqlite because what is saved is tab state, which belongs to the window the same way the tool allowlist and the terminal's root already do. The conversations themselves remain in claude's own transcript.

## How was it tested?

- `bunx tsc --noEmit` in `web/`, `bunx vite build`
- `bun test` — 81 web tests pass, including 10 new ones in `web/test/chat-persist.test.ts` covering the pack/restore rules: drafts and session ids survive, nothing in flight restores as if it still were, a reply the crash cut off does not come back mid-thought, images are shed but counted, huge tool output is clipped, an over-quota payload drops oldest-first, and a corrupt or unknown-version payload costs the tabs rather than the panel
- `bun scripts/smoke.ts` — the smoke run now opens two chats, types a draft, **reloads the real browser** and checks both tabs and the draft came back. This caught a genuine bug the unit tests could not: the `pagehide` save was unconditional, so a window that never touched a chat wrote its own empty store over the real one
- CI boots a server on port 4000 for the smoke step so that check has repos to work with instead of skipping itself
- Exercised by hand in the chat panel: open several chats, type drafts, reload, switch projects and back

Perf checked rather than assumed: worst realistic payload (8 chats x 60 messages with chunky tool output, 1.75MB) serializes in ~2.1ms, throttled to at most twice a second.

🤖 Generated with [Claude Code](https://claude.com/claude-code)