### PR TITLE
fix: don't let a page load rewrite the machine's theme

### DIFF
--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
-import { THEMES, applyTheme } from "../lib/themes.ts";
+import { THEMES, pickTheme } from "../lib/themes.ts";
 import { IS_DESKTOP } from "../lib/desktop.ts";
 import { api } from "../lib/api.ts";
 
@@ -75,7 +75,7 @@ export function CommandPalette({
     for (const t of types) list.push({ id: "type:" + t, group: "Filter by event", label: t, run: () => onFilter({ type: t }) });
     for (const w of [["15m", 900000], ["1h", 3600000], ["6h", 21600000], ["24h", 86400000], ["7d", 604800000]] as const)
       list.push({ id: "win:" + w[0], group: "Time window", label: w[0], run: () => onWindow(w[1] as number) });
-    for (const t of THEMES) list.push({ id: "theme:" + t.id, group: "Theme", label: t.name, run: () => { applyTheme(t.id); onTheme(t.id); } });
+    for (const t of THEMES) list.push({ id: "theme:" + t.id, group: "Theme", label: t.name, run: () => { pickTheme(t.id); onTheme(t.id); } });
     list.push({ id: "csv", group: "Export", label: "Download CSV", run: () => window.open(api.exportUrl("csv")) });
     list.push({ id: "json", group: "Export", label: "Download JSON", run: () => window.open(api.exportUrl("json")) });
     return list;

--- a/web/src/components/ThemeSwitcher.tsx
+++ b/web/src/components/ThemeSwitcher.tsx
@@ -1,6 +1,6 @@
 import { useRef, useState, useLayoutEffect } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import { THEMES, applyTheme, type Theme } from "../lib/themes.ts";
+import { THEMES, pickTheme, type Theme } from "../lib/themes.ts";
 import { Portal } from "./Portal.tsx";
 
 // Group themes by the luminance of their background — no per-theme flag needed.
@@ -75,7 +75,7 @@ export function ThemeSwitcher({ current, onChange }: { current: string; onChange
                         <button
                           key={t.id}
                           onClick={() => {
-                            applyTheme(t.id);
+                            pickTheme(t.id);
                             onChange(t.id);
                             setOpen(false);
                           }}

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -39,20 +39,39 @@ export const THEMES: Theme[] = [
 
 export const DEFAULT_THEME = "midnight-purple";
 
-export function applyTheme(id: string) {
-  const t = THEMES.find((x) => x.id === id) || THEMES[0];
+/**
+ * Paint the app in a theme.
+ *
+ * `sync` carries the palette out to tmux and nvim, and defaults to off because
+ * the files it writes are machine-global while the choice that drives it is
+ * per-browser. Only a deliberate pick may broadcast — see `pickTheme`.
+ */
+export function applyTheme(id: string, { sync = false } = {}) {
+  const known = THEMES.find((x) => x.id === id);
+  const t = known || THEMES[0];
   const root = document.documentElement;
   for (const [k, v] of Object.entries(t.vars)) root.style.setProperty(k, v);
   root.setAttribute("data-theme", t.id);
-  try { localStorage.setItem("agentglass-theme", t.id); } catch {}
-  /*
-   * Carry the palette out to tmux and nvim.
-   *
-   * Fire-and-forget on purpose: this reaches across to other processes, and
-   * none of them are allowed to make changing the app's own theme feel slow or
-   * fail. The server writes two files and pushes to any editor it can reach —
-   * see server/src/themesync.ts.
-   */
+  // Only ever persist a theme that exists. An id we don't recognise still gets
+  // painted in the fallback, but writing that fallback back to storage would
+  // turn one bad read into the permanent loss of a real choice.
+  if (known) { try { localStorage.setItem("agentglass-theme", t.id); } catch {} }
+  if (sync) syncTheme(t);
+}
+
+/**
+ * The user picked a theme, so tell the rest of the machine.
+ *
+ * Fire-and-forget on purpose: this reaches across to other processes, and none
+ * of them are allowed to make changing the app's own theme feel slow or fail.
+ * The server writes two files and pushes to any editor it can reach — see
+ * server/src/themesync.ts.
+ */
+export function pickTheme(id: string) {
+  applyTheme(id, { sync: true });
+}
+
+function syncTheme(t: Theme) {
   void fetch(`${SERVER}/theme/sync`, {
     method: "POST",
     headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Symptom

The tmux/nvim panes inside the cockpit change to Midnight Purple on their own, minutes after you set a green theme, with no user action. The app chrome stays green — only the panes flip, which makes it look like a terminal bug rather than a theme one.

## Cause

The theme choice is stored **per-browser** in `localStorage`. The files it syncs to are **machine-global**:

- `~/.config/agentglass/theme.tmux.conf`
- `~/.config/agentglass/theme.lua`

`applyTheme()` posted to `/theme/sync` unconditionally, and `main.tsx:8` calls it on every page load. So any client opening the bundle without a saved theme read `DEFAULT_THEME` (`midnight-purple`) and broadcast it to the whole machine.

The part that makes it fire "randomly": `SERVER` falls back to `http://${location.hostname}:4000` (`api.ts:8`), so a bundle served from *any* port on localhost still posts to the real server. Clients nobody is looking at count — the `make smoke` run, a CDP profiling session driving the shipped bundle. Each headless page load repaints the user's tmux.

That's why it correlates with test runs rather than with anything the user did.

## Fix

Syncing is opt-in per call, off by default:

- `applyTheme(id, { sync })` paints only.
- `pickTheme(id)` paints **and** broadcasts, wired to the two places a person actually chooses a theme (`ThemeSwitcher`, `CommandPalette`).
- A boot restoring its own saved theme paints and says nothing — it has nothing to tell the machine. This makes every headless load harmless by construction, rather than by adding a test-only guard.

Also fixed alongside: an unrecognised id was painted as `THEMES[0]` *and* written back to storage, so a single bad read permanently replaced a real choice. It still paints the fallback; it no longer saves it.

## Verification

Watched the synced file across two headless boots against a live server on `:4000`:

| build | mtime before | mtime after | result |
|---|---|---|---|
| this branch | `20:59:30` | `20:59:30` | untouched |
| previous | `20:59:30` | `21:00:51` | rewritten |

(Content hash identical in both, since the test machine's theme was already purple — the mtime is what exposes the write.)

`make typecheck` and `make test` (178 pass) green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)