### PR TITLE
fix(git): see the squash merges the branch panel kept denying

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -680,12 +680,71 @@ export function defaultBranch(root: string): string | null {
 const MERGED_TTL_MS = 30_000;
 const mergedCache = new Map<string, { at: number; set: Set<string> }>();
 
+/**
+ * Was this branch squash-merged into `ref`?
+ *
+ * `--merged` only knows ancestry, and a squash merge destroys it: the PR lands
+ * as one new commit with a new hash, so the branch tip never becomes an
+ * ancestor of the trunk. Every branch merged through the GitHub button is
+ * therefore "unmerged" by that test — which is most of them here, and which is
+ * why the panel dead-ended on "not fully merged" for work already in main.
+ *
+ * The test that survives the rewrite is by content, not ancestry: replay the
+ * branch's whole diff as a single commit on top of the merge base, then ask
+ * `git cherry` whether the trunk already holds an equivalent patch. That is
+ * exactly the shape a squash merge produces, so the patch-ids match; a leading
+ * `-` means "already upstream".
+ *
+ * `commit-tree` leaves one dangling commit behind. It's unreferenced and the
+ * next gc collects it — the standard price for this probe.
+ *
+ * False, never a throw, when the two share no history: this repo has unrelated
+ * histories in it, and "no merge base" means there is nothing to compare, not
+ * that the work is safe to delete.
+ */
+function isSquashMerged(root: string, ref: string, name: string): boolean {
+  const base = git(root, ["merge-base", ref, name]);
+  const mergeBase = base.stdout.trim();
+  if (base.code !== 0 || !mergeBase) return false;
+  const tree = git(root, ["rev-parse", `${name}^{tree}`]).stdout.trim();
+  if (!tree) return false;
+  // A branch holding nothing the base didn't already have has no patch to find,
+  // and would otherwise look "merged" on the strength of an empty diff.
+  if (tree === git(root, ["rev-parse", `${mergeBase}^{tree}`]).stdout.trim()) return false;
+  const dangling = git(root, ["commit-tree", tree, "-p", mergeBase, "-m", "_"]);
+  if (dangling.code !== 0) return false;
+  const cherry = git(root, ["cherry", ref, dangling.stdout.trim()]);
+  return cherry.code === 0 && cherry.stdout.trim().startsWith("-");
+}
+
+/**
+ * Four spawns per branch, so this can't run over every branch of a big repo on
+ * a 2.5s poll. The branches anyone is actually trying to delete are the recent
+ * ones, so probe those and leave the tail to the ancestry answer. A branch past
+ * the cap reads as unmerged, which is the safe direction to be wrong in: it
+ * keeps its confirmation prompt instead of losing it.
+ */
+const SQUASH_PROBE_MAX = 20;
+
 function mergedInto(root: string, ref: string): Set<string> {
   const key = `${root} ${ref}`;
   const hit = mergedCache.get(key);
   if (hit && Date.now() - hit.at < MERGED_TTL_MS) return hit.set;
   const r = git(root, ["for-each-ref", "--merged", ref, "refs/heads", "--format=%(refname:short)"]);
   const set = new Set(r.stdout.split("\n").filter(Boolean));
+  // Recover the squash merges ancestry can't see. Folded into the same set, and
+  // so into the same cache entry and the same invalidation, because callers ask
+  // one question — "is this work already in the trunk" — and both tests answer
+  // it. Newest first: that's the order for-each-ref gives with this sort, and
+  // the order that spends the probe budget where deletes actually happen.
+  const all = git(root, ["for-each-ref", "--sort=-committerdate", "refs/heads", "--format=%(refname:short)"])
+    .stdout.split("\n").filter(Boolean);
+  let probes = 0;
+  for (const name of all) {
+    if (set.has(name)) continue;
+    if (probes++ >= SQUASH_PROBE_MAX) break;
+    if (isSquashMerged(root, ref, name)) set.add(name);
+  }
   mergedCache.set(key, { at: Date.now(), set });
   return set;
 }

--- a/server/test/branch-merged.test.ts
+++ b/server/test/branch-merged.test.ts
@@ -1,0 +1,94 @@
+// "Is this branch already in the trunk?" has to survive a squash merge.
+//
+// The branches panel gates its delete on that answer: get it wrong and a branch
+// whose PR landed weeks ago still refuses to delete, with a "not fully merged"
+// error the user can only clear from a terminal. Ancestry alone always gets it
+// wrong here, because a squash merge replays the work as a brand new commit and
+// the branch tip never becomes an ancestor of anything.
+//
+// So this pins the two merge shapes separately, plus the two cases where the
+// answer must stay "no" — an open branch, and one sharing no history at all.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = realpathSync(mkdtempSync(join(tmpdir(), "agx-merged-")));
+const REPO = join(dir, "repo");
+
+process.env.XDG_CONFIG_HOME = dir; // never inherit the developer's own scope
+process.env.AGENTGLASS_DB = join(dir, "m.db");
+
+function git(...args: string[]) {
+  const p = Bun.spawnSync(["git", ...args], { cwd: REPO, stdout: "pipe", stderr: "pipe" });
+  if (p.exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${p.stderr.toString()}`);
+  return p.stdout.toString().trim();
+}
+
+function commit(file: string, body: string, message: string) {
+  writeFileSync(join(REPO, file), body);
+  git("add", "-A");
+  git("commit", "-q", "-m", message);
+}
+
+let gw: typeof import("../src/gitwork.ts");
+
+beforeAll(async () => {
+  mkdirSync(REPO, { recursive: true });
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@example.com");
+  git("config", "user.name", "t");
+  commit("README", "x\n", "root");
+
+  // Squash-merged: several commits collapsed into one new commit on main. This
+  // is the GitHub merge button, and the case the old ancestry test failed.
+  git("checkout", "-q", "-b", "squashed");
+  commit("feature.txt", "one\n", "wip one");
+  commit("feature.txt", "one\ntwo\n", "wip two");
+  git("checkout", "-q", "main");
+  git("merge", "-q", "--squash", "squashed");
+  git("commit", "-q", "-m", "feat: the whole branch, squashed (#1)");
+
+  // Merge-committed: ancestry still holds, and must keep being recognised.
+  git("checkout", "-q", "-b", "merged", "main");
+  commit("other.txt", "kept\n", "real merge work");
+  git("checkout", "-q", "main");
+  git("merge", "-q", "--no-ff", "-m", "merge branch 'merged'", "merged");
+
+  // Open: real work that is genuinely not in main.
+  git("checkout", "-q", "-b", "open", "main");
+  commit("open.txt", "unfinished\n", "still going");
+
+  // No shared history — this repo really does contain unrelated histories, and
+  // "no merge base" must read as "don't know", never as "safe to delete".
+  git("checkout", "-q", "--orphan", "stranger");
+  git("rm", "-rq", "--cached", ".");
+  commit("stranger.txt", "alien\n", "unrelated root");
+
+  git("checkout", "-q", "main");
+  gw = await import("../src/gitwork.ts");
+});
+
+describe("mergedIntoTrunk", () => {
+  const of = (name: string) => gw.branches(REPO).branches.find((b) => b.name === name);
+
+  test("names the trunk it compared against", () => {
+    expect(gw.branches(REPO).trunk).toBe("main");
+  });
+
+  test("a squash-merged branch counts as merged", () => {
+    expect(of("squashed")?.mergedIntoTrunk).toBe(true);
+  });
+
+  test("a normally merged branch still counts as merged", () => {
+    expect(of("merged")?.mergedIntoTrunk).toBe(true);
+  });
+
+  test("a branch with unlanded work does not", () => {
+    expect(of("open")?.mergedIntoTrunk).toBe(false);
+  });
+
+  test("an unrelated history does not", () => {
+    expect(of("stranger")?.mergedIntoTrunk).toBe(false);
+  });
+});


### PR DESCRIPTION
## What

Deleting a branch whose PR had already landed failed with `error: the branch 'worktree-chat-persistence' is not fully merged`, and the panel's own repair for that case never offered itself.

## Why

`GitPanel` gates both repairs on `mergedIntoTrunk`:

- the forced-retry prompt on a single delete (`GitPanel.tsx:582`)
- the bulk "delete gone" button, via `goneMerged` (`GitPanel.tsx:603`)

That flag came from `for-each-ref --merged`, which only knows **ancestry** — the one thing a squash merge destroys. The PR lands as a brand new commit, so the branch tip never becomes an ancestor of the trunk and the branch reads as unmerged forever. That is nearly every branch in this repo, so the "2 gone" branches were undeletable from the UI and the bulk button was a permanent no-op.

Reproduced against this repo before the fix — `for-each-ref --merged origin/main refs/heads` returned only `main`, despite both gone branches having landed as #101 and #96.

## How

When ancestry says no, ask by content instead: replay the branch's whole diff as a single commit on top of the merge base, then let `git cherry` check whether the trunk already holds an equivalent patch. That is exactly the shape a squash merge produces, so the patch-ids match.

Results fold into the existing merged set, so they inherit its cache and its invalidation with no new bookkeeping.

**Bounded deliberately.** Four spawns per branch is too much for a 2.5s poll on a big repo, so only the 20 most recent unmerged branches get probed. Past the cap a branch reads as unmerged — the safe direction to be wrong in, since it keeps its confirmation prompt rather than losing it. Unrelated histories (this repo has them) return false for the same reason.

## Verification

- New `server/test/branch-merged.test.ts` pins all four shapes: squash-merged, merge-committed, genuinely open, and no shared history.
- Confirmed non-vacuous: reverting only `gitwork.ts` fails exactly the squash case, 4 pass 1 fail.
- Full server suite green: 183 pass, 0 fail.
- Against the real repo, both `[gone]` branches now report merged, and no branch flipped to merged that shouldn't have.

🤖 Generated with [Claude Code](https://claude.com/claude-code)