### PR TITLE
fix(chat): stop crying refusal, and take dropped files

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -18,7 +18,8 @@
         "resizable": true,
         "center": true,
         "decorations": false,
-        "theme": "Dark"
+        "theme": "Dark",
+        "dragDropEnabled": false
       }
     ],
     "security": {

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -625,6 +625,44 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     setHint(await addAttachments(active.id, files));
   };
 
+  // A drag crossing a child element fires `dragleave` on the parent, so the
+  // highlight is counted in and out rather than toggled — otherwise it flickers
+  // off the moment the cursor passes over the textarea it is inviting you to
+  // drop on.
+  const [dragOver, setDragOver] = useState(false);
+  const dragDepth = useRef(0);
+  const onDragOver = (e: React.DragEvent) => {
+    if (!enabled || !active) return;
+    if (!Array.from(e.dataTransfer.items).some((i) => i.kind === "file")) return;
+    // Without this the browser answers the drop itself by navigating to the
+    // file, replacing the whole app with the image.
+    e.preventDefault();
+    e.dataTransfer.dropEffect = "copy";
+    dragDepth.current++;
+    setDragOver(true);
+  };
+  const onDragLeave = () => {
+    dragDepth.current = Math.max(0, dragDepth.current - 1);
+    if (!dragDepth.current) setDragOver(false);
+  };
+  const onDrop = async (e: React.DragEvent) => {
+    if (!active) return;
+    e.preventDefault();
+    dragDepth.current = 0;
+    setDragOver(false);
+    // Files, not just images: `addAttachments` quotes a text file into the
+    // draft, which is the same thing the picker and the paste path already do.
+    const files = Array.from(e.dataTransfer.files);
+    if (!files.length) {
+      // A drag from another window can carry an image as bytes with no File
+      // behind it; `imagesFrom` reads the item list the paste path relies on.
+      const items = imagesFrom(e.dataTransfer);
+      if (items.length) setHint(await addAttachments(active.id, items));
+      return;
+    }
+    setHint(await addAttachments(active.id, files));
+  };
+
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // The skill menu owns the arrows, Tab and Enter while it is showing, or
     // Enter would send `/rev` as a message instead of completing it.
@@ -839,7 +877,16 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                   )}
                   </div>
 
-                  <div className="shrink-0 border-t p-3" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                  <div className="shrink-0 border-t p-3 relative" onDragOver={onDragOver} onDragLeave={onDragLeave} onDrop={onDrop}
+                    style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                    {dragOver && (
+                      // Drawn over the composer rather than around it: a border
+                      // swap reflows the textarea under the cursor mid-drag.
+                      <div className="absolute inset-0 z-10 grid place-items-center rounded-lg pointer-events-none text-[11px] font-semibold"
+                        style={{ background: "color-mix(in srgb, var(--primary) 14%, transparent)", border: "1px dashed color-mix(in srgb, var(--primary) 60%, transparent)", color: "var(--text)" }}>
+                        drop to attach
+                      </div>
+                    )}
                     {!!active?.attachments.length && (
                       <div className="flex flex-wrap gap-2 mb-2">
                         {active.attachments.map((a) => (

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -649,7 +649,16 @@ export async function send(id: string, text: string, isActive: () => boolean, al
             break;
           }
         });
-        if (!/permission|requires approval|not allowed|denied/i.test(text)) continue;
+        // Bypass sends no allowlist and `--dangerously-skip-permissions`
+        // refuses nothing, so a refusal here can only be a misread — and it
+        // was one: the banner offered an "allow" button writing to a list
+        // that mode never sends.
+        if (chat.mode === "bypassPermissions") continue;
+        // Matched on what a refusal actually says rather than on words that
+        // turn up in ordinary output. A bare `permission`/`denied` raised the
+        // banner over any `Permission denied` a `find` or `grep` walked past,
+        // announcing a block on a turn where nothing had been blocked.
+        if (!/requires approval|requested permissions|permission to use|haven't granted/i.test(text)) continue;
         const tool = toolNames.get(useId);
         // Raised even while this chat is on screen: the composer's banner is
         // only visible if you are actually watching, and switching away must

--- a/web/test/chat-refusal.test.ts
+++ b/web/test/chat-refusal.test.ts
@@ -1,0 +1,67 @@
+import { test, expect, beforeAll } from "bun:test";
+
+// A tool the allowlist refused is invisible: `claude -p` has no terminal to
+// prompt from, so the turn carries on without it and the only symptom is the
+// model saying it is blocked. The banner exists to name it — which makes a
+// false positive expensive, since it teaches you to distrust the one signal
+// that means anything. These pin what does and does not raise it.
+
+let store: typeof import("../src/lib/chatStore.ts");
+let api: typeof import("../src/lib/api.ts")["api"];
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  api = (await import("../src/lib/api.ts")).api;
+  store = await import("../src/lib/chatStore.ts");
+});
+
+const active = () => true;
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/** Replay one Bash call and the result it came back with. */
+function replay(result: string) {
+  api.chatStream = (async (_p: unknown, onEvent: (o: Record<string, unknown>) => void) => {
+    onEvent({
+      type: "assistant",
+      message: { content: [{ type: "tool_use", id: "t1", name: "Bash", input: { command: "find /" } }] },
+    });
+    onEvent({
+      type: "user",
+      message: { content: [{ type: "tool_result", tool_use_id: "t1", is_error: true, content: result }] },
+    });
+  }) as typeof api.chatStream;
+}
+
+test("a real refusal names the tool so the banner can offer to allow it", async () => {
+  replay("Claude requested permissions to use Bash, but you haven't granted it yet.");
+  const c = store.newChat("/tmp/repo");
+  await store.send(c.id, "go", active);
+  await tick();
+  expect(store.getChat(c.id)!.blockedTool).toBe("Bash");
+  expect(store.getChat(c.id)!.attention).toBe("blocked");
+  store.closeChat(c.id);
+});
+
+test("`Permission denied` in ordinary output is not a refusal", async () => {
+  // The tool ran. It walked past a directory it could not read and said so —
+  // which used to be enough to announce a block on a turn nothing blocked.
+  replay("find: '/proc/1/task': Permission denied\nfind: '/root': Permission denied");
+  const c = store.newChat("/tmp/repo");
+  await store.send(c.id, "go", active);
+  await tick();
+  expect(store.getChat(c.id)!.blockedTool).toBeUndefined();
+  store.closeChat(c.id);
+});
+
+test("bypass mode never raises the banner", async () => {
+  // It sends no allowlist and `--dangerously-skip-permissions` refuses
+  // nothing, so the banner's offer to add the tool to a list is meaningless
+  // there — it points at a control the mode doesn't use.
+  replay("Claude requested permissions to use Bash, but you haven't granted it yet.");
+  const c = store.newChat("/tmp/repo");
+  store.update(c.id, (x) => { x.mode = "bypassPermissions"; });
+  await store.send(c.id, "go", active);
+  await tick();
+  expect(store.getChat(c.id)!.blockedTool).toBeUndefined();
+  store.closeChat(c.id);
+});


### PR DESCRIPTION
## What

Two composer bugs, both reported from a live bypass-mode chat that showed **"Bash was refused — it isn't in this chat's allowed tools"** while running `--dangerously-skip-permissions`.

### 1. The refusal banner fired on turns nothing was refused on

`chatStore.ts` flagged a refusal by regexing tool output for `permission|requires approval|not allowed|denied`. Ordinary stderr matches that: `find: '/proc/1/task': Permission denied` raised the banner over a read-only codebase scan where every tool ran fine.

It also fired in `bypassPermissions`, where it cannot be true — the server deliberately sends an empty allowlist there (`chat.ts:225`) and the UI hides the allowlist input (`ChatPanel.tsx:716`). The banner's "allow Bash" button appended to a list that mode never sends, so the only remedy offered was a no-op.

Now: silent in bypass, and matched against what a refusal actually says rather than words that turn up in normal output.

### 2. Dragging a file onto the chat did nothing

Paste and the paperclip picker both worked; drop had no handler at all. Adding one is only half of it — `dragDropEnabled` defaults to true in Tauri, so the native handler consumed the drop before the webview saw it. The window now opts out.

Drop reuses `addAttachments`, so it behaves identically to paste and pick: images attach, text files quote into the draft, same size and count limits.

## Testing

- New `web/test/chat-refusal.test.ts` — 3 tests: a real refusal still raises the banner, `Permission denied` in output does not, bypass never does. The middle one fails on `main`.
- Full suite: 267 pass, 0 fail.
- `tsc --noEmit` and `vite build` clean.
- Drop was verified by reading the event path; it needs a desktop rebuild to exercise, since the Tauri config half only applies to the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)