### PR TITLE
perf(dashboard): actually pause ambient loops when nobody's looking

### DIFF
--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -149,14 +149,38 @@ export function useLive(): LiveData {
     };
   }, [scheduleFlush]);
 
-  // Pause all ambient CSS animations while the tab is hidden — the stylesheet
-  // reads :root[data-idle="1"] and freezes the sweep/pulse/float/shimmer, so a
-  // backgrounded dashboard costs ~nothing on top of the browser's throttling.
+  // Pause all ambient CSS animations while nobody is looking at the window —
+  // the stylesheet reads :root[data-idle="1"] and freezes the
+  // sweep/pulse/float/shimmer.
+  //
+  // `document.hidden` alone was the whole test, and in the desktop app it is
+  // never true: a Tauri window has no tab to background, so the flag sat at "0"
+  // for the entire life of the process and none of these rules ever applied.
+  // The saving was real but only a browser ever collected it. That matters more
+  // here than in a tab, because WebKitGTK composites in software — every frame
+  // of every ambient loop is paid for on the CPU, and the dashboard idles hot
+  // with the radar sweep and a ping-ring per live session running forever.
+  //
+  // Focus is the signal that survives both environments: the dashboard's normal
+  // place is a second monitor or behind the terminal the agent is running in,
+  // so "not focused" is most of its life. Deliberately NOT an inactivity timer
+  // on top — this is a monitoring surface people leave on-screen and watch, and
+  // freezing the sweep under a still-visible, still-focused window would read as
+  // a hung app rather than a saving.
   useEffect(() => {
-    const sync = () => { document.documentElement.dataset.idle = document.hidden ? "1" : "0"; };
+    const sync = () => {
+      const looking = !document.hidden && document.hasFocus();
+      document.documentElement.dataset.idle = looking ? "0" : "1";
+    };
     sync();
     document.addEventListener("visibilitychange", sync);
-    return () => document.removeEventListener("visibilitychange", sync);
+    window.addEventListener("focus", sync);
+    window.addEventListener("blur", sync);
+    return () => {
+      document.removeEventListener("visibilitychange", sync);
+      window.removeEventListener("focus", sync);
+      window.removeEventListener("blur", sync);
+    };
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## What

The dashboard's ambient animations — the radar sweep, a `ping-ring` per live session, `float`, `shimmer` — kept running at full frame rate even when the window was in the background, burning CPU for nobody.

## Why

The app already ships the fix for this: `web/src/index.css` freezes all four loops under `:root[data-idle="1"]`. But the flag was only ever set from `document.hidden` (`useLive.ts`), and a Tauri window has no tab to background — so `data-idle` sat at `"0"` for the entire life of the process and **none of those rules ever applied in the desktop app**. The saving was written; only a browser tab ever collected it. The comment above the CSS even promises "~0% CPU when it isn't being looked at," which was never true in the app.

This costs more in the desktop app than in a browser: WebKitGTK composites in **software**, so every frame of every ambient loop is charged to the CPU. Measured on `main`, the app idles at ~161% combined CPU (main + renderer) while unfocused.

## How

Key `data-idle` off `document.hasFocus()` as well as `document.hidden`, and listen for `focus`/`blur`, so the existing pause finally fires when the window loses focus:

```js
const looking = !document.hidden && document.hasFocus();
document.documentElement.dataset.idle = looking ? "0" : "1";
```

No CSS changes — the rules already exist, they just never had a true flag to react to.

**Deliberately no inactivity timer.** This is a monitoring surface people leave on-screen and watch; freezing the radar under a still-focused window would read as a hung app rather than a saving. Focus is the honest signal, and the dashboard spends most of its life behind a terminal.

## Scope / honesty

- This targets the **unfocused** case, which is most of the dashboard's life. It does **not** reduce cost while the window is focused and idle — the animations are then legitimately running, and lowering that is a separate repaint-cost fix (e.g. the radar SVG, `backdrop-filter`).
- `bunx tsc --noEmit` clean.
- I could not attach a reliable headless before/after CPU number: concurrent sessions were swapping the installed binary and relaunching the app during testing, and I can't control window focus from the sandbox. The change is small and its effect is verifiable by eye — click to another window and watch CPU drop. Flagging that rather than quoting a number I couldn't measure cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)