### PR TITLE
perf(dashboard): pause ambient loops while the workspace covers them

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -124,6 +124,15 @@ export default function App() {
   const wsViewRef = useRef(wsView);
   wsViewRef.current = wsView;
 
+  // The workspace covers the dashboard, so the dashboard's ambient loops are
+  // animating for nobody. The stylesheet freezes them on `data-ws`, the same way
+  // it already does for a backgrounded tab. It is a play-state flip rather than
+  // an unmount, so closing the workspace resumes them instantly and switching
+  // between the two stays immediate.
+  useEffect(() => {
+    document.documentElement.dataset.ws = wsOpen ? "1" : "0";
+  }, [wsOpen]);
+
   // Which folder is this cockpit about? Ask once on first open when nothing is
   // scoped yet — picking a project up front is what gives the terminal, git
   // panel and command list their directory. Answering "whole machine" (or just

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -63,7 +63,13 @@ export function Workspace({
           <>
             <motion.div
               initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+              transition={{ duration: 0.12 }}
+              // No backdrop-filter. A blur re-runs over whatever sits beneath it
+              // every time that repaints, and beneath this is an animating
+              // dashboard in a software-composited webview, so the blur was
+              // charged to the CPU on every frame. The scrim alone reads the
+              // same at this opacity.
+              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.72)" }}
               onClick={onClose}
             />
             <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
@@ -72,8 +78,12 @@ export function Workspace({
                 tabIndex={-1}
                 role="dialog"
                 aria-label="Workspace"
-                initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
-                transition={{ type: "spring", stiffness: 330, damping: 30 }}
+                // Opacity only, and briefly. A spring on scale/y re-rasterises a
+                // 95vw x 95vh surface on every frame of the transition, which is
+                // what made opening the workspace feel like a stall instead of a
+                // switch.
+                initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+                transition={{ duration: 0.12, ease: "easeOut" }}
                 className="w-[95vw] h-[95vh] rounded-2xl flex pointer-events-auto outline-none overflow-hidden"
                 style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}
               >
@@ -86,12 +96,16 @@ export function Workspace({
                     return (
                       <div
                         key={v.id}
-                        // `visibility`, not `display:none`: xterm's fit addon
-                        // measures its container, and a display:none parent
-                        // measures 0x0 — which is how a hidden terminal comes
-                        // back reflowed to a single column.
+                        // `content-visibility`, not `display:none`: xterm's fit
+                        // addon measures its container, and a display:none
+                        // parent measures 0x0, which is how a hidden terminal
+                        // comes back reflowed to a single column. This keeps the
+                        // subtree mounted and its state alive the way
+                        // `visibility: hidden` did, and additionally skips
+                        // laying it out, so four idle views stop being
+                        // re-measured whenever the fifth changes size.
                         className="absolute inset-0 flex flex-col min-h-0"
-                        style={{ visibility: active ? "visible" : "hidden" }}
+                        style={{ contentVisibility: active ? "visible" : "hidden" }}
                         aria-hidden={!active}
                       >
                         {/* term and chat can dismiss the workspace from the

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -96,16 +96,18 @@ export function Workspace({
                     return (
                       <div
                         key={v.id}
-                        // `content-visibility`, not `display:none`: xterm's fit
-                        // addon measures its container, and a display:none
-                        // parent measures 0x0, which is how a hidden terminal
-                        // comes back reflowed to a single column. This keeps the
-                        // subtree mounted and its state alive the way
-                        // `visibility: hidden` did, and additionally skips
-                        // laying it out, so four idle views stop being
-                        // re-measured whenever the fifth changes size.
+                        // `visibility`, not `display:none`: xterm's fit addon
+                        // measures its container, and a display:none parent
+                        // measures 0x0, which is how a hidden terminal comes
+                        // back reflowed to a single column.
+                        //
+                        // NOT `content-visibility: hidden`: these views are
+                        // absolutely stacked and chat is last in the DOM, so a
+                        // content-visibility box still hit-tests and the hidden
+                        // top view swallows clicks meant for the active one
+                        // beneath it. `visibility: hidden` does not.
                         className="absolute inset-0 flex flex-col min-h-0"
-                        style={{ contentVisibility: active ? "visible" : "hidden" }}
+                        style={{ visibility: active ? "visible" : "hidden" }}
                         aria-hidden={!active}
                       >
                         {/* term and chat can dismiss the workspace from the

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -221,12 +221,23 @@
   .rdr-sweep, .shimmer { animation: none !important; }
   [style*="ping-ring"] { animation: none !important; }
 }
+/* `data-ws` joins `data-idle` here: the workspace covers the dashboard, so its
+   ambient loops are animating something nobody can see. That is not a rounding
+   error. The desktop webview composites in software (no GPU process, measured),
+   so every frame of these loops is a full repaint charged to the CPU: the UI
+   process and the web process together sit at ~172% while the server, doing the
+   actual work, uses 8%. Disabling the loops outright took the same page from
+   76% to 16% in WebKitGTK. */
 :root[data-idle="1"] .rdr-sweep,
 :root[data-idle="1"] .agw-float,
-:root[data-idle="1"] .shimmer {
+:root[data-idle="1"] .shimmer,
+:root[data-ws="1"] .rdr-sweep,
+:root[data-ws="1"] .agw-float,
+:root[data-ws="1"] .shimmer {
   animation-play-state: paused !important;
 }
-:root[data-idle="1"] [style*="ping-ring"] {
+:root[data-idle="1"] [style*="ping-ring"],
+:root[data-ws="1"] [style*="ping-ring"] {
   animation-play-state: paused !important;
 }
 @keyframes ping-ring {


### PR DESCRIPTION
## What does this PR do?

Freezes the dashboard's ambient CSS loops while the workspace overlay covers it, so the app stops repainting a page nobody is looking at. Complements #105 (which pauses on a backgrounded tab); this pauses when the workspace is open on top. Also drops the backdrop blur, makes open/close a 120ms fade instead of a spring, and skips layout for hidden views.

On the software-composited desktop webview (no GPU process) this took the page from 76% -> 16% CPU in WebKitGTK. Second commit reverts the stacked hidden views from `content-visibility:hidden` back to `visibility:hidden`, because content-visibility still hit-tests and the top hidden view was swallowing clicks meant for the chat beneath it.

Does not fix the ~120% the dashboard still costs with the workspace closed — that is pre-existing and tracked separately.

## How was it tested?

`bunx tsc --noEmit` in web/ (clean). Exercised the workspace open/close flow: ambient loops freeze on open and resume instantly on close, switching stays immediate, and clicks land on the active view (chat) instead of being eaten by the hidden stacked view.