### PR TITLE
fix(desktop): electron-builder metadata so release binaries build

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -4,6 +4,8 @@
   "version": "0.2.0",
   "description": "agentglass desktop shell (Electron)",
   "author": "SirAllap",
+  "homepage": "https://github.com/SirAllap/agentglass",
+  "repository": { "type": "git", "url": "https://github.com/SirAllap/agentglass.git" },
   "main": "main.js",
   "scripts": {
     "start": "electron .",
@@ -19,16 +21,21 @@
     "appId": "app.agentglass.desktop",
     "productName": "agentglass",
     "executableName": "agentglass",
+    "artifactName": "agentglass_${version}_${arch}.${ext}",
     "directories": { "output": "dist-app" },
     "files": ["main.js", "preload.js", "icons/**"],
     "extraResources": [
       { "from": "../web/dist", "to": "web" },
       { "from": "staging", "to": "." }
     ],
+    "publish": [
+      { "provider": "github", "owner": "SirAllap", "repo": "agentglass" }
+    ],
     "linux": {
       "target": ["AppImage", "deb"],
       "category": "Development",
-      "icon": "icons/icon-512.png"
+      "icon": "icons/icon-512.png",
+      "maintainer": "SirAllap <noreply@users.noreply.github.com>"
     },
     "mac": { "target": ["dmg"], "icon": "icons/icon.icns" },
     "win": { "target": ["nsis"], "icon": "icons/icon.ico" }


### PR DESCRIPTION
## What does this PR do?

Follow-up to #107. The `desktop-binaries` workflow failed on every platform: the `.deb` target needs a `homepage` + Linux maintainer, and the dmg/nsis targets threw on a null publish provider. Adds `homepage`, `repository`, a github `publish` provider, a deb `maintainer`, and a clean `artifactName` (`agentglass_<version>_<arch>`).

## How was it tested?

- Built the Linux AppImage + deb locally — both produced.
- Ran `desktop-binaries.yml` via workflow_dispatch on this branch: **all 4 jobs green** (Linux AppImage+deb, macOS arm64+x64 dmg, Windows nsis). Run: https://github.com/SirAllap/agentglass/actions/runs/29782202552

🤖 Generated with [Claude Code](https://claude.com/claude-code)