### PR TITLE
feat(server): serve the built web UI from the API port (single-port deploys)

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,18 @@ Open **http://localhost:6180**. Then see it move without wiring a real project:
 python3 hooks/seed_demo.py            # streams demo agents for ~30s
 ```
 
+**Single-port deploys** (a headless box, a systemd unit): build the UI once and
+the server serves it itself — one process, one port, API and dashboard on the
+same origin:
+
+```bash
+bun run build                         # web/dist
+cd server && bun run src/index.ts     # dashboard AND API on :4000
+```
+
+When `web/dist` doesn't exist (plain `bun run dev`), nothing changes — the
+server is API-only and the vite dev server owns the UI as before.
+
 Prefer `make`? Every entry point is a described Makefile target — `make help`
 lists them all (`make dev`, `make setup`, `make demo-feed`, `make desktop`, …),
 and the in-app terminal (`t` → **⚙ commands**) surfaces the same list, ready to
@@ -443,7 +455,7 @@ inference, prompt) to an event the same way.
 | `AGENTGLASS_WEBHOOK` | — | POST `{text}` alerts here (Slack/Discord compatible). |
 | `AGENTGLASS_NOTIFY` | — | `1` → fire `notify-send` desktop alerts. |
 | `AGENTGLASS_SERVER` | `http://localhost:4000` | Used by the hook/seed scripts. |
-| `VITE_CW_SERVER` | `http://<host>:4000` | UI → server URL (build/dev time). |
+| `VITE_CW_SERVER` | `http://<host>:4000` | UI → server URL (build/dev time). Unset, the UI resolves same-origin when the server itself served it (single-port mode), `:4000` otherwise. |
 | `AGENTGLASS_GIT_WRITE_DISABLED` | — | `1` → make the **Source control** panel read-only (no stage / commit / push). |
 | `AGENTGLASS_DOCKER_WRITE_DISABLED` | — | `1` → make the **Docker** panel read-only (no start / stop / restart / rm). |
 **Scope is a boundary, not just a filter.** With a project open, git writes, the

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,6 +52,7 @@ import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { rateOk } from "./ratelimit.ts";
 import { parseWindowMs } from "./params.ts";
+import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 /** When this process came up. /stats ships it so the dashboard's uptime is
@@ -217,6 +218,18 @@ const server = Bun.serve<WsData>({
     // missing Origin is a non-browser caller (curl, the hooks), not a drive-by,
     // so it's allowed; a foreign website is turned away here.
     if (!localOrigin(req)) return csrfBlocked();
+
+    // --- built web UI (single-port mode) ---
+    // Exact files only, GET/HEAD only, and ahead of the token gate: the bundle
+    // is the same public code that ships in the repo, and the ?token= flow
+    // needs index.html and its assets to load before the app can pick the
+    // token up and attach it — every data route below stays gated. API paths
+    // never collide here: none of them maps to a real file under web/dist, so
+    // for them this falls straight through to the routes.
+    if (req.method === "GET" || req.method === "HEAD") {
+      const asset = serveWeb(pathname, cors);
+      if (asset) return asset;
+    }
 
     // Shared-secret gate. When a token is configured, every route but the
     // append-only intake sinks needs it — this is what closes the door on other
@@ -597,6 +610,16 @@ const server = Bun.serve<WsData>({
       });
     }
 
+    // --- SPA fallback ---
+    // Every API route above has declined by now. A GET that asks for html is a
+    // browser navigating to a UI deep-link (or a bookmark of one) — hand it
+    // index.html and let the bundle take it from there. Anything else — curl,
+    // fetch, an exporter probing a bad path — still gets the JSON 404.
+    if (req.method === "GET" && (req.headers.get("accept") || "").includes("text/html")) {
+      const page = serveIndex(cors);
+      if (page) return page;
+    }
+
     return json({ error: "not found" }, 404);
   },
 
@@ -737,6 +760,7 @@ if (AUTH_TOKEN) {
     console.log(`🔑 AGENTGLASS_TOKEN set — clients must pass ?token= or Authorization: Bearer`);
   }
 }
+if (WEB_UI_ENABLED) console.log(`   Web UI      → http://localhost:${server.port}/ (serving web/dist)`);
 console.log(`   POST events → http://localhost:${server.port}/ingest`);
 console.log(`   WebSocket   → ws://localhost:${server.port}/stream`);
 console.log(`   Stats API   → http://localhost:${server.port}/stats`);

--- a/server/src/webui.ts
+++ b/server/src/webui.ts
@@ -1,0 +1,101 @@
+// Serve the built dashboard (web/dist) from the API port, when a build exists.
+//
+// This is what lets a headless install run ONE process: `bun run build` once,
+// then the server owns both the API and the UI on a single port — no vite
+// preview alongside it, no second unit to keep alive. The desktop shell already
+// proved the arrangement (it hosts web/dist over loopback HTTP itself); this
+// gives the same thing to server-only deploys. When web/dist is absent —
+// dev, or a hooks-only install that never built the UI — every route behaves
+// exactly as before.
+//
+// Two rules keep it from treading on the API:
+//   * exact files only, resolved traversal-safe under web/dist — an API path
+//     matches no file there, so it falls through to the routes untouched;
+//   * the SPA fallback runs LAST, after every API route has declined, and only
+//     for a GET that asks for html — curl on a bad path still gets the JSON 404.
+//
+// index.html is served with a planted marker (see injectSameOrigin) telling the
+// bundle it came from the API's own origin, so the web app can point its calls
+// at location.origin instead of assuming :4000 — that is the whole contract
+// between this file and web/src/lib/api.ts.
+
+import { resolve, sep } from "node:path";
+import { readFileSync, statSync } from "node:fs";
+
+/** web/dist, iff a build actually exists there (index.html present). */
+const DIST: string | null = (() => {
+  const root = resolve(import.meta.dir, "../../web/dist");
+  try {
+    return statSync(resolve(root, "index.html")).isFile() ? root : null;
+  } catch {
+    return null;
+  }
+})();
+
+export const WEB_UI_ENABLED = DIST !== null;
+
+/** The single-port marker. The bundle checks for it before falling back to the
+ *  conventional :4000 — see SERVER in web/src/lib/api.ts. */
+const MARKER = "<script>window.__AGENTGLASS_SAME_ORIGIN__=true</script>";
+
+/** Plant the marker in index.html on its way out. Injected at serve time, not
+ *  build time, so the SAME build still works under vite preview or the desktop
+ *  shell's static server — pages those serve never carry the marker. */
+export function injectSameOrigin(html: string): string {
+  const head = html.indexOf("</head>");
+  return head >= 0 ? html.slice(0, head) + MARKER + html.slice(head) : MARKER + html;
+}
+
+/** Map a request path to a real file under dist, or null. Clamped the same way
+ *  git.ts clamps translated paths: resolve first, then require the result to
+ *  still live under the root — `..`, encoded or not, walks out and gets null. */
+export function resolveAsset(pathname: string, dist: string | null = DIST): string | null {
+  if (!dist) return null;
+  let p: string;
+  try {
+    p = decodeURIComponent(pathname);
+  } catch {
+    return null; // malformed %-escape
+  }
+  if (p.includes("\0")) return null;
+  if (p === "/") p = "/index.html";
+  const abs = resolve(dist, "." + p);
+  if (abs !== dist && !abs.startsWith(dist + sep)) return null;
+  try {
+    return statSync(abs).isFile() ? abs : null;
+  } catch {
+    return null;
+  }
+}
+
+/** index.html, marker planted. Never cached: it's the one file whose content
+ *  names the (hashed) assets, so a stale copy pins a whole stale UI. */
+function indexResponse(dist: string, cors: Record<string, string>): Response {
+  const html = injectSameOrigin(readFileSync(resolve(dist, "index.html"), "utf8"));
+  return new Response(html, {
+    headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-cache", ...cors },
+  });
+}
+
+/** Serve `pathname` as a static UI file, or null when it maps to none (an API
+ *  route, a WS upgrade — anything that isn't a real file under web/dist). */
+export function serveWeb(pathname: string, cors: Record<string, string>): Response | null {
+  if (!DIST) return null;
+  const abs = resolveAsset(pathname);
+  if (!abs) return null;
+  if (abs === resolve(DIST, "index.html")) return indexResponse(DIST, cors);
+  // Bun.file knows the MIME from the extension. Vite content-hashes everything
+  // under assets/, which is what makes the far-future cache safe; the rest
+  // (favicon and friends) revalidates.
+  const cache = pathname.startsWith("/assets/")
+    ? "public, max-age=31536000, immutable"
+    : "no-cache";
+  return new Response(Bun.file(abs), { headers: { "cache-control": cache, ...cors } });
+}
+
+/** The SPA fallback: index.html for a UI deep-link. The caller has already let
+ *  every API route decline, and only calls this for a GET that accepts html. */
+export function serveIndex(cors: Record<string, string>): Response | null {
+  if (!DIST) return null;
+  return indexResponse(DIST, cors);
+}

--- a/server/test/webui.test.ts
+++ b/server/test/webui.test.ts
@@ -1,0 +1,77 @@
+// The static UI resolver shares a threat model with git.ts's safeAbs: a
+// request path is attacker-supplied, and a miss here serves files from outside
+// web/dist. Plus the marker injection api.ts keys same-origin resolution off.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+import { resolveAsset, injectSameOrigin } from "../src/webui.ts";
+
+let dist: string;
+
+beforeAll(() => {
+  dist = mkdtempSync(join(tmpdir(), "agentglass-webui-"));
+  writeFileSync(join(dist, "index.html"), "<html><head></head><body></body></html>");
+  writeFileSync(join(dist, "favicon.svg"), "<svg/>");
+  mkdirSync(join(dist, "assets"));
+  writeFileSync(join(dist, "assets", "index-CAFE1234.js"), "//js");
+  // A file that lives NEXT TO dist — what a traversal would reach.
+  writeFileSync(join(dist, "..", "agentglass-webui-outside.txt"), "secret");
+});
+
+afterAll(() => {
+  rmSync(dist, { recursive: true, force: true });
+  rmSync(join(dist, "..", "agentglass-webui-outside.txt"), { force: true });
+});
+
+describe("resolveAsset", () => {
+  test("maps / and real files under dist", () => {
+    expect(resolveAsset("/", dist)).toBe(resolve(dist, "index.html"));
+    expect(resolveAsset("/index.html", dist)).toBe(resolve(dist, "index.html"));
+    expect(resolveAsset("/favicon.svg", dist)).toBe(resolve(dist, "favicon.svg"));
+    expect(resolveAsset("/assets/index-CAFE1234.js", dist)).toBe(resolve(dist, "assets", "index-CAFE1234.js"));
+  });
+
+  test("misses (API routes, unknown files, directories) are null", () => {
+    expect(resolveAsset("/stats", dist)).toBe(null);
+    expect(resolveAsset("/git/status", dist)).toBe(null);
+    expect(resolveAsset("/assets", dist)).toBe(null); // a directory, not a file
+    expect(resolveAsset("/nope.js", dist)).toBe(null);
+  });
+
+  test("traversal cannot escape dist, encoded or not", () => {
+    for (const p of [
+      "/../agentglass-webui-outside.txt",
+      "/assets/../../agentglass-webui-outside.txt",
+      "/%2e%2e/agentglass-webui-outside.txt",
+      "/..%2fagentglass-webui-outside.txt",
+      "/assets/%2e%2e%2f%2e%2e%2fagentglass-webui-outside.txt",
+    ]) {
+      expect(resolveAsset(p, dist)).toBe(null);
+    }
+  });
+
+  test("malformed escapes and NUL bytes are refused, not thrown", () => {
+    expect(resolveAsset("/%zz", dist)).toBe(null);
+    expect(resolveAsset("/index.html%00.js", dist)).toBe(null);
+  });
+
+  test("a null dist (no build) resolves nothing", () => {
+    expect(resolveAsset("/index.html", null)).toBe(null);
+  });
+});
+
+describe("injectSameOrigin", () => {
+  test("plants the marker inside <head>", () => {
+    const out = injectSameOrigin("<html><head><title>x</title></head><body></body></html>");
+    expect(out).toContain("window.__AGENTGLASS_SAME_ORIGIN__=true");
+    expect(out.indexOf("__AGENTGLASS_SAME_ORIGIN__")).toBeLessThan(out.indexOf("</head>") + "</head>".length);
+    // Everything else survives untouched.
+    expect(out).toContain("<title>x</title>");
+    expect(out).toContain("<body></body>");
+  });
+
+  test("headless html still gets the marker (prepended)", () => {
+    expect(injectSameOrigin("<div/>").startsWith("<script>")).toBe(true);
+  });
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,9 +3,17 @@ import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
 
+/** Set when the agentglass server itself served this page (single-port mode) —
+ *  it plants the marker into index.html on the way out (server/src/webui.ts).
+ *  Serve-time, not build-time, so the same bundle still resolves :4000 under
+ *  vite dev/preview and the desktop shell's static server. */
+const SERVED_BY_API: boolean =
+  typeof window !== "undefined" &&
+  (window as unknown as { __AGENTGLASS_SAME_ORIGIN__?: boolean }).__AGENTGLASS_SAME_ORIGIN__ === true;
+
 export const SERVER: string =
   (import.meta.env.VITE_CW_SERVER as string | undefined)?.replace(/\/$/, "") ||
-  `http://${location.hostname}:4000`;
+  (SERVED_BY_API ? location.origin : `http://${location.hostname}:4000`);
 
 /** Auth token for a server that requires one (exposed / multi-user box). Read
  *  once from `?token=` — then stripped from the URL bar so it isn't shoulder-


### PR DESCRIPTION
## What does this PR do?

Teaches the server to serve the built web UI (`web/dist`) from the API port when a build exists — so a headless deploy can drop the second process entirely: one `bun` process, one port, dashboard and API on the same origin. The desktop shell already proved the server side of this arrangement (it hosts `web/dist` over loopback HTTP itself); this brings the same thing to server-only installs, e.g. a systemd unit on a home box.

Mechanics, kept deliberately narrow:

- **Exact files only, resolved traversal-safe** under `web/dist` (same clamp idiom as `safeAbs` in `git.ts`), MIME from the extension, far-future cache on the content-hashed `assets/`, `no-cache` on everything else. API and WS routes never collide — they map to no real file, so they fall through untouched.
- **SPA fallback runs last**, after every API route has declined, and only for a `GET` that asks for html — `curl` on a bad path still gets the JSON 404.
- Static files sit ahead of the token gate (the bundle is the same public code that ships in this repo, and the `?token=` flow needs `index.html` + assets to load before the app can pick the token up); every data route stays gated. Bind semantics are untouched.
- `index.html` goes out with a small planted marker, and `api.ts` resolves its API base **same-origin** when it sees one. Serve-time rather than build-time, so the identical bundle keeps resolving `:4000` under vite dev/preview and the desktop shell's static server. `VITE_CW_SERVER` still overrides everything.
- No `web/dist` (plain `bun run dev`, hooks-only installs) → the server is API-only, exactly as before.

## How was it tested?

- `bunx tsc --noEmit` clean in `server/` and `web/`; `bun test` green in both (190 server / 84 web, including new `server/test/webui.test.ts` covering the traversal clamp — encoded `..`, NUL bytes, malformed escapes — and the marker injection).
- Live on the WSL install this stack runs on daily: `/` serves the marker-carrying `index.html`, hashed assets come back `text/javascript` + `immutable`, `favicon.svg` as `image/svg+xml`, `/stats` and `/health` unchanged, a deep-link with `Accept: text/html` gets the SPA, `curl` on an unknown path gets the JSON 404, and `--path-as-is /assets/%2e%2e/%2e%2e/package.json` is refused.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)
