### PR TITLE
chore: remove leftover Tauri references after the Electron migration

### DIFF
--- a/.github/workflows/desktop-binaries.yml
+++ b/.github/workflows/desktop-binaries.yml
@@ -7,9 +7,6 @@ name: Desktop binaries
 #
 # Run it by hand (workflow_dispatch) to check the build still works without
 # cutting a tag; that path builds everything and uploads nothing.
-#
-# NOTE: rewritten for the Tauri -> Electron migration. Verify with one manual
-# dispatch before relying on it for a tagged release.
 
 on:
   push:

--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,7 @@ web/dist/
 __pycache__/
 *.pyc
 
-# desktop app build output — the sidecar is a ~100MB compiled server binary
-src-tauri/target/
-src-tauri/bin/
-src-tauri/icon-*.png
-src-tauri/gen/schemas/
+# desktop app build output (electron-builder) lives in electron/ and is
+# ignored there — the sidecar is a ~100MB compiled server binary.
 .claude/
 *.bun-build

--- a/electron/main.js
+++ b/electron/main.js
@@ -1,9 +1,9 @@
 // agentglass Electron shell.
 //
 // Runs the EXACT web UI (web/dist) in Chromium, which GPU-composites on Linux
-// where WebKitGTK (Tauri) fell back to software — the live radar and streaming
-// dashboard paint on the GPU instead of pinning a CPU core. Same pixels as the
-// web app.
+// where the previous WebKitGTK-based shell fell back to software — the live
+// radar and streaming dashboard paint on the GPU instead of pinning a CPU core.
+// Same pixels as the web app.
 //
 // It hosts web/dist over loopback HTTP (so the SPA's origin is http and its
 // WS/API to :4000 pass the server's loopback origin check) and brings the Bun

--- a/server/test/markdown-safety.test.ts
+++ b/server/test/markdown-safety.test.ts
@@ -29,7 +29,7 @@ describe("markdown link hrefs", () => {
 
   test("rejects schemes that reach the local machine", () => {
     expect(isSafeHref("file:///etc/passwd")).toBe(false);
-    expect(isSafeHref("tauri://localhost/x")).toBe(false);
+    expect(isSafeHref("app://localhost/x")).toBe(false);
   });
 
   test("rejects a scheme-relative or relative href", () => {

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -589,11 +589,10 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // intercepted when there is at least one image among them — a normal text
   // paste has to fall through to the textarea untouched.
   //
-  // Both `files` and `items` are read because the two engines this runs on
-  // disagree. Chromium populates `clipboardData.files` for a pasted image;
-  // WebKitGTK — which is what Tauri uses on Linux, i.e. the desktop app —
-  // delivers it through `items` and leaves `files` empty. Reading only `files`
-  // worked in a browser and silently did nothing in the app.
+  // Both `files` and `items` are read because engines disagree on where a
+  // pasted image lands. Chromium populates `clipboardData.files`; some engines
+  // deliver it only through `items` and leave `files` empty. Reading both
+  // covers either, so a paste never silently does nothing.
   const imagesFrom = (dt: DataTransfer): File[] => {
     const out = new Map<string, File>();
     for (const f of Array.from(dt.files)) {

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -111,9 +111,9 @@ export function Header({
   const hasFilter = filter.app || filter.type || filter.provider;
 
   return (
-    <header data-tauri-drag-region="" className="flex items-center gap-x-3 gap-y-2 px-3 sm:px-4 py-2.5 shrink-0 relative z-20 flex-wrap sm:flex-nowrap"
+    <header className="flex items-center gap-x-3 gap-y-2 px-3 sm:px-4 py-2.5 shrink-0 relative z-20 flex-wrap sm:flex-nowrap"
       style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", background: "color-mix(in srgb, var(--bg2) 94%, var(--bg))", paddingLeft: IS_MAC_DESKTOP ? 76 : undefined }}>
-      <div data-tauri-drag-region="" className="flex items-center gap-2.5 shrink-0">
+      <div className="flex items-center gap-2.5 shrink-0">
         <motion.span initial={{ rotate: -20, opacity: 0 }} animate={{ rotate: 0, opacity: 1 }} transition={{ type: "spring", stiffness: 200 }} className="flex pointer-events-none">
           <Logo size={26} title="agentglass" />
         </motion.span>
@@ -164,7 +164,7 @@ export function Header({
           wrapping, so the header stays a single line at any width / zoom.
           On phones it drops to its own full-width second row — otherwise the
           right-side controls get pushed off-screen and become unreachable. */}
-      <div data-tauri-drag-region="" className="flex items-center gap-2 grow min-w-0 overflow-x-auto agw-noscrollbar order-3 basis-full sm:order-none sm:basis-0">
+      <div className="flex items-center gap-2 grow min-w-0 overflow-x-auto agw-noscrollbar order-3 basis-full sm:order-none sm:basis-0">
       <div className="flex items-center gap-0.5 p-0.5 rounded-lg shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 35%, transparent)" }}>
         {WINDOWS.map((w) => (
           <button key={w.label} onClick={() => onWindow(w.ms)} className="px-2 py-1 rounded-md text-[11px] transition-all"
@@ -195,7 +195,7 @@ export function Header({
       {hasFilter && <button onClick={onClear} className="text-[11px] px-2 py-1 rounded-lg shrink-0 whitespace-nowrap" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>clear ✕</button>}
       </div>{/* middle scroll zone */}
 
-      <div data-tauri-drag-region="" className="shrink-0 flex items-center gap-1.5 sm:gap-2 ml-auto sm:ml-0 max-w-full overflow-x-auto agw-noscrollbar">
+      <div className="shrink-0 flex items-center gap-1.5 sm:gap-2 ml-auto sm:ml-0 max-w-full overflow-x-auto agw-noscrollbar">
         {/* Anthropic plan meters — only shown when viewing Anthropic (it's the
             one provider with a usage API), and only where there's room. */}
         {showUsage && <div className="hidden 2xl:block"><UsageWidget /></div>}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -242,10 +242,10 @@ const realApi = {
     try {
       for (;;) { const { done, value } = await reader.read(); if (done) break; buf += dec.decode(value, { stream: true }); let nl; while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); } }
     } catch (e) {
-      // The turn was accepted and then the connection died under it. WebKitGTK
-      // (the Tauri shell) reports every such failure as "TypeError: Load
-      // failed", so the raw error says nothing about what happened — the cause
-      // is named here instead, where it is known.
+      // The turn was accepted and then the connection died under it. The raw
+      // error is opaque (a bare "TypeError: Load failed" or similar, depending
+      // on the engine) and says nothing about what happened — the cause is
+      // named here instead, where it is known.
       if (e instanceof DOMException && e.name === "AbortError") throw e;
       throw new ChatStreamError("dropped", "");
     }

--- a/web/src/lib/highlight.ts
+++ b/web/src/lib/highlight.ts
@@ -20,18 +20,17 @@ let hp: Promise<Highlighter> | null = null;
  * The one shared highlighter, tokenizing with shiki's **JavaScript** RegExp
  * engine rather than its default Oniguruma one.
  *
- * Oniguruma is WebAssembly, and the desktop shell serves the bundle under the
- * CSP in `src-tauri/tauri.conf.json`, whose `script-src 'self'` omits
- * `'wasm-unsafe-eval'` — so the webview refuses to instantiate the module and
- * `createHighlighter` rejects before a theme or a language is ever requested.
- * That is why the diff was monochrome in the app but coloured in a browser,
- * and why the theme picker showed no complaint: the theme step never ran.
+ * Oniguruma is WebAssembly, and a packaged desktop shell can serve the bundle
+ * under a strict `script-src 'self'` CSP with no `'wasm-unsafe-eval'` — the
+ * webview then refuses to instantiate the module and `createHighlighter`
+ * rejects before a theme or a language is ever requested. That is what once
+ * made the diff monochrome in the app but coloured in a browser, with no
+ * complaint from the theme picker: the theme step never ran.
  *
  * The engine swap is preferred over widening the CSP because it keeps the
- * desktop app's script policy as tight as it is today, and because relying on
- * `'wasm-unsafe-eval'` would put us at the mercy of whether the host's
- * WebKitGTK recognises that token — an unknown source expression is simply
- * ignored, which would silently leave wasm blocked on older systems.
+ * script policy as tight as possible and stays correct no matter how strict
+ * the host's CSP is — the JavaScript engine needs no wasm eval at all, so a
+ * hostile or minimal policy can never silently leave highlighting broken.
  */
 export function getHighlighter(): Promise<Highlighter> {
   if (!hp) hp = shiki().then((m) => m.createHighlighter({ themes: [], langs: [], engine: createJavaScriptRegexEngine() }));

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -154,12 +154,11 @@ export function useLive(): LiveData {
   // sweep/pulse/float/shimmer.
   //
   // `document.hidden` alone was the whole test, and in the desktop app it is
-  // never true: a Tauri window has no tab to background, so the flag sat at "0"
-  // for the entire life of the process and none of these rules ever applied.
-  // The saving was real but only a browser ever collected it. That matters more
-  // here than in a tab, because WebKitGTK composites in software — every frame
-  // of every ambient loop is paid for on the CPU, and the dashboard idles hot
-  // with the radar sweep and a ping-ring per live session running forever.
+  // never true: a desktop window has no tab to background, so the flag sat at
+  // "0" for the entire life of the process and none of these rules ever
+  // applied. The saving was real but only a browser ever collected it — every
+  // frame of every ambient loop keeps the radar sweep and a ping-ring per live
+  // session running forever, and the dashboard idles hot for no one watching.
   //
   // Focus is the signal that survives both environments: the dashboard's normal
   // place is a second monitor or behind the terminal the agent is running in,

--- a/web/test/diff-theme.test.ts
+++ b/web/test/diff-theme.test.ts
@@ -14,8 +14,8 @@ const CODE = 'const greeting = "hello"; // note';
 
 // Stand in for the desktop shell's CSP for this whole file.
 //
-// The regression: shiki's default Oniguruma engine is WebAssembly, and
-// `src-tauri/tauri.conf.json` sets `script-src 'self'` with no
+// The regression: shiki's default Oniguruma engine is WebAssembly, and a
+// packaged desktop shell can serve the bundle under `script-src 'self'` with no
 // `'wasm-unsafe-eval'`, so the webview refuses to instantiate it and
 // `createHighlighter` rejects before a theme or grammar is ever asked for —
 // every diff in the app came out monochrome while browsers were fine. The


### PR DESCRIPTION
## What does this PR do?

Cleans up the last Tauri traces left behind after the desktop shell moved to Electron. All cosmetic — no behaviour changes:

- **`Header.tsx`** — drop four dead `data-tauri-drag-region` attributes (the Electron window is standard-framed, so the Tauri-only attribute did nothing).
- **`.gitignore`** — remove the obsolete `src-tauri/` lines; the electron-builder output is already ignored under `electron/`.
- **Stale comments reworded** to describe the behaviour generically instead of naming Tauri/WebKitGTK: `ChatPanel.tsx` (paste engines), `api.ts` (stream drop), `useLive.ts` (ambient-loop pause), `highlight.ts` + `web/test/diff-theme.test.ts` (the wasm/CSP rationale), and `electron/main.js`.
- **`server/test/markdown-safety.test.ts`** — swap the `tauri://` example for a generic `app://` scheme, keeping the exact same "schemes that reach the local machine are unsafe" assertion.
- **`.github/workflows/desktop-binaries.yml`** — drop the one-off Tauri→Electron migration note.

The logic at every touched site is unchanged and already correct under Electron; only dead attributes and outdated wording go away.

## How was it tested?

- `bunx tsc --noEmit` clean in both `web/` and `server/`.
- `bun test` green in both (190 server / 190 web).
- `bun run build` (vite production build) passes.
- Verified zero remaining `tauri` references across the tree (code, docs, manifests, lockfiles) and no `src-tauri` files tracked.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01C4DHEsVx9Ru4MyM3EcGZ1q)_