### PR TITLE
Desktop shell correctness, and a notch that mirrors your notifications

### DIFF
--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -4,7 +4,7 @@
 // from current source, never a stale dist.
 
 import { spawnSync } from "node:child_process";
-import { mkdirSync } from "node:fs";
+import { mkdirSync, rmSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
@@ -23,6 +23,11 @@ console.log("==> building web UI");
 run("bun", ["run", "build"], resolve(REPO, "web"));
 
 console.log("==> compiling server sidecar");
+// Wipe staging first. electron-builder copies *everything* in here into the
+// app's resources (extraResources: { from: "staging", to: "." }), so anything
+// left behind ships — a stray build of the sidecar is 100MB, and six of them
+// once made it into an installed app before anyone noticed the size.
+rmSync(resolve(HERE, "staging"), { recursive: true, force: true });
 mkdirSync(resolve(HERE, "staging"), { recursive: true });
 run("bun", [
   "build", "--compile", resolve(REPO, "server/src/index.ts"),

--- a/electron/install-local.sh
+++ b/electron/install-local.sh
@@ -17,9 +17,45 @@ echo "==> packaging (fresh web build + sidecar, unpacked)"
 SRC="$HERE/dist-app/linux-unpacked"
 [ -x "$SRC/agentglass" ] || { echo "electron-builder did not produce $SRC/agentglass" >&2; exit 1; }
 
+# Refuse to install something that is not an executable.
+#
+# `bun build --compile` can write a file that is the right size, exits 0, and is
+# not an ELF binary at all — writing the outfile onto tmpfs produced exactly
+# that. Installed, it left the app with a server that started and immediately
+# vanished, no error anywhere: the UI came up and every request failed. Checking
+# the artifact is one line and turns that into a build that stops.
+for exe in "$SRC/agentglass" "$SRC/resources/agentglass-server"; do
+  [ -f "$exe" ] || { echo "missing $exe" >&2; exit 1; }
+  case "$(file -b "$exe")" in
+    ELF*executable*|ELF*shared\ object*|Mach-O*) ;;
+    *) echo "refusing to install: $exe is not an executable ($(file -b "$exe" | cut -c1-40))" >&2; exit 1 ;;
+  esac
+done
+
+# A running instance holds these files open, and `rm -rf` under it leaves the
+# app alive on deleted inodes — it keeps running the old code and its sidecar
+# keeps :4000, so the next launch adopts a stale server. Stop it first.
+if pgrep -f "$APP/agentglass" >/dev/null 2>&1; then
+  echo "==> stopping the running instance"
+  pkill -f "$APP/agentglass" 2>/dev/null || true
+  sleep 2
+  pkill -9 -f "$APP/resources/agentglass-server" 2>/dev/null || true
+  sleep 1
+fi
+
 mkdir -p "$APP" "$BIN" "$DESKTOP"
-rm -rf "$APP"
-cp -r "$SRC" "$APP"
+# Everything except chrome-sandbox, which must stay root-owned and setuid.
+# Replacing it drops those bits and Electron then refuses to start on any
+# distro that restricts unprivileged user namespaces (Ubuntu 24.04+), which
+# needs a sudo round trip to undo.
+if [ -u "$APP/chrome-sandbox" ] 2>/dev/null; then
+  find "$APP" -mindepth 1 -maxdepth 1 ! -name chrome-sandbox -exec rm -rf {} +
+  cp -r "$SRC/." "$APP/" 2>/dev/null || true
+  # cp will have failed on chrome-sandbox alone; the rest is in place.
+else
+  rm -rf "$APP"
+  cp -r "$SRC" "$APP"
+fi
 ln -sf "$APP/agentglass" "$BIN/agentglass"
 
 install -m644 "$HERE/icons/icon-512.png" "$APP/icon.png" 2>/dev/null || true

--- a/electron/main.js
+++ b/electron/main.js
@@ -164,7 +164,40 @@ app.whenReady().then(async () => {
   createWindow();
 });
 
+/**
+ * Stop the sidecar, once, however we are going down.
+ *
+ * `window-all-closed` covers closing the window and nothing else. Kill the app
+ * any other way — SIGTERM from a script, SIGINT from the terminal it was
+ * launched in, a crash in the main process — and the server outlived it,
+ * holding :4000. The next launch then found something already answering
+ * /health, adopted it, and ran against a server from the *previous* build:
+ * a UI talking to code that no longer matched it, with no sign anything was
+ * wrong. That cost real debugging time.
+ *
+ * SIGKILL is the one case this cannot cover; nothing in-process can.
+ */
+let stopped = false;
+function stopSidecar() {
+  if (stopped) return;
+  stopped = true;
+  if (!sidecar) return;
+  try { sidecar.kill(); } catch { /* already gone */ }
+  // A server mid-request can ignore SIGTERM for a moment. Follow up, but only
+  // if it is genuinely still there.
+  const child = sidecar;
+  setTimeout(() => { try { if (child.exitCode === null && !child.killed) child.kill("SIGKILL"); } catch { /* gone */ } }, 1500).unref?.();
+  sidecar = null;
+}
+
+app.on("before-quit", stopSidecar);
+app.on("will-quit", stopSidecar);
+process.on("exit", stopSidecar);
+for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) {
+  process.on(sig, () => { stopSidecar(); app.quit(); });
+}
+
 app.on("window-all-closed", () => {
-  if (sidecar) { try { sidecar.kill(); } catch {} }
+  stopSidecar();
   app.quit();
 });

--- a/electron/main.js
+++ b/electron/main.js
@@ -158,10 +158,23 @@ function createWindow() {
   win.loadURL(`${APP_ORIGIN}/`);
 }
 
-app.whenReady().then(async () => {
+app.whenReady().then(() => {
   serveApp();
-  await ensureServer();
+  // The window does not wait for the server.
+  //
+  // It used to: `await ensureServer()` sat between ready and createWindow, so
+  // nothing appeared on screen until the sidecar answered /health — measured at
+  // 376ms of a 588ms startup on a warm cache, and unbounded when the 103MB
+  // binary has to come off disk cold. Up to twelve seconds of *nothing*, since
+  // the poll runs 40 times at 300ms, and a launch that shows no window reads as
+  // an app that failed to start.
+  //
+  // Nothing in the shell needs the server before the window exists, and the UI
+  // already copes with it being briefly absent: the live socket reconnects with
+  // backoff and every panel's fetch has a retry or an honest loading state. So
+  // the window comes up first and the server arrives underneath it.
   createWindow();
+  void ensureServer();
 });
 
 /**

--- a/electron/main.js
+++ b/electron/main.js
@@ -5,11 +5,19 @@
 // radar and streaming dashboard paint on the GPU instead of pinning a CPU core.
 // Same pixels as the web app.
 //
-// It hosts web/dist over loopback HTTP (so the SPA's origin is http and its
-// WS/API to :4000 pass the server's loopback origin check) and brings the Bun
-// server up with it unless one is already running.
+// It serves web/dist from the app's own `agentglass://` scheme and brings the
+// Bun server up with it unless one is already running.
+//
+// The scheme is not cosmetic. This used to be a loopback HTTP server on an
+// EPHEMERAL port, which meant the renderer's origin changed on every launch --
+// and localStorage is keyed by origin, so every restart handed the app an
+// empty store: theme, display size, chats, drafts, the saved token and every
+// preference, all silently reset. A fixed port would have fixed persistence
+// but reintroduced the bug the ephemeral port was chosen to avoid (a second
+// instance failing to bind). A custom scheme has neither problem: one stable
+// origin, no port, and any number of instances share it.
 
-const { app, BrowserWindow, ipcMain } = require("electron");
+const { app, BrowserWindow, ipcMain, protocol } = require("electron");
 const { spawn } = require("child_process");
 const http = require("http");
 const fs = require("fs");
@@ -19,6 +27,18 @@ const os = require("os");
 // GPU compositing on Wayland.
 app.commandLine.appendSwitch("ozone-platform-hint", "auto");
 app.commandLine.appendSwitch("enable-features", "UseOzonePlatform");
+
+// Must run before `ready`. `standard` is what gives the scheme a real origin
+// (and therefore its own persistent localStorage); `secure` keeps it a trusted
+// context so the SPA behaves exactly as it does over https.
+const APP_SCHEME = "agentglass";
+const APP_ORIGIN = `${APP_SCHEME}://app`;
+protocol.registerSchemesAsPrivileged([
+  {
+    scheme: APP_SCHEME,
+    privileges: { standard: true, secure: true, supportFetchAPI: true, stream: true, corsEnabled: true },
+  },
+]);
 
 const SERVER_PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 
@@ -40,24 +60,27 @@ const MIME = {
   ".ico": "image/x-icon", ".map": "application/json",
 };
 
-// Bind an ephemeral port (not a fixed one): a second instance, or anything else
-// already on a hardcoded port, would otherwise make listen() throw and the app
-// exit before a window ever shows. Resolves to the port actually assigned.
-function serveStatic() {
-  return new Promise((resolve, reject) => {
-    const srv = http.createServer((req, res) => {
-      let p = decodeURIComponent(req.url.split("?")[0]);
-      if (p === "/" || !path.extname(p)) p = "/index.html"; // SPA fallback
-      const file = path.join(DIST, p);
-      if (!file.startsWith(DIST)) { res.writeHead(403); res.end(); return; }
-      fs.readFile(file, (err, data) => {
-        if (err) { res.writeHead(404); res.end(); return; }
-        res.writeHead(200, { "content-type": MIME[path.extname(file)] || "application/octet-stream" });
-        res.end(data);
+/**
+ * Serve web/dist under agentglass://app/.
+ *
+ * Same job the loopback server did — SPA fallback for extensionless paths, a
+ * traversal guard, a MIME table — minus the port, which is the entire point.
+ */
+function serveApp() {
+  protocol.handle(APP_SCHEME, async (request) => {
+    let p = decodeURIComponent(new URL(request.url).pathname);
+    if (p === "/" || !path.extname(p)) p = "/index.html"; // SPA fallback
+    const file = path.join(DIST, p);
+    // Still guard traversal: the path comes from the page, not from us.
+    if (!file.startsWith(DIST)) return new Response("forbidden", { status: 403 });
+    try {
+      const data = await fs.promises.readFile(file);
+      return new Response(data, {
+        headers: { "content-type": MIME[path.extname(file)] || "application/octet-stream" },
       });
-    });
-    srv.on("error", reject);
-    srv.listen(0, "127.0.0.1", () => resolve(srv.address().port));
+    } catch {
+      return new Response("not found", { status: 404 });
+    }
   });
 }
 
@@ -121,7 +144,7 @@ function setAutostart(on) {
   return app.getLoginItemSettings().openAtLogin;
 }
 
-function createWindow(staticPort) {
+function createWindow() {
   const win = new BrowserWindow({
     width: 1440,
     height: 900,
@@ -132,13 +155,13 @@ function createWindow(staticPort) {
     webPreferences: { preload: path.join(__dirname, "preload.js") },
   });
   registerIpc(win);
-  win.loadURL(`http://127.0.0.1:${staticPort}/`);
+  win.loadURL(`${APP_ORIGIN}/`);
 }
 
 app.whenReady().then(async () => {
-  const staticPort = await serveStatic();
+  serveApp();
   await ensureServer();
-  createWindow(staticPort);
+  createWindow();
 });
 
 app.on("window-all-closed", () => {

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -8,6 +8,10 @@ const { contextBridge, ipcRenderer } = require("electron");
 contextBridge.exposeInMainWorld("agentglass", {
   desktop: true,
   platform: process.platform,
+  // Where the sidecar listens. The renderer is served from agentglass://app,
+  // whose hostname says nothing about the API — without this the web app would
+  // derive `http://app:4000` from location.hostname and reach nothing.
+  apiOrigin: `http://127.0.0.1:${Number(process.env.AGENTGLASS_PORT || 4000)}`,
   setFullscreen: (on) => ipcRenderer.invoke("ag:setFullscreen", on),
   isFullscreen: () => ipcRenderer.invoke("ag:isFullscreen"),
   setZoom: (factor) => ipcRenderer.invoke("ag:setZoom", factor),

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -307,17 +307,29 @@ async function main() {
       const panes = await evaluate(`document.querySelectorAll('${railSel}')[0]?.parentElement?.querySelectorAll(':scope > div > [aria-hidden]').length ?? 0`);
       if (panes !== 5) failures.push(`[workspace] expected all 5 views mounted, found ${panes}`);
 
-      await press("d"); // bare letter switches while the frame holds focus
-      const afterD = await selectedView();
-      if (afterD !== "diff") failures.push(`[workspace] "d" should select diff, selected ${afterD}`);
+      /**
+       * Press a key and wait for the view to actually be the one expected.
+       *
+       * Two animation frames is not a synchronisation primitive. Under load —
+       * a parallel build, a busy runner — React had not always committed the
+       * previous switch before the next key was read, and the run failed with
+       * `"t" should select term, selected diff`. The app was fine; the test was
+       * racing it. Poll for the outcome instead, with a ceiling so a genuine
+       * regression still fails rather than hanging.
+       */
+      const pressUntilView = async (key: string, want: string, mod = false) => {
+        await press(key, mod);
+        for (let i = 0; i < 40; i++) {
+          if ((await selectedView()) === want) return true;
+          await Bun.sleep(50);
+        }
+        return false;
+      };
 
-      await press("t");
-      const afterT = await selectedView();
-      if (afterT !== "term") failures.push(`[workspace] "t" should select term, selected ${afterT}`);
-
-      await press("1", true); // ⌘1 works even from inside a field
-      const after1 = await selectedView();
-      if (after1 !== "git") failures.push(`[workspace] Ctrl-1 should select git, selected ${after1}`);
+      if (!(await pressUntilView("d", "diff"))) failures.push(`[workspace] "d" should select diff, selected ${await selectedView()}`);
+      if (!(await pressUntilView("t", "term"))) failures.push(`[workspace] "t" should select term, selected ${await selectedView()}`);
+      // ⌘1 works even from inside a field
+      if (!(await pressUntilView("1", "git", true))) failures.push(`[workspace] Ctrl-1 should select git, selected ${await selectedView()}`);
 
       // Poll rather than check once: closing runs an AnimatePresence exit
       // animation, so the rail outlives the state change by a few hundred ms.

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -726,35 +726,106 @@ function isSquashMerged(root: string, ref: string, name: string): boolean {
  */
 const SQUASH_PROBE_MAX = 20;
 
+/** How long a completed squash sweep is trusted. Far longer than the ancestry
+ *  TTL because it costs ~5 spawns per branch: re-running it every 30s burns a
+ *  second of CPU to learn nothing, and anything that could change the answer
+ *  calls invalidateMerged() anyway. */
+const SQUASH_TTL_MS = 5 * 60_000;
+/** Keys whose sweep has finished, and when. Separate from mergedCache so the
+ *  cheap ancestry answer can keep refreshing on its own clock. */
+const squashAt = new Map<string, number>();
+/** Keys with a sweep in flight, so a burst of polls starts one, not ten. */
+const squashRunning = new Set<string>();
+
 function mergedInto(root: string, ref: string): Set<string> {
-  const key = `${root} ${ref}`;
+  // \u0000 rather than a raw NUL byte: written literally it makes the whole
+  // file `data` to grep, which then skips it silently — you get no matches
+  // and no warning. Same separator, same keys, still greppable.
+  const key = `${root}\u0000${ref}`;
   const hit = mergedCache.get(key);
   if (hit && Date.now() - hit.at < MERGED_TTL_MS) return hit.set;
   const r = git(root, ["for-each-ref", "--merged", ref, "refs/heads", "--format=%(refname:short)"]);
   const set = new Set(r.stdout.split("\n").filter(Boolean));
-  // Recover the squash merges ancestry can't see. Folded into the same set, and
-  // so into the same cache entry and the same invalidation, because callers ask
-  // one question — "is this work already in the trunk" — and both tests answer
-  // it. Newest first: that's the order for-each-ref gives with this sort, and
-  // the order that spends the probe budget where deletes actually happen.
-  const all = git(root, ["for-each-ref", "--sort=-committerdate", "refs/heads", "--format=%(refname:short)"])
-    .stdout.split("\n").filter(Boolean);
-  let probes = 0;
-  for (const name of all) {
-    if (set.has(name)) continue;
-    if (probes++ >= SQUASH_PROBE_MAX) break;
-    if (isSquashMerged(root, ref, name)) set.add(name);
-  }
   mergedCache.set(key, { at: Date.now(), set });
+  sweepSquashed(root, ref, key, set);
   return set;
 }
+
+/**
+ * Recover the squash merges ancestry can't see — off the request path.
+ *
+ * This used to run inline, and it is what made the Branches tab take five
+ * seconds on a 44-branch repo (measured: 4.95s cold against a 30s TTL, which
+ * guaranteed you met the cold path constantly; 130ms warm). Each probe is ~5
+ * git spawns, up to twenty of them, all before the response could be written.
+ *
+ * None of that has to happen before the list is shown. Ancestry — one spawn —
+ * already answers for most branches, and `mergedIntoTrunk` is allowed to be
+ * absent: the UI reads that as "we don't know" and keeps the delete
+ * confirmation, which is the safe direction to be wrong in. So the list goes
+ * out immediately and the sweep fills the very Set the cache entry holds, in
+ * place, so the next poll serves the fuller answer with no extra request.
+ *
+ * Newest first: that's the order for-each-ref gives with this sort, and the
+ * order that spends the probe budget where deletes actually happen.
+ */
+function sweepSquashed(root: string, ref: string, key: string, set: Set<string>): void {
+  if (squashRunning.has(key)) return;
+  const done = squashAt.get(key);
+  if (done && Date.now() - done < SQUASH_TTL_MS) return;
+  squashRunning.add(key);
+
+  // One branch per tick, not the whole sweep in one.
+  //
+  // `git()` is spawnSync, so moving the loop into a timeout does not stop it
+  // blocking — it only chooses a different victim. Measured: the first request
+  // dropped from 4.9s to 0.8s, and the *next* one paid 3.3s instead, because it
+  // arrived while the twenty probes were still running on the one thread.
+  //
+  // Yielding between probes bounds that to a single probe (~150ms) instead of
+  // the whole sweep, so the panel stays responsive while it fills in behind.
+  let idx = 0;
+  let probes = 0;
+  let all: string[] = [];
+  const step = () => {
+    try {
+      if (!all.length) {
+        all = git(root, ["for-each-ref", "--sort=-committerdate", "refs/heads", "--format=%(refname:short)"])
+          .stdout.split("\n").filter(Boolean);
+      }
+      while (idx < all.length) {
+        const name = all[idx++]!;
+        if (set.has(name)) continue;
+        if (probes++ >= SQUASH_PROBE_MAX) { idx = all.length; break; }
+        // Mutates the Set the cache entry already holds, so the next read sees
+        // the fuller answer without another sweep.
+        if (isSquashMerged(root, ref, name)) set.add(name);
+        setTimeout(step, 0); // one probe per turn of the loop
+        return;
+      }
+      squashAt.set(key, Date.now());
+      squashRunning.delete(key);
+    } catch {
+      // A failed sweep just leaves the ancestry answer standing.
+      squashRunning.delete(key);
+    }
+  };
+  setTimeout(step, 0);
+}
+
 
 /** Drop the cache after anything that can change what's merged, so the panel
  *  reflects your own action immediately rather than up to a TTL later. */
 export function invalidateMerged(root?: string): void {
-  if (!root) return mergedCache.clear();
-  for (const k of mergedCache.keys()) if (k.startsWith(`${root} `)) mergedCache.delete(k);
+  // Both maps, always. The sweep stamp has a far longer TTL than the ancestry
+  // entry, so clearing only the latter would hand the rebuilt entry a "swept
+  // recently" mark and skip the squash pass for minutes — exactly the window
+  // after a merge, when the answer has just changed.
+  if (!root) { mergedCache.clear(); squashAt.clear(); return; }
+  for (const k of mergedCache.keys()) if (k.startsWith(`${root}\u0000`)) mergedCache.delete(k);
+  for (const k of squashAt.keys()) if (k.startsWith(`${root}\u0000`)) squashAt.delete(k);
 }
+
 
 export function branches(rootIn: unknown): { current: string; branches: GitBranch[]; trunk: string | null } {
   const root = repoRoot(rootIn);

--- a/server/src/ignored.ts
+++ b/server/src/ignored.ts
@@ -1,0 +1,81 @@
+/**
+ * Which of these paths does git ignore?
+ *
+ * The file-changes list mixes what an agent actually wrote with everything it
+ * touched on the way — build output, caches, `.specs` scratch files, lockfile
+ * churn — because the agent's own edits are recorded whether or not the repo
+ * tracks the result. On a busy session that buries the handful of edits you
+ * came to review under a hundred you don't care about.
+ *
+ * Git already knows the answer, and it is the only thing that does: .gitignore
+ * has nested files, negations and per-repo excludes, so anything we
+ * reimplemented here would be a worse guess. `check-ignore --stdin` asks it
+ * once per repo instead of once per file — a hundred paths is one spawn.
+ */
+
+import { spawnSync } from "node:child_process";
+import { dirname, resolve } from "node:path";
+import { existsSync } from "node:fs";
+
+/** Repo root for a path, or null. Walks up looking for `.git` (a directory in
+ *  a normal checkout, a file in a linked worktree). */
+function repoRootOf(p: string): string | null {
+  let dir = dirname(resolve(p));
+  for (let i = 0; i < 40; i++) {
+    if (existsSync(`${dir}/.git`)) return dir;
+    const up = dirname(dir);
+    if (up === dir) return null;
+    dir = up;
+  }
+  return null;
+}
+
+const TTL_MS = 15_000;
+const cache = new Map<string, { at: number; ignored: boolean }>();
+
+/**
+ * Mark each path as ignored or not.
+ *
+ * Cached briefly: the changes list is polled, and .gitignore does not move on
+ * that timescale. A path we cannot place in a repo is reported as not ignored —
+ * "we don't know" must not hide something from you.
+ */
+export function markIgnored(paths: string[]): Map<string, boolean> {
+  const out = new Map<string, boolean>();
+  const now = Date.now();
+  const byRoot = new Map<string, string[]>();
+
+  for (const p of paths) {
+    if (out.has(p)) continue;
+    const hit = cache.get(p);
+    if (hit && now - hit.at < TTL_MS) { out.set(p, hit.ignored); continue; }
+    const root = repoRootOf(p);
+    if (!root) { out.set(p, false); continue; }
+    const list = byRoot.get(root);
+    if (list) list.push(p);
+    else byRoot.set(root, [p]);
+  }
+
+  for (const [root, list] of byRoot) {
+    let ignored = new Set<string>();
+    try {
+      // `--stdin` with one path per line; exit 0 means at least one matched, 1
+      // means none did, and both are normal. Anything else (not a repo, git
+      // missing) leaves the set empty, i.e. nothing hidden.
+      const r = spawnSync("git", ["-C", root, "check-ignore", "--stdin"], {
+        input: list.join("\n"),
+        encoding: "utf8",
+        timeout: 5_000,
+      });
+      if (r.status === 0 && r.stdout) ignored = new Set(r.stdout.split("\n").filter(Boolean));
+    } catch { /* treat as none ignored */ }
+    for (const p of list) {
+      const isIgnored = ignored.has(p);
+      cache.set(p, { at: now, ignored: isIgnored });
+      out.set(p, isIgnored);
+    }
+  }
+
+  if (cache.size > 5_000) cache.clear();
+  return out;
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -53,6 +53,7 @@ import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { rateOk } from "./ratelimit.ts";
 import { parseWindowMs } from "./params.ts";
 import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
+import { notifyCapability, subscribeNotifications, notifyWatching, openNote } from "./notifications.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 /** When this process came up. /stats ships it so the dashboard's uptime is
@@ -77,9 +78,13 @@ const TRUST_LAN = process.env.AGENTGLASS_TRUST_LAN === "1";
 // mints and prints one rather than running unauthenticated.
 const AUTH = resolveToken(LOOPBACK_ONLY);
 const AUTH_TOKEN = AUTH.token;
-/** One socket, two roles: the live event stream and PTY terminal shells. */
-type WsData = { kind: "events" } | PtyWsData;
+/** One socket, three roles: the live event stream, PTY terminal shells, and
+ *  the desktop-notification mirror. */
+type WsData = { kind: "events" } | { kind: "notify" } | PtyWsData;
 const clients = new Set<ServerWebSocket<WsData>>();
+/** Notification sockets, each holding the unsubscribe that keeps the D-Bus
+ *  monitor alive. Empty map => no monitor process. */
+const notifySubs = new Map<ServerWebSocket<WsData>, () => void>();
 
 // Reflect the caller's Origin instead of a blanket `*`. Foreign origins are
 // already turned away by localOrigin() before any body is served, so the old
@@ -111,9 +116,26 @@ const isPrivate = (h: string): boolean => privateHost(h, TRUST_LAN);
 // website is rejected. A request with NO Origin is not a browser, so it can't
 // be a drive-by — but it also can't be vouched for, which is why the routes
 // that hand out real capability check ORIGIN_REQUIRED instead.
+/**
+ * The desktop shell serves its renderer from its own scheme, not a loopback
+ * port — a port is assigned fresh on every launch, and localStorage is keyed
+ * by origin, so the app used to lose every preference each time it started.
+ *
+ * Trusting this origin is no weaker than trusting 127.0.0.1: nothing on the
+ * web can be served under a scheme that only exists inside the packaged app,
+ * and a page cannot forge an Origin header. Both origin gates below defer to
+ * it, so the two can never drift apart — which they did once already, and the
+ * app came up unable to reach its own API.
+ */
+const DESKTOP_ORIGIN_SCHEME = "agentglass:";
+function fromDesktopShell(origin: string): boolean {
+  try { return new URL(origin).protocol === DESKTOP_ORIGIN_SCHEME; } catch { return false; }
+}
+
 function localOrigin(req: Request): boolean {
   const o = req.headers.get("origin");
   if (!o) return true;
+  if (fromDesktopShell(o)) return true;
   try {
     return isPrivate(new URL(o).hostname);
   } catch { return false; }
@@ -132,6 +154,7 @@ function localOrigin(req: Request): boolean {
 function trustedCaller(req: Request): boolean {
   const o = req.headers.get("origin");
   if (!o) return LOOPBACK_ONLY; // no origin is only safe when nobody remote can connect
+  if (fromDesktopShell(o)) return true;
   try {
     return isPrivate(new URL(o).hostname);
   } catch { return false; }
@@ -273,8 +296,29 @@ const server = Bun.serve<WsData>({
       return new Response("upgrade failed", { status: 426 });
     }
 
+    // --- desktop notifications mirrored onto the notch ---
+    //
+    // The monitor runs only while a socket is open here, and the UI only opens
+    // one when the user has switched the feature on. Off means nothing is
+    // spawned and nothing is read — not "read it and don't show it".
+    if (pathname === "/notifications/capability") return json(notifyCapability());
+    if (pathname === "/notifications/open" && req.method === "POST") {
+      if (!trustedCaller(req)) return csrfBlocked();
+      let body: { id?: unknown };
+      try { body = (await req.json()) as { id?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const r = openNote(body?.id);
+      return json(r, r.ok ? 200 : 404);
+    }
+    if (pathname === "/notifications") {
+      if (!trustedCaller(req)) return csrfBlocked();
+      const cap = notifyCapability();
+      if (!cap.supported) return json({ error: cap.reason ?? "unsupported" }, 501);
+      if (srv.upgrade(req, { data: { kind: "notify" } })) return undefined as unknown as Response;
+      return new Response("upgrade failed", { status: 426 });
+    }
+
     // --- health ---
-    if (pathname === "/health") return json({ ok: true, clients: clients.size });
+    if (pathname === "/health") return json({ ok: true, clients: clients.size, notifyWatching: notifyWatching() });
 
     // --- ingest ---
     if (pathname === "/ingest" && req.method === "POST") {
@@ -626,6 +670,12 @@ const server = Bun.serve<WsData>({
   websocket: {
     open(ws: ServerWebSocket<WsData>) {
       if (ws.data?.kind === "pty") { ptyOpen(ws); return; }
+      if (ws.data?.kind === "notify") {
+        notifySubs.set(ws, subscribeNotifications((n) => {
+          try { ws.send(JSON.stringify(n)); } catch { /* closing */ }
+        }));
+        return;
+      }
       clients.add(ws);
       // openTools seeds the client's "running" state for tools whose PreToolUse
       // predates the 300-event initial slice — otherwise a long job in flight
@@ -635,6 +685,13 @@ const server = Bun.serve<WsData>({
     },
     close(ws: ServerWebSocket<WsData>) {
       if (ws.data?.kind === "pty") { ptyClose(ws); return; }
+      if (ws.data?.kind === "notify") {
+        // Unsubscribing is what stops the monitor process once the last
+        // listener goes, so this must run on every close path.
+        notifySubs.get(ws)?.();
+        notifySubs.delete(ws);
+        return;
+      }
       clients.delete(ws);
     },
     message(ws: ServerWebSocket<WsData>, msg) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -54,6 +54,7 @@ import { rateOk } from "./ratelimit.ts";
 import { parseWindowMs } from "./params.ts";
 import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
 import { notifyCapability, subscribeNotifications, notifyWatching, openNote } from "./notifications.ts";
+import { markIgnored } from "./ignored.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 /** When this process came up. /stats ships it so the dashboard's uptime is
@@ -441,7 +442,11 @@ const server = Bun.serve<WsData>({
     }
     if (pathname === "/changes") {
       const limit = Math.min(500, Number(url.searchParams.get("limit") || 200));
-      return json({ changes: getChanges(limit) });
+      const changes = getChanges(limit);
+      // One `git check-ignore` per repo, not per file, so the client can fold
+      // away build output without having to guess at .gitignore semantics.
+      const ignored = markIgnored(changes.map((c) => c.file_path));
+      return json({ changes: changes.map((c) => ({ ...c, ignored: ignored.get(c.file_path) === true })) });
     }
 
     // --- commit composer: live git working-tree status + commit ---

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -1,0 +1,352 @@
+/**
+ * Desktop notifications, mirrored onto the workspace notch.
+ *
+ * Why this exists: agentglass is a fullscreen daily driver. A Slack ping fires
+ * a system notification you never see, because the thing covering your screen
+ * is this app. The notch is the one strip that is always visible, so it is
+ * where that ping should land.
+ *
+ * How: every desktop notification on Linux is a D-Bus method call. Apps call
+ * `Notify` on org.freedesktop.Notifications (Slack, being Electron, does
+ * exactly this) and GTK apps call `AddNotification` on org.gtk.Notifications.
+ * We ask the session bus to make us a *monitor* for those two calls and read
+ * them as they fly past. We never become the notification daemon and never
+ * answer a call, so the user's normal pop-ups keep working exactly as they did
+ * — this is a copy, not an interception.
+ *
+ * Nothing here runs unless a client is subscribed, and the UI only subscribes
+ * when the user has turned the feature on. Nothing is ever written to disk.
+ */
+
+import { spawn, type Subprocess } from "bun";
+import { existsSync } from "node:fs";
+
+export type SystemNote = {
+  /** Stable within a session; used to key the UI's queue and to name the note
+   *  again when the UI asks to open its link. */
+  id: string;
+  app: string;
+  summary: string;
+  body: string;
+  /** freedesktop urgency: 0 low, 1 normal, 2 critical. */
+  urgency: 0 | 1 | 2;
+  at: number;
+  /**
+   * The first http(s) link in the notification's own text, when it has one.
+   *
+   * This is the honest half of "take me there". The real click-through belongs
+   * to the app that posted the notification -- the daemon signals it back and
+   * the app opens the right conversation -- and a monitor cannot invoke that
+   * without becoming the daemon. But a great many notifications simply carry
+   * the link in their text, and opening that lands you in the same place.
+   * When there is no link the UI offers nothing, rather than a button that
+   * pretends.
+   */
+  url?: string;
+};
+
+export type NotifyCapability = { supported: boolean; reason?: string };
+
+// ---------------------------------------------------------------------------
+// Capability
+//
+// Probed once and answered as a plain { supported, reason }. Every caller
+// treats an unsupported host as "the feature is absent", never as an error --
+// there is deliberately no code path where a machine that cannot do this
+// throws instead of simply going without.
+// ---------------------------------------------------------------------------
+
+let cached: NotifyCapability | null = null;
+
+export function notifyCapability(): NotifyCapability {
+  if (cached) return cached;
+  cached = probe();
+  return cached;
+}
+
+function probe(): NotifyCapability {
+  if (process.platform !== "linux") {
+    // macOS has no public API for reading other apps' notifications, and
+    // Windows' UserNotificationListener needs a packaged app plus a consent
+    // prompt. Both are a straight "not here" rather than a broken feature.
+    return { supported: false, reason: `not available on ${process.platform} — this needs a D-Bus session bus` };
+  }
+  const addr = process.env.DBUS_SESSION_BUS_ADDRESS;
+  const fallback = `/run/user/${process.getuid?.() ?? ""}/bus`;
+  if (!addr && !existsSync(fallback)) {
+    return { supported: false, reason: "no D-Bus session bus (headless, SSH or a container)" };
+  }
+  if (!Bun.which("dbus-monitor")) {
+    return { supported: false, reason: "dbus-monitor not found — install your distro's dbus package" };
+  }
+  return { supported: true };
+}
+
+// ---------------------------------------------------------------------------
+// Parsing dbus-monitor
+//
+// Its output is not a serialisation format and does not pretend to be one, so
+// the parser is written against what it actually emits, verified against real
+// notifications rather than the man page:
+//
+//   - Embedded quotes are NOT escaped:  string "He said "hi""
+//   - Strings keep raw newlines, so a two-line Slack message spans two lines
+//     of output with no continuation marker
+//   - Nothing is truncated, and emoji/markup pass through untouched
+//
+// So: split on the block header, treat lines at exactly three spaces of indent
+// as the top-level arguments, and let a string argument run until the next
+// such line. Trailing quote is stripped at the end rather than matched, which
+// is the only way to survive an unescaped quote inside the value.
+// ---------------------------------------------------------------------------
+
+type Block = {
+  member: string;
+  /** Top-level arguments, in call order, as raw text ("Slack", "0", "-1"). */
+  args: string[];
+  /** Every `dict entry(key, value)` found anywhere in the block, flattened. */
+  dict: Map<string, string>;
+};
+
+const HEADER = /^(?:method call|signal|method return|error)\s/;
+const TOP_ARG = /^ {3}(string|uint32|int32|int64|uint64|boolean|byte|double|array|variant|object path|signature)\b/;
+
+export function parseBlocks(text: string): Block[] {
+  const out: Block[] = [];
+  const lines = text.split("\n");
+  let i = 0;
+  while (i < lines.length) {
+    if (!HEADER.test(lines[i]!)) { i++; continue; }
+    const member = /member=(\S+)/.exec(lines[i]!)?.[1] ?? "";
+    i++;
+    const body: string[] = [];
+    while (i < lines.length && !HEADER.test(lines[i]!)) { body.push(lines[i]!); i++; }
+    out.push({ member, ...parseArgs(body) });
+  }
+  return out;
+}
+
+function parseArgs(lines: string[]): { args: string[]; dict: Map<string, string> } {
+  const args: string[] = [];
+  const dict = new Map<string, string>();
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+
+    // A dict entry can sit at any depth; the key is on one line and its value
+    // on the next. This is how both the freedesktop hints (urgency, and the
+    // x-shell-sender marker we dedup on) and the whole GTK payload arrive.
+    if (/^\s*dict entry\(/.test(line)) {
+      const k = strOf(lines[i + 1] ?? "");
+      const v = lines[i + 2] ?? "";
+      if (k !== null) dict.set(k, v.replace(/^\s*variant\s*/, "").trim());
+      continue;
+    }
+
+    if (!TOP_ARG.test(line)) continue;
+
+    const m = /^ {3}string "(.*)$/s.exec(line);
+    if (!m) {
+      // A non-string scalar, or the opening of an array we don't need to
+      // flatten (its dict entries are picked up by the branch above).
+      args.push(line.trim().replace(/^\S+\s*/, "").replace(/\s*\[$/, ""));
+      continue;
+    }
+    // Run to the next top-level argument: the value may span raw newlines.
+    let value = m[1]!;
+    let j = i + 1;
+    while (j < lines.length && !TOP_ARG.test(lines[j]!) && !/^\s*(array|dict entry)/.test(lines[j]!)) {
+      value += "\n" + lines[j]!;
+      j++;
+    }
+    i = j - 1;
+    args.push(value.replace(/"\s*$/, ""));
+  }
+  return { args, dict };
+}
+
+const strOf = (line: string): string | null => /^\s*string "(.*)"\s*$/.exec(line)?.[1] ?? null;
+
+/** Turn one parsed block into a note, or null if it isn't one we surface. */
+export function noteFrom(b: Block): Omit<SystemNote, "id" | "at"> | null {
+  // The daemon re-dispatches every notification to the shell, so each one
+  // crosses the bus twice. The forwarded copy is identical except that it
+  // carries these two hints — which makes them the cheapest possible dedup,
+  // and an exact one rather than a heuristic.
+  if (b.dict.has("x-shell-sender") || b.dict.has("x-shell-sender-pid")) return null;
+
+  if (b.member === "Notify") {
+    // Notify(app_name, replaces_id, app_icon, summary, body, actions, hints, timeout)
+    const [app = "", , , summary = "", body = ""] = b.args;
+    if (!summary && !body) return null;
+    const u = Number(/(\d+)/.exec(b.dict.get("urgency") ?? "")?.[1] ?? 1);
+    return { app, summary, body, urgency: (u === 0 || u === 2 ? u : 1) as 0 | 1 | 2 };
+  }
+
+  if (b.member === "AddNotification") {
+    // GTK apps: AddNotification(app_id, id, a{sv}) with title/body in the dict.
+    const app = b.args[0] ?? "";
+    const summary = strOf(" " + (b.dict.get("title") ?? "")) ?? unquote(b.dict.get("title"));
+    const body = strOf(" " + (b.dict.get("body") ?? "")) ?? unquote(b.dict.get("body"));
+    if (!summary && !body) return null;
+    return { app, summary, body, urgency: 1 };
+  }
+
+  return null;
+}
+
+/**
+ * The first http(s) URL in the text, trimmed of the punctuation that sentences
+ * put after a link. Deliberately conservative: a wrong link is worse than no
+ * link, because the button silently takes you somewhere else.
+ */
+export function urlIn(text: string): string | undefined {
+  const m = /https?:\/\/[^\s<>"'()]+/.exec(text);
+  if (!m) return undefined;
+  const raw = m[0].replace(/[.,;:!?]+$/, "");
+  try {
+    const u = new URL(raw);
+    return u.protocol === "http:" || u.protocol === "https:" ? u.href : undefined;
+  } catch { return undefined; }
+}
+
+const unquote = (v: string | undefined): string =>
+  (v ?? "").replace(/^\s*string\s*/, "").replace(/^"/, "").replace(/"$/, "").trim();
+
+// ---------------------------------------------------------------------------
+// The watch itself
+//
+// Reference-counted: the monitor process starts when the first subscriber
+// arrives and is killed when the last one leaves. With the feature off in the
+// UI nobody ever subscribes, so nothing is ever spawned and nothing is read.
+// ---------------------------------------------------------------------------
+
+const MATCHES = [
+  "type='method_call',interface='org.freedesktop.Notifications',member='Notify'",
+  "type='method_call',interface='org.gtk.Notifications',member='AddNotification'",
+];
+
+/** Identical notifications this close together are the same one arriving by a
+ *  second route — belt to x-shell-sender's braces, for desktops that forward
+ *  without the marker. */
+const DEDUP_MS = 1500;
+
+const subs = new Set<(n: SystemNote) => void>();
+let proc: Subprocess<"ignore", "pipe", "pipe"> | null = null;
+let seq = 0;
+const recent = new Map<string, number>();
+/** noteId -> url, for the notes we ourselves emitted. Bounded; insertion
+ *  ordered, so the oldest falls off first. */
+const openable = new Map<string, string>();
+
+/**
+ * Open a note's link in the user's normal browser.
+ *
+ * Keyed by note id rather than taking a URL, so the caller can only ever open
+ * something this process already saw on the bus. The platform opener is the
+ * portable part -- xdg-open, `open`, `start` -- and an unknown platform simply
+ * declines instead of guessing.
+ */
+export function openNote(id: unknown): { ok: boolean; error?: string } {
+  const url = typeof id === "string" ? openable.get(id) : undefined;
+  if (!url) return { ok: false, error: "no such notification, or it has no link" };
+  const cmd =
+    process.platform === "darwin" ? ["open", url] :
+    process.platform === "win32" ? ["cmd", "/c", "start", "", url] :
+    ["xdg-open", url];
+  try {
+    spawn({ cmd, stdout: "ignore", stderr: "ignore", stdin: "ignore" }).unref();
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, error: String(e) };
+  }
+}
+
+export function subscribeNotifications(fn: (n: SystemNote) => void): () => void {
+  subs.add(fn);
+  start();
+  return () => {
+    subs.delete(fn);
+    if (!subs.size) stop();
+  };
+}
+
+/** Live only while someone is listening — surfaced by /health for debugging. */
+export const notifyWatching = (): boolean => proc !== null;
+
+function emit(n: SystemNote) {
+  for (const fn of subs) {
+    try { fn(n); } catch { /* one bad subscriber must not kill the feed */ }
+  }
+}
+
+function start() {
+  if (proc || !notifyCapability().supported) return;
+  try {
+    proc = spawn({
+      cmd: ["dbus-monitor", "--session", ...MATCHES],
+      stdout: "pipe",
+      stderr: "pipe",
+      stdin: "ignore",
+    });
+  } catch (e) {
+    console.warn("notifications: could not start dbus-monitor —", e);
+    proc = null;
+    return;
+  }
+  void pump(proc);
+}
+
+function stop() {
+  proc?.kill();
+  proc = null;
+  recent.clear();
+}
+
+/**
+ * Read the monitor's stdout and turn it into notes.
+ *
+ * Buffered by block, not by chunk: a notification's text can span many lines
+ * and arrive across several reads, so we hold everything up to the last
+ * complete block and leave the tail for the next chunk.
+ */
+async function pump(p: Subprocess<"ignore", "pipe", "pipe">) {
+  const dec = new TextDecoder();
+  let buf = "";
+  try {
+    for await (const chunk of p.stdout as ReadableStream<Uint8Array>) {
+      buf += dec.decode(chunk, { stream: true });
+      // Keep the last (possibly incomplete) block in the buffer.
+      const lastHeader = buf.lastIndexOf("\nmethod call ");
+      if (lastHeader < 0) { if (buf.length > 1_000_000) buf = ""; continue; }
+      const done = buf.slice(0, lastHeader + 1);
+      buf = buf.slice(lastHeader + 1);
+
+      for (const block of parseBlocks(done)) {
+        const n = noteFrom(block);
+        if (!n) continue;
+        const key = `${n.app} ${n.summary} ${n.body}`;
+        const now = Date.now();
+        const prev = recent.get(key);
+        if (prev && now - prev < DEDUP_MS) continue;
+        recent.set(key, now);
+        if (recent.size > 200) for (const [k, t] of recent) if (now - t > DEDUP_MS) recent.delete(k);
+        const note: SystemNote = {
+          ...n,
+          id: `sys-${++seq}`,
+          at: now,
+          url: urlIn(`${n.summary}\n${n.body}`),
+        };
+        // Remembered so "open" can name a note instead of passing a URL: the
+        // UI never gets to say *what* to open, only *which of ours*. A page
+        // that got hold of the port still cannot turn this into a launcher.
+        if (note.url) {
+          openable.set(note.id, note.url);
+          if (openable.size > 100) openable.delete(openable.keys().next().value!);
+        }
+        emit(note);
+      }
+    }
+  } catch { /* the process was killed, which is how we stop it */ }
+  if (proc === p) { proc = null; if (subs.size) start(); } // died on its own: retry
+}

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -293,6 +293,21 @@ export function shutdownTerminals() {
 
 // --- project commands: Makefile targets + package.json scripts ---------------
 
+/**
+ * How many targets to take from a single Makefile.
+ *
+ * Was 60, which is fewer than a real project's Makefile holds: a monorepo root
+ * here defines 153, so 93 of them — everything after the sixtieth line of the
+ * file — were dropped, silently, while the picker still advertised a total as
+ * though that were all of them. `make migrate` sat at line 851 and simply did
+ * not exist as far as the app was concerned.
+ *
+ * The cap exists to stop a generated Makefile from flooding the list, so it
+ * stays; it is now set above what a hand-written Makefile plausibly contains,
+ * and the picker has a filter, which is what actually makes a long list usable.
+ */
+const MAKE_MAX_PER_FILE = 400;
+
 /** Parse Makefile text into named targets WITH their descriptions. A
  * description is taken from the `target: ## comment` convention, or from the
  * `# comment` line(s) directly above the target. */
@@ -320,7 +335,7 @@ export function parseMakeTargets(text: string): { name: string; desc: string }[]
     }
     pendingComment = [];
   }
-  return out.slice(0, 60);
+  return out.slice(0, MAKE_MAX_PER_FILE);
 }
 
 /** How deep below the repo root to look for Makefiles / package.jsons. A
@@ -328,7 +343,12 @@ export function parseMakeTargets(text: string): { name: string; desc: string }[]
  *  deeper is almost always vendored code. */
 const CMD_SCAN_DEPTH = 3;
 const CMD_MAX_DIRS = 40; // dropdown budget — beyond this it's noise, not help
-const CMD_MAX_TOTAL = 120; // across all folders; per-manifest caps still apply
+// Across all folders; per-manifest caps still apply. Raised with the per-file
+// cap: a monorepo root Makefile alone can hold 150+ targets, and a list you can
+// filter is not made better by being short — it is made wrong by being
+// incomplete, because a missing target reads as "this project has no such
+// command" rather than "the picker stopped counting".
+const CMD_MAX_TOTAL = 500;
 
 /** Directories that never hold the *project's own* commands — the repo
  *  sweeper's list plus build-output names that don't contain git checkouts. */

--- a/server/test/branch-merged.test.ts
+++ b/server/test/branch-merged.test.ts
@@ -72,12 +72,33 @@ beforeAll(async () => {
 describe("mergedIntoTrunk", () => {
   const of = (name: string) => gw.branches(REPO).branches.find((b) => b.name === name);
 
+  /**
+   * Squash detection is deliberately eventual.
+   *
+   * It costs ~5 git spawns per branch and used to run inline, which made the
+   * Branches tab take five seconds on a 44-branch repo. It now sweeps after the
+   * response goes out and fills the cached set in place, so the answer lands on
+   * a later read — the UI polls, and until then the branch simply keeps its
+   * delete confirmation, which is the safe direction to be wrong in.
+   *
+   * So the assertion is "becomes true", not "is true on the first call". It
+   * still fails if the squash logic itself breaks: the flag would never flip.
+   */
+  const settles = async (name: string, want: boolean, ms = 5000) => {
+    const deadline = Date.now() + ms;
+    for (;;) {
+      if (of(name)?.mergedIntoTrunk === want) return true;
+      if (Date.now() > deadline) return of(name)?.mergedIntoTrunk;
+      await Bun.sleep(25);
+    }
+  };
+
   test("names the trunk it compared against", () => {
     expect(gw.branches(REPO).trunk).toBe("main");
   });
 
-  test("a squash-merged branch counts as merged", () => {
-    expect(of("squashed")?.mergedIntoTrunk).toBe(true);
+  test("a squash-merged branch counts as merged, once the sweep has run", async () => {
+    expect(await settles("squashed", true)).toBe(true);
   });
 
   test("a normally merged branch still counts as merged", () => {

--- a/server/test/desktop-origin.test.ts
+++ b/server/test/desktop-origin.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join, resolve } from "node:path";
+
+/**
+ * The desktop shell must serve its UI from a stable origin.
+ *
+ * This is a guard against a bug that shipped and stayed shipped, because every
+ * gate we had looked straight past it: the shell hosted web/dist over loopback
+ * HTTP on an *ephemeral* port, so the renderer's origin changed on every
+ * launch. localStorage is keyed by origin, so each start handed the app an
+ * empty store — theme, display size, chats, drafts, the saved token, every
+ * preference, silently reset. Nobody was writing them wrong; nobody could read
+ * them back.
+ *
+ * `make smoke` asserted that chats and drafts survive a *reload*, which is the
+ * same origin and always passed. It never restarts the app, which is the case
+ * that broke — and driving a real Electron restart from a test is a heavier
+ * harness than this repo has. So this asserts the property that made the bug
+ * possible, at the only place it can be decided: how main.js chooses to serve
+ * the renderer.
+ *
+ * If you are here because this failed, the question to answer is not "how do I
+ * get the test to pass" — it is "what origin will the renderer have on its
+ * second launch, and is it the same one it had on its first".
+ */
+const MAIN = readFileSync(resolve(import.meta.dir, "..", "..", "electron", "main.js"), "utf8");
+
+describe("desktop shell origin", () => {
+  it("serves the renderer from a custom scheme, not a port", () => {
+    expect(MAIN).toContain("registerSchemesAsPrivileged");
+    expect(MAIN).toContain("protocol.handle");
+    // `standard: true` is what gives the scheme a real, persistent origin.
+    // Without it the page is opaque and localStorage is thrown away again.
+    expect(MAIN).toMatch(/standard:\s*true/);
+  });
+
+  it("loads the window from that scheme", () => {
+    const load = /win\.loadURL\(([^)]*)\)/.exec(MAIN)?.[1] ?? "";
+    expect(load).toContain("APP_ORIGIN");
+    expect(load).not.toContain("127.0.0.1");
+    expect(load).not.toContain("localhost");
+  });
+
+  it("never binds an ephemeral port to serve the UI", () => {
+    // `listen(0, …)` is the exact shape of the original bug. The sidecar's own
+    // fixed port is a different thing and is not spelled this way.
+    expect(MAIN).not.toMatch(/\.listen\(\s*0\s*,/);
+  });
+
+  it("stops the sidecar on every exit path, not only window-all-closed", () => {
+    // An orphaned server keeps :4000, and the next launch adopts it — running
+    // the new UI against the previous build's server, with nothing to show for
+    // it. SIGKILL is the one case no in-process handler can cover.
+    for (const sig of ["SIGTERM", "SIGINT", "SIGHUP"]) expect(MAIN).toContain(sig);
+    expect(MAIN).toContain("before-quit");
+    expect(MAIN).toContain("window-all-closed");
+  });
+});
+
+/**
+ * The installer must refuse an artifact that is not an executable.
+ *
+ * `bun build --compile` wrote a 103 MB file that exited 0 and was not an ELF
+ * binary at all (the outfile was on tmpfs). Installed, the app came up with a
+ * server that started and vanished instantly, no error anywhere.
+ */
+const INSTALL = readFileSync(resolve(import.meta.dir, "..", "..", "electron", "install-local.sh"), "utf8");
+
+describe("install-local.sh", () => {
+  it("checks the built binaries really are executables", () => {
+    expect(INSTALL).toContain("file -b");
+    expect(INSTALL).toMatch(/ELF/);
+    expect(INSTALL).toContain("refusing to install");
+  });
+
+  it("preserves the setuid chrome-sandbox", () => {
+    // Replacing it drops root ownership and the setuid bit, and Electron then
+    // refuses to start wherever unprivileged user namespaces are restricted —
+    // recoverable only with sudo.
+    expect(INSTALL).toContain("chrome-sandbox");
+  });
+});

--- a/server/test/ignored.test.ts
+++ b/server/test/ignored.test.ts
@@ -1,0 +1,60 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { markIgnored } from "../src/ignored.ts";
+
+/**
+ * Against a real repository, because the whole point of asking git is that
+ * .gitignore has nested files, negations and per-directory rules that any
+ * reimplementation would get subtly wrong.
+ */
+let repo: string;
+
+beforeAll(() => {
+  repo = mkdtempSync(join(tmpdir(), "agx-ignored-"));
+  const git = (...args: string[]) => spawnSync("git", ["-C", repo, ...args], { encoding: "utf8" });
+  git("init", "-q");
+  git("config", "user.email", "t@example.com");
+  git("config", "user.name", "t");
+  writeFileSync(join(repo, ".gitignore"), "dist/\n*.log\n!keep.log\n");
+  mkdirSync(join(repo, "dist"), { recursive: true });
+  mkdirSync(join(repo, "src"), { recursive: true });
+  writeFileSync(join(repo, "src", "app.ts"), "export {}\n");
+  writeFileSync(join(repo, "dist", "bundle.js"), "// built\n");
+  writeFileSync(join(repo, "noise.log"), "junk\n");
+  writeFileSync(join(repo, "keep.log"), "kept\n");
+});
+
+afterAll(() => { try { rmSync(repo, { recursive: true, force: true }); } catch { /* fine */ } });
+
+describe("markIgnored", () => {
+  it("marks ignored paths and leaves tracked ones alone", () => {
+    const m = markIgnored([
+      join(repo, "src", "app.ts"),
+      join(repo, "dist", "bundle.js"),
+      join(repo, "noise.log"),
+    ]);
+    expect(m.get(join(repo, "src", "app.ts"))).toBe(false);
+    expect(m.get(join(repo, "dist", "bundle.js"))).toBe(true);
+    expect(m.get(join(repo, "noise.log"))).toBe(true);
+  });
+
+  it("honours a negation, which is why git is asked rather than a glob", () => {
+    const m = markIgnored([join(repo, "keep.log")]);
+    expect(m.get(join(repo, "keep.log"))).toBe(false);
+  });
+
+  it("reports a path outside any repo as not ignored", () => {
+    // "We don't know" must never hide something from the review list.
+    const m = markIgnored(["/definitely/not/a/repo/file.ts"]);
+    expect(m.get("/definitely/not/a/repo/file.ts")).toBe(false);
+  });
+
+  it("answers for every path it was given", () => {
+    const paths = [join(repo, "src", "app.ts"), join(repo, "dist", "bundle.js"), "/nowhere/x.ts"];
+    const m = markIgnored(paths);
+    for (const p of paths) expect(m.has(p)).toBe(true);
+  });
+});

--- a/server/test/notifications.test.ts
+++ b/server/test/notifications.test.ts
@@ -1,0 +1,142 @@
+import { describe, expect, it } from "bun:test";
+import { parseBlocks, noteFrom, urlIn } from "../src/notifications.ts";
+
+/**
+ * These fixtures are verbatim dbus-monitor output, captured from a real GNOME
+ * session rather than written by hand. That matters: the format has three
+ * traps you would not invent — unescaped embedded quotes, strings that keep
+ * their raw newlines, and every notification crossing the bus twice.
+ */
+
+const SIMPLE = `signal time=1784625329.084378 sender=org.freedesktop.DBus -> destination=:1.3511 serial=2 path=/org/freedesktop/DBus; interface=org.freedesktop.DBus; member=NameAcquired
+   string ":1.3511"
+method call time=1784625335.884506 sender=:1.3514 -> destination=:1.42 serial=9 path=/org/freedesktop/Notifications; interface=org.freedesktop.Notifications; member=Notify
+   string "Slack"
+   uint32 0
+   string ""
+   string "Alex Rivera"
+   string "can you take the sync card?"
+   array [
+   ]
+   array [
+      dict entry(
+         string "urgency"
+         variant             byte 1
+      )
+      dict entry(
+         string "sender-pid"
+         variant             int64 1754978
+      )
+   ]
+   int32 -1
+method call time=1784625335.886139 sender=:1.42 -> destination=:1.31 serial=684 path=/org/freedesktop/Notifications; interface=org.freedesktop.Notifications; member=Notify
+   string "Slack"
+   uint32 0
+   string ""
+   string "Alex Rivera"
+   string "can you take the sync card?"
+   array [
+   ]
+   array [
+      dict entry(
+         string "urgency"
+         variant             byte 1
+      )
+      dict entry(
+         string "x-shell-sender-pid"
+         variant             uint32 1754978
+      )
+      dict entry(
+         string "x-shell-sender"
+         variant             string ":1.3514"
+      )
+   ]
+   int32 -1
+`;
+
+const AWKWARD = `method call time=1784625444.319273 sender=:1.3538 -> destination=:1.42 serial=9 path=/org/freedesktop/Notifications; interface=org.freedesktop.Notifications; member=Notify
+   string "Slack"
+   uint32 0
+   string ""
+   string "He said "hi""
+   string "line one
+line two — em dash, <b>markup</b>, emoji 🎉 and a tail"
+   array [
+   ]
+   array [
+      dict entry(
+         string "urgency"
+         variant             byte 2
+      )
+   ]
+   int32 -1
+`;
+
+describe("dbus-monitor parsing", () => {
+  it("reads app, summary, body and urgency off a Notify call", () => {
+    const notes = parseBlocks(SIMPLE).map(noteFrom).filter(Boolean);
+    expect(notes.length).toBe(1); // the daemon's forwarded copy is dropped
+    expect(notes[0]).toEqual({
+      app: "Slack",
+      summary: "Alex Rivera",
+      body: "can you take the sync card?",
+      urgency: 1,
+    });
+  });
+
+  it("drops the daemon's re-dispatch, which is what x-shell-sender marks", () => {
+    const blocks = parseBlocks(SIMPLE).filter((b) => b.member === "Notify");
+    expect(blocks.length).toBe(2); // both really are on the bus
+    expect(blocks.filter((b) => noteFrom(b) !== null).length).toBe(1);
+  });
+
+  it("survives unescaped quotes and multi-line bodies", () => {
+    const [note] = parseBlocks(AWKWARD).map(noteFrom).filter(Boolean);
+    expect(note!.summary).toBe(`He said "hi"`);
+    expect(note!.body).toBe("line one\nline two — em dash, <b>markup</b>, emoji 🎉 and a tail");
+    expect(note!.urgency).toBe(2);
+  });
+
+  it("finds the link a notification carries, and nothing else", () => {
+    // The real shape: a chat app quoting a message that contains a task link.
+    expect(urlIn("have a look at https://tasks.example.com/t/86c4abc12 when you can"))
+      .toBe("https://tasks.example.com/t/86c4abc12");
+    // Sentence punctuation is not part of the address.
+    expect(urlIn("see https://example.com/x.")).toBe("https://example.com/x");
+    // Nothing to open is the common case and must stay undefined, so the UI
+    // shows no button rather than one that goes nowhere.
+    expect(urlIn("Alex unassigned this task from: Nightly report")).toBeUndefined();
+    // Only the web. A notification is not allowed to name a local file.
+    expect(urlIn("file:///etc/passwd")).toBeUndefined();
+    expect(urlIn("javascript:alert(1)")).toBeUndefined();
+  });
+
+  it("ignores traffic that is not a notification", () => {
+    const signalOnly = SIMPLE.split("method call")[0]!;
+    expect(parseBlocks(signalOnly).map(noteFrom).filter(Boolean)).toEqual([]);
+  });
+
+  it("reads GTK's AddNotification, whose text lives in a dict", () => {
+    const gtk = `method call time=1.0 sender=:1.9 -> destination=:1.42 serial=3 path=/org/gtk/Notifications; interface=org.gtk.Notifications; member=AddNotification
+   string "org.gnome.Calendar"
+   string "event-1"
+   array [
+      dict entry(
+         string "title"
+         variant             string "Team standup"
+      )
+      dict entry(
+         string "body"
+         variant             string "starts in 5 minutes"
+      )
+   ]
+`;
+    const [note] = parseBlocks(gtk).map(noteFrom).filter(Boolean);
+    expect(note).toEqual({
+      app: "org.gnome.Calendar",
+      summary: "Team standup",
+      body: "starts in 5 minutes",
+      urgency: 1,
+    });
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -306,6 +306,11 @@ export interface FileChange {
   additions: number;
   deletions: number;
   hunks: DiffHunk[];
+  /** git ignores this path. The list hides these by default — an agent's edit
+   *  to build output is recorded like any other, and on a busy session that
+   *  buries the edits worth reviewing. Absent means "not asked" / "unknown",
+   *  which is never hidden. */
+  ignored?: boolean;
 }
 
 /** A tool call the server sees as still running: a PreToolUse with no matching

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -6,6 +6,7 @@ import { deriveAgents, deriveAlerts, buildTitles } from "./lib/derive.ts";
 import { providerOf } from "./lib/format.ts";
 import { api, IS_DEMO } from "./lib/api.ts";
 import { initialTheme, applyTheme } from "./lib/themes.ts";
+import { actionFor } from "./lib/keybindings.ts";
 import { currentScale, nudgeScale, resetScale } from "./lib/uiScale.ts";
 import { toggleFullscreen } from "./lib/desktop.ts";
 import { useAlertSound } from "./lib/useSound.ts";
@@ -27,7 +28,7 @@ import { HelpLegend } from "./components/HelpLegend.tsx";
 import { StatsModal } from "./components/StatsModal.tsx";
 import { SkillsModal } from "./components/SkillsModal.tsx";
 import { Workspace } from "./components/workspace/Workspace.tsx";
-import { LETTER_TO_VIEW, VIEW_IDS, loadLastView, type ViewId } from "./components/workspace/views.ts";
+import { VIEW_IDS, loadLastView, type ViewId } from "./components/workspace/views.ts";
 import { newChat, chatResuming, applyLiveEvent } from "./lib/chatStore.ts";
 import { sessionCwd } from "./lib/worktree.ts";
 import { SearchModal } from "./components/SearchModal.tsx";
@@ -352,11 +353,19 @@ export default function App() {
       const canNavigate = (focusFree && !anyPanelOpenRef.current) || (wsOpenRef.current && !typing);
       if (!canNavigate) return;
 
+      // Which action owns this letter, according to the user's bindings —
+      // which default to the shipped ones, so nothing changes until they say
+      // so. Read per keystroke rather than captured in this effect's closure:
+      // the effect has an empty dep array on purpose (it must not re-subscribe
+      // on every render), and a rebind has to take effect immediately, not
+      // after the next remount.
+      const action = actionFor(e.key);
+
       // A workspace letter either opens the workspace on that view or, if it's
-      // already open, switches to it. Same five keys as before, except they no
-      // longer stop working the moment you're actually using one of them.
-      const view = LETTER_TO_VIEW[e.key];
-      if (view) {
+      // already open, switches to it. They no longer stop working the moment
+      // you're actually using one of them.
+      if (action?.startsWith("view.")) {
+        const view = action.slice(5) as ViewId;
         e.preventDefault();
         // Pressing the current view's own letter closes the workspace, so a
         // key that opened something can also put it away.
@@ -368,11 +377,11 @@ export default function App() {
       // The remaining globals still open something *over* whatever you're in,
       // so they keep the original strict guard: dashboard only.
       if (!focusFree || anyPanelOpenRef.current || wsOpenRef.current) return;
-      switch (e.key) {
-        case "?": setHelpOpen((o) => !o); break;
-        case "s": e.preventDefault(); setStatsOpen((o) => !o); break;
-        case "k": e.preventDefault(); setSkillsOpen((o) => !o); break;
-        case "/": e.preventDefault(); setSearchOpen((o) => !o); break;
+      switch (action) {
+        case "open.help": setHelpOpen((o) => !o); break;
+        case "open.stats": e.preventDefault(); setStatsOpen((o) => !o); break;
+        case "open.skills": e.preventDefault(); setSkillsOpen((o) => !o); break;
+        case "open.search": e.preventDefault(); setSearchOpen((o) => !o); break;
       }
     };
     window.addEventListener("keydown", onKey);

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -333,11 +333,22 @@ export default function App() {
       // false and the old guard would swallow every letter. What actually
       // matters there is narrower: is the keystroke going into a field or a
       // shell? If not, it's navigation.
-      const typing = !!a && (
+      //
+      // The terminal is the exception, and it has to be the *view* that decides
+      // rather than what holds DOM focus. Asking `activeElement` worked only
+      // while the caret sat in xterm's helper textarea: click anything in the
+      // terminal's own toolbar — the repo picker, restart, clear — and focus
+      // parks on that button, so `typing` went false and the next letter of the
+      // command being typed was eaten as navigation. `t` closed the terminal
+      // mid-command, `g` jumped to git. While the terminal is the active view
+      // every bare letter belongs to the shell; ⌘1..5, ⌘\ and ⌘[/] still leave,
+      // which is exactly why they carry a modifier.
+      const termOwnsKeys = wsOpenRef.current && wsViewRef.current === "term";
+      const typing = termOwnsKeys || (!!a && (
         /^(input|textarea|select)$/i.test(a.tagName) ||
         (a as HTMLElement).isContentEditable ||
         !!a.closest?.(".xterm")
-      );
+      ));
       const canNavigate = (focusFree && !anyPanelOpenRef.current) || (wsOpenRef.current && !typing);
       if (!canNavigate) return;
 

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -593,6 +593,8 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
   const [changes, setChanges] = useState<FileChange[] | null>(null);
   const [titles, setTitles] = useState<ReadonlyMap<string, string>>(new Map());
   const [q, setQ] = useState("");
+  /** Ignored files start folded away — see `visible` below. */
+  const [showIgnored, setShowIgnored] = useState(false);
   const [selId, setSelId] = useState<number | null>(null);
   const [wrap, setWrap] = useState(false);
   const [split, setSplit] = useState(true);
@@ -670,7 +672,18 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
   useEffect(() => { try { localStorage.setItem(GROUPBY_KEY, groupBy); } catch { /* ignore */ } }, [groupBy]);
 
   const all = changes ?? [];
-  const filtered = useMemo(() => (q ? all.filter((c) => c.file_path.toLowerCase().includes(q.toLowerCase())) : all), [all, q]);
+  /**
+   * Files git ignores are folded away by default.
+   *
+   * An agent's edit is recorded whether or not the repo tracks the result, so
+   * build output, caches and scratch files sit in the list beside the code you
+   * came to review — and on a busy session they outnumber it. Hidden, never
+   * silently: the count is shown and one click brings them back, because a list
+   * that quietly drops entries is worse than a long one.
+   */
+  const ignoredCount = useMemo(() => all.reduce((n, c) => n + (c.ignored ? 1 : 0), 0), [all]);
+  const visible = useMemo(() => (showIgnored ? all : all.filter((c) => !c.ignored)), [all, showIgnored]);
+  const filtered = useMemo(() => (q ? visible.filter((c) => c.file_path.toLowerCase().includes(q.toLowerCase())) : visible), [visible, q]);
   const groups = useMemo(() => groupChanges(filtered, groupBy, titles), [filtered, groupBy, titles]);
   const shown = useMemo(() => groups.flatMap((g) => g.items), [groups]);
   const totals = useMemo(() => all.reduce((a, c) => ({ add: a.add + c.additions, del: a.del + c.deletions }), { add: 0, del: 0 }), [all]);
@@ -866,8 +879,25 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                             }}
                           >{d.label}</button>
                         ))}
+                        {/* Says what it is hiding, and offers it back. A
+                            filter that silently drops rows makes the list lie
+                            about what the session touched. */}
+                        {ignoredCount > 0 && (
+                          <button
+                            onClick={() => setShowIgnored((v) => !v)}
+                            className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors"
+                            title={showIgnored
+                              ? "hide files git ignores"
+                              : `${ignoredCount} file${ignoredCount === 1 ? "" : "s"} git ignores ${ignoredCount === 1 ? "is" : "are"} hidden — build output, caches, scratch files`}
+                            style={{
+                              background: showIgnored ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
+                              color: showIgnored ? "var(--text)" : "var(--text3)",
+                              border: `1px solid color-mix(in srgb, var(--border) ${showIgnored ? 45 : 18}%, transparent)`,
+                            }}
+                          >{showIgnored ? `✕ ${ignoredCount} ignored` : `+ ${ignoredCount} ignored`}</button>
+                        )}
                         {changes && all.length > 0 && (
-                          <span className="ml-auto text-[9.5px] t-dim2 tabular-nums" title="files reviewed">{revCount}/{all.length}</span>
+                          <span className="ml-auto text-[9.5px] t-dim2 tabular-nums" title="files reviewed">{revCount}/{visible.length}</span>
                         )}
                       </div>
                     </div>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -402,6 +402,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // below, which must not run on a guess.
   const [workspace, setWorkspace] = useState<string | null>(null);
   const [scopeKnown, setScopeKnown] = useState(false);
+  /** Whether the repo list has come back yet. Distinguishes "still finding your
+   *  projects" from "there are none" — the panel used to render both as the
+   *  same empty list, which reads as a broken feature rather than a pending one. */
+  const [reposKnown, setReposKnown] = useState(false);
+  /** Set when + new was pressed with nowhere to run. */
+  const [noRepo, setNoRepo] = useState(false);
 
   // Chats outlive the page now, so the panel can be holding tabs from a project
   // you are no longer in. They stay in the store, and stay saved, but a project
@@ -480,7 +486,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     api.gitRepos().then(({ repos }) => {
       setRepos(repos);
       setDefaultCwd((c) => c || repos[0]?.root || "");
-    }).catch(() => {});
+    }).catch(() => {}).finally(() => setReposKnown(true));
     api.chatEnabled().then((r) => { setEnabled(r.enabled); setBypassAllowed(!!r.bypass); }).catch(() => {});
     // Which project this instance is scoped to, if any. A failure here means we
     // never learn of a scope, so nothing is hidden, which is the safe direction.
@@ -542,11 +548,20 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     useStuckBottom(open ? active?.id ?? "" : null);
 
   const add = useCallback(() => {
-    const cwd = active?.cwd || defaultCwd || repos[0]?.root || "";
+    // `workspace` last: a scoped instance always has one, so the only way to
+    // reach "" now is a machine with no repo at all.
+    const cwd = active?.cwd || defaultCwd || repos[0]?.root || workspace || "";
+    // A chat with no directory cannot run — `claude` needs somewhere to start —
+    // so it used to appear in the list as "no repo" and fail at the first
+    // message. Before the repos call resolves every one of those fallbacks is
+    // empty, so clicking + new in that window produced exactly that dead tab
+    // and looked like new chats were broken. Refuse instead, and say why.
+    if (!cwd) { setNoRepo(true); return; }
+    setNoRepo(false);
     const c = newChat(cwd, active?.model ?? DEFAULT_MODEL, active?.mode ?? DEFAULT_MODE);
     setActiveId(c.id);
     requestAnimationFrame(() => inputRef.current?.focus());
-  }, [active, defaultCwd, repos]);
+  }, [active, defaultCwd, repos, workspace]);
 
   // Adopt an existing claude session. Focusing an already-open tab rather than
   // opening a second one is not a nicety: two chats resuming one session id
@@ -731,7 +746,23 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                     {shown.map((c) => (
                       <ChatRow key={c.id} chat={c} active={c.id === activeId} onPick={() => setActiveId(c.id)} onClose={() => drop(c.id)} />
                     ))}
-                    {!shown.length && <div className="px-2.5 py-3 text-[11px] t-dim2">no chats match</div>}
+                    {/* Three different situations that all used to say "no
+                        chats match": a filter that excluded everything, a list
+                        still being fetched, and a machine with no repo to run
+                        one in. Only the first is about matching. */}
+                    {!shown.length && (
+                      <div className="px-2.5 py-3 text-[11px] t-dim2">
+                        {query.trim() ? "no chats match"
+                          : !reposKnown || !scopeKnown ? "finding your projects…"
+                          : !repos.length ? "no git repository found to run a chat in"
+                          : "no chats yet — press + new"}
+                      </div>
+                    )}
+                    {noRepo && (
+                      <div className="px-2.5 py-2 text-[11px]" style={{ color: "var(--warning)" }}>
+                        nowhere to run a chat: no git repository was found
+                      </div>
+                    )}
                   </div>
                   {/* Pinned under the list, so context and spend for the chat you
                       are reading stay on screen while you scroll its history. */}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1165,7 +1165,7 @@ export function GitView({ active }: { active: boolean }) {
                         </div>
                       );
                     })}
-                    {!graph.length && <div className="grid place-items-center py-10 t-dim2 text-[12px]" style={{ fontFamily: "system-ui" }}>no commits</div>}
+                    {!graph.length && <PaneEmpty busy={busyView === "log"} what="commits" />}
                     <MoreRows shown={incGraph.rows.length} total={graph.length} onAll={incGraph.showAll} />
                   </div>
                 ) : view === "branches" ? (
@@ -1205,6 +1205,7 @@ export function GitView({ active }: { active: boolean }) {
                         )}
                       </div>
                     )}
+                    {!incBranches.rows.length && <PaneEmpty busy={busyView === "branches"} what="branches" />}
                     {incBranches.rows.map((b, i) => {
                       const t = trackChip(b.track);
                       const sel = i === rowIdx;
@@ -1304,7 +1305,7 @@ export function GitView({ active }: { active: boolean }) {
                         <span className="shrink-0 text-[9.5px] t-dim2">{e.date}</span>
                       </div>
                     ))}
-                    {!reflog.length && <div className="grid place-items-center py-10 t-dim2 text-[12px]">no reflog</div>}
+                    {!reflog.length && <PaneEmpty busy={busyView === "reflog"} what="reflog entries" />}
                     <MoreRows shown={incReflog.rows.length} total={reflog.length} onAll={incReflog.showAll} />
                   </div>
                 ) : (

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -134,6 +134,25 @@ const VIEW_KEYS: Record<View, [string, string][]> = {
  * selection off the bottom of a 200-row reflog and you're following an
  * invisible cursor.
  */
+/**
+ * What a list pane shows when it has no rows.
+ *
+ * "no worktrees" is a claim about the repository, and these views made it while
+ * the request was still in flight — so the answer to "does this repo have
+ * worktrees" flipped from no to three a second later, and every slow tab looked
+ * like an empty one. Nothing here is new information; it is the difference
+ * between not knowing yet and knowing the answer is none.
+ */
+function PaneEmpty({ busy, what }: { busy: boolean; what: string }) {
+  return (
+    <div className="grid place-items-center py-10 t-dim2 text-[12px]">
+      {busy
+        ? <span className="flex items-center gap-2"><span className="agx-spin" aria-hidden="true" />loading {what}…</span>
+        : <>no {what}</>}
+    </div>
+  );
+}
+
 const rowProps = (active: boolean) => ({
   ref: active
     ? (el: HTMLDivElement | null) => el?.scrollIntoView({ block: "nearest" })
@@ -344,6 +363,9 @@ export function GitView({ active }: { active: boolean }) {
   const [remotes, setRemotes] = useState<GitRemote[]>([]);
   const [tags, setTags] = useState<GitTag[]>([]);
   const [reflog, setReflog] = useState<GitReflogEntry[]>([]);
+  /** Which view has a request in flight, so "still loading" and "genuinely
+   *  empty" stop rendering as the same blank pane. */
+  const [busyView, setBusyView] = useState<View | null>(null);
   // Only the branches whose upstream is gone — the merged-and-tidied ones. Off
   // by default: it's a cleanup mode, not a way to read the branch list.
   const [onlyGone, setOnlyGone] = useState(false);
@@ -461,15 +483,30 @@ export function GitView({ active }: { active: boolean }) {
   useEffect(() => { if (open && root) loadTree(root); }, [root, open, loadTree]);
 
   // load the data a non-Changes view needs when it (or the repo) becomes active
+  //
+  // Every one of these ends in `.catch(() => {})` and leaves the previous
+  // view's state in place, so an in-flight fetch and an empty result were the
+  // same picture: a blank pane, or worse "no worktrees" under a repo that has
+  // three. `busy` marks the view whose request is outstanding, which is all the
+  // empty states need to tell the two apart.
   const loadView = useCallback(() => {
     if (!open || !root) return;
-    if (view === "branches") api.gitBranches(root).then(setBranchData).catch(() => {});
-    else if (view === "log") api.gitGraph(root, 500).then((r) => setGraph(r.lines)).catch(() => {});
-    else if (view === "stashes") api.gitStashes(root).then((r) => setStashes(r.stashes)).catch(() => {});
-    else if (view === "worktrees") api.gitWorktrees(root).then((r) => setWorktrees(r.worktrees)).catch(() => {});
-    else if (view === "remotes") api.gitRemotes(root).then((r) => setRemotes(r.remotes)).catch(() => {});
-    else if (view === "tags") api.gitTags(root).then((r) => setTags(r.tags)).catch(() => {});
-    else if (view === "reflog") api.gitReflog(root).then((r) => setReflog(r.entries)).catch(() => {});
+    const track = <T,>(p: Promise<T>, use: (v: T) => void) => {
+      setBusyView(view);
+      p.then(use).catch(() => {}).finally(() => {
+        // Only clear if this is still the view being looked at: switching tabs
+        // mid-flight would otherwise have the old request turn off the new
+        // one's spinner.
+        setBusyView((b) => (b === view ? null : b));
+      });
+    };
+    if (view === "branches") track(api.gitBranches(root), setBranchData);
+    else if (view === "log") track(api.gitGraph(root, 500), (r) => setGraph(r.lines));
+    else if (view === "stashes") track(api.gitStashes(root), (r) => setStashes(r.stashes));
+    else if (view === "worktrees") track(api.gitWorktrees(root), (r) => setWorktrees(r.worktrees));
+    else if (view === "remotes") track(api.gitRemotes(root), (r) => setRemotes(r.remotes));
+    else if (view === "tags") track(api.gitTags(root), (r) => setTags(r.tags));
+    else if (view === "reflog") track(api.gitReflog(root), (r) => setReflog(r.entries));
   }, [open, root, view]);
   useEffect(() => { loadView(); }, [loadView]);
 
@@ -915,13 +952,34 @@ export function GitView({ active }: { active: boolean }) {
     const num = ALL_VIEWS.indexOf(id) + 1;
     return (
       <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]} — press ${num}`}
-        className="text-[10.5px] px-2 py-1 rounded-md transition-colors flex items-center gap-1"
+        aria-keyshortcuts={String(num)}
+        className="text-[10.5px] px-2 py-1 rounded-md transition-colors flex items-center gap-1.5"
         style={{ background: view === id ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: view === id ? "var(--text)" : "var(--text3)", border: `1px solid color-mix(in srgb, var(--border) ${view === id ? 40 : 15}%, transparent)` }}>
         {/* The key that gets you here. lazygit does the same in its panel titles
             (gui.showPanelJumps) — a shortcut nothing advertises is a shortcut
-            nobody uses. */}
-        <span className="tabular-nums" style={{ fontSize: 8.5, opacity: view === id ? 0.75 : 0.45 }}>{num}</span>
-        {VIEW_LABEL[id]}{n != null && n > 0 && <span className="tabular-nums opacity-70">{n}</span>}
+            nobody uses.
+
+            Drawn as a keycap rather than a bare digit. Bare, it read as a
+            count — "1 Changes" looked like one change — and next to a real one
+            ("4 Branches 44") the row became two numbers with a word wedged
+            between them. An outlined cap says "press this"; the count beside
+            it is a filled chip, so the two are different kinds of object
+            before either is read. */}
+        <span
+          className="tabular-nums leading-none rounded-[3px] px-1 py-[1px]"
+          style={{
+            fontSize: 8.5,
+            opacity: view === id ? 0.85 : 0.5,
+            border: "1px solid color-mix(in srgb, var(--text3) 45%, transparent)",
+          }}
+        >{num}</span>
+        {VIEW_LABEL[id]}
+        {n != null && n > 0 && (
+          <span
+            className="tabular-nums leading-none rounded-full px-1.5 py-[1px]"
+            style={{ fontSize: 9, background: "color-mix(in srgb, var(--primary) 18%, transparent)", color: "var(--primary-hover)" }}
+          >{n}</span>
+        )}
       </button>
     );
   };
@@ -952,9 +1010,20 @@ export function GitView({ active }: { active: boolean }) {
                               ("20343"), which lives in the directory name. */}
                           {repos.filter((r) => { const q = repoQuery.trim().toLowerCase(); return !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q); }).map((r) => (
                             <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); setRepoQuery(""); setSelKey(null); }} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2" style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-                              {/* Indented under the project it belongs to, so the
-                                  list reads as "the project, then its branches". */}
-                              {r.worktreeOf && <span className="shrink-0 t-dim2 text-[9px]" title={`worktree of ${r.worktreeOf}`}>└</span>}
+                              {/* Was "└", an indent meaning "child of the line
+                                  above" — which says nothing once you filter
+                                  the list and the parent is off screen, and
+                                  left projects marked by the absence of a
+                                  character. A badge names the kind outright,
+                                  and reads the same wherever the row lands.
+                                  The terminal's picker uses the same one. */}
+                              <span
+                                className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                                title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
+                                style={r.worktreeOf
+                                  ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
+                                  : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
+                              >{r.worktreeOf ? "WT" : "REPO"}</span>
                               {/* A worktree IS its branch — that's the whole point
                                   of having one per ticket. The directory name is
                                   a terse stub of it (`orbit-WEB-1188` for a
@@ -1192,7 +1261,7 @@ export function GitView({ active }: { active: boolean }) {
                         )}
                       </div>
                     ))}
-                    {!stashes.length && <div className="grid place-items-center py-10 t-dim2 text-[12px]">no stashes</div>}
+                    {!stashes.length && <PaneEmpty busy={busyView === "stashes"} what="stashes" />}
                   </div>
                 ) : view === "remotes" ? (
                   <div className="agx-scroll flex-1 min-h-0 overflow-y-auto p-3">
@@ -1206,7 +1275,7 @@ export function GitView({ active }: { active: boolean }) {
                         {r.pushUrl && r.pushUrl !== r.fetchUrl && <span className="shrink-0 text-[9px] px-1 py-px rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 12%, transparent)" }} title={`pushes to ${r.pushUrl}`}>push ≠ fetch</span>}
                       </div>
                     ))}
-                    {!remotes.length && <div className="grid place-items-center py-10 t-dim2 text-[12px]">no remotes</div>}
+                    {!remotes.length && <PaneEmpty busy={busyView === "remotes"} what="remotes" />}
                   </div>
                 ) : view === "tags" ? (
                   <div onScroll={incTags.onScroll} className="agx-scroll flex-1 min-h-0 overflow-y-auto p-3">
@@ -1218,7 +1287,7 @@ export function GitView({ active }: { active: boolean }) {
                         <span className="shrink-0 text-[9.5px] t-dim2">{t.date}</span>
                       </div>
                     ))}
-                    {!tags.length && <div className="grid place-items-center py-10 t-dim2 text-[12px]">no tags</div>}
+                    {!tags.length && <PaneEmpty busy={busyView === "tags"} what="tags" />}
                     <MoreRows shown={incTags.rows.length} total={tags.length} onAll={incTags.showAll} />
                   </div>
                 ) : view === "reflog" ? (
@@ -1259,7 +1328,7 @@ export function GitView({ active }: { active: boolean }) {
                         {writeEnabled && !w.current && <button onClick={() => removeWorktree(w)} className="shrink-0 text-[10px] opacity-0 group-hover:opacity-100 px-1.5 py-0.5 rounded" style={{ color: "var(--error)" }} title="Remove worktree">remove</button>}
                       </div>
                     ))}
-                    {!worktrees.length && <div className="grid place-items-center py-10 t-dim2 text-[12px]">no worktrees</div>}
+                    {!worktrees.length && <PaneEmpty busy={busyView === "worktrees"} what="worktrees" />}
                   </div>
                 )}
 

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -17,6 +17,7 @@ import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
 import { sysNotifyMode, setSysNotifyMode, notifyCapability, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
 import { clock24, setClock24 } from "../lib/clockPref.ts";
+import { bindings, rebind, resetBindings, subscribeBindings, isCustomised, LABELS, DEFAULTS, type ActionId } from "../lib/keybindings.ts";
 
 function Toggle({ on, onClick, label, hint }: { on: boolean; onClick: () => void; label: string; hint: string }) {
   return (
@@ -121,6 +122,37 @@ function Section({ title, children }: { title: string; children: React.ReactNode
   );
 }
 
+/**
+ * One rebindable shortcut.
+ *
+ * Capturing is a mode rather than a text field: you press the key you want,
+ * which is the only input method that cannot disagree with what will actually
+ * fire. `keydown` on the window during capture, so the key never reaches the
+ * app's own handler and rebinding `t` does not also open the terminal.
+ */
+function KeyRow({ id, keyName, capturing, onCapture, error }: {
+  id: ActionId; keyName: string; capturing: boolean; onCapture: () => void; error: string | null;
+}) {
+  const { label, hint } = LABELS[id];
+  return (
+    <button onClick={onCapture}
+      className="w-full flex items-center gap-3 px-3 py-2 rounded-lg text-left hover:bg-white/5">
+      <span className="min-w-0 flex-1">
+        <span className="block text-[12.5px]" style={{ color: "var(--text)" }}>{label}</span>
+        <span className="block text-[10.5px] mt-0.5" style={{ color: error ? "var(--error)" : undefined }}>
+          <span className={error ? "" : "t-dim2"}>{error ?? hint}</span>
+        </span>
+      </span>
+      <kbd className="chip text-[10px] shrink-0 tabular-nums"
+        style={capturing
+          ? { color: "var(--primary-hover)", borderColor: "color-mix(in srgb, var(--primary) 60%, transparent)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }
+          : { color: "var(--text2)" }}>
+        {capturing ? "press a key…" : keyName === " " ? "space" : keyName}
+      </kbd>
+    </button>
+  );
+}
+
 export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, onOpenStats, onOpenHelp }: {
   open: boolean; onClose: () => void; sound: boolean; onSound: () => void;
   scale: number; onZoom: (dir: 1 | -1 | 0) => void;
@@ -139,6 +171,28 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
   useEffect(() => { if (open) void isFullscreen().then(setFullscreenState); }, [open]);
 
   const [h24, setH24] = useState<boolean>(() => clock24());
+  const [keys, setKeys] = useState(() => bindings());
+  const [capturing, setCapturing] = useState<ActionId | null>(null);
+  const [keyError, setKeyError] = useState<{ id: ActionId; msg: string } | null>(null);
+  useEffect(() => subscribeBindings(() => setKeys({ ...bindings() })), []);
+
+  // While capturing, this window handler runs first and swallows the key, so
+  // rebinding "t" cannot also trigger whatever "t" is currently bound to.
+  useEffect(() => {
+    if (!capturing) return;
+    const onKey = (e: KeyboardEvent) => {
+      e.preventDefault();
+      e.stopPropagation();
+      if (e.key === "Escape") { setCapturing(null); setKeyError(null); return; }
+      // Modifiers alone are not a binding; wait for the real key.
+      if (["Shift", "Control", "Alt", "Meta"].includes(e.key)) return;
+      const r = rebind(capturing, e.key);
+      if (r.ok) { setCapturing(null); setKeyError(null); }
+      else setKeyError({ id: capturing, msg: r.error });
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [capturing]);
   const [sysNotify, setSysNotifyState] = useState<SysNotifyMode>(() => sysNotifyMode());
   const [notifyCap, setNotifyCap] = useState<NotifyCapability | null>(null);
   useEffect(() => { if (open) void notifyCapability().then(setNotifyCap); }, [open]);
@@ -218,6 +272,28 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         { v: "titles", label: "Who" },
                         { v: "full", label: "Full" },
                       ]} />
+                  </Section>
+
+                  <Section title="Shortcuts">
+                    {(Object.keys(DEFAULTS) as ActionId[]).map((id) => (
+                      <KeyRow key={id} id={id} keyName={keys[id]}
+                        capturing={capturing === id}
+                        error={keyError?.id === id ? keyError.msg : null}
+                        onCapture={() => { setKeyError(null); setCapturing((c) => (c === id ? null : id)); }} />
+                    ))}
+                    <div className="px-3 pt-1 pb-1 flex items-center gap-3">
+                      <span className="text-[10px] t-dim2 flex-1">
+                        {/* Says why the rest of the keyboard is not on this list. */}
+                        Only the single-key shortcuts. {MOD_KEY}1–5, {MOD_KEY}\\ and {MOD_KEY}K are fixed — they are the ones that still work while you are typing.
+                      </span>
+                      {isCustomised() && (
+                        <button onClick={() => { resetBindings(); setKeyError(null); setCapturing(null); }}
+                          className="text-[10.5px] px-2 py-1 rounded-lg shrink-0"
+                          style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                          reset to defaults
+                        </button>
+                      )}
+                    </div>
                   </Section>
 
                   <Section title="Open">

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -15,6 +15,7 @@ import { api } from "../lib/api.ts";
 import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESKTOP } from "../lib/desktop.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
+import { sysNotifyMode, setSysNotifyMode, notifyCapability, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
 
 function Toggle({ on, onClick, label, hint }: { on: boolean; onClick: () => void; label: string; hint: string }) {
   return (
@@ -37,6 +38,36 @@ function Toggle({ on, onClick, label, hint }: { on: boolean; onClick: () => void
         }} />
       </span>
     </button>
+  );
+}
+
+/** A row of mutually exclusive choices, for a preference with three answers
+ *  rather than two. A toggle would have forced "show me their message" and
+ *  "just tell me someone wrote" to be the same decision. */
+function Choice<T extends string>({ label, hint, value, options, onPick, disabled, disabledHint }: {
+  label: string; hint: string; value: T; options: { v: T; label: string }[];
+  onPick: (v: T) => void; disabled?: boolean; disabledHint?: string;
+}) {
+  return (
+    <div className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left" style={{ opacity: disabled ? 0.55 : 1 }}>
+      <span className="min-w-0 flex-1">
+        <span className="block text-[12.5px]" style={{ color: "var(--text)" }}>{label}</span>
+        <span className="block text-[10.5px] t-dim2 mt-0.5">{disabled ? disabledHint ?? hint : hint}</span>
+      </span>
+      <span className="shrink-0 flex items-center gap-1 rounded-lg p-0.5"
+        style={{ background: "color-mix(in srgb, var(--border) 28%, transparent)" }}>
+        {options.map((o) => (
+          <button key={o.v} onClick={() => onPick(o.v)} disabled={disabled}
+            aria-pressed={value === o.v}
+            className="text-[10.5px] px-2 py-1 rounded-md transition-colors disabled:cursor-not-allowed"
+            style={value === o.v
+              ? { background: "color-mix(in srgb, var(--primary) 55%, transparent)", color: "var(--text)" }
+              : { color: "var(--text3)" }}>
+            {o.label}
+          </button>
+        ))}
+      </span>
+    </div>
   );
 }
 
@@ -106,6 +137,10 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
   useEffect(() => { if (open) autostartEnabled().then(setAutostartState); }, [open]);
   useEffect(() => { if (open) void isFullscreen().then(setFullscreenState); }, [open]);
 
+  const [sysNotify, setSysNotifyState] = useState<SysNotifyMode>(() => sysNotifyMode());
+  const [notifyCap, setNotifyCap] = useState<NotifyCapability | null>(null);
+  useEffect(() => { if (open) void notifyCapability().then(setNotifyCap); }, [open]);
+
   useEffect(() => {
     if (!open) return;
     const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") onClose(); };
@@ -158,6 +193,23 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         label="Start at login"
                         hint="Open agentglass automatically when you log in" />
                     )}
+                    {/* Off is the default and off means nothing is watching:
+                        with no client subscribed the server never starts the
+                        D-Bus monitor at all. On a machine that cannot do this
+                        the row stays but says why, rather than vanishing and
+                        leaving you wondering whether you imagined it. */}
+                    <Choice<SysNotifyMode>
+                      label="Desktop notifications on the notch"
+                      hint="Slack and the rest, mirrored onto the strip you can still see in fullscreen"
+                      disabled={notifyCap ? !notifyCap.supported : true}
+                      disabledHint={notifyCap ? `Unavailable — ${notifyCap.reason}` : "Checking…"}
+                      value={sysNotify}
+                      onPick={(m) => { setSysNotifyMode(m); setSysNotifyState(m); }}
+                      options={[
+                        { v: "off", label: "Off" },
+                        { v: "titles", label: "Who" },
+                        { v: "full", label: "Full" },
+                      ]} />
                   </Section>
 
                   <Section title="Open">

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -16,6 +16,7 @@ import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESK
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
 import { sysNotifyMode, setSysNotifyMode, notifyCapability, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
+import { clock24, setClock24 } from "../lib/clockPref.ts";
 
 function Toggle({ on, onClick, label, hint }: { on: boolean; onClick: () => void; label: string; hint: string }) {
   return (
@@ -137,6 +138,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
   useEffect(() => { if (open) autostartEnabled().then(setAutostartState); }, [open]);
   useEffect(() => { if (open) void isFullscreen().then(setFullscreenState); }, [open]);
 
+  const [h24, setH24] = useState<boolean>(() => clock24());
   const [sysNotify, setSysNotifyState] = useState<SysNotifyMode>(() => sysNotifyMode());
   const [notifyCap, setNotifyCap] = useState<NotifyCapability | null>(null);
   useEffect(() => { if (open) void notifyCapability().then(setNotifyCap); }, [open]);
@@ -198,6 +200,12 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         D-Bus monitor at all. On a machine that cannot do this
                         the row stays but says why, rather than vanishing and
                         leaving you wondering whether you imagined it. */}
+                    <Choice<"12" | "24">
+                      label="Clock"
+                      hint="How the workspace strip shows the time"
+                      value={h24 ? "24" : "12"}
+                      onPick={(v) => { setClock24(v === "24"); setH24(v === "24"); }}
+                      options={[{ v: "12", label: "12h" }, { v: "24", label: "24h" }]} />
                     <Choice<SysNotifyMode>
                       label="Desktop notifications on the notch"
                       hint="Slack and the rest, mirrored onto the strip you can still see in fullscreen"

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -10,7 +10,6 @@ import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 import type { GitRepoRef, ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
-import { worktreeTag } from "../lib/worktree.ts";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 
 const ROOT_KEY = "agentglass.terminalRoot";
@@ -323,8 +322,40 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const [repoQuery, setRepoQuery] = useState("");
   const [cmds, setCmds] = useState<TerminalCommands | null>(null);
   const [cmdsOpen, setCmdsOpen] = useState(false);
+  const [cmdQuery, setCmdQuery] = useState("");
+  /** Both dropdowns live in here, so one listener can tell "clicked outside"
+   *  from "clicked a row". */
+  const pickersRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [, force] = useReducer((x: number) => x + 1, 0);
+
+  // Click anywhere else and the dropdowns close, the way every menu on the
+  // machine behaves. They used to stay open until you picked something or
+  // toggled the same button again, so a picker you opened by accident sat over
+  // the shell you were trying to read. `mousedown` rather than `click` so it
+  // closes on press instead of waiting for the release, and Escape closes too.
+  useEffect(() => {
+    if (!repoOpen && !cmdsOpen) return;
+    const onDown = (e: MouseEvent) => {
+      if (pickersRef.current?.contains(e.target as Node)) return;
+      setRepoOpen(false);
+      setCmdsOpen(false);
+    };
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key !== "Escape") return;
+      // Stop it here: the workspace would otherwise close underneath, so one
+      // Escape would dismiss both the menu and the panel behind it.
+      e.stopPropagation();
+      setRepoOpen(false);
+      setCmdsOpen(false);
+    };
+    document.addEventListener("mousedown", onDown, true);
+    document.addEventListener("keydown", onKey, true);
+    return () => {
+      document.removeEventListener("mousedown", onDown, true);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [repoOpen, cmdsOpen]);
 
   useEffect(() => {
     if (!open) return;
@@ -495,12 +526,19 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                 {/* header: repo picker + command launcher + actions */}
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>▶ Terminal</span>
+                  <div ref={pickersRef} className="flex items-center gap-3">
                   <div className="relative">
                     <button onClick={() => { setRepoOpen((o) => !o); setCmdsOpen(false); }} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
                       <span className="font-medium">{repoRef ? repoName(repoRef.root) : "pick a repo"}</span><span className="t-dim2">▼</span>
                     </button>
                     {repoOpen && (
-                      <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 420, overflow: "hidden" }}>
+                      /* Wide enough for the whole worktree name and its branch.
+                         It used to be 320px with the branch clipped at 150, so
+                         a card-per-worktree checkout showed as "orbit-WEB-1042"
+                         beside an elided branch — the two pieces that tell them
+                         apart, both cut off. Source control shows them in full;
+                         this now matches it. */
+                      <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 460, maxWidth: "min(86vw, 760px)", maxHeight: 420, overflow: "hidden" }}>
                         <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                         <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
                           {/* The path is searchable too: with a worktree per card,
@@ -513,9 +551,39 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                                 {/* Indented under its project — a shell in a
                                     worktree is a shell in that branch, not in
                                     some unrelated repo that looks similar. */}
-                                {r.worktreeOf && <span className="shrink-0 t-dim2 text-[9px]" title={`worktree of ${r.worktreeOf}`}>└</span>}
-                                <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }}>{worktreeTag(r) ?? r.name}{live && <span title="live shell" style={{ color: "var(--success, #98c379)" }}> ●</span>}</span>
-                                <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }}>{r.branch}</span>
+                                {/* A worktree gets its own mark rather than an
+                                    indent. "└" only says "child of the line
+                                    above", which stops meaning anything once
+                                    the list is filtered and the parent is off
+                                    screen — and it reads as tree drawing, not
+                                    as a kind of thing. */}
+                                <span
+                                  className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                                  title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
+                                  style={r.worktreeOf
+                                    ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
+                                    : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
+                                >{r.worktreeOf ? "WT" : "REPO"}</span>
+                                {/* A worktree IS its branch — one per ticket is
+                                    the whole point — so the branch is the name
+                                    worth the wide column, and the directory is
+                                    only a terse stub of it. A project is the
+                                    other way round: the folder is the identity
+                                    and the branch is just what happens to be
+                                    checked out. Same rule Source control uses,
+                                    so the two pickers read alike.
+
+                                    `truncate` matters: without it a long
+                                    worktree name wrapped to seven lines and
+                                    collided with the branch beside it. */}
+                                <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.worktreeOf ? `${r.branch}\n${r.root}` : r.root}>
+                                  {r.worktreeOf ? r.branch : r.name}
+                                  {live && <span title="live shell" style={{ color: "var(--success, #98c379)" }}> ●</span>}
+                                </span>
+                                {!r.worktreeOf && <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.branch}>{r.branch}</span>}
+                                {r.dirty > 0 && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.dirty} changed file${r.dirty === 1 ? "" : "s"}`}>●{r.dirty}</span>}
+                                {r.behind > 0 && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.behind} behind upstream`}>↓{r.behind}</span>}
+                                {r.ahead > 0 && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--success)" }} title={`${r.ahead} ahead of upstream`}>↑{r.ahead}</span>}
                               </button>
                             );
                           })}
@@ -535,25 +603,40 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                     </button>
                     {cmdsOpen && cmds && (
                       <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", width: 460, maxHeight: 480, overflow: "hidden" }}>
+                        {/* A real project has more targets than fit on a screen
+                            — this repo's own reference monorepo has 150 in one
+                            Makefile — so scrolling to find `migrate` was the
+                            only way to run it. Matches the name and what the
+                            target says it does, since half of them are only
+                            recognisable by their description. */}
+                        <input autoFocus value={cmdQuery} onChange={(e) => setCmdQuery(e.target.value)}
+                          placeholder="filter commands…"
+                          className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
+                          style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                         <div className="agx-scroll overflow-y-auto py-1" style={{ minHeight: 0 }}>
                           {/* commands come from the whole selected project — the
                               root Makefile/package.json plus any in subfolders —
                               so each folder gets its own labelled group */}
-                          {groupByDir(cmds.make).map(([dir, list]) => (
+                          {groupByDir(matchCommands(cmds.make, cmdQuery)).map(([dir, list]) => (
                             <div key={"m:" + dir}>
                               <div className="px-3 pt-1.5 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider">make — {dir ? `${dir}/Makefile` : "Makefile"}</div>
                               {list.map((c) => <CommandRow key={"m:" + dir + ":" + c.name} c={c} onRun={run} />)}
                             </div>
                           ))}
-                          {groupByDir(cmds.scripts).map(([dir, list]) => (
+                          {groupByDir(matchCommands(cmds.scripts, cmdQuery)).map(([dir, list]) => (
                             <div key={"s:" + dir}>
                               <div className="px-3 pt-2 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider">scripts — {dir ? `${dir}/package.json` : "package.json"}</div>
                               {list.map((c) => <CommandRow key={"s:" + dir + ":" + c.name} c={c} onRun={run} />)}
                             </div>
                           ))}
+                          {!matchCommands(cmds.make, cmdQuery).length && !matchCommands(cmds.scripts, cmdQuery).length && (
+                            <div className="px-3 py-2 t-dim2">no command matches “{cmdQuery.trim()}”</div>
+                          )}
                         </div>
                       </div>
                     )}
+                  </div>
+
                   </div>
 
                   <div className="flex items-center gap-1 overflow-x-auto agx-scroll">
@@ -673,6 +756,19 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                 </div>
     </div>
   );
+}
+
+/**
+ * Filter the command list by name, description or folder.
+ *
+ * Description included deliberately: a Makefile names things like `infra.up`
+ * and `check.build_id`, so what you remember is usually what it *does*, not
+ * what it is called.
+ */
+function matchCommands(list: ProjectCommand[], query: string): ProjectCommand[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter((c) => `${c.name} ${c.desc ?? ""} ${c.dir ?? ""}`.toLowerCase().includes(q));
 }
 
 /** Bucket commands by the project folder they belong to, repo root first. */

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -1,9 +1,13 @@
 import { useEffect, useRef, useState, useSyncExternalStore } from "react";
 import { AnimatePresence, motion } from "motion/react";
-import { api, type UsagePayload } from "../../lib/api.ts";
+import { api, type UsagePayload, type UsageWindow } from "../../lib/api.ts";
 import { subscribeUsage, usedColor, usageError, resetLabel } from "../UsageWidget.tsx";
 import { subscribe as subscribeChats, listChats } from "../../lib/chatStore.ts";
 import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
+import {
+  subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
+  markNotifyRead, dismissNote, clearNotes, openNote, type SystemNote,
+} from "../../lib/sysNotify.ts";
 
 /**
  * The workspace's dynamic island.
@@ -18,14 +22,25 @@ import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
  * fallen behind its upstream.
  *
  * A notch, not a floating pill. It reads as carved from the top edge of the
- * frame it sits on (only the bottom corners are round), which is why it is
- * positioned at the frame's top rather than the screen's.
+ * screen (only the bottom corners are round), which is why it is welded to the
+ * viewport's top rather than to the frame beneath it.
  *
- * pointer-events: none, all the way down, on purpose and inherited from its
- * predecessor: one of the five views under it is a real terminal, and a strip
- * that swallowed a click meant for the shell would be worse than no strip. It
- * is ambient information, never a control.
+ * It does not overlap that frame. The workspace reserves NOTCH_BAND at the top
+ * of the viewport and starts below it, so the strip sits in clear black air
+ * with the frame's rounded corner beginning underneath. Everything that used to
+ * follow from overlapping -- covering a view's header, swallowing a click meant
+ * for the shell -- stops being a problem rather than being worked around.
+ *
+ * Every reading is captioned. A bare "1" next to a green dot and a bare "551"
+ * next to an arrow are two numbers you have to remember the meaning of; SHELLS
+ * over the 1 and TO PULL over the 551 are two you can read.
  */
+
+/** Height reserved at the top of the viewport for the notch, gap included.
+ *  Workspace pads itself by this, which is what makes the overlap zero. */
+export const NOTCH_BAND = 48;
+
+const NOTCH_H = 40;
 
 // ---------------------------------------------------------------------------
 // The clock. A one-second tick, in JS rather than a CSS animation, because the
@@ -35,7 +50,7 @@ import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
 // so it keeps time. It also stops itself when the tab is hidden: nobody reads a
 // clock they can't see, and the point of all this is to keep the CPU quiet.
 // ---------------------------------------------------------------------------
-function useClock(): { hh: string; mm: string; ss: string; ampm: string; colon: boolean } {
+function useClock(): { hhmm: string; ampm: string; colon: boolean; label: string } {
   const [now, setNow] = useState(() => new Date());
   useEffect(() => {
     let id: ReturnType<typeof setInterval> | null = null;
@@ -50,112 +65,141 @@ function useClock(): { hh: string; mm: string; ss: string; ampm: string; colon: 
   const ampm = h >= 12 ? "PM" : "AM";
   h = h % 12 || 12;
   const p2 = (n: number) => String(n).padStart(2, "0");
-  return { hh: p2(h), mm: p2(now.getMinutes()), ss: p2(now.getSeconds()), ampm, colon: now.getSeconds() % 2 === 0 };
-}
-
-/**
- * An LCD readout, the ghost-segment kind: the lit digits sit over a faint
- * all-8s layer, so the "off" segments show through exactly like a cheap digital
- * watch. That ghost is the whole reason this reads as an LCD and not just a
- * monospace number -- see the reference. The phosphor glow is a text-shadow on
- * the lit layer alone.
- */
-function Lcd({ hh, mm, ss, ampm, colon }: { hh: string; mm: string; ss: string; ampm: string; colon: boolean }) {
-  return (
-    <div className="agx-lcd flex items-end gap-[3px] leading-none select-none">
-      <span className="relative inline-block text-[19px] tracking-[0.06em]">
-        <span className="agx-lcd-ghost">88</span>
-        <span className="agx-lcd-lit absolute inset-0">{hh}</span>
-      </span>
-      <span className="relative inline-block text-[19px] w-[7px] text-center" style={{ opacity: colon ? 1 : 0.18 }}>
-        <span className="agx-lcd-ghost">:</span>
-        <span className="agx-lcd-lit absolute inset-0">:</span>
-      </span>
-      <span className="relative inline-block text-[19px] tracking-[0.06em]">
-        <span className="agx-lcd-ghost">88</span>
-        <span className="agx-lcd-lit absolute inset-0">{mm}</span>
-      </span>
-      <span className="flex flex-col items-start gap-[1px] ml-[3px] mb-[1px]">
-        <span className="agx-lcd-lit text-[7px] tracking-[0.12em] leading-none">{ampm}</span>
-        <span className="relative inline-block text-[9px] tracking-[0.05em] leading-none">
-          <span className="agx-lcd-ghost">88</span>
-          <span className="agx-lcd-lit absolute inset-0">{ss}</span>
-        </span>
-      </span>
-    </div>
-  );
+  return {
+    hhmm: `${p2(h)}:${p2(now.getMinutes())}`,
+    ampm,
+    colon: now.getSeconds() % 2 === 0,
+    label: now.toLocaleString([], { weekday: "long", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }),
+  };
 }
 
 // ---------------------------------------------------------------------------
-// The resting complications: a live-work pulse on the left, plan meters on the
-// right. Both derive from stores the workspace already reads, so nothing here
-// polls anything the app wasn't polling anyway.
+// Seven-segment digits.
+//
+// Not a monospace font with tabular numerals -- actual segments, mitred at the
+// ends with a gap at every corner, drawn over a ghost layer of the segments
+// that are off. That ghost is the whole tell of a real LCD: on a cheap alarm
+// clock you can always see the unlit bars of the 8 behind whatever digit is
+// showing. Geometry is computed once at module scope; a digit is seven
+// polygons and costs nothing to re-render.
 // ---------------------------------------------------------------------------
+const DW = 92, DH = 168, SEG_T = 18, SEG_S = 3.5, SEG_GAP = 15, COLON_W = 32;
 
-/** A tiny ring, 5h / weekly. conic-gradient for the arc, a radial mask punches
- *  the hole -- no SVG, so it costs one element. */
-function Ring({ tag, used }: { tag: string; used: number }) {
-  const color = usedColor(used);
-  return (
-    <span className="flex items-center gap-1" title={`${tag}: ${used}% used`}>
-      <span
-        className="relative grid place-items-center"
-        style={{
-          width: 18, height: 18, borderRadius: "50%",
-          background: `conic-gradient(${color} ${used * 3.6}deg, color-mix(in srgb, #fff 12%, transparent) 0deg)`,
-        }}
-      >
-        <span className="absolute rounded-full" style={{ inset: 3, background: "#0b0b0d" }} />
-      </span>
-      <span className="flex flex-col leading-none">
-        <span className="text-[7px] uppercase tracking-[0.1em]" style={{ color: "color-mix(in srgb, #fff 45%, transparent)" }}>{tag}</span>
-        <span className="text-[9px] font-semibold tabular-nums" style={{ color }}>{used}%</span>
-      </span>
-    </span>
-  );
-}
+/** A horizontal bar: flat top and bottom, mitred to a point at each end. */
+const hSeg = (y: number) => [
+  [SEG_T / 2 + SEG_S, y + SEG_T / 2], [SEG_T + SEG_S, y], [DW - SEG_T - SEG_S, y],
+  [DW - SEG_T / 2 - SEG_S, y + SEG_T / 2], [DW - SEG_T - SEG_S, y + SEG_T], [SEG_T + SEG_S, y + SEG_T],
+].map((p) => p.join(",")).join(" ");
 
-/** A count of live shells and waiting chats, as coloured pips. This is the
- *  left "avatar" slot of the reference -- but a status one: it says how much of
- *  the workspace is actually doing something right now. */
-function Pulse({ shells, waiting }: { shells: number; waiting: number }) {
-  if (!shells && !waiting) {
-    return <span className="w-2 h-2 rounded-full" style={{ background: "color-mix(in srgb, var(--primary) 45%, transparent)" }} title="workspace idle" />;
+/** A vertical bar, same treatment turned ninety degrees. */
+const vSeg = (x: number, ya: number, yb: number) => [
+  [x + SEG_T / 2, ya + SEG_T / 2 + SEG_S], [x + SEG_T, ya + SEG_T + SEG_S], [x + SEG_T, yb - SEG_T - SEG_S],
+  [x + SEG_T / 2, yb - SEG_T / 2 - SEG_S], [x, yb - SEG_T - SEG_S], [x, ya + SEG_T + SEG_S],
+].map((p) => p.join(",")).join(" ");
+
+const SEG: Record<string, string> = {
+  a: hSeg(0), g: hSeg((DH - SEG_T) / 2), d: hSeg(DH - SEG_T),
+  f: vSeg(0, 0, DH / 2), b: vSeg(DW - SEG_T, 0, DH / 2),
+  e: vSeg(0, DH / 2, DH), c: vSeg(DW - SEG_T, DH / 2, DH),
+};
+const SEG_KEYS = ["a", "b", "c", "d", "e", "f", "g"] as const;
+const LIT: Record<string, string> = {
+  "0": "abcdef", "1": "bc", "2": "abged", "3": "abgcd", "4": "fgbc",
+  "5": "afgcd", "6": "afgedc", "7": "abc", "8": "abcdefg", "9": "abcdfg",
+};
+
+function Lcd({ text, height, blink }: { text: string; height: number; blink: boolean }) {
+  const parts: JSX.Element[] = [];
+  let x = 0;
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (ch === ":") {
+      parts.push(
+        <g key={i} style={{ opacity: blink ? 1 : 0.16 }}>
+          <circle className="agx-seg on" cx={x + COLON_W / 2} cy={DH * 0.33} r={8.5} />
+          <circle className="agx-seg on" cx={x + COLON_W / 2} cy={DH * 0.67} r={8.5} />
+        </g>,
+      );
+      x += COLON_W + SEG_GAP;
+      continue;
+    }
+    const lit = LIT[ch] ?? "";
+    parts.push(
+      <g key={i} transform={`translate(${x},0)`}>
+        {SEG_KEYS.map((k) => (
+          <polygon key={k} points={SEG[k]} className={lit.includes(k) ? "agx-seg on" : "agx-seg"} />
+        ))}
+      </g>,
+    );
+    x += DW + SEG_GAP;
   }
+  const w = x - SEG_GAP;
   return (
-    <span className="flex items-center gap-1.5">
-      {shells > 0 && (
-        <span className="flex items-center gap-1" title={`${shells} live shell${shells === 1 ? "" : "s"}`}>
-          <span className="agx-pip w-1.5 h-1.5 rounded-full" style={{ background: "var(--success)" }} />
-          <span className="text-[10px] font-semibold tabular-nums" style={{ color: "var(--success)" }}>{shells}</span>
-        </span>
-      )}
-      {waiting > 0 && (
-        <span className="flex items-center gap-1" title={`${waiting} chat${waiting === 1 ? "" : "s"} waiting for you`}>
-          <span className="agx-pip w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} />
-          <span className="text-[10px] font-semibold tabular-nums" style={{ color: "var(--warning)" }}>{waiting}</span>
-        </span>
-      )}
+    <svg className="agx-lcd" viewBox={`0 0 ${w} ${DH}`} height={height} width={(w / DH) * height} aria-hidden="true">
+      {parts}
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The resting complications. Each one is a pill: a caption naming the reading,
+// the reading under it. Nothing on the strip is a number on its own.
+// ---------------------------------------------------------------------------
+
+function Pill({ cap, title, children }: { cap: string; title?: string; children: React.ReactNode }) {
+  return (
+    <span className="agx-pill" title={title}>
+      <span className="agx-cap">{cap}</span>
+      <span className="flex items-center gap-1.5 leading-none">{children}</span>
     </span>
+  );
+}
+
+/** A plan window: how much is gone, as a bar and a number, captioned with when
+ *  it comes back. "62%" alone never answered the question you actually have. */
+function MeterPill({ tag, w }: { tag: string; w: UsageWindow }) {
+  const color = usedColor(w.utilization);
+  const reset = resetLabel(w.resets_at);
+  return (
+    <Pill
+      cap={reset ? `${tag} · ${reset}` : tag}
+      title={`${tag}: ${w.utilization}% used${reset ? ` — resets ${reset}` : ""}`}
+    >
+      <span className="agx-bar" style={{ width: 38 }}>
+        <i style={{ width: `${Math.min(100, Math.max(0, w.utilization))}%`, background: color }} />
+      </span>
+      <span className="agx-val" style={{ color }}>{w.utilization}%</span>
+    </Pill>
   );
 }
 
 // ---------------------------------------------------------------------------
 // Notifications. A small queue: something worth surfacing arrives, the notch
 // morphs open to show it for a few seconds, then morphs back. Persistent facts
-// (chats waiting, a branch behind) live in the resting pips instead -- a toast
-// is for the transition, the pip is for the standing state.
+// (chats waiting, a branch behind) live in the resting pills instead -- a toast
+// is for the transition, the pill is for the standing state.
 // ---------------------------------------------------------------------------
-type NoteKind = "done" | "blocked" | "pull";
-type Note = { id: string; kind: NoteKind; title: string; sub: string; color: string };
+type NoteKind = "done" | "blocked" | "pull" | "system";
+type Note = { id: string; kind: NoteKind; title: string; sub: string; color: string; app?: string };
 
 const NOTE_MS = 4800;
 
 function NoteIcon({ kind }: { kind: NoteKind }) {
-  const p = { width: 15, height: 15, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2.2, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
+  const p = { width: 13, height: 13, viewBox: "0 0 24 24", fill: "none", stroke: "currentColor", strokeWidth: 2.4, strokeLinecap: "round" as const, strokeLinejoin: "round" as const };
   if (kind === "done") return <svg {...p}><path d="M4 12.5l5 5L20 6" /></svg>;
   if (kind === "blocked") return <svg {...p}><path d="M12 8v5M12 16.5v.01" /><circle cx="12" cy="12" r="9" /></svg>;
-  return <svg {...p}><path d="M12 4v11M6 11l6 6 6-6" /><path d="M5 20h14" /></svg>; // pull: a download arrow
+  if (kind === "system") return <svg {...p}><path d="M18 9a6 6 0 1 0-12 0c0 6-2 7-2 7h16s-2-1-2-7" /><path d="M10.5 20a2 2 0 0 0 3 0" /></svg>; // a bell
+  return <svg {...p}><path d="M12 4v11M6 11l6 6 6-6" /><path d="M4.5 20h15" /></svg>; // pull: a download arrow
+}
+
+/** A chat waiting on you. Its own glyph rather than a coloured dot, so the
+ *  three left-hand pills are told apart by shape and not only by hue. */
+function ChatIcon() {
+  return (
+    <svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2.4" strokeLinecap="round" strokeLinejoin="round">
+      <path d="M20 15a2 2 0 0 1-2 2H8l-4 3V6a2 2 0 0 1 2-2h12a2 2 0 0 1 2 2z" />
+    </svg>
+  );
 }
 
 /**
@@ -164,7 +208,7 @@ function NoteIcon({ kind }: { kind: NoteKind }) {
  * Only transitions, never standing state: it seeds the last-seen maps on the
  * first pass without emitting, so opening the workspace with three already-
  * finished chats does not fire three stale toasts. Those show as the resting
- * pip; a toast means "this just happened, while you were looking away".
+ * pill; a toast means "this just happened, while you were looking away".
  */
 function useNotes(): { note: Note | null; behind: number } {
   const [note, setNote] = useState<Note | null>(null);
@@ -205,6 +249,26 @@ function useNotes(): { note: Note | null; behind: number } {
     return subscribeChats(read);
   }, []);
 
+  // Desktop notifications, read off the D-Bus session bus by the server and
+  // mirrored here. They share the lane with agentglass's own events on
+  // purpose: from where you are sitting, "a teammate replied" and "the chat
+  // finished" are the same kind of interruption, and giving each its own
+  // surface would mean watching two places instead of one.
+  //
+  // Only while the setting is on -- with it off the socket is never opened, so
+  // the server never even starts watching. An unsupported platform simply
+  // never delivers anything and nothing here needs to know.
+  useEffect(() => subscribeSystemNotes((n) => {
+    push({
+      id: n.id,
+      kind: "system",
+      color: n.urgency === 2 ? "var(--error)" : "var(--primary)",
+      title: n.summary || n.app,
+      sub: n.body || n.app,
+      app: n.app,
+    });
+  }), []);
+
   // Branches falling behind their upstream -- "main has changes to pull". Its
   // own poll, deliberately slow: this moves on the scale of someone pushing to
   // a remote, not of anything the user is doing, so a minute and a half of
@@ -228,7 +292,7 @@ function useNotes(): { note: Note | null; behind: number } {
         }
         setBehind(total);
         first = false;
-      } catch { /* offline or no repos -- the pip just stays put */ }
+      } catch { /* offline or no repos -- the pill just stays put */ }
     };
     void poll();
     const id = setInterval(poll, 90_000);
@@ -236,6 +300,71 @@ function useNotes(): { note: Note | null; behind: number } {
   }, []);
 
   return { note, behind };
+}
+
+// ---------------------------------------------------------------------------
+// The inbox: what the notch was showing before you looked up.
+// ---------------------------------------------------------------------------
+
+/** Just the host, so the button can say where it goes without wrapping. */
+const hostOf = (url: string): string => {
+  try { return new URL(url).host.replace(/^www\./, ""); } catch { return "link"; }
+};
+
+const ago = (t: number) => {
+  const s = Math.max(0, Math.round((Date.now() - t) / 1000));
+  if (s < 60) return "just now";
+  const m = Math.round(s / 60);
+  if (m < 60) return `${m}m ago`;
+  return `${Math.round(m / 60)}h ago`;
+};
+
+function HistoryRow({ n, onGone }: { n: SystemNote; onGone: () => void }) {
+  const [open, setOpen] = useState(false);
+  const long = n.body.length > 90 || n.body.includes("\n");
+  return (
+    <div className="agx-note-row">
+      <div className="flex items-start gap-2">
+        <span className="flex flex-col min-w-0 flex-1 gap-[3px]">
+          <span className="flex items-center gap-2">
+            <span className="agx-cap">{n.app}</span>
+            <span className="agx-cap" style={{ opacity: 0.55 }}>{ago(n.at)}</span>
+            {n.urgency === 2 && <span className="agx-cap" style={{ color: "var(--error)" }}>urgent</span>}
+          </span>
+          <span className="text-[11.5px] font-semibold truncate" style={{ color: "#f4f4f6" }}>{n.summary}</span>
+          {/* Wraps, never widens. A nowrap line contributes its whole length to
+              the container's max-content width, which is what let one long
+              Slack message stretch the strip across the screen. Clamped to two
+              lines closed, unclamped open -- so expanding grows downward. */}
+          {n.body && (
+            <span
+              className={open ? "agx-note-body" : "agx-note-body agx-note-body-clamp"}
+            >{n.body}</span>
+          )}
+          {/* Named, not a bare arrow. An unlabelled ↗ next to a Slack
+              notification reads as "go to Slack", which is the one thing it
+              cannot do -- what it actually opens is the link inside the
+              message. Saying the host out loud makes the button honest. */}
+          {n.url && (
+            <button
+              className="agx-note-link self-start"
+              onClick={() => void openNote(n.id)}
+              title={n.url}
+            >
+              ↗ open {hostOf(n.url)}
+            </button>
+          )}
+        </span>
+        <span className="flex items-center gap-1 shrink-0">
+          {long && (
+            <button className="agx-note-btn" onClick={() => setOpen((v) => !v)}
+              title={open ? "collapse" : "show the whole message"}>{open ? "▴" : "▾"}</button>
+          )}
+          <button className="agx-note-btn" onClick={onGone} title="dismiss">✕</button>
+        </span>
+      </div>
+    </div>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -251,21 +380,57 @@ export function DynamicIsland() {
   useEffect(() => subscribeUsage(setU), []);
   const rateLimited = !u?.available && usageError()?.includes("429");
 
+  const anyLive = shells > 0 || waiting > 0 || behind > 0;
+
+  // The inbox behind the strip. Clicking the notch opens it, which is also
+  // what finally gives the notch a reason to take a click at all.
+  const [inbox, setInbox] = useState(false);
+  const hist = useSyncExternalStore(subscribeNotifyHistory, notifyHistory, notifyHistory);
+  const unread = useSyncExternalStore(subscribeNotifyHistory, notifyUnread, () => 0);
+  useEffect(() => { if (inbox) markNotifyRead(); }, [inbox, hist]);
+  useEffect(() => {
+    if (!inbox) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); setInbox(false); } };
+    // Capture, so Escape closes the inbox before the workspace sees it and
+    // closes itself -- one Escape should undo one thing.
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [inbox]);
+
   return (
     // Welded to the very top edge of the screen, not the modal's. It is a
     // property of the window, not of the frame beneath it -- it hangs off the
-    // top of the display the way a notch does, and reads the same no matter
-    // where the workspace frame happens to sit.
+    // top of the display the way a notch does, and the workspace keeps clear of
+    // it rather than the other way round.
+    //
+    // Nothing veils the band it sits in. A black strip across the top read as
+    // one more bar of chrome, which is the opposite of what a notch is: the
+    // backdrop alone is the ground, and the strip is the only object in it.
     <div className="fixed top-0 left-1/2 -translate-x-1/2 pointer-events-none" style={{ zIndex: 10002 }}>
       <motion.div
         layout
         transition={{ type: "spring", stiffness: 520, damping: 38, mass: 0.7 }}
-        className="agx-notch flex items-center overflow-hidden"
-        // Always a notch: only the bottom corners are round, and it stays
-        // welded to the top edge. A toast never rounds it into a floating pill
-        // -- it is the same carved shape whether it is telling the time or
-        // telling you a chat finished.
-        style={{ borderRadius: "0 0 20px 20px" }}
+        // pointer-events: auto, and only here -- the wrapper above stays
+        // none. The strip therefore eats its own clicks instead of letting
+        // them fall through to the backdrop, which is what used to dismiss the
+        // whole workspace when you clicked the clock. Nothing is under it any
+        // more (the frame starts below), so nothing loses a click to it either.
+        // flex-col, and the inbox lives INSIDE this element rather than under
+        // it. Two stacked boxes -- each with its own border, its own width and
+        // a seam where they met -- read as a panel appearing beneath a strip,
+        // however well the reveal was animated. One box that gets taller reads
+        // as the strip itself opening, which is the whole idea of a notch.
+        // `layout` then morphs the size with transforms rather than reflow.
+        className="agx-notch flex flex-col overflow-hidden pointer-events-auto"
+        style={{
+          borderRadius: "0 0 20px 20px",
+          minWidth: inbox ? 420 : undefined,
+          cursor: hist.length ? "pointer" : "default",
+        }}
+        onClick={(e) => { e.stopPropagation(); if (hist.length) setInbox((v) => !v); }}
+        // Only while closed: once the panel is open the tooltip floats over
+        // the list, labelling something you are already looking at.
+        title={hist.length && !inbox ? "notifications" : undefined}
       >
         {/* A wipe, not a fade. The content sweeps in from one side and, when its
             few seconds are up, sweeps out the same way -- a barrido that reads
@@ -277,19 +442,27 @@ export function DynamicIsland() {
               initial={{ clipPath: "inset(0 100% 0 0)" }}
               animate={{ clipPath: "inset(0 0% 0 0)" }}
               exit={{ clipPath: "inset(0 0 0 100%)" }}
+              layout="position"
               transition={{ duration: 0.34, ease: [0.4, 0, 0.2, 1] }}
-              className="flex items-center gap-2.5 px-3.5 h-[34px]"
+              className="flex items-center justify-center gap-2.5 px-3.5 shrink-0 w-full"
+              style={{ height: NOTCH_H }}
             >
               <span
                 className="grid place-items-center rounded-full shrink-0"
-                style={{ width: 20, height: 20, color: note.color, background: `color-mix(in srgb, ${note.color} 18%, transparent)` }}
+                style={{ width: 21, height: 21, color: note.color, background: `color-mix(in srgb, ${note.color} 18%, transparent)` }}
               >
                 <NoteIcon kind={note.kind} />
               </span>
               <span className="flex flex-col leading-none gap-[3px] min-w-0">
-                <span className="text-[12px] font-semibold truncate" style={{ color: "#f4f4f6", maxWidth: 260 }}>{note.title}</span>
-                <span className="text-[10px] truncate" style={{ color: note.color, maxWidth: 260 }}>{note.sub}</span>
+                <span className="text-[12px] font-semibold truncate" style={{ color: "#f4f4f6", maxWidth: 280 }}>{note.title}</span>
+                <span className="text-[10px] truncate" style={{ color: note.color, maxWidth: 280 }}>{note.sub}</span>
               </span>
+              {/* Which app it came from. Only for the mirrored ones: on our own
+                  events it would say "agentglass" to someone already looking
+                  at agentglass. */}
+              {note.kind === "system" && note.app && (
+                <span className="agx-cap shrink-0 pl-1">{note.app}</span>
+              )}
             </motion.div>
           ) : (
             <motion.div
@@ -298,40 +471,95 @@ export function DynamicIsland() {
               animate={{ clipPath: "inset(0 0% 0 0)" }}
               exit={{ clipPath: "inset(0 100% 0 0)" }}
               transition={{ duration: 0.34, ease: [0.4, 0, 0.2, 1] }}
-              className="flex items-center gap-3 px-3.5 h-[34px]"
+              // Centred and full width: once the inbox widens the strip, a
+              // left-aligned readout would drift away from under the clock.
+              className="flex items-center justify-center gap-[7px] px-[11px] shrink-0 w-full"
+              style={{ height: NOTCH_H }}
             >
-              {/* left: live-work pulse, plus a standing "behind" chip when a
-                  branch has fallen behind its upstream. */}
-              <Pulse shells={shells} waiting={waiting} />
+              {/* left: what is actually happening right now. Each pill leaves
+                  entirely when its count is zero -- an idle workspace should
+                  not spend width telling you three things are not happening. */}
+              {shells > 0 && (
+                <Pill cap="SHELLS" title={`${shells} terminal session${shells === 1 ? "" : "s"} running in this workspace`}>
+                  <span className="agx-pip w-1.5 h-1.5 rounded-full" style={{ background: "var(--success)" }} />
+                  <span className="agx-val" style={{ color: "var(--success)" }}>{shells}</span>
+                </Pill>
+              )}
+              {waiting > 0 && (
+                <Pill cap="WAITING" title={`${waiting} chat${waiting === 1 ? "" : "s"} finished or waiting on you`}>
+                  <span style={{ color: "var(--warning)", display: "flex" }}><ChatIcon /></span>
+                  <span className="agx-val" style={{ color: "var(--warning)" }}>{waiting}</span>
+                </Pill>
+              )}
               {behind > 0 && (
-                <span className="flex items-center gap-1" title={`${behind} commit${behind === 1 ? "" : "s"} to pull`}>
-                  <span style={{ color: "var(--info)" }}><NoteIcon kind="pull" /></span>
-                  <span className="text-[10px] font-semibold tabular-nums" style={{ color: "var(--info)" }}>{behind}</span>
-                </span>
+                <Pill cap="TO PULL" title={`${behind} commit${behind === 1 ? "" : "s"} on the upstream you have not pulled`}>
+                  <span style={{ color: "var(--info)", display: "flex" }}><NoteIcon kind="pull" /></span>
+                  <span className="agx-val" style={{ color: "var(--info)" }}>{behind}</span>
+                </Pill>
               )}
 
-              <span className="w-px h-4" style={{ background: "color-mix(in srgb, #fff 12%, transparent)" }} />
+              {/* Unread desktop notifications. A count rather than a dot: "3
+                  waiting" and "one, ages ago" are different situations. */}
+              {unread > 0 && (
+                <Pill cap="INBOX" title={`${unread} notification${unread === 1 ? "" : "s"} since you last looked`}>
+                  <span style={{ color: "var(--primary)", display: "flex" }}><NoteIcon kind="system" /></span>
+                  <span className="agx-val" style={{ color: "var(--primary)" }}>{unread}</span>
+                </Pill>
+              )}
 
-              {/* centre: the clock */}
-              <Lcd {...clock} />
+              {(anyLive || unread > 0) && <span className="agx-sep" />}
 
-              {/* right: plan meters, or a rate-limit note when the upstream is
-                  throttling us -- the meters vanishing looks like a bug. */}
+              {/* centre: the clock, captioned with the meridiem the way the
+                  reference alarm clock captions it. */}
+              <Pill cap={clock.ampm} title={clock.label}>
+                <Lcd text={clock.hhmm} height={20} blink={clock.colon} />
+              </Pill>
+
+              {/* right: the plan windows, or a rate-limit note when the upstream
+                  is throttling us -- the meters vanishing looks like a bug. */}
               {u?.available ? (
                 <>
-                  <span className="w-px h-4" style={{ background: "color-mix(in srgb, #fff 12%, transparent)" }} />
-                  {u.five_hour && <Ring tag="5h" used={u.five_hour.utilization} />}
-                  {u.seven_day && <Ring tag="wk" used={u.seven_day.utilization} />}
+                  <span className="agx-sep" />
+                  {u.five_hour && <MeterPill tag="5H" w={u.five_hour} />}
+                  {u.seven_day && <MeterPill tag="WEEK" w={u.seven_day} />}
                 </>
               ) : rateLimited ? (
                 <>
-                  <span className="w-px h-4" style={{ background: "color-mix(in srgb, #fff 12%, transparent)" }} />
-                  <span className="text-[9px]" style={{ color: "color-mix(in srgb, #fff 50%, transparent)" }}>usage rate-limited</span>
+                  <span className="agx-sep" />
+                  <Pill cap="PLAN" title="the usage endpoint is rate-limiting us; retrying">
+                    <span className="text-[10px]" style={{ color: "color-mix(in srgb, #fff 55%, transparent)" }}>rate-limited</span>
+                  </Pill>
                 </>
               ) : null}
             </motion.div>
           )}
         </AnimatePresence>
+
+        {/* Inside the strip, and mounted plainly -- no AnimatePresence.
+            An exit animation was what made closing lurch: the list stayed
+            mounted at full height while its own animation played, holding the
+            strip tall, and only then did the height snap back. Unmounting at
+            once lets the container's `layout` spring carry the whole close, and
+            overflow:hidden means you never see the content go. */}
+        {inbox && (
+          <motion.div
+            layout="position"
+            className="agx-inbox-body"
+            onClick={(e) => e.stopPropagation()}
+          >
+            <div className="flex items-center gap-2 px-3 pt-1 pb-1.5">
+              <span className="agx-cap">NOTIFICATIONS</span>
+              <span className="agx-cap" style={{ opacity: 0.5 }}>{hist.length}</span>
+              <button className="agx-note-btn ml-auto" onClick={() => { clearNotes(); setInbox(false); }}>clear all</button>
+              <button className="agx-note-btn" onClick={() => setInbox(false)} title="close (Esc)">✕</button>
+            </div>
+            <div className="agx-inbox-list">
+              {hist.map((n) => (
+                <HistoryRow key={n.id} n={n} onGone={() => dismissNote(n.id)} />
+              ))}
+            </div>
+          </motion.div>
+        )}
       </motion.div>
     </div>
   );

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -4,6 +4,7 @@ import { api, type UsagePayload, type UsageWindow } from "../../lib/api.ts";
 import { subscribeUsage, usedColor, usageError, resetLabel } from "../UsageWidget.tsx";
 import { subscribe as subscribeChats, listChats } from "../../lib/chatStore.ts";
 import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
+import { clock24, subscribeClock24 } from "../../lib/clockPref.ts";
 import {
   subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
   markNotifyRead, dismissNote, clearNotes, openNote, type SystemNote,
@@ -52,6 +53,7 @@ const NOTCH_H = 40;
 // ---------------------------------------------------------------------------
 function useClock(): { hhmm: string; ampm: string; colon: boolean; label: string } {
   const [now, setNow] = useState(() => new Date());
+  const h24 = useSyncExternalStore(subscribeClock24, clock24, () => false);
   useEffect(() => {
     let id: ReturnType<typeof setInterval> | null = null;
     const start = () => { if (!id) id = setInterval(() => setNow(new Date()), 1000); };
@@ -61,13 +63,15 @@ function useClock(): { hhmm: string; ampm: string; colon: boolean; label: string
     document.addEventListener("visibilitychange", onVis);
     return () => { stop(); document.removeEventListener("visibilitychange", onVis); };
   }, []);
-  let h = now.getHours();
-  const ampm = h >= 12 ? "PM" : "AM";
-  h = h % 12 || 12;
   const p2 = (n: number) => String(n).padStart(2, "0");
+  const raw = now.getHours();
+  // On 24h the meridiem has nothing to say, and an empty caption would leave
+  // the clock the only pill without a top line. The seconds take the slot —
+  // the one reading the strip doesn't show anywhere else.
+  const h = h24 ? raw : raw % 12 || 12;
   return {
     hhmm: `${p2(h)}:${p2(now.getMinutes())}`,
-    ampm,
+    ampm: h24 ? p2(now.getSeconds()) : raw >= 12 ? "PM" : "AM",
     colon: now.getSeconds() % 2 === 0,
     label: now.toLocaleString([], { weekday: "long", month: "short", day: "numeric", hour: "numeric", minute: "2-digit" }),
   };

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -9,7 +9,7 @@ import { DiffView } from "../ChangesModal.tsx";
 import { DockerView } from "../DockerPanel.tsx";
 import { TermView, subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
 import { ChatView } from "../ChatPanel.tsx";
-import { DynamicIsland } from "./DynamicIsland.tsx";
+import { DynamicIsland, NOTCH_BAND } from "./DynamicIsland.tsx";
 
 const BODY = {
   git: GitView,
@@ -73,7 +73,16 @@ export function Workspace({
               className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.72)" }}
               onClick={onClose}
             />
-            <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
+            {/* The top padding is the notch's band, and the height is clamped
+                so the frame can never grow back into it. Centring alone was not
+                enough: 95vh leaves 2.5vh of clearance, which is 28px on a 1123px
+                window — less than the strip is tall, so it covered the view's
+                header and ate clicks meant for it. Reserving the band makes the
+                overlap zero at every window size instead of at most of them. */}
+            <div
+              className="fixed inset-0 flex items-center justify-center px-3 pb-3 pointer-events-none"
+              style={{ zIndex: 10001, paddingTop: NOTCH_BAND }}
+            >
               <motion.div
                 ref={frameRef}
                 tabIndex={-1}
@@ -85,8 +94,13 @@ export function Workspace({
                 // switch.
                 initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
                 transition={{ duration: 0.12, ease: "easeOut" }}
-                className="w-[95vw] h-[95vh] rounded-2xl flex pointer-events-auto outline-none overflow-hidden"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}
+                className="w-[95vw] rounded-2xl flex pointer-events-auto outline-none overflow-hidden"
+                style={{
+                  height: `min(95vh, calc(100vh - ${NOTCH_BAND + 12}px))`,
+                  background: "var(--bg2)",
+                  border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)",
+                  boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)",
+                }}
               >
                 <ViewRail view={view} onSelect={onView} onClose={onClose} pips={pips} />
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -300,32 +300,190 @@
 
 /* The workspace dynamic island.
  *
- * A near-black notch, so the LCD and the meters read as a lit display carved
- * from the top edge of the frame. It keeps its own dark ground rather than the
- * theme's --bg2, on purpose: an amber/green phosphor only looks like one over
- * black, and the notch is a device, not a panel. */
+ * The one piece of the app pretending to be hardware, and hardware does not
+ * repaint itself when you change your wallpaper. Its ground is true #000 --
+ * not "very dark purple", not --bg2 -- so on an OLED the pixels above the
+ * workspace are genuinely off and the strip runs into the bezel with no seam.
+ * A phosphor readout only looks like one over black, too.
+ *
+ * The theme still gets in, just never on the ground: it tints the lip along
+ * the bottom edge, the dividers, the captions, and the shadow the strip casts.
+ * Swap themes and almost nothing here moves -- that restraint is the point. */
+/* No cast glow and no veil behind it. Both were doing the same wrong thing:
+   spreading the strip's presence past its own edges, so it read as a bar of
+   chrome with a halo instead of a solid object sitting in the dark. What
+   defines it now is a hairline and its own black — nothing outside the
+   silhouette. */
 .agx-notch {
-  background: linear-gradient(180deg, #131316, #0a0a0c);
-  border: 1px solid rgba(255, 255, 255, 0.08);
+  background: linear-gradient(180deg, #000 0%, #000 44%, #08080a 100%);
+  border: 1px solid rgba(255, 255, 255, 0.07);
   border-top: none;
-  box-shadow: 0 14px 34px -12px rgba(0, 0, 0, 0.85), inset 0 -1px 0 0 rgba(255, 255, 255, 0.04);
+  /* A readout, not a document and not a button: no I-beam over the digits, and
+     dragging across it must not paint a text selection. */
+  cursor: default;
+  user-select: none;
+  -webkit-user-select: none;
+  box-shadow: inset 0 -1px 0 0 color-mix(in srgb, var(--primary) 20%, transparent);
+  /* One declaration, not two: a second `transition` further down would silently
+     replace this one and the border-radius would snap. The radius squares off
+     when the inbox attaches beneath. */
+  transition: box-shadow 0.18s ease, border-color 0.18s ease, border-radius 0.18s ease;
+  /* A ceiling, or one long message drags the strip out to the width of the
+     screen. Comfortably wider than the resting readout, so closing never
+     squeezes the pills -- it only stops the inbox from growing sideways. */
+  max-width: min(92vw, 560px);
+}
+/* It is ambient information, not a control, so hovering firms up the hairline
+   rather than offering a button. The pill under the pointer answers with a
+   tint of its own -- enough to say "this thing is reading you" without
+   implying there is something to press. */
+.agx-notch:hover {
+  border-color: rgba(255, 255, 255, 0.14);
+  box-shadow: inset 0 -1px 0 0 color-mix(in srgb, var(--primary) 45%, transparent);
 }
 
-/* Ghost-segment LCD. The lit layer glows; the ghost is the same glyph run at a
-   whisper of opacity so the unlit segments of an all-8s readout show through --
-   the tell of a real digital watch. A hair of skew gives the italic slant those
-   displays have. */
-.agx-lcd {
-  font-family: ui-monospace, "SF Mono", "JetBrains Mono", "Menlo", monospace;
+/* One reading per pill: the caption names it, the value sits under it.
+   Hovering one lights it up and nothing else -- no box, no outline. Drawing a
+   container around the reading under the pointer put a second rectangle inside
+   a strip that is already a rectangle; brightness says the same thing without
+   adding an edge. The name of the thing still comes from the tooltip. */
+.agx-pill {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 4px;
+  padding: 5px 9px;
+  transition: filter 0.15s ease;
+}
+.agx-notch:hover .agx-pill:hover {
+  filter: brightness(1.45);
+}
+.agx-cap {
+  font-size: 7.5px;
+  letter-spacing: 0.13em;
+  text-transform: uppercase;
+  line-height: 1;
+  white-space: nowrap;
+  color: color-mix(in srgb, var(--primary) 30%, rgba(255, 255, 255, 0.46));
+}
+.agx-val {
+  font-size: 11px;
+  font-weight: 600;
+  line-height: 1;
   font-variant-numeric: tabular-nums;
-  transform: skewX(-4deg);
 }
-.agx-lcd-ghost {
-  color: rgba(120, 255, 190, 0.1);
+.agx-sep {
+  width: 1px;
+  align-self: stretch;
+  margin: 9px 0;
+  background: color-mix(in srgb, var(--primary) 34%, rgba(255, 255, 255, 0.07));
 }
-.agx-lcd-lit {
-  color: #bcffd8;
-  text-shadow: 0 0 5px rgba(90, 255, 170, 0.55), 0 0 12px rgba(60, 220, 150, 0.3);
+.agx-bar {
+  position: relative;
+  height: 3px;
+  border-radius: 2px;
+  background: rgba(255, 255, 255, 0.13);
+  overflow: hidden;
+}
+.agx-bar > i {
+  position: absolute;
+  inset: 0 auto 0 0;
+  border-radius: 2px;
+  transition: width 0.5s cubic-bezier(0.4, 0, 0.2, 1);
+}
+
+/* The inbox behind the strip. Continues the notch's shape downward rather than
+   floating over the workspace: same black, same hairline, and only the bottom
+   corners are round, so the strip reads as having grown. */
+/* The inbox is part of the strip, not a panel under it: no border of its own,
+   no background of its own, no width of its own. It is simply what the notch
+   contains once it has grown, which is why the two never read as two things.
+   The only seam is one hairline separating the readout from the list. */
+.agx-inbox-body {
+  width: 100%;
+  border-top: 1px solid rgba(255, 255, 255, 0.06);
+}
+.agx-inbox-list {
+  max-height: 46vh;
+  overflow-y: auto;
+  padding: 0 6px 8px;
+}
+.agx-note-row {
+  padding: 8px 8px;
+  border-radius: 10px;
+}
+.agx-note-body {
+  font-size: 10.5px;
+  line-height: 1.45;
+  color: color-mix(in srgb, #fff 62%, transparent);
+  white-space: pre-wrap;
+  /* Long URLs are one unbreakable word; without this they set the container's
+     minimum width and the strip grows sideways again. */
+  overflow-wrap: anywhere;
+}
+/* Two lines closed. line-clamp rather than nowrap+ellipsis on purpose: it
+   crops vertically, so a long message never contributes its full length to the
+   width calculation. */
+.agx-note-body-clamp {
+  display: -webkit-box;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+  line-clamp: 2;
+  overflow: hidden;
+}
+.agx-note-row + .agx-note-row {
+  border-top: 1px solid rgba(255, 255, 255, 0.05);
+}
+.agx-note-row:hover {
+  background: rgba(255, 255, 255, 0.04);
+}
+/* The one place in the strip that really is a control, so here a pointer and a
+   hover fill are honest rather than misleading. */
+.agx-note-btn {
+  font-size: 10px;
+  line-height: 1;
+  padding: 4px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: color-mix(in srgb, #fff 55%, transparent);
+  transition: background 0.12s ease, color 0.12s ease;
+}
+.agx-note-btn:hover {
+  background: color-mix(in srgb, var(--primary) 22%, transparent);
+  color: #fff;
+}
+/* The link button says where it goes, so it is wider than an icon and belongs
+   under the message rather than in the corner with the row's controls. */
+.agx-note-link {
+  margin-top: 3px;
+  font-size: 10px;
+  line-height: 1;
+  padding: 4px 7px;
+  border-radius: 6px;
+  cursor: pointer;
+  color: var(--primary);
+  background: color-mix(in srgb, var(--primary) 12%, transparent);
+  border: 1px solid color-mix(in srgb, var(--primary) 26%, transparent);
+  transition: background 0.12s ease, border-color 0.12s ease;
+}
+.agx-note-link:hover {
+  background: color-mix(in srgb, var(--primary) 26%, transparent);
+  border-color: color-mix(in srgb, var(--primary) 55%, transparent);
+}
+
+/* Seven-segment digits, drawn rather than typed: mitred bars with a gap at
+   every corner, over a ghost layer of the segments that are off. That ghost is
+   the tell of a real LCD -- on a cheap alarm clock you can always see the unlit
+   bars of the 8 behind whatever digit is showing. */
+.agx-lcd {
+  display: block;
+}
+.agx-seg {
+  fill: rgba(120, 255, 190, 0.085);
+}
+.agx-seg.on {
+  fill: #b8ffd6;
+  filter: drop-shadow(0 0 4px rgba(80, 255, 170, 0.55));
 }
 
 /* The live-work pips breathe when something is running, so a green shell dot is

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -395,6 +395,22 @@
 /* The inbox behind the strip. Continues the notch's shape downward rather than
    floating over the workspace: same black, same hairline, and only the bottom
    corners are round, so the strip reads as having grown. */
+/* A pending request, drawn rather than spelled. Border-only so it costs one
+   element, and paused with every other ambient loop when the page is idle. */
+@keyframes agx-spin { to { transform: rotate(360deg); } }
+.agx-spin {
+  display: inline-block;
+  width: 11px;
+  height: 11px;
+  border-radius: 50%;
+  border: 1.5px solid color-mix(in srgb, var(--primary) 25%, transparent);
+  border-top-color: var(--primary);
+  animation: agx-spin 0.7s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) {
+  .agx-spin { animation-duration: 2s; }
+}
+
 /* The inbox is part of the strip, not a panel under it: no border of its own,
    no background of its own, no width of its own. It is simply what the notch
    contains once it has grown, which is why the two never read as two things.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -11,8 +11,18 @@ const SERVED_BY_API: boolean =
   typeof window !== "undefined" &&
   (window as unknown as { __AGENTGLASS_SAME_ORIGIN__?: boolean }).__AGENTGLASS_SAME_ORIGIN__ === true;
 
+/** The desktop shell's API origin. Needed because the packaged renderer is
+ *  served from `agentglass://app`, whose hostname says nothing about where the
+ *  sidecar listens — `http://${location.hostname}:4000` would resolve to the
+ *  nonsense `http://app:4000`. */
+const DESKTOP_API: string | undefined =
+  typeof window !== "undefined"
+    ? (window as unknown as { agentglass?: { apiOrigin?: string } }).agentglass?.apiOrigin
+    : undefined;
+
 export const SERVER: string =
   (import.meta.env.VITE_CW_SERVER as string | undefined)?.replace(/\/$/, "") ||
+  DESKTOP_API?.replace(/\/$/, "") ||
   (SERVED_BY_API ? location.origin : `http://${location.hostname}:4000`);
 
 /** Auth token for a server that requires one (exposed / multi-user box). Read
@@ -34,12 +44,12 @@ const TOKEN: string = (() => {
 })();
 
 /** Attach the bearer token to fetch headers when one is configured. */
-const authHeaders = (h: Record<string, string> = {}): Record<string, string> =>
+export const authHeaders = (h: Record<string, string> = {}): Record<string, string> =>
   TOKEN ? { ...h, authorization: `Bearer ${TOKEN}` } : h;
 
 /** Append ?token= to URLs a browser can't put a header on: WS upgrades and the
  *  download navigations (export links). */
-const withToken = (url: string): string =>
+export const withToken = (url: string): string =>
   TOKEN ? url + (url.includes("?") ? "&" : "?") + "token=" + encodeURIComponent(TOKEN) : url;
 
 /** Whether this client has a shared-secret token configured. */

--- a/web/src/lib/clockPref.ts
+++ b/web/src/lib/clockPref.ts
@@ -1,0 +1,44 @@
+/**
+ * 12- or 24-hour on the workspace notch.
+ *
+ * Defaults to whatever the machine's locale says rather than to 12h: most of
+ * the world reads 24h, and a clock that starts wrong for the majority is a
+ * setting everyone has to find before the strip is useful. The preference,
+ * once set, wins over the locale — including the case where you want 24h on a
+ * machine set to en-US, which is exactly the case that prompted this.
+ */
+
+const KEY = "agentglass.clock24";
+
+/** What the locale would do, when nothing has been chosen. */
+function localeIs24(): boolean {
+  try {
+    // `hour12` is undefined for locales that use neither convention explicitly,
+    // so fall back to formatting an hour we can recognise: 13:00 stays 13 on a
+    // 24h locale and becomes 1 on a 12h one.
+    const opts = new Intl.DateTimeFormat(undefined, { hour: "numeric" }).resolvedOptions();
+    if (typeof opts.hour12 === "boolean") return !opts.hour12;
+    return /13/.test(new Intl.DateTimeFormat(undefined, { hour: "numeric" }).format(new Date(2020, 0, 1, 13)));
+  } catch { return false; }
+}
+
+export function clock24(): boolean {
+  try {
+    const v = localStorage.getItem(KEY);
+    if (v === "1") return true;
+    if (v === "0") return false;
+  } catch { /* private mode */ }
+  return localeIs24();
+}
+
+const listeners = new Set<() => void>();
+
+export function setClock24(on: boolean) {
+  try { localStorage.setItem(KEY, on ? "1" : "0"); } catch { /* non-fatal */ }
+  for (const fn of listeners) fn();
+}
+
+export function subscribeClock24(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}

--- a/web/src/lib/keybindings.ts
+++ b/web/src/lib/keybindings.ts
@@ -1,0 +1,112 @@
+import { VIEWS, type ViewId } from "../components/workspace/views.ts";
+
+/**
+ * The single-letter shortcuts, and the ability to change them.
+ *
+ * Only the bare letters are rebindable. The modified ones — ⌘1..5, ⌘\, ⌘[/],
+ * ⌘K, ⌘±  — are structural: they are the bindings that keep working while the
+ * caret sits in a composer or a shell, and letting those be reassigned would
+ * let you lock yourself out of the workspace from inside a text field.
+ *
+ * Stored as action → key, not key → action. A key can only be held by one
+ * action, but an action must always have exactly one key, and that is the
+ * invariant worth making unrepresentable.
+ */
+
+export type ActionId =
+  | `view.${ViewId}`
+  | "open.help"
+  | "open.stats"
+  | "open.skills"
+  | "open.search";
+
+export type Binding = { id: ActionId; label: string; hint: string; key: string };
+
+/** Defaults come from VIEWS so the rail, the palette and this cannot drift. */
+export const DEFAULTS: Record<ActionId, string> = {
+  ...(Object.fromEntries(VIEWS.map((v) => [`view.${v.id}`, v.key])) as Record<`view.${ViewId}`, string>),
+  "open.help": "?",
+  "open.stats": "s",
+  "open.skills": "k",
+  "open.search": "/",
+};
+
+export const LABELS: Record<ActionId, { label: string; hint: string }> = {
+  ...(Object.fromEntries(VIEWS.map((v) => [`view.${v.id}`, { label: `Workspace — ${v.label}`, hint: v.hint }])) as Record<`view.${ViewId}`, { label: string; hint: string }>),
+  "open.help": { label: "Legend & shortcuts", hint: "what the colours mean, and every key binding" },
+  "open.stats": { label: "Statistics", hint: "totals, tool latency and cost breakdowns" },
+  "open.skills": { label: "Skills catalog", hint: "every skill the fleet has available" },
+  "open.search": { label: "Search", hint: "find a session, a file or an error" },
+};
+
+const KEY = "agentglass.keybindings";
+
+/**
+ * Keys that may not be bound.
+ *
+ * Escape closes things everywhere and is the way out of a mistake; Enter and
+ * Tab belong to whatever has focus; a bare digit is how the git panel's tabs
+ * are reached. Binding any of them would break something the user cannot then
+ * use the keyboard to fix.
+ */
+const RESERVED = new Set(["Escape", "Enter", "Tab", " ", "0", "1", "2", "3", "4", "5", "6", "7", "8", "9"]);
+
+let cache: Record<ActionId, string> | null = null;
+const listeners = new Set<() => void>();
+
+export function bindings(): Record<ActionId, string> {
+  if (cache) return cache;
+  let stored: Partial<Record<ActionId, string>> = {};
+  try { stored = JSON.parse(localStorage.getItem(KEY) || "{}"); } catch { /* corrupt or absent */ }
+  // Merged over the defaults rather than replacing them: a binding added in a
+  // later version must appear for someone whose stored map predates it, instead
+  // of that action silently having no key at all.
+  cache = { ...DEFAULTS };
+  for (const [id, k] of Object.entries(stored)) {
+    if (id in DEFAULTS && typeof k === "string" && k.length > 0) cache[id as ActionId] = k;
+  }
+  return cache;
+}
+
+/** action for a pressed key, or null. */
+export function actionFor(key: string): ActionId | null {
+  const map = bindings();
+  for (const id of Object.keys(map) as ActionId[]) if (map[id] === key) return id;
+  return null;
+}
+
+export type RebindResult = { ok: true } | { ok: false; error: string };
+
+export function rebind(id: ActionId, key: string): RebindResult {
+  if (!key || key.length !== 1 && !/^[A-Za-z?/]$/.test(key)) {
+    if (key.length !== 1) return { ok: false, error: "pick a single character" };
+  }
+  if (RESERVED.has(key)) return { ok: false, error: `${key === " " ? "space" : key} is reserved` };
+  const map = bindings();
+  const clash = (Object.keys(map) as ActionId[]).find((a) => a !== id && map[a] === key);
+  // Refuse rather than steal: silently unbinding another action leaves you with
+  // a shortcut that stopped working and no clue why.
+  if (clash) return { ok: false, error: `already bound to ${LABELS[clash].label}` };
+  cache = { ...map, [id]: key };
+  persist();
+  return { ok: true };
+}
+
+export function resetBindings() {
+  cache = { ...DEFAULTS };
+  persist();
+}
+
+function persist() {
+  try { localStorage.setItem(KEY, JSON.stringify(cache)); } catch { /* non-fatal */ }
+  for (const fn of listeners) fn();
+}
+
+export function subscribeBindings(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}
+
+/** Whether anything has been changed from the shipped defaults. */
+export const isCustomised = (): boolean =>
+  (Object.keys(DEFAULTS) as ActionId[]).some((id) => bindings()[id] !== DEFAULTS[id]);

--- a/web/src/lib/sysNotify.ts
+++ b/web/src/lib/sysNotify.ts
@@ -1,0 +1,205 @@
+import { SERVER, withToken, authHeaders } from "./api.ts";
+
+/**
+ * Desktop notifications, mirrored onto the notch.
+ *
+ * The server does the reading (it monitors the D-Bus session bus); this is the
+ * client half: a preference, a capability probe, and a socket that only exists
+ * while the preference says it should.
+ *
+ * Three states rather than a toggle, because "show me that Slack pinged me"
+ * and "show me what they said on my screen while I share it" are different
+ * answers. Nothing here is ever persisted beyond the preference itself — the
+ * notes live in memory for the few seconds the notch shows them.
+ */
+
+export type SysNotifyMode = "off" | "titles" | "full";
+export type SystemNote = {
+  id: string;
+  app: string;
+  summary: string;
+  body: string;
+  urgency: 0 | 1 | 2;
+  at: number;
+  /** Present when the notification's own text carried a link. */
+  url?: string;
+};
+export type NotifyCapability = { supported: boolean; reason?: string };
+
+const KEY = "agentglass.sysNotify";
+
+/** Off unless asked for. Reading every notification you receive is not a
+ *  default anyone should be opted into. */
+export function sysNotifyMode(): SysNotifyMode {
+  const v = localStorage.getItem(KEY);
+  return v === "full" || v === "titles" ? v : "off";
+}
+
+export function setSysNotifyMode(m: SysNotifyMode) {
+  localStorage.setItem(KEY, m);
+  for (const fn of modeListeners) fn(m);
+  retune();
+}
+
+const modeListeners = new Set<(m: SysNotifyMode) => void>();
+export function subscribeSysNotifyMode(fn: (m: SysNotifyMode) => void): () => void {
+  modeListeners.add(fn);
+  return () => modeListeners.delete(fn);
+}
+
+// ---------------------------------------------------------------------------
+// Capability. Asked once, cached, and never allowed to reject: a host that
+// cannot do this is a host where the feature is absent, not one where
+// something failed.
+// ---------------------------------------------------------------------------
+
+let capPromise: Promise<NotifyCapability> | null = null;
+
+export function notifyCapability(): Promise<NotifyCapability> {
+  capPromise ??= fetch(SERVER + "/notifications/capability", { headers: authHeaders() })
+    .then((r) => (r.ok ? (r.json() as Promise<NotifyCapability>) : { supported: false, reason: "server does not support it" }))
+    .catch(() => ({ supported: false, reason: "server unreachable" }));
+  return capPromise;
+}
+
+// ---------------------------------------------------------------------------
+// The socket. Opening it is what starts the server's monitor, so it stays shut
+// while the mode is "off" — the feature being off means nothing is watching,
+// not that something is watching quietly.
+// ---------------------------------------------------------------------------
+
+const noteListeners = new Set<(n: SystemNote) => void>();
+let ws: WebSocket | null = null;
+let retry = 0;
+let retryTimer: ReturnType<typeof setTimeout> | null = null;
+
+// ---------------------------------------------------------------------------
+// History.
+//
+// A toast is gone in five seconds, which is fine for "something happened" and
+// useless for "what was it again". This is the list behind the notch: the last
+// few dozen, newest first, in memory only.
+//
+// Deliberately not persisted. The whole feature reads every notification you
+// receive; writing those bodies to disk would turn an ambient mirror into a
+// log of your messages that outlives the session. It dies with the page.
+// ---------------------------------------------------------------------------
+
+const HISTORY_MAX = 60;
+let history: SystemNote[] = [];
+let unread = 0;
+const historyListeners = new Set<() => void>();
+
+export const notifyHistory = (): SystemNote[] => history;
+export const notifyUnread = (): number => unread;
+
+export function subscribeNotifyHistory(fn: () => void): () => void {
+  historyListeners.add(fn);
+  return () => historyListeners.delete(fn);
+}
+
+function historyChanged() {
+  for (const fn of historyListeners) fn();
+}
+
+export function markNotifyRead() {
+  if (!unread) return;
+  unread = 0;
+  historyChanged();
+}
+
+export function dismissNote(id: string) {
+  history = history.filter((n) => n.id !== id);
+  historyChanged();
+}
+
+export function clearNotes() {
+  history = [];
+  unread = 0;
+  historyChanged();
+}
+
+/** Ask the server to open a note's link. It resolves the URL from the note it
+ *  saw itself, so this can never be pointed at an arbitrary address. */
+export async function openNote(id: string): Promise<boolean> {
+  try {
+    const r = await fetch(SERVER + "/notifications/open", {
+      method: "POST",
+      headers: authHeaders({ "content-type": "application/json" }),
+      body: JSON.stringify({ id }),
+    });
+    return r.ok;
+  } catch { return false; }
+}
+
+export function subscribeSystemNotes(fn: (n: SystemNote) => void): () => void {
+  noteListeners.add(fn);
+  retune();
+  return () => {
+    noteListeners.delete(fn);
+    retune();
+  };
+}
+
+/**
+ * Whether the socket should be open.
+ *
+ * The mode alone decides it -- deliberately not "and something is listening".
+ * The notch only exists while the workspace overlay is open, so tying the
+ * socket to it meant agentglass stopped watching the moment you looked at the
+ * dashboard, and a Slack ping in that window was lost with nothing to show it
+ * had ever happened. On means on, for as long as the app is running; the notch
+ * is just the thing that displays what the store already collected.
+ */
+function wanted(): boolean {
+  return sysNotifyMode() !== "off";
+}
+
+function retune() {
+  if (wanted()) void open();
+  else close();
+}
+
+async function open() {
+  if (ws || retryTimer) return;
+  const cap = await notifyCapability();
+  if (!cap.supported || !wanted()) return;
+
+  const sock = new WebSocket(withToken(SERVER.replace(/^http/, "ws") + "/notifications"));
+  ws = sock;
+  sock.onmessage = (ev) => {
+    let n: SystemNote;
+    try { n = JSON.parse(String(ev.data)) as SystemNote; } catch { return; }
+    // Applied here rather than on the server so the choice is the viewer's and
+    // takes effect the instant it is changed, without a reconnect.
+    if (sysNotifyMode() === "titles") n = { ...n, body: "" };
+    history = [n, ...history].slice(0, HISTORY_MAX);
+    unread++;
+    historyChanged();
+    for (const fn of noteListeners) fn(n);
+  };
+  sock.onopen = () => { retry = 0; };
+  sock.onclose = () => {
+    if (ws !== sock) return;
+    ws = null;
+    if (!wanted()) return;
+    // Backing off rather than hammering: the common reason for a close is that
+    // the server went away, and it is not coming back any faster for being
+    // asked every second.
+    const delay = Math.min(30_000, 1000 * 2 ** retry++);
+    retryTimer = setTimeout(() => { retryTimer = null; retune(); }, delay);
+  };
+  sock.onerror = () => { /* onclose does the recovery */ };
+}
+
+function close() {
+  if (retryTimer) { clearTimeout(retryTimer); retryTimer = null; }
+  const sock = ws;
+  ws = null;
+  sock?.close();
+}
+
+// Connect as soon as this module is loaded, if the preference says so, rather
+// than waiting for something to subscribe. Off still means off: retune() opens
+// nothing unless the mode allows it, so the D-Bus monitor stays unspawned.
+retune();

--- a/web/test/keybindings.test.ts
+++ b/web/test/keybindings.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it } from "bun:test";
+
+/**
+ * The bindings store, exercised through a stand-in localStorage.
+ *
+ * The rules worth pinning down are the ones that stop the keyboard becoming
+ * unusable: a key belongs to exactly one action, the escape hatches cannot be
+ * taken, and an action always has a key even if the stored map predates it.
+ */
+const store = new Map<string, string>();
+(globalThis as unknown as { localStorage: Storage }).localStorage = {
+  getItem: (k: string) => store.get(k) ?? null,
+  setItem: (k: string, v: string) => void store.set(k, v),
+  removeItem: (k: string) => void store.delete(k),
+  clear: () => store.clear(),
+  key: () => null,
+  length: 0,
+} as unknown as Storage;
+
+const load = async () => {
+  // Fresh module per test: the store caches, which is the point of it.
+  const mod = await import(`../src/lib/keybindings.ts?t=${Math.random()}`);
+  return mod as typeof import("../src/lib/keybindings.ts");
+};
+
+beforeEach(() => store.clear());
+
+describe("keybindings", () => {
+  it("starts on the shipped defaults", async () => {
+    const kb = await load();
+    expect(kb.bindings()["view.term"]).toBe("t");
+    expect(kb.bindings()["open.stats"]).toBe("s");
+    expect(kb.isCustomised()).toBe(false);
+  });
+
+  it("resolves a key to its action", async () => {
+    const kb = await load();
+    expect(kb.actionFor("g")).toBe("view.git");
+    expect(kb.actionFor("¬")).toBe(null);
+  });
+
+  it("rebinds, and the new key resolves", async () => {
+    const kb = await load();
+    expect(kb.rebind("view.term", "y")).toEqual({ ok: true });
+    expect(kb.actionFor("y")).toBe("view.term");
+    expect(kb.actionFor("t")).toBe(null);
+    expect(kb.isCustomised()).toBe(true);
+  });
+
+  it("refuses a key another action already holds, rather than stealing it", async () => {
+    const kb = await load();
+    const r = kb.rebind("view.term", "g");
+    expect(r.ok).toBe(false);
+    // Silently unbinding the other one leaves a shortcut that stopped working
+    // with nothing to say why.
+    expect(kb.actionFor("g")).toBe("view.git");
+  });
+
+  it("refuses the keys that are the way out of a mistake", async () => {
+    const kb = await load();
+    for (const k of ["Escape", "Enter", "Tab", "1"]) {
+      expect(kb.rebind("view.term", k).ok).toBe(false);
+    }
+    expect(kb.actionFor("t")).toBe("view.term");
+  });
+
+  it("gives a new action its default even when the stored map predates it", async () => {
+    store.set("agentglass.keybindings", JSON.stringify({ "view.git": "q" }));
+    const kb = await load();
+    expect(kb.bindings()["view.git"]).toBe("q");      // the stored choice stands
+    expect(kb.bindings()["open.search"]).toBe("/");   // and the rest are not lost
+  });
+
+  it("ignores a corrupt stored map instead of throwing", async () => {
+    store.set("agentglass.keybindings", "{not json");
+    const kb = await load();
+    expect(kb.bindings()["view.term"]).toBe("t");
+  });
+
+  it("reset puts every default back", async () => {
+    const kb = await load();
+    kb.rebind("view.term", "y");
+    kb.resetBindings();
+    expect(kb.bindings()["view.term"]).toBe("t");
+    expect(kb.isCustomised()).toBe(false);
+  });
+});


### PR DESCRIPTION
First of four stacked PRs from a day of work on the workspace. **Merge in order** — each is based on the one before, and GitHub will retarget the next to `main` as this lands.

### What's here

**The desktop app starts, stays started, and stops cleanly.** Electron refused to launch on any distro restricting unprivileged user namespaces because `chrome-sandbox` lost its setuid bit on install; the installer now preserves it and grants it when missing. The sidecar is stopped on every exit path rather than only the graceful one, so a second launch no longer adopts a stale server holding the port. And the window is shown before the server is awaited, because a blank rectangle for several seconds reads as a crash.

**The UI is served from a stable origin.** It was on an ephemeral loopback port, and `localStorage` is keyed by origin — so every preference was silently forgotten whenever the port changed. It now uses a privileged custom scheme, which also became the basis for the strictest gate in the server.

**A notch that mirrors desktop notifications.** Slack and the rest are invisible in fullscreen; this puts them on a strip above the workspace. True black rather than the theme's background, so it blends into an OLED bezel. Capability-probed on the server: an unsupported platform degrades to a notch with no inbox instead of a broken one.

**Rebindable single-key shortcuts**, with reserved keys and a refusal on clashes rather than silently stealing a binding from another action.

### Verification

`298 tests pass`, typecheck clean at this commit. Verified on the running app rather than asserted: notification capture end to end over D-Bus, and preferences surviving a restart.

🤖 Generated with [Claude Code](https://claude.com/claude-code)