### PR TITLE
Git: sync from base, resolve conflicts, and undo a merge

### DIFF
--- a/electron/install-local.sh
+++ b/electron/install-local.sh
@@ -22,6 +22,27 @@ rm -rf "$APP"
 cp -r "$SRC" "$APP"
 ln -sf "$APP/agentglass" "$BIN/agentglass"
 
+# Chromium won't run unsandboxed: it wants chrome-sandbox owned by root with
+# the setuid bit, and the namespace sandbox it would otherwise fall back to is
+# disabled on Ubuntu 24.04+ (kernel.apparmor_restrict_unprivileged_userns=1).
+# So this is not optional there — without it the app aborts at launch instead
+# of opening a window. The cp above gives the helper our uid and starts from a
+# clean dir, so it has to be re-applied on every install.
+#
+# Never fatal, and kept out of `set -e`'s reach by living in `if` conditions:
+# leaving a half-installed app with no launcher would be worse than one that
+# needs a single manual command.
+sandbox_ok=false
+if sudo -n true 2>/dev/null || [ -t 0 ]; then
+  if sudo chown root:root "$APP/chrome-sandbox" && sudo chmod 4755 "$APP/chrome-sandbox"; then
+    sandbox_ok=true
+  fi
+fi
+if [ "$sandbox_ok" = false ]; then
+  echo "warn: chrome-sandbox needs root, or the app will abort at launch. Run:" >&2
+  echo "  sudo chown root:root $APP/chrome-sandbox && sudo chmod 4755 $APP/chrome-sandbox" >&2
+fi
+
 install -m644 "$HERE/icons/icon-512.png" "$APP/icon.png" 2>/dev/null || true
 cat > "$DESKTOP/agentglass.desktop" <<EOF
 [Desktop Entry]

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -326,10 +326,23 @@ async function main() {
         return false;
       };
 
-      if (!(await pressUntilView("d", "diff"))) failures.push(`[workspace] "d" should select diff, selected ${await selectedView()}`);
-      if (!(await pressUntilView("t", "term"))) failures.push(`[workspace] "t" should select term, selected ${await selectedView()}`);
-      // ⌘1 works even from inside a field
+      // Inside the workspace, navigation carries a modifier. VIEWS order is
+      // git, diff, docker, term, chat — so ⌘2 and ⌘4.
+      if (!(await pressUntilView("2", "diff", true))) failures.push(`[workspace] Ctrl-2 should select diff, selected ${await selectedView()}`);
+      if (!(await pressUntilView("4", "term", true))) failures.push(`[workspace] Ctrl-4 should select term, selected ${await selectedView()}`);
       if (!(await pressUntilView("1", "git", true))) failures.push(`[workspace] Ctrl-1 should select git, selected ${await selectedView()}`);
+
+      // And the property this replaced a heuristic to guarantee: a bare letter
+      // inside the workspace belongs to whatever has focus — a shell, a commit
+      // message — and must never navigate. It used to, whenever focus happened
+      // to sit on <body>, which is why typing `g` in the terminal jumped to git
+      // at random. Pressed with focus deliberately on the body: the worst case
+      // for the old guard.
+      await evaluate(`document.activeElement?.blur?.(); document.body.focus?.(); true`);
+      await press("d");
+      await Bun.sleep(400);
+      const afterBare = await selectedView();
+      if (afterBare !== "git") failures.push(`[workspace] a bare letter must not navigate inside the workspace — "d" moved to ${afterBare}`);
 
       // Poll rather than check once: closing runs an AnimatePresence exit
       // animation, so the rail outlives the state change by a few hundred ms.

--- a/server/src/editor.ts
+++ b/server/src/editor.ts
@@ -14,8 +14,8 @@
 // up — which matters, because a feature that needs setup is a feature nobody
 // turns on.
 
-import { readdirSync, statSync } from "node:fs";
-import { join } from "node:path";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { dirname, join } from "node:path";
 import { homedir } from "node:os";
 import { safeAbs } from "./git.ts";
 import { inScope } from "./config.ts";
@@ -82,27 +82,73 @@ async function ask(sock: string, expr: string): Promise<string> {
  * `orbit-WEB-1042` would be worse than opening a new window — it lands in
  * someone else's session, silently.
  */
-async function socketFor(absPath: string): Promise<{ sock: string | null; otherCwds: string[]; stuck: number }> {
+/**
+ * The repository family a path belongs to: the main checkout's path, shared by
+ * a repo and all of its linked worktrees.
+ *
+ * A worktree lives in a *sibling* directory — `orbit` and `orbit-WEB-1042` —
+ * so no prefix test will ever relate them, which is why an nvim open on the
+ * main checkout refused files from a worktree of the same project.
+ *
+ * `.git` is a directory in a normal checkout and a file in a linked worktree,
+ * and that file names the main repo: `gitdir: /path/to/main/.git/worktrees/x`.
+ * That is the whole trick, and it needs no subprocess.
+ */
+function familyOf(absPath: string): string | null {
+  let dir = absPath;
+  for (let i = 0; i < 40; i++) {
+    const dotGit = join(dir, ".git");
+    try {
+      const st = statSync(dotGit);
+      if (st.isDirectory()) return dir;
+      if (st.isFile()) {
+        const m = /gitdir:\s*(.+)/.exec(readFileSync(dotGit, "utf8"));
+        const g = m?.[1]?.trim();
+        const wt = g ? /^(.*)\/\.git\/worktrees\//.exec(g) : null;
+        return wt?.[1] ?? dir;
+      }
+    } catch { /* keep walking up */ }
+    const up = dirname(dir);
+    if (up === dir) return null;
+    dir = up;
+  }
+  return null;
+}
+
+async function socketFor(absPath: string): Promise<{ sock: string | null; otherCwds: string[]; stuck: number; viaFamily: string | null }> {
   // All at once: probing serially means the worst case is the sum of every
   // stuck editor's timeout, and the whole point of the timeout is to bound it.
   const socks = nvimSockets();
   const cwds = await Promise.all(socks.map((s) => ask(s, "getcwd()")));
   const otherCwds: string[] = [];
+  const family: { sock: string; cwd: string }[] = [];
+  const mine = familyOf(absPath);
   let stuck = 0;
   for (let i = 0; i < socks.length; i++) {
     const cwd = cwds[i];
     if (!cwd) { stuck++; continue; } // dead or wedged — left behind by a crash
-    if (absPath === cwd || absPath.startsWith(cwd.replace(/\/$/, "") + "/")) return { sock: socks[i], otherCwds, stuck };
-    otherCwds.push(cwd);
+    // The editor actually rooted in this checkout always wins.
+    if (absPath === cwd || absPath.startsWith(cwd.replace(/\/$/, "") + "/")) {
+      return { sock: socks[i], otherCwds, stuck, viaFamily: null };
+    }
+    // Otherwise remember it if it is the same project by another checkout: one
+    // worktree per ticket means the nvim you have open is often the main one,
+    // and refusing there sent you to the clipboard for a file that editor can
+    // open perfectly well.
+    if (mine && familyOf(cwd) === mine) family.push({ sock: socks[i], cwd });
+    else otherCwds.push(cwd);
   }
-  return { sock: null, otherCwds, stuck };
+  // Deliberately after the loop, so a later exact match still beats an earlier
+  // family one however the sockets happen to be ordered.
+  if (family.length) return { sock: family[0]!.sock, otherCwds, stuck, viaFamily: family[0]!.cwd };
+  return { sock: null, otherCwds, stuck, viaFamily: null };
 }
 
 /** Escape for the inside of a `:edit` typed into nvim. */
 const esc = (p: string) => p.replace(/([ \\|"'%#])/g, "\\$1");
 
 export type OpenResult =
-  | { ok: true; how: "remote"; socket: string }
+  | { ok: true; how: "remote"; socket: string; viaFamily?: string }
   /** Nothing reachable for this file. `otherCwds` names the editors that ARE
    *  running elsewhere — "no nvim running" is a lie when one is open two panes
    *  away, and the real reason (it's editing another repo) is the useful one. */
@@ -126,7 +172,7 @@ export async function openInEditor(pathIn: unknown, lineIn: unknown): Promise<Op
   try { statSync(abs); } catch { return { ok: false, error: "file does not exist" }; }
   const line = Math.max(1, Math.min(10_000_000, Math.floor(Number(lineIn)) || 1));
 
-  const { sock, otherCwds, stuck } = await socketFor(abs);
+  const { sock, otherCwds, stuck, viaFamily } = await socketFor(abs);
   if (sock) {
     // <C-\><C-N> first: the editor may be in insert or terminal mode, and a
     // bare `:edit` typed into insert mode inserts the literal text instead.
@@ -136,7 +182,7 @@ export async function openInEditor(pathIn: unknown, lineIn: unknown): Promise<Op
       const timer = setTimeout(() => { try { proc.kill(); } catch { /* gone */ } }, 2000);
       await proc.exited;
       clearTimeout(timer);
-      return { ok: true, how: "remote", socket: sock };
+      return { ok: true, how: "remote", socket: sock, ...(viaFamily ? { viaFamily } : {}) };
     } catch { /* fall through to spawning one */ }
   }
 

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1060,6 +1060,34 @@ export function mergeContinue(rootIn: unknown): GitActionResult {
   return run(root, ["commit", "--no-edit"]);
 }
 
+/**
+ * What you can sensibly merge from.
+ *
+ * Local heads *and* remote-tracking refs, because the default base is a remote
+ * one — `origin/master`, the master that has actually been fetched. Offering
+ * only local branches meant the picker's `master` was a different, usually
+ * staler commit than the base it was replacing, and nothing said so.
+ *
+ * Remotes first: on a repo where every branch is a ticket, the thing you merge
+ * from is nearly always upstream.
+ */
+export function baseCandidates(rootIn: unknown): { ok: boolean; refs: { name: string; remote: boolean }[] } {
+  const root = repoRoot(rootIn);
+  if (!root) return { ok: false, refs: [] };
+  const read = (ref: string) =>
+    git(root, ["for-each-ref", "--sort=-committerdate", ref, "--format=%(refname:short)"])
+      .stdout.split("\n").filter(Boolean);
+  // Drop `origin/HEAD` and the bare `origin` symref: neither is a branch you
+  // merge from, and the bare one reads as if it were.
+  const remotes = read("refs/remotes").filter((n) => !n.endsWith("/HEAD") && n.includes("/"));
+  const locals = read("refs/heads");
+  const seen = new Set<string>();
+  const refs: { name: string; remote: boolean }[] = [];
+  for (const n of remotes) if (!seen.has(n)) { seen.add(n); refs.push({ name: n, remote: true }); }
+  for (const n of locals) if (!seen.has(n)) { seen.add(n); refs.push({ name: n, remote: false }); }
+  return { ok: true, refs };
+}
+
 export function worktrees(rootIn: unknown): GitWorktree[] {
   const root = repoRoot(rootIn);
   if (!root) return [];

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -176,6 +176,7 @@ function branchInfo(root: string): GitBranchInfo {
     name, upstream, ahead, behind, detached, state: treeState(root),
     base,
     behindBase: base ? behindBase(root, name, base) : 0,
+    canUndoMerge: undoableMerge(root, ahead, upstream),
   };
 }
 
@@ -1091,6 +1092,48 @@ export function baseCandidates(rootIn: unknown): { ok: boolean; refs: { name: st
   for (const n of remotes) if (!seen.has(n)) { seen.add(n); refs.push({ name: n, remote: true }); }
   for (const n of locals) if (!seen.has(n)) { seen.add(n); refs.push({ name: n, remote: false }); }
   return { ok: true, refs };
+}
+
+/**
+ * Is the tip an undoable merge?
+ *
+ * Three conditions, all about not destroying anything you cannot get back:
+ *
+ *  - the tip is a merge commit (two parents), so there is a "before" to return
+ *    to that is exactly the branch as it was;
+ *  - nothing is committed on top of it, which the first condition already
+ *    guarantees — a later commit would be the tip instead;
+ *  - it has not been pushed. Rewriting local history is free; rewriting
+ *    published history is somebody else's problem tomorrow.
+ *
+ * A dirty tree disqualifies it too: the undo is a hard reset, and there is no
+ * version of "discard your uncommitted work as a side effect" worth offering.
+ */
+export function undoableMerge(root: string, ahead: number, upstream: string | null): boolean {
+  // Pushed work is never undone this way. `ahead` is already computed for the
+  // header, so this costs nothing for a branch level with its remote.
+  //
+  // No upstream at all is the *safest* case, not the most dangerous: nothing
+  // has been published anywhere, so there is nobody to surprise. Reading
+  // ahead===0 as "already pushed" got that exactly backwards and refused the
+  // one situation where the undo is unambiguously free.
+  if (upstream && ahead < 1) return false;
+  const parents = git(root, ["rev-list", "--parents", "-n", "1", "HEAD"]).stdout.trim().split(/\s+/);
+  if (parents.length < 3) return false; // sha + two parents = a merge
+  return !git(root, ["status", "--porcelain"]).stdout.trim();
+}
+
+/** Put the branch back exactly as it stood before its last merge. */
+export function undoMerge(rootIn: unknown): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  // Re-checked here, never trusted from the client: this is a hard reset, and
+  // these conditions are the only thing making it safe.
+  const info = branchInfo(root);
+  if (!undoableMerge(root, info.ahead, info.upstream)) {
+    return { ok: false, error: "nothing to undo — the tip is not an unpushed merge, or the tree is dirty" };
+  }
+  return run(root, ["reset", "--hard", "HEAD^1"]);
 }
 
 export function worktrees(rootIn: unknown): GitWorktree[] {

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -519,6 +519,11 @@ function run(root: string, args: string[]): GitActionResult {
   // against a header that already said the branch was up to date. Nothing
   // re-fetched afterwards, so it stayed wrong until the next action.
   invalidateRepos(root);
+  // And the behind-the-base counts. They have their own 15s TTL, so after a
+  // sync the header went on advertising "↓370" against a branch that had just
+  // taken those very commits — while the push count beside it had already
+  // updated, which is worse than both being stale.
+  behindCache.clear();
   // One signal out to every panel. Without it each of them discovered the
   // change on its own clock — 5s, 90s, or not until it was remounted.
   try { onGitChange?.(); } catch { /* a broken listener must not fail the op */ }

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -169,7 +169,14 @@ function branchInfo(root: string): GitBranchInfo {
     behind = Number(c[0]) || 0;
     ahead = Number(c[1]) || 0;
   }
-  return { name, upstream, ahead, behind, detached, state: treeState(root) };
+  // What this branch was cut from, and how far it has drifted — the header's
+  // "sync" affordance. Cheap and cached; nothing here is per-branch fan-out.
+  const base = detached ? null : baseOf(root, name);
+  return {
+    name, upstream, ahead, behind, detached, state: treeState(root),
+    base,
+    behindBase: base ? behindBase(root, name, base) : 0,
+  };
 }
 
 /** Full working-tree state for one repo. */

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1004,6 +1004,62 @@ export function syncFromBase(dirIn: unknown, baseIn?: unknown): GitActionResult 
   return run(dir, ["merge", "--no-edit", base]);
 }
 
+/**
+ * Files git has left conflicted, from `--diff-filter=U`.
+ *
+ * A conflicted file is not "modified": it is a file git has stopped in the
+ * middle of and will not commit until you say what it should contain. The
+ * working-tree lists showed them alongside ordinary edits with no way to tell,
+ * which is how you end up committing a file with `<<<<<<<` in it.
+ */
+export function conflicts(rootIn: unknown): { ok: boolean; state: GitTreeState; files: string[]; error?: string } {
+  const root = repoRoot(rootIn);
+  if (!root) return { ok: false, state: "clean", files: [], error: "not a git repository root" };
+  const r = git(root, ["diff", "--name-only", "--diff-filter=U", "-z"]);
+  const files = r.stdout.split("\u0000").filter(Boolean).map((rel) => join(root, rel));
+  return { ok: true, state: treeState(root), files };
+}
+
+/** Take one side of a conflicted file wholesale, and stage it — the two
+ *  resolutions that need no editor and cover most conflicts (a lockfile, a
+ *  generated migration, a file the other branch deleted). */
+export function resolveWith(rootIn: unknown, relIn: unknown, side: unknown): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  if (side !== "ours" && side !== "theirs") return { ok: false, error: "side must be ours or theirs" };
+  const rels = validRels(root, Array.isArray(relIn) ? relIn : [relIn]);
+  if (!rels?.length) return { ok: false, error: "invalid path" };
+  const co = run(root, ["checkout", `--${side}`, "--", ...rels]);
+  if (!co.ok) return co;
+  return run(root, ["add", "--", ...rels]);
+}
+
+/** Abandon the merge and put the tree back exactly as it was. The only move
+ *  that is always safe, and the one someone reaches for first. */
+export function mergeAbort(rootIn: unknown): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  const state = treeState(root);
+  if (state === "rebasing") return run(root, ["rebase", "--abort"]);
+  if (state === "cherry-picking") return run(root, ["cherry-pick", "--abort"]);
+  if (state === "reverting") return run(root, ["revert", "--abort"]);
+  return run(root, ["merge", "--abort"]);
+}
+
+/** Finish once every conflict is staged. Refuses while any remain rather than
+ *  letting git fail with a message nobody reads. */
+export function mergeContinue(rootIn: unknown): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  const left = git(root, ["diff", "--name-only", "--diff-filter=U"]).stdout.trim();
+  if (left) return { ok: false, error: `still conflicted: ${left.split("\n").length} file(s) to resolve` };
+  const state = treeState(root);
+  if (state === "rebasing") return run(root, ["-c", "core.editor=true", "rebase", "--continue"]);
+  if (state === "cherry-picking") return run(root, ["-c", "core.editor=true", "cherry-pick", "--continue"]);
+  // `merge --continue` needs an editor; --no-edit keeps git's own message.
+  return run(root, ["commit", "--no-edit"]);
+}
+
 export function worktrees(rootIn: unknown): GitWorktree[] {
   const root = repoRoot(rootIn);
   if (!root) return [];

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -330,6 +330,13 @@ const REPO_CACHE_MS = 5_000;
 // sweep plus a git subprocess per repo).
 const repoCache = new Map<string, { at: number; repos: GitRepoRef[] }>();
 
+/** Drop cached repo listings touching `root`. Keys are scope-dependent and a
+ *  worktree's counts live in its parent's listing too, so this clears the lot:
+ *  the list is one directory sweep and is about to be asked for again anyway. */
+export function invalidateRepos(_root?: string): void {
+  repoCache.clear();
+}
+
 export async function discoverRepos(paths: string[], knownRoots: string[] = [], opts: { ignoreScope?: boolean } = {}): Promise<GitRepoRef[]> {
   // The workspace is part of the key: switching projects at runtime must not
   // serve the old scope's answer for the next five seconds.
@@ -485,12 +492,29 @@ function validRels(root: string, rels: unknown): string[] | null {
   return out;
 }
 
+/**
+ * Told when a repository mutates, so the server can push a nudge to every
+ * client. A hook rather than an import: gitwork must not depend on the HTTP
+ * layer, and this keeps the direction of that dependency honest.
+ */
+let onGitChange: (() => void) | null = null;
+export function setGitChangeHook(fn: (() => void) | null): void { onGitChange = fn; }
+
 function run(root: string, args: string[]): GitActionResult {
   const r = git(root, args);
   // Every mutating path goes through here, so this is the one place that has to
   // know the merged-set may have moved — rather than each of the twenty callers
   // remembering to say so.
   invalidateMerged(root);
+  // And the repo list, for the same reason. It is cached for 5s, and the panel
+  // re-fetches the instant an action returns — so a pull answered from the
+  // cache written moments earlier, and the picker went on showing "behind 351"
+  // against a header that already said the branch was up to date. Nothing
+  // re-fetched afterwards, so it stayed wrong until the next action.
+  invalidateRepos(root);
+  // One signal out to every panel. Without it each of them discovered the
+  // change on its own clock — 5s, 90s, or not until it was remounted.
+  try { onGitChange?.(); } catch { /* a broken listener must not fail the op */ }
   if (r.code !== 0) return { ok: false, error: r.stderr.trim() || r.stdout.trim() || `git ${args[0]} failed`, output: (r.stdout + r.stderr).trim() };
   return { ok: true, output: (r.stdout + r.stderr).trim() };
 }
@@ -898,6 +922,81 @@ export function logGraph(rootIn: unknown, limit = 400): { lines: GitGraphLine[] 
 }
 
 // --- worktrees (the user's per-card unit of work) ----------------------------
+/**
+ * The branch this one was cut from — what a PR would call its base.
+ *
+ * Git does not record it. `@{upstream}` is the *remote* tracking branch, not
+ * the branch the work forked off, and nothing else in the repository stores
+ * the answer: it lives in the pull request, on a server we are not talking to.
+ *
+ * So: an explicit answer if there is one, the trunk otherwise. The override is
+ * written to the repository's own config (`branch.<name>.agentglassbase`), so
+ * it survives restarts, travels with the checkout, and can be read or changed
+ * with plain `git config` by someone who has never heard of this app.
+ *
+ * Deliberately not inferred by walking merge-bases against every other branch:
+ * that is one subprocess per branch for a guess that is wrong exactly when
+ * branches are stacked — the case where being wrong costs you a bad merge.
+ */
+export function baseOf(root: string, branch: string): string | null {
+  if (!branch || branch === "(detached)") return null;
+  const cfg = git(root, ["config", "--get", `branch.${branch}.agentglassbase`]).stdout.trim();
+  if (cfg && validRef(cfg) && git(root, ["rev-parse", "--verify", "--quiet", cfg]).code === 0) return cfg;
+  const trunk = defaultBranch(root);
+  // A branch is not its own base; the trunk checkout simply has none.
+  if (!trunk || trunk === branch || trunk.replace(/^origin\//, "") === branch) return null;
+  return trunk;
+}
+
+export function setBase(rootIn: unknown, branch: unknown, base: unknown): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  if (typeof branch !== "string" || !validRef(branch)) return { ok: false, error: "invalid branch" };
+  if (base === null || base === "") return run(root, ["config", "--unset", `branch.${branch}.agentglassbase`]);
+  if (typeof base !== "string" || !validRef(base)) return { ok: false, error: "invalid base" };
+  return run(root, ["config", `branch.${branch}.agentglassbase`, base]);
+}
+
+/** How many commits the base has that this branch does not. Cached: it moves
+ *  only when something fetches or merges, and these views poll. */
+const BEHIND_TTL_MS = 15_000;
+const behindCache = new Map<string, { at: number; n: number }>();
+export function behindBase(root: string, branch: string, base: string): number {
+  const key = `${root}\u0000${branch}\u0000${base}`;
+  const hit = behindCache.get(key);
+  if (hit && Date.now() - hit.at < BEHIND_TTL_MS) return hit.n;
+  const r = git(root, ["rev-list", "--count", `${branch}..${base}`]);
+  const n = r.code === 0 ? Number(r.stdout.trim()) || 0 : 0;
+  if (behindCache.size > 400) behindCache.clear();
+  behindCache.set(key, { at: Date.now(), n });
+  return n;
+}
+
+/**
+ * Bring the base's commits into a checkout — "update from base", the action a
+ * pull request page offers as "Update branch".
+ *
+ * A merge, not a rebase. Rebase rewrites commits that may already be pushed,
+ * which turns a one-click convenience into a force-push and somebody else's
+ * bad afternoon. The merge runs *in the worktree that has the branch checked
+ * out*, which is what makes this possible at all: you cannot merge into a
+ * branch you are not on, and a worktree per card means every branch is on one.
+ */
+export function syncFromBase(dirIn: unknown, baseIn?: unknown): GitActionResult {
+  const dir = repoRoot(dirIn); if (!dir) return { ok: false, error: "not a git repository root" };
+  const g = guard(dir); if (g) return g;
+  const branch = currentBranch(dir);
+  if (!branch || branch === "(detached)") return { ok: false, error: "this checkout is not on a branch" };
+  const base = typeof baseIn === "string" && baseIn ? baseIn : baseOf(dir, branch);
+  if (!base) return { ok: false, error: "no base branch is known for this checkout" };
+  if (!validRef(base)) return { ok: false, error: "invalid base" };
+  // Refuse on a dirty tree rather than merging over uncommitted work: git would
+  // usually stop anyway, but "usually" is not a promise worth making with
+  // somebody's changes.
+  if (git(dir, ["status", "--porcelain"]).stdout.trim()) return { ok: false, error: "commit or stash your changes first" };
+  return run(dir, ["merge", "--no-edit", base]);
+}
+
 export function worktrees(rootIn: unknown): GitWorktree[] {
   const root = repoRoot(rootIn);
   if (!root) return [];
@@ -919,6 +1018,13 @@ export function worktrees(rootIn: unknown): GitWorktree[] {
     else if (line.startsWith("locked")) cur.locked = true;
   }
   flush();
+  // How far each checkout has drifted from what it was branched off. One
+  // rev-list per worktree, cached, and only for the ones on a real branch.
+  for (const w of out) {
+    const base = w.branch === "(detached)" ? null : baseOf(root, w.branch);
+    w.base = base;
+    w.behindBase = base ? behindBase(root, w.branch, base) : 0;
+  }
   return out;
 }
 export function addWorktree(rootIn: string, pathIn: unknown, branch: string, newBranch: boolean): GitActionResult {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -32,7 +32,7 @@ import {
   branches as gitBranches, checkout as gitCheckout, createBranch, deleteBranch,
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
-  worktrees as gitWorktrees, addWorktree, removeWorktree, startAutoFetch,
+  worktrees as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
   remotes as gitRemotes, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
 import { recent as gitCommandLog } from "./gitlog.ts";
@@ -177,6 +177,10 @@ const ALLOWED_HOSTS = new Set(
   (process.env.AGENTGLASS_ALLOWED_HOSTS || "").split(",").map((h) => h.trim().toLowerCase()).filter(Boolean)
 );
 const trustedHost = (url: URL) => isPrivate(url.hostname) || ALLOWED_HOSTS.has(url.hostname.toLowerCase());
+
+// Every git mutation nudges the clients that are showing git state. Registered
+// here rather than in gitwork so that module stays unaware of the socket.
+setGitChangeHook(() => broadcast({ type: "git" }));
 
 function broadcast(frame: WsFrame) {
   const msg = JSON.stringify(frame);
@@ -548,6 +552,10 @@ const server = Bun.serve<WsData>({
         case "/git/reset": res = resetTo(root, String(b.ref || ""), b.mode); break;
         case "/git/worktree-add": res = addWorktree(root, b.path, String(b.branch || ""), !!b.newBranch); break;
         case "/git/worktree-remove": res = removeWorktree(root, b.path, !!b.force); break;
+        // `root` here is the checkout being updated — a worktree updates
+        // itself, because the merge has to run where the branch is checked out.
+        case "/git/sync-base": res = syncFromBase(root, b.base); break;
+        case "/git/set-base": res = setBase(root, b.branch, b.base ?? null); break;
         default: res = null;
       }
       if (res) return json(res, res.ok ? 200 : 400);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
   worktrees as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
-  conflicts as gitConflicts, resolveWith, mergeAbort, mergeContinue,
+  conflicts as gitConflicts, resolveWith, mergeAbort, mergeContinue, baseCandidates,
   remotes as gitRemotes, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
 import { recent as gitCommandLog } from "./gitlog.ts";
@@ -496,6 +496,7 @@ const server = Bun.serve<WsData>({
     if (pathname === "/git/graph") return json(logGraph(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 400)));
     if (pathname === "/git/worktrees") return json({ worktrees: gitWorktrees(url.searchParams.get("root") || "") });
     if (pathname === "/git/conflicts") return json(gitConflicts(url.searchParams.get("root") || ""));
+    if (pathname === "/git/base-candidates") return json(baseCandidates(url.searchParams.get("root") || ""));
     if (pathname === "/git/log") return json({ commits: gitLog(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 100)) });
     if (pathname === "/git/commit-diff") return json({ changes: commitDiff(url.searchParams.get("root") || "", url.searchParams.get("hash") || "") });
     if (pathname === "/git/stashes") return json({ stashes: stashList(url.searchParams.get("root") || "") });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
   worktrees as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
-  conflicts as gitConflicts, resolveWith, mergeAbort, mergeContinue, baseCandidates,
+  conflicts as gitConflicts, resolveWith, mergeAbort, mergeContinue, baseCandidates, undoMerge,
   remotes as gitRemotes, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
 import { recent as gitCommandLog } from "./gitlog.ts";
@@ -562,6 +562,7 @@ const server = Bun.serve<WsData>({
         case "/git/resolve": res = resolveWith(root, b.paths ?? b.path, b.side); break;
         case "/git/merge-abort": res = mergeAbort(root); break;
         case "/git/merge-continue": res = mergeContinue(root); break;
+        case "/git/undo-merge": res = undoMerge(root); break;
         default: res = null;
       }
       if (res) return json(res, res.ok ? 200 : 400);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,6 +33,7 @@ import {
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
   worktrees as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
+  conflicts as gitConflicts, resolveWith, mergeAbort, mergeContinue,
   remotes as gitRemotes, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
 import { recent as gitCommandLog } from "./gitlog.ts";
@@ -494,6 +495,7 @@ const server = Bun.serve<WsData>({
     if (pathname === "/git/branches") return json(gitBranches(url.searchParams.get("root") || ""));
     if (pathname === "/git/graph") return json(logGraph(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 400)));
     if (pathname === "/git/worktrees") return json({ worktrees: gitWorktrees(url.searchParams.get("root") || "") });
+    if (pathname === "/git/conflicts") return json(gitConflicts(url.searchParams.get("root") || ""));
     if (pathname === "/git/log") return json({ commits: gitLog(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 100)) });
     if (pathname === "/git/commit-diff") return json({ changes: commitDiff(url.searchParams.get("root") || "", url.searchParams.get("hash") || "") });
     if (pathname === "/git/stashes") return json({ stashes: stashList(url.searchParams.get("root") || "") });
@@ -556,6 +558,9 @@ const server = Bun.serve<WsData>({
         // itself, because the merge has to run where the branch is checked out.
         case "/git/sync-base": res = syncFromBase(root, b.base); break;
         case "/git/set-base": res = setBase(root, b.branch, b.base ?? null); break;
+        case "/git/resolve": res = resolveWith(root, b.paths ?? b.path, b.side); break;
+        case "/git/merge-abort": res = mergeAbort(root); break;
+        case "/git/merge-continue": res = mergeContinue(root); break;
         default: res = null;
       }
       if (res) return json(res, res.ok ? 200 : 400);

--- a/server/test/conflicts.test.ts
+++ b/server/test/conflicts.test.ts
@@ -1,0 +1,85 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, readFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * A real conflict, produced the way one actually happens: two branches editing
+ * the same line, merged. Nothing here is worth testing against a fake — the
+ * whole feature is about what git does when it stops.
+ */
+let repo: string, gw: typeof import("../src/gitwork.ts");
+const run = (dir: string, ...args: string[]) => spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), "agx-conflict-"));
+  process.env.AGENTGLASS_ROOT = repo;
+  run(repo, "init", "-q", "-b", "main");
+  run(repo, "config", "user.email", "t@example.com");
+  run(repo, "config", "user.name", "t");
+  const commit = (body: string, msg: string) => {
+    writeFileSync(join(repo, "shared.txt"), body);
+    run(repo, "add", "-A");
+    run(repo, "commit", "-qm", msg);
+  };
+  commit("original\n", "base");
+  run(repo, "checkout", "-q", "-b", "feature");
+  commit("from the feature branch\n", "feature edit");
+  run(repo, "checkout", "-q", "main");
+  commit("from main\n", "main edit");
+  gw = await import("../src/gitwork.ts");
+});
+
+afterAll(() => { try { rmSync(repo, { recursive: true, force: true }); } catch { /* fine */ } });
+
+describe("merge conflicts", () => {
+  it("reports nothing to resolve on a clean tree", () => {
+    const c = gw.conflicts(repo);
+    expect(c.state).toBe("clean");
+    expect(c.files).toEqual([]);
+  });
+
+  it("names the conflicted files once a merge stops", () => {
+    const r = run(repo, "merge", "--no-edit", "feature");
+    expect(r.status).not.toBe(0); // it really did conflict
+    const c = gw.conflicts(repo);
+    expect(c.state).toBe("merging");
+    expect(c.files).toEqual([join(repo, "shared.txt")]);
+  });
+
+  it("refuses to continue while anything is still conflicted", () => {
+    const r = gw.mergeContinue(repo);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/still conflicted/i);
+  });
+
+  it("takes one side wholesale and stages it", () => {
+    const r = gw.resolveWith(repo, "shared.txt", "theirs");
+    expect(r.ok).toBe(true);
+    expect(readFileSync(join(repo, "shared.txt"), "utf8")).toBe("from the feature branch\n");
+    // Resolved *and* staged: an unstaged resolution still blocks the commit.
+    expect(gw.conflicts(repo).files).toEqual([]);
+  });
+
+  it("completes the merge once everything is resolved", () => {
+    const r = gw.mergeContinue(repo);
+    expect(r.ok).toBe(true);
+    expect(gw.conflicts(repo).state).toBe("clean");
+  });
+
+  it("aborts a merge and leaves the tree as it was", () => {
+    const before = readFileSync(join(repo, "shared.txt"), "utf8");
+    run(repo, "checkout", "-q", "-b", "second", "HEAD~1");
+    writeFileSync(join(repo, "shared.txt"), "a third opinion\n");
+    run(repo, "commit", "-qam", "third");
+    run(repo, "checkout", "-q", "main");
+    expect(run(repo, "merge", "--no-edit", "second").status).not.toBe(0);
+    expect(gw.conflicts(repo).state).toBe("merging");
+
+    const r = gw.mergeAbort(repo);
+    expect(r.ok).toBe(true);
+    expect(gw.conflicts(repo).state).toBe("clean");
+    expect(readFileSync(join(repo, "shared.txt"), "utf8")).toBe(before);
+  });
+});

--- a/server/test/sync-base.test.ts
+++ b/server/test/sync-base.test.ts
@@ -72,6 +72,58 @@ describe("base branch", () => {
   });
 });
 
+describe("undo merge", () => {
+  it("offers nothing when the tip is an ordinary commit", () => {
+    // Not a merge: there is no single "before" to return to.
+    expect(gw.undoableMerge(repo, 1, null)).toBe(false);
+  });
+
+  it("offers nothing for work that has been pushed", () => {
+    // ahead === 0 means the remote already has it, and rewriting published
+    // history is a different, worse problem than undoing a local mistake.
+    // Upstream present and nothing ahead of it: the remote already has this.
+    expect(gw.undoableMerge(repo, 0, "origin/main")).toBe(false);
+  });
+
+  it("undoes an unpushed merge exactly, and refuses once there is nothing to undo", () => {
+    // Two branches that genuinely diverge, or the merge is a no-op and there
+    // is nothing to undo.
+    run(repo, "checkout", "-q", "-b", "undo-side");
+    writeFileSync(join(repo, "side.txt"), "from the side\n");
+    run(repo, "add", "-A"); run(repo, "commit", "-qm", "side work");
+    run(repo, "checkout", "-q", "main");
+    run(repo, "checkout", "-q", "-b", "undo-me");
+    writeFileSync(join(repo, "mine.txt"), "from mine\n");
+    run(repo, "add", "-A"); run(repo, "commit", "-qm", "my work");
+
+    const before = run(repo, "rev-parse", "HEAD").stdout.trim();
+    run(repo, "merge", "--no-edit", "undo-side");
+    const merged = run(repo, "rev-parse", "HEAD").stdout.trim();
+    expect(merged).not.toBe(before);
+    expect(gw.undoableMerge(repo, 1, null)).toBe(true);
+
+    expect(gw.undoMerge(repo).ok).toBe(true);
+    expect(run(repo, "rev-parse", "HEAD").stdout.trim()).toBe(before);
+
+    // And now there is nothing to undo, which it says rather than resetting
+    // another commit off the branch.
+    const second = gw.undoMerge(repo);
+    expect(second.ok).toBe(false);
+    expect(second.error).toMatch(/nothing to undo/i);
+    run(repo, "checkout", "-q", "main");
+  });
+
+  it("refuses while the tree is dirty, since the undo is a hard reset", () => {
+    run(repo, "checkout", "-q", "-b", "undo-dirty");
+    run(repo, "merge", "--no-edit", "undo-side");
+    writeFileSync(join(repo, "scratch.txt"), "work in progress\n");
+    expect(gw.undoableMerge(repo, 1, null)).toBe(false);
+    expect(gw.undoMerge(repo).ok).toBe(false);
+    rmSync(join(repo, "scratch.txt"));
+    run(repo, "checkout", "-q", "main");
+  });
+});
+
 describe("syncFromBase", () => {
   it("refuses when the checkout has uncommitted work", () => {
     writeFileSync(join(wt, "scratch.txt"), "wip\n");

--- a/server/test/sync-base.test.ts
+++ b/server/test/sync-base.test.ts
@@ -1,0 +1,98 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Against a real repository with a real worktree, because the whole point of
+ * this feature is that the merge runs in the checkout that has the branch out —
+ * a property no mock would have.
+ */
+let repo: string, wt: string, gw: typeof import("../src/gitwork.ts");
+
+/**
+ * These are write operations, so they meet the scope guard — which reads the
+ * running machine's real config. Point the scope at the fixture instead, via
+ * the env override that workspaceRoot() keys its cache on for exactly this
+ * reason. Set before gitwork is imported.
+ */
+
+const run = (dir: string, ...args: string[]) => spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), "agx-base-"));
+  process.env.AGENTGLASS_ROOT = repo;
+  run(repo, "init", "-q", "-b", "main");
+  run(repo, "config", "user.email", "t@example.com");
+  run(repo, "config", "user.name", "t");
+  const commit = (f: string, body: string, msg: string) => {
+    writeFileSync(join(repo, f), body);
+    run(repo, "add", "-A");
+    run(repo, "commit", "-qm", msg);
+  };
+  commit("a.txt", "one\n", "first");
+
+  // A card branch, checked out in its own worktree — David's actual shape.
+  wt = `${repo}-CARD-1`;
+  run(repo, "worktree", "add", "-q", "-b", "CARD-1", wt);
+
+  // main moves on twice after the branch was cut.
+  commit("b.txt", "two\n", "second");
+  commit("c.txt", "three\n", "third");
+
+  gw = await import("../src/gitwork.ts");
+});
+
+afterAll(() => {
+  for (const d of [wt, repo]) { try { rmSync(d, { recursive: true, force: true }); } catch { /* fine */ } }
+});
+
+describe("base branch", () => {
+  it("falls back to the trunk when nothing is configured", () => {
+    expect(gw.baseOf(repo, "CARD-1")).toBe("main");
+  });
+
+  it("gives the trunk itself no base", () => {
+    // Otherwise the trunk offers to merge itself into itself.
+    expect(gw.baseOf(repo, "main")).toBe(null);
+  });
+
+  it("honours an explicit override, because not every branch is cut from trunk", () => {
+    run(repo, "branch", "release-9");
+    gw.setBase(repo, "CARD-1", "release-9");
+    expect(gw.baseOf(repo, "CARD-1")).toBe("release-9");
+    gw.setBase(repo, "CARD-1", null); // back to inferred
+    expect(gw.baseOf(repo, "CARD-1")).toBe("main");
+  });
+
+  it("counts what the base has and the branch does not", () => {
+    expect(gw.behindBase(repo, "CARD-1", "main")).toBe(2);
+    expect(gw.behindBase(repo, "main", "main")).toBe(0);
+  });
+});
+
+describe("syncFromBase", () => {
+  it("refuses when the checkout has uncommitted work", () => {
+    writeFileSync(join(wt, "scratch.txt"), "wip\n");
+    const r = gw.syncFromBase(wt);
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/commit or stash/i);
+    rmSync(join(wt, "scratch.txt"));
+  });
+
+  it("merges the base into the worktree's branch and clears the gap", () => {
+    expect(gw.behindBase(repo, "CARD-1", "main")).toBe(2);
+    const r = gw.syncFromBase(wt);
+    expect(r.ok).toBe(true);
+    // The cache is keyed per branch+base and has a TTL, so read past it.
+    const after = spawnSync("git", ["-C", repo, "rev-list", "--count", "CARD-1..main"], { encoding: "utf8" });
+    expect(Number(after.stdout.trim())).toBe(0);
+  });
+
+  it("refuses a checkout with no base rather than guessing one", () => {
+    const r = gw.syncFromBase(repo); // repo is on main, which has no base
+    expect(r.ok).toBe(false);
+    expect(r.error).toMatch(/no base/i);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -328,7 +328,11 @@ export interface OpenToolCall {
 export type WsFrame =
   | { type: "initial"; data: WatchEvent[]; openTools?: OpenToolCall[] }
   | { type: "event"; data: WatchEvent }
-  | { type: "session"; data: SessionRollup };
+  | { type: "session"; data: SessionRollup }
+  /** Something mutated a repository. Carries no payload on purpose: the panels
+   *  each need a different slice of git state, so they re-read what they show
+   *  rather than the server guessing which of them cares about what. */
+  | { type: "git" };
 
 // --- commit composer (live git working-tree) ---------------------------------
 export interface GitFileStatus {
@@ -503,6 +507,11 @@ export interface GitWorktree {
   current: boolean;
   bare: boolean;
   locked: boolean;
+  /** The branch this one was cut from — trunk unless overridden per branch.
+   *  Null on the trunk checkout itself, which has no base. */
+  base?: string | null;
+  /** Commits the base has that this checkout does not. */
+  behindBase?: number;
 }
 
 // --- live docker panel (lazydocker replacement) ------------------------------

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -380,6 +380,11 @@ export interface GitBranchInfo {
   detached: boolean;
   /** Absent on older payloads; treat as "clean". */
   state?: GitTreeState;
+  /** The branch this one was cut from — what a PR calls its base. Null on the
+   *  trunk itself. Merging it in is "update from base". */
+  base?: string | null;
+  /** Commits the base has that this branch does not. */
+  behindBase?: number;
 }
 export interface WorkingTree {
   root: string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -385,6 +385,9 @@ export interface GitBranchInfo {
   base?: string | null;
   /** Commits the base has that this branch does not. */
   behindBase?: number;
+  /** The tip is an unpushed merge on a clean tree — so it can be undone
+   *  exactly, by resetting to its first parent. */
+  canUndoMerge?: boolean;
 }
 export interface WorkingTree {
   root: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -330,27 +330,22 @@ export default function App() {
       const a = document.activeElement;
       const focusFree = !a || a === document.body || a === document.documentElement;
 
-      // Inside the workspace the frame itself holds focus, so `focusFree` is
-      // false and the old guard would swallow every letter. What actually
-      // matters there is narrower: is the keystroke going into a field or a
-      // shell? If not, it's navigation.
+      // Bare letters belong to the dashboard, and only to it.
       //
-      // The terminal is the exception, and it has to be the *view* that decides
-      // rather than what holds DOM focus. Asking `activeElement` worked only
-      // while the caret sat in xterm's helper textarea: click anything in the
-      // terminal's own toolbar — the repo picker, restart, clear — and focus
-      // parks on that button, so `typing` went false and the next letter of the
-      // command being typed was eaten as navigation. `t` closed the terminal
-      // mid-command, `g` jumped to git. While the terminal is the active view
-      // every bare letter belongs to the shell; ⌘1..5, ⌘\ and ⌘[/] still leave,
-      // which is exactly why they carry a modifier.
-      const termOwnsKeys = wsOpenRef.current && wsViewRef.current === "term";
-      const typing = termOwnsKeys || (!!a && (
-        /^(input|textarea|select)$/i.test(a.tagName) ||
-        (a as HTMLElement).isContentEditable ||
-        !!a.closest?.(".xterm")
-      ));
-      const canNavigate = (focusFree && !anyPanelOpenRef.current) || (wsOpenRef.current && !typing);
+      // They used to switch views inside the workspace too, guarded by asking
+      // `document.activeElement` whether the keystroke was going into a field
+      // or a shell. That guard could not hold: focus inside the workspace falls
+      // back to <body> constantly — xterm losing it, a click landing on padding
+      // — and a body-focused keystroke read as "not typing", so a `g` typed
+      // into the terminal jumped to git. Intermittently, which is the worst
+      // way for a keyboard to be wrong: you stop trusting every key you press.
+      //
+      // There is no version of "is this keystroke meant for the app or for the
+      // shell" that a heuristic answers reliably, so the rule is positional
+      // instead of behavioural. Inside the workspace, navigation carries a
+      // modifier — ⌘1..5, ⌘\, ⌘[/] — which no shell will ever consume, and the
+      // rail is a click away.
+      const canNavigate = focusFree && !anyPanelOpenRef.current && !wsOpenRef.current;
       if (!canNavigate) return;
 
       // Which action owns this letter, according to the user's bindings —
@@ -361,22 +356,18 @@ export default function App() {
       // after the next remount.
       const action = actionFor(e.key);
 
-      // A workspace letter either opens the workspace on that view or, if it's
-      // already open, switches to it. They no longer stop working the moment
-      // you're actually using one of them.
+      // A workspace letter opens the workspace on that view. Only from the
+      // dashboard now — the guard above has already established that — so it
+      // opens rather than toggles: there is no open workspace to close from
+      // here, and ⌘\ is the key that puts it away from inside.
       if (action?.startsWith("view.")) {
         const view = action.slice(5) as ViewId;
         e.preventDefault();
-        // Pressing the current view's own letter closes the workspace, so a
-        // key that opened something can also put it away.
-        if (wsOpenRef.current && view === wsViewRef.current) setWsOpen(false);
-        else { setWsView(view); setWsOpen(true); }
+        setWsView(view);
+        setWsOpen(true);
         return;
       }
 
-      // The remaining globals still open something *over* whatever you're in,
-      // so they keep the original strict guard: dashboard only.
-      if (!focusFree || anyPanelOpenRef.current || wsOpenRef.current) return;
       switch (action) {
         case "open.help": setHelpOpen((o) => !o); break;
         case "open.stats": e.preventDefault(); setStatsOpen((o) => !o); break;

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -313,15 +313,14 @@ function fileType(c: FileChange): { label: string; color: string } {
   return { label, color: TYPE_STYLE[label] ?? "var(--info)" };
 }
 
-type GroupBy = "session" | "date" | "agent" | "folder" | "tool";
+type GroupBy = "session" | "agent" | "folder" | "tool";
 const GROUP_DIMS: { id: GroupBy; label: string }[] = [
   { id: "session", label: "Session" },
-  { id: "date", label: "Date" },
   { id: "agent", label: "Agent" },
   { id: "folder", label: "Folder" },
   { id: "tool", label: "Tool" },
 ];
-type FileGroup = { key: string; label: string; sub?: string; items: FileChange[]; add: number; del: number };
+type FileGroup = { key: string; label: string; sub?: string; /** Set when split by day, so the list can head each run of groups. */ day?: string; items: FileChange[]; add: number; del: number };
 
 const dirOf = (path: string) => {
   const base = path.split("/").pop() ?? "";
@@ -347,7 +346,16 @@ function dayLabel(d: Date): string {
   return d.toLocaleDateString([], { day: "numeric", month: "short" });
 }
 
-function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<string, string>): FileGroup[] {
+/**
+ * Group by a dimension, optionally split by day first.
+ *
+ * Date was one of the mutually exclusive dimensions, which made it useless in
+ * practice: choosing it told you *when* and took away *who* — a day's worth of
+ * edits with no session, agent or folder to make sense of them. It is a second
+ * axis, not a fifth option, so it layers: sections stay Session (or Agent, or
+ * Folder), and each one is scoped to a day when the split is on.
+ */
+function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<string, string>, byDate = false): FileGroup[] {
   const map = new Map<string, FileGroup>();
   const order: string[] = [];
   for (const c of list) {
@@ -361,20 +369,21 @@ function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<stri
       label = titles?.get(c.session_id) ?? agentKey({ source_app: c.source_app, session_id: c.session_id });
       sub = c.source_app;
     }
-    else if (by === "date") {
-      // Keyed on the local calendar day, not on the raw timestamp: the point is
-      // "what did we do on Tuesday", and the rows are already newest-first, so
-      // the days come out in order without a second sort.
-      const d = new Date(c.timestamp);
-      key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
-      label = dayLabel(d);
-      sub = d.toLocaleDateString([], { day: "numeric", month: "short", year: "numeric" });
-    }
     else if (by === "agent") { key = c.source_app || "—"; label = c.source_app || "unknown"; }
     else if (by === "tool") { key = c.tool || "—"; label = c.tool || "unknown"; }
     else { const d = dirOf(c.file_path); key = d; label = shortDir(d); }
+    // The day, when the split is on, is part of the identity — so one session
+    // spanning midnight becomes two sections rather than one that lies about
+    // which day it belongs to. `day` also rides along so the list can draw a
+    // heading when it changes.
+    let day: string | undefined;
+    if (byDate) {
+      const d = new Date(c.timestamp);
+      day = dayLabel(d);
+      key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}|${key}`;
+    }
     let g = map.get(key);
-    if (!g) { g = { key, label, sub, items: [], add: 0, del: 0 }; map.set(key, g); order.push(key); }
+    if (!g) { g = { key, label, sub, day, items: [], add: 0, del: 0 }; map.set(key, g); order.push(key); }
     g.items.push(c); g.add += c.additions; g.del += c.deletions;
   }
   // Newest first *within* a group, stated rather than inherited. The rows
@@ -627,6 +636,8 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
   const [q, setQ] = useState("");
   /** Ignored files start folded away — see `visible` below. */
   const [showIgnored, setShowIgnored] = useState(false);
+  /** Split whichever grouping is chosen by day as well. */
+  const [byDate, setByDate] = useState(false);
   const [selId, setSelId] = useState<number | null>(null);
   const [wrap, setWrap] = useState(false);
   const [split, setSplit] = useState(true);
@@ -716,7 +727,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
   const ignoredCount = useMemo(() => all.reduce((n, c) => n + (c.ignored ? 1 : 0), 0), [all]);
   const visible = useMemo(() => (showIgnored ? all : all.filter((c) => !c.ignored)), [all, showIgnored]);
   const filtered = useMemo(() => (q ? visible.filter((c) => c.file_path.toLowerCase().includes(q.toLowerCase())) : visible), [visible, q]);
-  const groups = useMemo(() => groupChanges(filtered, groupBy, titles), [filtered, groupBy, titles]);
+  const groups = useMemo(() => groupChanges(filtered, groupBy, titles, byDate), [filtered, groupBy, titles, byDate]);
   const shown = useMemo(() => groups.flatMap((g) => g.items), [groups]);
   const totals = useMemo(() => all.reduce((a, c) => ({ add: a.add + c.additions, del: a.del + c.deletions }), { add: 0, del: 0 }), [all]);
   const revCount = useMemo(() => all.reduce((n, c) => n + (reviewed.has(c.id) ? 1 : 0), 0), [all, reviewed]);
@@ -915,6 +926,20 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                             }}
                           >{d.label}</button>
                         ))}
+                        {/* A modifier, not a fifth dimension — it sits after a
+                            separator because it changes what the four to its
+                            left do rather than replacing them. */}
+                        <span className="w-px h-4 mx-0.5 shrink-0" style={{ background: "color-mix(in srgb, var(--border) 45%, transparent)" }} />
+                        <button
+                          onClick={() => setByDate((v) => !v)}
+                          className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors whitespace-nowrap leading-5"
+                          title={byDate ? "one section per group" : "split each group by day"}
+                          style={{
+                            background: byDate ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
+                            color: byDate ? "var(--text)" : "var(--text3)",
+                            border: `1px solid color-mix(in srgb, var(--border) ${byDate ? 45 : 18}%, transparent)`,
+                          }}
+                        >by date</button>
                         {/* Says what it is hiding, and offers it back. A
                             filter that silently drops rows makes the list lie
                             about what the session touched. */}
@@ -944,7 +969,13 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                     <div className="agx-scroll flex-1 min-h-0 overflow-y-auto px-2 pb-2">
                       {!changes && <div className="t-dim2 text-center py-10 text-[12px]">loading changes…</div>}
                       {changes && shown.length === 0 && <div className="t-dim2 text-center py-10 text-[12px]">{q ? "no files match your filter" : "no file changes captured yet"}</div>}
-                      {groups.map((g) => (
+                      {groups.map((g, gi) => (
+                        <div key={`w:${g.key}`}>
+                          {/* Only when it changes: repeating "Today" above every
+                              session turns a heading into wallpaper. */}
+                          {g.day && g.day !== groups[gi - 1]?.day && (
+                            <div className="px-1 pt-2 pb-1 text-[10px] uppercase tracking-wider" style={{ color: "var(--primary-hover)" }}>{g.day}</div>
+                          )}
                         <GroupBlock
                           key={g.key}
                           g={g}
@@ -957,6 +988,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                           onToggleReviewed={toggleReviewed}
                           onToggleGroup={toggleGroup}
                         />
+                        </div>
                       ))}
                     </div>
                   </div>

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -866,12 +866,16 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                         className="w-full px-3 py-1.5 rounded-lg text-[11px] outline-none"
                         style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }}
                       />
-                      <div className="flex items-center gap-1">
+                      {/* One row, one height. `flex-wrap` rather than letting a
+                          chip grow: on a narrow panel the row wraps as a row,
+                          which is legible, instead of one button becoming two
+                          lines tall and dragging its neighbours' baseline. */}
+                      <div className="flex items-center flex-wrap gap-1">
                         {GROUP_DIMS.map((d) => (
                           <button
                             key={d.id}
                             onClick={() => setGroupBy(d.id)}
-                            className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors"
+                            className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors whitespace-nowrap leading-5"
                             style={{
                               background: groupBy === d.id ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
                               color: groupBy === d.id ? "var(--text)" : "var(--text3)",
@@ -885,7 +889,11 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                         {ignoredCount > 0 && (
                           <button
                             onClick={() => setShowIgnored((v) => !v)}
-                            className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors"
+                            // nowrap: "+ 23 ignored" broke across two lines and
+                            // made this chip taller than the four beside it.
+                            // A button that changes height with its own label
+                            // is never worth the width it saves.
+                            className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors whitespace-nowrap leading-5"
                             title={showIgnored
                               ? "hide files git ignores"
                               : `${ignoredCount} file${ignoredCount === 1 ? "" : "s"} git ignores ${ignoredCount === 1 ? "is" : "are"} hidden — build output, caches, scratch files`}

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -313,9 +313,10 @@ function fileType(c: FileChange): { label: string; color: string } {
   return { label, color: TYPE_STYLE[label] ?? "var(--info)" };
 }
 
-type GroupBy = "session" | "agent" | "folder" | "tool";
+type GroupBy = "session" | "date" | "agent" | "folder" | "tool";
 const GROUP_DIMS: { id: GroupBy; label: string }[] = [
   { id: "session", label: "Session" },
+  { id: "date", label: "Date" },
   { id: "agent", label: "Agent" },
   { id: "folder", label: "Folder" },
   { id: "tool", label: "Tool" },
@@ -334,6 +335,18 @@ const shortDir = (dir: string) => {
 
 /** Bucket the (already path-filtered) changes into groups, preserving first-seen
  *  order — the API returns newest-first, so recent activity floats to the top. */
+/** "Today" / "Yesterday" / "Tuesday" for the last week, then a plain date.
+ *  A weekday is how you actually remember recent work; past that it stops
+ *  being unambiguous and the date is the only honest label. */
+function dayLabel(d: Date): string {
+  const startOf = (x: Date) => new Date(x.getFullYear(), x.getMonth(), x.getDate()).getTime();
+  const days = Math.round((startOf(new Date()) - startOf(d)) / 86_400_000);
+  if (days === 0) return "Today";
+  if (days === 1) return "Yesterday";
+  if (days < 7) return d.toLocaleDateString([], { weekday: "long" });
+  return d.toLocaleDateString([], { day: "numeric", month: "short" });
+}
+
 function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<string, string>): FileGroup[] {
   const map = new Map<string, FileGroup>();
   const order: string[] = [];
@@ -348,6 +361,15 @@ function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<stri
       label = titles?.get(c.session_id) ?? agentKey({ source_app: c.source_app, session_id: c.session_id });
       sub = c.source_app;
     }
+    else if (by === "date") {
+      // Keyed on the local calendar day, not on the raw timestamp: the point is
+      // "what did we do on Tuesday", and the rows are already newest-first, so
+      // the days come out in order without a second sort.
+      const d = new Date(c.timestamp);
+      key = `${d.getFullYear()}-${d.getMonth()}-${d.getDate()}`;
+      label = dayLabel(d);
+      sub = d.toLocaleDateString([], { day: "numeric", month: "short", year: "numeric" });
+    }
     else if (by === "agent") { key = c.source_app || "—"; label = c.source_app || "unknown"; }
     else if (by === "tool") { key = c.tool || "—"; label = c.tool || "unknown"; }
     else { const d = dirOf(c.file_path); key = d; label = shortDir(d); }
@@ -355,6 +377,11 @@ function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<stri
     if (!g) { g = { key, label, sub, items: [], add: 0, del: 0 }; map.set(key, g); order.push(key); }
     g.items.push(c); g.add += c.additions; g.del += c.deletions;
   }
+  // Newest first *within* a group, stated rather than inherited. The rows
+  // arrive in timestamp order today, so this changes nothing — until something
+  // upstream reorders them and a day's work silently stops reading
+  // chronologically, which is the one thing a date grouping is for.
+  for (const g of map.values()) g.items.sort((a, b) => b.timestamp - a.timestamp);
   return order.map((k) => map.get(k)!);
 }
 
@@ -403,7 +430,12 @@ function FileItem({ c, active, reviewed, info, onSelect, onToggleReviewed }: { c
         </span>
       </div>
       {info?.description ? (
-        <div className="mt-0.5 text-[10px] pl-[22px] truncate" style={{ color: "var(--text3)" }} title={info.description}>{info.description}</div>
+        // The clock stays even when a description takes the line: with the list
+        // grouped by day, "when" is half of what you are reading it for.
+        <div className="mt-0.5 flex items-center gap-1.5 text-[10px] pl-[22px]" style={{ color: "var(--text3)" }}>
+          <span className="truncate min-w-0" title={info.description}>{info.description}</span>
+          <span className="ml-auto shrink-0 tabular-nums opacity-80">{fmtTime(c.timestamp)}</span>
+        </div>
       ) : (
         <div className="flex items-center gap-1.5 mt-0.5 text-[9.5px] t-dim2 pl-[22px]">
           <span className="truncate min-w-0" title={c.file_path}>{dirOf(c.file_path)}</span>

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -6,6 +6,7 @@ import type { DockerOverview, DockerContainer, DockerStat } from "../../../share
 import { api } from "../lib/api.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
+import { ConsoleStrip, lastTerminalRoot } from "./TerminalPanel.tsx";
 
 // Strip ANSI CSI (colors, cursor moves, erases) + OSC sequences, not just SGR.
 const ANSI = /\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g; // eslint-disable-line no-control-regex
@@ -61,7 +62,18 @@ function ContainerRow({ c, stat, active, writeEnabled, busy, onSelect, onAction 
 
 /** Docker as a workspace view. `active` means "visible right now" — the view
  *  stays mounted while you're off in the diff, it just stops polling. */
+const CONSOLE_KEY = "agentglass.docker.console";
+
 export function DockerView({ active }: { active: boolean }) {
+  // A shell docked under the logs, for the `make migrate` you always end up
+  // needing while watching a container. Its height is remembered and it is
+  // keyed on the repo, not on the container, so selecting a different one
+  // above never disturbs what is running below.
+  const [consoleOpen, setConsoleOpen] = useState(false);
+  const [consoleH, setConsoleH] = useState<number>(() => {
+    try { return Math.min(0.85, Math.max(0.08, Number(localStorage.getItem(CONSOLE_KEY)) || 0.1)); } catch { return 0.1; }
+  });
+  useEffect(() => { try { localStorage.setItem(CONSOLE_KEY, String(consoleH)); } catch { /* non-fatal */ } }, [consoleH]);
   const [ov, setOv] = useState<DockerOverview | null>(null);
   const [stats, setStats] = useState<Record<string, DockerStat>>({});
   const [view, setView] = useState<View>("containers");
@@ -282,11 +294,32 @@ export function DockerView({ active }: { active: boolean }) {
                   </div>
                 )}
 
+                {/* Docked shell. Sits above the hint bar and below everything
+                    else, so opening it takes room from the logs rather than
+                    covering them. */}
+                <ConsoleStrip
+                  root={lastTerminalRoot()}
+                  open={consoleOpen}
+                  height={consoleH}
+                  onHeight={setConsoleH}
+                  onClose={() => setConsoleOpen(false)}
+                />
+
                 {ov?.available && view === "containers" && (
                   <div className="shrink-0 px-4 py-1 border-t text-[9.5px] t-dim2 flex items-center gap-3" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                     <span><b className="font-semibold">j/k</b> container</span>
                     <span><b className="font-semibold">s</b> start/stop</span>
                     <span><b className="font-semibold">r</b> restart</span>
+                    <button
+                      onClick={() => setConsoleOpen((v) => !v)}
+                      className="px-2 py-0.5 rounded text-[9.5px] whitespace-nowrap transition-colors"
+                      title="a shell in this project, docked under the logs — it keeps running while you look around"
+                      style={{
+                        background: consoleOpen ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
+                        color: consoleOpen ? "var(--text)" : "var(--text3)",
+                        border: `1px solid color-mix(in srgb, var(--border) ${consoleOpen ? 45 : 20}%, transparent)`,
+                      }}
+                    >{consoleOpen ? "▾ console" : "▸ console"}</button>
                     <span className="ml-auto">logs auto-refresh · stats every 5s</span>
                   </div>
                 )}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -31,21 +31,42 @@ function ContainerRow({ c, stat, active, writeEnabled, busy, onSelect, onAction 
   onSelect: () => void; onAction: (verb: "start" | "stop" | "restart" | "rm") => void;
 }) {
   const running = c.state === "running";
+  // The first published port, which is the one you actually reach the service
+  // on. The full list is in the tooltip; the row is not a table.
+  const port = /(\d+)->/.exec(c.ports || "")?.[1];
   return (
     <div onClick={onSelect} data-cid={active ? "active" : undefined}
-      className="group flex items-center gap-2 pl-2 pr-1.5 py-1 rounded-md cursor-pointer"
-      style={{ background: active ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-      <span className="w-2 h-2 rounded-full shrink-0" style={{ background: STATE_TINT[c.state] ?? "var(--text3)" }} title={c.status} />
-      <span className="min-w-0 flex-1 truncate text-[11.5px]" style={{ color: active ? "var(--text)" : "var(--text2)" }}>
-        {c.service || c.name}
-        {c.service && <span className="t-dim2 text-[9.5px] ml-1.5 truncate">{c.image}</span>}
+      className="group grid items-center gap-x-2 pl-2 pr-1.5 py-1 rounded-md cursor-pointer"
+      // A grid, not a flex row: every container's numbers line up in the same
+      // columns, which is what makes a list of twelve scannable instead of
+      // twelve individually-arranged lines. lazydocker does the same.
+      style={{
+        gridTemplateColumns: "10px minmax(0,1fr) 46px 46px 52px auto",
+        background: active ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent",
+      }}
+      title={`${c.name}\n${c.image}\n${c.status}${c.ports ? `\n${c.ports}` : ""}`}>
+      <span className="w-2 h-2 rounded-full shrink-0" style={{ background: STATE_TINT[c.state] ?? "var(--text3)" }} />
+
+      <span className="min-w-0 flex flex-col leading-tight">
+        <span className="truncate text-[11.5px]" style={{ color: active ? "var(--text)" : "var(--text2)" }}>{c.service || c.name}</span>
+        {/* The image was competing with the name on one line and both lost.
+            Underneath, dimmer, it reads as what it is — provenance, not
+            identity. */}
+        <span className="truncate text-[9px] t-dim2">{c.image}</span>
       </span>
-      {stat && running && (
-        <span className="shrink-0 flex items-center gap-1 text-[8.5px] t-dim2 tabular-nums" title={`CPU ${stat.cpu}% · MEM ${stat.mem}% (${stat.memUsage})`}>
-          <Bar pct={stat.cpu} tint="var(--info)" /><Bar pct={stat.mem} tint="var(--warning)" />
-        </span>
-      )}
-      <div className="shrink-0 flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity" onClick={(e) => e.stopPropagation()}>
+
+      {/* Numbers, not two unlabelled bars. A bar with no scale and no figure
+          says "something is happening"; 0.24% says which container is busy. */}
+      <span className="text-[9.5px] tabular-nums text-right" style={{ color: stat && running && stat.cpu >= 50 ? "var(--warning)" : "var(--text3)" }}>
+        {stat && running ? `${stat.cpu.toFixed(1)}%` : ""}
+      </span>
+      <span className="text-[9.5px] tabular-nums text-right" style={{ color: stat && running && stat.mem >= 80 ? "var(--warning)" : "var(--text3)" }}
+        title={stat ? `memory ${stat.mem}% (${stat.memUsage})` : undefined}>
+        {stat && running ? `${stat.mem.toFixed(0)}%` : ""}
+      </span>
+      <span className="text-[9px] tabular-nums truncate" style={{ color: "var(--info)" }}>{port ? `:${port}` : ""}</span>
+
+      <div className="flex items-center gap-0.5 opacity-0 group-hover:opacity-100 transition-opacity" onClick={(e) => e.stopPropagation()}>
         {writeEnabled && (running
           ? <>
               <button disabled={busy} onClick={() => onAction("restart")} title="Restart" className="w-5 h-5 grid place-items-center rounded text-[11px]" style={{ color: "var(--warning)" }}>⟳</button>
@@ -59,6 +80,7 @@ function ContainerRow({ c, stat, active, writeEnabled, busy, onSelect, onAction 
     </div>
   );
 }
+
 
 /** Docker as a workspace view. `active` means "visible right now" — the view
  *  stays mounted while you're off in the diff, it just stops polling. */
@@ -228,6 +250,14 @@ export function DockerView({ active }: { active: boolean }) {
                           <div className="flex items-center gap-2 px-2.5 py-1 sticky top-0 z-10" style={{ background: "var(--bg2)" }}>
                             <span className="text-[10px] uppercase tracking-wider font-semibold" style={{ color: "var(--text2)" }}>{proj}</span>
                             <span className="text-[9px] t-dim2 tabular-nums">{cs.filter((c) => c.state === "running").length}/{cs.length}</span>
+                            {/* Names the columns once per project, in the same
+                                grid the rows use, so the figures below are not
+                                three anonymous numbers. */}
+                            <span className="ml-auto grid gap-x-2 text-[8.5px] t-dim2 uppercase tracking-wider" style={{ gridTemplateColumns: "46px 46px 52px" }}>
+                              <span className="text-right">cpu</span>
+                              <span className="text-right">mem</span>
+                              <span>port</span>
+                            </span>
                           </div>
                           <div className="px-1">
                             {cs.map((c) => <ContainerRow key={c.id} c={c} stat={stats[c.id]} active={selected?.id === c.id} writeEnabled={writeEnabled} busy={busy} onSelect={() => { setSelId(c.id); setTab("logs"); }} onAction={(v) => doAction(c.id, v)} />)}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -6,6 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
+import { newChat, update, setActiveChatId } from "../lib/chatStore.ts";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
 import { usePoll } from "../lib/usePoll.ts";
 import { worktreeTag } from "../lib/worktree.ts";
@@ -352,7 +353,7 @@ function Section({ title, count, tint, action, onAll, children }: { title: strin
  *  Staying mounted while hidden is worth more here than anywhere else: the
  *  commit message drafts (`title`/`body`) used to be destroyed every time you
  *  looked at something else, which is precisely what you do before committing. */
-export function GitView({ active }: { active: boolean }) {
+export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: () => void }) {
   const open = active;
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState<string>("");
@@ -381,6 +382,41 @@ export function GitView({ active }: { active: boolean }) {
   const [busyView, setBusyView] = useState<View | null>(null);
   /** The "merge from…" list on the header's sync button. */
   const [baseOpen, setBaseOpen] = useState(false);
+  /** Files git has stopped on. Only ever non-empty mid-merge. */
+  const [conflicts, setConflicts] = useState<string[]>([]);
+  const mergeState = tree?.branch.state ?? "clean";
+  useEffect(() => {
+    if (!open || !root || mergeState === "clean") { setConflicts([]); return; }
+    api.gitConflicts(root).then((r) => setConflicts(r.files ?? [])).catch(() => {});
+  }, [open, root, mergeState, tree]);
+
+  /**
+   * Hand the conflict to Claude, in the repo it happened in.
+   *
+   * The expensive part of a conflict is understanding two intents well enough
+   * to reconcile them, which is the one thing an agent sitting in this repo is
+   * genuinely good at — and the chat already runs `claude` in a given cwd, so
+   * this is a prompt and a tab rather than a feature.
+   */
+  const askClaude = () => {
+    const rels = conflicts.map((p) => p.startsWith(root) ? p.slice(root.length + 1) : p);
+    const c = newChat(root);
+    update(c.id, (ch) => {
+      ch.title = "resolve merge conflicts";
+      ch.draft = [
+        `I am mid-merge in ${root} and git has left ${rels.length} file(s) conflicted:`,
+        "",
+        ...rels.map((r) => `- ${r}`),
+        "",
+        "Please resolve each conflict, keeping both sides' intent where they do",
+        "different things and preferring the incoming change where they do the",
+        "same thing differently. Explain anything you had to choose between.",
+        "Do not commit — leave the resolution staged so I can review it.",
+      ].join("\n");
+    });
+    setActiveChatId(c.id);
+    onOpenChat?.();
+  };
   // Only the branches whose upstream is gone — the merged-and-tidied ones. Off
   // by default: it's a cleanup mode, not a way to read the branch list.
   const [onlyGone, setOnlyGone] = useState(false);
@@ -1167,6 +1203,55 @@ export function GitView({ active }: { active: boolean }) {
                     <button onClick={() => loadTree(root)} title="Refresh" className="text-[13px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>⟳</button>
                   </div>
                 </div>
+
+                {/* Git has stopped in the middle of something. It used to say
+                    so in the header chip and offer nothing — leaving you in a
+                    conflicted repo with a toast and no way forward, which is
+                    the worst moment for the app to go quiet. */}
+                {mergeState !== "clean" && (
+                  <div className="shrink-0 px-4 py-2 border-b flex flex-col gap-1.5"
+                    style={{ borderColor: "color-mix(in srgb, var(--warning) 45%, transparent)", background: "color-mix(in srgb, var(--warning) 8%, transparent)" }}>
+                    <div className="flex items-center gap-2 flex-wrap">
+                      <span className="text-[11px] font-semibold whitespace-nowrap" style={{ color: "var(--warning)" }}>
+                        {mergeState} — {conflicts.length} conflicted file{conflicts.length === 1 ? "" : "s"}
+                      </span>
+                      {/* Abort first, and always available: it is the only move
+                          that is guaranteed safe, and the one you reach for
+                          when you did not mean to start this. */}
+                      <button onClick={() => act(() => api.gitMergeAbort(root), "merge aborted", "abort")} disabled={busy}
+                        className="text-[10.5px] px-2 py-0.5 rounded-lg whitespace-nowrap"
+                        style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}
+                        title="Throw the merge away and put the tree back exactly as it was">abort</button>
+                      <button onClick={() => act(() => api.gitMergeContinue(root), "merge completed", "continue")} disabled={busy || conflicts.length > 0}
+                        className="text-[10.5px] px-2 py-0.5 rounded-lg whitespace-nowrap"
+                        style={{ color: "var(--success)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)", opacity: conflicts.length ? 0.4 : 1 }}
+                        title={conflicts.length ? "resolve every file first" : "commit the merge"}>continue</button>
+                      {conflicts.length > 0 && (
+                        <button onClick={askClaude}
+                          className="text-[10.5px] px-2 py-0.5 rounded-lg whitespace-nowrap"
+                          style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}
+                          title="Open a chat in this repo, asking Claude to resolve them">✦ ask claude</button>
+                      )}
+                    </div>
+                    {/* Whole-file resolutions: the two that need no editor, and
+                        between them most conflicts — a lockfile, a generated
+                        migration, a file the other side deleted. */}
+                    {conflicts.map((f) => {
+                      const relPath = f.startsWith(root) ? f.slice(root.length + 1) : f;
+                      return (
+                        <div key={f} className="flex items-center gap-2 text-[10.5px]">
+                          <span className="min-w-0 flex-1 truncate" style={{ color: "var(--text2)" }} title={f}>{relPath}</span>
+                          <button onClick={() => act(() => api.gitResolve(root, [relPath], "ours"), `kept ours for ${relPath}`)} disabled={busy}
+                            className="px-1.5 py-0.5 rounded shrink-0" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
+                            title="Keep this branch's version">ours</button>
+                          <button onClick={() => act(() => api.gitResolve(root, [relPath], "theirs"), `took theirs for ${relPath}`)} disabled={busy}
+                            className="px-1.5 py-0.5 rounded shrink-0" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
+                            title="Take the incoming version">theirs</button>
+                        </div>
+                      );
+                    })}
+                  </div>
+                )}
 
                 {view === "changes" ? (
                   <div className="flex-1 min-h-0 flex">

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1140,6 +1140,29 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                   </div>
                   <div className="ml-auto flex items-center gap-1.5 min-w-0">
                     {branch && <BranchChip branch={branch} onCopied={(n) => flash(true, `copied ${n}`)} />}
+                    {/* Offered only while undoing is exact: an unpushed merge
+                        at the tip, on a clean tree. Once anything is committed
+                        on top the tip is no longer the merge; once it is
+                        pushed the honest undo is a revert, not a rewrite.
+                        Deliberately a sibling of the sync block rather than
+                        inside it — nested there it inherited "there is
+                        something to merge" as a visibility condition and so
+                        vanished the instant a sync succeeded, which is exactly
+                        the moment it exists for. */}
+                    {branch?.canUndoMerge && (
+                      <button
+                        onClick={() => {
+                          if (!confirm(`Undo the last merge on ${branch.name}?\n\nThe branch goes back to exactly where it was. Nothing has been pushed, so nothing anyone else has is affected.`)) return;
+                          void act(() => api.gitUndoMerge(root), "merge undone", "undo");
+                        }}
+                        disabled={!writeEnabled || busy}
+                        className="text-[11px] px-2 py-1 rounded-lg whitespace-nowrap shrink-0"
+                    style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", opacity: busy ? 0.5 : 1 }}
+                    title="Undo the last merge — the branch returns to exactly where it was. Offered only because it is unpushed and nothing sits on top of it.">
+                    {pending === "undo" ? "undoing…" : "⎌ undo merge"}
+                      </button>
+                    )}
+
                     {/* Update from base — merge master's latest into the branch
                         you are on, in this checkout. Sits with fetch/pull/push
                         because it belongs to the same family of "bring this
@@ -1149,23 +1172,6 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         itself, which has no base. */}
                     {branch?.base && (branch.behindBase ?? 0) > 0 && (
                       <div className="relative flex items-center">
-                        {/* Only while it is safe and exact: an unpushed merge at
-                        the tip, on a clean tree. Once anything is committed on
-                        top the tip is no longer the merge, and once it is
-                        pushed the honest undo is a revert, not a rewrite. */}
-                    {branch?.canUndoMerge && (
-                      <button
-                        onClick={() => {
-                          if (!confirm(`Undo the last merge on ${branch.name}?\n\nThe branch goes back to exactly where it was. Nothing has been pushed, so nothing anyone else has is affected.`)) return;
-                          void act(() => api.gitUndoMerge(root), "merge undone", "undo");
-                        }}
-                        disabled={!writeEnabled || busy}
-                        className="text-[11px] px-2 py-1 rounded-lg whitespace-nowrap shrink-0"
-                        style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", opacity: busy ? 0.5 : 1 }}
-                        title="Undo the last merge — the branch returns to exactly where it was. Offered only because it is unpushed and nothing sits on top of it.">
-                        {pending === "undo" ? "undoing…" : "⎌ undo merge"}
-                      </button>
-                    )}
                     {/* A merge over uncommitted work is refused by the
                             server, so the button should not offer it. Saying
                             why beats a click that produces an error toast —

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1122,7 +1122,13 @@ export function GitView({ active }: { active: boolean }) {
                             to merge from and remembers it in the repo's own
                             config, so the choice sticks per branch. */}
                         <button
-                          onClick={() => setBaseOpen((o) => !o)}
+                          onClick={() => {
+                            // Load them on demand. Depending on the Branches
+                            // tab having been visited made the picker useless
+                            // exactly when you reach for it — the first time.
+                            if (!branchData.branches.length) api.gitBranches(root).then(setBranchData).catch(() => {});
+                            setBaseOpen((o) => !o);
+                          }}
                           disabled={!writeEnabled || busy}
                           className="text-[11px] px-1.5 py-1 rounded-r-lg"
                           style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", opacity: (!writeEnabled || busy) ? 0.5 : 1 }}
@@ -1141,7 +1147,7 @@ export function GitView({ active }: { active: boolean }) {
                                   style={{ background: b.name === branch.base ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent", color: "var(--text)" }}
                                   title={b.name}>{b.name}</button>
                               ))}
-                              {!branchData.branches.length && <div className="px-2.5 py-2 t-dim2">open the Branches tab first</div>}
+                              {!branchData.branches.length && <div className="px-2.5 py-2 t-dim2">loading branches…</div>}
                             </div>
                           </div>
                         )}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1178,11 +1178,18 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                             and the reason is the fix. */}
                         <button
                           onClick={() => act(() => api.gitSyncBase(root), `merged ${branch.base}`, "sync")}
-                          disabled={!writeEnabled || busy || !tree?.clean}
+                          disabled={!writeEnabled || busy || !tree?.clean || branch.behind > 0}
                           className="text-[11px] px-2 py-1 rounded-l-lg whitespace-nowrap"
-                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy || !tree?.clean) ? 0.45 : 1 }}
+                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy || !tree?.clean || branch.behind > 0) ? 0.45 : 1 }}
                           title={!tree?.clean
                             ? "Commit or stash your changes first — merging over uncommitted work is how you lose it"
+                            : branch.behind > 0
+                            // Syncing while behind your own remote makes a
+                            // second merge commit for content the remote has
+                            // already merged — the two then have to be
+                            // reconciled. Pull is the move; sync afterwards if
+                            // anything is still missing.
+                            ? `Pull first — ${branch.behind} commit${branch.behind === 1 ? "" : "s"} on your remote branch you do not have. Syncing now would make a duplicate merge and diverge from it.`
                             : `Merge ${branch.base} into ${branch.name}. Brings the base branch's latest commits into this one — a merge, not a rebase, so nothing already pushed is rewritten.`}>
                           {pending === "sync" ? "syncing…" : `⇣ sync ↓${branch.behindBase}`}
                         </button>

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -72,14 +72,22 @@ const STATE_LABEL: Record<string, string> = {
  * "never fetched" look identical, and the whole point of the auto-fetch is that
  * you can now trust the difference.
  */
-function BranchChip({ branch }: { branch: GitBranchInfo }) {
+function BranchChip({ branch, onCopied }: { branch: GitBranchInfo; onCopied?: (name: string) => void }) {
   const { ahead, behind, upstream, state } = branch;
   const busy = state && state !== "clean" ? STATE_LABEL[state] : null;
   return (
-    <span className="px-2 py-0.5 rounded-md text-[11px] inline-flex items-center gap-1"
+    // One line, always. A ticket-shaped branch name is 60 characters and used
+    // to wrap inside the chip, which made the whole header two rows tall and
+    // pushed everything else down. The name truncates, the counts never do —
+    // they are the part you are actually reading — and the full name is one
+    // hover or one click away.
+    <span className="px-2 py-0.5 rounded-md text-[11px] inline-flex items-center gap-1 max-w-[min(46vw,520px)] cursor-pointer"
       style={{ background: "color-mix(in srgb, var(--primary) 12%, transparent)", color: "var(--primary-hover)" }}
-      title={upstream ? `tracking ${upstream}` : "no upstream — nothing to compare against"}>
-      <span>⎇ {branch.name}</span>
+      onClick={() => {
+        navigator.clipboard?.writeText(branch.name).then(() => onCopied?.(branch.name)).catch(() => { /* no clipboard permission */ });
+      }}
+      title={`${branch.name}${upstream ? `\ntracking ${upstream}` : "\nno upstream — nothing to compare against"}\n\nclick to copy the branch name`}>
+      <span className="truncate min-w-0">⎇ {branch.name}</span>
       {busy && <span style={{ color: "var(--warning)" }}>({busy})</span>}
       {/* Behind first, then ahead — it reads as "pull this many, push that many",
           and it's the order lazygit uses, so the shape is already familiar. */}
@@ -424,8 +432,13 @@ export function GitView({ active }: { active: boolean }) {
       if (!r.ok) return flash(false, r.error || "could not open the editor");
       if (r.how === "remote") {
         // It landed in a window that may be behind this one, so say so —
-        // otherwise pressing `e` looks like it did nothing at all.
-        flash(true, `sent to your open nvim · ${baseName(c.file_path)}:${line}`);
+        // otherwise pressing `e` looks like it did nothing at all. And when it
+        // went to a sibling checkout of the same project rather than this one,
+        // name it: the file opens in the nvim you have, which is the point, but
+        // you should not have to work out which window it appeared in.
+        flash(true, r.viaFamily
+          ? `sent to your nvim in ${r.viaFamily.split("/").pop()} · ${baseName(c.file_path)}:${line}`
+          : `sent to your open nvim · ${baseName(c.file_path)}:${line}`);
       } else if (r.command) {
         // Nothing reachable for *this* file. Saying "no nvim running" when one
         // is open two panes away sends you looking for a bug; naming the repo
@@ -1012,8 +1025,12 @@ export function GitView({ active }: { active: boolean }) {
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>Source control</span>
                   <div className="relative">
-                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
-                      <span className="font-medium">{repoRef?.name ?? "repo"}</span><span className="t-dim2">▼</span>
+                    {/* Also one line. A worktree directory carries the whole
+                        ticket name, and wrapped it made the button two rows
+                        tall and shoved the tab strip down with it. */}
+                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[240px]" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
+                      title={repoRef ? `${repoRef.name}\n${repoRef.root}` : undefined}>
+                      <span className="font-medium truncate min-w-0">{repoRef?.name ?? "repo"}</span><span className="t-dim2 shrink-0">▼</span>
                     </button>
                     {repoOpen && (
                       <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 420, overflow: "hidden" }}>
@@ -1068,7 +1085,7 @@ export function GitView({ active }: { active: boolean }) {
                     {VIEW_GROUPS.map((g) => <ViewGroup key={g.label} views={g.views} />)}
                   </div>
                   <div className="ml-auto flex items-center gap-1.5">
-                    {branch && <BranchChip branch={branch} />}
+                    {branch && <BranchChip branch={branch} onCopied={(n) => flash(true, `copied ${n}`)} />}
                     {/* Each says what it's doing while it does it. A pull over a
                         slow network is several seconds of nothing otherwise, and
                         the honest reading of that is "the button is broken". */}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -384,6 +384,9 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const [baseOpen, setBaseOpen] = useState(false);
   /** Files git has stopped on. Only ever non-empty mid-merge. */
   const [conflicts, setConflicts] = useState<string[]>([]);
+  /** Local heads and remote-tracking refs, for the "merge from…" list. */
+  const [baseRefs, setBaseRefs] = useState<{ name: string; remote: boolean }[]>([]);
+  const [baseQuery, setBaseQuery] = useState("");
   const mergeState = tree?.branch.state ?? "clean";
   useEffect(() => {
     if (!open || !root || mergeState === "clean") { setConflicts([]); return; }
@@ -1162,7 +1165,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                             // Load them on demand. Depending on the Branches
                             // tab having been visited made the picker useless
                             // exactly when you reach for it — the first time.
-                            if (!branchData.branches.length) api.gitBranches(root).then(setBranchData).catch(() => {});
+                            if (!baseRefs.length) api.gitBaseCandidates(root).then((r) => setBaseRefs(r.refs ?? [])).catch(() => {});
                             setBaseOpen((o) => !o);
                           }}
                           disabled={!writeEnabled || busy}
@@ -1173,17 +1176,60 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                           <div className="absolute right-0 top-full mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col"
                             style={{ zIndex: 40, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 260, maxHeight: 320, overflow: "hidden" }}>
                             <div className="px-2.5 py-1.5 t-dim2 text-[9.5px] uppercase tracking-wider shrink-0">merge into {branch.name} from…</div>
+                            {/* The base it will actually use, pinned and above
+                                the search — the answer to "what does this
+                                button do" should not require scrolling a list
+                                of 800 to find the highlighted row. */}
+                            <div className="mx-1.5 mb-1 px-2 py-1.5 rounded-md flex items-center gap-2 shrink-0"
+                              style={{ background: "color-mix(in srgb, var(--primary) 15%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)" }}>
+                              <span className="shrink-0" style={{ color: "var(--primary-hover)" }}>✓</span>
+                              <span className="min-w-0 flex-1 truncate" style={{ color: "var(--text)" }} title={branch.base ?? ""}>{branch.base}</span>
+                              <span className="shrink-0 text-[9px] t-dim2">current base</span>
+                            </div>
+                            <div className="px-2.5 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider shrink-0">or change to…</div>
+                            {/* A real repo has hundreds of refs — this one
+                                offers 827 — so the list is only usable with a
+                                filter, and only sane with the answer you
+                                probably want already at the top. */}
+                            <input autoFocus value={baseQuery} onChange={(e) => setBaseQuery(e.target.value)}
+                              placeholder="filter branches…"
+                              className="mx-1.5 mb-1 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
+                              style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                             <div className="agx-scroll overflow-y-auto pb-1">
-                              {branchData.branches.filter((b) => b.name !== branch.name).map((b) => (
+                              {baseRefs
+                                .filter((b) => b.name !== branch.name && b.name !== branch.base)
+                                .filter((b) => { const q = baseQuery.trim().toLowerCase(); return !q || b.name.toLowerCase().includes(q); })
+                                // Current base first, then the trunk, then the
+                                // rest as git ordered them (most recent first).
+                                .sort((a, b) => Number(b.name === branch.base) - Number(a.name === branch.base)
+                                  || Number(/(^|\/)(master|main)$/.test(b.name)) - Number(/(^|\/)(master|main)$/.test(a.name)))
+                                .slice(0, 200)
+                                .map((b) => (
                                 <button key={b.name} onClick={async () => {
                                   setBaseOpen(false);
                                   await act(() => api.gitSetBase(root, branch.name, b.name), `base set to ${b.name}`, "sync");
                                 }}
-                                  className="w-full text-left px-2.5 py-1.5 truncate"
+                                  className="w-full text-left px-2.5 py-1.5 flex items-center gap-2"
                                   style={{ background: b.name === branch.base ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent", color: "var(--text)" }}
-                                  title={b.name}>{b.name}</button>
+                                  title={b.name}>
+                                  {/* Which kind of ref this is, because it
+                                      changes what you get: `master` is your
+                                      copy, which may be weeks behind the
+                                      `origin/master` the default base uses. */}
+                                  <span className="shrink-0 text-[8.5px] px-1 py-[1px] rounded"
+                                    style={b.remote
+                                      ? { color: "var(--info)", border: "1px solid color-mix(in srgb, var(--info) 35%, transparent)" }
+                                      : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                                    {b.remote ? "REMOTE" : "LOCAL"}
+                                  </span>
+                                  <span className="min-w-0 flex-1 truncate">{b.name}</span>
+                                  {b.name === branch.base && <span className="shrink-0 text-[9px]" style={{ color: "var(--primary-hover)" }}>current</span>}
+                                </button>
                               ))}
-                              {!branchData.branches.length && <div className="px-2.5 py-2 t-dim2">loading branches…</div>}
+                              {!baseRefs.length && <div className="px-2.5 py-2 t-dim2">loading branches…</div>}
+                              {baseRefs.length > 200 && !baseQuery.trim() && (
+                                <div className="px-2.5 py-1.5 t-dim2 text-[9.5px]">showing 200 of {baseRefs.length} — type to find the rest</div>
+                              )}
                             </div>
                           </div>
                         )}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -81,7 +81,7 @@ function BranchChip({ branch, onCopied }: { branch: GitBranchInfo; onCopied?: (n
     // pushed everything else down. The name truncates, the counts never do —
     // they are the part you are actually reading — and the full name is one
     // hover or one click away.
-    <span className="px-2 py-0.5 rounded-md text-[11px] inline-flex items-center gap-1 max-w-[min(46vw,520px)] cursor-pointer"
+    <span className="px-2 py-0.5 rounded-md text-[11px] inline-flex items-center gap-1 min-w-0 max-w-[min(30vw,340px)] cursor-pointer"
       style={{ background: "color-mix(in srgb, var(--primary) 12%, transparent)", color: "var(--primary-hover)" }}
       onClick={() => {
         navigator.clipboard?.writeText(branch.name).then(() => onCopied?.(branch.name)).catch(() => { /* no clipboard permission */ });
@@ -182,8 +182,12 @@ function RemoteButton({ label, runningLabel, running, disabled, primary, onClick
   label: string; runningLabel?: string; running: boolean; disabled: boolean; primary?: boolean; onClick: () => void;
 }) {
   return (
+    // nowrap + shrink-0: this row holds a 60-character branch name, and flex
+    // was solving the overflow by breaking "↑ push (1)" across two lines and
+    // making the whole header taller. The branch chip is the one thing here
+    // that may shrink; the controls are not negotiable.
     <button onClick={onClick} disabled={disabled}
-      className="text-[11px] px-2.5 py-1 rounded-lg transition-opacity active:scale-[0.97]"
+      className="text-[11px] px-2.5 py-1 rounded-lg transition-opacity active:scale-[0.97] whitespace-nowrap shrink-0"
       style={{
         color: primary ? "var(--text)" : "var(--text2)",
         fontWeight: primary ? 500 : undefined,
@@ -981,7 +985,7 @@ export function GitView({ active }: { active: boolean }) {
     return (
       <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]} — press ${num}`}
         aria-keyshortcuts={String(num)}
-        className="text-[10.5px] px-2 py-1 rounded-md transition-colors flex items-center gap-1.5"
+        className="text-[10.5px] px-2 py-1 rounded-md transition-colors flex items-center gap-1.5 whitespace-nowrap shrink-0"
         style={{ background: view === id ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: view === id ? "var(--text)" : "var(--text3)", border: `1px solid color-mix(in srgb, var(--border) ${view === id ? 40 : 15}%, transparent)` }}>
         {/* The key that gets you here. lazygit does the same in its panel titles
             (gui.showPanelJumps) — a shortcut nothing advertises is a shortcut
@@ -1024,13 +1028,18 @@ export function GitView({ active }: { active: boolean }) {
     <div ref={frameRef} tabIndex={-1} onKeyDown={onKey}
       className="flex-1 min-h-0 flex flex-col outline-none overflow-hidden relative">
                 <style>{SCROLLBAR_CSS}</style>
+                {/* No overflow-hidden here, ever: the repo picker's dropdown is
+                    absolutely positioned inside this row, and clipping the row
+                    clipped the menu to a sliver. Overflow is prevented by the
+                    branch chip yielding space and the tab strip scrolling —
+                    not by cutting off whatever escapes. */}
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
-                  <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>Source control</span>
+                  <span className="text-[15px] font-semibold whitespace-nowrap shrink-0" style={{ color: "var(--text)" }}>Source control</span>
                   <div className="relative">
                     {/* Also one line. A worktree directory carries the whole
                         ticket name, and wrapped it made the button two rows
                         tall and shoved the tab strip down with it. */}
-                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[240px]" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
+                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[240px] shrink-0 whitespace-nowrap" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
                       title={repoRef ? `${repoRef.name}\n${repoRef.root}` : undefined}>
                       <span className="font-medium truncate min-w-0">{repoRef?.name ?? "repo"}</span><span className="t-dim2 shrink-0">▼</span>
                     </button>
@@ -1083,10 +1092,14 @@ export function GitView({ active }: { active: boolean }) {
                       </div>
                     )}
                   </div>
-                  <div className="flex items-center gap-2 ml-1">
+                  {/* Scrolls rather than shoves. Eight tabs plus a long branch
+                      name will not fit a narrow window, and something has to
+                      give — a strip you can flick is better than controls
+                      pushed off the right edge. */}
+                  <div className="flex items-center gap-2 ml-1 min-w-0 overflow-x-auto agw-noscrollbar">
                     {VIEW_GROUPS.map((g) => <ViewGroup key={g.label} views={g.views} />)}
                   </div>
-                  <div className="ml-auto flex items-center gap-1.5">
+                  <div className="ml-auto flex items-center gap-1.5 min-w-0">
                     {branch && <BranchChip branch={branch} onCopied={(n) => flash(true, `copied ${n}`)} />}
                     {/* Update from base — merge master's latest into the branch
                         you are on, in this checkout. Sits with fetch/pull/push

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -5,6 +5,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
+import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
 import { usePoll } from "../lib/usePoll.ts";
 import { worktreeTag } from "../lib/worktree.ts";
@@ -509,6 +510,18 @@ export function GitView({ active }: { active: boolean }) {
     else if (view === "reflog") track(api.gitReflog(root), (r) => setReflog(r.entries));
   }, [open, root, view]);
   useEffect(() => { loadView(); }, [loadView]);
+
+  // Any repository mutation, from anywhere — this panel, another window, or a
+  // `git pull` typed into the app's own terminal — re-reads what is on screen.
+  // The dropdown's counts in particular came from a 5s server cache that the
+  // panel re-fetched *immediately* after an action, so it kept answering with
+  // numbers from before it.
+  useEffect(() => subscribeGitChanged(() => {
+    if (!open) return;
+    if (root) loadTree(root);
+    loadView();
+    api.gitRepos().then((r) => setRepos(r.repos)).catch(() => {});
+  }), [open, root, loadTree, loadView]);
 
   // The working tree changes from outside this app — a commit in a terminal, a
   // branch switch, an agent editing files — and none of that emits an event we
@@ -1326,6 +1339,29 @@ export function GitView({ active }: { active: boolean }) {
                         <span className="shrink-0 text-[9.5px] tabular-nums t-dim2">{w.head}</span>
                         {w.locked && <span className="shrink-0 text-[9px]" style={{ color: "var(--warning)" }}>locked</span>}
                         <span className="min-w-0 flex-1 truncate text-[9.5px] t-dim2">{w.path}</span>
+                        {/* How far this checkout has drifted from what it was
+                            branched off, and the one-click way to close the
+                            gap. Shown only when there is a gap: a checkout
+                            level with its base needs no button, and the trunk
+                            has no base at all. */}
+                        {!!w.base && (w.behindBase ?? 0) > 0 && (
+                          <>
+                            <span className="shrink-0 text-[9.5px] tabular-nums" style={{ color: "var(--warning)" }}
+                              title={`${w.behindBase} commit${w.behindBase === 1 ? "" : "s"} on ${w.base} that this branch does not have`}>
+                              ↓{w.behindBase} behind {w.base}
+                            </span>
+                            {writeEnabled && (
+                              <button
+                                onClick={() => act(() => api.gitSyncBase(w.path, w.base ?? undefined), `merged ${w.base}`, "sync")}
+                                disabled={busy}
+                                className="shrink-0 text-[10px] px-1.5 py-0.5 rounded"
+                                style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: busy ? 0.5 : 1 }}
+                                title={`Merge ${w.base} into ${w.branch}, in that worktree. A merge, not a rebase — nothing already pushed gets rewritten.`}>
+                                {pending === "sync" ? "syncing…" : "sync"}
+                              </button>
+                            )}
+                          </>
+                        )}
                         {writeEnabled && !w.current && <button onClick={() => removeWorktree(w)} className="shrink-0 text-[10px] opacity-0 group-hover:opacity-100 px-1.5 py-0.5 rounded" style={{ color: "var(--error)" }} title="Remove worktree">remove</button>}
                       </div>
                     ))}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1149,7 +1149,24 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         itself, which has no base. */}
                     {branch?.base && (branch.behindBase ?? 0) > 0 && (
                       <div className="relative flex items-center">
-                        {/* A merge over uncommitted work is refused by the
+                        {/* Only while it is safe and exact: an unpushed merge at
+                        the tip, on a clean tree. Once anything is committed on
+                        top the tip is no longer the merge, and once it is
+                        pushed the honest undo is a revert, not a rewrite. */}
+                    {branch?.canUndoMerge && (
+                      <button
+                        onClick={() => {
+                          if (!confirm(`Undo the last merge on ${branch.name}?\n\nThe branch goes back to exactly where it was. Nothing has been pushed, so nothing anyone else has is affected.`)) return;
+                          void act(() => api.gitUndoMerge(root), "merge undone", "undo");
+                        }}
+                        disabled={!writeEnabled || busy}
+                        className="text-[11px] px-2 py-1 rounded-lg whitespace-nowrap shrink-0"
+                        style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", opacity: busy ? 0.5 : 1 }}
+                        title="Undo the last merge — the branch returns to exactly where it was. Offered only because it is unpushed and nothing sits on top of it.">
+                        {pending === "undo" ? "undoing…" : "⎌ undo merge"}
+                      </button>
+                    )}
+                    {/* A merge over uncommitted work is refused by the
                             server, so the button should not offer it. Saying
                             why beats a click that produces an error toast —
                             and the reason is the fix. */}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -375,6 +375,8 @@ export function GitView({ active }: { active: boolean }) {
   /** Which view has a request in flight, so "still loading" and "genuinely
    *  empty" stop rendering as the same blank pane. */
   const [busyView, setBusyView] = useState<View | null>(null);
+  /** The "merge from…" list on the header's sync button. */
+  const [baseOpen, setBaseOpen] = useState(false);
   // Only the branches whose upstream is gone — the merged-and-tidied ones. Off
   // by default: it's a cleanup mode, not a way to read the branch list.
   const [onlyGone, setOnlyGone] = useState(false);
@@ -1086,6 +1088,52 @@ export function GitView({ active }: { active: boolean }) {
                   </div>
                   <div className="ml-auto flex items-center gap-1.5">
                     {branch && <BranchChip branch={branch} onCopied={(n) => flash(true, `copied ${n}`)} />}
+                    {/* Update from base — merge master's latest into the branch
+                        you are on, in this checkout. Sits with fetch/pull/push
+                        because it belongs to the same family of "bring this
+                        checkout up to date"; it was only on the Worktrees tab
+                        before, which is not where anyone looks for it.
+                        Hidden when there is nothing to merge, and on the trunk
+                        itself, which has no base. */}
+                    {branch?.base && (branch.behindBase ?? 0) > 0 && (
+                      <div className="relative flex items-center">
+                        <button
+                          onClick={() => act(() => api.gitSyncBase(root), `merged ${branch.base}`, "sync")}
+                          disabled={!writeEnabled || busy}
+                          className="text-[11px] px-2 py-1 rounded-l-lg whitespace-nowrap"
+                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy) ? 0.5 : 1 }}
+                          title={`Merge ${branch.base} into ${branch.name}. Brings the base branch's latest commits into this one — a merge, not a rebase, so nothing already pushed is rewritten.`}>
+                          {pending === "sync" ? "syncing…" : `⇣ sync ↓${branch.behindBase}`}
+                        </button>
+                        {/* Not every branch is cut from trunk. This picks what
+                            to merge from and remembers it in the repo's own
+                            config, so the choice sticks per branch. */}
+                        <button
+                          onClick={() => setBaseOpen((o) => !o)}
+                          disabled={!writeEnabled || busy}
+                          className="text-[11px] px-1.5 py-1 rounded-r-lg"
+                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", opacity: (!writeEnabled || busy) ? 0.5 : 1 }}
+                          title={`Merging from ${branch.base} — pick a different base`}>▾</button>
+                        {baseOpen && (
+                          <div className="absolute right-0 top-full mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col"
+                            style={{ zIndex: 40, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 260, maxHeight: 320, overflow: "hidden" }}>
+                            <div className="px-2.5 py-1.5 t-dim2 text-[9.5px] uppercase tracking-wider shrink-0">merge into {branch.name} from…</div>
+                            <div className="agx-scroll overflow-y-auto pb-1">
+                              {branchData.branches.filter((b) => b.name !== branch.name).map((b) => (
+                                <button key={b.name} onClick={async () => {
+                                  setBaseOpen(false);
+                                  await act(() => api.gitSetBase(root, branch.name, b.name), `base set to ${b.name}`, "sync");
+                                }}
+                                  className="w-full text-left px-2.5 py-1.5 truncate"
+                                  style={{ background: b.name === branch.base ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent", color: "var(--text)" }}
+                                  title={b.name}>{b.name}</button>
+                              ))}
+                              {!branchData.branches.length && <div className="px-2.5 py-2 t-dim2">open the Branches tab first</div>}
+                            </div>
+                          </div>
+                        )}
+                      </div>
+                    )}
                     {/* Each says what it's doing while it does it. A pull over a
                         slow network is several seconds of nothing otherwise, and
                         the honest reading of that is "the button is broken". */}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1149,12 +1149,18 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         itself, which has no base. */}
                     {branch?.base && (branch.behindBase ?? 0) > 0 && (
                       <div className="relative flex items-center">
+                        {/* A merge over uncommitted work is refused by the
+                            server, so the button should not offer it. Saying
+                            why beats a click that produces an error toast —
+                            and the reason is the fix. */}
                         <button
                           onClick={() => act(() => api.gitSyncBase(root), `merged ${branch.base}`, "sync")}
-                          disabled={!writeEnabled || busy}
+                          disabled={!writeEnabled || busy || !tree?.clean}
                           className="text-[11px] px-2 py-1 rounded-l-lg whitespace-nowrap"
-                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy) ? 0.5 : 1 }}
-                          title={`Merge ${branch.base} into ${branch.name}. Brings the base branch's latest commits into this one — a merge, not a rebase, so nothing already pushed is rewritten.`}>
+                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy || !tree?.clean) ? 0.45 : 1 }}
+                          title={!tree?.clean
+                            ? "Commit or stash your changes first — merging over uncommitted work is how you lose it"
+                            : `Merge ${branch.base} into ${branch.name}. Brings the base branch's latest commits into this one — a merge, not a rebase, so nothing already pushed is rewritten.`}>
                           {pending === "sync" ? "syncing…" : `⇣ sync ↓${branch.behindBase}`}
                         </button>
                         {/* Not every branch is cut from trunk. This picks what
@@ -1571,7 +1577,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                                 disabled={busy}
                                 className="shrink-0 text-[10px] px-1.5 py-0.5 rounded"
                                 style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: busy ? 0.5 : 1 }}
-                                title={`Merge ${w.base} into ${w.branch}, in that worktree. A merge, not a rebase — nothing already pushed gets rewritten.`}>
+                                title={`Merge ${w.base} into ${w.branch}, in that worktree. A merge, not a rebase — nothing already pushed gets rewritten. Refused if that checkout has uncommitted changes.`}>
                                 {pending === "sync" ? "syncing…" : "sync"}
                               </button>
                             )}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -284,7 +284,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                     <div className="px-3 pt-1 pb-1 flex items-center gap-3">
                       <span className="text-[10px] t-dim2 flex-1">
                         {/* Says why the rest of the keyboard is not on this list. */}
-                        Only the single-key shortcuts. {MOD_KEY}1–5, {MOD_KEY}\\ and {MOD_KEY}K are fixed — they are the ones that still work while you are typing.
+                        Single keys, and they work from the dashboard only — inside the workspace every keystroke belongs to whatever has focus, usually a shell. There, navigation is {MOD_KEY}1–5, {MOD_KEY}\\ and {MOD_KEY}[ / {MOD_KEY}], which no shell consumes.
                       </span>
                       {isCustomised() && (
                         <button onClick={() => { resetBindings(); setKeyError(null); setCapturing(null); }}

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -13,6 +13,25 @@ import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../li
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 
 const ROOT_KEY = "agentglass.terminalRoot";
+/** The repo the terminal view last used — what a docked console should open
+ *  in, so the console and the terminal are the same shell in the same place. */
+export function lastTerminalRoot(): string {
+  try { return localStorage.getItem(ROOT_KEY) || ""; } catch { return ""; }
+}
+
+/** Marks the one shell per repo that belongs to a docked console strip. */
+const CONSOLE_TITLE = "console";
+
+/** Status dot, for anywhere that shows a shell's state. TermView builds a
+ *  richer one that names the shell; this is the shared minimum. */
+const SESS_DOT: Record<SessStatus, { color: string; label: string }> = {
+  idle: { color: "var(--text2)", label: "idle" },
+  connecting: { color: "var(--warning)", label: "connecting…" },
+  live: { color: "var(--success, #98c379)", label: "live" },
+  exited: { color: "var(--text2)", label: "exited" },
+  error: { color: "var(--error)", label: "disconnected" },
+  unauthorized: { color: "var(--error)", label: "unauthorized ⚿" },
+};
 const QUICK = ["git status", "git log --oneline -15", "git diff --stat", "git branch -vv"];
 const repoName = (p: string) => p.split("/").pop() || p;
 
@@ -314,6 +333,94 @@ function runInShell(s: Sess, cmd: string) {
  *
  *  `onClose` is still needed here (unlike the other views) because the shell
  *  itself can dismiss the workspace with Shift+Esc — see `panelClose`. */
+/**
+ * A shell strip that lives at the bottom of another panel.
+ *
+ * Same machinery as the terminal view — same module-level session store, same
+ * PTY, same xterm — deliberately: a second, lesser terminal would be a second
+ * set of bugs, and a console you cannot run `make migrate` in properly is not
+ * worth the room it takes.
+ *
+ * Keyed on the repo, not on the panel's selection, which is the point. Docker's
+ * console must not restart because you clicked a different container: the whole
+ * value of a console under the logs is that it keeps its history and its
+ * running job while you look around above it.
+ */
+export function ConsoleStrip({ root, open, height, onHeight, onClose }: {
+  root: string; open: boolean; height: number; onHeight: (h: number) => void; onClose: () => void;
+}) {
+  const slot = useRef<HTMLDivElement>(null);
+  const [, redraw] = useReducer((x: number) => x + 1, 0);
+  const [sid, setSid] = useState<string>("");
+
+  // One console shell per repo, reused. `sessionsFor` already orders by
+  // creation, so the first console-tagged one is stable across remounts.
+  useEffect(() => {
+    if (!open || !root || IS_DEMO) return;
+    const existing = sessionsFor(root).find((x) => x.title === CONSOLE_TITLE);
+    const s = existing ?? createSession(root);
+    s.title = CONSOLE_TITLE;
+    setSid(s.id);
+  }, [open, root]);
+
+  useEffect(() => {
+    if (!open || IS_DEMO) return;
+    const s = sessions.get(sid);
+    const el = slot.current;
+    if (!s || !el) return;
+    el.appendChild(s.holder);
+    if (!s.opened) { s.term.open(s.holder); s.opened = true; }
+    s.term.options.theme = themeFromCss();
+    const unTheme = applyThemeLive(s);
+    s.subs.add(redraw);
+    const doFit = () => { try { s.fit.fit(); } catch { /* not measurable yet */ } };
+    doFit();
+    if (s.status === "idle") connect(s);
+    const ro = new ResizeObserver(doFit);
+    ro.observe(el);
+    return () => {
+      ro.disconnect();
+      unTheme();
+      s.subs.delete(redraw);
+      // Detached, never killed: the shell and its scrollback outlive the strip
+      // being closed, so reopening lands you back in the same session.
+      if (s.holder.parentElement === el) el.removeChild(s.holder);
+    };
+  }, [open, sid]);
+
+  // Drag the top edge. Bounded so it can neither vanish nor swallow the panel
+  // it is a strip of.
+  const drag = (e: React.MouseEvent) => {
+    e.preventDefault();
+    const startY = e.clientY;
+    const startH = height;
+    const move = (ev: MouseEvent) => {
+      const next = Math.min(0.85, Math.max(0.08, startH + (startY - ev.clientY) / window.innerHeight));
+      onHeight(next);
+    };
+    const up = () => { window.removeEventListener("mousemove", move); window.removeEventListener("mouseup", up); };
+    window.addEventListener("mousemove", move);
+    window.addEventListener("mouseup", up);
+  };
+
+  const sess = sessions.get(sid);
+  if (!open) return null;
+  return (
+    <div className="shrink-0 flex flex-col" style={{ height: `${Math.round(height * 100)}%`, borderTop: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+      <div onMouseDown={drag}
+        className="shrink-0 flex items-center gap-2 px-3 py-1 cursor-row-resize select-none"
+        style={{ background: "color-mix(in srgb, var(--bg3) 45%, transparent)" }}>
+        <span className="text-[10px] uppercase tracking-wider" style={{ color: "var(--primary-hover)" }}>console</span>
+        <span className="text-[9.5px] t-dim2 truncate">{root ? repoName(root) : "no repo"}</span>
+        {sess && <span className="text-[9px]" style={{ color: SESS_DOT[sess.status].color }}>● {SESS_DOT[sess.status].label}</span>}
+        <span className="ml-auto text-[9px] t-dim2">drag to resize</span>
+        <button onClick={(e) => { e.stopPropagation(); onClose(); }} className="text-[12px] leading-none px-1.5 t-dim2 hover:opacity-70" title="hide the console (the shell keeps running)">✕</button>
+      </div>
+      <div ref={slot} className="flex-1 min-h-0" style={{ background: "var(--bg)" }} onClick={() => sess?.term.focus()} />
+    </div>
+  );
+}
+
 export function TermView({ active, onClose = () => {} }: { active: boolean; onClose?: () => void }) {
   const open = active;
   const [repos, setRepos] = useState<GitRepoRef[]>([]);

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -5,6 +5,7 @@ import { subscribeUsage, usedColor, usageError, resetLabel } from "../UsageWidge
 import { subscribe as subscribeChats, listChats } from "../../lib/chatStore.ts";
 import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
 import { clock24, subscribeClock24 } from "../../lib/clockPref.ts";
+import { subscribeGitChanged } from "../../lib/gitBus.ts";
 import {
   subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
   markNotifyRead, dismissNote, clearNotes, openNote, type SystemNote,
@@ -300,7 +301,12 @@ function useNotes(): { note: Note | null; behind: number } {
     };
     void poll();
     const id = setInterval(poll, 90_000);
-    return () => { dead = true; clearInterval(id); };
+    // 90s is right for "someone else pushed", and far too slow for "you just
+    // pulled" — the strip went on advertising commits you had already taken
+    // until the workspace was closed and opened again. The server says when a
+    // repo moved, so read it then too.
+    const off = subscribeGitChanged(() => { void poll(); });
+    return () => { dead = true; clearInterval(id); off(); };
   }, []);
 
   return { note, behind };

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -8,7 +8,7 @@ import { clock24, subscribeClock24 } from "../../lib/clockPref.ts";
 import { subscribeGitChanged } from "../../lib/gitBus.ts";
 import {
   subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
-  markNotifyRead, dismissNote, clearNotes, openNote, type SystemNote,
+  markNotifyRead, dismissNote, clearNotes, openNote, recordNote, type SystemNote,
 } from "../../lib/sysNotify.ts";
 
 /**
@@ -244,8 +244,10 @@ function useNotes(): { note: Note | null; behind: number } {
         if (first || c.attention === prev || c.attention === "none") continue;
         if (c.attention === "blocked") {
           push({ id: `${c.id}-b-${c.messages.length}`, kind: "blocked", color: "var(--error)", title: c.title || "chat", sub: c.blockedTool ? `needs "${c.blockedTool}"` : "waiting on you" });
+          recordNote({ app: "chat", summary: c.title || "chat", body: c.blockedTool ? `blocked — needs "${c.blockedTool}"` : "blocked — waiting on you", urgency: 2 });
         } else if (c.attention === "done") {
           push({ id: `${c.id}-d-${c.messages.length}`, kind: "done", color: "var(--success)", title: c.title || "chat", sub: "turn finished" });
+          recordNote({ app: "chat", summary: c.title || "chat", body: "turn finished" });
         }
       }
       first = false;
@@ -293,6 +295,7 @@ function useNotes(): { note: Note | null; behind: number } {
           seen.set(r.root, r.behind);
           if (!first && r.behind > prev) {
             push({ id: `${r.root}-${r.behind}`, kind: "pull", color: "var(--info)", title: r.name, sub: `${r.behind} to pull on ${r.branch}` });
+            recordNote({ app: "git", summary: r.name, body: `${r.behind} commit${r.behind === 1 ? "" : "s"} to pull on ${r.branch}` });
           }
         }
         setBehind(total);

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -1,4 +1,5 @@
 import { VIEWS, type ViewId } from "./views.ts";
+import { MOD_KEY } from "../../lib/format.ts";
 
 export type RailPip = { dot?: boolean; count?: number };
 
@@ -41,7 +42,7 @@ export function ViewRail({
         background: "color-mix(in srgb, var(--bg) 55%, transparent)",
       }}
     >
-      {VIEWS.map((v) => {
+      {VIEWS.map((v, i) => {
         const on = v.id === view;
         const pip = pips?.[v.id];
         const Icon = v.icon;
@@ -55,7 +56,11 @@ export function ViewRail({
             tabIndex={on ? 0 : -1}
             onClick={() => onSelect(v.id)}
             className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
-            data-tip={`${v.label} · ${v.key}`}
+            // The modifier binding, not the bare letter. Inside the workspace
+            // the letters no longer navigate — they belong to whatever has
+            // focus, usually a shell — and a tooltip advertising a key that
+            // does nothing is worse than no tooltip.
+            data-tip={`${v.label} · ${MOD_KEY}${i + 1}`}
             style={{
               color: on ? "var(--primary-hover)" : "var(--text4)",
               background: on ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -131,6 +131,7 @@ export function Workspace({
                         <View
                           active={active}
                           {...(v.id === "chat" ? { focusId: chatFocusId, onClose } : {})}
+                          {...(v.id === "git" ? { onOpenChat: () => onView("chat") } : {})}
                           {...(v.id === "term" ? { onClose } : {})}
                         />
                       </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -203,7 +203,10 @@ const realApi = {
   editorCapability: () => get<{ hasNvim: boolean; editor: string | null }>("/editor/capability"),
   editorTarget: (path: string) => get<{ running: boolean; hasNvim: boolean }>(`/editor/target?path=${encodeURIComponent(path)}`),
   editorOpen: (path: string, line: number) =>
-    post<{ ok: boolean; how?: "remote" | "spawn"; command?: string; otherCwds?: string[]; stuck?: number; error?: string }>("/editor/open", { path, line }),
+    post<{ ok: boolean; how?: "remote" | "spawn"; command?: string; otherCwds?: string[]; stuck?: number; error?: string;
+      /** Set when the file went to an nvim rooted in a *sibling* checkout of the
+       *  same project — a worktree of the repo you are looking at. */
+      viaFamily?: string }>("/editor/open", { path, line }),
   gitCheckout: (root: string, name: string) => post<GitActionResult>("/git/checkout", { root, name }),
   gitBranchCreate: (root: string, name: string) => post<GitActionResult>("/git/branch-create", { root, name }),
   gitBranchDelete: (root: string, name: string, force: boolean) => post<GitActionResult>("/git/branch-delete", { root, name, force }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -220,6 +220,9 @@ const realApi = {
   gitReset: (root: string, ref: string, mode: "soft" | "mixed" | "hard") => post<GitActionResult>("/git/reset", { root, ref, mode }),
   gitWorktreeAdd: (root: string, path: string, branch: string, newBranch: boolean) => post<GitActionResult>("/git/worktree-add", { root, path, branch, newBranch }),
   gitWorktreeRemove: (root: string, path: string, force: boolean) => post<GitActionResult>("/git/worktree-remove", { root, path, force }),
+  /** Merge a checkout's base branch into it — "update from base". `root` is the
+   *  checkout doing the updating, since the merge runs where the branch is. */
+  gitSyncBase: (root: string, base?: string) => post<GitActionResult>("/git/sync-base", { root, base }),
   // --- live docker panel (lazydocker-style) ---
   dockerOverview: () => get<DockerOverview>("/docker/overview"),
   dockerStats: () => get<{ stats: DockerStat[] }>("/docker/stats"),
@@ -331,6 +334,7 @@ const demoApi: typeof realApi = {
   gitBranchRename: (_root: string, _name: string, _to: string) => D(demo.gitActionUnavailable()),
   gitReset: (_root: string, _ref: string, _mode: "soft" | "mixed" | "hard") => D(demo.gitActionUnavailable()),
   gitWorktreeAdd: (_root: string, _path: string, _branch: string, _newBranch: boolean) => D(demo.gitActionUnavailable()),
+  gitSyncBase: (_root: string, _base?: string) => D(demo.gitActionUnavailable()),
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -229,6 +229,10 @@ const realApi = {
   /** Remember which branch this one was cut from. Written to the repo's own
    *  config, so it survives restarts and is readable with plain `git config`. */
   gitSetBase: (root: string, branch: string, base: string | null) => post<GitActionResult>("/git/set-base", { root, branch, base }),
+  gitConflicts: (root: string) => get<{ ok: boolean; state: string; files: string[]; error?: string }>(`/git/conflicts?root=${encodeURIComponent(root)}`),
+  gitResolve: (root: string, paths: string[], side: "ours" | "theirs") => post<GitActionResult>("/git/resolve", { root, paths, side }),
+  gitMergeAbort: (root: string) => post<GitActionResult>("/git/merge-abort", { root }),
+  gitMergeContinue: (root: string) => post<GitActionResult>("/git/merge-continue", { root }),
   // --- live docker panel (lazydocker-style) ---
   dockerOverview: () => get<DockerOverview>("/docker/overview"),
   dockerStats: () => get<{ stats: DockerStat[] }>("/docker/stats"),
@@ -342,6 +346,10 @@ const demoApi: typeof realApi = {
   gitWorktreeAdd: (_root: string, _path: string, _branch: string, _newBranch: boolean) => D(demo.gitActionUnavailable()),
   gitSyncBase: (_root: string, _base?: string) => D(demo.gitActionUnavailable()),
   gitSetBase: (_root: string, _branch: string, _base: string | null) => D(demo.gitActionUnavailable()),
+  gitConflicts: (_root: string) => D({ ok: true, state: "clean", files: [] }),
+  gitResolve: (_root: string, _paths: string[], _side: "ours" | "theirs") => D(demo.gitActionUnavailable()),
+  gitMergeAbort: (_root: string) => D(demo.gitActionUnavailable()),
+  gitMergeContinue: (_root: string) => D(demo.gitActionUnavailable()),
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -229,6 +229,7 @@ const realApi = {
   /** Remember which branch this one was cut from. Written to the repo's own
    *  config, so it survives restarts and is readable with plain `git config`. */
   gitSetBase: (root: string, branch: string, base: string | null) => post<GitActionResult>("/git/set-base", { root, branch, base }),
+  gitBaseCandidates: (root: string) => get<{ ok: boolean; refs: { name: string; remote: boolean }[] }>(`/git/base-candidates?root=${encodeURIComponent(root)}`),
   gitConflicts: (root: string) => get<{ ok: boolean; state: string; files: string[]; error?: string }>(`/git/conflicts?root=${encodeURIComponent(root)}`),
   gitResolve: (root: string, paths: string[], side: "ours" | "theirs") => post<GitActionResult>("/git/resolve", { root, paths, side }),
   gitMergeAbort: (root: string) => post<GitActionResult>("/git/merge-abort", { root }),
@@ -346,6 +347,7 @@ const demoApi: typeof realApi = {
   gitWorktreeAdd: (_root: string, _path: string, _branch: string, _newBranch: boolean) => D(demo.gitActionUnavailable()),
   gitSyncBase: (_root: string, _base?: string) => D(demo.gitActionUnavailable()),
   gitSetBase: (_root: string, _branch: string, _base: string | null) => D(demo.gitActionUnavailable()),
+  gitBaseCandidates: (_root: string) => D({ ok: true, refs: [] }),
   gitConflicts: (_root: string) => D({ ok: true, state: "clean", files: [] }),
   gitResolve: (_root: string, _paths: string[], _side: "ours" | "theirs") => D(demo.gitActionUnavailable()),
   gitMergeAbort: (_root: string) => D(demo.gitActionUnavailable()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -226,6 +226,9 @@ const realApi = {
   /** Merge a checkout's base branch into it — "update from base". `root` is the
    *  checkout doing the updating, since the merge runs where the branch is. */
   gitSyncBase: (root: string, base?: string) => post<GitActionResult>("/git/sync-base", { root, base }),
+  /** Remember which branch this one was cut from. Written to the repo's own
+   *  config, so it survives restarts and is readable with plain `git config`. */
+  gitSetBase: (root: string, branch: string, base: string | null) => post<GitActionResult>("/git/set-base", { root, branch, base }),
   // --- live docker panel (lazydocker-style) ---
   dockerOverview: () => get<DockerOverview>("/docker/overview"),
   dockerStats: () => get<{ stats: DockerStat[] }>("/docker/stats"),
@@ -338,6 +341,7 @@ const demoApi: typeof realApi = {
   gitReset: (_root: string, _ref: string, _mode: "soft" | "mixed" | "hard") => D(demo.gitActionUnavailable()),
   gitWorktreeAdd: (_root: string, _path: string, _branch: string, _newBranch: boolean) => D(demo.gitActionUnavailable()),
   gitSyncBase: (_root: string, _base?: string) => D(demo.gitActionUnavailable()),
+  gitSetBase: (_root: string, _branch: string, _base: string | null) => D(demo.gitActionUnavailable()),
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -233,6 +233,7 @@ const realApi = {
   gitConflicts: (root: string) => get<{ ok: boolean; state: string; files: string[]; error?: string }>(`/git/conflicts?root=${encodeURIComponent(root)}`),
   gitResolve: (root: string, paths: string[], side: "ours" | "theirs") => post<GitActionResult>("/git/resolve", { root, paths, side }),
   gitMergeAbort: (root: string) => post<GitActionResult>("/git/merge-abort", { root }),
+  gitUndoMerge: (root: string) => post<GitActionResult>("/git/undo-merge", { root }),
   gitMergeContinue: (root: string) => post<GitActionResult>("/git/merge-continue", { root }),
   // --- live docker panel (lazydocker-style) ---
   dockerOverview: () => get<DockerOverview>("/docker/overview"),
@@ -351,6 +352,7 @@ const demoApi: typeof realApi = {
   gitConflicts: (_root: string) => D({ ok: true, state: "clean", files: [] }),
   gitResolve: (_root: string, _paths: string[], _side: "ours" | "theirs") => D(demo.gitActionUnavailable()),
   gitMergeAbort: (_root: string) => D(demo.gitActionUnavailable()),
+  gitUndoMerge: (_root: string) => D(demo.gitActionUnavailable()),
   gitMergeContinue: (_root: string) => D(demo.gitActionUnavailable()),
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
   dockerOverview: () => D(demo.dockerOverview()),

--- a/web/src/lib/gitBus.ts
+++ b/web/src/lib/gitBus.ts
@@ -1,0 +1,30 @@
+/**
+ * "Git changed" — one signal, every consumer.
+ *
+ * The panels each cached or polled git state on their own clock: the repo
+ * dropdown on a 5s server cache, the notch's behind-count on a 90s poll, the
+ * working tree on 2.5s. So a pull updated the header immediately, left the
+ * dropdown claiming "behind 351" until the next action, and left the notch
+ * wrong until you closed the workspace and opened it again. Each was correct
+ * in isolation and the app as a whole was lying.
+ *
+ * The server knows the moment anything mutates — every write goes through one
+ * function — so it says so on the socket the client already holds, and
+ * everything that shows git state listens here. No new polling, and it also
+ * covers the case a client-side hook never could: a `git pull` typed into the
+ * app's own terminal.
+ */
+
+const listeners = new Set<() => void>();
+
+/** Called by the live socket when the server reports a mutation. */
+export function gitChanged(): void {
+  for (const fn of listeners) {
+    try { fn(); } catch { /* one bad listener must not stop the rest */ }
+  }
+}
+
+export function subscribeGitChanged(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}

--- a/web/src/lib/sysNotify.ts
+++ b/web/src/lib/sysNotify.ts
@@ -102,6 +102,29 @@ function historyChanged() {
   for (const fn of historyListeners) fn();
 }
 
+/**
+ * Record something agentglass itself raised — a chat that finished, a branch
+ * that fell behind — into the same history the mirrored ones land in.
+ *
+ * They share the notch's toast lane already, so they should share its memory:
+ * a toast holds "3755 commits to pull" for five seconds and is then gone, and
+ * the number was the whole message. One inbox, whatever raised it.
+ */
+export function recordNote(n: { app: string; summary: string; body: string; urgency?: 0 | 1 | 2 }) {
+  const note: SystemNote = {
+    id: `app-${++localSeq}`,
+    app: n.app,
+    summary: n.summary,
+    body: n.body,
+    urgency: n.urgency ?? 1,
+    at: Date.now(),
+  };
+  history = [note, ...history].slice(0, HISTORY_MAX);
+  unread++;
+  historyChanged();
+}
+let localSeq = 0;
+
 export function markNotifyRead() {
   if (!unread) return;
   unread = 0;

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -2,6 +2,7 @@ import { useEffect, useRef, useState, useCallback } from "react";
 import type { WatchEvent, WsFrame, OpenToolCall } from "../../../shared/types.ts";
 import { WS_URL, IS_DEMO, hasToken, probeAuth } from "./api.ts";
 import * as demo from "./demo.ts";
+import { gitChanged } from "./gitBus.ts";
 
 const MAX_EVENTS = 2000;
 const FLUSH_MS = 220; // coalesce bursts into ~5 renders/sec
@@ -120,6 +121,11 @@ export function useLive(): LiveData {
       try {
         frame = JSON.parse(msg.data);
       } catch {
+        return;
+      }
+      if (frame.type === "git") {
+        // Not our data — a nudge for whoever is showing git state.
+        gitChanged();
         return;
       }
       if (frame.type === "initial") {


### PR DESCRIPTION
Second of four stacked PRs. **Based on #119** — merge that first.

### What's here

**Sync a checkout from its base.** The "merge master's latest into this branch" that otherwise means leaving the app. Disabled while the tree is dirty, because merging over uncommitted work is how you lose it.

**Resolve merge conflicts without leaving.** Conflicted files are listed as what they are — files git has stopped in the middle of, not ordinary edits — so you cannot commit one with `<<<<<<<` still in it. Whole-file `ours`/`theirs` for the lockfile case, and a "send it to Claude" path for the rest.

**Undo the last merge, while that is still exactly reversible.** Only when nothing is committed on top and nothing is pushed. The guard was inverted first time: a branch with no upstream reports zero commits ahead, which is the *safest* case, and it was being refused. A test caught it.

**The base picker offers refs you can actually merge from**, and loads its own branches rather than borrowing another pane's.

**Loading states everywhere they were missing.** Worktrees, tags, remotes and branches all painted "none" while still fetching, so an empty result and a pending request looked identical.

**Header fixes.** The branch chip, repo button, title and pull/push counts each wrapped to a second line and shoved the tab strip down. Fixed at the component level after fixing it four times individually — and then the `overflow-hidden` that fixed it clipped the repo dropdown to a sliver, so overflow is now prevented by the content yielding rather than by cutting off what escapes.

**A squash-merge sweep that no longer stalls the branches request** — it yields one probe per tick, after a first attempt that only moved the stall from request 1 to request 2.

### Verification

`315 tests pass`, typecheck clean at this commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)