### PR TITLE
fix(desktop): don't adopt a foreign server on :4000

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -40,7 +40,13 @@ protocol.registerSchemesAsPrivileged([
   },
 ]);
 
-const SERVER_PORT = Number(process.env.AGENTGLASS_PORT || 4000);
+// Where the sidecar is asked to listen. Resolved at startup (see pickPort) --
+// the preferred port is only the first candidate, not a promise.
+const PREFERRED_PORT = Number(process.env.AGENTGLASS_PORT || 4000);
+// How far to walk when the preferred port is taken by something that is not us.
+const PORT_CANDIDATES = 8;
+let SERVER_PORT = PREFERRED_PORT;
+let apiOrigin = `http://127.0.0.1:${SERVER_PORT}`;
 
 // Paths differ between `electron .` (repo checkout) and a packaged app, where
 // electron-builder copies web/dist and the compiled sidecar into resources/.
@@ -84,24 +90,79 @@ function serveApp() {
   });
 }
 
-function health() {
+/**
+ * What is answering on a port: our server, someone else's, or nothing.
+ *
+ * "Answers 200" is NOT proof it is us, and treating it as proof is a bug with
+ * teeth: a machine that autostarts any other local dev server on :4000 -- an
+ * observability server, an API stub, anything -- handed agentglass a stranger,
+ * which the shell then adopted. Every panel fetched from it, got whatever it
+ * says, and the app came up empty ("no repos found") with no error anywhere.
+ * That is why /health names itself and why this reads the body.
+ */
+function probe(port, timeoutMs = 1000) {
   return new Promise((resolve) => {
-    const req = http.get(`http://127.0.0.1:${SERVER_PORT}/health`, (r) => {
-      resolve(r.statusCode === 200);
-      r.resume();
+    const req = http.get(`http://127.0.0.1:${port}/health`, (r) => {
+      if (r.statusCode !== 200) { r.resume(); return resolve("foreign"); }
+      let body = "";
+      r.setEncoding("utf8");
+      // Bounded: a foreign server may stream something enormous at us.
+      r.on("data", (c) => { body += c; if (body.length > 4096) req.destroy(); });
+      r.on("end", () => {
+        try {
+          const j = JSON.parse(body);
+          // `service` is the marker; the shape check keeps a sidecar built
+          // before that field existed adoptable rather than orphaned.
+          const ours = j.service === "agentglass" || (j.ok === true && typeof j.clients === "number");
+          resolve(ours ? "ours" : "foreign");
+        } catch { resolve("foreign"); }
+      });
+      r.on("error", () => resolve("foreign"));
     });
-    req.on("error", () => resolve(false));
-    req.setTimeout(1000, () => { req.destroy(); resolve(false); });
+    req.on("error", () => resolve("free")); // refused == nothing listening
+    req.setTimeout(timeoutMs, () => { req.destroy(); resolve("foreign") });
   });
 }
 
-async function ensureServer() {
-  if (await health()) return; // a dev server or another instance is already up
+/**
+ * Pick the port to talk to: ours if one is already up, else the first free one.
+ *
+ * Probed in parallel, so this costs one round trip on loopback rather than one
+ * per candidate -- it runs before the window opens and must not be felt.
+ */
+async function pickPort() {
+  const ports = Array.from({ length: PORT_CANDIDATES }, (_, i) => PREFERRED_PORT + i);
+  const states = await Promise.all(ports.map((p) => probe(p, 400)));
+  const ours = ports.find((_, i) => states[i] === "ours");
+  if (ours !== undefined) return { port: ours, adopt: true };
+  const free = ports.find((_, i) => states[i] === "free");
+  // Everything taken by strangers is not a state worth guessing around: fall
+  // back to the preferred port and let the sidecar report the bind failure.
+  return { port: free ?? PREFERRED_PORT, adopt: false };
+}
+
+/** Settle the API origin. Must finish before the window opens -- the renderer
+ *  reads it synchronously at module load and cannot be told again later. */
+async function resolvePort() {
+  const { port, adopt } = await pickPort();
+  SERVER_PORT = port;
+  apiOrigin = `http://127.0.0.1:${port}`;
+  if (port !== PREFERRED_PORT) {
+    console.log(`[agentglass] :${PREFERRED_PORT} is in use by another app; using :${port}. ` +
+      `Hooks posting to :${PREFERRED_PORT} need AGENTGLASS_SERVER=${apiOrigin}.`);
+  }
+  return adopt;
+}
+
+async function ensureServer(adopt) {
+  const port = SERVER_PORT;
+  if (adopt) return; // a dev server or another instance is already up
+  const env = { ...process.env, AGENTGLASS_PORT: String(port) };
   sidecar = PACKAGED
-    ? spawn(SIDECAR_BIN, [], { stdio: "ignore" })
-    : spawn("bun", ["run", path.join(REPO, "server", "src", "index.ts")], { stdio: "ignore" });
+    ? spawn(SIDECAR_BIN, [], { stdio: "ignore", env })
+    : spawn("bun", ["run", path.join(REPO, "server", "src", "index.ts")], { stdio: "ignore", env });
   for (let i = 0; i < 40; i++) {
-    if (await health()) return;
+    if ((await probe(port)) === "ours") return;
     await new Promise((r) => setTimeout(r, 300));
   }
 }
@@ -158,8 +219,19 @@ function createWindow() {
   win.loadURL(`${APP_ORIGIN}/`);
 }
 
-app.whenReady().then(() => {
+app.whenReady().then(async () => {
   serveApp();
+  // Synchronous on purpose: the preload publishes `apiOrigin` as a plain value
+  // because web/src/lib/api.ts reads it while its module body runs, before any
+  // promise could resolve. Safe because the port is settled just below, before
+  // any window (and therefore any preload) exists.
+  ipcMain.on("ag:apiOrigin", (e) => { e.returnValue = apiOrigin; });
+
+  // Which port, decided before the window — the renderer bakes the origin in at
+  // load and there is no second chance to correct it. This is a parallel round
+  // trip on loopback (~ms), not the sidecar boot the comment below is about.
+  const adopt = await resolvePort();
+
   // The window does not wait for the server.
   //
   // It used to: `await ensureServer()` sat between ready and createWindow, so
@@ -174,7 +246,7 @@ app.whenReady().then(() => {
   // backoff and every panel's fetch has a retry or an honest loading state. So
   // the window comes up first and the server arrives underneath it.
   createWindow();
-  void ensureServer();
+  void ensureServer(adopt);
 });
 
 /**

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -11,7 +11,14 @@ contextBridge.exposeInMainWorld("agentglass", {
   // Where the sidecar listens. The renderer is served from agentglass://app,
   // whose hostname says nothing about the API — without this the web app would
   // derive `http://app:4000` from location.hostname and reach nothing.
-  apiOrigin: `http://127.0.0.1:${Number(process.env.AGENTGLASS_PORT || 4000)}`,
+  //
+  // Asked of the main process rather than assumed from the env: the port is not
+  // knowable up front, since another app may already hold the preferred one and
+  // the shell then moves aside (electron/main.js). Sync because api.ts reads
+  // this during module evaluation.
+  apiOrigin: (() => {
+    try { return ipcRenderer.sendSync("ag:apiOrigin") || null; } catch { return null; }
+  })() || `http://127.0.0.1:${Number(process.env.AGENTGLASS_PORT || 4000)}`,
   setFullscreen: (on) => ipcRenderer.invoke("ag:setFullscreen", on),
   isFullscreen: () => ipcRenderer.invoke("ag:isFullscreen"),
   setZoom: (factor) => ipcRenderer.invoke("ag:setZoom", factor),

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -339,7 +339,11 @@ const server = Bun.serve<WsData>({
     }
 
     // --- health ---
-    if (pathname === "/health") return json({ ok: true, clients: clients.size, notifyWatching: notifyWatching() });
+    // `service` is the identity marker: the desktop shell probes :4000 before
+    // spawning its sidecar, and "answers 200" is not the same as "is us". Any
+    // other local dev server squatting the port answers 200 too, and adopting
+    // it pointed the whole cockpit at a stranger's API. See electron/main.js.
+    if (pathname === "/health") return json({ ok: true, service: "agentglass", clients: clients.size, notifyWatching: notifyWatching() });
 
     // --- ingest ---
     if (pathname === "/ingest" && req.method === "POST") {


### PR DESCRIPTION
## What does this PR do?

Fixes #126. The Electron shell probed `127.0.0.1:4000/health` before starting its sidecar and treated any 200 as "agentglass is already up", so any other local server holding that port was adopted as our API: the cockpit rendered, every fetch went to a stranger, "Open a project" said *no repos found*, and nothing reported an error. The other half of the same bug was just as quiet — when the occupant did not answer 200, the sidecar was spawned, died on `EADDRINUSE`, and `stdio: "ignore"` swallowed it.

Now `/health` names itself (`"service": "agentglass"`), the shell reads the body instead of the status line, and probes a short range of ports in parallel: adopt ours if one is up, otherwise take the first free port and start the sidecar there with an explicit `AGENTGLASS_PORT`. The renderer learns the resolved origin over sync IPC, because `web/src/lib/api.ts` bakes the API origin in during module evaluation and cannot be corrected later — which is why the port is settled before the window is created. That step is a parallel round trip on loopback (~10ms measured), so the deliberate "window first, server underneath" startup is unchanged.

A sidecar built before the `service` field existed is still adopted (the shape check on `ok`/`clients` covers it), so a running dev server keeps working.

## How was it tested?

- `bunx tsc --noEmit` in `server/` and `web/`, clean.
- `bun test` in `server/`: 246 pass, 0 fail.
- On a machine with another server holding `:4000`: built and installed the desktop app, which logged `:4000 is in use by another app; using :4001`, started its sidecar there, and the project picker went from *no repos found* to 20 repos. Restarted with an agentglass server already up on `:4001` and confirmed it adopts it instead of spawning a second one.
- Port classification checked directly against the three cases: foreign 200, ours, and nothing listening.

One known leftover, not addressed here: the Claude Code hooks default to `http://localhost:4000`, so when the shell moves aside they keep posting to whatever holds it. The startup log now says which `AGENTGLASS_SERVER` value fixes that, and the transcript scanner reads `~/.claude/projects` directly, so live data still arrives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)