### PR TITLE
fix(git): don't block sync when upstream is the base branch

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -177,6 +177,10 @@ function branchInfo(root: string): GitBranchInfo {
     name, upstream, ahead, behind, detached, state: treeState(root),
     base,
     behindBase: base ? behindBase(root, name, base) : 0,
+    // Two rev-parses, so only when the answer can change a decision: the
+    // panel asks it to decide whether being behind upstream is a reason to
+    // refuse a base merge, and that question only exists while behind.
+    upstreamIsBase: upstream && base && behind > 0 ? sameBranch(root, upstream, base) : undefined,
     canUndoMerge: undoableMerge(root, ahead, upstream),
   };
 }
@@ -960,6 +964,31 @@ export function baseOf(root: string, branch: string): string | null {
   // A branch is not its own base; the trunk checkout simply has none.
   if (!trunk || trunk === branch || trunk.replace(/^origin\//, "") === branch) return null;
   return trunk;
+}
+
+/**
+ * Do two refs name the same branch, ignoring which remote they came through?
+ *
+ * `origin/main` and `main` are one branch wearing two names, and telling them
+ * apart matters: a branch that tracks the trunk directly — every local-only
+ * branch made with `git branch --track main`, and every worktree cut from one —
+ * has `@{upstream}` pointing at the trunk rather than at a remote copy of
+ * itself. Comparing the strings says "different"; comparing what they resolve
+ * to says "the same", and only the second answer is useful.
+ *
+ * Compared as full ref names rather than by stripping a slash, because branch
+ * names contain slashes too: chopping the first segment off `native/egui-shell`
+ * leaves `egui-shell`, which is not a branch anyone has.
+ */
+function sameBranch(root: string, a: string, b: string): boolean {
+  const short = (ref: string): string => {
+    const full = git(root, ["rev-parse", "--symbolic-full-name", ref]).stdout.trim();
+    return full
+      .replace(/^refs\/heads\//, "")
+      .replace(/^refs\/remotes\/[^/]+\//, "");
+  };
+  const x = short(a);
+  return !!x && x === short(b);
 }
 
 export function setBase(rootIn: unknown, branch: unknown, base: unknown): GitActionResult {

--- a/server/test/sync-guard.test.ts
+++ b/server/test/sync-guard.test.ts
@@ -1,0 +1,126 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Whether a branch's upstream is its own remote copy or the base branch itself.
+ *
+ * The panel refuses "merge the base in" while you are behind upstream, because
+ * a remote copy of your branch may already contain that merge. That reasoning
+ * does not apply to a branch tracking the trunk directly — there upstream IS
+ * the base, and merging it is the only way to close the gap. Getting this wrong
+ * disabled the button on exactly the branches that needed it, so it is tested
+ * against real clones with real tracking refs.
+ */
+let origin: string, work: string, other: string, gw: typeof import("../src/gitwork.ts");
+
+const run = (dir: string, ...args: string[]) => spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+
+beforeAll(async () => {
+  const base = mkdtempSync(join(tmpdir(), "agx-guard-"));
+  origin = join(base, "origin.git");
+  work = join(base, "work");
+  other = join(base, "other");
+
+  spawnSync("git", ["init", "-q", "--bare", "-b", "main", origin], { encoding: "utf8" });
+  spawnSync("git", ["clone", "-q", origin, work], { encoding: "utf8" });
+  run(work, "config", "user.email", "t@example.com");
+  run(work, "config", "user.name", "t");
+  writeFileSync(join(work, "a.txt"), "one\n");
+  run(work, "add", "-A");
+  run(work, "commit", "-qm", "first");
+  run(work, "push", "-q", "-u", "origin", "main");
+
+  // The reads below meet the scope guard, which otherwise reads the running
+  // machine's config. Point it at the fixture, before gitwork is imported.
+  process.env.AGENTGLASS_ROOT = work;
+
+  // A second clone stands in for "somebody else pushed", so the fixture's own
+  // branches can fall behind without rewriting anything.
+  spawnSync("git", ["clone", "-q", origin, other], { encoding: "utf8" });
+  run(other, "config", "user.email", "u@example.com");
+  run(other, "config", "user.name", "u");
+
+  gw = await import("../src/gitwork.ts");
+});
+
+afterAll(() => {
+  for (const d of [work, other, origin]) { try { rmSync(d, { recursive: true, force: true }); } catch { /* fine */ } }
+});
+
+/** Move the trunk on the server, then make `work` aware of it. Puts the second
+ *  clone back on main first: a case that left it on a branch would otherwise
+ *  commit there and push a trunk that never moved. */
+const advanceTrunk = (file: string) => {
+  run(other, "checkout", "-q", "main");
+  run(other, "pull", "-q", "--ff-only", "origin", "main");
+  writeFileSync(join(other, file), "more\n");
+  run(other, "add", "-A");
+  run(other, "commit", "-qm", `trunk ${file}`);
+  run(other, "push", "-q", "origin", "main");
+  run(work, "fetch", "-q", "origin");
+};
+
+describe("upstream is the base", () => {
+  it("says so for a local-only branch that tracks the trunk", () => {
+    // The shape every `git branch --track main` produces, and every worktree
+    // cut from one: no remote copy of this branch exists at all.
+    run(work, "checkout", "-q", "-b", "local-only", "--track", "origin/main");
+    writeFileSync(join(work, "mine.txt"), "local work\n");
+    run(work, "add", "-A");
+    run(work, "commit", "-qm", "local work");
+    advanceTrunk("b.txt");
+
+    const b = gw.workingTree(work).branch;
+    expect(b.upstream).toBe("origin/main");
+    expect(b.behind).toBeGreaterThan(0);
+    expect(b.ahead).toBeGreaterThan(0); // diverged, so `pull --ff-only` cannot run
+    expect(b.upstreamIsBase).toBe(true);
+  });
+
+  it("says no when the branch has a remote copy of its own", () => {
+    // Here being behind really does mean "your remote branch has commits you
+    // do not", which is the case the guard was written for.
+    run(work, "checkout", "-q", "-b", "twin");
+    run(work, "push", "-q", "-u", "origin", "twin");
+    run(other, "fetch", "-q", "origin");
+    run(other, "checkout", "-q", "-b", "twin", "origin/twin");
+    writeFileSync(join(other, "theirs.txt"), "from elsewhere\n");
+    run(other, "add", "-A");
+    run(other, "commit", "-qm", "their work");
+    run(other, "push", "-q", "origin", "twin");
+    advanceTrunk("c.txt");
+
+    const b = gw.workingTree(work).branch;
+    expect(b.upstream).toBe("origin/twin");
+    expect(b.behind).toBeGreaterThan(0);
+    expect(b.upstreamIsBase).toBe(false);
+  });
+
+  it("does not ask while the branch is level with its upstream", () => {
+    // Nothing is blocked when behind is zero, so the two rev-parses it costs
+    // would buy nothing on every poll of every repo.
+    run(work, "checkout", "-q", "main");
+    run(work, "merge", "-q", "--ff-only", "origin/main");
+
+    const b = gw.workingTree(work).branch;
+    expect(b.behind).toBe(0);
+    expect(b.upstreamIsBase).toBeUndefined();
+  });
+
+  it("is not fooled by a slash in the branch name", () => {
+    // Naive prefix-stripping turns `native/egui-shell` into `egui-shell` and
+    // compares that against the trunk, which is how this gets quietly wrong.
+    run(work, "checkout", "-q", "-b", "native/egui-shell", "--track", "origin/main");
+    writeFileSync(join(work, "native.txt"), "shell\n");
+    run(work, "add", "-A");
+    run(work, "commit", "-qm", "native work");
+    advanceTrunk("d.txt");
+
+    const b = gw.workingTree(work).branch;
+    expect(b.name).toBe("native/egui-shell");
+    expect(b.upstreamIsBase).toBe(true);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -385,6 +385,12 @@ export interface GitBranchInfo {
   base?: string | null;
   /** Commits the base has that this branch does not. */
   behindBase?: number;
+  /** `@{upstream}` and the base are the same branch under two names —
+   *  a local-only branch tracking the trunk (upstream `origin/main`, base
+   *  `main`). Then "behind upstream" and "behind base" count the same commits,
+   *  and merging the base is the way to close both. Only computed while it
+   *  could matter (behind > 0, base known); absent otherwise. */
+  upstreamIsBase?: boolean;
   /** The tip is an unpushed merge on a clean tree — so it can be undone
    *  exactly, by resetting to its first parent. */
   canUndoMerge?: boolean;

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1046,6 +1046,21 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
 
   const repoRef = repos.find((r) => r.root === root);
   const branch = tree?.branch;
+  /**
+   * Behind a remote copy *of this branch* — the only case where merging the
+   * base is the wrong move, because that copy has already merged what you are
+   * about to merge again.
+   *
+   * A branch that tracks the trunk directly is not that case: its upstream IS
+   * the base, so "behind upstream" and "behind base" are the same commits and
+   * the merge is exactly how you close them. Treating the two alike disabled
+   * the button on every local-only branch and sent people to a pull that
+   * cannot run — `pull --ff-only` refuses the moment you are also ahead.
+   *
+   * `undefined` means a server too old to answer: keep the old, careful
+   * behaviour rather than assuming.
+   */
+  const twinBehind = !!branch && branch.behind > 0 && branch.upstreamIsBase !== true;
   const toggleDir = (path: string) =>
     setCollapsed((prev) => {
       const next = new Set(prev);
@@ -1284,18 +1299,18 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                             and the reason is the fix. */}
                         <button
                           onClick={() => act(() => api.gitSyncBase(root), `merged ${branch.base}`, "sync")}
-                          disabled={!writeEnabled || busy || !tree?.clean || branch.behind > 0}
+                          disabled={!writeEnabled || busy || !tree?.clean || twinBehind}
                           className="text-[11px] px-2 py-1 rounded-l-lg whitespace-nowrap"
-                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy || !tree?.clean || branch.behind > 0) ? 0.45 : 1 }}
+                          style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", borderRight: "none", opacity: (!writeEnabled || busy || !tree?.clean || twinBehind) ? 0.45 : 1 }}
                           title={!tree?.clean
                             ? "Commit or stash your changes first — merging over uncommitted work is how you lose it"
-                            : branch.behind > 0
+                            : twinBehind
                             // Syncing while behind your own remote makes a
                             // second merge commit for content the remote has
                             // already merged — the two then have to be
                             // reconciled. Pull is the move; sync afterwards if
                             // anything is still missing.
-                            ? `Pull first — ${branch.behind} commit${branch.behind === 1 ? "" : "s"} on your remote branch you do not have. Syncing now would make a duplicate merge and diverge from it.`
+                            ? `Pull first — ${branch.behind} commit${branch.behind === 1 ? "" : "s"} on ${branch.upstream} you do not have. Syncing now would make a duplicate merge and diverge from it.`
                             : `Merge ${branch.base} into ${branch.name}. Brings the base branch's latest commits into this one — a merge, not a rebase, so nothing already pushed is rewritten.`}>
                           {pending === "sync" ? "syncing…" : `⇣ sync ↓${branch.behindBase}`}
                         </button>


### PR DESCRIPTION
## What does this PR do?

Fixes #129. The Source control header disabled **sync** whenever the branch was behind its upstream. That is correct for a branch with a remote copy of itself, where syncing over a copy that already merged the base produces a duplicate merge. It is wrong for a branch that tracks the trunk directly, the shape `git branch --track main` and every worktree cut from one produce: there upstream *is* the base, so "behind upstream" and "behind base" are the same commits and merging the base is the only way to close them.

The result was a button disabled on precisely the branches that needed it, a tooltip describing a remote branch that had never been pushed, and a recommended pull that could not run, since pull is `--ff-only` and such a branch is ahead by definition. Hitting it means dropping to a terminal to do the thing the button exists for.

`branchInfo` now reports `upstreamIsBase`. It compares full ref names (`refs/remotes/origin/main` against `refs/heads/main`) rather than stripping the first path segment, because branch names contain slashes too and chopping one off `native/egui-shell` leaves `egui-shell`. It costs two `rev-parse`s and runs only while the branch is behind, which is the only moment anything is blocked, so a checkout level with its upstream pays nothing on every poll.

The panel blocks on that narrower condition and names the real upstream ref when it does block. A server too old to answer sends `undefined`, and the panel then keeps the previous, careful behaviour rather than assuming.

The worktrees tab's sync button never had this guard, so that path was already working. Only the header refused.

## How was it tested?

- New `server/test/sync-guard.test.ts`, against real clones with real tracking refs rather than mocks: a local-only branch tracking the trunk (diverged, so pull genuinely cannot fast-forward) reports `true`; a branch with its own pushed copy that someone else advanced reports `false`; a branch level with its upstream is not asked at all; and a slashy name (`native/egui-shell`) is not mistaken for a different branch.
- `bun test` in `server/`: 250 pass, 0 fail.
- `bunx tsc --noEmit` in `server/` and `web/`, both clean.
- Reproduced against a live checkout first: `{"upstream":"origin/main","ahead":10,"behind":62,"base":"main","behindBase":62}` with the button disabled, and `git pull --ff-only` there aborting with `Not possible to fast-forward`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)