### PR TITLE
fix(gate): stop a restart from auto-allowing what a human was deciding

### DIFF
--- a/README.md
+++ b/README.md
@@ -418,6 +418,13 @@ Safe by design — it **never blocks your agents by accident**:
 - no one decides within `AGENTGLASS_GATE_TIMEOUT` (default 60s) → **auto-allow**
 - only sessions wired to the gate are gated; everything else is untouched
 
+It also survives a restart. Pending requests are persisted, so restarting or
+crashing the server brings the queue back instead of quietly auto-allowing
+everything that was waiting on you — the hook re-attaches to the request it was
+already holding. A request whose window ran out while the server was down is
+resolved by your configured policy and **says so** in "What needs you", because
+an outcome nobody chose is the one worth showing.
+
 Scope it with the `matcher` (e.g. `Bash` only, or a specific tool) so you're not
 gating every call. Denying returns a `PreToolUse` deny with your reason.
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -82,6 +82,18 @@ Contract:
 - Dashboard list: `GET /gate/pending`. Decide: `POST /gate/decide`
   with `{ "id", "decision": "allow"|"deny", "reason"? }` (CSRF-protected for
   browser origins).
+- **Durable.** Every request is persisted on arrival, so a server restart
+  re-hydrates the queue instead of stranding held agents. Send your own uuid as
+  `"id"` and the POST becomes idempotent: re-sending it re-attaches to the same
+  request rather than raising a second prompt.
+- **Reconnect** with `GET /gate/status?id=<your uuid>` when a held connection
+  drops. It holds open while the request is pending, answers immediately once
+  decided, and **404s on an id it has no record of** — treat that as "no answer"
+  and apply your own policy, never as an approval.
+- Resolved requests: `GET /gate/history?limit=50`. `resolution` says who decided
+  — `human`, `timeout`, or `restart` (the window closed while the server was
+  down). The last two are the outcomes nobody chose, which is exactly why they
+  are recorded rather than dropped.
 
 Claude Code wiring lives in `hooks/gate_event.py` (see README control-plane
 section). Any harness can long-poll the same endpoint.

--- a/hooks/gate_event.py
+++ b/hooks/gate_event.py
@@ -12,6 +12,11 @@ Safety by design — it NEVER blocks your agents by accident:
   * if no one decides within the timeout → the server auto-allows
   * only sessions wired to this hook are gated; everything else is untouched
 
+Durable across a server restart: the hook picks the request id, so if the
+connection drops mid-wait (agentglass restarted, a crash, a proxy hanging up)
+it re-attaches to that same request instead of giving up and falling into the
+timeout branch. It only gives up once its own deadline has passed.
+
 Deny/allow are returned to Claude Code via the PreToolUse permissionDecision.
 
 Env:
@@ -22,7 +27,11 @@ import argparse
 import json
 import os
 import sys
+import time
+import urllib.error
+import urllib.parse
 import urllib.request
+import uuid
 
 DEFAULT_SERVER = os.environ.get("AGENTGLASS_SERVER", "http://localhost:4000")
 
@@ -81,7 +90,12 @@ def main():
     except json.JSONDecodeError:
         allow_silently()
 
+    # The id is ours, not the server's. That is what makes a dropped connection
+    # recoverable: without it there is no name for the request we were waiting
+    # on, and a restart mid-wait can only be read as "no answer".
+    gate_id = str(uuid.uuid4())
     body = json.dumps({
+        "id": gate_id,
         "source_app": args.source_app,
         "session_id": payload.get("session_id") or "unknown",
         "tool_name": payload.get("tool_name") or "?",
@@ -98,17 +112,68 @@ def main():
     if token:
         headers["Authorization"] = "Bearer " + token
 
-    req = urllib.request.Request(
-        args.server.rstrip("/") + "/gate",
-        data=body,
-        headers=headers,
-        method="POST",
-    )
+    base = args.server.rstrip("/")
+
+    def submit(remaining):
+        """POST the request. Idempotent on our id: the server re-attaches to a
+        live request rather than raising a second prompt for the same call."""
+        req = urllib.request.Request(base + "/gate", data=body, headers=headers, method="POST")
+        with urllib.request.urlopen(req, timeout=remaining) as resp:
+            return json.loads(resp.read())
+
+    def reattach(remaining):
+        """Long-poll the request we already sent. 404 means the server has no
+        record of it — it never arrived — so the caller re-submits."""
+        url = base + "/gate/status?" + urllib.parse.urlencode({"id": gate_id})
+        req = urllib.request.Request(url, headers=headers, method="GET")
+        try:
+            with urllib.request.urlopen(req, timeout=remaining) as resp:
+                return json.loads(resp.read())
+        except urllib.error.HTTPError as e:
+            if e.code == 404:
+                return None
+            raise
+
+    # Our own deadline, a little past the server's, so a decision that lands
+    # just as the window closes still reaches us. Every drop inside it is a
+    # reconnect, not a verdict: the request is persisted server-side, so giving
+    # up early would convert "a human is deciding" into a silent auto-allow.
+    deadline = time.monotonic() + TIMEOUT + 10
+    out = None
+    sent = True
+    backoff = 0.5
+    # The first POST is still allowed to fail fast. "Nothing is listening" is not
+    # the same failure as "the thing we were talking to went away": retrying a
+    # refused connection for a full timeout would stall every gated tool call on
+    # a machine where agentglass simply isn't running.
     try:
-        # Wait a hair longer than the server's own timeout.
-        with urllib.request.urlopen(req, timeout=TIMEOUT + 5) as resp:
-            out = json.loads(resp.read())
+        out = submit(TIMEOUT + 5)
+    except urllib.error.HTTPError:
+        # The server answered, just not with a decision — retrying won't help.
+        deadline = time.monotonic()
+    except urllib.error.URLError as e:
+        if isinstance(e.reason, ConnectionRefusedError):
+            deadline = time.monotonic()  # nobody home — skip the retry loop
     except Exception:
+        pass  # connected, then dropped — worth re-attaching
+
+    while out is None:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        time.sleep(min(backoff, remaining))
+        backoff = min(backoff * 2, 5)
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            break
+        try:
+            out = reattach(remaining) if sent else submit(remaining)
+            if out is None:
+                sent = False  # 404 — the POST never landed, so send it again
+        except Exception:
+            sent = True  # dropped again mid-wait — keep re-attaching
+
+    if out is None:
         if FAIL_CLOSED:
             emit("deny", "agentglass unreachable (fail-closed)")
         allow_silently()  # unreachable / error → never block (default)

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -181,6 +181,99 @@ for (const col of ["project_path", "cwd_path"]) {
 }
 db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_path)");
 
+// ---------------------------------------------------------------------------
+// Control plane: gate requests.
+//
+// The gate used to live only in memory, which made the one feature whose job is
+// human oversight the least durable thing in the server: a restart dropped
+// every held request, the hook's long-poll fell into its timeout branch, and
+// "waiting for a human" silently became "auto-allowed". Every request is now
+// written on arrival and updated when it resolves, so a restart can re-hydrate
+// the queue and every outcome — including the ones nobody decided — has a row.
+//
+// `decision` NULL means still pending. `resolution` records *who* decided:
+// human, timeout, or restart (expired while the server was down).
+// ---------------------------------------------------------------------------
+db.exec(`
+CREATE TABLE IF NOT EXISTS gates (
+  id TEXT PRIMARY KEY,
+  source_app TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  tool_name TEXT NOT NULL,
+  summary TEXT NOT NULL DEFAULT '',
+  created INTEGER NOT NULL,
+  expires INTEGER NOT NULL,
+  decision TEXT,
+  reason TEXT,
+  resolution TEXT,
+  decided_at INTEGER
+);
+CREATE INDEX IF NOT EXISTS idx_gates_pending ON gates(decision, expires);
+CREATE INDEX IF NOT EXISTS idx_gates_created ON gates(created);
+`);
+
+export interface GateRow {
+  id: string;
+  source_app: string;
+  session_id: string;
+  tool_name: string;
+  summary: string;
+  created: number;
+  expires: number;
+  decision: "allow" | "deny" | null;
+  reason: string | null;
+  resolution: "human" | "timeout" | "restart" | null;
+  decided_at: number | null;
+}
+
+const gateInsert = db.query(`
+  INSERT OR REPLACE INTO gates (id, source_app, session_id, tool_name, summary, created, expires)
+  VALUES ($id, $source_app, $session_id, $tool_name, $summary, $created, $expires)`);
+// Only ever resolves a still-pending row: a decision already recorded wins over
+// a late timeout, so a human's approve can't be overwritten by the clock.
+const gateResolve = db.query(`
+  UPDATE gates SET decision = $decision, reason = $reason, resolution = $resolution, decided_at = $decided_at
+   WHERE id = $id AND decision IS NULL`);
+const gateById = db.query<GateRow, [string]>(`SELECT * FROM gates WHERE id = ?`);
+const gatesPending = db.query<GateRow, []>(`SELECT * FROM gates WHERE decision IS NULL ORDER BY created ASC`);
+const gatesRecent = db.query<GateRow, [number]>(
+  `SELECT * FROM gates WHERE decision IS NOT NULL ORDER BY decided_at DESC LIMIT ?`);
+
+export function recordGate(g: {
+  id: string; source_app: string; session_id: string; tool_name: string;
+  summary: string; created: number; expires: number;
+}): void {
+  gateInsert.run({
+    $id: g.id, $source_app: g.source_app, $session_id: g.session_id, $tool_name: g.tool_name,
+    $summary: g.summary, $created: g.created, $expires: g.expires,
+  } as any);
+}
+
+export function resolveGateRow(
+  id: string,
+  decision: "allow" | "deny",
+  reason: string,
+  resolution: "human" | "timeout" | "restart",
+  decided_at = Date.now(),
+): void {
+  gateResolve.run({ $id: id, $decision: decision, $reason: reason, $resolution: resolution, $decided_at: decided_at } as any);
+}
+
+export function getGate(id: string): GateRow | null {
+  return gateById.get(id) ?? null;
+}
+
+/** Gate requests written but never resolved — the queue to re-hydrate on boot. */
+export function undecidedGates(): GateRow[] {
+  return gatesPending.all();
+}
+
+/** Recently resolved gates, newest first — the "what happened while you were
+ *  away" record, including the ones a timeout or a restart decided for you. */
+export function gateHistory(limit = 50): GateRow[] {
+  return gatesRecent.all(Math.max(1, Math.min(500, limit)));
+}
+
 /** Coarse vendor for a model name — the provider dimension. Returns null for an
  *  unknown/absent model so a session's known provider is never overwritten.
  *  Kept in sync with the web's providerOf() in web/src/lib/format.ts. */
@@ -336,6 +429,9 @@ export function pruneOldRows(): { events: number; sessions: number } {
   db.run(`DELETE FROM events_fts WHERE rowid IN (SELECT id FROM events WHERE timestamp < ?)`, [cutoff]);
   const ev = db.run(`DELETE FROM events WHERE timestamp < ?`, [cutoff]);
   const se = db.run(`DELETE FROM sessions WHERE last_seen < ?`, [cutoff]);
+  // Resolved gates only — a pending one is a live request, never retention's
+  // business no matter how old its row looks.
+  db.run(`DELETE FROM gates WHERE decision IS NOT NULL AND created < ?`, [cutoff]);
   return { events: ev.changes, sessions: se.changes };
 }
 

--- a/server/src/gate.ts
+++ b/server/src/gate.ts
@@ -4,12 +4,23 @@
 //
 // Safety: default-allow on timeout, and the hook exits 0 (allow) if agentglass
 // is unreachable — the control plane never blocks agents by accident.
+//
+// Durability: every request is written to SQLite on arrival and updated when it
+// resolves. A restart re-hydrates the still-live ones (see restoreGates), so a
+// crash no longer turns "waiting for a human" into a silent auto-allow, and the
+// held connection is no longer the only place a pending request exists — a hook
+// whose connection dropped can re-attach with awaitGate(id).
 import type { PendingGate } from "../../shared/types.ts";
 import { pushGate } from "./alerts.ts";
+import { recordGate, resolveGateRow, undecidedGates, getGate } from "./db.ts";
 export type GateDecision = "allow" | "deny";
+export type GateOutcome = { decision: GateDecision; reason: string };
 
-interface Waiter extends PendingGate {
-  resolve: (d: { decision: GateDecision; reason: string }) => void;
+interface Pending extends PendingGate {
+  expires: number;
+  // The held connection, when there is one. A restored request has none until a
+  // hook re-attaches — it is still pending, still decidable, still in the queue.
+  resolve?: (d: GateOutcome) => void;
   timer: ReturnType<typeof setTimeout>;
 }
 
@@ -25,46 +36,103 @@ const FAIL_CLOSED = process.env.AGENTGLASS_GATE_FAILCLOSED === "1";
 // operator's own configured timeout now raises the ceiling.
 export const GATE_MAX_MS = Math.max(120_000, (Number(process.env.AGENTGLASS_GATE_TIMEOUT) || 60) * 1000);
 
-const waiters = new Map<string, Waiter>();
+const waiters = new Map<string, Pending>();
 let onChange: () => void = () => {};
 export function onGateChange(fn: () => void) { onChange = fn; }
 
+/** What a timeout resolves to, under the configured policy. */
+function timeoutOutcome(): GateOutcome {
+  if (FAIL_CLOSED) return { decision: "deny", reason: "gate timeout — no decision (fail-closed)" };
+  // Empty reason so the hook falls through to Claude Code's own permission
+  // prompt instead of force-allowing — an auto-allow shouldn't silently
+  // skip the human it was meant to ask.
+  return { decision: "allow", reason: "" };
+}
+
+/** Ids come from the hook now (so it can re-attach after a dropped connection),
+ *  which makes them attacker-influenceable. Accept only uuid-shaped ones; a
+ *  request that brings anything else gets a server-generated id instead. */
+const ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+export const validGateId = (id: unknown): id is string => typeof id === "string" && ID_RE.test(id);
+
+function finish(id: string, out: GateOutcome, resolution: "human" | "timeout" | "restart"): void {
+  const w = waiters.get(id);
+  if (w) {
+    clearTimeout(w.timer);
+    waiters.delete(id);
+  }
+  resolveGateRow(id, out.decision, out.reason, resolution);
+  w?.resolve?.(out);
+  onChange();
+}
+
+/** Arm the expiry timer for a pending request. Anchored to the *original*
+ *  deadline, so a reconnect (or a restart) never extends the window. */
+function arm(id: string, expires: number): ReturnType<typeof setTimeout> {
+  const t = setTimeout(() => finish(id, timeoutOutcome(), "timeout"), Math.max(0, expires - Date.now()));
+  // Don't let a held gate keep the process alive on its own.
+  (t as any).unref?.();
+  return t;
+}
+
 /** Hold a tool call until decided or the timeout auto-allows. */
 export function submitGate(
-  req: { source_app: string; session_id: string; tool_name: string; summary: string },
+  req: { source_app: string; session_id: string; tool_name: string; summary: string; id?: string },
   timeoutMs: number
-): Promise<{ decision: GateDecision; reason: string }> {
+): Promise<GateOutcome> {
   // Floor the timeout: a negative value (a repo-local settings.json can set
   // AGENTGLASS_GATE_TIMEOUT=-1) makes setTimeout fire immediately, turning the
   // gate into an instant auto-allow. Never below 1s, never above 2min.
   const wait = Math.max(1000, Math.min(GATE_MAX_MS, Number.isFinite(timeoutMs) ? timeoutMs : 60_000));
+  // A hook that re-POSTs an id it already sent is retrying, not asking twice:
+  // re-attach to the live request (or replay the outcome it missed) instead of
+  // creating a second one that would strand the first's held connection.
+  if (validGateId(req.id)) {
+    const again = awaitGate(req.id);
+    if (again) return Promise.resolve(again);
+  }
+  const id = validGateId(req.id) ? req.id : crypto.randomUUID();
+  const created = Date.now();
+  const expires = created + wait;
+  const { source_app, session_id, tool_name, summary } = req;
+  // Persist before holding the connection: if the process dies a millisecond
+  // later, the request still exists somewhere a restart can find it.
+  recordGate({ id, source_app, session_id, tool_name, summary, created, expires });
   return new Promise((resolve) => {
-    const id = crypto.randomUUID();
-    const timer = setTimeout(() => {
-      waiters.delete(id);
-      onChange();
-      if (FAIL_CLOSED) {
-        resolve({ decision: "deny", reason: "gate timeout — no decision (fail-closed)" });
-        return;
-      }
-      // Empty reason so the hook falls through to Claude Code's own permission
-      // prompt instead of force-allowing — an auto-allow shouldn't silently
-      // skip the human it was meant to ask.
-      resolve({ decision: "allow", reason: "" });
-    }, wait);
-    waiters.set(id, { id, ...req, created: Date.now(), resolve, timer });
-    pushGate(`${req.source_app}:${req.session_id.slice(0, 8)}`, req.tool_name, req.summary);
+    waiters.set(id, { id, source_app, session_id, tool_name, summary, created, expires, resolve, timer: arm(id, expires) });
+    pushGate(`${source_app}:${session_id.slice(0, 8)}`, tool_name, summary);
     onChange();
   });
 }
 
-export function decideGate(id: string, decision: GateDecision, reason: string): boolean {
+/**
+ * Re-attach to a request whose connection dropped (a server restart, a proxy
+ * hanging up). Returns the recorded outcome if it has already been decided, a
+ * promise that resolves when it is if it's still pending, or null when the id
+ * is unknown — which the hook must treat as "no answer" rather than as a
+ * decision.
+ */
+export function awaitGate(id: string): Promise<GateOutcome> | GateOutcome | null {
+  if (!validGateId(id)) return null;
   const w = waiters.get(id);
-  if (!w) return false;
-  clearTimeout(w.timer);
-  waiters.delete(id);
-  w.resolve({ decision, reason: reason || (decision === "deny" ? "denied from dashboard" : "approved from dashboard") });
-  onChange();
+  if (w) {
+    return new Promise((resolve) => {
+      // Last connection wins. The previous one is already gone — that is why
+      // the hook is here — and resolving it would write to a dead socket.
+      w.resolve = resolve;
+    });
+  }
+  const row = getGate(id);
+  if (!row || !row.decision) return null;
+  return { decision: row.decision, reason: row.reason || "" };
+}
+
+export function decideGate(id: string, decision: GateDecision, reason: string): boolean {
+  const row = getGate(id);
+  // Decidable while pending, whether or not a connection is currently held: a
+  // restored request has no waiter and must still take the operator's answer.
+  if (!row || row.decision) return false;
+  finish(id, { decision, reason: reason || (decision === "deny" ? "denied from dashboard" : "approved from dashboard") }, "human");
   return true;
 }
 
@@ -72,4 +140,39 @@ export function pendingGates(): PendingGate[] {
   return [...waiters.values()]
     .map(({ id, source_app, session_id, tool_name, summary, created }) => ({ id, source_app, session_id, tool_name, summary, created }))
     .sort((a, b) => a.created - b.created);
+}
+
+/**
+ * Rebuild the queue from SQLite at boot.
+ *
+ * Requests still inside their window go back into "what needs you" and stay
+ * decidable — the agent is still held, and its hook is re-polling for exactly
+ * this. Ones whose window elapsed while the server was down are resolved by the
+ * configured policy and *recorded* as such, so the outcome shows up in history
+ * instead of vanishing.
+ */
+export function restoreGates(): { restored: number; expired: number } {
+  const now = Date.now();
+  let restored = 0, expired = 0;
+  for (const row of undecidedGates()) {
+    if (row.expires <= now) {
+      const out = timeoutOutcome();
+      resolveGateRow(row.id, out.decision, out.reason || `gate expired while the server was down (${out.decision})`, "restart", now);
+      expired++;
+      continue;
+    }
+    waiters.set(row.id, {
+      id: row.id,
+      source_app: row.source_app,
+      session_id: row.session_id,
+      tool_name: row.tool_name,
+      summary: row.summary,
+      created: row.created,
+      expires: row.expires,
+      timer: arm(row.id, row.expires),
+    });
+    restored++;
+  }
+  if (restored || expired) onChange();
+  return { restored, expired };
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -17,12 +17,13 @@ import {
   searchEvents,
   ftsText,
   providerOf,
+  gateHistory,
 } from "./db.ts";
 import { maybeAlert } from "./alerts.ts";
 import { getSkills, catalogMarkdown, catalogCsv } from "./skills.ts";
 import { getInsights } from "./insights.ts";
 import { getUsage } from "./usage.ts";
-import { submitGate, decideGate, pendingGates, GATE_MAX_MS } from "./gate.ts";
+import { submitGate, decideGate, pendingGates, awaitGate, restoreGates, GATE_MAX_MS } from "./gate.ts";
 import { otlpTracesToEvents, otlpLogsToEvents } from "./otlp.ts";
 import { decodeOtlpTraces, decodeOtlpLogs } from "./otlp_pb.ts";
 import { statusForPaths, commit as gitCommit, COMMIT_ENABLED } from "./git.ts";
@@ -446,12 +447,27 @@ const server = Bun.serve<WsData>({
       const ti = b.tool_input ?? {};
       const summary = String(ti.command || ti.file_path || ti.path || ti.pattern || ti.query || ti.description || b.tool_name || "").slice(0, 300);
       const decision = await submitGate(
-        { source_app: String(b.source_app || "unknown"), session_id: String(b.session_id || "unknown"), tool_name: String(b.tool_name || "?"), summary },
+        // The hook picks the id so it can re-attach to this exact request after
+        // a dropped connection (see /gate/status). Shape-checked in gate.ts;
+        // anything else falls back to a server-generated one.
+        { id: typeof b.id === "string" ? b.id : undefined, source_app: String(b.source_app || "unknown"), session_id: String(b.session_id || "unknown"), tool_name: String(b.tool_name || "?"), summary },
         Math.min(GATE_MAX_MS, Number(b.timeout_ms) || 60_000)
       );
       return json(decision);
     }
+    // Re-attach to a request whose connection dropped — a server restart, a
+    // proxy hanging up. Holds open like /gate does when it's still pending,
+    // answers immediately when it's already decided, and 404s on an id it has
+    // never heard of so the hook falls back to its own policy instead of
+    // reading "no answer" as an approval.
+    if (pathname === "/gate/status") {
+      const out = await awaitGate(String(url.searchParams.get("id") || ""));
+      return out ? json(out) : json({ decision: null, reason: "unknown gate" }, 404);
+    }
     if (pathname === "/gate/pending") return json({ gates: pendingGates() });
+    // What was decided while you weren't looking — including the requests a
+    // timeout or a restart resolved for you.
+    if (pathname === "/gate/history") return json({ gates: gateHistory(Number(url.searchParams.get("limit") || 50)) });
     if (pathname === "/gate/decide" && req.method === "POST") {
       if (!localOrigin(req)) return csrfBlocked();
       let b: any = {};
@@ -850,6 +866,14 @@ startScanner(({ event, session }) => {
   broadcast({ type: "session", data: session });
   maybeAlert(event);
 });
+
+// Bring back the gate requests that were in flight when this process last
+// stopped. Anything still inside its window returns to "what needs you"; the
+// rest is resolved by the configured policy and recorded, never dropped.
+const gates = restoreGates();
+if (gates.restored || gates.expired) {
+  console.log(`✋ gate: ${gates.restored} pending restored, ${gates.expired} expired while down (${process.env.AGENTGLASS_GATE_FAILCLOSED === "1" ? "denied" : "allowed"})`);
+}
 
 // Hang up shells and clean temp dirs on the way out — a bare kill leaves them
 // orphaned. Re-raise so the default disposition still terminates the process.

--- a/server/test/gate-durability.test.ts
+++ b/server/test/gate-durability.test.ts
@@ -1,0 +1,156 @@
+// The gate is the one feature whose job is human oversight, and it used to keep
+// its pending requests in a Map and nowhere else. A restart dropped them, the
+// hook's long-poll fell into its timeout branch, and "waiting for a human"
+// silently became "auto-allowed" — the worst possible failure for this feature.
+//
+// These tests drive the real module against a throwaway DB and simulate the
+// restart by re-importing it with a fresh module registry, because the whole
+// regression is "the state only existed in this process".
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-gate-"));
+process.env.AGENTGLASS_DB = join(dir, "gate.db");
+process.env.XDG_CONFIG_HOME = dir; // keep the developer's own scope out of it
+
+let gate: typeof import("../src/gate.ts");
+let db: typeof import("../src/db.ts");
+
+const req = (over: Record<string, unknown> = {}) => ({
+  source_app: "orbit",
+  session_id: "11111111-2222-3333-4444-555555555555",
+  tool_name: "Bash",
+  summary: "rm -rf build",
+  ...over,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  gate = await import("../src/gate.ts");
+});
+
+describe("a gate request outlives the process that took it", () => {
+  test("it is written to the database the moment it arrives", () => {
+    const id = "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee";
+    gate.submitGate(req({ id }), 60_000); // held: nobody decides it here
+    const row = db.getGate(id);
+    expect(row).not.toBeNull();
+    expect(row!.decision).toBeNull(); // pending, not resolved
+    expect(row!.tool_name).toBe("Bash");
+    expect(row!.expires).toBeGreaterThan(Date.now());
+  });
+
+  test("a decision is recorded, with who made it", async () => {
+    const id = "aaaaaaaa-bbbb-cccc-dddd-000000000001";
+    const held = gate.submitGate(req({ id }), 60_000);
+    expect(gate.decideGate(id, "deny", "not on my watch")).toBe(true);
+    await expect(held).resolves.toEqual({ decision: "deny", reason: "not on my watch" });
+    const row = db.getGate(id)!;
+    expect(row.decision).toBe("deny");
+    expect(row.resolution).toBe("human");
+    expect(row.decided_at).toBeGreaterThan(0);
+  });
+
+  test("a timeout is an outcome with a record, not a disappearance", async () => {
+    const id = "aaaaaaaa-bbbb-cccc-dddd-000000000002";
+    // Floored to 1s by submitGate — a gate can never auto-resolve instantly.
+    await gate.submitGate(req({ id }), 1);
+    const row = db.getGate(id)!;
+    expect(row.decision).toBe("allow"); // fail-open default
+    expect(row.resolution).toBe("timeout");
+    expect(gate.pendingGates().some((g) => g.id === id)).toBe(false);
+  });
+
+  test("deciding twice is refused — the first answer stands", async () => {
+    const id = "aaaaaaaa-bbbb-cccc-dddd-000000000003";
+    const held = gate.submitGate(req({ id }), 60_000);
+    expect(gate.decideGate(id, "allow", "ok")).toBe(true);
+    await held;
+    expect(gate.decideGate(id, "deny", "changed my mind")).toBe(false);
+    expect(db.getGate(id)!.decision).toBe("allow");
+  });
+
+  test("an unknown id is not decidable", () => {
+    expect(gate.decideGate("aaaaaaaa-bbbb-cccc-dddd-00000000dead", "allow", "")).toBe(false);
+  });
+});
+
+describe("re-attaching after the connection drops", () => {
+  test("a pending request can be waited on again, and the new waiter is the one answered", async () => {
+    const id = "bbbbbbbb-bbbb-cccc-dddd-000000000001";
+    gate.submitGate(req({ id }), 60_000); // the original connection, now "dropped"
+    const again = gate.awaitGate(id) as Promise<{ decision: string; reason: string }>;
+    expect(again).toBeInstanceOf(Promise);
+    gate.decideGate(id, "allow", "approved from dashboard");
+    await expect(again).resolves.toEqual({ decision: "allow", reason: "approved from dashboard" });
+  });
+
+  test("a decision made while the hook was away is replayed, not lost", async () => {
+    const id = "bbbbbbbb-bbbb-cccc-dddd-000000000002";
+    gate.submitGate(req({ id }), 60_000);
+    gate.decideGate(id, "deny", "no");
+    expect(gate.awaitGate(id)).toEqual({ decision: "deny", reason: "no" });
+  });
+
+  test("an id the server never saw returns null — the hook must not read that as approval", () => {
+    expect(gate.awaitGate("cccccccc-bbbb-cccc-dddd-000000000001")).toBeNull();
+    expect(gate.awaitGate("not-a-uuid")).toBeNull();
+  });
+
+  test("re-submitting the same id re-attaches instead of raising a second prompt", async () => {
+    const id = "bbbbbbbb-bbbb-cccc-dddd-000000000003";
+    gate.submitGate(req({ id }), 60_000);
+    const before = gate.pendingGates().filter((g) => g.id === id).length;
+    const retry = gate.submitGate(req({ id }), 60_000);
+    expect(gate.pendingGates().filter((g) => g.id === id).length).toBe(before);
+    gate.decideGate(id, "allow", "once");
+    await expect(retry).resolves.toEqual({ decision: "allow", reason: "once" });
+  });
+
+  test("a client-supplied id that isn't uuid-shaped is replaced, not trusted", async () => {
+    const held = gate.submitGate(req({ id: "../../etc/passwd" }), 1);
+    await held;
+    expect(db.getGate("../../etc/passwd")).toBeNull();
+  });
+});
+
+describe("restart", () => {
+  // A second module registry = a second process, sharing only the database.
+  // This is the actual claim under test: the queue comes back from disk.
+  test("still-live requests return to the queue; expired ones resolve and are recorded", async () => {
+    const live = "dddddddd-bbbb-cccc-dddd-000000000001";
+    const stale = "dddddddd-bbbb-cccc-dddd-000000000002";
+    // Only gate.ts is re-imported: the database is the thing that survives, so
+    // it stays shared on purpose. What comes back empty is the in-memory queue.
+    // Indirected through a variable: the query string is what forces a second
+    // instance, and tsc can't resolve it as a literal specifier.
+    const restarted = "../src/gate.ts?restart=1";
+    const fresh = await import(restarted) as typeof import("../src/gate.ts");
+    expect(fresh.pendingGates()).toHaveLength(0); // the process that held them is gone
+
+    const now = Date.now();
+    db.recordGate({ ...req(), id: live, summary: "still waiting", created: now, expires: now + 120_000 });
+    db.recordGate({ ...req(), id: stale, summary: "died in flight", created: now - 300_000, expires: now - 60_000 });
+
+    // Counts are >= because the tests above left their own rows in this DB —
+    // which is itself the point: a restart picks up everything still open.
+    const { restored, expired } = fresh.restoreGates();
+    expect(restored).toBeGreaterThanOrEqual(1);
+    expect(expired).toBeGreaterThanOrEqual(1);
+
+    // The live one is back in "what needs you", and still decidable.
+    expect(fresh.pendingGates().map((g) => g.id)).toContain(live);
+    expect(fresh.decideGate(live, "deny", "caught it")).toBe(true);
+    expect(db.getGate(live)!.resolution).toBe("human");
+
+    // The one whose window closed while the server was down did not vanish: it
+    // has an outcome, attributed to the restart, and it shows up in history.
+    const gone = db.getGate(stale)!;
+    expect(gone.decision).toBe("allow"); // fail-open default
+    expect(gone.resolution).toBe("restart");
+    expect(gone.reason).toContain("while the server was down");
+    expect(db.gateHistory(50).map((g) => g.id)).toContain(stale);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -197,6 +197,18 @@ export interface PendingGate {
   created: number;
 }
 
+/** A gate request that has been resolved. `resolution` is who resolved it:
+ *  a human from the dashboard, the timeout, or a restart that found the window
+ *  already closed. The last one is why this record exists — an outcome nobody
+ *  chose is exactly the one that must not disappear. */
+export interface GateRecord extends PendingGate {
+  expires: number;
+  decision: "allow" | "deny";
+  reason: string | null;
+  resolution: "human" | "timeout" | "restart" | null;
+  decided_at: number | null;
+}
+
 export interface SearchHit {
   id: number;
   timestamp: number;

--- a/web/src/components/Alerts.tsx
+++ b/web/src/components/Alerts.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import type { Alert, AgentCard } from "../lib/derive.ts";
 import { collectAttention } from "../lib/attention.ts";
 import { listChats, subscribe as subscribeChats } from "../lib/chatStore.ts";
-import type { Insight, PendingGate } from "../../../shared/types.ts";
+import type { Insight, PendingGate, GateRecord } from "../../../shared/types.ts";
 import { Panel } from "./Panel.tsx";
 import { api } from "../lib/api.ts";
 import { fmtAgo } from "../lib/format.ts";
@@ -38,6 +38,32 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
     return () => { alive = false; clearInterval(id); };
   }, []);
 
+  /*
+   * The gates you didn't decide.
+   *
+   * A request resolved by the timeout — or by a restart that found its window
+   * already closed — used to leave no trace at all: the card simply left the
+   * panel, indistinguishable from one you approved. For the feature whose whole
+   * purpose is human oversight, an outcome nobody chose is the single most
+   * important one to say out loud, so the recent ones stay visible here.
+   */
+  const [autoResolved, setAutoResolved] = useState<GateRecord[]>([]);
+  useEffect(() => {
+    let alive = true;
+    const load = () =>
+      api
+        .gateHistory(25)
+        .then((r) => {
+          if (!alive) return;
+          const cutoff = Date.now() - 30 * 60_000;
+          setAutoResolved(r.gates.filter((g) => g.resolution !== "human" && (g.decided_at ?? 0) > cutoff).slice(0, 3));
+        })
+        .catch(() => {});
+    load();
+    const id = setInterval(load, 15_000);
+    return () => { alive = false; clearInterval(id); };
+  }, []);
+
   const decide = (g: PendingGate, decision: "allow" | "deny") => {
     setActing((a) => ({ ...a, [g.id]: true }));
     setGates((gs) => gs.filter((x) => x.id !== g.id)); // optimistic
@@ -59,7 +85,7 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
     [gates, insights, alerts, chats, agents],
   );
   const openCount = attention.length;
-  const empty = openCount === 0 && insights.length === 0;
+  const empty = openCount === 0 && insights.length === 0 && autoResolved.length === 0;
 
   return (
     <Panel
@@ -120,6 +146,30 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
             </motion.div>
           ))}
         </AnimatePresence>
+
+        {autoResolved.length > 0 && (
+          <div className="mb-2">
+            {autoResolved.map((g) => (
+              <div
+                key={g.id}
+                className="flex items-start gap-2 rounded-xl px-2.5 py-1.5 mb-1.5"
+                style={{ background: "color-mix(in srgb, var(--text4) 10%, transparent)", border: "1px dashed color-mix(in srgb, var(--text4) 45%, transparent)" }}
+                title={g.summary}
+              >
+                <span className="shrink-0 t-dim2">{g.decision === "deny" ? "✕" : "✓"}</span>
+                <div className="min-w-0 flex-1">
+                  <div className="truncate text-[11px]" style={{ color: "var(--text2)" }}>
+                    {g.tool_name} {g.decision === "deny" ? "denied" : "allowed"} without you
+                  </div>
+                  <div className="text-[9.5px] t-dim2 truncate">
+                    {g.resolution === "restart" ? "window closed while the server was down" : "no decision before the timeout"} · {g.source_app}
+                  </div>
+                </div>
+                <span className="text-[9.5px] t-dim2 shrink-0">{fmtAgo(g.decided_at ?? g.created)}</span>
+              </div>
+            ))}
+          </div>
+        )}
 
         <AnimatePresence initial={false}>
           {alerts.map((a) => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -148,6 +148,7 @@ const realApi = {
   insights: () => get<{ insights: Insight[] }>(`/insights`),
   search: (q: string) => get<{ hits: SearchHit[] }>(`/search?q=${encodeURIComponent(q)}`),
   gatePending: () => get<{ gates: PendingGate[] }>(`/gate/pending`),
+  gateHistory: (limit = 25) => get<{ gates: GateRecord[] }>(`/gate/history?limit=${limit}`),
   gateDecide: (id: string, decision: "allow" | "deny", reason = "") =>
     fetch(SERVER + "/gate/decide", {
       method: "POST",
@@ -306,6 +307,7 @@ const demoApi: typeof realApi = {
   insights: () => D(demo.insights()),
   search: (q: string) => D(demo.search(q)),
   gatePending: () => D(demo.gatePending()),
+  gateHistory: () => D({ gates: [] as GateRecord[] }),
   gateDecide: (id: string) => D(demo.gateDecide(id)),
   gitStatus: (_paths: string[]) => D(demo.gitStatus()),
   gitCommit: (_payload: { root: string; files: string[]; title: string; body: string }) => D(demo.gitCommit()),


### PR DESCRIPTION
## What does this PR do?

Makes the control plane durable. Pending gate requests lived in a `Map` and nowhere else, so a restart or crash dropped every one of them: the held connections died, `gate_event.py` fell into its timeout branch, and a tool call waiting on a human turned into a silent auto-allow (or auto-deny under fail-closed), with the operator's queue coming back empty and no record the requests ever existed.

Requests are now persisted to SQLite on arrival and updated when they resolve. `restoreGates()` runs at boot: anything still inside its window returns to **"What needs you"**, still decidable, with its original deadline intact; anything whose window closed while the server was down is resolved by the configured policy and recorded as `resolution = restart` rather than vanishing.

The hook picks the request id now, which is what makes reconnecting possible — a dropped connection finally has a name to ask about. It re-attaches with `GET /gate/status?id=` (holds open while pending, answers immediately once decided, **404s on an unknown id** so the hook applies its own policy instead of reading silence as approval) and re-POSTs if the request never landed; `POST /gate` is idempotent on that id, so a retry re-attaches instead of raising a second prompt.

Fail-open is unchanged where it matters: a server that isn't running still gets a refused connection and an immediate allow (~65ms). "Nothing is listening" and "the thing we were talking to went away" are different failures, and only the second is retried.

Also adds `GET /gate/history`, and a strip in "What needs you" for gates resolved **without** you, saying whether the timeout or a restart decided them.

Closes #43

## How was it tested?

- `bun test` — 367 pass, including a new `server/test/gate-durability.test.ts` (11 tests: persistence, decision attribution, double-decide refusal, re-attach, replay of a decision made while the hook was away, unknown-id returns null, non-uuid ids rejected, restart restore/expire)
- `bunx tsc --noEmit` in `web/` and `server/`, `bun run build` in `web/`
- End to end against a real server, both acceptance criteria from the issue:
  1. Submitted a gate through `hooks/gate_event.py` → `kill -9` the server mid-wait → restarted → boot logged `✋ gate: 1 pending restored, 0 expired while down (allowed)`, the request was still in `/gate/pending`, and approving it from the API delivered the deny to the **original waiting hook process**, which emitted the correct `PreToolUse` JSON.
  2. Submitted with an 8s window, killed the server, waited past expiry, restarted → logged `0 pending restored, 1 expired while down (allowed)` and the request shows in `/gate/history` with `resolution: "restart"` and reason `gate expired while the server was down (allow)`.
- Regression check on the fail-fast path: with no server listening, the hook exits 0 in ~65ms (fail-open) and emits deny in ~64ms under `AGENTGLASS_GATE_FAILCLOSED=1`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)