### PR TITLE
fix(desktop): stop the app instead of shooting every process it owns

### DIFF
--- a/electron/appctl.sh
+++ b/electron/appctl.sh
@@ -1,0 +1,116 @@
+#!/usr/bin/env bash
+# Finding and stopping an installed agentglass desktop instance.
+#
+# Sourced by install-local.sh (and exercised by server/test/install-stop.test.ts),
+# which is why it is a library rather than inline: the interesting part is not
+# the install, it is knowing which processes belong to this install and waiting
+# for them to actually be gone.
+#
+# Expects APP to be set to the install directory (…/agentglass-desktop).
+
+# The resolved binary behind a pid, or nothing.
+#
+# /proc/<pid>/exe rather than the command line, for three reasons this script has
+# been bitten by: an instance launched through the ~/.local/bin symlink has a
+# different argv[0]; every Electron helper repeats the same path in its own argv,
+# so a cmdline match cannot tell main from renderer; and an instance whose files
+# were already replaced still answers here, with a "(deleted)" suffix, which is
+# precisely the state we are trying to avoid creating.
+_exe_of() {
+  local link
+  link=$(readlink "/proc/$1/exe" 2>/dev/null) || return 1
+  printf '%s\n' "${link% (deleted)}"
+}
+
+# Anything whose command line mentions us at all — the cheap first pass.
+#
+# One grep over /proc beats a readlink per pid by a wide margin, and it matters:
+# app_pids is called in a polling loop, and walking every process on a busy
+# machine took the best part of a second per call, which turned a bounded wait
+# into a visible stall. This over-matches on purpose (a shell sitting in a
+# directory named agentglass lands here too); app_pids does the precise part.
+_candidate_pids() {
+  local f
+  for f in $(grep -la -e agentglass /proc/[0-9]*/cmdline 2>/dev/null); do
+    f=${f#/proc/}
+    printf '%s\n' "${f%/cmdline}"
+  done
+}
+
+# Every pid belonging to this install: the app and its sidecar, helpers included.
+app_pids() {
+  local pid exe
+  for pid in $(_candidate_pids); do
+    exe=$(_exe_of "$pid") || continue
+    case "$exe" in
+      "$APP/agentglass"|"$APP/resources/agentglass-server") printf '%s\n' "$pid" ;;
+    esac
+  done
+}
+
+# The Electron main process alone.
+#
+# This is the one that must receive the SIGTERM. Signalling the whole tree at
+# once — which is what `pkill -f "$APP/agentglass"` did — tears the children out
+# from under the main process while it is running its own quit path
+# (stopSidecar() then app.quit()), and the result is a frozen window that can
+# outlive the rebuild by half an hour. Every helper carries --type=; main does
+# not.
+main_pids() {
+  local pid exe args
+  for pid in $(app_pids); do
+    exe=$(_exe_of "$pid") || continue
+    [ "$exe" = "$APP/agentglass" ] || continue
+    args=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) || continue
+    case " $args " in
+      *" --type="*) ;;
+      *) printf '%s\n' "$pid" ;;
+    esac
+  done
+}
+
+# Wait until nothing from this install is left, up to `$1` tenths of a second.
+# Returns 0 when the install is clear, 1 if the deadline passed with survivors.
+_wait_gone() {
+  local tries=$1
+  while [ "$tries" -gt 0 ]; do
+    if [ -z "$(app_pids)" ]; then return 0; fi
+    sleep 0.1
+    tries=$((tries - 1))
+  done
+  [ -z "$(app_pids)" ]
+}
+
+# Stop the running instance, politely first. Returns 1 if anything survives,
+# because the caller's next move is rm -rf over these very files.
+stop_app() {
+  local mains leftovers grace
+  grace=${APPCTL_GRACE_TENTHS:-100}
+  [ -n "$(app_pids)" ] || return 0
+
+  mains=$(main_pids)
+  if [ -n "$mains" ]; then
+    echo "==> stopping the running instance (main: $(echo "$mains" | tr '\n' ' '))"
+    kill $mains 2>/dev/null || true
+  else
+    # No main process: helpers that outlived their parent, or a sidecar left
+    # behind by a previous wedge. Nothing to ask politely, so skip to the end.
+    echo "==> clearing leftovers from a previous instance"
+  fi
+
+  # Poll rather than sleep a fixed guess. Measured against the main process
+  # alone, a healthy instance is gone in about two seconds; the window here is
+  # generous so that a slow quit gets waited out instead of raced by the copy.
+  # (The knob exists so the tests can reach the escalation path in under a
+  # second. Nothing outside them should set it.)
+  if [ -n "$mains" ] && _wait_gone "$grace"; then return 0; fi
+
+  leftovers=$(app_pids)
+  if [ -n "$leftovers" ]; then
+    echo "   still up after $((grace / 10))s — killing $(echo "$leftovers" | wc -l) process(es)"
+    kill -9 $leftovers 2>/dev/null || true
+    _wait_gone 30 || true
+  fi
+
+  [ -z "$(app_pids)" ]
+}

--- a/electron/install-local.sh
+++ b/electron/install-local.sh
@@ -34,13 +34,15 @@ done
 
 # A running instance holds these files open, and `rm -rf` under it leaves the
 # app alive on deleted inodes — it keeps running the old code and its sidecar
-# keeps :4000, so the next launch adopts a stale server. Stop it first.
-if pgrep -f "$APP/agentglass" >/dev/null 2>&1; then
-  echo "==> stopping the running instance"
-  pkill -f "$APP/agentglass" 2>/dev/null || true
-  sleep 2
-  pkill -9 -f "$APP/resources/agentglass-server" 2>/dev/null || true
-  sleep 1
+# keeps :4000, so the next launch adopts a stale server. Stop it first, and
+# refuse to continue if it will not stop: an install that fails loudly is worth
+# more than one that quietly produces that state.
+# shellcheck source=appctl.sh
+. "$HERE/appctl.sh"
+if ! stop_app; then
+  echo "refusing to install over a running instance — still alive: $(app_pids | tr '\n' ' ')" >&2
+  echo "  kill -9 those pids and run this again" >&2
+  exit 1
 fi
 
 mkdir -p "$APP" "$BIN" "$DESKTOP"

--- a/server/test/install-stop.test.ts
+++ b/server/test/install-stop.test.ts
@@ -1,0 +1,139 @@
+// electron/install-local.sh used to stop a running install with
+// `pkill -f "$APP/agentglass"`, and every Electron helper — gpu-process,
+// zygote, utility, renderer — carries that same path in its own command line.
+// So the whole tree got SIGTERM at once and the main process was left running
+// its quit path with its children pulled out from under it: a frozen window
+// that in one case was still alive 34 minutes later, holding deleted inodes,
+// while the script had already copied a new build over it.
+//
+// These tests drive electron/appctl.sh against a fake install: a real directory
+// with a real binary in it, and real processes running that binary, because the
+// bug was entirely about which processes a pattern matches. Asserting on the
+// script's text would have passed against the broken version too.
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, copyFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const APPCTL = join(import.meta.dir, "..", "..", "electron", "appctl.sh");
+const spawned: number[] = [];
+
+/** A fake install: our own copy of a shell, named the way the real one is. The
+ *  copy matters — /proc/<pid>/exe has to point inside the install directory. */
+function fakeInstall() {
+  const app = mkdtempSync(join(tmpdir(), "agx-install-"));
+  mkdirSync(join(app, "resources"));
+  copyFileSync("/bin/sh", join(app, "agentglass"));
+  copyFileSync("/bin/sh", join(app, "resources", "agentglass-server"));
+  return app;
+}
+
+/** Run a process out of the fake install. `; true` keeps the shell from
+ *  exec'ing the sleep away, which would replace the exe we are matching on. */
+function launch(exe: string, script: string, ...args: string[]): number {
+  const p = Bun.spawn([exe, "-c", `${script}; true`, ...args], { stdio: ["ignore", "ignore", "ignore"] });
+  p.unref();
+  spawned.push(p.pid);
+  return p.pid;
+}
+
+/** Call a function from appctl.sh with APP pointed at the fake install. */
+async function appctl(app: string, call: string, env: Record<string, string> = {}) {
+  const p = Bun.spawn(["bash", "-c", `APP="${app}"; . "${APPCTL}"; ${call}`], {
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const out = await new Response(p.stdout).text();
+  return { code: await p.exited, out: out.trim() };
+}
+
+const pids = (out: string) => out.split("\n").filter((l) => /^\d+$/.test(l)).map(Number);
+const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+
+afterEach(() => {
+  for (const pid of spawned.splice(0)) { try { process.kill(pid, 9); } catch { /* already gone */ } }
+});
+
+describe("finding the processes that belong to an install", () => {
+  test("helpers are not mistaken for the main process", async () => {
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30");
+    // The four shapes Electron actually spawns, all sharing the main's path.
+    const helpers = [
+      launch(join(app, "agentglass"), "sleep 30", "--type=zygote"),
+      launch(join(app, "agentglass"), "sleep 30", "--type=gpu-process", "--ozone-platform=wayland"),
+      launch(join(app, "agentglass"), "sleep 30", "--type=utility", "--utility-sub-type=network.mojom.NetworkService"),
+      launch(join(app, "agentglass"), "sleep 30", "--type=renderer"),
+    ];
+    const sidecar = launch(join(app, "resources", "agentglass-server"), "sleep 30");
+    await Bun.sleep(200);
+
+    const all = pids((await appctl(app, "app_pids")).out);
+    expect(all.sort()).toEqual([main, ...helpers, sidecar].sort());
+
+    // The whole fix in one assertion: only the main process gets signalled.
+    expect(pids((await appctl(app, "main_pids")).out)).toEqual([main]);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("another install's processes are left alone", async () => {
+    const mine = fakeInstall();
+    const theirs = fakeInstall();
+    const other = launch(join(theirs, "agentglass"), "sleep 30");
+    await Bun.sleep(200);
+    expect((await appctl(mine, "app_pids")).out).toBe("");
+    expect(alive(other)).toBe(true);
+    for (const d of [mine, theirs]) rmSync(d, { recursive: true, force: true });
+  });
+});
+
+describe("stopping it", () => {
+  test("a healthy instance is waited out, not raced", async () => {
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30");
+    // A helper that goes when its main goes, the way a real one does.
+    const helper = launch(join(app, "agentglass"), `while kill -0 ${main} 2>/dev/null; do sleep 0.05; done`, "--type=renderer");
+    const sidecar = launch(join(app, "resources", "agentglass-server"), `while kill -0 ${main} 2>/dev/null; do sleep 0.05; done`);
+    await Bun.sleep(200);
+
+    const { code } = await appctl(app, "stop_app");
+    expect(code).toBe(0);
+    // stop_app only returns 0 once nothing from the install is left — which is
+    // the guarantee the caller needs before it starts rm -rf'ing these files.
+    for (const pid of [main, helper, sidecar]) expect(alive(pid)).toBe(false);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("something that ignores SIGTERM is escalated, not slept through", async () => {
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30");
+    const stubborn = launch(join(app, "agentglass"), "trap '' TERM; sleep 30", "--type=renderer");
+    await Bun.sleep(200);
+
+    const { code, out } = await appctl(app, "stop_app", { APPCTL_GRACE_TENTHS: "5" });
+    expect(code).toBe(0);
+    expect(out).toContain("still up after");
+    expect(alive(stubborn)).toBe(false);
+    expect(alive(main)).toBe(false);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("a sidecar left behind by a previous wedge is cleared", async () => {
+    const app = fakeInstall();
+    const orphan = launch(join(app, "resources", "agentglass-server"), "trap '' TERM; sleep 30");
+    await Bun.sleep(200);
+
+    const { code, out } = await appctl(app, "stop_app", { APPCTL_GRACE_TENTHS: "5" });
+    expect(code).toBe(0);
+    expect(out).toContain("leftovers");
+    expect(alive(orphan)).toBe(false);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("nothing running is a no-op success", async () => {
+    const app = fakeInstall();
+    expect((await appctl(app, "stop_app")).code).toBe(0);
+    rmSync(app, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`install-local.sh` stopped a running install with `pkill -f "$APP/agentglass"`. That path is in the command line of **every** Electron process, so main, zygote, gpu-process, utility and renderer all took SIGTERM at once, and the main process was left running its quit path (`stopSidecar()` then `app.quit()`) with its children pulled out from under it. That is the wedge: a frozen window that outlives the rebuild, once still alive 34 minutes later on deleted inodes with the sidecar still holding the port. The `sleep 2` afterwards was a guess, and the script would `rm -rf` and copy over whatever was still running.

Process handling moves into `electron/appctl.sh`:

- pids come from `/proc/<pid>/exe`, not the command line: that resolves an instance started through the `~/.local/bin` symlink, tells main from helper (helpers all carry `--type=`), and still recognises an install whose files were already replaced, which reads as `(deleted)`
- SIGTERM goes to the **main process alone** and Electron shuts itself down
- the wait polls for an empty install instead of sleeping, escalates to SIGKILL on anything left after 10s, and returns non-zero if something survives, at which point `install-local.sh` refuses to install rather than copying over a live app
- candidates are narrowed with one `grep` over `/proc/*/cmdline` before any `readlink`, because a readlink per pid cost the best part of a second per call and turned the polling loop into the stall it was meant to remove

Closes #132

## How was it tested?

- New `server/test/install-stop.test.ts`: builds a fake install (a real copied binary in a real directory) and runs real processes out of it, because the bug was entirely about which processes a pattern matches. Covers the four helper shapes Electron actually spawns, a second install that must be left alone, a healthy shutdown, a process that ignores SIGTERM (must be escalated, not slept through), an orphaned sidecar, and the nothing-running no-op.
- `bun test` (server + web): **377 pass, 0 fail**.
- Against the **real app** on this machine: launched the installed build, confirmed 8 processes with exactly one main, then `stop_app` sent SIGTERM to that one pid and every process was gone in **0.2s** with no escalation and no survivors.
- Full `install-local.sh` run end to end afterwards: packaged, installed, and the app launches from the new install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)