### PR TITLE
fix(gate): stop approval requests dying to Do Not Disturb

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -2,6 +2,16 @@
 // Delivery channels are opt-in via env:
 //   AGENTGLASS_WEBHOOK   — POST {text} to this URL (Slack/Discord-compatible)
 //   AGENTGLASS_NOTIFY=1  — run `notify-send` (Linux desktop) if available
+//
+// Both of these leave the process, and neither is guaranteed to arrive. In
+// particular `notify-send` hands the notification to the desktop's daemon,
+// which is free to hold it: with Do Not Disturb on it is queued silently and
+// the command still exits 0, so there is no failure for this file to see. That
+// is fine for "an agent errored", and not fine for a gate hold, where an agent
+// is stopped until a human answers. The durable route for those is in-app --
+// web/src/lib/gateStore.ts raises every new hold onto the notch, which no
+// desktop setting can suppress. Treat everything below as best-effort reach
+// for when nobody is looking at agentglass at all.
 import type { WatchEvent } from "../../shared/types.ts";
 
 const WEBHOOK = process.env.AGENTGLASS_WEBHOOK;
@@ -33,12 +43,21 @@ async function deliver(title: string, body: string) {
   }
   if (DESKTOP) {
     try {
-      Bun.spawn(["notify-send", "-u", "critical", "--", title, body], { stdout: "ignore" });
-    } catch {
-      /* notify-send not installed — ignore */
+      Bun.spawn(["notify-send", "-a", "agentglass", "-u", "critical", "--", title, body], { stdout: "ignore" });
+    } catch (e) {
+      // Said once, not on every alert: the cause is a missing binary, so it
+      // will be just as true the next thousand times and the log is the only
+      // place anyone would find out. Silence here used to make "notify-send is
+      // not installed" look exactly like "your ping was delivered".
+      if (!warnedNoNotifySend) {
+        warnedNoNotifySend = true;
+        console.warn("[alerts] AGENTGLASS_NOTIFY=1 but notify-send could not be run:", e);
+      }
     }
   }
 }
+
+let warnedNoNotifySend = false;
 
 /** A tool call is being held at the control-plane gate — ping the human. */
 export function pushGate(agent: string, tool: string, summary: string) {

--- a/web/src/components/Alerts.tsx
+++ b/web/src/components/Alerts.tsx
@@ -3,6 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import type { Alert, AgentCard } from "../lib/derive.ts";
 import { collectAttention } from "../lib/attention.ts";
 import { listChats, subscribe as subscribeChats } from "../lib/chatStore.ts";
+import { listGates, subscribeGates, forgetGate } from "../lib/gateStore.ts";
 import type { Insight, PendingGate, GateRecord } from "../../../shared/types.ts";
 import { Panel } from "./Panel.tsx";
 import { api } from "../lib/api.ts";
@@ -18,8 +19,17 @@ const KIND_ICON: Record<Insight["kind"], string> = { loop: "↻", spend: "🔥",
 
 export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Alert[]; agents?: AgentCard[]; onSelectApp?: (app: string) => void; bump?: number }) {
   const [insights, setInsights] = useState<Insight[]>([]);
-  const [gates, setGates] = useState<PendingGate[]>([]);
   const [acting, setActing] = useState<Record<string, boolean>>({});
+
+  /*
+   * Read, not polled.
+   *
+   * The watching moved to gateStore, which keeps going while this panel is
+   * unmounted. A hold that arrives while you are in the workspace is what the
+   * notch is for, and it cannot be raised by a poll that only runs on the
+   * dashboard.
+   */
+  const gates = useSyncExternalStore(subscribeGates, listGates, listGates);
 
   useEffect(() => {
     let alive = true;
@@ -28,15 +38,6 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
     const id = setInterval(load, 15_000);
     return () => { alive = false; clearInterval(id); };
   }, [bump]);
-
-  // Pending gate requests are the most urgent thing — poll fast.
-  useEffect(() => {
-    let alive = true;
-    const load = () => api.gatePending().then((r) => alive && setGates(r.gates)).catch(() => {});
-    load();
-    const id = setInterval(load, 2000);
-    return () => { alive = false; clearInterval(id); };
-  }, []);
 
   /*
    * The gates you didn't decide.
@@ -66,7 +67,7 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
 
   const decide = (g: PendingGate, decision: "allow" | "deny") => {
     setActing((a) => ({ ...a, [g.id]: true }));
-    setGates((gs) => gs.filter((x) => x.id !== g.id)); // optimistic
+    forgetGate(g.id); // optimistic
     api.gateDecide(g.id, decision).catch(() => {});
   };
 

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -6,6 +6,7 @@ import { subscribe as subscribeChats, listChats } from "../../lib/chatStore.ts";
 import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
 import { clock24, subscribeClock24 } from "../../lib/clockPref.ts";
 import { subscribeGitChanged } from "../../lib/gitBus.ts";
+import { subscribeNewGates } from "../../lib/gateStore.ts";
 import {
   subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
   markNotifyRead, dismissNote, clearNotes, openNote, recordNote, type SystemNote,
@@ -266,6 +267,23 @@ function useNotes(): { note: Note | null; behind: number; ahead: number } {
     read();
     return subscribeChats(read);
   }, []);
+
+  // A tool call held at the gate. The most interrupting thing the notch shows,
+  // because an agent is stopped until it is answered, and unlike everything
+  // else here it cannot be caught up on later: the hold expires on its own.
+  //
+  // The store raises the history entry; this is only the toast. The Approve
+  // buttons live on the dashboard's "What needs you", so the toast names the
+  // tool and points there rather than pretending to be actionable itself.
+  useEffect(() => subscribeNewGates((g) => {
+    push({
+      id: `gate-${g.id}`,
+      kind: "blocked",
+      color: "var(--warning)",
+      title: `Approve ${g.tool_name}?`,
+      sub: `${g.source_app}:${g.session_id.slice(0, 8)} is waiting on you`,
+    });
+  }), []);
 
   // Desktop notifications, read off the D-Bus session bus by the server and
   // mirrored here. They share the lane with agentglass's own events on

--- a/web/src/lib/gateStore.ts
+++ b/web/src/lib/gateStore.ts
@@ -1,0 +1,179 @@
+import { api } from "./api.ts";
+import { recordNote } from "./sysNotify.ts";
+import type { PendingGate } from "../../../shared/types.ts";
+
+/**
+ * Pending gate requests: the tool calls an agent is blocked on until a human
+ * says yes or no.
+ *
+ * This is a module-level store rather than a hook because of what it is for. A
+ * gate hold is the one event in agentglass with a running agent stopped at the
+ * other end of it, and the panel that renders them is mounted only on the
+ * dashboard. Polling from that panel meant agentglass stopped noticing new
+ * holds the moment you opened the workspace, which is the same mistake
+ * sysNotify.ts already documents about tying its socket to the notch.
+ *
+ * It also raises each new hold onto the notch. That is the part that matters:
+ * the only other "come and look" signal was `notify-send`, spawned by the
+ * server, which a desktop Do Not Disturb setting swallows without telling
+ * anyone. An in-app note cannot be silenced by a setting agentglass does not
+ * own, so the request survives whatever the desktop is doing.
+ */
+
+const POLL_MS = 2000;
+
+const subs = new Set<() => void>();
+
+// Compared by identity by useSyncExternalStore, so it is replaced only when
+// the contents actually change. Polling every two seconds and handing back a
+// fresh array each time would re-render every consumer on every tick.
+let snapshot: PendingGate[] = [];
+
+export const listGates = (): PendingGate[] => snapshot;
+
+export function subscribeGates(fn: () => void): () => void {
+  subs.add(fn);
+  return () => subs.delete(fn);
+}
+
+function changed() {
+  for (const fn of subs) fn();
+}
+
+/**
+ * Newly-arrived holds, for surfaces that show the *transition* rather than the
+ * standing list. The notch's toast is the one consumer today.
+ *
+ * Kept here rather than re-derived by each surface so there is one answer to
+ * "is this new", and so a surface that mounts late cannot mistake the backlog
+ * it finds for a burst of arrivals.
+ */
+const arrivals = new Set<(g: PendingGate) => void>();
+
+export function subscribeNewGates(fn: (g: PendingGate) => void): () => void {
+  arrivals.add(fn);
+  return () => arrivals.delete(fn);
+}
+
+const sameIds = (a: PendingGate[], b: PendingGate[]) =>
+  a.length === b.length && a.every((g, i) => g.id === b[i]!.id);
+
+/**
+ * Gates already announced.
+ *
+ * Keyed by gate id, which the server keeps stable for the life of a hold, so a
+ * request that sits there for a minute is announced once rather than thirty
+ * times. Ids of resolved gates are dropped as they leave the pending list, and
+ * the set is therefore bounded by what is actually outstanding.
+ */
+const announced = new Set<string>();
+
+/**
+ * Seeded on the first successful poll without announcing anything.
+ *
+ * Opening agentglass onto three gates that have been waiting is a standing
+ * state, and the panel shows it. A note means "this just arrived while you
+ * were looking elsewhere", so the first read establishes the baseline and only
+ * what appears after it is worth interrupting for.
+ */
+let seeded = false;
+
+/**
+ * Raise a new hold on the notch, and tell anyone watching for arrivals.
+ *
+ * The note is written here rather than by the notch so that it happens whether
+ * or not the notch is mounted: the history behind it is the record that you
+ * were asked, and leaving that to a component would mean the record existed
+ * only when you were already looking at the surface that shows it.
+ */
+function announce(g: PendingGate) {
+  const agent = `${g.source_app}:${g.session_id.slice(0, 8)}`;
+  recordNote({
+    app: "gate",
+    summary: `Approve ${g.tool_name}?`,
+    body: g.summary ? `${agent} · ${g.summary}` : `${agent} is held until you decide`,
+    urgency: 2,
+  });
+  for (const fn of arrivals) {
+    try { fn(g); } catch { /* one bad listener must not stop the rest */ }
+  }
+}
+
+/**
+ * Take a fresh pending list and reconcile it: announce what is new, forget what
+ * has resolved, and publish a snapshot if the set actually moved.
+ *
+ * Exported because it is the seam. Everything stateful about this store is
+ * decided here, which is what the tests drive, and if the server ever pushes
+ * gates over a socket instead of being polled it is the one function that
+ * needs to be called.
+ */
+export function ingestGates(gates: PendingGate[]) {
+  if (seeded) {
+    for (const g of gates) {
+      if (announced.has(g.id)) continue;
+      announced.add(g.id);
+      announce(g);
+    }
+  } else {
+    for (const g of gates) announced.add(g.id);
+    seeded = true;
+  }
+
+  const live = new Set(gates.map((g) => g.id));
+  for (const id of announced) if (!live.has(id)) announced.delete(id);
+
+  if (sameIds(snapshot, gates)) return;
+  snapshot = gates;
+  changed();
+}
+
+/**
+ * Drop a gate locally the moment its decision is sent.
+ *
+ * The poll is two seconds behind, and a card that stays on screen after you
+ * click Approve reads as a click that did not register. Its id stays in
+ * `announced` until the server also stops listing it, so a decision in flight
+ * cannot be re-announced by a poll that overlaps it.
+ */
+export function forgetGate(id: string) {
+  const next = snapshot.filter((g) => g.id !== id);
+  if (next.length === snapshot.length) return;
+  snapshot = next;
+  changed();
+}
+
+// ---------------------------------------------------------------------------
+// The poll.
+//
+// Always on while the page is, and paused while the tab is hidden: nobody is
+// going to approve anything they cannot see, and the note raised on the way
+// back in is the same note either way. A failed request is left alone rather
+// than clearing the list, since "the server blinked" and "nothing is pending"
+// must not look alike when one of them means an agent is still waiting.
+// ---------------------------------------------------------------------------
+
+let timer: ReturnType<typeof setTimeout> | null = null;
+
+async function tick() {
+  timer = null;
+  if (typeof document === "undefined" || !document.hidden) {
+    try {
+      const { gates } = await api.gatePending();
+      ingestGates(gates);
+    } catch { /* offline or starting up: keep the last known list */ }
+  }
+  timer = setTimeout(tick, POLL_MS);
+}
+
+if (typeof window !== "undefined") {
+  void tick();
+  // Coming back to a hidden tab should not wait out the remaining interval:
+  // a gate raised while you were away is exactly what you returned to answer.
+  document.addEventListener("visibilitychange", () => {
+    if (document.hidden || !timer) return;
+    clearTimeout(timer);
+    timer = null;
+    void tick();
+  });
+}

--- a/web/test/gate-store.test.ts
+++ b/web/test/gate-store.test.ts
@@ -1,0 +1,110 @@
+import { test, expect, beforeAll } from "bun:test";
+import type { PendingGate } from "../../shared/types.ts";
+
+// A gate hold is the one thing in agentglass with a stopped agent on the other
+// end of it, and the only "come and look" signal used to be a `notify-send`
+// that a desktop Do Not Disturb setting swallows without a word. The store now
+// raises every new hold in-app instead, where no desktop setting can reach it.
+//
+// These pin the part that decides whether you are interrupted: that arriving to
+// a backlog is not a burst of alarms, that a hold waiting through thirty polls
+// is announced once, and that answering one cannot make it announce itself
+// again on the way out.
+
+const cell = new Map<string, string>();
+
+let store: typeof import("../src/lib/gateStore.ts");
+let sysNotify: typeof import("../src/lib/sysNotify.ts");
+
+beforeAll(async () => {
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  // The store reaches api.ts, which resolves the server address at import time.
+  (globalThis as any).location = { hostname: "localhost", origin: "http://localhost:4000" };
+  // No `window` in this environment, so importing the store does not start its
+  // poll: the tests drive ingestGates directly, which is the same seam.
+  store = await import("../src/lib/gateStore.ts");
+  sysNotify = await import("../src/lib/sysNotify.ts");
+});
+
+const gate = (id: string, over: Partial<PendingGate> = {}): PendingGate => ({
+  id,
+  source_app: "claude",
+  session_id: "abcdef0123456789",
+  tool_name: "Bash",
+  summary: "rm -rf build",
+  created: 1_700_000_000_000,
+  ...over,
+});
+
+/** Notes raised on the notch for gates, newest first. */
+const gateNotes = () => sysNotify.notifyHistory().filter((n) => n.app === "gate");
+
+const arrivals: PendingGate[] = [];
+let unsub: (() => void) | null = null;
+
+test("arriving to gates that were already waiting does not raise a note", () => {
+  unsub = store.subscribeNewGates((g) => arrivals.push(g));
+
+  store.ingestGates([gate("a"), gate("b")]);
+
+  // They are the standing state, and the panel shows them. A note means
+  // "this just happened", so the first read is a baseline, not an event.
+  expect(gateNotes()).toHaveLength(0);
+  expect(arrivals).toHaveLength(0);
+  expect(store.listGates().map((g) => g.id)).toEqual(["a", "b"]);
+});
+
+test("a hold that arrives afterwards is announced", () => {
+  store.ingestGates([gate("a"), gate("b"), gate("c", { tool_name: "Write" })]);
+
+  expect(arrivals.map((g) => g.id)).toEqual(["c"]);
+  const notes = gateNotes();
+  expect(notes).toHaveLength(1);
+  expect(notes[0]!.summary).toBe("Approve Write?");
+  // Urgency 2 is what the notch colours as the interrupting kind.
+  expect(notes[0]!.urgency).toBe(2);
+});
+
+test("a hold still waiting is not announced again on every poll", () => {
+  for (let i = 0; i < 30; i++) store.ingestGates([gate("a"), gate("b"), gate("c")]);
+
+  expect(arrivals.map((g) => g.id)).toEqual(["c"]);
+  expect(gateNotes()).toHaveLength(1);
+});
+
+test("the snapshot keeps its identity while the set is unchanged", () => {
+  const before = store.listGates();
+  store.ingestGates([gate("a"), gate("b"), gate("c")]);
+  // Polling every two seconds must not re-render every consumer that reads it.
+  expect(store.listGates()).toBe(before);
+});
+
+/*
+ * The overlap that would undo the whole thing.
+ *
+ * Approving drops the card immediately, but the poll in flight was sent before
+ * the decision and still lists it. If forgetting the card also forgot that it
+ * had been announced, that reply would announce it a second time -- a toast for
+ * a request you just answered, which teaches you to distrust the toasts.
+ */
+test("answering a gate does not let an in-flight poll re-announce it", () => {
+  store.forgetGate("c");
+  expect(store.listGates().map((g) => g.id)).toEqual(["a", "b"]);
+
+  store.ingestGates([gate("a"), gate("b"), gate("c")]); // the stale reply
+  expect(arrivals.map((g) => g.id)).toEqual(["c"]);
+  expect(gateNotes()).toHaveLength(1);
+});
+
+test("a gate that resolves and is later reissued is announced again", () => {
+  store.ingestGates([gate("a")]);            // b and c resolved
+  store.ingestGates([gate("a"), gate("b")]); // b comes back as a new hold
+
+  expect(arrivals.map((g) => g.id)).toEqual(["c", "b"]);
+  expect(gateNotes()).toHaveLength(2);
+  unsub?.();
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #135. A gate hold stops an agent until a human answers it, but the only "come and look" signal left the process: a `notify-send` spawned by the server. Do Not Disturb queues that silently and the command still exits 0, so nothing could tell a delivered ping from a swallowed one.

Holds are now raised in-app, where no desktop setting can reach them. The watching moves out of the `Alerts` panel into a new `web/src/lib/gateStore.ts`, for the reason `sysNotify.ts` already documents about its own socket: the panel only mounts on the dashboard, so polling from it meant agentglass stopped noticing new holds the moment you opened the workspace. The store polls while the page is up, pauses on a hidden tab, and puts each new hold on the notch. `Alerts` and the notch now read one list instead of each keeping their own.

Announcing is about the transition, not the standing state: the first read seeds a baseline silently (arriving to three waiting gates is not three alarms), a hold waiting through thirty polls is announced once, and answering one keeps its id until the server stops listing it so the in-flight poll cannot toast a request you just decided.

No DND detection, deliberately. There is no portable way to read it: `GetServerInformation` returns a name and not a state, and quickshell exposes no `Inhibited` property at all, so covering the field would mean a per-daemon adapter each for KDE, dunst, GNOME, mako, swaync and quickshell just to render a badge. Making the in-app path durable removes the need to know.

Also: `notify-send`'s failure is no longer swallowed by a bare `catch` that made a missing binary look like a delivered ping (refs #85), and it passes `-a` so notifications are attributed to agentglass.

The mirror path in `server/src/notifications.ts` was never affected and is unchanged: it eavesdrops the `Notify` method call on the bus rather than acting as the daemon, so DND cannot touch it.

## How was it tested?

- New `web/test/gate-store.test.ts`, 6 cases covering the interrupt logic: seeding on arrival, announcing a later hold, not re-announcing across 30 polls, snapshot identity held stable so the 2s poll does not re-render consumers, the answered-gate/in-flight-poll overlap, and a resolved id being announced again if reissued.
- Full suite: 377 pass, 0 fail.
- `bunx tsc --noEmit` clean in both `web/` and `server/`; `bun run build` clean.
- Verified live that the mirror path is genuinely DND-proof: a notification fired with DND on never appeared on the desktop and still landed in the notch.
