### PR TITLE
fix(desktop): identify the app by its binary, not by its command line

### DIFF
--- a/electron/appctl.sh
+++ b/electron/appctl.sh
@@ -1,0 +1,122 @@
+#!/usr/bin/env bash
+# Finding and stopping an installed agentglass desktop instance.
+#
+# Sourced by install-local.sh (and exercised by server/test/install-stop.test.ts),
+# which is why it is a library rather than inline: the interesting part is not
+# the install, it is knowing which processes belong to this install and waiting
+# for them to actually be gone.
+#
+# Expects APP to be set to the install directory (…/agentglass-desktop).
+
+# The resolved binary behind a pid, or nothing.
+#
+# /proc/<pid>/exe rather than the command line, for three reasons this script has
+# been bitten by: an instance launched through the ~/.local/bin symlink has a
+# different argv[0]; every Electron helper repeats the same path in its own argv,
+# so a cmdline match cannot tell main from renderer; and an instance whose files
+# were already replaced still answers here, with a "(deleted)" suffix, which is
+# precisely the state we are trying to avoid creating.
+_exe_of() {
+  local link
+  link=$(readlink "/proc/$1/exe" 2>/dev/null) || return 1
+  printf '%s\n' "${link% (deleted)}"
+}
+
+# Anything whose command line mentions us at all — the cheap first pass.
+#
+# One grep over /proc beats a readlink per pid by a wide margin, and it matters:
+# app_pids is called in a polling loop, and walking every process on a busy
+# machine took the best part of a second per call, which turned a bounded wait
+# into a visible stall. This over-matches on purpose (a shell sitting in a
+# directory named agentglass lands here too); app_pids does the precise part.
+_candidate_pids() {
+  local f
+  for f in $(grep -la -e agentglass /proc/[0-9]*/cmdline 2>/dev/null); do
+    f=${f#/proc/}
+    printf '%s\n' "${f%/cmdline}"
+  done
+}
+
+# Every pid belonging to this install: the app and its sidecar, helpers included.
+app_pids() {
+  local pid exe
+  for pid in $(_candidate_pids); do
+    exe=$(_exe_of "$pid") || continue
+    case "$exe" in
+      "$APP/agentglass"|"$APP/resources/agentglass-server") printf '%s\n' "$pid" ;;
+    esac
+  done
+}
+
+# The Electron main process alone.
+#
+# This is the one that must receive the SIGTERM. Signalling the whole tree at
+# once — which is what `pkill -f "$APP/agentglass"` did — tears the children out
+# from under the main process while it is running its own quit path
+# (stopSidecar() then app.quit()), and the result is a frozen window that can
+# outlive the rebuild by half an hour.
+#
+# The test is --type=, which every helper carries and main never does. Not the
+# shape of the whole command line: `^$APP/agentglass$` excludes the helpers
+# correctly and also excludes `agentglass --ozone-platform=wayland`, which is an
+# ordinary way to launch this app. Missing the main process there is worse than
+# the bug being fixed, because the caller reads "nothing running" and installs
+# over it.
+main_pids() {
+  local pid exe args
+  for pid in $(app_pids); do
+    exe=$(_exe_of "$pid") || continue
+    [ "$exe" = "$APP/agentglass" ] || continue
+    args=$(tr '\0' ' ' < "/proc/$pid/cmdline" 2>/dev/null) || continue
+    case " $args " in
+      *" --type="*) ;;
+      *) printf '%s\n' "$pid" ;;
+    esac
+  done
+}
+
+# Wait until nothing from this install is left, up to `$1` tenths of a second.
+# Returns 0 when the install is clear, 1 if the deadline passed with survivors.
+_wait_gone() {
+  local tries=$1
+  while [ "$tries" -gt 0 ]; do
+    if [ -z "$(app_pids)" ]; then return 0; fi
+    sleep 0.1
+    tries=$((tries - 1))
+  done
+  [ -z "$(app_pids)" ]
+}
+
+# Stop the running instance, politely first. Returns 1 if anything survives,
+# because the caller's next move is rm -rf over these very files.
+stop_app() {
+  local mains leftovers grace
+  grace=${APPCTL_GRACE_TENTHS:-100}
+  [ -n "$(app_pids)" ] || return 0
+
+  mains=$(main_pids)
+  if [ -n "$mains" ]; then
+    echo "==> stopping the running instance (main: $(echo "$mains" | tr '\n' ' '))"
+    kill $mains 2>/dev/null || true
+  else
+    # No main process: helpers that outlived their parent, or a sidecar left
+    # behind by a previous wedge. Nothing to ask politely, so skip to the end.
+    echo "==> clearing leftovers from a previous instance"
+  fi
+
+  # Poll rather than sleep a fixed guess. Measured against the main process
+  # alone, a healthy instance is gone in about two seconds; the window here is
+  # generous so that a slow quit gets waited out instead of raced by the copy.
+  # (The knob exists so the tests can reach the escalation path in under a
+  # second. Nothing outside them should set it.)
+  if [ -n "$mains" ] && _wait_gone "$grace"; then return 0; fi
+
+  leftovers=$(app_pids)
+  if [ -n "$leftovers" ]; then
+    echo "   still up after $((grace / 10))s — killing $(echo "$leftovers" | wc -l) process(es)"
+    kill -9 $leftovers 2>/dev/null || true
+    _wait_gone 30 || true
+  fi
+
+  [ -z "$(app_pids)" ]
+}

--- a/electron/install-local.sh
+++ b/electron/install-local.sh
@@ -42,41 +42,19 @@ done
 # (stopSidecar, then app.quit) wedges it: the window freezes for a long time,
 # and sometimes it never exits at all. That is how a rebuild ends up copying
 # over an app that is still running. Asked properly it goes down in under two
-# seconds.
+# seconds — eight processes, 0.2s, measured against the real tree.
 #
-# Matched against both paths it can be launched by: the desktop entry runs
-# $APP/agentglass, self-update.sh relaunches through the $BIN symlink, and the
-# main process carries whichever one was used in its cmdline.
-#
-# Every pattern here is anchored to the START of the command line, for the same
-# reason: unanchored, `-f` matches anything that merely mentions the path —
-# a shell that echoed it, an editor with the file open, the install script's own
-# parent. This script sends SIGKILL, so a loose pattern is not a cosmetic
-# problem. (It bit exactly that way while this fix was being tested.)
-MAIN_PAT="^($APP|$BIN)/agentglass$"
-TREE_PAT="^($APP|$BIN)/agentglass( |$)"       # main plus its gpu/zygote/renderer children
-SIDECAR_PAT="^$APP/resources/agentglass-server( |$)"
-
-if pgrep -f "$MAIN_PAT" >/dev/null 2>&1; then
-  echo "==> stopping the running instance"
-  pkill -TERM -f "$MAIN_PAT" 2>/dev/null || true
-  # Wait for it to actually go, rather than sleeping a fixed two seconds and
-  # assuming: the assumption is what left an app running on deleted inodes.
-  for _ in $(seq 1 40); do
-    pgrep -f "$MAIN_PAT" >/dev/null 2>&1 || break
-    sleep 0.25
-  done
-  # Anything still standing after ten seconds is not leaving on its own. Take
-  # the whole tree, then the sidecar it should have taken with it — a survivor
-  # holds the port and the next launch adopts a server from the old build.
-  pkill -9 -f "$TREE_PAT" 2>/dev/null || true
-  pkill -9 -f "$SIDECAR_PAT" 2>/dev/null || true
-  # Give the kernel a moment to release the port and the file handles.
-  sleep 0.5
-  if pgrep -f "$MAIN_PAT" >/dev/null 2>&1; then
-    echo "refusing to install over a running app: $(pgrep -f "$MAIN_PAT" | tr '\n' ' ')survived SIGKILL" >&2
-    exit 1
-  fi
+# Which pid is which comes from /proc/<pid>/exe rather than from the shape of
+# the command line, because every cmdline pattern precise enough to exclude the
+# helpers also excludes a main process that was started with an argument, and
+# `agentglass --ozone-platform=wayland` or `--no-sandbox` is an ordinary way to
+# start this app. A stop step that silently matches nothing is the original bug
+# with extra steps: the script would sail past it into rm -rf. See appctl.sh.
+# shellcheck source=appctl.sh
+. "$HERE/appctl.sh"
+if ! stop_app; then
+  echo "refusing to install over a running app: $(app_pids | tr '\n' ' ')survived SIGKILL" >&2
+  exit 1
 fi
 
 mkdir -p "$APP" "$BIN" "$DESKTOP"

--- a/server/test/install-stop.test.ts
+++ b/server/test/install-stop.test.ts
@@ -1,0 +1,157 @@
+// electron/install-local.sh used to stop a running install with
+// `pkill -f "$APP/agentglass"`, and every Electron helper — gpu-process,
+// zygote, utility, renderer — carries that same path in its own command line.
+// So the whole tree got SIGTERM at once and the main process was left running
+// its quit path with its children pulled out from under it: a frozen window
+// that in one case was still alive 34 minutes later, holding deleted inodes,
+// while the script had already copied a new build over it.
+//
+// #136 fixed that by signalling only what matched `^($APP|$BIN)/agentglass$`,
+// which excludes the helpers correctly and also excludes a main process started
+// with a flag. This file guards the version that identifies processes by the
+// binary behind them instead.
+//
+// These tests drive electron/appctl.sh against a fake install: a real directory
+// with a real binary in it, and real processes running that binary, because the
+// bug was entirely about which processes get matched. Asserting on the script's
+// text would have passed against the broken version too.
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, mkdirSync, copyFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const APPCTL = join(import.meta.dir, "..", "..", "electron", "appctl.sh");
+const spawned: number[] = [];
+
+/** A fake install: our own copy of a shell, named the way the real one is. The
+ *  copy matters — /proc/<pid>/exe has to point inside the install directory. */
+function fakeInstall() {
+  const app = mkdtempSync(join(tmpdir(), "agx-install-"));
+  mkdirSync(join(app, "resources"));
+  copyFileSync("/bin/sh", join(app, "agentglass"));
+  copyFileSync("/bin/sh", join(app, "resources", "agentglass-server"));
+  return app;
+}
+
+/** Run a process out of the fake install. `; true` keeps the shell from
+ *  exec'ing the sleep away, which would replace the exe we are matching on. */
+function launch(exe: string, script: string, ...args: string[]): number {
+  const p = Bun.spawn([exe, "-c", `${script}; true`, ...args], { stdio: ["ignore", "ignore", "ignore"] });
+  p.unref();
+  spawned.push(p.pid);
+  return p.pid;
+}
+
+/** Call a function from appctl.sh with APP pointed at the fake install. */
+async function appctl(app: string, call: string, env: Record<string, string> = {}) {
+  const p = Bun.spawn(["bash", "-c", `APP="${app}"; . "${APPCTL}"; ${call}`], {
+    env: { ...process.env, ...env },
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+  const out = await new Response(p.stdout).text();
+  return { code: await p.exited, out: out.trim() };
+}
+
+const pids = (out: string) => out.split("\n").filter((l) => /^\d+$/.test(l)).map(Number);
+const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+
+afterEach(() => {
+  for (const pid of spawned.splice(0)) { try { process.kill(pid, 9); } catch { /* already gone */ } }
+});
+
+describe("finding the processes that belong to an install", () => {
+  test("helpers are not mistaken for the main process", async () => {
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30");
+    // The four shapes Electron actually spawns, all sharing the main's path.
+    const helpers = [
+      launch(join(app, "agentglass"), "sleep 30", "--type=zygote"),
+      launch(join(app, "agentglass"), "sleep 30", "--type=gpu-process", "--ozone-platform=wayland"),
+      launch(join(app, "agentglass"), "sleep 30", "--type=utility", "--utility-sub-type=network.mojom.NetworkService"),
+      launch(join(app, "agentglass"), "sleep 30", "--type=renderer"),
+    ];
+    const sidecar = launch(join(app, "resources", "agentglass-server"), "sleep 30");
+    await Bun.sleep(200);
+
+    const all = pids((await appctl(app, "app_pids")).out);
+    expect(all.sort()).toEqual([main, ...helpers, sidecar].sort());
+
+    // The whole fix in one assertion: only the main process gets signalled.
+    expect(pids((await appctl(app, "main_pids")).out)).toEqual([main]);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("a main process started with a flag is still found", async () => {
+    // The gap in matching by command-line shape: a pattern anchored tightly
+    // enough to exclude the helpers (`^$APP/agentglass$`) also excludes this,
+    // and launching with --ozone-platform=wayland or --no-sandbox is ordinary.
+    // The caller then reads "nothing is running" and installs over a live app,
+    // which is the failure this whole file exists to prevent.
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30", "--ozone-platform=wayland");
+    await Bun.sleep(200);
+    expect(pids((await appctl(app, "main_pids")).out)).toEqual([main]);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("another install's processes are left alone", async () => {
+    const mine = fakeInstall();
+    const theirs = fakeInstall();
+    const other = launch(join(theirs, "agentglass"), "sleep 30");
+    await Bun.sleep(200);
+    expect((await appctl(mine, "app_pids")).out).toBe("");
+    expect(alive(other)).toBe(true);
+    for (const d of [mine, theirs]) rmSync(d, { recursive: true, force: true });
+  });
+});
+
+describe("stopping it", () => {
+  test("a healthy instance is waited out, not raced", async () => {
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30");
+    // A helper that goes when its main goes, the way a real one does.
+    const helper = launch(join(app, "agentglass"), `while kill -0 ${main} 2>/dev/null; do sleep 0.05; done`, "--type=renderer");
+    const sidecar = launch(join(app, "resources", "agentglass-server"), `while kill -0 ${main} 2>/dev/null; do sleep 0.05; done`);
+    await Bun.sleep(200);
+
+    const { code } = await appctl(app, "stop_app");
+    expect(code).toBe(0);
+    // stop_app only returns 0 once nothing from the install is left — which is
+    // the guarantee the caller needs before it starts rm -rf'ing these files.
+    for (const pid of [main, helper, sidecar]) expect(alive(pid)).toBe(false);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("something that ignores SIGTERM is escalated, not slept through", async () => {
+    const app = fakeInstall();
+    const main = launch(join(app, "agentglass"), "sleep 30");
+    const stubborn = launch(join(app, "agentglass"), "trap '' TERM; sleep 30", "--type=renderer");
+    await Bun.sleep(200);
+
+    const { code, out } = await appctl(app, "stop_app", { APPCTL_GRACE_TENTHS: "5" });
+    expect(code).toBe(0);
+    expect(out).toContain("still up after");
+    expect(alive(stubborn)).toBe(false);
+    expect(alive(main)).toBe(false);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("a sidecar left behind by a previous wedge is cleared", async () => {
+    const app = fakeInstall();
+    const orphan = launch(join(app, "resources", "agentglass-server"), "trap '' TERM; sleep 30");
+    await Bun.sleep(200);
+
+    const { code, out } = await appctl(app, "stop_app", { APPCTL_GRACE_TENTHS: "5" });
+    expect(code).toBe(0);
+    expect(out).toContain("leftovers");
+    expect(alive(orphan)).toBe(false);
+    rmSync(app, { recursive: true, force: true });
+  });
+
+  test("nothing running is a no-op success", async () => {
+    const app = fakeInstall();
+    expect((await appctl(app, "stop_app")).code).toBe(0);
+    rmSync(app, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Follow-up to #136, which fixed the wedge (signalling the whole Electron tree at once) and is correct about that. It identifies the main process with `^($APP|$BIN)/agentglass$`. That pattern has to be exact, because every helper repeats the same path in its own argv, and being exact means it also excludes a main process started with an argument.

Verified against a running instance on this machine, launched as `agentglass --ozone-platform=wayland`:

```
their MAIN_PAT matches: []
actual main:            1249618 /home/…/agentglass --ozone-platform=wayland
```

`pgrep` finds nothing, the whole stop block is skipped, and the script goes straight to `rm -rf` over a live install. That is the deleted-inode state from #132, reached silently. `--ozone-platform=wayland` and `--no-sandbox` are ordinary ways to launch this app (the script itself warns about the case that needs `--no-sandbox`).

So process handling moves into `electron/appctl.sh` and works from `/proc/<pid>/exe`, the resolved binary:

- argv cannot confuse it: a flag changes nothing, and an instance launched through the `~/.local/bin` symlink resolves to the same binary, so the `$BIN` alternation is no longer load-bearing
- helpers are told apart by `--type=` alone, which is the one thing that reliably distinguishes them
- an install whose files were already replaced still answers, as `(deleted)`, which is precisely the state worth detecting
- the survivor check now covers the **sidecar** as well as the main process. A sidecar on deleted inodes still holds the port, and that is what makes the next launch adopt a stale server
- candidates are narrowed with one `grep` over `/proc/*/cmdline` before any `readlink`, because a readlink per pid cost close to a second per call on a busy machine and would have turned the polling loop into the stall it exists to remove

Refs #132

## How was it tested?

- New `server/test/install-stop.test.ts` (7 tests). It builds a fake install (a real copied binary in a real directory) and runs real processes out of it, because every version of this bug has been about which processes get matched, and asserting on the script's text would pass against the broken version too. Covers: the four helper shapes Electron actually spawns, **a main started with a flag** (the gap above), a second install that must be left alone, a healthy shutdown, a process that ignores SIGTERM (escalated, not slept through), an orphaned sidecar, and the nothing-running no-op.
- `bun test`: **378 pass, 0 fail**.
- Against the real app: launched the installed build, confirmed 8 processes with exactly one main, `stop_app` sent SIGTERM to that single pid and every process was gone in **0.2s**, no escalation, no survivors.
- `install-local.sh` run end to end twice, including over a running instance; the app launches from the resulting install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)