### PR TITLE
feat(fleet): report evidence of life for an open tool call

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -618,7 +618,8 @@ export function getRecent(limit = 300, provider?: string): WatchEvent[] {
 const OPEN_TOOL_MAX_MS = 30 * 60_000;
 const openToolSql = (scoped: string) =>
   `SELECT p.session_id AS session_id, p.source_app AS source_app,
-          COALESCE(p.tool_name, 'tool') AS tool_name, p.timestamp AS since
+          COALESCE(p.tool_name, 'tool') AS tool_name, p.timestamp AS since,
+          json_extract(p.payload, '$.tool_input.file_path') AS target
      FROM events p
     WHERE p.hook_event_type = 'PreToolUse'
       AND p.timestamp >= ?

--- a/server/src/evidence.ts
+++ b/server/src/evidence.ts
@@ -1,0 +1,84 @@
+/**
+ * Evidence of life for a running tool call.
+ *
+ * A tool call that has been open for eight minutes is either a long build or a
+ * wedged CLI, and the input side cannot tell you which: both look like a
+ * PreToolUse with no Post. Every threshold built on elapsed time alone is
+ * therefore a guess, and it is wrong in both directions — warn at five minutes
+ * and half the warnings are healthy builds, write the pair off at thirty and a
+ * genuinely long job vanishes from the fleet while it is still working.
+ *
+ * So ask a different question: not "how long has this been open" but "when did
+ * this session last produce evidence that it is alive". Two sources, both local
+ * and both independent of the hook stream that has gone quiet:
+ *
+ *  - the transcript file, which the CLI appends to as a turn streams. Growth
+ *    there is the strongest signal available and costs one stat.
+ *  - the file a write tool named in its own input. If Edit said it would touch
+ *    src/foo.ts, then src/foo.ts changing is that tool doing its job.
+ *
+ * This module only *reports* freshness; nothing here classifies a session. That
+ * is deliberate: the numbers want watching against real runs — including a real
+ * hang — before any state machine is moved onto them.
+ */
+import { statSync } from "node:fs";
+import type { OpenToolCall } from "../../shared/types.ts";
+import { transcriptPathOf } from "./transcripts.ts";
+
+/** Tools whose own input names a file they are about to change. Bash is absent
+ *  on purpose: its command may write anywhere, or nowhere, and guessing a path
+ *  for it would manufacture evidence rather than find it. */
+const WRITES_A_FILE = new Set(["Edit", "MultiEdit", "Write", "NotebookEdit"]);
+
+/** mtime in ms, or null when the path is gone, unreadable, or was never given.
+ *  A tool that has not created its target yet is not evidence of anything. */
+function mtimeOf(path: string | null | undefined): number | null {
+  if (!path) return null;
+  try {
+    return statSync(path).mtimeMs;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Attach the freshest evidence found for each open call.
+ *
+ * Kept out of db.ts because it reaches the filesystem and the transcript index,
+ * and a query module that quietly stats files is a query module nobody can
+ * reason about. Two stats per open call, and the list is capped at 200.
+ */
+export function withEvidence(calls: OpenToolCall[]): OpenToolCall[] {
+  // One transcript stat per session, not per call: a session with four tools
+  // open would otherwise stat the same file four times for one answer.
+  const perSession = new Map<string, number | null>();
+
+  return calls.map((c) => {
+    if (!perSession.has(c.session_id)) {
+      perSession.set(c.session_id, mtimeOf(transcriptPathOf(c.session_id)));
+    }
+    const transcriptAt = perSession.get(c.session_id) ?? null;
+    const targetAt = WRITES_A_FILE.has(c.tool_name) ? mtimeOf(c.target) : null;
+
+    // Freshest wins, and which one it was is reported: "the transcript grew"
+    // and "the file it promised to touch changed" are different claims, and a
+    // reader deciding whether to trust the number wants to know which was made.
+    let evidenceAt: number | undefined;
+    let evidenceKind: OpenToolCall["evidenceKind"];
+    if (transcriptAt !== null && (targetAt === null || transcriptAt >= targetAt)) {
+      evidenceAt = transcriptAt;
+      evidenceKind = "transcript";
+    } else if (targetAt !== null) {
+      evidenceAt = targetAt;
+      evidenceKind = "target";
+    } else {
+      // Nothing to read. Not the same as "nothing happened": a tool with no
+      // expected artifact and a session whose transcript we cannot find both
+      // land here, and calling either of them stuck would be the old mistake
+      // in a new place.
+      evidenceKind = "none";
+    }
+
+    return { ...c, ...(evidenceAt === undefined ? {} : { evidenceAt }), evidenceKind };
+  });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -58,6 +58,7 @@ import { parseWindowMs } from "./params.ts";
 import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
 import { notifyCapability, subscribeNotifications, notifyWatching, openNote } from "./notifications.ts";
 import { markIgnored } from "./ignored.ts";
+import { withEvidence } from "./evidence.ts";
 
 const PORT = Number(process.env.AGENTGLASS_PORT || 4000);
 /** When this process came up. /stats ships it so the dashboard's uptime is
@@ -753,7 +754,10 @@ const server = Bun.serve<WsData>({
       // openTools seeds the client's "running" state for tools whose PreToolUse
       // predates the 300-event initial slice — otherwise a long job in flight
       // when the page loads shows as idle (or missing) until its Post arrives.
-      const frame: WsFrame = { type: "initial", data: getRecent(300), openTools: openToolCalls() };
+      // Each open call carries when its session last showed evidence of life —
+      // read here rather than in db.ts, which has no business touching the
+      // filesystem. See evidence.ts for why elapsed time alone cannot answer it.
+      const frame: WsFrame = { type: "initial", data: getRecent(300), openTools: withEvidence(openToolCalls()) };
       ws.send(JSON.stringify(frame));
     },
     close(ws: ServerWebSocket<WsData>) {

--- a/server/src/transcripts.ts
+++ b/server/src/transcripts.ts
@@ -88,6 +88,21 @@ const owned = new Set<string>();
 export function ownsSession(session_id: string): boolean {
   return SCAN_ENABLED && owned.has(session_id);
 }
+/** Where this session's transcript lives on disk, or null if we have never read
+ *  one for it (hook-only sessions, or a scan that has not reached it yet).
+ *
+ *  The file is appended to as a turn streams, so its mtime is the cheapest
+ *  honest answer to "is this session still alive" — see evidence.ts. Newest
+ *  first, because a session resumed into a second file has two rows and the
+ *  older one stopped growing when the first one ended. */
+const transcriptForSession = db.query<{ path: string }, [string]>(
+  "SELECT path FROM transcript_files WHERE session_id = ? ORDER BY mtime DESC LIMIT 1"
+);
+export function transcriptPathOf(session_id: string): string | null {
+  if (!session_id) return null;
+  return transcriptForSession.get(session_id)?.path ?? null;
+}
+
 // Seeded at startup: a backfill sweep walks every project on the machine, and
 // until it finishes the guard would let hook posts through for sessions the
 // scanner is about to read from disk — counting the same turns twice.

--- a/server/test/evidence.test.ts
+++ b/server/test/evidence.test.ts
@@ -1,0 +1,116 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import type { OpenToolCall } from "../../shared/types.ts";
+
+/**
+ * Evidence of life, against real files with real mtimes.
+ *
+ * The whole point of the signal is that it reads something the hook stream
+ * cannot fake, so mocking the filesystem here would test the opposite of what
+ * matters.
+ */
+let dir: string, transcript: string, target: string, ev: typeof import("../src/evidence.ts");
+
+/** Sessions the fixture transcript belongs to. Registered in the same table the
+ *  scanner writes, since that is what the lookup reads. */
+const SESSION = "sess-alive";
+
+const call = (over: Partial<OpenToolCall> = {}): OpenToolCall => ({
+  session_id: SESSION,
+  source_app: "claude-code",
+  tool_name: "Bash",
+  since: Date.now() - 60_000,
+  ...over,
+});
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-evidence-"));
+  process.env.AGENTGLASS_ROOT = dir;
+  transcript = join(dir, "session.jsonl");
+  target = join(dir, "target.ts");
+  writeFileSync(transcript, "{}\n");
+  writeFileSync(target, "export const x = 1;\n");
+
+  const { db } = await import("../src/db.ts");
+  await import("../src/transcripts.ts"); // creates transcript_files
+  db.query(
+    `INSERT INTO transcript_files (path, session_id, source_app, project_path, lines_done, size, mtime)
+     VALUES (?, ?, 'claude-code', ?, 1, 2, 0)`
+  ).run(transcript, SESSION, dir);
+
+  ev = await import("../src/evidence.ts");
+});
+
+afterAll(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ } });
+
+/** Backdate a file, so "fresh" and "stale" are facts rather than timing luck. */
+const age = (path: string, secondsAgo: number) => {
+  const t = Date.now() / 1000 - secondsAgo;
+  utimesSync(path, t, t);
+};
+
+describe("evidence of life", () => {
+  it("reports the transcript growing, which is evidence the hooks cannot give", () => {
+    age(transcript, 3);
+    const [r] = ev.withEvidence([call()]);
+    expect(r!.evidenceKind).toBe("transcript");
+    expect(Date.now() - r!.evidenceAt!).toBeLessThan(10_000);
+  });
+
+  it("reports the file a write tool named, when that is the fresher signal", () => {
+    // The shape that matters: a long Edit whose transcript went quiet, but
+    // whose target is being written right now.
+    age(transcript, 600);
+    age(target, 2);
+    const [r] = ev.withEvidence([call({ tool_name: "Edit", target })]);
+    expect(r!.evidenceKind).toBe("target");
+    expect(Date.now() - r!.evidenceAt!).toBeLessThan(10_000);
+  });
+
+  it("prefers the freshest of the two rather than a fixed order", () => {
+    age(transcript, 2);
+    age(target, 600);
+    const [r] = ev.withEvidence([call({ tool_name: "Edit", target })]);
+    expect(r!.evidenceKind).toBe("transcript");
+  });
+
+  it("ignores a target for tools that write nowhere in particular", () => {
+    // Bash may write anywhere or nowhere. Reading a path off it would be
+    // manufacturing evidence, which is worse than having none.
+    age(transcript, 900);
+    age(target, 1);
+    const [r] = ev.withEvidence([call({ tool_name: "Bash", target })]);
+    expect(r!.evidenceKind).toBe("transcript");
+    expect(Date.now() - r!.evidenceAt!).toBeGreaterThan(800_000 / 1000);
+  });
+
+  it("says `none` rather than guessing when nothing is readable", () => {
+    // An unknown session and a target that does not exist: the honest answer is
+    // that we cannot tell, and it must not read as "stuck".
+    const [r] = ev.withEvidence([
+      call({ session_id: "sess-unknown", tool_name: "Edit", target: join(dir, "never-created.ts") }),
+    ]);
+    expect(r!.evidenceKind).toBe("none");
+    expect(r!.evidenceAt).toBeUndefined();
+  });
+
+  it("stats a session's transcript once however many of its calls are open", () => {
+    // Four open tools on one session is one question about that session.
+    const calls = [call(), call({ tool_name: "Grep" }), call({ tool_name: "Read" }), call({ tool_name: "Glob" })];
+    const out = ev.withEvidence(calls);
+    expect(out).toHaveLength(4);
+    expect(new Set(out.map((r) => r.evidenceAt)).size).toBe(1);
+  });
+
+  it("leaves every field it was given alone", () => {
+    // It enriches; it must not become a place where open-call data is rewritten.
+    const c = call({ tool_name: "Edit", target, since: 123 });
+    const [r] = ev.withEvidence([c]);
+    expect(r!.session_id).toBe(c.session_id);
+    expect(r!.tool_name).toBe("Edit");
+    expect(r!.since).toBe(123);
+    expect(r!.target).toBe(target);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -334,6 +334,17 @@ export interface OpenToolCall {
   source_app: string;
   tool_name: string;
   since: number; // ms — the PreToolUse timestamp
+  /** The file this tool's own input said it would touch, when it named one.
+   *  Null for Bash and for anything that writes nowhere in particular. */
+  target?: string | null;
+  /** When this session last showed evidence of being alive: the transcript
+   *  growing, or the file above changing. Independent of the hook stream, which
+   *  by definition has gone quiet while a call is open. Absent when there was
+   *  nothing to read. */
+  evidenceAt?: number;
+  /** Which evidence the timestamp came from. `none` means no source was
+   *  readable — deliberately not the same claim as "nothing happened". */
+  evidenceKind?: "transcript" | "target" | "none";
 }
 
 /** WebSocket frames. */

--- a/web/src/components/Fleet.tsx
+++ b/web/src/components/Fleet.tsx
@@ -22,6 +22,25 @@ const STATUS: Record<string, { color: string; label: string }> = {
 const RANK: Record<string, number> = { working: 0, waiting: 1, errored: 2, idle: 3 };
 // Within the idle pile, surface what still wants something from you.
 const OUTCOME_RANK: Record<AgentOutcome, number> = { unanswered: 0, faulted: 1, unclear: 2, settled: 3 };
+
+/**
+ * What the server last saw this session actually do, for a card whose tool call
+ * is still open.
+ *
+ * A tooltip and nothing more, on purpose. "Running Bash · 8m" cannot tell a
+ * long build from a hang, and neither can any threshold on that number — but
+ * "the transcript grew 3s ago" and "nothing readable in 8m" are different
+ * situations, and this is the cheapest way to find out how well the signal
+ * holds before any status depends on it.
+ */
+function evidenceNote(a: AgentCard): string | undefined {
+  if (!a.runningTool || !a.evidenceKind) return undefined;
+  if (a.evidenceKind === "none" || !a.evidenceAt) {
+    return `${a.runningTool} open ${fmtAgo(a.runningSince)} · no evidence source readable (not the same as nothing happening)`;
+  }
+  const what = a.evidenceKind === "transcript" ? "transcript last grew" : "the file it named last changed";
+  return `${a.runningTool} open ${fmtAgo(a.runningSince)} · ${what} ${fmtAgo(a.evidenceAt)}`;
+}
 /**
  * The outcome mark: a small glyph beside the metrics, never the status rail.
  *
@@ -126,7 +145,7 @@ function SessionCard({ a, selected, onSelect }: { a: AgentCard; selected: boolea
         <span className="chip shrink-0" style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }}>{model}</span>
       </div>
       <div className="mt-1 flex items-center justify-between">
-        <span className="text-[11px] t-dim2 truncate">{a.lastAction || st.label}</span>
+        <span className="text-[11px] t-dim2 truncate" title={evidenceNote(a)}>{a.lastAction || st.label}</span>
         <Spark data={a.spark} color={st.color} />
       </div>
       {/* subagents this session spawned — the real parent→child structure */}

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -51,6 +51,12 @@ export interface AgentCard {
   /** A tool call that started (PreToolUse) and hasn't reported back yet. */
   runningTool: string | null;
   runningSince: number;
+  /** When this session last showed evidence of life while that call has been
+   *  open — the transcript growing, or the file the tool named changing. Read
+   *  and reported only: nothing here decides `status` yet. The point of showing
+   *  it first is to find out where it lies before anything depends on it. */
+  evidenceAt: number | null;
+  evidenceKind: "transcript" | "target" | "none" | null;
   /** Context-window estimate: the latest turn's full prompt size (input +
    *  cache read + cache write — each API call re-sends the conversation, so
    *  that sum IS the context). 0 = no turn seen yet. */
@@ -99,6 +105,8 @@ function blankCard(key: string, source_app: string, session_id: string, model_na
     subagentTypes: [],
     runningTool: null,
     runningSince: 0,
+    evidenceAt: null,
+    evidenceKind: null,
     ctxTokens: 0,
     ctxTs: 0,
     ctxLimit: 200_000,
@@ -223,7 +231,15 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
       a.lastType = "PreToolUse";
       map.set(key, a);
     }
-    if (s.since >= a.runningSince) { a.runningTool = s.tool_name; a.runningSince = s.since; }
+    if (s.since >= a.runningSince) {
+      a.runningTool = s.tool_name;
+      a.runningSince = s.since;
+      // Carried through untouched. The classifier below still runs on elapsed
+      // time alone; this rides alongside it so the two can be compared against
+      // real runs before either replaces the other.
+      a.evidenceAt = s.evidenceAt ?? null;
+      a.evidenceKind = s.evidenceKind ?? null;
+    }
   }
 
   // Spark buckets over the last 20 * 3s = 60s window.


### PR DESCRIPTION
## What does this PR do?

First step of #134, deliberately scoped to **reporting only**.

An open tool call says a tool started and never reported back. It cannot separate a twelve-minute build from a wedged CLI, which is why `TOOL_RUN_WARN_MS` (5m) and `TOOL_RUN_MAX_MS` (30m) are guesses dressed as knowledge: warn early and half the warnings are healthy builds, write the pair off late and a genuinely long job vanishes from the fleet while it is still working.

This adds the other half of the question: not how long the call has been open, but **when the session last produced evidence it is alive**, from two sources that do not depend on the hook stream that has by definition gone quiet:

- **the transcript file**, appended to as a turn streams. One `stat`, and the strongest signal available.
- **the file a write tool named in its own input**. If `Edit` said it would touch `src/foo.ts`, then `src/foo.ts` changing is that tool doing its job.

Freshest wins, and which source it came from is reported, because "the transcript grew" and "the file it promised to touch changed" are different claims and a reader deciding whether to trust the number wants to know which was made.

Two deliberate refusals:

- **Bash gets no target.** Its command may write anywhere or nowhere, and reading a path off it would manufacture evidence rather than find it.
- **`none` is a real answer.** No readable source is not the same claim as "nothing happened", and rendering it as a hang would be the current mistake in a new place.

**Nothing classifies on this yet.** `deriveAgents` still decides status on elapsed time exactly as before; the new number rides alongside in a tooltip on the running-tool line. Shipping the classifier in the same PR would trade one confident guess for another, and this signal wants watching against real runs — including a deliberate hang — before anything depends on it.

Cost: two stats per open call, one transcript stat per session however many of its calls it has open, over a list already capped at 200. The filesystem work lives in `evidence.ts` rather than `db.ts`, which has no business stat-ing files.

Credit for the framing: Richard Clifton (`@eatmonster`), whose watch tier checks artifact freshness rather than whether an endpoint answers.

## How was it tested?

- New `server/test/evidence.test.ts`, 7 tests against real files with real mtimes (backdated with `utimes`, so fresh and stale are facts rather than timing luck): transcript growth reported, a write tool's target winning when it is fresher, the freshest of the two winning rather than a fixed order, Bash refusing a target it was handed, `none` when nothing is readable, one stat per session across four open calls, and every input field preserved.
- `cd server && bun test`: 268 pass, 0 fail. `cd web && bun test`: 110 pass, 0 fail. Both typechecks clean.

Honest limitation: I could not observe this against a live open call on this machine, because the Claude Code hooks here post to `:4000`, which another local server holds, so open-tool rows never materialise and the data arrives via the transcript scanner instead (which writes Pre and Post together). That is precisely why this PR ships the reporting and not the classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)