### PR TITLE
fix(git): tell the conflict chat which side is which

### DIFF
--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -3,6 +3,7 @@
 // (browse commits, view a commit's diff), and stash — all with the same diff
 // renderer as the telemetry view.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
@@ -507,15 +508,12 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     const c = newChat(root);
     update(c.id, (ch) => {
       ch.title = "resolve merge conflicts";
+      // Read from `tree`/`repos` rather than the `branch`/`repoRef` consts
+      // declared further down: same values, no dependence on where in this
+      // component the declarations happen to sit.
       ch.draft = [
-        `I am mid-merge in ${root} and git has left ${rels.length} file(s) conflicted:`,
-        "",
-        ...rels.map((r) => `- ${r}`),
-        "",
-        "Please resolve each conflict, keeping both sides' intent where they do",
-        "different things and preferring the incoming change where they do the",
-        "same thing differently. Explain anything you had to choose between.",
-        "Do not commit — leave the resolution staged so I can review it.",
+        ...conflictBriefing(root, tree?.branch, repos.find((r) => r.root === root), mergeState, rels),
+        ...CONFLICT_ASK,
       ].join("\n");
     });
     setActiveChatId(c.id);

--- a/web/src/lib/conflictBrief.ts
+++ b/web/src/lib/conflictBrief.ts
@@ -1,0 +1,72 @@
+import type { GitBranchInfo, GitRepoRef, GitTreeState } from "../../../shared/types.ts";
+
+/**
+ * Which side is which, per operation.
+ *
+ * This is the part a conflict prompt cannot leave out. "Prefer the incoming
+ * change" is meaningless until incoming has a name, and under a rebase the
+ * names swap: git replays YOUR commits onto the other branch, so "ours" is the
+ * branch being replayed onto and "theirs" is your own work. An agent told to
+ * favour theirs during a rebase, thinking that means the base, resolves every
+ * conflict backwards with complete confidence.
+ */
+export function sidesOf(state: GitTreeState, branchName: string, incoming: string | null): string | null {
+  const other = incoming ?? "the other side";
+  switch (state) {
+    case "merging":
+      return `"ours"/HEAD is ${branchName}, "theirs"/MERGE_HEAD is ${other} (the incoming side).`;
+    case "rebasing":
+      // Worth spelling out rather than naming: this inversion is a classic way
+      // to resolve a whole rebase the wrong way round.
+      return `This is a REBASE, so the sides are inverted from what you may expect: "ours" is ${other} (the branch my commits are being replayed onto) and "theirs" is my own commit being replayed.`;
+    case "cherry-picking":
+      return `"ours"/HEAD is ${branchName}; "theirs" is the commit being cherry-picked onto it.`;
+    case "reverting":
+      return `"ours"/HEAD is ${branchName}; "theirs" is the reverse of the commit being reverted.`;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The situation, not just the file list.
+ *
+ * Everything here is already on screen — the branch, its base, whether this
+ * checkout is a linked worktree, what git stopped in the middle of. Leaving it
+ * out made the agent re-derive from `git status` what the panel already knew,
+ * and guess at the one thing status does not spell out: which ref is incoming.
+ */
+export function conflictBriefing(
+  root: string,
+  branch: GitBranchInfo | undefined,
+  repoRef: GitRepoRef | undefined,
+  state: GitTreeState,
+  rels: string[],
+): string[] {
+  const name = branch?.name || "(unknown branch)";
+  const incoming = branch?.base ?? null;
+  const doing = state === "clean" ? "mid-merge" : `mid-${state.replace(/ing$/, "")}`;
+  const where = repoRef?.worktreeOf
+    ? `the linked worktree ${root} (a worktree of ${repoRef.worktreeOf})`
+    : root;
+
+  const sides = sidesOf(state, name, incoming);
+  return [
+    `I am on ${name} in ${where}, ${doing}${incoming ? `, bringing ${incoming} in` : ""}.`,
+    ...(sides ? [sides] : []),
+    "",
+    `Git has left ${rels.length} file(s) conflicted:`,
+    "",
+    ...rels.map((r) => `- ${r}`),
+    "",
+  ];
+}
+
+/** The ask, unchanged in substance: reconcile intent, explain the judgement
+ *  calls, and stop short of committing so the resolution can be reviewed. */
+export const CONFLICT_ASK = [
+  "Please resolve each conflict, keeping both sides' intent where they do",
+  "different things. Where they do the same thing differently, prefer the",
+  "incoming side named above. Explain anything you had to choose between.",
+  "Do not commit — leave the resolution staged so I can review it.",
+];

--- a/web/test/conflict-brief.test.ts
+++ b/web/test/conflict-brief.test.ts
@@ -1,0 +1,102 @@
+import { describe, expect, it } from "bun:test";
+import { conflictBriefing, sidesOf, CONFLICT_ASK } from "../src/lib/conflictBrief.ts";
+import type { GitBranchInfo, GitRepoRef } from "../../shared/types.ts";
+
+/**
+ * The briefing handed to Claude when git stops mid-merge.
+ *
+ * Its job is to name the situation the panel already knows: which branch, what
+ * is coming in, whether this is a linked worktree, and above all which side is
+ * "theirs". Get that last one wrong and the agent resolves every conflict
+ * backwards, confidently.
+ */
+const branch = (over: Partial<GitBranchInfo> = {}): GitBranchInfo => ({
+  name: "native/egui-shell",
+  upstream: "origin/main",
+  ahead: 3,
+  behind: 0,
+  detached: false,
+  base: "main",
+  ...over,
+});
+
+const repo = (over: Partial<GitRepoRef> = {}): GitRepoRef => ({
+  root: "/home/me/code/app",
+  name: "app",
+  branch: "native/egui-shell",
+  dirty: 2,
+  ahead: 0,
+  behind: 0,
+  ...over,
+});
+
+const text = (...args: Parameters<typeof conflictBriefing>) => conflictBriefing(...args).join("\n");
+
+describe("conflict briefing", () => {
+  it("names the branch, the incoming ref and the files", () => {
+    const s = text("/home/me/code/app", branch(), repo(), "merging", ["src/a.ts", "src/b.ts"]);
+    expect(s).toContain("native/egui-shell");
+    expect(s).toContain("bringing main in");
+    expect(s).toContain("- src/a.ts");
+    expect(s).toContain("2 file(s) conflicted");
+  });
+
+  it("says which side is theirs during a merge", () => {
+    const s = text("/home/me/code/app", branch(), repo(), "merging", ["src/a.ts"]);
+    expect(s).toContain('"theirs"/MERGE_HEAD is main');
+  });
+
+  it("warns that the sides are inverted during a rebase", () => {
+    // The whole reason this exists: git replays YOUR commits onto the base, so
+    // "theirs" is your own work. An agent told to prefer theirs, believing that
+    // means the base, resolves the entire rebase the wrong way round.
+    const s = text("/home/me/code/app", branch(), repo(), "rebasing", ["src/a.ts"]);
+    expect(s).toContain("REBASE");
+    expect(s).toContain("inverted");
+    expect(s).toContain("my own commit being replayed");
+    expect(s).not.toContain("MERGE_HEAD");
+  });
+
+  it("says a cherry-pick is a cherry-pick", () => {
+    const s = text("/home/me/code/app", branch(), repo(), "cherry-picking", ["src/a.ts"]);
+    expect(s).toContain("cherry-picked");
+  });
+
+  it("identifies a linked worktree, and the repo it belongs to", () => {
+    // "I am in /some/path" is not enough when that path is one of a dozen
+    // checkouts of the same repository.
+    const wt = "/home/me/code/app/.claude/worktrees/native-egui";
+    const s = text(wt, branch(), repo({ root: wt, worktreeOf: "/home/me/code/app" }), "merging", ["src/a.ts"]);
+    expect(s).toContain("linked worktree");
+    expect(s).toContain("/home/me/code/app");
+  });
+
+  it("does not claim a worktree for an ordinary checkout", () => {
+    const s = text("/home/me/code/app", branch(), repo(), "merging", ["src/a.ts"]);
+    expect(s).not.toContain("linked worktree");
+  });
+
+  it("stays honest when the base is unknown", () => {
+    // Trunk itself has no base. Better to say nothing about incoming than to
+    // name a ref that is not there.
+    const s = text("/home/me/code/app", branch({ name: "main", base: null }), repo(), "merging", ["src/a.ts"]);
+    expect(s).not.toContain("bringing null");
+    expect(s).toContain("the other side");
+  });
+
+  it("survives a checkout it knows nothing about", () => {
+    const s = text("/home/me/code/app", undefined, undefined, "merging", ["src/a.ts"]);
+    expect(s).toContain("(unknown branch)");
+    expect(s).toContain("- src/a.ts");
+  });
+
+  it("keeps the do-not-commit boundary in the ask", () => {
+    // The agent resolves; the human reviews and runs `continue`. That line is
+    // the whole safety story of this feature.
+    expect(CONFLICT_ASK.join(" ")).toContain("Do not commit");
+  });
+
+  it("offers no sides for a clean tree", () => {
+    expect(sidesOf("clean", "main", "main")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #133. The conflict handoff prefilled a chat describing the conflict but not the situation: `I am mid-merge in /path and git has left 3 file(s) conflicted`, followed by "prefer the incoming change". Incoming was never named.

That matters more than it sounds. During a sync from base incoming is `main`; during a pull it is the remote; and under a **rebase the sides invert** — git replays your commits onto the other branch, so `theirs` is your own work. An agent told to favour theirs, reasonably believing that means the base, resolves an entire rebase backwards and explains each choice confidently while doing it.

The briefing now states what the panel already knows:

- the branch, and the ref being brought in
- whether this is a linked worktree, and of which repository (`/path` is not enough when a dozen checkouts of one repo are open)
- what git actually stopped in the middle of, from the tree state rather than the word "merge"
- which side is ours and which is theirs, per operation, with the rebase inversion spelled out instead of implied

Moved from inside the component to `web/src/lib/conflictBrief.ts`, so the ours/theirs mapping is testable. It is the part that is expensive to get wrong and invisible when it is.

The ask is unchanged in substance, including the boundary that is the whole safety story here: **do not commit, leave the resolution staged for review**. The agent resolves, the human clicks `continue`.

## How was it tested?

- New `web/test/conflict-brief.test.ts`, 10 tests: the merge case names `MERGE_HEAD`, the rebase case says REBASE and inverted and never mentions `MERGE_HEAD`, cherry-pick is named, a linked worktree is identified along with its parent repo, an ordinary checkout is not called a worktree, a branch with no base says "the other side" rather than printing `null`, an unknown checkout degrades to `(unknown branch)` instead of throwing, and the do-not-commit line is still in the ask.
- `cd web && bun test`: 126 pass, 0 fail. `cd server && bun test`: 275 pass, 0 fail. Both typechecks clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)