### PR TITLE
fix(tests): mint the evidence fixture's session per run

### DIFF
--- a/server/test/evidence.test.ts
+++ b/server/test/evidence.test.ts
@@ -13,9 +13,19 @@ import type { OpenToolCall } from "../../shared/types.ts";
  */
 let dir: string, transcript: string, target: string, ev: typeof import("../src/evidence.ts");
 
-/** Sessions the fixture transcript belongs to. Registered in the same table the
- *  scanner writes, since that is what the lookup reads. */
-const SESSION = "sess-alive";
+/**
+ * The session the fixture transcript belongs to, registered in the same table
+ * the scanner writes, since that is what the lookup reads.
+ *
+ * Minted per run rather than fixed. db.ts binds its file at import and the
+ * first suite to import it decides that file for the whole process, so in a
+ * full `bun test` this one can land on the developer's real database — where
+ * every previous run of this test has left a row pointing at a temp directory
+ * that no longer exists. The lookup takes the newest row for the session, hands
+ * back a deleted path, and the evidence this file is about reads as "none".
+ * A fresh id cannot collide with its own history.
+ */
+const SESSION = `sess-alive-${crypto.randomUUID().slice(0, 8)}`;
 
 const call = (over: Partial<OpenToolCall> = {}): OpenToolCall => ({
   session_id: SESSION,
@@ -50,7 +60,16 @@ beforeAll(async () => {
   ev = await import("../src/evidence.ts");
 });
 
-afterAll(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ } });
+afterAll(async () => {
+  // Take the fixture row out again. On a machine where the temp database above
+  // did not win, this row lands in the real one, and a test that leaves debris
+  // in the database it borrowed is a test that breaks the next run.
+  try {
+    const { db } = await import("../src/db.ts");
+    db.query("DELETE FROM transcript_files WHERE session_id = ?").run(SESSION);
+  } catch { /* nothing to clean */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
 
 /** Backdate a file, so "fresh" and "stale" are facts rather than timing luck. */
 const age = (path: string, secondsAgo: number) => {


### PR DESCRIPTION
## What does this PR do?

Finishes #144. Giving the suite its own `AGENTGLASS_DB` was right and is not sufficient: `db.ts` binds its file at import, so whichever suite imports it first decides that file for the whole process, and in a full `bun test` this one can still land on the developer's real database.

There it met its own history. Every previous run left a `transcript_files` row for the fixed session id `sess-alive`, pointing at a temp directory that has since been deleted. The lookup takes the newest row for a session (`ORDER BY mtime DESC LIMIT 1`), handed back one of those dead paths, `statSync` failed, and the evidence this file exists to prove read as `none`. Three failures on any machine that had run the suite before, zero in CI, where the database is always new.

Two changes: the session id is minted per run, so it cannot collide with its own past, and the fixture row is deleted in `afterAll`, so the next run inherits nothing. Eleven of those rows had accumulated in the real database on this machine; a test that leaves debris in a database it borrowed is a test that breaks the next run.

## How was it tested?

- `bun test` twice back to back on a machine with a populated real database: **416 pass, 0 fail** both times. Before this, the same command failed 3 every time after the suite's first run.
- Verified the mechanism directly before fixing: a fresh session id resolved its transcript correctly against the same real database, while `sess-alive` resolved to a deleted path from an earlier run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)