### PR TITLE
fix(notch): stop the toast lane narrating old news, and let holds jump it

### DIFF
--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -7,6 +7,7 @@ import { subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
 import { clock24, subscribeClock24 } from "../../lib/clockPref.ts";
 import { subscribeGitChanged } from "../../lib/gitBus.ts";
 import { subscribeNewGates } from "../../lib/gateStore.ts";
+import { enqueue, dequeue } from "../../lib/toastQueue.ts";
 import {
   subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
   markNotifyRead, dismissNote, clearNotes, openNote, recordNote, type SystemNote,
@@ -186,7 +187,13 @@ function MeterPill({ tag, w }: { tag: string; w: UsageWindow }) {
 // is for the transition, the pill is for the standing state.
 // ---------------------------------------------------------------------------
 type NoteKind = "done" | "blocked" | "pull" | "system";
-type Note = { id: string; kind: NoteKind; title: string; sub: string; color: string; app?: string };
+type Note = {
+  id: string; kind: NoteKind; title: string; sub: string; color: string; app?: string;
+  /** When it was queued. The lane drops what went stale waiting; see toastQueue.ts. */
+  at: number;
+  /** Something is blocked until you answer. Jumps the queue, never dropped. */
+  urgent?: boolean;
+};
 
 const NOTE_MS = 4800;
 
@@ -233,12 +240,13 @@ function useNotes(): { note: Note | null; behind: number; ahead: number } {
   const queue = useRef<Note[]>([]);
   const showing = useRef(false);
 
-  const push = (n: Note) => {
-    queue.current.push(n);
+  /** Callers describe the note; the lane stamps when it arrived. */
+  const push = (n: Omit<Note, "at">) => {
+    enqueue(queue.current, { ...n, at: Date.now() });
     if (!showing.current) advance();
   };
   const advance = () => {
-    const next = queue.current.shift();
+    const next = dequeue(queue.current, Date.now());
     if (!next) { showing.current = false; setNote(null); return; }
     showing.current = true;
     setNote(next);
@@ -255,7 +263,8 @@ function useNotes(): { note: Note | null; behind: number; ahead: number } {
         seen.set(c.id, c.attention);
         if (first || c.attention === prev || c.attention === "none") continue;
         if (c.attention === "blocked") {
-          push({ id: `${c.id}-b-${c.messages.length}`, kind: "blocked", color: "var(--error)", title: c.title || "chat", sub: c.blockedTool ? `needs "${c.blockedTool}"` : "waiting on you" });
+          // Blocked, not merely finished: the chat cannot continue without you.
+          push({ id: `${c.id}-b-${c.messages.length}`, kind: "blocked", color: "var(--error)", title: c.title || "chat", sub: c.blockedTool ? `needs "${c.blockedTool}"` : "waiting on you", urgent: true });
           recordNote({ app: "chat", summary: c.title || "chat", body: c.blockedTool ? `blocked — needs "${c.blockedTool}"` : "blocked — waiting on you", urgency: 2 });
         } else if (c.attention === "done") {
           push({ id: `${c.id}-d-${c.messages.length}`, kind: "done", color: "var(--success)", title: c.title || "chat", sub: "turn finished" });
@@ -282,6 +291,9 @@ function useNotes(): { note: Note | null; behind: number; ahead: number } {
       color: "var(--warning)",
       title: `Approve ${g.tool_name}?`,
       sub: `${g.source_app}:${g.session_id.slice(0, 8)} is waiting on you`,
+      // Ahead of the chatter, and never dropped for being late: the hold is
+      // still holding. This is what keeps #138 working during a burst.
+      urgent: true,
     });
   }), []);
 
@@ -302,6 +314,9 @@ function useNotes(): { note: Note | null; behind: number; ahead: number } {
       title: n.summary || n.app,
       sub: n.body || n.app,
       app: n.app,
+      // A sender marked it critical. Rare from third-party apps, and the one
+      // signal we have that it is not chatter.
+      urgent: n.urgency === 2,
     });
   }), []);
 

--- a/web/src/lib/toastQueue.ts
+++ b/web/src/lib/toastQueue.ts
@@ -1,0 +1,84 @@
+/**
+ * The notch's toast lane: which note to show next, and which to give up on.
+ *
+ * A toast is a claim that something *just* happened. The lane plays one note at
+ * a time for a fixed few seconds, so it can only ever drain at a fixed rate,
+ * and anything arriving faster than that queues. Left unbounded that queue
+ * stops being a feed and becomes a backlog: notes are shown minutes after the
+ * thing they describe, and the notch narrates a past you already lived through.
+ *
+ * That was observed rather than theorised. A notification raised while Do Not
+ * Disturb was on was still being toasted about two minutes later, behind a
+ * queue of others released at the same moment.
+ *
+ * So the lane has a policy, and it lives here rather than inside the component
+ * because it is the part worth testing:
+ *
+ *   - notes that went stale while queued are dropped, not shown late
+ *   - the queue is capped, so a burst collapses instead of promising to play
+ *     every item
+ *   - urgent notes jump ahead of ordinary ones and are exempt from both
+ *
+ * That last rule is the point of the whole file. Since #138 a gate hold shares
+ * this lane with Slack, and a gate hold has a stopped agent behind it: it must
+ * not wait out a backlog of chatter, and it must never be discarded for being
+ * late, because "late" still means someone is blocked.
+ */
+
+/** The queue only needs these two fields; the notch's own Note supplies the rest. */
+export type Queueable = { at: number; urgent?: boolean };
+
+/** A toast is for the transition. Past this, the history behind the notch is
+ *  the right place for it, and it has one: nothing is lost by not toasting. */
+export const STALE_MS = 10_000;
+
+/** Past this the lane is a backlog, not a feed. Chosen against NOTE_MS: four
+ *  notes is already about twenty seconds of talking. */
+export const QUEUE_MAX = 4;
+
+/**
+ * Add a note, in place, and return the queue.
+ *
+ * Urgent notes are placed ahead of every ordinary one but behind other urgent
+ * ones, so an agent waiting on you is never stuck behind a sticker, and two
+ * blocked agents are still answered in the order they blocked.
+ *
+ * Trimming only ever discards ordinary notes. A queue that is all urgent is
+ * allowed to exceed the cap: dropping one would mean silently declining to
+ * mention that something is blocked.
+ */
+export function enqueue<T extends Queueable>(queue: T[], note: T, max = QUEUE_MAX): T[] {
+  if (note.urgent) {
+    const firstOrdinary = queue.findIndex((n) => !n.urgent);
+    if (firstOrdinary < 0) queue.push(note);
+    else queue.splice(firstOrdinary, 0, note);
+  } else {
+    queue.push(note);
+  }
+
+  // Oldest ordinary first: in a burst the newest are the ones still worth
+  // saying, and the old ones are exactly what made the lane fall behind.
+  while (queue.length > max) {
+    const oldest = queue.findIndex((n) => !n.urgent);
+    if (oldest < 0) break;
+    queue.splice(oldest, 1);
+  }
+  return queue;
+}
+
+/**
+ * Take the next note worth showing, discarding any that went stale while they
+ * waited. Returns null when nothing is left to say.
+ *
+ * Staleness is measured from when the note was queued, not from when the thing
+ * happened, because that is what the lane is responsible for: if a note sat
+ * here for longer than a toast is worth, the lane failed it and showing it now
+ * only misleads about when it arrived.
+ */
+export function dequeue<T extends Queueable>(queue: T[], now: number, staleMs = STALE_MS): T | null {
+  for (;;) {
+    const next = queue.shift();
+    if (!next) return null;
+    if (next.urgent || now - next.at <= staleMs) return next;
+  }
+}

--- a/web/test/toast-queue.test.ts
+++ b/web/test/toast-queue.test.ts
@@ -1,0 +1,107 @@
+import { test, expect } from "bun:test";
+import { enqueue, dequeue, QUEUE_MAX, STALE_MS } from "../src/lib/toastQueue.ts";
+
+// The lane plays one note at a time for a fixed few seconds, so it drains at a
+// fixed rate and anything faster queues. Unbounded, that queue stopped being a
+// feed and became a backlog: a notification raised under Do Not Disturb was
+// still being toasted about two minutes later.
+//
+// These pin the policy that fixes it, and above all the exemption that keeps
+// #138 working: a gate hold has a stopped agent behind it, so it must not wait
+// out a burst of chatter and must never be dropped for arriving late.
+
+type N = { id: string; at: number; urgent?: boolean };
+const n = (id: string, at: number, urgent = false): N => ({ id, at, urgent });
+const ids = (q: N[]) => q.map((x) => x.id);
+
+const T = 1_000_000;
+
+test("ordinary notes keep their arrival order", () => {
+  const q: N[] = [];
+  enqueue(q, n("a", T));
+  enqueue(q, n("b", T + 1));
+  enqueue(q, n("c", T + 2));
+  expect(ids(q)).toEqual(["a", "b", "c"]);
+});
+
+test("an urgent note goes ahead of everything ordinary that is waiting", () => {
+  const q: N[] = [];
+  enqueue(q, n("slack1", T));
+  enqueue(q, n("slack2", T + 1));
+  enqueue(q, n("gate", T + 2, true));
+  // An agent is stopped; the stickers can wait.
+  expect(ids(q)).toEqual(["gate", "slack1", "slack2"]);
+});
+
+test("two urgent notes are still answered in the order they blocked", () => {
+  const q: N[] = [];
+  enqueue(q, n("gate1", T, true));
+  enqueue(q, n("chatter", T + 1));
+  enqueue(q, n("gate2", T + 2, true));
+  expect(ids(q)).toEqual(["gate1", "gate2", "chatter"]);
+});
+
+test("a burst is capped, dropping the oldest ordinary notes", () => {
+  const q: N[] = [];
+  for (let i = 0; i < 10; i++) enqueue(q, n(`n${i}`, T + i));
+  expect(q).toHaveLength(QUEUE_MAX);
+  // The newest are the ones still worth saying; the old ones are what made the
+  // lane fall behind in the first place.
+  expect(ids(q)).toEqual(["n6", "n7", "n8", "n9"]);
+});
+
+test("the cap never discards an urgent note", () => {
+  const q: N[] = [];
+  enqueue(q, n("gate", T, true));
+  for (let i = 0; i < 20; i++) enqueue(q, n(`n${i}`, T + 1 + i));
+  expect(q).toHaveLength(QUEUE_MAX);
+  expect(q[0]!.id).toBe("gate");
+  expect(q.filter((x) => x.urgent)).toHaveLength(1);
+});
+
+test("a queue that is entirely urgent is allowed to exceed the cap", () => {
+  const q: N[] = [];
+  for (let i = 0; i < 8; i++) enqueue(q, n(`gate${i}`, T + i, true));
+  // Dropping one would mean silently declining to mention something is blocked.
+  expect(q).toHaveLength(8);
+});
+
+test("a note that went stale while queued is skipped, not shown late", () => {
+  const q: N[] = [];
+  enqueue(q, n("old", T));
+  enqueue(q, n("fresh", T + STALE_MS));
+  const got = dequeue(q, T + STALE_MS + 1);
+  expect(got?.id).toBe("fresh");
+});
+
+test("an entirely stale queue yields nothing rather than narrating the past", () => {
+  const q: N[] = [];
+  enqueue(q, n("a", T));
+  enqueue(q, n("b", T + 10));
+  expect(dequeue(q, T + STALE_MS + 5_000)).toBeNull();
+  expect(q).toHaveLength(0);
+});
+
+/*
+ * The exemption that matters most.
+ *
+ * "Late" for a gate hold does not mean "no longer interesting", it means
+ * someone has been blocked for a while. Dropping it would turn a delay into a
+ * silence, which is the exact failure #135 was about.
+ */
+test("an urgent note is never dropped for being stale", () => {
+  const q: N[] = [];
+  enqueue(q, n("gate", T, true));
+  const got = dequeue(q, T + 10 * STALE_MS);
+  expect(got?.id).toBe("gate");
+});
+
+test("a note exactly at the staleness boundary is still shown", () => {
+  const q: N[] = [];
+  enqueue(q, n("edge", T));
+  expect(dequeue(q, T + STALE_MS)?.id).toBe("edge");
+});
+
+test("an empty queue dequeues to null", () => {
+  expect(dequeue([] as N[], T)).toBeNull();
+});


### PR DESCRIPTION
## What does this PR do?

Fixes #147. The notch's toast lane plays one note at a time for a fixed `NOTE_MS`, so it drains at roughly twelve a minute regardless of arrival rate. Nothing bounded the queue, so once it fell behind it never caught up. Observed live: a notification raised under Do Not Disturb was still being toasted about two minutes later, behind a pile released at the same moment.

The reason this was worth fixing immediately rather than filing and moving on: since #138 a gate hold shares this lane, and a gate hold has a stopped agent behind it. Arriving during a burst it queued behind the chatter and could be minutes late, or expire before being shown, quietly undoing the fix that just shipped.

The policy now lives in `web/src/lib/toastQueue.ts` rather than inside the component, because it is the part worth testing:

- **Stale notes are skipped**, not shown late. The history behind the notch already keeps the record, so nothing is lost by declining to toast.
- **The queue is capped**, dropping the oldest ordinary notes. In a burst the newest are the ones still worth saying, and the old ones are what caused the backlog.
- **Urgent notes jump the queue**, survive the cap, and are exempt from staleness.

That last rule is the point. "Late" for a gate hold does not mean it stopped being interesting, it means someone has been blocked for a while, so dropping it would turn a delay into a silence, which is the exact failure #135 was about. A queue that is entirely urgent may exceed the cap for the same reason.

`urgent` is set for gate holds, for a chat blocked on a refused tool, and for mirrored notifications whose sender marked them critical. Ordinary traffic (a finished turn, a branch behind, a Slack message) is not.

## How was it tested?

- New `web/test/toast-queue.test.ts`, 11 cases: arrival order, urgent jumping ahead, urgent-vs-urgent staying FIFO, the cap dropping oldest-ordinary-first, the cap never touching an urgent note, an all-urgent queue exceeding the cap, stale skipping, an entirely stale queue yielding null, the staleness boundary, and the exemption that keeps a gate hold alive after ten times the staleness window.
- Full suite: 427 pass, 0 fail.
- `bunx tsc --noEmit` clean in `web/`; `bun run build` clean.
