### PR TITLE
fix: stop three source files hiding themselves from grep

### DIFF
--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -325,7 +325,7 @@ async function pump(p: Subprocess<"ignore", "pipe", "pipe">) {
       for (const block of parseBlocks(done)) {
         const n = noteFrom(block);
         if (!n) continue;
-        const key = `${n.app} ${n.summary} ${n.body}`;
+        const key = `${n.app}\u0000${n.summary}\u0000${n.body}`;
         const now = Date.now();
         const prev = recent.get(key);
         if (prev && now - prev < DEDUP_MS) continue;

--- a/server/test/source-hygiene.test.ts
+++ b/server/test/source-hygiene.test.ts
@@ -1,0 +1,61 @@
+import { test, expect } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/*
+ * Source files must stay searchable.
+ *
+ * Three files used a raw NUL (and a raw SOH/STX) as a field separator, written
+ * as literal bytes rather than escapes. grep and ripgrep classify any file
+ * containing them as binary and then report *no matches with no error*, so a
+ * recursive search over the tree silently skipped them.
+ *
+ * That is not a cosmetic problem. `web/src/App.tsx` is the file most likely to
+ * answer "where is this component mounted", and while investigating #135 a
+ * search across web/src/ came back empty and led to the conclusion that the
+ * gate approval UI did not exist anywhere in the app. It did, at App.tsx:467.
+ * `server/src/notifications.ts` was skipped the same way in the same session.
+ * A silent no-match is indistinguishable from a genuine absence.
+ *
+ * The escapes are byte-identical at runtime, so there is never a reason to
+ * commit the raw character. This test keeps it that way.
+ */
+
+const ROOTS = ["web/src", "server/src", "shared", "electron", "hooks", "scripts"];
+const EXTS = [".ts", ".tsx", ".js", ".jsx", ".mjs", ".json", ".css", ".html", ".py", ".sh"];
+
+/** Tab, newline and carriage return are the only control characters that
+ *  belong in source. Everything else below 0x20 makes the file "binary". */
+const offending = (buf: Buffer): number[] => {
+  const out: number[] = [];
+  for (const b of buf) if (b < 0x09 || b === 0x0b || b === 0x0c || (b >= 0x0e && b <= 0x1f)) out.push(b);
+  return out;
+};
+
+function walk(dir: string, hits: string[]) {
+  let entries;
+  try { entries = readdirSync(dir); } catch { return; }
+  for (const name of entries) {
+    if (name === "node_modules" || name === "dist" || name.startsWith(".")) continue;
+    const p = join(dir, name);
+    let s;
+    try { s = statSync(p); } catch { continue; }
+    if (s.isDirectory()) { walk(p, hits); continue; }
+    if (!EXTS.some((e) => name.endsWith(e))) continue;
+    const bad = offending(readFileSync(p));
+    if (bad.length) {
+      const codes = [...new Set(bad)].map((b) => `U+${b.toString(16).toUpperCase().padStart(4, "0")}`);
+      hits.push(`${p} (${bad.length}x ${codes.join(", ")})`);
+    }
+  }
+}
+
+test("no source file contains a raw control character that would hide it from grep", () => {
+  const root = new URL("../..", import.meta.url).pathname;
+  const hits: string[] = [];
+  for (const r of ROOTS) walk(join(root, r), hits);
+
+  // Written out in full: the whole point is that the failure names the file,
+  // since the symptom otherwise is a search that quietly finds nothing.
+  expect(hits).toEqual([]);
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -223,7 +223,7 @@ export default function App() {
   const sessionProvider = useMemo(() => {
     const map = new Map<string, string>();
     for (const a of agentsAll) if (a.model_name) map.set(a.session_id, providerOf(a.model_name));
-    const sig = [...map].map(([k, v]) => k + " " + v).join("");
+    const sig = [...map].map(([k, v]) => k + "\u0000" + v).join("\u0001");
     if (sig === providerSig.current) return providerRef.current;
     providerSig.current = sig;
     providerRef.current = map;

--- a/web/src/components/SearchModal.tsx
+++ b/web/src/components/SearchModal.tsx
@@ -10,7 +10,7 @@ import { fmtTime, fmtUsd, fmtMs, agentKey } from "../lib/format.ts";
 function Snippet({ text }: { text: string }) {
   const clean = text.replace(/\s*\n\s*/g, " · ");
   const segs: { t: string; h: boolean }[] = [];
-  const re = /([^]*)/g;
+  const re = /\u0001([^\u0002]*)\u0002/g;
   let last = 0, m: RegExpExecArray | null;
   while ((m = re.exec(clean))) {
     if (m.index > last) segs.push({ t: clean.slice(last, m.index), h: false });


### PR DESCRIPTION
## What does this PR do?

Fixes #149, and the problem turned out to be wider than the issue described.

Three source files used a raw control character as a field separator, written as a literal byte rather than an escape:

| file | line | bytes |
|---|---|---|
| `web/src/App.tsx` | 226 | U+0000, U+0001 |
| `web/src/components/SearchModal.tsx` | 13 | U+0001, U+0002 (in a regex literal) |
| `server/src/notifications.ts` | 328 | U+0000 |

`grep` and `ripgrep` classify any file containing one as binary and then report **no matches with no error**, so a recursive search over the tree skips them in silence.

That is not cosmetic. `App.tsx` is the file most likely to answer "where is this component mounted", and while investigating #135 a search across `web/src/` came back empty and led me to conclude the gate approval UI did not exist anywhere in the app. It does, at `App.tsx:467`. In the same session a `grep` over `server/src/*.ts` skipped `notifications.ts` while that file was the actual subject of the investigation. A silent no-match is indistinguishable from a genuine absence, which makes this a trap for contributors and for any tooling that greps the tree.

The escapes are byte-identical at runtime, so the separators, the signature strings and the search regex all behave exactly as before. The files just become plain text again.

Also adds `server/test/source-hygiene.test.ts`, which walks the source roots and fails on any raw control character other than tab, newline or carriage return, naming the offending file and code point. Without it this quietly comes back the next time someone types a separator instead of escaping it.

## How was it tested?

- **Escape equivalence verified in the engine rather than assumed**: the U+0000 escape compares equal to `String.fromCharCode(0)`, same for U+0001.
- **The guard was proven to fail**: planted a raw NUL in a throwaway file under `web/src/`, confirmed the test fails and names it (`__guard_probe.ts (1x U+0000)`), then removed it and confirmed it passes. A guard that has never failed is worth nothing.
- **Searchability confirmed**: `grep -rn '<Alerts' web/src/` now returns `App.tsx:467`, where before it returned nothing at all.
- Full suite: 428 pass, 0 fail. `bunx tsc --noEmit` clean in both `web/` and `server/`; `bun run build` clean.
- Rebased onto current `main` (c225da2) so CI tests the real merge result.
