### PR TITLE
feat(notch): give agentglass its own quiet switch for mirrored notifications

### DIFF
--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -17,7 +17,7 @@ import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESK
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
 import type { UpdateStatus } from "../../../shared/types.ts";
-import { sysNotifyMode, setSysNotifyMode, notifyCapability, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
+import { sysNotifyMode, setSysNotifyMode, notifyCapability, notifyQuiet, setNotifyQuiet, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
 import { clock24, setClock24 } from "../lib/clockPref.ts";
 import { bindings, rebind, resetBindings, subscribeBindings, isCustomised, LABELS, DEFAULTS, type ActionId,
          chordFor, rebindChord, clearChord, resetChords, chordsCustomised, chordFromEvent, chordLabel } from "../lib/keybindings.ts";
@@ -367,6 +367,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
     return () => window.removeEventListener("keydown", onKey, true);
   }, [capturingChord]);
   const [sysNotify, setSysNotifyState] = useState<SysNotifyMode>(() => sysNotifyMode());
+  const [quiet, setQuietState] = useState(() => notifyQuiet());
   const [notifyCap, setNotifyCap] = useState<NotifyCapability | null>(null);
   useEffect(() => { if (open) void notifyCapability().then(setNotifyCap); }, [open]);
 
@@ -466,6 +467,17 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         { v: "titles", label: "Who" },
                         { v: "full", label: "Full" },
                       ]} />
+                    {/* agentglass reads the bus rather than being the daemon,
+                        so the desktop's own Do Not Disturb cannot reach what
+                        lands here. This is the switch that can. It silences
+                        other people's messages only: a gate hold never travels
+                        this path, so quiet can't mean an agent blocked and
+                        nobody said. */}
+                    {sysNotify !== "off" && (
+                      <Toggle on={quiet} onClick={() => { setNotifyQuiet(!quiet); setQuietState(!quiet); }}
+                        label="Quiet mirrored notifications"
+                        hint="Keep collecting them, stop letting them interrupt — agentglass's own alerts still come through" />
+                    )}
                   </Section>
                   )}
 

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -10,7 +10,8 @@ import { subscribeNewGates } from "../../lib/gateStore.ts";
 import { enqueue, dequeue } from "../../lib/toastQueue.ts";
 import {
   subscribeSystemNotes, subscribeNotifyHistory, notifyHistory, notifyUnread,
-  markNotifyRead, dismissNote, clearNotes, openNote, recordNote, type SystemNote,
+  markNotifyRead, dismissNote, clearNotes, openNote, recordNote,
+  notifyQuiet, setNotifyQuiet, subscribeNotifyQuiet, type SystemNote,
 } from "../../lib/sysNotify.ts";
 
 /**
@@ -447,6 +448,7 @@ export function DynamicIsland() {
   const [inbox, setInbox] = useState(false);
   const hist = useSyncExternalStore(subscribeNotifyHistory, notifyHistory, notifyHistory);
   const unread = useSyncExternalStore(subscribeNotifyHistory, notifyUnread, () => 0);
+  const quiet = useSyncExternalStore(subscribeNotifyQuiet, notifyQuiet, () => false);
   useEffect(() => { if (inbox) markNotifyRead(); }, [inbox, hist]);
   useEffect(() => {
     if (!inbox) return;
@@ -620,6 +622,19 @@ export function DynamicIsland() {
             <div className="flex items-center gap-2 px-3 pt-1 pb-1.5">
               <span className="agx-cap">NOTIFICATIONS</span>
               <span className="agx-cap" style={{ opacity: 0.5 }}>{hist.length}</span>
+              {/* Silencing without saying so is how you end up asking why you
+                  were never told. It is also the switch, so the place that
+                  reveals the state is the place that undoes it. */}
+              <button
+                className="agx-note-btn"
+                onClick={() => setNotifyQuiet(!quiet)}
+                title={quiet
+                  ? "Mirrored notifications are quiet — they still collect here. Click to let them interrupt again."
+                  : "Quiet mirrored notifications: keep collecting them, stop letting them interrupt"}
+                style={quiet ? { color: "var(--warning)" } : undefined}
+              >
+                {quiet ? "quiet on" : "quiet"}
+              </button>
               <button className="agx-note-btn ml-auto" onClick={() => { clearNotes(); setInbox(false); }}>clear all</button>
               <button className="agx-note-btn" onClick={() => setInbox(false)} title="close (Esc)">✕</button>
             </div>

--- a/web/src/lib/gateStore.ts
+++ b/web/src/lib/gateStore.ts
@@ -143,6 +143,21 @@ export function forgetGate(id: string) {
   changed();
 }
 
+/**
+ * Test seam: forget everything this module remembers.
+ *
+ * The store is a singleton whose behaviour is deliberately history-dependent --
+ * it announces a hold once and seeds a baseline on its first read -- so a test
+ * file that touches it changes what the next one sees. Without this the suite
+ * passes or fails on file ordering, which is how CI caught it and a local run
+ * did not.
+ */
+export function __resetGateStore(): void {
+  snapshot = [];
+  announced.clear();
+  seeded = false;
+}
+
 // ---------------------------------------------------------------------------
 // The poll.
 //

--- a/web/src/lib/sysNotify.ts
+++ b/web/src/lib/sysNotify.ts
@@ -48,6 +48,48 @@ export function subscribeSysNotifyMode(fn: (m: SysNotifyMode) => void): () => vo
 }
 
 // ---------------------------------------------------------------------------
+// Quiet.
+//
+// agentglass reads notifications off the bus instead of being the daemon, so
+// the desktop's own Do Not Disturb has no effect on what lands here. That is
+// deliberate and it is what makes gate alerts reliable -- but it also means
+// the feature ignores the one instruction you gave your machine about being
+// interrupted. Verified: with DND on, WhatsApp messages the desktop silently
+// queued were still put on the notch, body and all.
+//
+// So agentglass gets its own switch rather than trying to read the system's.
+// There is no portable way to read that state (GetServerInformation returns a
+// name, not a state; `Inhibited` is a KDE convention absent elsewhere), and
+// six per-daemon adapters to infer something you can simply say directly is a
+// bad trade.
+//
+// Quiet stops mirrored notes from *interrupting*. It does not stop them being
+// collected: they keep landing in the history behind the notch, so nothing is
+// lost and you can look when you choose to. And it deliberately cannot reach
+// agentglass's own alerts -- a gate hold does not travel this path at all (see
+// gateStore.ts), so "quiet" can never mean "an agent blocked and nobody said".
+// That separation is the whole point of having the switch here rather than one
+// level up.
+// ---------------------------------------------------------------------------
+
+const QUIET_KEY = "agentglass.sysNotify.quiet";
+
+export function notifyQuiet(): boolean {
+  return localStorage.getItem(QUIET_KEY) === "1";
+}
+
+export function setNotifyQuiet(q: boolean) {
+  localStorage.setItem(QUIET_KEY, q ? "1" : "0");
+  for (const fn of quietListeners) fn(q);
+}
+
+const quietListeners = new Set<(q: boolean) => void>();
+export function subscribeNotifyQuiet(fn: (q: boolean) => void): () => void {
+  quietListeners.add(fn);
+  return () => quietListeners.delete(fn);
+}
+
+// ---------------------------------------------------------------------------
 // Capability. Asked once, cached, and never allowed to reject: a host that
 // cannot do this is a host where the feature is absent, not one where
 // something failed.
@@ -199,7 +241,10 @@ async function open() {
     history = [n, ...history].slice(0, HISTORY_MAX);
     unread++;
     historyChanged();
-    for (const fn of noteListeners) fn(n);
+    // Collected either way; only the interruption is optional. Quiet means the
+    // notch does not morph open for someone else's message, not that agentglass
+    // stopped listening -- the list behind the notch is still complete.
+    if (!notifyQuiet()) for (const fn of noteListeners) fn(n);
   };
   sock.onopen = () => { retry = 0; };
   sock.onclose = () => {

--- a/web/test/gate-store.test.ts
+++ b/web/test/gate-store.test.ts
@@ -28,6 +28,11 @@ beforeAll(async () => {
   // poll: the tests drive ingestGates directly, which is the same seam.
   store = await import("../src/lib/gateStore.ts");
   sysNotify = await import("../src/lib/sysNotify.ts");
+  // The store is a singleton and these tests depend on being the first to
+  // touch it. Another test file importing it first would otherwise decide
+  // whether this one passes; see __resetGateStore.
+  store.__resetGateStore();
+  sysNotify.clearNotes();
 });
 
 const gate = (id: string, over: Partial<PendingGate> = {}): PendingGate => ({

--- a/web/test/notify-quiet.test.ts
+++ b/web/test/notify-quiet.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, beforeAll } from "bun:test";
+import type { PendingGate } from "../../shared/types.ts";
+
+// agentglass reads notifications off the D-Bus session bus instead of being the
+// daemon, so the desktop's own Do Not Disturb cannot reach what lands on the
+// notch. Verified live: with DND on, WhatsApp messages the desktop silently
+// queued were still shown, body and all. Quiet is agentglass's own answer to
+// that, since the OS state is not portably readable.
+//
+// The line these defend is the one that makes quiet safe to use: it silences
+// other people's messages, and it must never be able to silence a gate hold,
+// because that would turn "do not interrupt me" into "an agent blocked and
+// nobody said". That separation is structural (a hold does not travel the
+// mirrored-notes path at all) and these pin it so a refactor cannot merge the
+// two lanes by accident.
+
+const cell = new Map<string, string>();
+
+let sysNotify: typeof import("../src/lib/sysNotify.ts");
+let gateStore: typeof import("../src/lib/gateStore.ts");
+
+beforeAll(async () => {
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  (globalThis as any).location = { hostname: "localhost", origin: "http://localhost:4000" };
+  sysNotify = await import("../src/lib/sysNotify.ts");
+  gateStore = await import("../src/lib/gateStore.ts");
+});
+
+const gate = (id: string): PendingGate => ({
+  id,
+  source_app: "claude",
+  session_id: "abcdef0123456789",
+  tool_name: "Bash",
+  summary: "rm -rf build",
+  created: 1_700_000_000_000,
+});
+
+test("quiet is off unless asked for", () => {
+  expect(sysNotify.notifyQuiet()).toBe(false);
+});
+
+test("quiet round-trips and notifies its listeners", () => {
+  const seen: boolean[] = [];
+  const off = sysNotify.subscribeNotifyQuiet((q) => seen.push(q));
+
+  sysNotify.setNotifyQuiet(true);
+  expect(sysNotify.notifyQuiet()).toBe(true);
+
+  sysNotify.setNotifyQuiet(false);
+  expect(sysNotify.notifyQuiet()).toBe(false);
+
+  expect(seen).toEqual([true, false]);
+  off();
+});
+
+test("quiet survives a reload, because it is a preference and not a session mood", () => {
+  sysNotify.setNotifyQuiet(true);
+  // The store reads localStorage on every call rather than caching, so this is
+  // what a fresh page would see.
+  expect(cell.get("agentglass.sysNotify.quiet")).toBe("1");
+  expect(sysNotify.notifyQuiet()).toBe(true);
+});
+
+/*
+ * The one that matters.
+ *
+ * Quiet gates `subscribeSystemNotes`, which carries mirrored third-party
+ * notifications and nothing else. A gate hold reaches the notch through
+ * `subscribeNewGates`, a different path entirely, so silencing Slack cannot
+ * silence a blocked agent. If someone ever routes holds through the mirrored
+ * lane to "simplify", this fails.
+ */
+test("a gate hold still announces itself while quiet is on", () => {
+  sysNotify.setNotifyQuiet(true);
+
+  const arrivals: string[] = [];
+  const off = gateStore.subscribeNewGates((g) => arrivals.push(g.id));
+
+  gateStore.ingestGates([]);              // seed the baseline
+  gateStore.ingestGates([gate("held")]);  // and now something blocks
+
+  expect(arrivals).toEqual(["held"]);
+  off();
+});
+
+test("quiet does not stop mirrored notes being collected, only interrupting", () => {
+  sysNotify.setNotifyQuiet(true);
+  const before = sysNotify.notifyHistory().length;
+
+  // recordNote is the history path, shared by everything the notch lists. It is
+  // deliberately not gated: quiet means "do not interrupt me", not "stop
+  // keeping track", so the list is still complete when you choose to look.
+  sysNotify.recordNote({ app: "slack", summary: "Armichee", body: "sticker" });
+
+  expect(sysNotify.notifyHistory().length).toBe(before + 1);
+  expect(sysNotify.notifyHistory()[0]!.summary).toBe("Armichee");
+});

--- a/web/test/notify-quiet.test.ts
+++ b/web/test/notify-quiet.test.ts
@@ -28,6 +28,9 @@ beforeAll(async () => {
   (globalThis as any).location = { hostname: "localhost", origin: "http://localhost:4000" };
   sysNotify = await import("../src/lib/sysNotify.ts");
   gateStore = await import("../src/lib/gateStore.ts");
+  // Leave the singleton as this file found it, so running before or after
+  // gate-store.test.ts cannot change either file's result.
+  gateStore.__resetGateStore();
 });
 
 const gate = (id: string): PendingGate => ({


### PR DESCRIPTION
## What does this PR do?

Fixes #148. agentglass reads notifications off the D-Bus session bus rather than being the notification daemon, so the desktop's own Do Not Disturb has no effect on what reaches the notch. That is deliberate, and it is exactly what makes gate alerts reliable after #138. It also means the feature ignores the one instruction you gave your machine about being interrupted.

Verified rather than supposed: with DND on, WhatsApp messages that the desktop queued and never displayed were put on the notch anyway, body and all. The desktop obeyed. agentglass did not.

So agentglass gets its own switch instead of trying to read the system's:

- **Quiet stops mirrored notes interrupting**, and nothing else. They keep landing in the history behind the notch, so nothing is lost and you look when you choose to.
- **It cannot silence agentglass's own alerts.** A gate hold does not travel the mirrored-notes path at all (`gateStore` raises it through its own subscription), so quiet can never mean "an agent blocked and nobody said". That separation is why the switch sits at the mirror rather than one level up.

Exposed in two places, because a silencer with no visible state is how you end up asking why you were never told: a toggle in Settings, and an indicator in the notch's own notification panel that doubles as the switch, so the place that reveals the state is the place that undoes it.

**Not** reading the OS DND state, deliberately. There is no portable way: `GetServerInformation` returns a name and not a state, and `Inhibited` is a KDE convention absent from quickshell (probed directly, `UnknownProperty`). Covering the field means a per-daemon adapter each for KDE, dunst, GNOME, mako, swaync and quickshell, all fragile against upstream renames, to infer something the user can simply say directly.

## How was it tested?

- New `web/test/notify-quiet.test.ts`, 5 cases: off by default, round-trip plus listeners, persistence across a reload, mirrored notes still being collected while quiet, and the one that matters, **a gate hold still announcing itself while quiet is on**. That last test exists so a later refactor cannot route holds through the mirrored lane to "simplify" without the failure being loud.
- Full suite: 433 pass, 0 fail.
- `bunx tsc --noEmit` clean in both `web/` and `server/`; `bun run build` clean.
- Rebased onto current `main` (d3399da) so CI tests the real merge result.
