### PR TITLE
feat(terminal): draw tmux's windows as the panel's own tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,15 @@ in the menu, each with the right runner (`bun` / `npm` / `pnpm` / `yarn`)
 detected from that folder's lockfile. agentglass's own `Makefile` is annotated
 this way — `make help` prints the same list in the shell.
 
+Run **tmux** in it and the panel adopts its windows as its own tabs. The list
+comes from tmux, the pixels come from agentglass: click to switch, `+` for a new
+window, double-click to rename, and tmux's own status line steps aside (one
+click brings it back, and it is restored when the panel closes). Nothing about
+the keyboard changes — `^b c`, `^b n`, `^b 2` and everything else still go
+straight to tmux, and the tabs follow. The point is that the window list stops
+being the one strip of the workspace themed by whichever `.tmux.conf` the
+machine happens to carry.
+
 ![terminal panel](.github/assets/terminal.png)
 
 ### 💬 Chat — drive Claude sessions from the browser &nbsp;`c`

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -80,6 +80,13 @@ type Session = {
   /** Cleared on close — a stray interval would keep reading /proc for a pty
    *  that no longer exists, once per session, forever. */
   tmuxPoll?: ReturnType<typeof setInterval> | null;
+  /** The tmux session this shell is attached to, once one is found. */
+  tmux?: TmuxTarget | null;
+  /** Whether we hid tmux's own status line, so it can be given back on the way
+   *  out. Restoring is not optional: a session left with `status off` after the
+   *  panel closed would look broken in the user's real terminal, and they would
+   *  have no reason to connect it to us. */
+  tmuxStatusHidden?: boolean;
 };
 const sessions = new Map<PtyWs, Session>();
 
@@ -107,6 +114,8 @@ function killGroup(s: Session, sigNum: number) {
     else s.proc.kill(sigNum);
   } catch { /* already gone */ }
 }
+
+import { resolveTarget, listWindows, runAction, setStatusLine, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 
 const enc = new TextEncoder();
 const ctl = (ws: PtyWs, frame: Record<string, unknown>) => { try { ws.send(JSON.stringify(frame)); } catch { /* closed */ } };
@@ -202,12 +211,33 @@ export function ptyOpen(ws: PtyWs) {
    * stale layout is noticeable, and the check is a couple of small /proc reads.
    */
   let sawTmux = false;
+  let sentWindows = "";
   const tmuxPoll = setInterval(() => {
     if (session.closed || session.exited) return;
     const now = tmuxRunning(proc.pid);
-    if (now === sawTmux) return;
-    sawTmux = now;
-    ctl(ws, { t: "tmux", active: now });
+    if (now !== sawTmux) {
+      sawTmux = now;
+      if (!now) {
+        // Detached. Forget the session rather than keep polling a target that
+        // is no longer ours, and stop describing windows nobody is looking at.
+        session.tmux = null;
+        session.tmuxStatusHidden = false;
+        sentWindows = "";
+        ctl(ws, { t: "tmux", active: false, windows: [] });
+        return;
+      }
+    }
+    if (!now) return;
+    // Resolved once per attach: the join walks /proc and shells out to
+    // list-clients, and neither answer changes while the same client is up.
+    if (!session.tmux) session.tmux = resolveTarget(proc.pid);
+    const windows = session.tmux ? listWindows(session.tmux) : [];
+    // Only speak when something changed. A tab strip that re-renders every two
+    // seconds is a tab strip that drops the click you were halfway through.
+    const shape = JSON.stringify(windows);
+    if (shape === sentWindows && sawTmux === now) return;
+    sentWindows = shape;
+    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, windows });
   }, 2000);
   session.tmuxPoll = tmuxPoll;
 
@@ -240,7 +270,7 @@ export function ptyOpen(ws: PtyWs) {
 export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
   const s = sessions.get(ws);
   if (!s) return;
-  let msg: { t?: string; d?: string; cols?: number; rows?: number };
+  let msg: { t?: string; d?: string; cols?: number; rows?: number; cmd?: string; index?: number; name?: string; visible?: boolean };
   try { msg = JSON.parse(typeof raw === "string" ? raw : raw.toString()); } catch { return; }
   if (msg.t === "in" && typeof msg.d === "string" && msg.d) {
     try {
@@ -256,6 +286,25 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       writeSizeFile(s.sizeDir, rows, cols);
       process.kill(s.proc.pid, "SIGWINCH"); // bridge applies TIOCSWINSZ + forwards
     } catch { /* shell gone */ }
+  } else if (msg.t === "tmux") {
+    /*
+     * A tab was clicked.
+     *
+     * Everything here is something a keybinding could already do, so this adds
+     * no capability to a socket that already carries a shell — it adds a second
+     * way to reach four commands. The target is the session *we* resolved from
+     * /proc, never one the client names, so a page cannot address somebody
+     * else's tmux by asking nicely.
+     */
+    if (!s.tmux) return;
+    if (msg.cmd === "status") {
+      const visible = msg.visible !== false;
+      if (setStatusLine(s.tmux, visible)) s.tmuxStatusHidden = !visible;
+      return;
+    }
+    const action = msg.cmd as TmuxAction;
+    if (!["select", "new", "kill", "rename"].includes(action)) return;
+    runAction(s.tmux, action, msg.index, msg.name);
   }
 }
 
@@ -276,6 +325,10 @@ export function ptyClose(ws: PtyWs) {
 function cleanup(ws: PtyWs, s: Session) {
   sessions.delete(ws);
   if (s.tmuxPoll) { clearInterval(s.tmuxPoll); s.tmuxPoll = null; }
+  // Give the status line back before letting go. The panel borrowed it; a
+  // session left with `status off` after the panel closed looks broken in the
+  // user's real terminal, and nothing there would point back at us.
+  if (s.tmuxStatusHidden && s.tmux) { setStatusLine(s.tmux, true); s.tmuxStatusHidden = false; }
   if (s.sizeDir) { try { rmSync(s.sizeDir, { recursive: true, force: true }); } catch { /* tmp reaper will get it */ } s.sizeDir = null; }
 }
 

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -1,0 +1,228 @@
+/**
+ * Talking to the tmux session running inside a panel's shell.
+ *
+ * The panel used to do the opposite of this: detect tmux and stand down, on the
+ * grounds that tmux owns the tabs. It does own them, and that left the one strip
+ * of the workspace we do not control being drawn by whatever `.tmux.conf` the
+ * machine happens to carry — the same user, on two laptops, gets two different
+ * looking window lists pasted across an otherwise coherent panel.
+ *
+ * So: we draw, tmux decides. Everything here either asks tmux what it has or
+ * asks it to do something a keybinding could already have done. No state is kept
+ * about which window is active, no input is intercepted, and every keybinding
+ * behaves exactly as it did before, because the shell still receives every byte.
+ * A click on a tab is `select-window` and nothing more.
+ *
+ * Linux-only, like the detection it grew out of: it reads /proc to find the tmux
+ * client and the terminal it is attached to. Anywhere else this reports nothing
+ * and the panel keeps its own chrome, which is the correct fallback rather than
+ * a degraded one.
+ */
+import { readFileSync, readlinkSync } from "node:fs";
+import type { TmuxWindow } from "../../shared/types.ts";
+
+/** How long a tmux call may take before we give up on it. Generous for a local
+ *  socket, and short enough that a wedged tmux server cannot stall the poll. */
+const TMUX_TIMEOUT_MS = 2000;
+
+export interface TmuxTarget {
+  /** The tmux client process inside our shell. */
+  pid: number;
+  /** `-S <path>` / `-L <name>` as the client itself was invoked, so we reach the
+   *  same server rather than the default one. Empty for the default socket. */
+  socket: string[];
+  /** The session that client is attached to, for display. */
+  session: string;
+  /** tmux's own id for it (`$0`), which is what every command below targets.
+   *  Names are matched by prefix unless you fight the syntax for it, and even
+   *  then `set-option -t =name` is rejected outright by tmux 3.7 while
+   *  `list-windows -t =name` accepts it. An id is unambiguous everywhere and
+   *  survives a rename, so there is nothing to get subtly wrong. */
+  id: string;
+}
+
+/**
+ * The tmux client running under this shell, if there is one.
+ *
+ * Walks the process tree rather than asking the shell: the shell is busy being
+ * a terminal, and injecting a command to interrogate it would echo into whatever
+ * the user is halfway through typing. `tmux: client` and `tmux: server` both
+ * report as `tmux` in comm, but the server is a daemon and never a child of our
+ * shell, so anything found here is a client.
+ */
+export function tmuxClientPid(pid: number, depth = 0): number | null {
+  if (process.platform !== "linux" || depth > 4) return null;
+  let children: string[];
+  try {
+    // `children` needs CONFIG_PROC_CHILDREN; when absent this reads empty and
+    // we report no tmux, rather than throwing.
+    children = readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim().split(/\s+/).filter(Boolean);
+  } catch { return null; }
+  for (const c of children) {
+    let comm: string;
+    try { comm = readFileSync(`/proc/${c}/comm`, "utf8").trim(); } catch { continue; }
+    if (comm === "tmux" || comm.startsWith("tmux")) return Number(c);
+    const deeper = tmuxClientPid(Number(c), depth + 1);
+    if (deeper) return deeper;
+  }
+  return null;
+}
+
+/** The terminal a process is attached to, as tmux reports it in `client_tty`. */
+function ttyOf(pid: number): string | null {
+  for (const fd of [0, 1, 2]) {
+    try {
+      const link = readlinkSync(`/proc/${pid}/fd/${fd}`);
+      if (link.startsWith("/dev/pts/") || link.startsWith("/dev/tty")) return link;
+    } catch { /* fd closed or redirected — try the next one */ }
+  }
+  return null;
+}
+
+/**
+ * Which socket this client is talking to.
+ *
+ * A user with `-L work` or `-S /run/user/1000/tmux` is on a different server
+ * from the default one, and asking the default server about their windows
+ * answers confidently about somebody else's session. Read it off the client's
+ * own command line, which is the only place that is certain to be right.
+ */
+export function socketFromArgv(argv: string[]): string[] {
+  for (let i = 1; i < argv.length - 1; i++) {
+    if (argv[i] === "-S" || argv[i] === "-L") return [argv[i]!, argv[i + 1]!];
+  }
+  return [];
+}
+
+function socketOf(pid: number): string[] {
+  try {
+    return socketFromArgv(readFileSync(`/proc/${pid}/cmdline`, "utf8").split("\0").filter(Boolean));
+  } catch { return []; }
+}
+
+/** Run a tmux command against a specific server. stdout only; a failure is a
+ *  null, never a throw, because every caller is inside a poll. */
+function tmux(socket: string[], args: string[]): string | null {
+  try {
+    const r = Bun.spawnSync(["tmux", ...socket, ...args], {
+      stdout: "pipe",
+      stderr: "pipe",
+      timeout: TMUX_TIMEOUT_MS,
+      env: process.env,
+    });
+    if (r.exitCode !== 0) return null;
+    return r.stdout.toString();
+  } catch { return null; }
+}
+
+/**
+ * Resolve the pid of a tmux client to the session it is showing.
+ *
+ * The join is the terminal: our pty is that client's controlling tty, and tmux
+ * will name it back to us in `client_tty`. Guessing instead — taking the most
+ * recent session, say — is wrong the moment a user has two sessions open, which
+ * is the normal case for the people who use tmux at all.
+ */
+export function resolveTarget(shellPid: number): TmuxTarget | null {
+  const pid = tmuxClientPid(shellPid);
+  if (!pid) return null;
+  const tty = ttyOf(pid);
+  if (!tty) return null;
+  const socket = socketOf(pid);
+  const out = tmux(socket, ["list-clients", "-F", "#{client_tty}\t#{session_name}\t#{session_id}"]);
+  if (!out) return null;
+  for (const line of out.split("\n")) {
+    const [clientTty, session, id] = line.split("\t");
+    if (clientTty === tty && session && id) return { pid, socket, session, id };
+  }
+  return null;
+}
+
+/**
+ * The session's windows, in tmux's own order.
+ *
+ * `window_flags` carries tmux's own marks (`*` current, `-` last, `!` bell,
+ * `#` activity, `Z` zoomed). They are passed through rather than interpreted
+ * here: the panel decides what to show, and tmux stays the single source of
+ * truth for what is true.
+ */
+export function parseWindows(out: string): TmuxWindow[] {
+  const windows: TmuxWindow[] = [];
+  for (const line of out.split("\n")) {
+    if (!line.trim()) continue;
+    // Tab-separated, because window names routinely contain spaces and a
+    // space-separated format would split "npm run dev" into three windows.
+    const [index, name, active, flags] = line.split("\t");
+    const i = Number(index);
+    if (!Number.isInteger(i)) continue;
+    windows.push({ index: i, name: name ?? "", active: active === "1", flags: (flags ?? "").trim() });
+  }
+  return windows;
+}
+
+export function listWindows(t: TmuxTarget): TmuxWindow[] {
+  const out = tmux(t.socket, [
+    "list-windows",
+    "-t", t.id,
+    "-F", "#{window_index}\t#{window_name}\t#{window_active}\t#{window_flags}",
+  ]);
+  return out ? parseWindows(out) : [];
+}
+
+/**
+ * The commands a tab strip is allowed to send.
+ *
+ * A closed list, and every one of them is something the user could already do
+ * from the keyboard — this adds no capability, it adds a second way to reach
+ * the same four. That matters because the terminal is already the widest thing
+ * this server hands out, and "the panel can run arbitrary tmux commands" would
+ * quietly widen it further.
+ */
+export type TmuxAction = "select" | "new" | "kill" | "rename";
+
+/** Window names are echoed back into a shell prompt and a status line, so they
+ *  are held to printable, single-line, and short. tmux itself is happy with far
+ *  worse, which is exactly why this is checked here. */
+export const sanitizeWindowName = (s: unknown): string | null => {
+  if (typeof s !== "string") return null;
+  const name = s.replace(/[\u0000-\u001f\u007f]/g, "").trim().slice(0, 64);
+  return name || null;
+};
+
+export function runAction(t: TmuxTarget, action: TmuxAction, index?: number, name?: string): boolean {
+  const target = (i: number) => `${t.id}:${i}`;
+  const idx = Number.isInteger(index) ? (index as number) : null;
+  switch (action) {
+    case "select":
+      return idx === null ? false : tmux(t.socket, ["select-window", "-t", target(idx)]) !== null;
+    case "new":
+      // After the current window rather than at the end, which is where `^b c`
+      // puts it when `renumber-windows` is on and where the eye expects it.
+      return tmux(t.socket, ["new-window", "-a", "-t", t.id]) !== null;
+    case "kill":
+      return idx === null ? false : tmux(t.socket, ["kill-window", "-t", target(idx)]) !== null;
+    case "rename": {
+      const clean = sanitizeWindowName(name);
+      if (idx === null || !clean) return false;
+      return tmux(t.socket, ["rename-window", "-t", target(idx), clean]) !== null;
+    }
+    default:
+      return false;
+  }
+}
+
+/**
+ * Hide or restore tmux's own status line for this session.
+ *
+ * Opt-in, and it has to be: `status` is a session option, not a client one, so a
+ * second client attached to the same session from a real terminal loses its
+ * status line too. Nobody should have that happen to them because they opened a
+ * panel. `set-option -u` puts it back exactly as their config had it, rather
+ * than guessing at "on".
+ */
+export function setStatusLine(t: TmuxTarget, visible: boolean): boolean {
+  const args = visible
+    ? ["set-option", "-t", t.id, "-u", "status"]
+    : ["set-option", "-t", t.id, "status", "off"];
+  return tmux(t.socket, args) !== null;
+}

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -1,0 +1,113 @@
+// The panel draws tmux's window list as its own tabs, so these are the parts
+// where a wrong answer would be silent: a window list read badly still renders,
+// it just renders somebody else's windows or the wrong names.
+//
+// The live half (resolving a client to a session, running select-window) is
+// exercised against a real tmux server in the PR description rather than here,
+// because a test that spawns tmux is a test that fails on a machine without it.
+// What is unit-tested is everything that turns tmux's text into our shapes, and
+// everything that decides whether a command is allowed to run at all.
+import { describe, expect, test } from "bun:test";
+import { parseWindows, socketFromArgv, runAction, sanitizeWindowName, type TmuxTarget } from "../src/tmuxctl.ts";
+
+describe("reading tmux's window list", () => {
+  test("index, name, active flag and tmux's own marks", () => {
+    const out = "1\tAI01\t0\t-\n2\tlazygit\t1\t*\n";
+    expect(parseWindows(out)).toEqual([
+      { index: 1, name: "AI01", active: false, flags: "-" },
+      { index: 2, name: "lazygit", active: true, flags: "*" },
+    ]);
+  });
+
+  test("names with spaces survive", () => {
+    // The reason the format is tab-separated. A space-separated one turns this
+    // single window into three, and the tab strip grows phantom tabs.
+    const [w] = parseWindows("3\tnpm run dev\t1\t*\n");
+    expect(w!.name).toBe("npm run dev");
+    expect(w!.index).toBe(3);
+  });
+
+  test("a window with no name is not dropped", () => {
+    const [w] = parseWindows("4\t\t0\t\n");
+    expect(w).toEqual({ index: 4, name: "", active: false, flags: "" });
+  });
+
+  test("blank lines and unparseable indexes are skipped, not guessed at", () => {
+    expect(parseWindows("\n\n")).toEqual([]);
+    expect(parseWindows("no such session: =agx\n")).toEqual([]);
+    expect(parseWindows("1\tok\t1\t*\ngarbage\n")).toHaveLength(1);
+  });
+
+  test("bell and activity marks are passed through for the panel to interpret", () => {
+    const [bell, activity] = parseWindows("1\tbuild\t0\t!\n2\ttest\t0\t#\n");
+    expect(bell!.flags).toBe("!");
+    expect(activity!.flags).toBe("#");
+  });
+});
+
+describe("finding the right tmux server", () => {
+  // Asking the default server about a session that lives on another socket gets
+  // a confident answer about somebody else's windows, so this is read off the
+  // client's own command line rather than assumed.
+  test("-L and -S are carried over", () => {
+    expect(socketFromArgv(["tmux", "-L", "work", "attach", "-t", "main"])).toEqual(["-L", "work"]);
+    expect(socketFromArgv(["tmux", "-S", "/run/user/1000/tmux", "new"])).toEqual(["-S", "/run/user/1000/tmux"]);
+  });
+
+  test("the default socket is expressed as no flags at all", () => {
+    expect(socketFromArgv(["tmux", "attach"])).toEqual([]);
+    expect(socketFromArgv(["tmux"])).toEqual([]);
+  });
+
+  test("a trailing -S with nothing after it is not a socket", () => {
+    expect(socketFromArgv(["tmux", "attach", "-S"])).toEqual([]);
+  });
+});
+
+describe("what a tab strip is allowed to ask for", () => {
+  // The terminal socket already carries a shell, so this cannot widen anything
+  // — but it must not become a way to run arbitrary tmux commands either. Each
+  // of these is refused before tmux is invoked at all.
+  const t: TmuxTarget = { pid: 1, socket: ["-L", "nonexistent-agx-test"], session: "s", id: "$0" };
+
+  test("an action outside the four is refused", () => {
+    expect((runAction as unknown as (t: TmuxTarget, a: string) => boolean)(t, "kill-server")).toBe(false);
+    expect((runAction as unknown as (t: TmuxTarget, a: string) => boolean)(t, "run-shell")).toBe(false);
+  });
+
+  test("selecting or killing without a window index is refused", () => {
+    expect(runAction(t, "select")).toBe(false);
+    expect(runAction(t, "kill")).toBe(false);
+    expect(runAction(t, "select", 1.5)).toBe(false);
+    expect(runAction(t, "select", NaN)).toBe(false);
+  });
+
+  test("a rename with no usable name, or no window, is refused", () => {
+    expect(runAction(t, "rename", 1, "\u001b\u0007\u0000")).toBe(false); // nothing left after cleaning
+    expect(runAction(t, "rename", 1, "   ")).toBe(false);
+    expect(runAction(t, "rename", 1, "")).toBe(false);
+    expect(runAction(t, "rename", undefined, "valid")).toBe(false);
+  });
+});
+
+describe("window names", () => {
+  // A name is echoed into a status line and a shell title, so an escape
+  // sequence smuggled through it writes wherever it likes on the terminal.
+  // Stripped rather than rejected: the printable part of "buil\u001b[2Jd" is
+  // still what the user meant to call it.
+  test("control characters are removed, the rest is kept", () => {
+    expect(sanitizeWindowName("buil\u001b[2Jd")).toBe("buil[2Jd");
+    expect(sanitizeWindowName("npm run dev")).toBe("npm run dev");
+    expect(sanitizeWindowName("api\u0000")).toBe("api");
+  });
+
+  test("a name that is only control characters is not a name", () => {
+    expect(sanitizeWindowName("\u001b\u0007")).toBeNull();
+    expect(sanitizeWindowName("  ")).toBeNull();
+    expect(sanitizeWindowName(42)).toBeNull();
+  });
+
+  test("absurdly long names are cut, not passed on", () => {
+    expect(sanitizeWindowName("x".repeat(500))!.length).toBe(64);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -187,6 +187,17 @@ export interface StatsSummary {
   server_started_at?: number;
 }
 
+/** One tmux window, as tmux itself reports it. The panel renders these as its
+ *  own tabs; tmux stays the source of truth for which is active. `flags` is
+ *  tmux's own marks (`*` current, `-` last, `!` bell, `#` activity, `Z` zoomed),
+ *  passed through rather than interpreted server-side. */
+export interface TmuxWindow {
+  index: number;
+  name: string;
+  active: boolean;
+  flags: string;
+}
+
 /** A tool call held at the gate, awaiting a remote approve/deny. */
 export interface PendingGate {
   id: string;

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -10,7 +10,7 @@ import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/Vi
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
-import type { GitRepoRef, ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
+import type { GitRepoRef, ProjectCommand, TerminalCommands, TmuxWindow } from "../../../shared/types.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 
@@ -76,6 +76,12 @@ type Sess = {
   /** A tmux client is running in this shell — the panel hides its own tabs and
    *  split while that's true, since tmux owns those. */
   tmux: boolean;
+  /** tmux's own windows, as tmux reports them. The panel draws these as tabs so
+   *  the strip belongs to the app rather than to whatever .tmux.conf this
+   *  machine carries; tmux still decides what is in it and which is active. */
+  tmuxWindows: TmuxWindow[];
+  /** The session those windows belong to, for the status-line toggle. */
+  tmuxSession: string | null;
   pending: string[]; // input queued while (re)connecting — flushed on ready
   createdAt: number;
   lastUsed: number;
@@ -175,7 +181,7 @@ function connect(s: Sess) {
   ws.onmessage = (ev) => {
     if (s.ws !== ws) return; // a stale socket (replaced by ⟲ new shell) must not touch the session
     if (typeof ev.data !== "string") { s.term.write(new Uint8Array(ev.data as ArrayBuffer)); return; }
-    let f: { t?: string; mode?: "pty" | "pipe"; shell?: string; resize?: boolean; code?: number; error?: string; active?: boolean };
+    let f: { t?: string; mode?: "pty" | "pipe"; shell?: string; resize?: boolean; code?: number; error?: string; active?: boolean; windows?: TmuxWindow[]; session?: string | null };
     try { f = JSON.parse(ev.data); } catch { return; }
     if (f.t === "ready") {
       reconnected(s);
@@ -186,10 +192,15 @@ function connect(s: Sess) {
       ws.send(JSON.stringify({ t: "resize", cols: s.term.cols, rows: s.term.rows }));
       notify(s);
     } else if (f.t === "tmux") {
-      // tmux brings its own tabs, splits and status line. Once it's running,
-      // the panel's copies of all three are a worse duplicate sitting on top of
-      // the real ones — so stand them down, and put them back on detach.
+      // tmux brings its own tabs, splits and status line. The panel's split and
+      // its own shell tabs stand down while it runs, since two pane models is
+      // how you get a split inside a split you didn't ask for. The *window*
+      // list is different: we draw that one ourselves, from what tmux reports,
+      // so it stops being the one strip of the workspace styled by a config
+      // file the app has never seen.
       s.tmux = f.active === true;
+      s.tmuxWindows = Array.isArray(f.windows) ? f.windows : [];
+      s.tmuxSession = typeof f.session === "string" ? f.session : null;
       notify(s);
     } else if (f.t === "exit" || f.t === "fatal") {
       s.status = f.t === "exit" ? "exited" : "error";
@@ -294,7 +305,7 @@ function createSession(root: string): Sess {
   const holder = document.createElement("div");
   holder.style.cssText = "width:100%;height:100%";
   const id = `t${++seq}-${Date.now().toString(36)}`;
-  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
+  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, tmuxWindows: [], tmuxSession: null, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
   term.onData((d) => {
     sess.lastUsed = Date.now();
     if (sess.status === "live" && sess.ws?.readyState === WebSocket.OPEN) sess.ws.send(JSON.stringify({ t: "in", d }));
@@ -592,6 +603,54 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const tmuxActive = !!sess?.tmux;
   const status: SessStatus = sess?.status ?? "idle";
 
+  /*
+   * tmux's windows, drawn by us.
+   *
+   * The panel stands down from tabs and splits while tmux runs, because two
+   * pane models fight. Its *window list* is a different case: it is the one
+   * strip of the workspace styled by a file the app has never seen, so the same
+   * user on two machines gets two different looking bars across an otherwise
+   * coherent panel. So the list comes from tmux and the pixels come from here.
+   *
+   * Nothing about the keyboard changes. Every button below sends a command tmux
+   * would have run anyway, and "which window is active" is always tmux's answer
+   * arriving on the next poll, never a local guess that could disagree with it.
+   */
+  const tmuxWindows = sess?.tmuxWindows ?? [];
+  const tmuxCmd = useCallback((cmd: string, extra: Record<string, unknown> = {}) => {
+    const s = sess;
+    if (!s || s.ws?.readyState !== WebSocket.OPEN) return;
+    s.ws.send(JSON.stringify({ t: "tmux", cmd, ...extra }));
+  }, [sess]);
+  const [renaming, setRenaming] = useState<number | null>(null);
+
+  /*
+   * Whether tmux keeps drawing its own status line underneath our tabs.
+   *
+   * Hidden by default, because leaving it on means two window lists stacked on
+   * top of each other and the point of this was to stop the workspace carrying
+   * a strip it does not control. It is only ever hidden when we actually have
+   * tabs to put in its place, it is one click to bring back, the choice is
+   * remembered, and the server restores it when the panel closes.
+   *
+   * The caveat, and the reason the button is right there in the strip rather
+   * than buried in settings: `status` is a session option, not a client one.
+   * Someone attached to the same session from a real terminal loses their
+   * status line too, and some people keep things there we do not draw — the
+   * session name, a battery, a prefix indicator.
+   */
+  const [tmuxBar, setTmuxBar] = useState<boolean>(() => {
+    try { return localStorage.getItem("agentglass-tmux-bar") === "on"; } catch { return false; }
+  });
+  useEffect(() => {
+    // Nothing to replace it with means nothing to hide: if the session never
+    // resolved (no /proc, an unusual socket, a tmux we could not reach), the
+    // user keeps exactly the bar they had.
+    if (!tmuxActive || !tmuxWindows.length) return;
+    tmuxCmd("status", { visible: tmuxBar });
+    try { localStorage.setItem("agentglass-tmux-bar", tmuxBar ? "on" : "off"); } catch { /* private mode */ }
+  }, [tmuxActive, tmuxBar, tmuxCmd, tmuxWindows.length]);
+
   const addShell = useCallback(() => {
     if (!root || IS_DEMO) return;
     const s = createSession(root);
@@ -830,6 +889,61 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       );
                     })}
                     <button onClick={addShell} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title="new shell in this repo">+</button>
+                  </div>
+                )}
+
+                {/* tmux's windows, as our own tabs.
+                    Same shape as the shell tabs above on purpose: from the
+                    user's side this is the same control, and which program is
+                    behind it should not change how the workspace looks. */}
+                {tmuxActive && tmuxWindows.length > 0 && (
+                  <div className="shrink-0 flex items-center gap-1 px-3 py-1 border-b overflow-x-auto agw-noscrollbar" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                    {tmuxWindows.map((w) => {
+                      // tmux's own marks, straight through: `!` is a bell, `#`
+                      // is activity in a window you are not looking at. Both
+                      // mean "something happened over here", which is the whole
+                      // reason the strip is worth looking at at all.
+                      const alerting = w.flags.includes("!") || w.flags.includes("#");
+                      return (
+                        <div key={w.index}
+                          onClick={() => { if (!w.active) tmuxCmd("select", { index: w.index }); }}
+                          onDoubleClick={() => setRenaming(w.index)}
+                          title={`window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
+                          className="group flex items-center gap-1.5 px-2 py-1 rounded-md text-[10.5px] cursor-pointer shrink-0"
+                          style={w.active
+                            ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)" }
+                            : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)" }}>
+                          <span className="tabular-nums" style={{ color: "var(--text4)" }}>{w.index}</span>
+                          {renaming === w.index ? (
+                            <input
+                              autoFocus
+                              defaultValue={w.name}
+                              onClick={(e) => e.stopPropagation()}
+                              onBlur={() => setRenaming(null)}
+                              onKeyDown={(e) => {
+                                if (e.key === "Escape") { setRenaming(null); return; }
+                                if (e.key !== "Enter") return;
+                                const name = (e.target as HTMLInputElement).value.trim();
+                                if (name && name !== w.name) tmuxCmd("rename", { index: w.index, name });
+                                setRenaming(null);
+                              }}
+                              className="bg-transparent outline-none w-20 text-[10.5px]"
+                              style={{ color: "var(--text)", borderBottom: "1px solid color-mix(in srgb, var(--primary) 60%, transparent)" }}
+                            />
+                          ) : (
+                            <span>{w.name || "shell"}</span>
+                          )}
+                          {alerting && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="activity" />}
+                          <button onClick={(e) => { e.stopPropagation(); tmuxCmd("kill", { index: w.index }); }}
+                            className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="close window (kill-window)">✕</button>
+                        </div>
+                      );
+                    })}
+                    <button onClick={() => tmuxCmd("new")} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title="new tmux window (^b c)">+</button>
+                    <button onClick={() => setTmuxBar((v) => !v)} className="ml-auto shrink-0 px-2 py-1 rounded-md text-[10px]" style={{ color: "var(--text3)" }}
+                      title={tmuxBar ? "hide tmux's own status line for this session" : "show tmux's own status line again"}>
+                      {tmuxBar ? "hide tmux bar" : "show tmux bar"}
+                    </button>
                   </div>
                 )}
 


### PR DESCRIPTION
## What does this PR do?

The panel already stood down when tmux appeared: its own tabs and its split button hide, because two pane models fight and tmux owns the panes. The one thing it could not stand down from was tmux's **status line**, which kept drawing the window list in whatever colors that machine's `.tmux.conf` specifies. The same user, same project, on two laptops, gets two differently shaped strips pasted across an otherwise coherent workspace, and cannot fix it centrally, because that config is also correct for every other terminal they use it in.

So the window list now comes from tmux and the pixels come from us.

**We draw, tmux decides.** Every control sends a command a keybinding could already have run, and "which window is active" is always tmux's answer arriving on the next poll, never a local guess that can disagree with it. Input is untouched: `^b c`, `^b n`, `^b 2`, rename and kill behave exactly as before, and the tabs follow.

`server/src/tmuxctl.ts` is the tmux side:

- the client is found by walking `/proc`, the way the existing detection already does, and its socket is read off its own command line, because a user on `-L work` must not be answered with the default server's windows
- the session is resolved by joining our pty's tty against `list-clients`, since "the most recent session" is wrong the moment someone has two
- everything targets tmux's **session id** (`$0`) rather than the name. Names match by prefix, and `set-option -t =name` is rejected outright by tmux 3.7 while `list-windows -t =name` accepts it, which is the kind of difference that works right up until it does not
- four commands, closed list, every argument validated; window names are stripped of control characters, since they land in a status line

tmux's status line is hidden while we have tabs to put in its place, one click brings it back, and the server restores it on the way out. `status` is a session option rather than a client one, so a second client attached to the same session sees the change too. That is exactly why the toggle sits in the strip instead of in settings.

Polling rather than control mode: `tmux -CC` is the better source and needs the PTY bridge to speak a protocol, so this reuses the two-second poll that was already watching for tmux, and only speaks when the shape changes.

Closes #153

## How was it tested?

- `bun test`: **442 pass, 0 fail**, including 14 new cases in `server/test/tmux-tabs.test.ts` (window parsing including names with spaces, blank and unparseable lines, bell and activity marks; socket detection for `-L` / `-S` / default / a trailing flag; and the refusal paths: an action outside the four, select or kill with no index or a fractional one, a rename with nothing usable left, and name sanitising).
- `bunx tsc --noEmit` in `server/` and `web/`, plus `bun run build`.
- **Against a real tmux server** (`tmux -L agxtest`, two windows, attached inside a pty): the socket was picked up from the client's command line, the session resolved through the tty join, and select, new, kill and rename all drove tmux and came back reflected in the next list.
- **End to end through the actual WebSocket**, which is the path the panel uses. Started the server, opened `/terminal/pty`, typed `tmux attach` into it, and watched the frames:

```
latest windows: {"t":"tmux","active":true,"session":"agx","windows":[
  {"index":1,"name":"notes","active":true,"flags":"*"},
  {"index":2,"name":"lazygit","active":false,"flags":"-"}]}
after new:      [{"index":1,...,"active":false},{"index":2,"name":"bash","active":true},{"index":3,"name":"lazygit"}]
status option while hidden:        status off
status option after panel closed:  (inherited: restored)
```

The new window landed after the current one, the way `^b c` does, and the status line was given back when the socket closed.

- Detaching tmux sends `{ active: false, windows: [] }` and the panel's own shell tabs come back, unchanged from today.

🤖 Generated with [Claude Code](https://claude.com/claude-code)