### PR TITLE
fix(terminal): address tmux windows by id, not by the index on the tab

### DIFF
--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -270,7 +270,7 @@ export function ptyOpen(ws: PtyWs) {
 export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
   const s = sessions.get(ws);
   if (!s) return;
-  let msg: { t?: string; d?: string; cols?: number; rows?: number; cmd?: string; index?: number; name?: string; visible?: boolean };
+  let msg: { t?: string; d?: string; cols?: number; rows?: number; cmd?: string; window?: string; name?: string; visible?: boolean };
   try { msg = JSON.parse(typeof raw === "string" ? raw : raw.toString()); } catch { return; }
   if (msg.t === "in" && typeof msg.d === "string" && msg.d) {
     try {
@@ -304,7 +304,7 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
     }
     const action = msg.cmd as TmuxAction;
     if (!["select", "new", "kill", "rename"].includes(action)) return;
-    runAction(s.tmux, action, msg.index, msg.name);
+    runAction(s.tmux, action, msg.window, msg.name);
   }
 }
 

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -138,6 +138,10 @@ export function resolveTarget(shellPid: number): TmuxTarget | null {
   return null;
 }
 
+/** tmux window ids are `@` and digits, and nothing a client sends is trusted to
+ *  be one without being checked: these go on a command line. */
+const WINDOW_ID = /^@\d+$/;
+
 /**
  * The session's windows, in tmux's own order.
  *
@@ -152,10 +156,10 @@ export function parseWindows(out: string): TmuxWindow[] {
     if (!line.trim()) continue;
     // Tab-separated, because window names routinely contain spaces and a
     // space-separated format would split "npm run dev" into three windows.
-    const [index, name, active, flags] = line.split("\t");
+    const [id, index, name, active, flags] = line.split("\t");
     const i = Number(index);
-    if (!Number.isInteger(i)) continue;
-    windows.push({ index: i, name: name ?? "", active: active === "1", flags: (flags ?? "").trim() });
+    if (!WINDOW_ID.test(id ?? "") || !Number.isInteger(i)) continue;
+    windows.push({ id: id!, index: i, name: name ?? "", active: active === "1", flags: (flags ?? "").trim() });
   }
   return windows;
 }
@@ -164,7 +168,7 @@ export function listWindows(t: TmuxTarget): TmuxWindow[] {
   const out = tmux(t.socket, [
     "list-windows",
     "-t", t.id,
-    "-F", "#{window_index}\t#{window_name}\t#{window_active}\t#{window_flags}",
+    "-F", "#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}",
   ]);
   return out ? parseWindows(out) : [];
 }
@@ -189,22 +193,27 @@ export const sanitizeWindowName = (s: unknown): string | null => {
   return name || null;
 };
 
-export function runAction(t: TmuxTarget, action: TmuxAction, index?: number, name?: string): boolean {
-  const target = (i: number) => `${t.id}:${i}`;
-  const idx = Number.isInteger(index) ? (index as number) : null;
+export function runAction(t: TmuxTarget, action: TmuxAction, window?: string, name?: string): boolean {
+  // Windows are addressed by tmux's id, never by the index the tab is showing.
+  // The strip is up to a poll out of date, and an index is not a name: kill
+  // window 2 with `renumber-windows` on and what was 3 becomes 2, so a click
+  // landing a moment later selects, renames or kills something the user was not
+  // pointing at. An id refers to the same window for as long as it exists, and
+  // to nothing at all once it does not.
+  const id = WINDOW_ID.test(window ?? "") ? window! : null;
   switch (action) {
     case "select":
-      return idx === null ? false : tmux(t.socket, ["select-window", "-t", target(idx)]) !== null;
+      return id === null ? false : tmux(t.socket, ["select-window", "-t", id]) !== null;
     case "new":
       // After the current window rather than at the end, which is where `^b c`
       // puts it when `renumber-windows` is on and where the eye expects it.
       return tmux(t.socket, ["new-window", "-a", "-t", t.id]) !== null;
     case "kill":
-      return idx === null ? false : tmux(t.socket, ["kill-window", "-t", target(idx)]) !== null;
+      return id === null ? false : tmux(t.socket, ["kill-window", "-t", id]) !== null;
     case "rename": {
       const clean = sanitizeWindowName(name);
-      if (idx === null || !clean) return false;
-      return tmux(t.socket, ["rename-window", "-t", target(idx), clean]) !== null;
+      if (id === null || !clean) return false;
+      return tmux(t.socket, ["rename-window", "-t", id, clean]) !== null;
     }
     default:
       return false;

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -11,35 +11,37 @@ import { describe, expect, test } from "bun:test";
 import { parseWindows, socketFromArgv, runAction, sanitizeWindowName, type TmuxTarget } from "../src/tmuxctl.ts";
 
 describe("reading tmux's window list", () => {
-  test("index, name, active flag and tmux's own marks", () => {
-    const out = "1\tAI01\t0\t-\n2\tlazygit\t1\t*\n";
+  test("id, index, name, active flag and tmux's own marks", () => {
+    const out = "@0\t1\tAI01\t0\t-\n@4\t2\tlazygit\t1\t*\n";
     expect(parseWindows(out)).toEqual([
-      { index: 1, name: "AI01", active: false, flags: "-" },
-      { index: 2, name: "lazygit", active: true, flags: "*" },
+      { id: "@0", index: 1, name: "AI01", active: false, flags: "-" },
+      { id: "@4", index: 2, name: "lazygit", active: true, flags: "*" },
     ]);
   });
 
   test("names with spaces survive", () => {
     // The reason the format is tab-separated. A space-separated one turns this
     // single window into three, and the tab strip grows phantom tabs.
-    const [w] = parseWindows("3\tnpm run dev\t1\t*\n");
+    const [w] = parseWindows("@2\t3\tnpm run dev\t1\t*\n");
     expect(w!.name).toBe("npm run dev");
     expect(w!.index).toBe(3);
   });
 
   test("a window with no name is not dropped", () => {
-    const [w] = parseWindows("4\t\t0\t\n");
-    expect(w).toEqual({ index: 4, name: "", active: false, flags: "" });
+    const [w] = parseWindows("@7\t4\t\t0\t\n");
+    expect(w).toEqual({ id: "@7", index: 4, name: "", active: false, flags: "" });
   });
 
   test("blank lines and unparseable indexes are skipped, not guessed at", () => {
     expect(parseWindows("\n\n")).toEqual([]);
     expect(parseWindows("no such session: =agx\n")).toEqual([]);
-    expect(parseWindows("1\tok\t1\t*\ngarbage\n")).toHaveLength(1);
+    expect(parseWindows("@0\t1\tok\t1\t*\ngarbage\n")).toHaveLength(1);
+    // A line without a window id is not a window, whatever else it looks like.
+    expect(parseWindows("1\tok\t1\t*\n")).toEqual([]);
   });
 
   test("bell and activity marks are passed through for the panel to interpret", () => {
-    const [bell, activity] = parseWindows("1\tbuild\t0\t!\n2\ttest\t0\t#\n");
+    const [bell, activity] = parseWindows("@0\t1\tbuild\t0\t!\n@1\t2\ttest\t0\t#\n");
     expect(bell!.flags).toBe("!");
     expect(activity!.flags).toBe("#");
   });
@@ -75,17 +77,21 @@ describe("what a tab strip is allowed to ask for", () => {
     expect((runAction as unknown as (t: TmuxTarget, a: string) => boolean)(t, "run-shell")).toBe(false);
   });
 
-  test("selecting or killing without a window index is refused", () => {
+  test("selecting or killing without a real window id is refused", () => {
+    // Ids go on a command line, and the strip they came from is up to a poll
+    // stale, so anything that is not `@` plus digits is not addressed at all.
     expect(runAction(t, "select")).toBe(false);
     expect(runAction(t, "kill")).toBe(false);
-    expect(runAction(t, "select", 1.5)).toBe(false);
-    expect(runAction(t, "select", NaN)).toBe(false);
+    expect(runAction(t, "select", "2")).toBe(false);          // an index, not an id
+    expect(runAction(t, "select", "@1 ; kill-server")).toBe(false);
+    expect(runAction(t, "kill", "@")).toBe(false);
+    expect(runAction(t, "select", "$0")).toBe(false);          // a session, not a window
   });
 
   test("a rename with no usable name, or no window, is refused", () => {
-    expect(runAction(t, "rename", 1, "\u001b\u0007\u0000")).toBe(false); // nothing left after cleaning
-    expect(runAction(t, "rename", 1, "   ")).toBe(false);
-    expect(runAction(t, "rename", 1, "")).toBe(false);
+    expect(runAction(t, "rename", "@1", "\u001b\u0007\u0000")).toBe(false); // nothing left after cleaning
+    expect(runAction(t, "rename", "@1", "   ")).toBe(false);
+    expect(runAction(t, "rename", "@1", "")).toBe(false);
     expect(runAction(t, "rename", undefined, "valid")).toBe(false);
   });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -192,6 +192,10 @@ export interface StatsSummary {
  *  tmux's own marks (`*` current, `-` last, `!` bell, `#` activity, `Z` zoomed),
  *  passed through rather than interpreted server-side. */
 export interface TmuxWindow {
+  /** tmux's own id for the window (`@3`). Stable for the window's whole life,
+   *  which the index is not: killing a window renumbers the ones after it when
+   *  `renumber-windows` is on. Commands target this; the index is for display. */
+  id: string;
   index: number;
   name: string;
   active: boolean;

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -622,7 +622,9 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     if (!s || s.ws?.readyState !== WebSocket.OPEN) return;
     s.ws.send(JSON.stringify({ t: "tmux", cmd, ...extra }));
   }, [sess]);
-  const [renaming, setRenaming] = useState<number | null>(null);
+  // Keyed by tmux's window id, not the index: a rename in flight must follow the
+  // window even if killing another one renumbers the strip underneath it.
+  const [renaming, setRenaming] = useState<string | null>(null);
 
   /*
    * Whether tmux keeps drawing its own status line underneath our tabs.
@@ -905,16 +907,16 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       // reason the strip is worth looking at at all.
                       const alerting = w.flags.includes("!") || w.flags.includes("#");
                       return (
-                        <div key={w.index}
-                          onClick={() => { if (!w.active) tmuxCmd("select", { index: w.index }); }}
-                          onDoubleClick={() => setRenaming(w.index)}
+                        <div key={w.id}
+                          onClick={() => { if (!w.active) tmuxCmd("select", { window: w.id }); }}
+                          onDoubleClick={() => setRenaming(w.id)}
                           title={`window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
                           className="group flex items-center gap-1.5 px-2 py-1 rounded-md text-[10.5px] cursor-pointer shrink-0"
                           style={w.active
                             ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)" }
                             : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)" }}>
                           <span className="tabular-nums" style={{ color: "var(--text4)" }}>{w.index}</span>
-                          {renaming === w.index ? (
+                          {renaming === w.id ? (
                             <input
                               autoFocus
                               defaultValue={w.name}
@@ -924,7 +926,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                                 if (e.key === "Escape") { setRenaming(null); return; }
                                 if (e.key !== "Enter") return;
                                 const name = (e.target as HTMLInputElement).value.trim();
-                                if (name && name !== w.name) tmuxCmd("rename", { index: w.index, name });
+                                if (name && name !== w.name) tmuxCmd("rename", { window: w.id, name });
                                 setRenaming(null);
                               }}
                               className="bg-transparent outline-none w-20 text-[10.5px]"
@@ -934,7 +936,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                             <span>{w.name || "shell"}</span>
                           )}
                           {alerting && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="activity" />}
-                          <button onClick={(e) => { e.stopPropagation(); tmuxCmd("kill", { index: w.index }); }}
+                          <button onClick={(e) => { e.stopPropagation(); tmuxCmd("kill", { window: w.id }); }}
                             className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="close window (kill-window)">✕</button>
                         </div>
                       );


### PR DESCRIPTION
## What does this PR do?

#154 sent `select-window`, `kill-window` and `rename-window` at `session:index`, taking the index off the strip the user clicked. The strip is up to one poll old, and an index is not a name: with `renumber-windows on`, killing a window shifts every index after it.

Demonstrated against a live session, four windows, one killed from the keyboard between the render and the click:

```
strip shown to user: 1:one  2:two  3:three  4:four
tmux after ^b &:     1:two  2:three  3:four
user clicks the tab labelled "two" (index 2, id @1)
  by index -> would select: three
  by id    -> actually selected: two
```

So the click selected, renamed or killed a window the user was not pointing at, silently, and the strip then re-rendered as though that had been the intent. **Kill is the one that matters**: the wrong window is gone and nothing says so.

Windows now carry tmux's own id (`@3`), which refers to the same window for as long as it exists and to nothing at all once it does not. The id is what goes on the command line, checked against `/^@\d+$/` on the way in; the index is kept for display only. The rename-in-flight state is keyed by id too, for the same reason.

Also switches the format string from `#{window_flags}` to `#{window_raw_flags}`: the former escapes `#` as `##`, so the activity mark arrived doubled and any exact match on it would have quietly failed.

Both found while researching how iTerm2 and Ghostty drive tmux, which is also where #157 comes from.

Refs #153

## How was it tested?

- The transcript above is a real run against a live `tmux` server with `renumber-windows on`, driving the actual module.
- `bun test`: **447 pass, 0 fail**, with the unit tests moved onto ids, including the refusal cases: an index where an id belongs (`"2"`), a session id (`"$0"`), a bare `"@"`, and `"@1 ; kill-server"`.
- `bunx tsc --noEmit` in `server/` and `web/`, plus `bun run build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)