### PR TITLE
fix(terminal): make the tmux tabs answer at once, and say when tmux is listening

### DIFF
--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -240,7 +240,7 @@ export function ptyOpen(ws: PtyWs) {
     const shape = JSON.stringify(windows);
     if (shape === sentWindows && sawTmux === now) return;
     sentWindows = shape;
-    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, prefix: prefixKeys(session.tmux), windows });
+    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, prefix: session.tmux ? prefixKeys(session.tmux) : [], windows });
   };
   session.tmuxSweep = sweep;
   /*

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -82,6 +82,9 @@ type Session = {
   tmuxPoll?: ReturnType<typeof setInterval> | null;
   /** The tmux session this shell is attached to, once one is found. */
   tmux?: TmuxTarget | null;
+  /** Re-read tmux and push if anything moved. Held so an action can refresh
+   *  immediately instead of leaving the strip stale until the next tick. */
+  tmuxSweep?: () => void;
   /** Whether we hid tmux's own status line, so it can be given back on the way
    *  out. Restoring is not optional: a session left with `status off` after the
    *  panel closed would look broken in the user's real terminal, and they would
@@ -115,7 +118,7 @@ function killGroup(s: Session, sigNum: number) {
   } catch { /* already gone */ }
 }
 
-import { resolveTarget, listWindows, runAction, setStatusLine, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
+import { resolveTarget, listWindows, runAction, setStatusLine, prefixKeys, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 
 const enc = new TextEncoder();
 const ctl = (ws: PtyWs, frame: Record<string, unknown>) => { try { ws.send(JSON.stringify(frame)); } catch { /* closed */ } };
@@ -212,7 +215,7 @@ export function ptyOpen(ws: PtyWs) {
    */
   let sawTmux = false;
   let sentWindows = "";
-  const tmuxPoll = setInterval(() => {
+  const sweep = () => {
     if (session.closed || session.exited) return;
     const now = tmuxRunning(proc.pid);
     if (now !== sawTmux) {
@@ -232,13 +235,25 @@ export function ptyOpen(ws: PtyWs) {
     // list-clients, and neither answer changes while the same client is up.
     if (!session.tmux) session.tmux = resolveTarget(proc.pid);
     const windows = session.tmux ? listWindows(session.tmux) : [];
-    // Only speak when something changed. A tab strip that re-renders every two
-    // seconds is a tab strip that drops the click you were halfway through.
+    // Only speak when something changed. A tab strip that re-renders on every
+    // tick is a tab strip that drops the click you were halfway through.
     const shape = JSON.stringify(windows);
     if (shape === sentWindows && sawTmux === now) return;
     sentWindows = shape;
-    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, windows });
-  }, 2000);
+    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, prefix: prefixKeys(session.tmux), windows });
+  };
+  session.tmuxSweep = sweep;
+  /*
+   * How often to look.
+   *
+   * Two seconds was chosen for "has tmux appeared", where being a beat late
+   * costs nothing. It is far too slow for a tab strip: `^b n` moved the focus
+   * instantly in the terminal and the tabs sat on the old answer for up to two
+   * seconds, which reads as the app being broken rather than behind. Half a
+   * second is the ceiling for "instant" and the check is one small tmux call
+   * that only speaks when something actually changed.
+   */
+  const tmuxPoll = setInterval(sweep, 500);
   session.tmuxPoll = tmuxPoll;
 
   const pump = async (readable: ReadableStream<Uint8Array> | null | undefined) => {
@@ -304,7 +319,12 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
     }
     const action = msg.cmd as TmuxAction;
     if (!["select", "new", "kill", "rename"].includes(action)) return;
-    runAction(s.tmux, action, msg.window, msg.name);
+    if (!runAction(s.tmux, action, msg.window, msg.name)) return;
+    // Answer now rather than at the next tick. The command has already been
+    // applied by the time it returns, so the strip can be correct within a
+    // round trip instead of within half a second — and the click that caused
+    // it is exactly when a stale answer is most obvious.
+    s.tmuxSweep?.();
   }
 }
 

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -174,6 +174,31 @@ export function listWindows(t: TmuxTarget): TmuxWindow[] {
 }
 
 /**
+ * The keys tmux is waiting for as its prefix, as tmux spells them (`C-b`,
+ * `C-f`, `M-a`), including `prefix2` when one is set.
+ *
+ * The panel needs this to say "tmux is listening" the instant the key is
+ * pressed. That indicator used to come free: it lives in the status line most
+ * configs draw, and hiding that line to make room for our tabs took it away
+ * with everything else. Asking tmux which key it is beats hardcoding `C-b`,
+ * because the people most likely to have rebound it are exactly the people who
+ * use tmux enough to notice the indicator missing.
+ *
+ * Read once per attach and carried on the frame: the prefix does not change
+ * while a client is up unless someone sources a config mid-session, and the
+ * next attach picks that up.
+ */
+export function prefixKeys(t: TmuxTarget): string[] {
+  const keys: string[] = [];
+  for (const opt of ["prefix", "prefix2"]) {
+    const v = (tmux(t.socket, ["show-options", "-gv", opt]) || "").trim();
+    // "None" is how tmux says a second prefix is unset.
+    if (v && v !== "None") keys.push(v);
+  }
+  return keys;
+}
+
+/**
  * The commands a tab strip is allowed to send.
  *
  * A closed list, and every one of them is something the user could already do

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -8,7 +8,7 @@
 // What is unit-tested is everything that turns tmux's text into our shapes, and
 // everything that decides whether a command is allowed to run at all.
 import { describe, expect, test } from "bun:test";
-import { parseWindows, socketFromArgv, runAction, sanitizeWindowName, type TmuxTarget } from "../src/tmuxctl.ts";
+import { parseWindows, socketFromArgv, runAction, sanitizeWindowName, prefixKeys, type TmuxTarget } from "../src/tmuxctl.ts";
 
 describe("reading tmux's window list", () => {
   test("id, index, name, active flag and tmux's own marks", () => {
@@ -115,5 +115,15 @@ describe("window names", () => {
 
   test("absurdly long names are cut, not passed on", () => {
     expect(sanitizeWindowName("x".repeat(500))!.length).toBe(64);
+  });
+});
+
+describe("the prefix the panel advertises", () => {
+  // The "tmux is listening" mark has to know which key that is. Hardcoding C-b
+  // would light up for everyone except the people who rebound it, who are the
+  // ones who use tmux enough to have missed the indicator in the first place.
+  test("an unreachable server yields no prefix rather than a guessed one", () => {
+    const t: TmuxTarget = { pid: 1, socket: ["-L", "nonexistent-agx-test"], session: "s", id: "$0" };
+    expect(prefixKeys(t)).toEqual([]);
   });
 });

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -82,6 +82,12 @@ type Sess = {
   tmuxWindows: TmuxWindow[];
   /** The session those windows belong to, for the status-line toggle. */
   tmuxSession: string | null;
+  /** The keys tmux treats as its prefix, as tmux spells them ("C-f"). */
+  tmuxPrefix: string[];
+  /** When one of them was last pressed. The status line most configs draw
+   *  flashes to say "tmux is listening"; hiding it for our tabs took that away,
+   *  so the strip says it instead. */
+  tmuxPrefixAt: number;
   pending: string[]; // input queued while (re)connecting — flushed on ready
   createdAt: number;
   lastUsed: number;
@@ -89,6 +95,28 @@ type Sess = {
   retryTimer: number | null;
   subs: Set<() => void>;
 };
+/** How long the "listening" mark stays up with no second key. tmux itself waits
+ *  indefinitely, but a mark that never clears is a mark nobody reads. */
+const PREFIX_MS = 2000;
+
+/**
+ * The byte a terminal sends for a key spelled the way tmux spells it.
+ *
+ * Only the two forms a prefix is ever bound to: `C-x` (the control byte) and
+ * `M-x` (escape then the key). Anything else returns null and simply never
+ * matches, which is the right failure — a missing indicator, not a wrong one.
+ */
+function keyByte(k: string): string | null {
+  const m = /^([CM])-(.)$/.exec(k);
+  if (!m) return null;
+  const [, mod, ch] = m;
+  if (mod === "C") {
+    const code = ch!.toUpperCase().charCodeAt(0);
+    return code >= 64 && code <= 95 ? String.fromCharCode(code & 0x1f) : null;
+  }
+  return "\u001b" + ch;
+}
+
 const sessions = new Map<string, Sess>();
 let seq = 0;
 /** Shells for one repo, in creation order. */
@@ -181,7 +209,7 @@ function connect(s: Sess) {
   ws.onmessage = (ev) => {
     if (s.ws !== ws) return; // a stale socket (replaced by ⟲ new shell) must not touch the session
     if (typeof ev.data !== "string") { s.term.write(new Uint8Array(ev.data as ArrayBuffer)); return; }
-    let f: { t?: string; mode?: "pty" | "pipe"; shell?: string; resize?: boolean; code?: number; error?: string; active?: boolean; windows?: TmuxWindow[]; session?: string | null };
+    let f: { t?: string; mode?: "pty" | "pipe"; shell?: string; resize?: boolean; code?: number; error?: string; active?: boolean; windows?: TmuxWindow[]; session?: string | null; prefix?: string[] };
     try { f = JSON.parse(ev.data); } catch { return; }
     if (f.t === "ready") {
       reconnected(s);
@@ -201,6 +229,7 @@ function connect(s: Sess) {
       s.tmux = f.active === true;
       s.tmuxWindows = Array.isArray(f.windows) ? f.windows : [];
       s.tmuxSession = typeof f.session === "string" ? f.session : null;
+      s.tmuxPrefix = Array.isArray(f.prefix) ? f.prefix : [];
       notify(s);
     } else if (f.t === "exit" || f.t === "fatal") {
       s.status = f.t === "exit" ? "exited" : "error";
@@ -305,9 +334,33 @@ function createSession(root: string): Sess {
   const holder = document.createElement("div");
   holder.style.cssText = "width:100%;height:100%";
   const id = `t${++seq}-${Date.now().toString(36)}`;
-  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, tmuxWindows: [], tmuxSession: null, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
+  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, tmuxWindows: [], tmuxSession: null, tmuxPrefix: [], tmuxPrefixAt: 0, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
   term.onData((d) => {
     sess.lastUsed = Date.now();
+    /*
+     * "tmux is listening."
+     *
+     * Read off the keystroke on its way past rather than asked of tmux,
+     * because this has to land on the same frame as the keypress: a poll, at
+     * any interval anyone would accept, answers after the moment it is meant
+     * to describe. tmux is told which key it is (see prefixKeys), so a rebound
+     * prefix — and anyone who rebinds it is exactly who notices this missing —
+     * lights up the same as the default.
+     *
+     * A best-effort mirror of tmux's own state, not a model of it: the byte is
+     * also the prefix when it is being sent *through* to a nested tmux or to
+     * an application that wants it. Wrong in that case for two seconds, and it
+     * never touches what the shell receives.
+     */
+    if (sess.tmux && d.length === 1 && sess.tmuxPrefix.some((k) => keyByte(k) === d)) {
+      sess.tmuxPrefixAt = Date.now();
+      notify(sess);
+      setTimeout(() => { if (Date.now() - sess.tmuxPrefixAt >= PREFIX_MS) notify(sess); }, PREFIX_MS + 50);
+    } else if (sess.tmuxPrefixAt) {
+      // The next key is the one the prefix was for: tmux has stopped waiting.
+      sess.tmuxPrefixAt = 0;
+      notify(sess);
+    }
     if (sess.status === "live" && sess.ws?.readyState === WebSocket.OPEN) sess.ws.send(JSON.stringify({ t: "in", d }));
     else if (sess.status === "connecting") sess.pending.push(d); // don't drop keys typed before the shell is up
     else if (sess.status === "unauthorized" && d.includes("\r")) reauthPrompt(); // Enter → re-enter the token
@@ -617,6 +670,20 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
    * arriving on the next poll, never a local guess that could disagree with it.
    */
   const tmuxWindows = sess?.tmuxWindows ?? [];
+  // Lit while tmux is waiting for the second half of a prefix sequence.
+  const prefixLive = !!sess?.tmuxPrefixAt && Date.now() - sess.tmuxPrefixAt < PREFIX_MS;
+  /*
+   * The tab you clicked highlights now, not when tmux confirms it.
+   *
+   * The server re-reads tmux the moment the command returns, so the real answer
+   * is a round trip away rather than a poll away — but a round trip is still
+   * long enough to feel like the click missed, and this is the one interaction
+   * where the user already knows what the answer will be. Cleared on the next
+   * frame, so if tmux disagrees (the window went away underneath), tmux wins.
+   */
+  const [pendingWindow, setPendingWindow] = useState<string | null>(null);
+  useEffect(() => { setPendingWindow(null); }, [tmuxWindows]);
+  const activeWindow = pendingWindow ?? tmuxWindows.find((w) => w.active)?.id ?? null;
   const tmuxCmd = useCallback((cmd: string, extra: Record<string, unknown> = {}) => {
     const s = sess;
     if (!s || s.ws?.readyState !== WebSocket.OPEN) return;
@@ -900,6 +967,14 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                     behind it should not change how the workspace looks. */}
                 {tmuxActive && tmuxWindows.length > 0 && (
                   <div className="shrink-0 flex items-center gap-1 px-3 py-1 border-b overflow-x-auto agw-noscrollbar" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                    <span
+                      title={prefixLive ? "tmux is waiting for the rest of the sequence" : `tmux prefix: ${(sess?.tmuxPrefix ?? []).join(" or ") || "unknown"}`}
+                      className="shrink-0 px-1.5 py-1 rounded-md text-[10px] font-semibold tabular-nums transition-colors duration-75"
+                      style={prefixLive
+                        ? { background: "var(--primary)", color: "var(--bg2)" }
+                        : { color: "var(--text4)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                      {(sess?.tmuxPrefix[0] ?? "tmux")}
+                    </span>
                     {tmuxWindows.map((w) => {
                       // tmux's own marks, straight through: `!` is a bell, `#`
                       // is activity in a window you are not looking at. Both
@@ -908,11 +983,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       const alerting = w.flags.includes("!") || w.flags.includes("#");
                       return (
                         <div key={w.id}
-                          onClick={() => { if (!w.active) tmuxCmd("select", { window: w.id }); }}
+                          onClick={() => { if (w.id !== activeWindow) { setPendingWindow(w.id); tmuxCmd("select", { window: w.id }); } }}
                           onDoubleClick={() => setRenaming(w.id)}
                           title={`window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
                           className="group flex items-center gap-1.5 px-2 py-1 rounded-md text-[10.5px] cursor-pointer shrink-0"
-                          style={w.active
+                          style={w.id === activeWindow
                             ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)" }
                             : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)" }}>
                           <span className="tabular-nums" style={{ color: "var(--text4)" }}>{w.index}</span>


### PR DESCRIPTION
## What does this PR do?

Two things the first cut got wrong, both from real use.

**The strip was up to two seconds behind.** It rides the poll written for "has tmux appeared", where being a beat late costs nothing. A tab strip is not that: `prefix n` moves the focus instantly in the terminal while the tabs sit on the old answer, which reads as the app being broken rather than behind.

- an action sweeps immediately instead of waiting for the next tick, since tmux has already applied it by the time the command returns
- the poll runs at 500ms while tmux is attached, for switches made from the keyboard
- the clicked tab highlights on the click, reconciled by the next frame so tmux wins if the window went away underneath

Measured through the real WebSocket against a live session:

```
click one:   strip updated in 12ms      (was up to 2000ms)
click three: strip updated in 12ms
click two:   strip updated in 12ms

keyboard prefix+n: three -> one in 18ms
keyboard prefix+n: one -> two in 504ms   (poll-bound, was up to 2000ms)
keyboard prefix+n: two -> three in 498ms
```

**The prefix key had no feedback.** That indicator was never ours: it lives in the status line most configs draw, and hiding that line for these tabs took it away with everything else in there. Without it there is no way to tell whether tmux caught the prefix, which is the difference between pressing `2` and getting window 2, and pressing `2` into whatever is running.

The strip now shows the prefix key and lights it while tmux is waiting. The key comes from tmux itself (`show-options -gv prefix`, plus `prefix2`) rather than being hardcoded to `C-b`, because anyone who rebound it is exactly who noticed the indicator missing. Verified against this machine's config, which reports `C-f`.

Detection is client-side, off the keystroke on its way past, because a poll at any acceptable interval answers *after* the moment it is meant to describe. It is a best-effort mirror rather than a model of tmux's state: the same byte on its way to a nested tmux lights it too, wrongly, for two seconds. It never touches what the shell receives.

Refs #153. The remaining reports from the same session are in #160, and #157 replaces the poll entirely.

## How was it tested?

- `bun test`: **447 pass, 0 fail**, plus a case pinning that an unreachable tmux yields no prefix rather than a guessed `C-b`.
- `bunx tsc --noEmit` in `server/` and `web/`.
- Against live tmux: `prefixKeys()` returns `["C-f"]` for this machine's config, and the latency numbers above come from driving the real server over its own WebSocket, timing from "command sent" to "frame says so".

🤖 Generated with [Claude Code](https://claude.com/claude-code)
