### PR TITLE
chore: bump the package version to 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentglass",
-  "version": "0.2.0",
+  "version": "0.4.0",
   "private": true,
   "description": "Real-time observability dashboard for Claude Code multi-agent workflows — cost, tokens, tool latency, error rates, and session timelines.",
   "license": "MIT",


### PR DESCRIPTION
## What does this PR do?

`package.json` has read `0.2.0` since that release, through v0.2.1 and v0.3.0, because cutting a tag never touched it.

Published installers were unaffected: `desktop-binaries.yml` syncs the version to the tag before packaging, so a `v0.3.0` tag shipped `v0.3.0` files. A **local** build has no tag to sync from and stamps `build-info.json` straight from this file, so `install-local.sh` builds have been telling the About pane "agentglass 0.2.0" while sitting twenty commits past v0.3.0.

Set to `0.4.0`, the release about to be cut, rather than to the last one — the next thing that happens to this commit is the tag.

## How was it tested?

- `bunx tsc --noEmit` in `server/` and `web/`, both clean; `cd server && bun test` and `cd web && bun test` both green.
- Verified this is the only manifest carrying a version: `find . -maxdepth 2 -name package.json -not -path "./node_modules/*"` returns only the root one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)