### PR TITLE
docs(landing): say what the app became, and stop hand-typing the version

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -3,10 +3,17 @@ name: Deploy landing + demo to GitHub Pages
 # Publishes the static landing page (landing/) at the site root and the
 # web UI built in demo mode (VITE_DEMO=1 → fabricated data, no server)
 # under /demo/, on every push to main.
+#
+# Also runs when a release is published, because the landing page names the
+# current version and links straight at the installers for it. Those used to be
+# typed by hand, which meant every release made the site quietly wrong until
+# somebody noticed.
 
 on:
   push:
     branches: [main]
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:
@@ -37,6 +44,13 @@ jobs:
           cp -r landing/. site/
           cp -r web/dist/. site/demo/
           touch site/.nojekyll
+      # Fills in the version and the per-OS download links. Never fatal: the
+      # page ships with copy that is true without it, so a missing release or an
+      # API hiccup costs precision, not correctness.
+      - name: Stamp the current release into the landing page
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
+        run: bun scripts/landing-release.mjs site/index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: site

--- a/landing/index.html
+++ b/landing/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>agentglass — mission control for every AI coding agent on your machine</title>
-<meta name="description" content="Open-source real-time dashboard and workspace for AI coding agents. Claude Code, Codex, Gemini CLI — every tool call, token and dollar on one radar, plus diff, git, docker and a real terminal." />
+<meta name="description" content="Open-source mission control and workspace for AI coding agents. Claude Code, Codex, Gemini CLI — every tool call, token and dollar on one radar, plus diff review, git, docker, a real terminal with native tmux tabs, and a control plane that holds risky tool calls for your approval. Desktop app for macOS, Linux and Windows." />
 <meta property="og:title" content="agentglass — every agent, one tower" />
-<meta property="og:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, then act — without leaving the glass." />
+<meta property="og:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, hold risky tool calls for approval, then act — diff, git, docker, terminal and chat, without leaving the glass." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://sirallap.github.io/agentglass/" />
 <meta property="og:image" content="https://sirallap.github.io/agentglass/og.png" />
@@ -15,7 +15,7 @@
 <meta property="og:image:alt" content="agentglass — a loupe whose lens is a mission-control radar, tracking your fleet of AI coding agents" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="agentglass — every agent, one tower" />
-<meta name="twitter:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, then act — without leaving the glass." />
+<meta name="twitter:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, hold risky tool calls for approval, then act — diff, git, docker, terminal and chat, without leaving the glass." />
 <meta name="twitter:image" content="https://sirallap.github.io/agentglass/og.png" />
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2032%2032%22%3E%3Cline%20x1=%2220.2%22%20y1=%2220.2%22%20x2=%2227%22%20y2=%2227%22%20stroke=%22%237c3aed%22%20stroke-width=%223.4%22%20stroke-linecap=%22round%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%229%22%20fill=%22%23a78bfa%22%20fill-opacity=%220.14%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%225.6%22%20fill=%22none%22%20stroke=%22%23a78bfa%22%20stroke-opacity=%220.35%22%20stroke-width=%221%22/%3E%3Cpath%20d=%22M13.5%2013.5%20L13.5%204.6%20A8.9%208.9%200%200%201%2019.7%207%20Z%22%20fill=%22%23a78bfa%22%20fill-opacity=%220.28%22/%3E%3Cline%20x1=%2213.5%22%20y1=%2213.5%22%20x2=%2219.7%22%20y2=%227%22%20stroke=%22%23c4b5fd%22%20stroke-width=%221%22/%3E%3Ccircle%20cx=%229%22%20cy=%2216.4%22%20r=%221.9%22%20fill=%22%2334d399%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%229.6%22%20fill=%22none%22%20stroke=%22%237c3aed%22%20stroke-width=%222.5%22/%3E%3C/svg%3E" />
 <style>
@@ -502,14 +502,17 @@
     <p class="sub">
       Claude Code, Codex, Gemini CLI — every AI coding agent on your machine, on one radar.
       But <b>agentglass</b> is not a viewer: it's mission control <b>and a full workspace</b>.
-      The dashboard watches every tool call, token and dollar live; the cockpit acts —
-      review diffs, stage &amp; push, drive docker, drop into a <b>real terminal</b>,
-      chat with Claude — without leaving the glass.
+      The dashboard watches every tool call, token and dollar live. The control plane can
+      <b>hold a risky tool call until you approve it</b>, from any device, and it survives a
+      restart. And the cockpit acts — review diffs, stage &amp; push, drive docker, drop into
+      a <b>real terminal</b> (with your tmux windows as native tabs), chat with Claude —
+      without leaving the glass. Runs in the browser, or as a desktop app.
     </p>
 
     <div class="ctas">
       <a class="btn-a" href="./demo/">▶ Enter the live demo</a>
-      <button class="btn-b" id="copy-npx" title="Copy to clipboard"><span class="c">$</span> <span id="npx-txt">npx agentglass</span></button>
+      <a class="btn-b" data-dl="any" href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener">⬇ Download <span data-agx="version">the desktop app</span></a>
+      <button class="btn-b" id="copy-npx" data-copy="git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev" title="Copy: git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev"><span class="c">$</span> <span id="npx-txt">git clone … &amp;&amp; bun install &amp;&amp; bun run dev</span></button>
     </div>
 
     <div class="keys" aria-label="Workspace panels, one keystroke away">
@@ -535,6 +538,10 @@
       <span><b>o</b> api-worker <i>restarted</i> · logs streaming</span>
       <span><b>t</b> make test · <i>running</i> in a real PTY</span>
       <span><b>c</b> claude replied · shop-web chat</span>
+      <span>✓ approved · gate restored after restart, agent still held</span>
+      <span><b>t</b> tmux · 3 windows as native tabs · C-f listening</span>
+      <span>◷ AG-5F6D open 9m · transcript still growing — working, not stuck</span>
+      <span>⬇ <span data-agx="version">a new release</span> available · release notes in Settings ▸ About</span>
     </div>
   </div>
 </header>
@@ -588,7 +595,7 @@
           <div class="m-row"><span style="color:var(--warning)">M</span> web/src/components/Cart.tsx</div>
           <div class="m-hd">Commit</div>
           <div class="m-row" style="border:1px solid color-mix(in srgb, var(--border) 60%, transparent); border-radius:8px; color:var(--text2)">fix: round prices at checkout<span style="margin-left:auto"></span><button class="m-btn pri">Commit</button></div>
-          <div class="m-keys">lazygit-style, write-gated · <b>s</b> stage · <b>u</b> unstage · <b>x</b> discard · interactive hunk staging · branches, log, stashes</div>
+          <div class="m-keys">lazygit-style, write-gated · <b>s</b> stage · <b>u</b> unstage · <b>x</b> discard · interactive hunk staging · branches, log, stashes, worktrees · resolve conflicts, or hand them to a chat</div>
         </div>
 
         <div class="wpane" id="wp-o" role="tabpanel">
@@ -613,7 +620,7 @@ bun test v1.2.19
 
  <span class="ok">3 pass</span> · 0 fail · 41 expect() calls
 <span style="color:var(--success)">dev@machine</span> <span style="color:var(--info)">shop-api</span> % <span class="caret"></span></div>
-          <div class="m-keys">a real PTY — your login shell over a WebSocket, not an emulation · per-repo, persistent · <b>⚙</b> discovers Makefile targets &amp; package.json scripts</div>
+          <div class="m-keys">a real PTY — your login shell over a WebSocket, not an emulation · per-repo, persistent · <b>⚙</b> discovers Makefile targets &amp; package.json scripts · run <b>tmux</b> and its windows become native tabs, keybindings untouched</div>
         </div>
 
         <div class="wpane" id="wp-c" role="tabpanel">
@@ -624,7 +631,7 @@ bun test v1.2.19
             Found it — totals were summed before rounding. Patched <b>round()</b> into <b>pricing.ts</b> and added a guard in checkout. Running the tests now.
           </div>
           <div class="m-msg ai m-typing"><i></i><i></i><i></i></div>
-          <div class="m-keys">drives your local <b>claude</b> CLI · pick repo, model, permission mode · sessions join the fleet like any other agent</div>
+          <div class="m-keys">drives your local <b>claude</b> CLI · pick repo, model, permission mode · queue a message mid-turn · chats survive a crash or a project switch · sessions join the fleet like any other agent</div>
         </div>
 
       </div>
@@ -684,9 +691,9 @@ bun test v1.2.19
       <div class="read">Opus 352.0k <span class="a">$188.00</span> · GPT-4o 275.2k <span class="a">$94.42</span> · Sonnet <span class="a">$34.42</span></div>
     </div>
     <div class="card arm rv d1">
-      <div class="head"><span class="led"></span><span class="klabel">Alerts</span></div>
+      <div class="head"><span class="led"></span><span class="klabel">Control plane</span></div>
       <h3>What needs you</h3>
-      <p>Dangerous tool calls <b>hold for your clearance</b>. Approve or deny remotely — opt-in, audited.</p>
+      <p>Dangerous tool calls <b>hold for your clearance</b>. Approve or deny remotely — opt-in, audited, and <b>durable</b>: restart the server and the request is still there, still held.</p>
       <div class="read"><span class="w">✋ Approve Bash?</span> kubectl delete deploy api <span class="g">[Approve]</span> <span class="r">[Deny]</span></div>
     </div>
     <div class="card rv d2">
@@ -694,6 +701,24 @@ bun test v1.2.19
       <h3>Any aircraft, any fleet</h3>
       <p>Claude Code hooks, or <b>any OpenTelemetry GenAI exporter</b>: Codex, Gemini CLI, Bedrock, LangChain, LiteLLM.</p>
       <div class="read">otel/genai ▸ rx <span class="a">1.33 events/sec</span> · peak 2/s</div>
+    </div>
+    <div class="card rv">
+      <div class="head"><span class="led"></span><span class="klabel">Stuck or slow</span></div>
+      <h3>Evidence of life</h3>
+      <p>A tool call open for nine minutes is a long build or a wedged CLI, and elapsed time cannot tell you which. So the glass reads what the session is <b>still doing</b> — the transcript growing, the file a write tool named changing — instead of guessing from a stopwatch.</p>
+      <div class="read">AG-5F6D · Bash <span class="a">9m 12s</span> · transcript touched <span class="a">3s ago</span></div>
+    </div>
+    <div class="card rv d1">
+      <div class="head"><span class="led"></span><span class="klabel">The notch</span></div>
+      <h3>Above everything</h3>
+      <p>Approvals, finished turns and desktop notifications land in a notch that hangs from the top of the frame, wherever you are in the app. One switch mutes it without touching your system's Do Not Disturb.</p>
+      <div class="read">✋ 1 waiting · <span class="a">2 turns finished</span> · quiet <span class="g">off</span></div>
+    </div>
+    <div class="card rv d2">
+      <div class="head"><span class="led"></span><span class="klabel">Desktop</span></div>
+      <h3>Not just a tab</h3>
+      <p>Installers for <b>macOS</b> (Apple silicon and Intel), <b>Linux</b> (deb and AppImage) and <b>Windows</b>. It checks for new releases in the background and shows you the incoming commits before you take them.</p>
+      <div class="read"><span data-agx="version">a new release</span> available · <span class="a">the commits it brings</span>, listed before you take them</div>
     </div>
   </div>
 </section>
@@ -708,16 +733,18 @@ bun test v1.2.19
   <div class="txgrid">
     <div class="txlog rv">
       <div><span class="who p">pilot ▸</span> request startup.</div>
-      <div><span class="who">tower ▸</span> cleared. run <span class="cmd">npx agentglass</span></div>
-      <div class="dim">◇ server listening on :4177</div>
+      <div><span class="who">tower ▸</span> cleared. two ways in —</div>
+      <div class="dim">◇ <a href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener" style="text-decoration:underline">download the desktop app</a> · macOS, Linux, Windows</div>
+      <div class="dim">◇ or <span class="cmd">git clone</span> · <span class="cmd">bun install</span> · <span class="cmd">bun run dev</span></div>
       <div class="dim">◇ scanning ~/.claude/projects … 18 sessions found</div>
-      <div class="dim">◇ claude code hooks installed</div>
+      <div class="dim">◇ <span class="cmd">bun run setup</span> wires the Claude Code hooks — opt-in</div>
       <div><span class="who p">pilot ▸</span> tower in sight. <span class="caret"></span></div>
     </div>
     <div class="txlog rv d1">
       <div><span class="who">tower ▸</span> a note on security —</div>
       <div class="dim">◇ local-first: SQLite on your disk, nothing phones home</div>
       <div class="dim">◇ the control plane is opt-in and audited</div>
+      <div class="dim">◇ the approval queue is persisted — a crash cannot silently auto-allow</div>
       <div class="dim">◇ MIT license · Bun server · React UI · Electron desktop app</div>
       <div class="dim">◇ read <a href="https://github.com/SirAllap/agentglass/blob/main/SECURITY.md" target="_blank" rel="noopener" style="text-decoration:underline">SECURITY.md</a> before installing — we mean it</div>
       <div><span class="who">tower ▸</span> <a href="https://github.com/SirAllap/agentglass/issues" target="_blank" rel="noopener" style="text-decoration:underline">github issues</a> welcome, frequency monitored.</div>
@@ -727,8 +754,8 @@ bun test v1.2.19
 
 <!-- ══════════ STAT BAND ══════════ -->
 <div class="band">
-  <div class="tile rv"><div class="n">1 <em>cmd</em></div><div class="k">from zero to cockpit — npx agentglass</div></div>
-  <div class="tile rv d1"><div class="n">p50/<em>p95</em></div><div class="k">tool-latency percentiles, live</div></div>
+  <div class="tile rv"><div class="n">3 <em>OSes</em></div><div class="k">desktop installers — macOS (Apple silicon &amp; Intel), Linux (deb &amp; AppImage), Windows</div></div>
+  <div class="tile rv d1"><div class="n">p50/<em>p95</em></div><div class="k">tool-latency percentiles, live — measured PreToolUse ▸ PostToolUse</div></div>
   <div class="tile rv d2"><div class="n">22</div><div class="k">themes — this page rolled <b id="th-tile">Ember</b>; hit 🎲 below to reroll</div></div>
   <div class="tile rv"><div class="n"><em>100%</em></div><div class="k">local-first — your data never leaves your machine</div></div>
 </div>
@@ -738,9 +765,12 @@ bun test v1.2.19
   <div class="rv">
     <span class="stamp">Cleared for takeoff</span>
     <h2>Your agents are already flying.<br><em>Get a tower.</em></h2>
-    <button class="cmdline" id="copy-npx2" title="Copy to clipboard"><span class="p">$</span> <span id="npx-txt2">npx agentglass</span></button>
+    <button class="cmdline" id="copy-npx2" data-copy="git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev" title="Copy: git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev"><span class="p">$</span> <span id="npx-txt2">git clone … &amp;&amp; bun install &amp;&amp; bun run dev</span></button>
     <div class="row">
       <a class="btn-a" href="./demo/">▶ Live demo — no install</a>
+      <a class="btn-b" data-dl="mac" href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener">⬇ macOS</a>
+      <a class="btn-b" data-dl="linux" href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener">⬇ Linux</a>
+      <a class="btn-b" data-dl="win" href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener">⬇ Windows</a>
       <a class="btn-b" href="https://github.com/SirAllap/agentglass" target="_blank" rel="noopener">★ Star on GitHub</a>
     </div>
     <p class="meta">Open source · MIT · Bun + SQLite · React + Vite · Electron desktop · 22 themes</p>
@@ -865,16 +895,23 @@ bun test v1.2.19
     applyTheme(current); /* re-sync active state now that options exist */
   })();
 
-  /* ── copy npx command ── */
+  /* ── copy the command the button is showing ── */
   function wireCopy(btnId, txtId){
     var btn = document.getElementById(btnId);
-    if(!btn) return;
+    var txt = document.getElementById(txtId);
+    if(!btn || !txt) return;
+    /* Captured once, at wire time. The label is swapped to "copied ✓" while the
+       toast is up, so reading it at click time can copy the toast — and it used
+       to copy a hardcoded string, which meant the button could paste something
+       other than what it was showing. */
+    /* The label may be abbreviated with an ellipsis to fit the button; what
+       gets copied is the whole command, carried on the element itself. */
+    var cmd = btn.getAttribute('data-copy') || txt.textContent;
     btn.addEventListener('click', function(){
-      var txt = document.getElementById(txtId);
-      navigator.clipboard && navigator.clipboard.writeText('npx agentglass').then(function(){
-        var old = txt.textContent;
+      if(!navigator.clipboard) return;
+      navigator.clipboard.writeText(cmd).then(function(){
         txt.textContent = 'copied ✓';
-        setTimeout(function(){ txt.textContent = old; }, 1400);
+        setTimeout(function(){ txt.textContent = cmd; }, 1400);
       });
     });
   }

--- a/scripts/landing-release.mjs
+++ b/scripts/landing-release.mjs
@@ -1,0 +1,100 @@
+#!/usr/bin/env bun
+/**
+ * Stamp the current release into the landing page at deploy time.
+ *
+ * The page used to name a version in its own copy, which meant every release
+ * quietly made the site wrong until someone remembered to edit it. Nobody ever
+ * remembers, so the version and the per-OS download links are markers now and
+ * this fills them in as the site is assembled.
+ *
+ * Deliberately a build step rather than a fetch in the page:
+ *
+ *  - the deploy already runs on every push to main and on a published release,
+ *    so the answer is fresh without a request from every visitor;
+ *  - no rate limit, no third-party call at render time, and it works with
+ *    JavaScript off;
+ *  - and if it fails, it leaves the page alone. The markers ship with copy that
+ *    is true without them ("Download the desktop app", pointing at
+ *    releases/latest), so the worst case is a page that is vaguer than it could
+ *    be, never one that names a version that does not exist.
+ *
+ * Usage: bun scripts/landing-release.mjs site/index.html
+ */
+const file = process.argv[2];
+if (!file) {
+  console.error("usage: landing-release.mjs <path-to-index.html>");
+  process.exit(2);
+}
+
+const REPO = process.env.GITHUB_REPOSITORY || "SirAllap/agentglass";
+const headers = { accept: "application/vnd.github+json", "user-agent": "agentglass-landing" };
+if (process.env.GITHUB_TOKEN) headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+/** The newest published release, or null if there isn't one we can read. */
+async function latestRelease() {
+  try {
+    const r = await fetch(`https://api.github.com/repos/${REPO}/releases/latest`, { headers });
+    if (!r.ok) {
+      console.warn(`landing: no release to stamp (${r.status}) — leaving the page as written`);
+      return null;
+    }
+    return await r.json();
+  } catch (e) {
+    console.warn(`landing: could not reach the releases API (${e}) — leaving the page as written`);
+    return null;
+  }
+}
+
+/**
+ * Pick the asset a visitor on this OS wants.
+ *
+ * Ordered, because more than one can match and the first is the one most
+ * people should get: Apple silicon before Intel, and the AppImage before the
+ * .deb since it runs on any distribution.
+ */
+const PICKS = {
+  mac: [/arm64.*\.dmg$/i, /\.dmg$/i],
+  linux: [/\.AppImage$/i, /\.deb$/i],
+  win: [/\.exe$/i, /\.msi$/i],
+};
+
+function assetFor(assets, os) {
+  for (const pattern of PICKS[os] ?? []) {
+    const hit = assets.find((a) => pattern.test(a.name));
+    if (hit) return hit;
+  }
+  return null;
+}
+
+const release = await latestRelease();
+if (!release) process.exit(0);
+
+const version = String(release.tag_name || "").trim();
+const assets = Array.isArray(release.assets) ? release.assets : [];
+let html = await Bun.file(file).text();
+let stamped = 0;
+
+if (version) {
+  // `<span data-agx="version">whatever the page says by default</span>`
+  html = html.replace(
+    /(<span data-agx="version"[^>]*>)([^<]*)(<\/span>)/g,
+    (_m, open, _old, close) => { stamped++; return `${open}${version}${close}`; },
+  );
+}
+
+for (const os of ["mac", "linux", "win"]) {
+  const asset = assetFor(assets, os);
+  if (!asset?.browser_download_url) continue;
+  html = html.replace(
+    new RegExp(`(<a[^>]*data-dl="${os}"[^>]*href=")([^"]*)(")`, "g"),
+    (_m, open, _old, close) => { stamped++; return `${open}${asset.browser_download_url}${close}`; },
+  );
+}
+
+if (!stamped) {
+  console.warn("landing: nothing to stamp — the markers are missing, so the page is unchanged");
+  process.exit(0);
+}
+
+await Bun.write(file, html);
+console.log(`landing: stamped ${version || "(no tag)"} into ${stamped} place(s) · assets: ${assets.map((a) => a.name).join(", ") || "none"}`);


### PR DESCRIPTION
## What does this PR do?

The landing page still described a dashboard with a few panels bolted on, and it named a version in its own copy, so every release quietly made the site wrong until somebody noticed.

**Copy now matches what shipped**: the control plane holding a risky tool call for approval *and surviving a restart* (the differentiated thing, previously not mentioned at all), tmux windows as native tabs in the terminal, chats surviving a crash or project switch, git worktrees and conflict handoff, evidence of life for stuck-versus-slow, the notch and its quiet switch, and the fact that there is a desktop app for three operating systems. The three telemetry cards became six, which the existing grid already handled.

**The version stopped being hand-typed.** It and the per-OS download links are markers now, filled in from the published release while the site is assembled (`scripts/landing-release.mjs`), and the deploy also triggers on `release: published`. Verified against the real API:

```
landing: stamped v0.4.0 into 5 place(s) · assets: agentglass_0.4.0_amd64.deb,
  agentglass_0.4.0_arm64.dmg, agentglass_0.4.0_x64.dmg, agentglass_0.4.0_x86_64.AppImage

data-dl="mac"   → …/download/v0.4.0/agentglass_0.4.0_arm64.dmg
data-dl="linux" → …/download/v0.4.0/agentglass_0.4.0_x86_64.AppImage
data-dl="win"   → …/releases/latest      ← v0.4.0 has no .exe asset yet
```

It is never fatal: the markers ship with copy that is true without them, so a missing release or an API hiccup costs precision, not correctness. That Windows line is the mechanism working, and it is also worth knowing on its own — **v0.3.0 shipped an `.exe` and the v0.4.0 assets do not have one yet**.

**Two things that were quietly false:**

- The primary CTA was `npx agentglass`, and the stat band called it *"1 cmd — from zero to cockpit"*. It is neither. I ran it: it prints a banner telling you to clone the repo, and the published package is `0.1.0` from 19 July. The CTAs are now the desktop download and a clone one-liner, both of which do what they say.
- The copy button copied a hardcoded `npx agentglass` regardless of what it displayed. It now copies what it shows, with the full command carried on the element when the label is abbreviated to fit.

## How was it tested?

- `scripts/landing-release.mjs` run against the live GitHub API, output above, and against a repo with no release (leaves the page untouched, exits 0).
- Rendered in headless Chromium at 1440 wide: hero, CTAs, stamped version and the theme roll all come up clean, HTML parses without errors.
- The page is static, so there is no build to break; the deploy workflow gains one step and one trigger.

🤖 Generated with [Claude Code](https://claude.com/claude-code)