### PR TITLE
fix(desktop): stop the About pane reporting a version nobody shipped

### DIFF
--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -38,7 +38,22 @@ run("bun", [
 // to update itself. Without it the server would have to guess where the source
 // lives, and a wrong guess would build a stranger's repository.
 const commit = spawnSync("git", ["-C", REPO, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout?.trim() ?? "";
-const version = JSON.parse(readFileSync(resolve(HERE, "package.json"), "utf8")).version ?? "0.0.0";
+// Two manifests carry a version and only one of them is synced from the tag by
+// CI (electron/package.json), so they drift: the v0.4.0 release shipped correct
+// installers while every local and self-update build stamped 0.2.0 and the
+// About pane reported it for weeks. Read both, take the higher, and say so when
+// they disagree — a build that quietly reports the wrong version is how nobody
+// notices the bump was half-done.
+const readVersion = (p) => {
+  try { return JSON.parse(readFileSync(p, "utf8")).version ?? ""; } catch { return ""; }
+};
+const rank = (v) => (v.match(/\d+/g) ?? []).map(Number).reduce((n, part) => n * 1000 + part, 0);
+const shellVersion = readVersion(resolve(HERE, "package.json"));
+const rootVersion = readVersion(resolve(REPO, "package.json"));
+const version = (rank(rootVersion) > rank(shellVersion) ? rootVersion : shellVersion) || "0.0.0";
+if (shellVersion && rootVersion && shellVersion !== rootVersion) {
+  console.warn(`warn: package.json versions disagree (root ${rootVersion}, electron ${shellVersion}) — using ${version}`);
+}
 // The remote, so the updater can clone it without ever needing this checkout.
 const origin = spawnSync("git", ["-C", REPO, "remote", "get-url", "origin"], { encoding: "utf8" }).stdout?.trim() ?? "";
 // `v0.2.1-48-g4a459f5`: the nearest release and the distance from it. This, not

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentglass-electron",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "agentglass desktop shell (Electron)",
   "author": "SirAllap",
   "homepage": "https://github.com/SirAllap/agentglass",


### PR DESCRIPTION
## What does this PR do?

v0.4.0 shipped correct installers and an app that calls itself **0.2.0**. Screenshot from the self-update that just ran on my machine: `agentglass 0.2.0 · 03b4a62 · built 7/22/2026` — where `03b4a62` is literally the commit that bumped the version.

Two manifests carry a version:

- `package.json` — bumped in #161 for the release
- `electron/package.json` — **the one `electron/build.mjs:41` actually reads**, and the only one `desktop-binaries.yml` syncs from the tag

So CI produced correct `agentglass_0.4.0_*` artifacts because it rewrites the electron manifest at build time, while every local `install-local.sh` build and every self-update build stamped `build-info.json` from the stale 0.2.0 and the About pane dutifully reported it. The release bump changed a file nothing reads.

Fix: the electron manifest catches up to 0.4.0, and `build.mjs` reads both manifests and takes the higher, so whichever one a future release remembers to bump is the one that shows. When the two disagree it prints a warning at build time, because a build that silently reports the wrong version is how this survived three releases.

Note `baseTag`/`distance` were always right — `git describe` is what the updater compares, which is why the update path itself worked correctly throughout.

## How was it tested?

- Version selection checked against the cases that matter: `0.10.0` beats `0.9.0` (numeric rank, not string compare), either manifest missing falls back to the other, both missing yields `0.0.0`, and equal values are a no-op. 8/8.
- `build.mjs` parses and executes under Node's ESM loader.
- Post-merge I will rebuild locally and confirm the About pane reads 0.4.0, which is the actual acceptance test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)