### PR TITLE
feat(update): show what changed the first time a new version runs

### DIFF
--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -38,7 +38,22 @@ run("bun", [
 // to update itself. Without it the server would have to guess where the source
 // lives, and a wrong guess would build a stranger's repository.
 const commit = spawnSync("git", ["-C", REPO, "rev-parse", "HEAD"], { encoding: "utf8" }).stdout?.trim() ?? "";
-const version = JSON.parse(readFileSync(resolve(HERE, "package.json"), "utf8")).version ?? "0.0.0";
+// Two manifests carry a version and only one of them is synced from the tag by
+// CI (electron/package.json), so they drift: the v0.4.0 release shipped correct
+// installers while every local and self-update build stamped 0.2.0 and the
+// About pane reported it for weeks. Read both, take the higher, and say so when
+// they disagree — a build that quietly reports the wrong version is how nobody
+// notices the bump was half-done.
+const readVersion = (p) => {
+  try { return JSON.parse(readFileSync(p, "utf8")).version ?? ""; } catch { return ""; }
+};
+const rank = (v) => (v.match(/\d+/g) ?? []).map(Number).reduce((n, part) => n * 1000 + part, 0);
+const shellVersion = readVersion(resolve(HERE, "package.json"));
+const rootVersion = readVersion(resolve(REPO, "package.json"));
+const version = (rank(rootVersion) > rank(shellVersion) ? rootVersion : shellVersion) || "0.0.0";
+if (shellVersion && rootVersion && shellVersion !== rootVersion) {
+  console.warn(`warn: package.json versions disagree (root ${rootVersion}, electron ${shellVersion}) — using ${version}`);
+}
 // The remote, so the updater can clone it without ever needing this checkout.
 const origin = spawnSync("git", ["-C", REPO, "remote", "get-url", "origin"], { encoding: "utf8" }).stdout?.trim() ?? "";
 // `v0.2.1-48-g4a459f5`: the nearest release and the distance from it. This, not

--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentglass-electron",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.4.0",
   "description": "agentglass desktop shell (Electron)",
   "author": "SirAllap",
   "homepage": "https://github.com/SirAllap/agentglass",

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,7 +52,7 @@ import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } f
 import { workspaceRoot, setWorkspaceRoot, inScope, CONFIG_PATH } from "./config.ts";
 import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
-import { updateStatus, startUpdate, updateLog } from "./selfupdate.ts";
+import { updateStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
 import { rateOk } from "./ratelimit.ts";
 import { parseWindowMs } from "./params.ts";
 import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
@@ -536,6 +536,12 @@ const server = Bun.serve<WsData>({
     if (pathname === "/update/status") {
       if (!desktopOnly(req)) return csrfBlocked();
       return json(updateStatus());
+    }
+    // What changed in the release this build came from. Same desktop-only gate
+    // as the rest of /update: the build's origin and tag are in the answer.
+    if (pathname === "/update/notes") {
+      if (!desktopOnly(req)) return csrfBlocked();
+      return json(await releaseNotes(url.searchParams.get("tag") || undefined));
     }
     if (pathname === "/update/log") {
       if (!desktopOnly(req)) return csrfBlocked();

--- a/server/src/selfupdate.ts
+++ b/server/src/selfupdate.ts
@@ -45,7 +45,10 @@ export type BuildInfo = {
 
 /** A release looks like this. Anything else is somebody's private tag. */
 const TAG_RE = /^v\d+\.\d+\.\d+$/;
-const SRC = join(homedir(), ".cache", "agentglass", "source");
+// Overridable by the same env var the update script already reads, so a test
+// can point the clone at a fixture instead of writing into the developer's
+// real one — the mistake #144 fixed for the database.
+const SRC = process.env.AGENTGLASS_UPDATE_SRC || join(homedir(), ".cache", "agentglass", "source");
 const LOG = join(tmpdir(), "agentglass-update.log");
 const STAMP = join(homedir(), ".cache", "agentglass", "last-update.json");
 
@@ -190,4 +193,58 @@ export function startUpdate(): { ok: boolean; error?: string; log?: string } {
 export function updateLog(): { ok: boolean; text: string } {
   try { return { ok: true, text: readFileSync(LOG, "utf8").slice(-8000) }; }
   catch { return { ok: true, text: "" }; }
+}
+
+/**
+ * The notes for a release, so the app can say what changed after it updates
+ * itself.
+ *
+ * Two sources, in the order that keeps working when the network does not.
+ *
+ * The update clone under ~/.cache already has every tag, and the annotation IS
+ * the release notes (release.yml creates the GitHub release from it), so a
+ * machine that has updated once can answer this with no network at all. A
+ * machine installed from a downloaded binary has no clone, and falls back to
+ * the releases API.
+ *
+ * Cached for an hour: notes for a published tag do not change, and the only
+ * caller is a modal that opens once per version.
+ */
+const notesCache = new Map<string, { at: number; notes: string; source: string }>();
+const NOTES_TTL_MS = 60 * 60_000;
+
+export async function releaseNotes(tagIn?: string): Promise<{ ok: boolean; tag: string; notes: string; source: string; error?: string }> {
+  const tag = tagIn && TAG_RE.test(tagIn) ? tagIn : buildInfo().baseTag;
+  if (!tag || !TAG_RE.test(tag)) return { ok: false, tag: "", notes: "", source: "", error: "this build descends from no release" };
+
+  const hit = notesCache.get(tag);
+  if (hit && Date.now() - hit.at < NOTES_TTL_MS) return { ok: true, tag, notes: hit.notes, source: hit.source };
+
+  const keep = (notes: string, source: string) => {
+    if (notesCache.size > 20) notesCache.clear();
+    notesCache.set(tag, { at: Date.now(), notes, source });
+    return { ok: true, tag, notes, source };
+  };
+
+  // The tag object may be there without its annotation if the clone fetched it
+  // shallowly, hence the emptiness check rather than trusting exit status.
+  if (existsSync(join(SRC, ".git"))) {
+    const r = git(SRC, ["tag", "-l", "--format=%(contents)", tag]);
+    const local = r.status === 0 ? r.stdout.trim() : "";
+    if (local) return keep(local, "clone");
+  }
+
+  const repo = /github\.com[:/]+([^/]+)\/(.+?)(?:\.git)?$/.exec(buildInfo().origin);
+  if (!repo) return { ok: false, tag, notes: "", source: "", error: "no release notes available offline for this origin" };
+  try {
+    const res = await fetch(`https://api.github.com/repos/${repo[1]}/${repo[2]}/releases/tags/${tag}`, {
+      headers: { accept: "application/vnd.github+json", "user-agent": "agentglass" },
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) return { ok: false, tag, notes: "", source: "", error: `github answered ${res.status}` };
+    const body = String(((await res.json()) as { body?: unknown }).body ?? "").trim();
+    return body ? keep(body, "github") : { ok: false, tag, notes: "", source: "", error: "that release has no notes" };
+  } catch {
+    return { ok: false, tag, notes: "", source: "", error: "could not reach github for the notes" };
+  }
 }

--- a/server/test/release-notes.test.ts
+++ b/server/test/release-notes.test.ts
@@ -1,0 +1,64 @@
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/**
+ * Release notes read from the update clone.
+ *
+ * The annotation IS the release body (release.yml creates the GitHub release
+ * from it), so a machine that has updated once can answer offline. This drives
+ * that path against a real annotated tag; the GitHub fallback is not exercised
+ * here because a unit test that reaches the network is a flake with a schedule.
+ */
+let clone: string, su: typeof import("../src/selfupdate.ts");
+
+const run = (dir: string, ...args: string[]) => spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+
+const NOTES = "### Terminal\n\n- tmux windows are the panel's own tabs (#154).\n";
+
+beforeAll(async () => {
+  // A fixture clone, not the developer's real one under ~/.cache: selfupdate.ts
+  // reads AGENTGLASS_UPDATE_SRC, set here before it is imported.
+  clone = join(mkdtempSync(join(tmpdir(), "agx-notes-")), "source");
+  process.env.AGENTGLASS_UPDATE_SRC = clone;
+  mkdirSync(clone, { recursive: true });
+  run(clone, "init", "-q", "-b", "main");
+  run(clone, "config", "user.email", "t@example.com");
+  run(clone, "config", "user.name", "t");
+  writeFileSync(join(clone, "a.txt"), "one\n");
+  run(clone, "add", "-A");
+  run(clone, "commit", "-qm", "first");
+  spawnSync("git", ["-C", clone, "tag", "-a", "--cleanup=verbatim", "v9.9.9", "-F", "-"], { input: NOTES, encoding: "utf8" });
+  su = await import("../src/selfupdate.ts");
+});
+
+afterAll(() => { try { rmSync(clone, { recursive: true, force: true }); } catch { /* fine */ } });
+
+describe("release notes", () => {
+  it("refuses a tag that is not a release rather than shelling it out", async () => {
+    // The tag reaches `git` as an argument. Anything that is not vN.N.N falls
+    // back to this build's own base tag instead of being passed through.
+    const r = await su.releaseNotes("; rm -rf /");
+    expect(r.tag === "" || /^v\d+\.\d+\.\d+$/.test(r.tag)).toBe(true);
+  });
+
+  it("reads the annotation out of the update clone, with no network", async () => {
+    const r = await su.releaseNotes("v9.9.9");
+    expect(r.ok).toBe(true);
+    expect(r.source).toBe("clone");
+    expect(r.notes).toContain("tmux windows are the panel's own tabs");
+  });
+
+  it("answers with a shape the client can always read", async () => {
+    // Every failure path returns the same fields, so the modal never has to
+    // guess whether `notes` exists before trimming it.
+    const r = await su.releaseNotes("v0.0.1");
+    expect(typeof r.ok).toBe("boolean");
+    expect(typeof r.tag).toBe("string");
+    expect(typeof r.notes).toBe("string");
+    expect(typeof r.source).toBe("string");
+    if (!r.ok) expect(typeof r.error).toBe("string");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -687,6 +687,18 @@ export type ConflictBlock = {
 /** What to write for one block. `both` keeps ours then theirs. */
 export type BlockChoice = "ours" | "theirs" | "both" | "theirs-first";
 
+/** The notes for one release: the tag annotation the GitHub release was made
+ *  from, read from the update clone when there is one and from the releases API
+ *  otherwise. `source` says which, because "offline" is a useful thing to know
+ *  when the answer is empty. */
+export interface ReleaseNotes {
+  ok: boolean;
+  tag: string;
+  notes: string;
+  source: "clone" | "github" | "";
+  error?: string;
+}
+
 /** What the installed app was built from, and what is waiting upstream. */
 export type UpdateStatus = {
   ok: boolean;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import { newChat, chatResuming, applyLiveEvent } from "./lib/chatStore.ts";
 import { sessionCwd } from "./lib/worktree.ts";
 import { SearchModal } from "./components/SearchModal.tsx";
 import { SettingsModal } from "./components/SettingsModal.tsx";
+import { WhatsNew } from "./components/WhatsNew.tsx";
 import { SessionModal } from "./components/SessionModal.tsx";
 import { ProjectPicker, PICKER_ANSWERED_KEY } from "./components/ProjectPicker.tsx";
 
@@ -486,6 +487,10 @@ export default function App() {
       <SkillsModal open={skillsOpen} onClose={() => setSkillsOpen(false)} />
       <Workspace open={wsOpen} view={wsView} onView={setWsView} onClose={closeWorkspace} chatFocusId={chatFocus} />
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} onSelectApp={(app) => setFilter((f) => ({ ...f, app }))} />
+      {/* Shows once when the app first runs a version it has not run before —
+          the update button restarts into a new build and otherwise says nothing
+          about what changed. */}
+      <WhatsNew />
       <SettingsModal
         open={settingsOpen}
         onClose={() => setSettingsOpen(false)}

--- a/web/src/components/WhatsNew.tsx
+++ b/web/src/components/WhatsNew.tsx
@@ -1,0 +1,92 @@
+import { useEffect, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { api, IS_DEMO } from "../lib/api.ts";
+import { Markdown } from "../lib/markdown.tsx";
+import { markSeen, releaseToAnnounce } from "../lib/whatsNew.ts";
+
+/**
+ * What changed, the first time the app runs a version it has not run before.
+ *
+ * Updating restarted the app and said nothing. The notes already exist — the
+ * tag annotation is what the GitHub release is made from — so the app can show
+ * them once instead of leaving you to go and find the release page, which
+ * nobody does.
+ *
+ * Once. `releaseToAnnounce` decides, and it deliberately stays quiet on a fresh
+ * install and on a downgrade; this component only renders what it is told.
+ * Dismissing marks the version seen, and so does failing to load the notes: an
+ * empty modal on every launch would be worse than no modal at all.
+ */
+export function WhatsNew() {
+  const [tag, setTag] = useState<string | null>(null);
+  const [notes, setNotes] = useState("");
+
+  useEffect(() => {
+    if (IS_DEMO) return;
+    let live = true;
+    // Deliberately after the first paint rather than racing it: the dashboard
+    // connecting matters more than the notes, and the modal is not urgent.
+    const t = setTimeout(() => {
+      api.updateNotes()
+        .then((r) => {
+          if (!live || !r.tag) return;
+          const announce = releaseToAnnounce(r.tag);
+          if (!announce) return;
+          if (!r.ok || !r.notes.trim()) { markSeen(r.tag); return; }
+          setTag(announce);
+          setNotes(r.notes);
+        })
+        .catch(() => { /* offline, or a browser tab the desktop gate refuses */ });
+    }, 2500);
+    return () => { live = false; clearTimeout(t); };
+  }, []);
+
+  const close = () => { if (tag) markSeen(tag); setTag(null); };
+
+  useEffect(() => {
+    if (!tag) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [tag]);
+
+  return (
+    <AnimatePresence>
+      {tag && (
+        <>
+          <motion.div
+            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+            className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+            onClick={close} />
+          <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none" style={{ zIndex: 10001 }}>
+            <motion.div
+              role="dialog" aria-modal="true" aria-label={`What's new in ${tag}`}
+              initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}
+              transition={{ type: "spring", stiffness: 340, damping: 30 }}
+              className="w-[720px] max-w-[95vw] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
+              style={{ maxHeight: "min(78vh, 640px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+
+              <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>What's new</span>
+                <span className="chip" style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }}>{tag}</span>
+                <button onClick={close} className="ml-auto text-[18px] leading-none px-2 t-dim2 hover:opacity-70" aria-label="Close">✕</button>
+              </div>
+
+              <div className="px-5 py-4 overflow-y-auto agx-scroll text-[12.5px]" style={{ color: "var(--text2)" }}>
+                <Markdown text={notes} />
+              </div>
+
+              <div className="px-5 py-3 border-t shrink-0 flex justify-end" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                <button onClick={close} autoFocus
+                  className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
+                  style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)" }}>
+                  got it
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        </>
+      )}
+    </AnimatePresence>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -243,6 +243,7 @@ const realApi = {
   dockerStats: () => get<{ stats: DockerStat[] }>("/docker/stats"),
   dockerLogs: (id: string, tail = 400) => get<{ ok: boolean; text: string; error?: string }>(`/docker/logs?id=${encodeURIComponent(id)}&tail=${tail}`),
   updateStatus: () => get<UpdateStatus>("/update/status"),
+  updateNotes: () => get<ReleaseNotes>("/update/notes"),
   updateRun: () => post<{ ok: boolean; error?: string }>("/update/run", {}),
   updateLog: () => get<{ ok: boolean; text: string }>("/update/log"),
   dockerInspect: (id: string) => get<{ ok: boolean; env: string[]; config: string; error?: string }>(`/docker/inspect?id=${encodeURIComponent(id)}`),
@@ -369,6 +370,7 @@ const demoApi: typeof realApi = {
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),
+  updateNotes: () => D({ ok: false, tag: "", notes: "", source: "", error: "not available in the demo" } as ReleaseNotes),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),
   updateRun: () => D({ ok: false, error: "not available in the demo" }),
   updateLog: () => D({ ok: true, text: "" }),

--- a/web/src/lib/whatsNew.ts
+++ b/web/src/lib/whatsNew.ts
@@ -1,0 +1,49 @@
+/**
+ * Showing the release notes once, after the app has updated itself.
+ *
+ * The update button restarts the app into a new build and says nothing about
+ * what changed — you are left to go and read the release page, which nobody
+ * does. The notes exist (the tag annotation is what the GitHub release is made
+ * from), so the app can simply show them the first time it runs a version it
+ * has not run before.
+ *
+ * Kept out of the component so the one rule with any judgement in it — when NOT
+ * to interrupt — is testable without rendering anything.
+ */
+
+const SEEN_KEY = "agentglass_seen_release";
+
+function read(): string {
+  try { return localStorage.getItem(SEEN_KEY) || ""; } catch { return ""; }
+}
+
+/** Remember a version as seen, whether or not its notes were shown. */
+export function markSeen(tag: string): void {
+  try { localStorage.setItem(SEEN_KEY, tag); } catch { /* private mode */ }
+}
+
+/**
+ * Announce this version, or quietly record it?
+ *
+ * `null` means record and stay silent. That covers the two cases where a modal
+ * would be an intrusion rather than news:
+ *
+ *  - **Nothing seen before.** A fresh install, or the first run after this
+ *    feature shipped. Neither of those is "what changed since last time", and
+ *    greeting someone with release notes for a version they just chose to
+ *    install is noise. The feature starts working from the next release.
+ *  - **A downgrade, or the same version again.** Rolling back is deliberate,
+ *    and being told what is new in the build you just left is nonsense.
+ */
+export function releaseToAnnounce(tag: string, seen = read()): string | null {
+  if (!tag) return null;
+  if (!seen) { markSeen(tag); return null; }
+  if (rank(tag) <= rank(seen)) { markSeen(tag); return null; }
+  return tag;
+}
+
+/** Compare v-prefixed release tags numerically. String order gets v0.10.0 wrong
+ *  against v0.9.0, which is the one comparison that has to survive a year. */
+function rank(tag: string): number {
+  return (tag.match(/\d+/g) ?? []).map(Number).reduce((n, part) => n * 1000 + part, 0);
+}

--- a/web/test/whats-new.test.ts
+++ b/web/test/whats-new.test.ts
@@ -1,0 +1,73 @@
+import { beforeAll, beforeEach, describe, expect, it } from "bun:test";
+
+/**
+ * When to show the release notes, and — the part that matters — when not to.
+ *
+ * A modal that greets a fresh install with notes for the version it just chose,
+ * or congratulates someone on a build they deliberately rolled back from, is
+ * noise. Both cases still record the version, so they resolve rather than
+ * repeat.
+ */
+let wn: typeof import("../src/lib/whatsNew.ts");
+const mem = new Map<string, string>();
+
+beforeAll(async () => {
+  // Assigned, not defaulted: another suite installs its own stub at module
+  // scope, and `??=` silently left this file writing into theirs — green alone,
+  // red in the full run.
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => mem.get(k) ?? null,
+    setItem: (k: string, v: string) => { mem.set(k, v); },
+    removeItem: (k: string) => { mem.delete(k); },
+  };
+  wn = await import("../src/lib/whatsNew.ts");
+});
+
+beforeEach(() => mem.clear());
+
+const seen = () => mem.get("agentglass_seen_release") ?? null;
+
+describe("what's new", () => {
+  it("announces a version newer than the one last seen", () => {
+    expect(wn.releaseToAnnounce("v0.4.0", "v0.3.0")).toBe("v0.4.0");
+  });
+
+  it("stays silent on a first run, and records it", () => {
+    // Nothing seen before is a fresh install or the first launch after this
+    // shipped. Neither is "what changed since last time".
+    expect(wn.releaseToAnnounce("v0.4.0", "")).toBeNull();
+    expect(seen()).toBe("v0.4.0");
+  });
+
+  it("stays silent on the same version", () => {
+    expect(wn.releaseToAnnounce("v0.4.0", "v0.4.0")).toBeNull();
+  });
+
+  it("stays silent on a downgrade, and records where we now are", () => {
+    // Rolling back is deliberate; being told what is new in the build you just
+    // left is nonsense. Recording it means the next upgrade announces again.
+    expect(wn.releaseToAnnounce("v0.3.0", "v0.4.0")).toBeNull();
+    expect(seen()).toBe("v0.3.0");
+  });
+
+  it("compares numerically, so v0.10.0 beats v0.9.0", () => {
+    // The one comparison that has to survive a year of releases.
+    expect(wn.releaseToAnnounce("v0.10.0", "v0.9.0")).toBe("v0.10.0");
+    expect(wn.releaseToAnnounce("v0.9.0", "v0.10.0")).toBeNull();
+  });
+
+  it("does nothing at all without a tag", () => {
+    // A build that descends from no release has nothing to announce, and must
+    // not poison the record with an empty version.
+    expect(wn.releaseToAnnounce("", "v0.4.0")).toBeNull();
+    expect(seen()).toBeNull();
+  });
+
+  it("marks a version seen on demand, for notes that failed to load", () => {
+    // An empty modal on every launch would be worse than no modal, so the
+    // component records the version even when it cannot show anything.
+    wn.markSeen("v0.4.0");
+    expect(seen()).toBe("v0.4.0");
+    expect(wn.releaseToAnnounce("v0.4.0")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Updating restarts the app into a new build and says nothing about what is in it. You just did exactly that — v0.4.0 installed, app reopened, About said "up to date" and that was the whole story. The notes already exist (`release.yml` builds the GitHub release from the tag annotation), so the app can show them once rather than leaving you to go and find the release page, which nobody does.

**Server**: `GET /update/notes` reads the annotation out of the update clone under `~/.cache/agentglass/source`, so a machine that has updated once answers **with no network at all**. An install that came from a downloaded binary has no clone and falls back to the releases API. Cached for an hour, behind the same desktop-only gate as the rest of `/update`.

**Client**: a modal on first run of a version, opening 2.5s after mount so it never competes with the dashboard connecting.

**The judgement lives in `web/src/lib/whatsNew.ts`, not the component**, because when *not* to interrupt is the only interesting part:

- **First run ever** records the version and stays silent. A fresh install is not "what changed since last time", and greeting someone with notes for the version they just chose to install is noise. The practical consequence is that this feature starts working from the *next* release, which I think is the right trade.
- **A downgrade** records and stays silent. Rolling back is deliberate; being told what is new in the build you just left is nonsense.
- **Notes that fail to load** record the version too. An empty modal on every launch would be worse than no modal.

Versions compare numerically, so `v0.10.0` beats `v0.9.0` rather than losing a string comparison a year from now.

Also makes the update clone path honour `AGENTGLASS_UPDATE_SRC` — the variable `self-update.sh` already takes — so tests stop reaching for the developer's real clone, the same class of problem #144 fixed for the database.

## How was it tested?

- New `web/test/whats-new.test.ts`, 7 tests over the announce/record rule: newer announces, first run silent-and-recorded, same version silent, downgrade silent-and-recorded, `v0.10.0` vs `v0.9.0` numeric, empty tag records nothing, explicit `markSeen` suppresses.
- New `server/test/release-notes.test.ts`, 3 tests against a real annotated tag in a fixture clone: the offline clone path returns the annotation, a non-release tag argument is refused rather than shelled out, and every failure path returns the same shape so the modal never guesses.
- `cd server && bun test`: 301 pass. `cd web && bun test`: 157 pass. Both typechecks clean, `vite build` clean.
- One test-isolation bug found and fixed in the process: my suite used `??=` to install a `localStorage` stub, which silently wrote into a stub another suite had already installed. Green alone, red in the full run.

Depends on nothing in #164, but reads best after it — that one fixes the version this modal will be announcing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)