### PR TITLE
fix(git): the panel tells the truth about branches, worktrees and remotes

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -760,24 +760,100 @@ function isSquashMerged(root: string, ref: string, name: string): boolean {
 }
 
 /**
- * Four spawns per branch, so this can't run over every branch of a big repo on
- * a 2.5s poll. The branches anyone is actually trying to delete are the recent
- * ones, so probe those and leave the tail to the ancestry answer. A branch past
- * the cap reads as unmerged, which is the safe direction to be wrong in: it
- * keeps its confirmation prompt instead of losing it.
+ * Was this branch rebase-merged into `ref` — replayed commit by commit?
+ *
+ * Neither check above can see that shape. Ancestry can't, because the replay
+ * gives every commit a new hash. And the squash probe can't either: it asks
+ * about ONE commit carrying the branch's whole diff, and that combined patch-id
+ * matches nothing when the rebase left several separate commits upstream. A
+ * branch merged this way reads as unmerged forever, on both tests at once.
+ *
+ * `git cherry` is the check shaped for it — patch-ids compared per commit, with
+ * a leading `-` on the ones already upstream. Every line a `-` means every
+ * commit this branch adds is in the trunk already under a different hash.
+ *
+ * One spawn, against the squash probe's five, so it goes first.
+ *
+ * Empty output is not an answer, and must not be read as one. It means there
+ * are no non-merge commits ahead: either an ancestor, which `--merged` has
+ * already said, or a branch whose only commits ahead are merges — and a merge
+ * can carry conflict resolutions that exist nowhere else. This can't vouch for
+ * those, so it declines and leaves the branch its confirmation.
+ *
+ * Where it stops, precisely: `git cherry` skips merge commits, so a branch that
+ * pulled the trunk in and hand-resolved a conflict into content living nowhere
+ * else is the one thing a clean run of dashes can still miss. Reaching this
+ * code at all means the remote branch is gone — the PR closed, taking that
+ * resolution upstream with it — so the gap is narrow enough to be worth the
+ * branches it frees. It is the only gap.
  */
-const SQUASH_PROBE_MAX = 20;
+function isRebaseMerged(root: string, ref: string, name: string): boolean {
+  const r = git(root, ["cherry", ref, name]);
+  if (r.code !== 0) return false;
+  const lines = r.stdout.split("\n").filter(Boolean);
+  return lines.length > 0 && lines.every((l) => l.startsWith("-"));
+}
 
-/** How long a completed squash sweep is trusted. Far longer than the ancestry
- *  TTL because it costs ~5 spawns per branch: re-running it every 30s burns a
+/**
+ * Up to five spawns per branch, so this can't run over every branch of a big
+ * repo on a 2.5s poll. The branches anyone is actually trying to delete are the
+ * recent ones, so probe those and leave the tail to the ancestry answer. A
+ * branch past the cap reads as unmerged, which is the safe direction to be
+ * wrong in: it keeps its confirmation prompt instead of losing it.
+ */
+const PROBE_MAX = 20;
+
+/** How long a completed sweep is trusted. Far longer than the ancestry TTL
+ *  because it costs several spawns per branch: re-running it every 30s burns a
  *  second of CPU to learn nothing, and anything that could change the answer
  *  calls invalidateMerged() anyway. */
-const SQUASH_TTL_MS = 5 * 60_000;
+const PROBE_TTL_MS = 5 * 60_000;
 /** Keys whose sweep has finished, and when. Separate from mergedCache so the
  *  cheap ancestry answer can keep refreshing on its own clock. */
-const squashAt = new Map<string, number>();
+const probedAt = new Map<string, number>();
 /** Keys with a sweep in flight, so a burst of polls starts one, not ten. */
-const squashRunning = new Set<string>();
+const probeRunning = new Set<string>();
+
+/**
+ * What the sweep proved, and the tip it proved it at: key → branch → sha.
+ *
+ * The sweep fills the Set the cache entry holds, in place. That works right up
+ * until MERGED_TTL_MS expires and mergedInto() builds a *new* Set from ancestry
+ * alone — and the sweep will not refill it, because PROBE_TTL_MS is ten times
+ * longer and its "swept recently" stamp turns the next call into a no-op. So
+ * every squash- and rebase-merged branch was recognised for thirty seconds out
+ * of every five minutes, and read "not merged — kept" for the other four and a
+ * half. This is what makes a verdict outlive the Set it was written into.
+ *
+ * Keyed by tip sha, because a branch that has moved since is a branch carrying
+ * commits nobody has checked — and the button behind this answer is `branch -D`.
+ */
+const probeMemo = new Map<string, Map<string, string>>();
+
+/** Every local branch and the commit it points at, newest first — one spawn. */
+function branchTips(root: string): Map<string, string> {
+  const r = git(root, ["for-each-ref", "--sort=-committerdate", "refs/heads", `--format=%(refname:short)${US}%(objectname)`]);
+  const out = new Map<string, string>();
+  for (const line of r.stdout.split("\n")) {
+    if (!line) continue;
+    const [name, sha] = line.split(US);
+    if (name && sha) out.set(name, sha);
+  }
+  return out;
+}
+
+/** Re-apply the sweep's verdicts to a freshly built ancestry set, forgetting
+ *  any whose branch has since moved or gone. Costs a spawn, and only when there
+ *  is something to re-apply. */
+function applyMemo(root: string, key: string, set: Set<string>): void {
+  const memo = probeMemo.get(key);
+  if (!memo?.size) return;
+  const tips = branchTips(root);
+  for (const [name, sha] of memo) {
+    if (tips.get(name) === sha) set.add(name);
+    else memo.delete(name);
+  }
+}
 
 function mergedInto(root: string, ref: string): Set<string> {
   // \u0000 rather than a raw NUL byte: written literally it makes the whole
@@ -788,13 +864,15 @@ function mergedInto(root: string, ref: string): Set<string> {
   if (hit && Date.now() - hit.at < MERGED_TTL_MS) return hit.set;
   const r = git(root, ["for-each-ref", "--merged", ref, "refs/heads", "--format=%(refname:short)"]);
   const set = new Set(r.stdout.split("\n").filter(Boolean));
+  applyMemo(root, key, set);
   mergedCache.set(key, { at: Date.now(), set });
-  sweepSquashed(root, ref, key, set);
+  sweepProbes(root, ref, key, set);
   return set;
 }
 
 /**
- * Recover the squash merges ancestry can't see — off the request path.
+ * Recover the merges ancestry can't see — squashed and rebased — off the
+ * request path.
  *
  * This used to run inline, and it is what made the Branches tab take five
  * seconds on a 44-branch repo (measured: 4.95s cold against a 30s TTL, which
@@ -806,16 +884,18 @@ function mergedInto(root: string, ref: string): Set<string> {
  * absent: the UI reads that as "we don't know" and keeps the delete
  * confirmation, which is the safe direction to be wrong in. So the list goes
  * out immediately and the sweep fills the very Set the cache entry holds, in
- * place, so the next poll serves the fuller answer with no extra request.
+ * place, so the next poll serves the fuller answer with no extra request — and
+ * records each verdict in probeMemo, which is what carries it past the moment
+ * that Set is thrown away and rebuilt.
  *
  * Newest first: that's the order for-each-ref gives with this sort, and the
  * order that spends the probe budget where deletes actually happen.
  */
-function sweepSquashed(root: string, ref: string, key: string, set: Set<string>): void {
-  if (squashRunning.has(key)) return;
-  const done = squashAt.get(key);
-  if (done && Date.now() - done < SQUASH_TTL_MS) return;
-  squashRunning.add(key);
+function sweepProbes(root: string, ref: string, key: string, set: Set<string>): void {
+  if (probeRunning.has(key)) return;
+  const done = probedAt.get(key);
+  if (done && Date.now() - done < PROBE_TTL_MS) return;
+  probeRunning.add(key);
 
   // One branch per tick, not the whole sweep in one.
   //
@@ -828,28 +908,34 @@ function sweepSquashed(root: string, ref: string, key: string, set: Set<string>)
   // the whole sweep, so the panel stays responsive while it fills in behind.
   let idx = 0;
   let probes = 0;
-  let all: string[] = [];
+  let started = false;
+  let all: [string, string][] = [];
   const step = () => {
     try {
-      if (!all.length) {
-        all = git(root, ["for-each-ref", "--sort=-committerdate", "refs/heads", "--format=%(refname:short)"])
-          .stdout.split("\n").filter(Boolean);
-      }
+      if (!started) { all = [...branchTips(root)]; started = true; }
       while (idx < all.length) {
-        const name = all[idx++]!;
+        const [name, sha] = all[idx++]!;
         if (set.has(name)) continue;
-        if (probes++ >= SQUASH_PROBE_MAX) { idx = all.length; break; }
-        // Mutates the Set the cache entry already holds, so the next read sees
-        // the fuller answer without another sweep.
-        if (isSquashMerged(root, ref, name)) set.add(name);
+        if (probes++ >= PROBE_MAX) { idx = all.length; break; }
+        // Cheapest test first: one spawn, and it answers for every branch the
+        // trunk took by rebase. The squash probe's five only run when it can't.
+        if (isRebaseMerged(root, ref, name) || isSquashMerged(root, ref, name)) {
+          // Mutates the Set the cache entry already holds, so the next read
+          // sees the fuller answer without another sweep — and the memo keeps
+          // it once that Set expires.
+          set.add(name);
+          let memo = probeMemo.get(key);
+          if (!memo) probeMemo.set(key, (memo = new Map()));
+          memo.set(name, sha);
+        }
         setTimeout(step, 0); // one probe per turn of the loop
         return;
       }
-      squashAt.set(key, Date.now());
-      squashRunning.delete(key);
+      probedAt.set(key, Date.now());
+      probeRunning.delete(key);
     } catch {
       // A failed sweep just leaves the ancestry answer standing.
-      squashRunning.delete(key);
+      probeRunning.delete(key);
     }
   };
   setTimeout(step, 0);
@@ -859,13 +945,17 @@ function sweepSquashed(root: string, ref: string, key: string, set: Set<string>)
 /** Drop the cache after anything that can change what's merged, so the panel
  *  reflects your own action immediately rather than up to a TTL later. */
 export function invalidateMerged(root?: string): void {
-  // Both maps, always. The sweep stamp has a far longer TTL than the ancestry
+  // All three, always. The sweep stamp has a far longer TTL than the ancestry
   // entry, so clearing only the latter would hand the rebuilt entry a "swept
-  // recently" mark and skip the squash pass for minutes — exactly the window
-  // after a merge, when the answer has just changed.
-  if (!root) { mergedCache.clear(); squashAt.clear(); return; }
-  for (const k of mergedCache.keys()) if (k.startsWith(`${root}\u0000`)) mergedCache.delete(k);
-  for (const k of squashAt.keys()) if (k.startsWith(`${root}\u0000`)) squashAt.delete(k);
+  // recently" mark and skip the probe pass for minutes — exactly the window
+  // after a merge, when the answer has just changed. The memo goes with them,
+  // or a verdict recorded before the merge is re-applied to the rebuilt set and
+  // outlives the very event that invalidated it.
+  if (!root) { mergedCache.clear(); probedAt.clear(); probeMemo.clear(); return; }
+  const mine = `${root}\u0000`;
+  for (const m of [mergedCache, probedAt, probeMemo] as Map<string, unknown>[]) {
+    for (const k of m.keys()) if (k.startsWith(mine)) m.delete(k);
+  }
 }
 
 

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -13,7 +13,7 @@ import type {
   ConflictBlock, BlockChoice,
   GitFileChange, GitBranchInfo, WorkingTree, GitRepoRef, GitActionResult, DiffHunk, GitFileStatus,
   GitBranch, GitCommit, GitStash, GitWorktree, GitGraphLine, GitTreeState,
-  GitRemote, GitTag, GitReflogEntry,
+  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry,
 } from "../../shared/types.ts";
 
 export const GIT_WRITE_ENABLED = process.env.AGENTGLASS_GIT_WRITE_DISABLED !== "1";
@@ -918,16 +918,27 @@ export function resetTo(rootIn: string, ref: string, mode: "soft" | "mixed" | "h
   return run(root, ["reset", `--${mode}`, ref]);
 }
 
-/** `git log --graph` rendered to rows: the graph glyphs plus commit fields
- *  (graph-only connector rows carry just `graph`). */
-export function logGraph(rootIn: unknown, limit = 400): { lines: GitGraphLine[] } {
+/**
+ * `git log --graph` rendered to rows: the graph glyphs plus commit fields
+ * (graph-only connector rows carry just `graph`).
+ *
+ * `scope` decides whose history this is, and the default matters. It used to be
+ * `--all` unconditionally, so a worktree on a ticket branch showed 500 commits
+ * belonging to every branch in the repo — on a busy repo the top of the log was
+ * other people's work, and the branch you were standing on was nowhere near the
+ * top. That reads as a bug even though git was doing exactly what it was asked.
+ *
+ * So: HEAD by default — the log of the checkout you are in — with `--all` still
+ * a click away for the times you genuinely want the whole graph.
+ */
+export function logGraph(rootIn: unknown, limit = 400, scope: "head" | "all" = "head"): { lines: GitGraphLine[]; scope: "head" | "all"; branch: string } {
   const root = repoRoot(rootIn);
-  if (!root) return { lines: [] };
+  if (!root) return { lines: [], scope, branch: "" };
   const n = Math.max(1, Math.min(2000, limit | 0));
   // NUL can't go in an argv string (execve truncates at it), so use the same
   // \x1f unit-separator the branch code uses — safe in args, absent from commits.
   const fmt = `${US}%h${US}%an${US}%ar${US}%s${US}%D`;
-  const r = git(root, ["-c", "core.quotePath=false", "log", "--graph", "--all", "--date=relative", `-n${n}`, `--format=${fmt}`]);
+  const r = git(root, ["-c", "core.quotePath=false", "log", "--graph", ...(scope === "all" ? ["--all"] : []), "--date=relative", `-n${n}`, `--format=${fmt}`]);
   const lines: GitGraphLine[] = [];
   for (const raw of r.stdout.split("\n")) {
     if (!raw) continue;
@@ -936,7 +947,9 @@ export function logGraph(rootIn: unknown, limit = 400): { lines: GitGraphLine[] 
     const [hash, author, date, subject, refs] = raw.slice(i + 1).split(US);
     lines.push({ graph: raw.slice(0, i), hash, author, date, subject, refs });
   }
-  return { lines };
+  // Named so the pane can say whose history it is showing rather than leaving
+  // the user to infer it from the commits.
+  return { lines, scope, branch: currentBranch(root) };
 }
 
 // --- worktrees (the user's per-card unit of work) ----------------------------
@@ -1166,9 +1179,10 @@ export function undoMerge(rootIn: unknown): GitActionResult {
   return run(root, ["reset", "--hard", "HEAD^1"]);
 }
 
-export function worktrees(rootIn: unknown): GitWorktree[] {
-  const root = repoRoot(rootIn);
-  if (!root) return [];
+/** `git worktree list --porcelain`, parsed and nothing more — no base branch,
+ *  no rev-list, no per-checkout status. The cheap half, for callers that only
+ *  need to know which paths exist and what is checked out in them. */
+function worktreeList(root: string): GitWorktree[] {
   const r = git(root, ["worktree", "list", "--porcelain"]);
   const out: GitWorktree[] = [];
   let cur: Partial<GitWorktree> | null = null;
@@ -1187,6 +1201,13 @@ export function worktrees(rootIn: unknown): GitWorktree[] {
     else if (line.startsWith("locked")) cur.locked = true;
   }
   flush();
+  return out;
+}
+
+export function worktrees(rootIn: unknown): GitWorktree[] {
+  const root = repoRoot(rootIn);
+  if (!root) return [];
+  const out = worktreeList(root);
   // How far each checkout has drifted from what it was branched off. One
   // rev-list per worktree, cached, and only for the ones on a real branch.
   for (const w of out) {
@@ -1196,20 +1217,81 @@ export function worktrees(rootIn: unknown): GitWorktree[] {
   }
   return out;
 }
-export function addWorktree(rootIn: string, pathIn: unknown, branch: string, newBranch: boolean): GitActionResult {
+
+/**
+ * The worktree list, plus how dirty each checkout is.
+ *
+ * Split from `worktrees()` because it costs a `git status` per checkout — a
+ * dozen subprocesses on a worktree-heavy repo, which the repo picker already
+ * pays for the same paths, but which callers like `discoverRepos` must not pay
+ * twice. Run concurrently, so it's one status' worth of wall clock rather than
+ * a dozen.
+ *
+ * The panel needs this for one reason: `syncFromBase` refuses to merge into a
+ * dirty checkout, and a button that can only fail is worse than a disabled one.
+ */
+export async function worktreesWithState(rootIn: unknown): Promise<GitWorktree[]> {
+  const out = worktrees(rootIn);
+  await Promise.all(out.map(async (w) => {
+    if (w.bare) return; // no working tree to be dirty
+    const r = await gitAsync(w.path, ["status", "--porcelain"]);
+    // A checkout whose directory was deleted from under git answers non-zero;
+    // "unknown" is honest there, and leaves the button enabled rather than
+    // silently blocking on a status we never got.
+    if (r.code === 0) w.dirty = r.stdout.split("\n").filter(Boolean).length;
+  }));
+  return out;
+}
+/**
+ * Where a new worktree is allowed to land.
+ *
+ * safeAbs alone accepts any absolute path, which would let a caller plant a
+ * full checkout anywhere the server can write — a served web root, an autostart
+ * directory. So this is an allowlist of two shapes, and only two:
+ *
+ *   * `<repo>-<name>` beside the repo — the sibling layout, which is what the
+ *     panel's own "+ add worktree" has always sent (`${root}-${branch}`) and
+ *     what a worktree-per-ticket setup looks like on disk. It was NOT accepted
+ *     here, so that button answered "worktree path must be under
+ *     <repo>/.worktrees/" every single time it was pressed, for every user,
+ *     since the first release. The rule and its only caller disagreed, and the
+ *     rule was the one nobody read.
+ *   * `<repo>/.worktrees/<name>` — the nested layout, kept because it was the
+ *     documented one. It has a cost the sibling layout doesn't: the directory
+ *     is untracked, so the repo reports itself dirty forever after.
+ *
+ * A prefix test is enough for both because the name is a single path segment:
+ * `dirname` of the candidate must be exactly the repo's parent (so `../..`
+ * cannot climb) and the basename must start with the repo's own.
+ */
+function worktreeSpot(root: string, abs: string): boolean {
+  const nested = resolve(root, ".worktrees");
+  if (abs !== nested && abs.startsWith(nested + sep)) return true;
+  const parent = dirname(root);
+  return dirname(abs) === parent && basename(abs).startsWith(basename(root) + "-");
+}
+
+/**
+ * `startPoint` is what the new branch is cut from — a remote branch, when the
+ * Remotes tab is the one asking. Omitted it means HEAD, which is right for
+ * "start a new card from where I am" and wrong for "give me a checkout of
+ * somebody's branch", and those are the two things this call is used for.
+ */
+export function addWorktree(rootIn: string, pathIn: unknown, branch: string, newBranch: boolean, startPoint?: unknown): GitActionResult {
   const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
   const g = guard(root); if (g) return g;
   const abs = safeAbs(pathIn); if (!abs) return { ok: false, error: "invalid path" };
-  // Confine the checkout to the repo's own .worktrees/. safeAbs alone accepts
-  // any absolute path, which let a caller plant a full checkout anywhere it
-  // could write — a served web root, an autostart dir. A worktree belongs under
-  // its repo; nothing legitimate needs it elsewhere.
-  const wtBase = resolve(root, ".worktrees");
-  if (abs !== wtBase && !abs.startsWith(wtBase + sep)) {
-    return { ok: false, error: "worktree path must be under <repo>/.worktrees/" };
+  if (!worktreeSpot(root, abs)) {
+    return { ok: false, error: `worktree path must be ${basename(root)}-<name> beside the repo, or under ${basename(root)}/.worktrees/` };
   }
   if (!validRef(branch)) return { ok: false, error: "invalid branch name" };
-  return run(root, newBranch ? ["worktree", "add", "-b", branch, abs] : ["worktree", "add", abs, branch]);
+  let from: string[] = [];
+  if (startPoint != null && startPoint !== "") {
+    if (typeof startPoint !== "string" || !validRef(startPoint)) return { ok: false, error: "invalid start point" };
+    if (git(root, ["rev-parse", "--verify", "--quiet", startPoint]).code !== 0) return { ok: false, error: `${startPoint} does not exist here — fetch first` };
+    from = [startPoint];
+  }
+  return run(root, newBranch ? ["worktree", "add", "-b", branch, abs, ...from] : ["worktree", "add", abs, branch]);
 }
 export function removeWorktree(rootIn: string, pathIn: unknown, force: boolean): GitActionResult {
   const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
@@ -1284,6 +1366,99 @@ export function remotes(rootIn: unknown): GitRemote[] {
     byName.set(name, cur);
   }
   return [...byName.values()];
+}
+
+/**
+ * The branches on one remote, newest first, each marked with whether you
+ * already have it.
+ *
+ * Read from `refs/remotes/<remote>/*` — the last fetch's answer, not a live
+ * call to the server. That is the honest thing to show: every other number in
+ * this panel (ahead, behind, gone) is measured against exactly these refs, and
+ * a list that quietly went and asked the network would disagree with all of
+ * them.
+ *
+ * Sent whole rather than paged. 800 refs is one `for-each-ref` and ~100KB of
+ * JSON; paging it server-side would mean a round trip per keystroke of the
+ * search box, for a list the client can filter in a frame. The rendering side
+ * is where the cost actually was, and useIncremental already handles that.
+ *
+ * `origin/HEAD` is dropped: it is a symbolic pointer at another row in this
+ * same list, not a branch of its own.
+ */
+export function remoteBranches(rootIn: unknown, remoteIn: unknown, limit = 3000): { ok: boolean; remote: string; branches: GitRemoteBranch[]; error?: string } {
+  const root = repoRoot(rootIn);
+  if (!root) return { ok: false, remote: "", branches: [], error: "not a git repository root" };
+  const remote = typeof remoteIn === "string" && remoteIn ? remoteIn : (remotes(root)[0]?.name ?? "");
+  if (!remote) return { ok: true, remote: "", branches: [] };
+  if (!validRef(remote) || remote.includes("/")) return { ok: false, remote: "", branches: [], error: "invalid remote" };
+
+  // What you already have, so the list can answer "do I have this one" without
+  // a call per row: local heads, what each one tracks, and which checkout has
+  // it out.
+  const localTracks = new Map<string, string>(); // local branch -> its upstream
+  for (const line of git(root, ["for-each-ref", `--format=%(refname:short)${US}%(upstream:short)`, "refs/heads"]).stdout.split("\n")) {
+    if (!line) continue;
+    const [name, upstream] = line.split(US);
+    if (name) localTracks.set(name, upstream || "");
+  }
+  const checkedOut = new Map<string, string>(); // branch -> worktree path
+  for (const w of worktreeList(root)) if (w.branch && w.branch !== "(detached)") checkedOut.set(w.branch, w.path);
+
+  const n = Math.max(1, Math.min(10_000, limit | 0));
+  const fmt = `%(refname:short)${US}%(objectname:short)${US}%(contents:subject)${US}%(authorname)${US}%(committerdate:relative)`;
+  const r = git(root, ["-c", "core.quotePath=false", "for-each-ref", "--sort=-committerdate", `--count=${n}`, `refs/remotes/${remote}`, `--format=${fmt}`]);
+  const branches: GitRemoteBranch[] = [];
+  for (const line of r.stdout.split("\n")) {
+    if (!line) continue;
+    const [ref, hash, subject, author, date] = line.split(US);
+    if (!ref || !ref.startsWith(remote + "/")) continue;
+    const name = ref.slice(remote.length + 1);
+    if (!name || name === "HEAD") continue;
+    const upstream = localTracks.get(name);
+    branches.push({
+      name, ref, hash: hash || "", subject: subject || "", author: author || "", date: date || "",
+      local: upstream !== undefined,
+      tracking: upstream === ref,
+      ...(checkedOut.has(name) ? { worktree: checkedOut.get(name)! } : {}),
+    });
+  }
+  return { ok: true, remote, branches };
+}
+
+/**
+ * Make a remote branch local: a branch of the same name, tracking it.
+ *
+ * `switch` decides whether this checkout moves onto it. Both exist because both
+ * are wanted — "let me look at this PR" wants the switch, and "grab it, I'll
+ * open it in a worktree later" must not yank the working tree out from under
+ * an agent that is mid-edit.
+ *
+ * Refuses when the local name is taken rather than silently reusing it: the
+ * existing branch may be a *different* branch that happens to share a name, and
+ * the difference between checking that out and checking out the remote's
+ * version is somebody's afternoon.
+ */
+export function trackRemoteBranch(rootIn: unknown, refIn: unknown, opts: { switch?: boolean } = {}): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  const ref = typeof refIn === "string" ? refIn : "";
+  if (!validRef(ref) || !ref.includes("/")) return { ok: false, error: "invalid remote branch" };
+  // The remote prefix has to be a real remote, or "origin/feature/x" and a
+  // local branch literally called that are indistinguishable.
+  const remote = ref.slice(0, ref.indexOf("/"));
+  if (!remotes(root).some((r) => r.name === remote)) return { ok: false, error: `no remote called ${remote}` };
+  const name = ref.slice(remote.length + 1);
+  if (!name || name === "HEAD" || !validRef(name)) return { ok: false, error: "invalid branch name" };
+  if (git(root, ["rev-parse", "--verify", "--quiet", `refs/remotes/${ref}`]).code !== 0) {
+    return { ok: false, error: `${ref} is not here — fetch first` };
+  }
+  if (git(root, ["rev-parse", "--verify", "--quiet", `refs/heads/${name}`]).code === 0) {
+    return { ok: false, error: `you already have a local ${name} — check it out from the Branches tab` };
+  }
+  return opts.switch
+    ? run(root, ["switch", "-c", name, "--track", ref])
+    : run(root, ["branch", "--track", name, ref]);
 }
 
 /** Tags, newest first. `creatordate` rather than `taggerdate` so lightweight

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1353,7 +1353,10 @@ export function remotes(rootIn: unknown): GitRemote[] {
   const counts = new Map<string, number>();
   for (const line of git(root, ["for-each-ref", "--format=%(refname:short)", "refs/remotes"]).stdout.split("\n")) {
     const name = line.split("/")[0];
-    if (name) counts.set(name, (counts.get(name) ?? 0) + 1);
+    // `origin/HEAD` is a pointer at another ref in this list, not a branch of
+    // its own — remoteBranches() drops it, so counting it here made the tab
+    // claim 790 over a list of 789.
+    if (name && !line.endsWith("/HEAD")) counts.set(name, (counts.get(name) ?? 0) + 1);
   }
   const byName = new Map<string, GitRemote>();
   for (const line of git(root, ["remote", "-v"]).stdout.split("\n")) {

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1353,10 +1353,14 @@ export function remotes(rootIn: unknown): GitRemote[] {
   const counts = new Map<string, number>();
   for (const line of git(root, ["for-each-ref", "--format=%(refname:short)", "refs/remotes"]).stdout.split("\n")) {
     const name = line.split("/")[0];
-    // `origin/HEAD` is a pointer at another ref in this list, not a branch of
-    // its own — remoteBranches() drops it, so counting it here made the tab
-    // claim 790 over a list of 789.
-    if (name && !line.endsWith("/HEAD")) counts.set(name, (counts.get(name) ?? 0) + 1);
+    // Count `origin/x`, never `origin` on its own.
+    //
+    // That bare line IS `refs/remotes/origin/HEAD`: `%(refname:short)` shortens
+    // a remote's HEAD all the way down to the remote's name, so the obvious
+    // guard — skipping refs that end in `/HEAD` — silently matches nothing.
+    // It is a pointer at another ref in this same list, and remoteBranches()
+    // drops it, so counting it made the tab claim 790 over a list of 789.
+    if (name && line.includes("/") && !line.endsWith("/HEAD")) counts.set(name, (counts.get(name) ?? 0) + 1);
   }
   const byName = new Map<string, GitRemote>();
   for (const line of git(root, ["remote", "-v"]).stdout.split("\n")) {

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1011,9 +1011,23 @@ export function invalidateMerged(root?: string): void {
 }
 
 
-export function branches(rootIn: unknown): { current: string; branches: GitBranch[]; trunk: string | null } {
+/**
+ * Is the squash/rebase sweep still running for this trunk?
+ *
+ * It fills in behind the response on purpose (see sweepProbes), so a branch
+ * merged through the GitHub button is recognised a moment AFTER the list is
+ * first drawn. Left unsaid, that reads as a bug: the button says "delete 3
+ * merged" when the panel opens and "delete 4 merged" when you come back to it,
+ * with nothing on screen accounting for the extra one.
+ */
+export function mergedSweeping(rootIn: unknown, ref: string): boolean {
   const root = repoRoot(rootIn);
-  if (!root) return { current: "", branches: [], trunk: null };
+  return !!root && probeRunning.has(`${root}\u0000${ref}`);
+}
+
+export function branches(rootIn: unknown): { current: string; branches: GitBranch[]; trunk: string | null; sweeping: boolean } {
+  const root = repoRoot(rootIn);
+  if (!root) return { current: "", branches: [], trunk: null, sweeping: false };
   const fmt = `%(refname:short)${US}%(HEAD)${US}%(upstream:short)${US}%(upstream:track)${US}%(committerdate:relative)${US}%(contents:subject)`;
   const r = git(root, ["for-each-ref", "--sort=-committerdate", "refs/heads", `--format=${fmt}`]);
   const trunk = defaultBranch(root);
@@ -1030,7 +1044,10 @@ export function branches(rootIn: unknown): { current: string; branches: GitBranc
       ...(merged ? { mergedIntoTrunk: merged.has(name) } : {}),
     });
   }
-  return { current: currentBranch(root), branches: list, trunk };
+  // Read AFTER mergedInto(), which is what starts the sweep — asked before, it
+  // is always false on the very first call and the caller never learns that the
+  // count it is showing is still moving.
+  return { current: currentBranch(root), branches: list, trunk, sweeping: !!trunk && mergedSweeping(root, trunk) };
 }
 
 // lazygit-style branch ops

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -13,7 +13,7 @@ import type {
   ConflictBlock, BlockChoice,
   GitFileChange, GitBranchInfo, WorkingTree, GitRepoRef, GitActionResult, DiffHunk, GitFileStatus,
   GitBranch, GitCommit, GitStash, GitWorktree, GitGraphLine, GitTreeState,
-  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry,
+  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, WorktreeLeftovers,
 } from "../../shared/types.ts";
 
 export const GIT_WRITE_ENABLED = process.env.AGENTGLASS_GIT_WRITE_DISABLED !== "1";
@@ -1435,6 +1435,110 @@ export function addWorktree(rootIn: string, pathIn: unknown, branch: string, new
   }
   return run(root, newBranch ? ["worktree", "add", "-b", branch, abs, ...from] : ["worktree", "add", abs, branch]);
 }
+/**
+ * Ignored paths that are output, not work — safe to leave out of "here is what
+ * you lose", because deleting them costs a rebuild and nothing else.
+ *
+ * Deliberately short, and matched on whole path segments. Every name here is
+ * one whose contents are reproducible from the repo by definition of the tool
+ * that writes it. `dist`, `build`, `target`, `out` and `.cache` are NOT here
+ * and are not oversights: they're plausible directory names for real sources in
+ * a repo somebody else laid out, and the cost of being wrong is asymmetric —
+ * over-listing makes a confirmation dialog longer, under-listing deletes work.
+ */
+const REBUILDABLE = new Set([
+  "__pycache__", ".mypy_cache", ".ruff_cache", ".pytest_cache", ".tox",
+  "node_modules", ".venv", "venv", ".turbo", ".parcel-cache", ".next",
+  ".gradle", ".eggs", ".nyc_output", ".sass-cache", "htmlcov", "coverage",
+  ".DS_Store",
+]);
+const rebuildable = (rel: string): boolean =>
+  rel.split("/").some((seg) => REBUILDABLE.has(seg) || seg.endsWith(".egg-info")) ||
+  /\.(pyc|pyo)$/.test(rel);
+
+/** How many paths a single leftovers report will name before it starts
+ *  counting. Long enough to be a list you read, short enough to stay one. */
+const LEFTOVERS_MAX = 12;
+/** Ignored directories opened up to see what's inside — one git call each. */
+const EXPAND_MAX = 8;
+
+/**
+ * What `git worktree remove` would delete here that git would never warn about.
+ *
+ * The whole point is the ignored files. Git refuses to remove a worktree with
+ * modified or untracked files, so those already have a guard; ignored ones have
+ * none, and `remove` (no `--force`) deletes them silently — measured, not
+ * assumed: a worktree whose only content is a gitignored `secrets.env` reports
+ * `status --porcelain` empty and is removed with exit 0, file included.
+ *
+ * On a real checkout that is `compose/envs/*.env` and a page of local notes
+ * sitting beside four hundred `__pycache__/` directories, so the ignored list
+ * is filtered through REBUILDABLE — otherwise the noise buries the one line
+ * that mattered, and a dialog nobody reads guards nothing.
+ *
+ * `--ignored` in its traditional mode, not `=matching`: it collapses an ignored
+ * directory to one entry instead of listing every file under it, which is the
+ * difference between 403 lines and 3356 on this repo, and 100ms of work.
+ */
+export async function worktreeLeftovers(rootIn: string, pathIn: unknown): Promise<WorktreeLeftovers> {
+  const root = repoRoot(rootIn);
+  const abs = safeAbs(pathIn);
+  if (!root || !abs) return { path: String(pathIn ?? ""), files: [], more: 0, skipped: 0, error: "invalid path" };
+  // Only a path this repo actually owns as a worktree, so this can't be used to
+  // enumerate arbitrary directories through the API.
+  if (!worktreeList(root).some((w) => w.path === abs)) {
+    return { path: abs, files: [], more: 0, skipped: 0, error: "not a worktree of this repository" };
+  }
+  const r = await gitAsync(abs, ["-c", "core.quotePath=false", "status", "--porcelain=v1", "--ignored"]);
+  // A directory git can't read is not an empty one. Say so, and let the caller
+  // present it as a reason to keep the worktree rather than a green light.
+  if (r.code !== 0) return { path: abs, files: [], more: 0, skipped: 0, error: r.stderr.trim() || "could not read that checkout" };
+
+  const parse = (out: string): { code: string; rel: string }[] =>
+    out.split("\n").filter((l) => l.length >= 4).map((l) => ({
+      code: l.slice(0, 2),
+      // Quoted when the path has odd bytes in it; core.quotePath=false keeps
+      // UTF-8 readable, and the quotes that remain are honest about the rest.
+      rel: l.slice(3).replace(/^"|"$/g, ""),
+    })).filter((e) => e.rel);
+
+  const work: string[] = [];    // modified / untracked — git already guards these
+  const ignored: string[] = []; // the ones nothing guards
+  const dirs: string[] = [];    // ignored directories worth looking inside
+  let skipped = 0;
+  for (const { code, rel } of parse(r.stdout)) {
+    if (code !== "!!") { work.push(rel); continue; }
+    if (rebuildable(rel)) { skipped++; continue; }
+    if (rel.endsWith("/")) dirs.push(rel); else ignored.push(rel);
+  }
+
+  // A directory whose every entry is ignored collapses to one line — `cfg/`,
+  // not `cfg/local.env` and `cfg/__pycache__/`. That single line is both too
+  // alarming and too vague: it can be nothing but a cache, or it can be the one
+  // env file you needed, and it reads identically either way. So look inside
+  // the ones we don't already recognise, one level, and let the names speak.
+  //
+  // Bounded, and only ever a handful in practice: a directory collapses only
+  // when it holds nothing tracked at all. Past the cap the directory keeps its
+  // own name in the list, which over-reports rather than under-reports.
+  const expand = dirs.slice(0, EXPAND_MAX);
+  ignored.push(...dirs.slice(EXPAND_MAX));
+  const inner = await Promise.all(expand.map((d) =>
+    gitAsync(abs, ["-c", "core.quotePath=false", "status", "--porcelain=v1", "--ignored=matching", "--", d])));
+  for (let i = 0; i < expand.length; i++) {
+    const entries = inner[i]!.code === 0 ? parse(inner[i]!.stdout).filter((e) => e.code === "!!") : [];
+    // Couldn't see inside, or it told us nothing new: keep the directory itself
+    // on the list rather than dropping it.
+    if (!entries.length) { ignored.push(expand[i]!); continue; }
+    for (const { rel } of entries) { if (rebuildable(rel)) skipped++; else ignored.push(rel); }
+  }
+
+  // Work git would have stopped for goes first: if there is any, the answer is
+  // "don't do this" and it should be the first thing read.
+  const all = [...work, ...ignored];
+  return { path: abs, files: all.slice(0, LEFTOVERS_MAX), more: Math.max(0, all.length - LEFTOVERS_MAX), skipped };
+}
+
 export function removeWorktree(rootIn: string, pathIn: unknown, force: boolean): GitActionResult {
   const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
   const g = guard(root); if (g) return g;

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -13,7 +13,7 @@ import type {
   ConflictBlock, BlockChoice,
   GitFileChange, GitBranchInfo, WorkingTree, GitRepoRef, GitActionResult, DiffHunk, GitFileStatus,
   GitBranch, GitCommit, GitStash, GitWorktree, GitGraphLine, GitTreeState,
-  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, WorktreeLeftovers, LeftoverEntry,
+  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, WorktreeLeftovers, LeftoverEntry, BlockedByOwner,
 } from "../../shared/types.ts";
 
 export const GIT_WRITE_ENABLED = process.env.AGENTGLASS_GIT_WRITE_DISABLED !== "1";
@@ -1521,6 +1521,69 @@ function readOneLevel(worktree: string, dir: string): string[] {
   } catch { return [dir]; }
 }
 
+/** Entries walked looking for foreign owners before the answer becomes "at
+ *  least this many". One is already enough to block the removal; the rest of
+ *  the count is only there to make the message honest. */
+const OWNER_SCAN_MAX = 20_000;
+
+/**
+ * Paths in this checkout that belong to somebody else.
+ *
+ * A repo built with docker-compose gets `tmp/`, `.mypy_cache/` and
+ * `.ruff_cache/` written by a container running as root, straight into the
+ * bind-mounted worktree. They are root:root on the host, so nothing the user
+ * runs can delete them — and `git worktree remove --force` finds that out
+ * halfway through, AFTER it has already deleted the worktree's registration.
+ * What is left is a directory that is no longer a worktree of anything, with
+ * some of its tracked files gone: measured on a real repo, 1450 files deleted
+ * out of one checkout and its registration destroyed, while the root-owned
+ * caches sat there untouched.
+ *
+ * So this is a precondition, not a diagnosis after the fact.
+ *
+ * Reported per top-level directory because that is the unit that gets fixed:
+ * one `chown -R` on `tmp/` settles the four hundred files under it.
+ */
+export function foreignOwned(dir: string): BlockedByOwner | null {
+  const me = typeof process.getuid === "function" ? process.getuid() : -1;
+  if (me < 0) return null; // no uids to compare (Windows) — nothing to claim
+  const tops = new Set<string>();
+  const owners = new Set<string>();
+  let count = 0, seen = 0, more = false;
+
+  const walk = (abs: string, top: string): void => {
+    if (seen >= OWNER_SCAN_MAX) { more = true; return; }
+    let entries;
+    try { entries = readdirSync(abs, { withFileTypes: true }); } catch { return; }
+    for (const e of entries) {
+      if (seen++ >= OWNER_SCAN_MAX) { more = true; return; }
+      const child = join(abs, e.name);
+      if (e.isSymbolicLink()) continue; // the link is ours even when the target isn't
+      let st;
+      try { st = statSync(child); } catch { continue; }
+      if (st.uid !== me) {
+        count++;
+        tops.add(top || e.name);
+        owners.add(String(st.uid));
+        // No need to descend: the whole subtree goes in one chown, and walking
+        // 30k root-owned cache files to raise a number nobody reads is waste.
+        if (e.isDirectory()) continue;
+      } else if (e.isDirectory()) {
+        walk(child, top || e.name);
+      }
+    }
+  };
+  walk(dir, "");
+  if (!count) return null;
+  return {
+    count, more,
+    paths: [...tops].sort().slice(0, 12),
+    // uid 0 is root everywhere; anything else is named by number, which is
+    // still what `chown` wants.
+    owners: [...owners].map((u) => (u === "0" ? "root" : `uid ${u}`)),
+  };
+}
+
 /** The repository's main working checkout — where a rescued file belongs.
  *  `git worktree list` puts it first; that is its documented order, and it is
  *  the one entry whose `.git` is a real directory rather than a file. */
@@ -1681,9 +1744,13 @@ export async function worktreeLeftovers(rootIn: string, pathIn: unknown): Promis
   // gets cut at twelve.
   entries.sort((a, b) =>
     Number(a.vsMain === "differs") - Number(b.vsMain === "differs") || a.bytes - b.bytes || a.path.localeCompare(b.path));
+  // Asked here rather than at removal time so the dialog can say "this one
+  // can't go" while there is still a decision to make about it.
+  const blocked = foreignOwned(abs);
   return {
     path: abs, entries: entries.slice(0, LEFTOVERS_MAX),
     more: Math.max(0, entries.length - LEFTOVERS_MAX), skipped, identical,
+    ...(blocked ? { blocked } : {}),
   };
 }
 
@@ -1742,12 +1809,114 @@ export async function rescueLeftovers(rootIn: string, pathIn: unknown, relsIn: u
   return { ok: skipped.length === 0, copied, skipped, ...(skipped.length ? { error: `${skipped.length} of ${rels.length} not copied` } : {}) };
 }
 
+/**
+ * Put back the administrative entry `git worktree remove` deletes first.
+ *
+ * Its removal is not atomic: the registration under `.git/worktrees/<name>`
+ * goes before the files do, so a removal that fails partway — a root-owned
+ * cache it cannot unlink — leaves a full directory that is no longer a worktree
+ * of anything. `git worktree repair` does not help: it relinks a worktree that
+ * MOVED, and refuses here because the directory it would point at is gone.
+ *
+ * Rebuilding it by hand is three small files and a `reset`, which is what git
+ * itself writes. The reset restores the index from HEAD without touching the
+ * working tree, so tracked files that survived stay exactly as they are and the
+ * ones the failed removal did delete show up as deletions to restore, rather
+ * than as a checkout nobody can read.
+ */
+function restoreRegistration(root: string, abs: string, branch: string): boolean {
+  try {
+    const dotgit = join(abs, ".git");
+    if (!existsSync(dotgit)) return false;
+    // The name git used, read back out of the worktree's own .git pointer, so
+    // this cannot invent a different one.
+    const ref = readFileSync(dotgit, "utf8").replace(/^gitdir:\s*/, "").trim();
+    const name = basename(ref);
+    if (!name) return false;
+    const admin = join(gitDir(root) ?? join(root, ".git"), "worktrees", name);
+    if (existsSync(admin)) return false; // still registered — nothing to undo
+    mkdirSync(admin, { recursive: true });
+    writeFileSync(join(admin, "gitdir"), `${dotgit}\n`);
+    writeFileSync(join(admin, "commondir"), "../..\n");
+    writeFileSync(join(admin, "HEAD"), branch && branch !== "(detached)" ? `ref: refs/heads/${branch}\n` : "");
+    git(abs, ["reset", "-q"]);
+    return true;
+  } catch { return false; }
+}
+
+/**
+ * Hand a worktree's files back to the user, through the system's own auth
+ * dialog, so the removal it blocks can proceed.
+ *
+ * Three deliberate limits, because this is the only place in the app that
+ * reaches root:
+ *
+ *   1. `pkexec`, not `sudo`. The password prompt is the desktop's, it shows the
+ *      exact command being elevated, and this process never sees, stores or
+ *      transports the password. An input of our own asking for a sudo password
+ *      is the thing not to build, whatever it would save.
+ *   2. `chown` and nothing else. Never `rm` as root. Root's job is to give the
+ *      files back; the deletion still happens as the user afterwards, subject
+ *      to every check that already exists. The worst outcome of a bug here is
+ *      that a directory the user owns becomes a directory the user owns.
+ *   3. The path is not taken from the caller. It has to match a worktree this
+ *      repository currently reports, so a crafted request cannot point root at
+ *      an arbitrary directory. Arguments go as an array — there is no shell to
+ *      inject into.
+ */
+export function fixWorktreeOwnership(rootIn: string, pathIn: unknown): GitActionResult {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  const abs = safeAbs(pathIn); if (!abs) return { ok: false, error: "invalid path" };
+  // Only a path git itself vouches for, and never the checkout we are in.
+  if (abs === root) return { ok: false, error: "that is the main checkout" };
+  if (!worktreeList(root).some((w) => w.path === abs)) return { ok: false, error: "not a worktree of this repository" };
+  if (!foreignOwned(abs)) return { ok: true, output: "already yours" };
+
+  const uid = typeof process.getuid === "function" ? process.getuid() : -1;
+  const gid = typeof process.getgid === "function" ? process.getgid() : -1;
+  if (uid < 0 || gid < 0) return { ok: false, error: "no user to hand ownership to on this platform" };
+
+  const p = Bun.spawnSync(["pkexec", "chown", "-R", `${uid}:${gid}`, "--", abs], { stdout: "pipe", stderr: "pipe" });
+  const err = p.stderr?.toString().trim() ?? "";
+  if (p.exitCode === 126 || /dismissed|not authorized/i.test(err)) return { ok: false, error: "cancelled" };
+  if (p.exitCode !== 0) return { ok: false, error: err || `pkexec exited ${p.exitCode}` };
+  // Verified, not assumed: pkexec can succeed while chown skips something.
+  const left = foreignOwned(abs);
+  return left
+    ? { ok: false, error: `still ${left.count}${left.more ? "+" : ""} files owned by ${left.owners.join(", ")}` }
+    : { ok: true, output: "ownership restored" };
+}
+
 export function removeWorktree(rootIn: string, pathIn: unknown, force: boolean): GitActionResult {
   const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
   const g = guard(root); if (g) return g;
   const abs = safeAbs(pathIn); if (!abs) return { ok: false, error: "invalid path" };
   if (abs === root) return { ok: false, error: "can't remove the current worktree" };
-  return run(root, force ? ["worktree", "remove", "--force", abs] : ["worktree", "remove", abs]);
+
+  // Refuse rather than start something that cannot finish. Git deletes the
+  // registration before the files, so "try it and see" is not free: the failure
+  // mode is a directory that is no longer a worktree, missing some of its
+  // tracked files, with the undeletable ones still sitting there.
+  const blocked = foreignOwned(abs);
+  if (blocked) {
+    const what = blocked.paths.map((p) => `${basename(abs)}/${p}`).join(" ");
+    return {
+      ok: false,
+      error: `${blocked.count}${blocked.more ? "+" : ""} files here belong to ${blocked.owners.join(", ")} — a container wrote them. `
+        + `Nothing can delete them as you, and a partial removal would leave this directory orphaned.\n\n`
+        + `Fix it first:\n  sudo chown -R "$(id -un):$(id -gn)" ${what}`,
+    };
+  }
+
+  // The branch, captured while the worktree is still registered — it is what
+  // the registration has to be rebuilt from if the removal fails anyway.
+  const branch = worktreeList(root).find((w) => w.path === abs)?.branch ?? "";
+  const r = run(root, force ? ["worktree", "remove", "--force", abs] : ["worktree", "remove", abs]);
+  if (!r.ok && existsSync(abs) && restoreRegistration(root, abs, branch)) {
+    return { ...r, error: `${r.error ?? "worktree remove failed"} — the worktree is still registered; nothing was left orphaned` };
+  }
+  return r;
 }
 
 export function checkout(rootIn: string, name: string): GitActionResult {

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1803,6 +1803,13 @@ export async function rescueLeftovers(rootIn: string, pathIn: unknown, relsIn: u
       // preserve. `-n` is a second refusal to clobber behind the check above.
       const p = Bun.spawnSync(["cp", "-Rn", from, to], { stdout: "pipe", stderr: "pipe" });
       if (p.exitCode !== 0) { skipped.push({ path: rel, why: p.stderr?.toString().trim() || "copy failed" }); continue; }
+      // Look, rather than believe the exit code. `cp -n` returns 0 when it
+      // declines to overwrite, and a caller about to delete the original needs
+      // "it is there" to mean the file is there. Five screenshots were reported
+      // copied, were not on disk, and the checkout holding them was removed
+      // straight after — the cause is still unknown, so this closes the hole
+      // the cause can come through.
+      if (!existsSync(to)) { skipped.push({ path: rel, why: "copy reported success but nothing arrived" }); continue; }
       copied.push(rel);
     } catch (e) { skipped.push({ path: rel, why: String(e) }); }
   }

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -5,7 +5,7 @@
 // every mutating op is gated by AGENTGLASS_GIT_WRITE_DISABLED=1.
 
 import { resolve, basename, relative, dirname, sep, join } from "node:path";
-import { statSync, readFileSync, writeFileSync, readdirSync, existsSync } from "node:fs";
+import { statSync, readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs";
 import { git, gitAsync, safeAbs, repoRootOf, currentBranch } from "./git.ts";
 import { configuredRepoDirs, workspaceRoot, inScope } from "./config.ts";
 import { worktreeParent, gitDir } from "./worktree.ts";
@@ -13,7 +13,7 @@ import type {
   ConflictBlock, BlockChoice,
   GitFileChange, GitBranchInfo, WorkingTree, GitRepoRef, GitActionResult, DiffHunk, GitFileStatus,
   GitBranch, GitCommit, GitStash, GitWorktree, GitGraphLine, GitTreeState,
-  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, WorktreeLeftovers,
+  GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, WorktreeLeftovers, LeftoverEntry,
 } from "../../shared/types.ts";
 
 export const GIT_WRITE_ENABLED = process.env.AGENTGLASS_GIT_WRITE_DISABLED !== "1";
@@ -1461,6 +1461,95 @@ const rebuildable = (rel: string): boolean =>
 const LEFTOVERS_MAX = 12;
 /** Ignored directories opened up to see what's inside — one git call each. */
 const EXPAND_MAX = 8;
+/** Above this, two same-sized files are called `differs` rather than read.
+ *  Being wrong here only over-reports: it lists an entry that had nothing to
+ *  lose, and refuses to pre-select it. Reading 12 MB to say "identical" is not
+ *  worth blocking the dialog for. */
+const COMPARE_MAX_BYTES = 2 * 1024 * 1024;
+/** Files walked when measuring a directory. Past it the size is a floor, which
+ *  is all the number is for — nobody needs `dist/` weighed precisely. */
+const WALK_MAX = 4000;
+
+/** How many children a wholly-ignored directory is broken into before it stays
+ *  one row. Past this it is a build output or a dependency tree, and forty rows
+ *  of it would bury the file the list exists for. */
+const CHILDREN_MAX = 40;
+
+/**
+ * The immediate children of a directory git refused to look inside, as paths
+ * relative to the worktree. Directories keep their trailing slash so the rest
+ * of the pipeline treats them as directories.
+ *
+ * Falls back to the directory itself when it is too crowded to be worth
+ * splitting, or unreadable — both of which have to keep the entry on the list
+ * rather than drop it.
+ */
+function readOneLevel(worktree: string, dir: string): string[] {
+  const rel = dir.endsWith("/") ? dir.slice(0, -1) : dir;
+  try {
+    const kids = readdirSync(join(worktree, rel), { withFileTypes: true });
+    if (!kids.length || kids.length > CHILDREN_MAX) return [dir];
+    return kids.map((k) => `${rel}/${k.name}${k.isDirectory() ? "/" : ""}`);
+  } catch { return [dir]; }
+}
+
+/** The repository's main working checkout — where a rescued file belongs.
+ *  `git worktree list` puts it first; that is its documented order, and it is
+ *  the one entry whose `.git` is a real directory rather than a file. */
+function mainCheckout(root: string): string {
+  return worktreeList(root)[0]?.path ?? root;
+}
+
+/** Bytes under `p`, recursive, bounded. -1 when it can't be read at all. */
+function sizeOf(p: string): number {
+  try {
+    const st = statSync(p);
+    if (!st.isDirectory()) return st.size;
+    let total = 0, seen = 0;
+    const walk = (d: string): void => {
+      if (seen >= WALK_MAX) return;
+      for (const e of readdirSync(d, { withFileTypes: true })) {
+        if (seen++ >= WALK_MAX) return;
+        const child = join(d, e.name);
+        // Never follow a symlink out of the tree we're measuring.
+        if (e.isSymbolicLink()) continue;
+        if (e.isDirectory()) walk(child);
+        else { try { total += statSync(child).size; } catch { /* vanished mid-walk */ } }
+      }
+    };
+    walk(p);
+    return total;
+  } catch { return -1; }
+}
+
+/**
+ * What the main checkout has at this path, and how big the worktree's copy is.
+ *
+ * "Same" has to mean byte-identical, because the entire consequence of the
+ * answer is that the entry stops being shown at all. Size first (one stat, and
+ * it settles most of them), contents only when the sizes match and the file is
+ * small enough to be worth reading.
+ *
+ * Directories are never called "same": proving it means walking both trees, and
+ * the answer that costs nothing — list it, don't pre-select it — is already the
+ * safe one.
+ */
+async function compareToMain(main: string, worktree: string, rel: string): Promise<{ vsMain: "same" | "absent" | "differs"; bytes: number }> {
+  const clean = rel.endsWith("/") ? rel.slice(0, -1) : rel;
+  const mine = join(worktree, clean);
+  const theirs = join(main, clean);
+  const bytes = sizeOf(mine);
+  let a, b;
+  try { a = statSync(mine); } catch { return { vsMain: "absent", bytes }; }
+  try { b = statSync(theirs); } catch { return { vsMain: "absent", bytes }; }
+  if (a.isDirectory() || b.isDirectory()) return { vsMain: "differs", bytes };
+  if (a.size !== b.size) return { vsMain: "differs", bytes };
+  if (a.size > COMPARE_MAX_BYTES) return { vsMain: "differs", bytes };
+  try {
+    const [x, y] = await Promise.all([Bun.file(mine).arrayBuffer(), Bun.file(theirs).arrayBuffer()]);
+    return { vsMain: Buffer.from(x).equals(Buffer.from(y)) ? "same" : "differs", bytes };
+  } catch { return { vsMain: "differs", bytes }; }
+}
 
 /**
  * What `git worktree remove` would delete here that git would never warn about.
@@ -1483,16 +1572,16 @@ const EXPAND_MAX = 8;
 export async function worktreeLeftovers(rootIn: string, pathIn: unknown): Promise<WorktreeLeftovers> {
   const root = repoRoot(rootIn);
   const abs = safeAbs(pathIn);
-  if (!root || !abs) return { path: String(pathIn ?? ""), files: [], more: 0, skipped: 0, error: "invalid path" };
+  if (!root || !abs) return { path: String(pathIn ?? ""), entries: [], more: 0, skipped: 0, identical: 0, error: "invalid path" };
   // Only a path this repo actually owns as a worktree, so this can't be used to
   // enumerate arbitrary directories through the API.
   if (!worktreeList(root).some((w) => w.path === abs)) {
-    return { path: abs, files: [], more: 0, skipped: 0, error: "not a worktree of this repository" };
+    return { path: abs, entries: [], more: 0, skipped: 0, identical: 0, error: "not a worktree of this repository" };
   }
   const r = await gitAsync(abs, ["-c", "core.quotePath=false", "status", "--porcelain=v1", "--ignored"]);
   // A directory git can't read is not an empty one. Say so, and let the caller
   // present it as a reason to keep the worktree rather than a green light.
-  if (r.code !== 0) return { path: abs, files: [], more: 0, skipped: 0, error: r.stderr.trim() || "could not read that checkout" };
+  if (r.code !== 0) return { path: abs, entries: [], more: 0, skipped: 0, identical: 0, error: r.stderr.trim() || "could not read that checkout" };
 
   const parse = (out: string): { code: string; rel: string }[] =>
     out.split("\n").filter((l) => l.length >= 4).map((l) => ({
@@ -1526,17 +1615,103 @@ export async function worktreeLeftovers(rootIn: string, pathIn: unknown): Promis
   const inner = await Promise.all(expand.map((d) =>
     gitAsync(abs, ["-c", "core.quotePath=false", "status", "--porcelain=v1", "--ignored=matching", "--", d])));
   for (let i = 0; i < expand.length; i++) {
+    const dir = expand[i]!;
     const entries = inner[i]!.code === 0 ? parse(inner[i]!.stdout).filter((e) => e.code === "!!") : [];
-    // Couldn't see inside, or it told us nothing new: keep the directory itself
-    // on the list rather than dropping it.
-    if (!entries.length) { ignored.push(expand[i]!); continue; }
-    for (const { rel } of entries) { if (rebuildable(rel)) skipped++; else ignored.push(rel); }
+    // Git will not descend when the ignore rule names the DIRECTORY — a
+    // `.gitignore` line of `.specs/` makes `--ignored=matching -- .specs/`
+    // answer `.specs/` again, forever. That is the common shape, and left here
+    // it costs the whole feature: an undivided `.specs/` is "differs" against
+    // the main checkout's own `.specs/`, so it can never be pre-ticked and the
+    // rescue would refuse it as already-existing. The one file inside that
+    // nobody has a copy of never gets offered.
+    //
+    // So when git says nothing new, read the directory. One level: deeper turns
+    // a screenshots folder into forty rows, and the directory is the useful
+    // unit anyway.
+    const useful = entries.filter((e) => e.rel !== dir);
+    if (!useful.length) { for (const child of readOneLevel(abs, dir)) { if (rebuildable(child)) skipped++; else ignored.push(child); } continue; }
+    for (const { rel } of useful) { if (rebuildable(rel)) skipped++; else ignored.push(rel); }
   }
 
+  // Now the question that turns a warning into an offer: what does the main
+  // checkout already have at each of these paths? A worktree is a second copy
+  // of the repo, so most of this list is a duplicate of a file sitting safely
+  // in the main checkout — on the repo this was built for, 20 of 34.
+  const main = mainCheckout(root);
+  const entries: LeftoverEntry[] = [];
+  let identical = 0;
   // Work git would have stopped for goes first: if there is any, the answer is
   // "don't do this" and it should be the first thing read.
-  const all = [...work, ...ignored];
-  return { path: abs, files: all.slice(0, LEFTOVERS_MAX), more: Math.max(0, all.length - LEFTOVERS_MAX), skipped };
+  for (const rel of [...work, ...ignored]) {
+    const cmp = await compareToMain(main, abs, rel);
+    if (cmp.vsMain === "same") { identical++; continue; }
+    entries.push({ path: rel, bytes: cmp.bytes, dir: rel.endsWith("/"), vsMain: cmp.vsMain });
+  }
+  // Safe-to-rescue first, then by size ascending. Notes are small and unique;
+  // build output is large and already-there. Sorting this way is what stops a
+  // 708K directory of screenshots hiding behind 22 MB of `dist/` in a list that
+  // gets cut at twelve.
+  entries.sort((a, b) =>
+    Number(a.vsMain === "differs") - Number(b.vsMain === "differs") || a.bytes - b.bytes || a.path.localeCompare(b.path));
+  return {
+    path: abs, entries: entries.slice(0, LEFTOVERS_MAX),
+    more: Math.max(0, entries.length - LEFTOVERS_MAX), skipped, identical,
+  };
+}
+
+/**
+ * Copy chosen leftovers out of a worktree and into the main checkout, at the
+ * same relative path, before the worktree is removed.
+ *
+ * The main checkout rather than an invented archive directory, because that is
+ * where these files already live: this repo's `.specs/` in the main checkout
+ * holds 157 of exactly these notes, and the worktree's three are simply the
+ * ones that never made it back. A rescue folder would be a second place to
+ * look for the same thing.
+ *
+ * Refuses to overwrite. That is the whole safety property: a "rescue" that
+ * clobbers the main checkout's `tmp/` or `dist/` with the dying worktree's
+ * version is the exact accident this feature exists to prevent, and it would
+ * happen silently. Callers that genuinely want that must delete the target
+ * themselves; there is no force flag, on purpose.
+ *
+ * Every path is re-derived from the worktree root here rather than trusted from
+ * the request, so `../` in a relative path lands outside and is rejected rather
+ * than reaching into the filesystem.
+ */
+export async function rescueLeftovers(rootIn: string, pathIn: unknown, relsIn: unknown): Promise<GitActionResult & { copied?: string[]; skipped?: { path: string; why: string }[] }> {
+  const root = repoRoot(rootIn); if (!root) return { ok: false, error: "not a git repository root" };
+  const g = guard(root); if (g) return g;
+  const abs = safeAbs(pathIn); if (!abs) return { ok: false, error: "invalid path" };
+  if (!worktreeList(root).some((w) => w.path === abs)) return { ok: false, error: "not a worktree of this repository" };
+  const main = mainCheckout(root);
+  if (main === abs) return { ok: false, error: "that is the main checkout — nothing to rescue it into" };
+  if (!Array.isArray(relsIn)) return { ok: false, error: "no paths given" };
+  const rels = relsIn.filter((r): r is string => typeof r === "string" && !!r).slice(0, 500);
+
+  const copied: string[] = [];
+  const skipped: { path: string; why: string }[] = [];
+  for (const rel of rels) {
+    const clean = rel.endsWith("/") ? rel.slice(0, -1) : rel;
+    const from = resolve(abs, clean);
+    const to = resolve(main, clean);
+    // Both ends have to stay inside their tree. `resolve` has already collapsed
+    // any `..`, so this catches it wherever it appeared in the string.
+    if (from !== abs && !from.startsWith(abs + sep)) { skipped.push({ path: rel, why: "outside the worktree" }); continue; }
+    if (to !== main && !to.startsWith(main + sep)) { skipped.push({ path: rel, why: "outside the main checkout" }); continue; }
+    if (existsSync(to)) { skipped.push({ path: rel, why: "already exists in the main checkout" }); continue; }
+    if (!existsSync(from)) { skipped.push({ path: rel, why: "no longer in the worktree" }); continue; }
+    try {
+      mkdirSync(dirname(to), { recursive: true });
+      // `cp -R` rather than a hand-rolled walk: it is one spawn for a file or a
+      // whole tree, and it preserves what a copy of somebody's notes should
+      // preserve. `-n` is a second refusal to clobber behind the check above.
+      const p = Bun.spawnSync(["cp", "-Rn", from, to], { stdout: "pipe", stderr: "pipe" });
+      if (p.exitCode !== 0) { skipped.push({ path: rel, why: p.stderr?.toString().trim() || "copy failed" }); continue; }
+      copied.push(rel);
+    } catch (e) { skipped.push({ path: rel, why: String(e) }); }
+  }
+  return { ok: skipped.length === 0, copied, skipped, ...(skipped.length ? { error: `${skipped.length} of ${rels.length} not copied` } : {}) };
 }
 
 export function removeWorktree(rootIn: string, pathIn: unknown, force: boolean): GitActionResult {

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1456,9 +1456,20 @@ const rebuildable = (rel: string): boolean =>
   rel.split("/").some((seg) => REBUILDABLE.has(seg) || seg.endsWith(".egg-info")) ||
   /\.(pyc|pyo)$/.test(rel);
 
-/** How many paths a single leftovers report will name before it starts
- *  counting. Long enough to be a list you read, short enough to stay one. */
-const LEFTOVERS_MAX = 12;
+/**
+ * How many paths a report names before it starts counting.
+ *
+ * Twelve, back when this filled a text `confirm()` and the list was only ever
+ * read. It now fills a scrolling modal where each row is a thing you can TICK,
+ * so anything past the cap is not merely unmentioned — it cannot be rescued at
+ * all, and the count that replaces it offers no way to get at it. On a real
+ * checkout twelve hid eight entries.
+ *
+ * Sixty scrolls fine and comfortably clears the worst checkout here (34).
+ * Entries are sorted safe-and-small first, so a cap that does bite still bites
+ * the build output rather than the notes.
+ */
+const LEFTOVERS_MAX = 60;
 /** Ignored directories opened up to see what's inside — one git call each. */
 const EXPAND_MAX = 8;
 /** Above this, two same-sized files are called `differs` rather than read.

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -310,7 +310,14 @@ function codeRootsOf(knownRoots: string[]): string[] {
  *  Both counts are only as fresh as the last fetch — they compare against the
  *  local origin/* refs, not the remote. See startAutoFetch(). */
 async function repoRef(root: string): Promise<GitRepoRef | null> {
-  const r = await gitAsync(root, ["status", "--porcelain=v1", "--branch"]);
+  // Two questions, asked at once: what is dirty here, and when did work last
+  // land on this branch. The second is 3ms against the first's 75ms on a large
+  // repo, and both are awaited rather than blocking — see the perf note on
+  // `git()`.
+  const [r, tip] = await Promise.all([
+    gitAsync(root, ["status", "--porcelain=v1", "--branch"]),
+    gitAsync(root, ["log", "-1", "--format=%ct", "HEAD"]),
+  ]);
   if (r.code !== 0) return null;
   const lines = r.stdout.split("\n").filter(Boolean);
   const head = lines[0]?.startsWith("##") ? lines[0] : "";
@@ -328,8 +335,43 @@ async function repoRef(root: string): Promise<GitRepoRef | null> {
     root, name: basename(root), branch, dirty: lines.length - (head ? 1 : 0),
     ahead: Number(head.match(/ahead (\d+)/)?.[1]) || 0,
     behind: Number(head.match(/behind (\d+)/)?.[1]) || 0,
+    touchedAt: touchedAt(root, tip.code === 0 ? (Number(tip.stdout.trim()) || 0) * 1000 : 0),
     ...(parent ? { worktreeOf: parent } : {}),
   };
+}
+
+/**
+ * When this checkout was last worked in — what the pickers sort on.
+ *
+ * `HEAD` and the reflog (`logs/HEAD`) inside the checkout's own git dir,
+ * whichever is newer. Git appends to the reflog every time HEAD moves — commit,
+ * checkout, merge, rebase, reset, pull — and rewrites HEAD on a branch switch,
+ * so between them they answer "when did I last do something here" for two
+ * stats and no subprocess. A linked worktree has its own pair under
+ * `.git/worktrees/<dir>/`, which is what makes this per-checkout rather than
+ * per-repository.
+ *
+ * NOT the index, which is the obvious choice and the wrong one: `git status`
+ * refreshes it and writes it back, and this server runs `git status` against
+ * every checkout on a five-second sweep to fill in the dirty counts. The
+ * timestamp would have been "when the picker last polled", identical
+ * everywhere, and the order would have come out as whichever parallel status
+ * happened to finish last. Measured, not assumed — a backdated index came back
+ * stamped `now` after a single status.
+ *
+ * NOT the working tree's own files either: a build writing into `dist/` would
+ * make an untouched checkout look like the freshest one on the machine.
+ *
+ * 0 when it could not be read; those sort last rather than first.
+ */
+function touchedAt(root: string, tipMs: number): number {
+  const dir = gitDir(root);
+  if (!dir) return tipMs;
+  let newest = tipMs;
+  // HEAD itself, not the reflog beside it: a symref file git rewrites on
+  // checkout and leaves alone otherwise.
+  try { newest = Math.max(newest, statSync(join(dir, "HEAD")).mtimeMs); } catch { /* mid-write, or gone */ }
+  return Math.round(newest);
 }
 
 // Opening git, terminal and chat each asks for the same list, and a user
@@ -381,8 +423,14 @@ export async function discoverRepos(paths: string[], knownRoots: string[] = [], 
     // order among peers, but it shouldn't bury the main checkout behind a
     // worktree that happens to have more edits open — the dropdown is read as
     // "the project, and the branches I have checked out beside it".
+    // The project itself stays at the top — it is the thing the others are
+    // worktrees OF, and hunting for it in a list of seventeen is not a thing
+    // anyone should have to do. Below it, most recently worked in first: on a
+    // ticket-per-worktree repo that is the only ordering that puts what you are
+    // doing today above what you did in March. Dirty-first used to be the rule
+    // and is subsumed by it — staging a file touches the index.
     scoped.sort((a, b) =>
-      Number(!!a.worktreeOf) - Number(!!b.worktreeOf) || b.dirty - a.dirty || a.name.localeCompare(b.name));
+      Number(!!a.worktreeOf) - Number(!!b.worktreeOf) || b.touchedAt - a.touchedAt || a.name.localeCompare(b.name));
     repoCache.set(key, { at: Date.now(), repos: scoped });
     return scoped;
   }
@@ -449,29 +497,33 @@ export async function discoverRepos(paths: string[], knownRoots: string[] = [], 
   const out = (await Promise.all([...roots].map((r) => repoRef(r)))).filter((r): r is GitRepoRef => !!r);
   for (const r of out) { const n = folded.get(r.root); if (n) r.worktrees = n; }
   const scoped = only.length ? within(out, only) : out;
-  // Families stay together, dirtiest family first, the project ahead of its own
-  // worktrees. Sorting the flat list by dirty count alone scatters a repo's
+  // Families stay together, most recently worked-in family first, the project
+  // ahead of its own worktrees. Sorting the flat list alone scatters a repo's
   // checkouts through the dropdown, so `orbit` and `orbit-WEB-1042` end up
   // pages apart — the one arrangement that makes a worktree look like an
   // unrelated project, which is the confusion this whole change is about.
+  //
+  // A family is as recent as its most recent checkout: work happens in the
+  // worktrees, so ranking a project by its own main checkout would sink an
+  // actively-worked repo below one nobody has opened in a month.
   const family = (r: GitRepoRef) => r.worktreeOf ?? r.root;
-  const rank = new Map<string, { dirty: number; name: string }>();
+  const rank = new Map<string, { touchedAt: number; name: string }>();
   for (const r of scoped) {
     const f = family(r);
     const cur = rank.get(f);
     // The family's name comes from the project itself, not from whichever
     // worktree happens to sort first.
-    if (!cur || (!r.worktreeOf && cur.name !== r.name) || r.dirty > cur.dirty) {
-      rank.set(f, { dirty: Math.max(cur?.dirty ?? 0, r.dirty), name: r.worktreeOf ? cur?.name ?? r.name : r.name });
+    if (!cur || (!r.worktreeOf && cur.name !== r.name) || r.touchedAt > cur.touchedAt) {
+      rank.set(f, { touchedAt: Math.max(cur?.touchedAt ?? 0, r.touchedAt), name: r.worktreeOf ? cur?.name ?? r.name : r.name });
     }
   }
   scoped.sort((a, b) => {
     const fa = family(a), fb = family(b);
     if (fa !== fb) {
       const ra = rank.get(fa)!, rb = rank.get(fb)!;
-      return rb.dirty - ra.dirty || ra.name.localeCompare(rb.name);
+      return rb.touchedAt - ra.touchedAt || ra.name.localeCompare(rb.name);
     }
-    return Number(!!a.worktreeOf) - Number(!!b.worktreeOf) || b.dirty - a.dirty || a.name.localeCompare(b.name);
+    return Number(!!a.worktreeOf) - Number(!!b.worktreeOf) || b.touchedAt - a.touchedAt || a.name.localeCompare(b.name);
   });
   repoCache.set(key, { at: Date.now(), repos: scoped });
   return scoped;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
   branches as gitBranches, checkout as gitCheckout, createBranch, deleteBranch,
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
-  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, rescueLeftovers, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
+  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, rescueLeftovers, fixWorktreeOwnership, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
   conflicts as gitConflicts, resolveWith, conflictBlocks, resolveBlocks, mergeAbort, mergeContinue, baseCandidates, undoMerge,
   remotes as gitRemotes, remoteBranches as gitRemoteBranches, trackRemoteBranch, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
@@ -628,6 +628,9 @@ const server = Bun.serve<WsData>({
         // Copy chosen leftovers into the main checkout before the worktree
         // holding them is removed. Never overwrites — see rescueLeftovers().
         case "/git/worktree-rescue": res = await rescueLeftovers(root, b.path, b.paths); break;
+        // Elevates — the only route that does. chown only, never rm, and the
+        // path must match a worktree git reports. See fixWorktreeOwnership().
+        case "/git/worktree-chown": res = fixWorktreeOwnership(root, b.path); break;
         // `root` here is the checkout being updated — a worktree updates
         // itself, because the merge has to run where the branch is checked out.
         case "/git/sync-base": res = syncFromBase(root, b.base); break;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,9 +33,9 @@ import {
   branches as gitBranches, checkout as gitCheckout, createBranch, deleteBranch,
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
-  worktrees as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
+  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
   conflicts as gitConflicts, resolveWith, conflictBlocks, resolveBlocks, mergeAbort, mergeContinue, baseCandidates, undoMerge,
-  remotes as gitRemotes, tags as gitTags, reflog as gitReflog,
+  remotes as gitRemotes, remoteBranches as gitRemoteBranches, trackRemoteBranch, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
 import { recent as gitCommandLog } from "./gitlog.ts";
 import { openInEditor, editorTarget, editorCapability, HAS_NVIM } from "./editor.ts";
@@ -529,8 +529,10 @@ const server = Bun.serve<WsData>({
       return json(workingTree(root));
     }
     if (pathname === "/git/branches") return json(gitBranches(url.searchParams.get("root") || ""));
-    if (pathname === "/git/graph") return json(logGraph(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 400)));
-    if (pathname === "/git/worktrees") return json({ worktrees: gitWorktrees(url.searchParams.get("root") || "") });
+    // `scope=all` is the whole graph; anything else is this checkout's own
+    // history, which is what the pane defaults to.
+    if (pathname === "/git/graph") return json(logGraph(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 400), url.searchParams.get("scope") === "all" ? "all" : "head"));
+    if (pathname === "/git/worktrees") return json({ worktrees: await gitWorktrees(url.searchParams.get("root") || "") });
     // Update: reads are gated too, since the status alone reveals the source
     // path on disk.
     if (pathname === "/update/status") {
@@ -558,6 +560,9 @@ const server = Bun.serve<WsData>({
     // Open a file at a line in the editor the user already has running.
     if (pathname === "/editor/target") return json({ ...(await editorTarget(url.searchParams.get("path") || "")), hasNvim: HAS_NVIM });
     if (pathname === "/git/remotes") return json({ remotes: gitRemotes(url.searchParams.get("root") || "") });
+    // Every branch on one remote, as the last fetch left them. Whole, not
+    // paged — see remoteBranches() for why.
+    if (pathname === "/git/remote-branches") return json(gitRemoteBranches(url.searchParams.get("root") || "", url.searchParams.get("remote") || ""));
     if (pathname === "/git/tags") return json({ tags: gitTags(url.searchParams.get("root") || "") });
     if (pathname === "/git/reflog") return json({ entries: gitReflog(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 200)) });
     // Carry the cockpit's palette out to tmux and nvim — see themesync.ts.
@@ -606,7 +611,10 @@ const server = Bun.serve<WsData>({
         case "/git/rebase": res = rebaseBranch(root, String(b.name || "")); break;
         case "/git/branch-rename": res = renameBranch(root, String(b.name || ""), String(b.to || "")); break;
         case "/git/reset": res = resetTo(root, String(b.ref || ""), b.mode); break;
-        case "/git/worktree-add": res = addWorktree(root, b.path, String(b.branch || ""), !!b.newBranch); break;
+        case "/git/worktree-add": res = addWorktree(root, b.path, String(b.branch || ""), !!b.newBranch, b.startPoint); break;
+        // Bring a remote branch local. `switch` moves this checkout onto it;
+        // without it the branch is created and nothing else moves.
+        case "/git/track-remote": res = trackRemoteBranch(root, String(b.ref || ""), { switch: !!b.switch }); break;
         case "/git/worktree-remove": res = removeWorktree(root, b.path, !!b.force); break;
         // `root` here is the checkout being updated — a worktree updates
         // itself, because the merge has to run where the branch is checked out.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
   branches as gitBranches, checkout as gitCheckout, createBranch, deleteBranch,
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
-  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
+  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
   conflicts as gitConflicts, resolveWith, conflictBlocks, resolveBlocks, mergeAbort, mergeContinue, baseCandidates, undoMerge,
   remotes as gitRemotes, remoteBranches as gitRemoteBranches, trackRemoteBranch, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
@@ -533,6 +533,15 @@ const server = Bun.serve<WsData>({
     // history, which is what the pane defaults to.
     if (pathname === "/git/graph") return json(logGraph(url.searchParams.get("root") || "", Number(url.searchParams.get("limit") || 400), url.searchParams.get("scope") === "all" ? "all" : "head"));
     if (pathname === "/git/worktrees") return json({ worktrees: await gitWorktrees(url.searchParams.get("root") || "") });
+    // What a worktree removal would destroy, per path — asked before offering
+    // the removal, never after. Repeatable `path=` so the bulk delete can price
+    // every worktree it is about to touch in one round trip; concurrent because
+    // each is a `git status --ignored` and a dozen sequential ones is a second.
+    if (pathname === "/git/worktree-leftovers") {
+      const root = url.searchParams.get("root") || "";
+      const paths = url.searchParams.getAll("path").slice(0, 50);
+      return json({ leftovers: await Promise.all(paths.map((p) => worktreeLeftovers(root, p))) });
+    }
     // Update: reads are gated too, since the status alone reveals the source
     // path on disk.
     if (pathname === "/update/status") {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -33,7 +33,7 @@ import {
   branches as gitBranches, checkout as gitCheckout, createBranch, deleteBranch,
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
-  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
+  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, rescueLeftovers, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
   conflicts as gitConflicts, resolveWith, conflictBlocks, resolveBlocks, mergeAbort, mergeContinue, baseCandidates, undoMerge,
   remotes as gitRemotes, remoteBranches as gitRemoteBranches, trackRemoteBranch, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
@@ -625,6 +625,9 @@ const server = Bun.serve<WsData>({
         // without it the branch is created and nothing else moves.
         case "/git/track-remote": res = trackRemoteBranch(root, String(b.ref || ""), { switch: !!b.switch }); break;
         case "/git/worktree-remove": res = removeWorktree(root, b.path, !!b.force); break;
+        // Copy chosen leftovers into the main checkout before the worktree
+        // holding them is removed. Never overwrites — see rescueLeftovers().
+        case "/git/worktree-rescue": res = await rescueLeftovers(root, b.path, b.paths); break;
         // `root` here is the checkout being updated — a worktree updates
         // itself, because the merge has to run where the branch is checked out.
         case "/git/sync-base": res = syncFromBase(root, b.base); break;

--- a/server/test/branch-merged.test.ts
+++ b/server/test/branch-merged.test.ts
@@ -1,14 +1,17 @@
-// "Is this branch already in the trunk?" has to survive a squash merge.
+// "Is this branch already in the trunk?" has to survive a rewritten history.
 //
 // The branches panel gates its delete on that answer: get it wrong and a branch
 // whose PR landed weeks ago still refuses to delete, with a "not fully merged"
 // error the user can only clear from a terminal. Ancestry alone always gets it
-// wrong here, because a squash merge replays the work as a brand new commit and
-// the branch tip never becomes an ancestor of anything.
+// wrong for the two shapes GitHub's merge button actually produces — squash
+// replays the work as one brand new commit, rebase replays it as several, and
+// in neither case does the branch tip become an ancestor of anything.
 //
-// So this pins the two merge shapes separately, plus the two cases where the
-// answer must stay "no" — an open branch, and one sharing no history at all.
-import { describe, expect, test, beforeAll } from "bun:test";
+// So this pins the three merge shapes separately, plus the two cases where the
+// answer must stay "no" — an open branch, and one sharing no history at all —
+// plus the two ways a correct answer can still be lost afterwards: an expiring
+// cache, and a branch that grows new commits once the verdict is already in.
+import { describe, expect, test, beforeAll, afterAll, setSystemTime } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, realpathSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -48,6 +51,21 @@ beforeAll(async () => {
   git("checkout", "-q", "main");
   git("merge", "-q", "--squash", "squashed");
   git("commit", "-q", "-m", "feat: the whole branch, squashed (#1)");
+
+  // Rebase-merged: the same commits replayed one by one onto main, each with a
+  // new hash. This is the other GitHub merge button, and the one that defeats
+  // the squash probe too — that probe looks for a single combined patch, and a
+  // rebase never leaves one.
+  //
+  // Main has to move first. Replayed straight onto the commit they branched
+  // from, the picks reproduce byte-identical commits, main fast-forwards, and
+  // plain ancestry answers — which is not the case under test.
+  git("checkout", "-q", "-b", "rebased");
+  commit("rebase-a.txt", "a\n", "first half");
+  commit("rebase-b.txt", "b\n", "second half");
+  git("checkout", "-q", "main");
+  commit("trunk.txt", "moved on\n", "unrelated trunk work");
+  git("cherry-pick", "rebased~1", "rebased");
 
   // Merge-committed: ancestry still holds, and must keep being recognised.
   git("checkout", "-q", "-b", "merged", "main");
@@ -101,6 +119,10 @@ describe("mergedIntoTrunk", () => {
     expect(await settles("squashed", true)).toBe(true);
   });
 
+  test("a rebase-merged branch counts as merged, once the sweep has run", async () => {
+    expect(await settles("rebased", true)).toBe(true);
+  });
+
   test("a normally merged branch still counts as merged", () => {
     expect(of("merged")?.mergedIntoTrunk).toBe(true);
   });
@@ -112,4 +134,35 @@ describe("mergedIntoTrunk", () => {
   test("an unrelated history does not", () => {
     expect(of("stranger")?.mergedIntoTrunk).toBe(false);
   });
+
+  /**
+   * The two TTLs are an order of magnitude apart, and that gap used to eat the
+   * answer: the ancestry entry expires after 30s and is rebuilt from `--merged`
+   * alone, while the sweep that found the squashes declines to re-run for five
+   * minutes because it swept recently. Every branch above flipped back to "not
+   * merged — kept" for four and a half minutes out of every five.
+   *
+   * A minute is squarely inside that window. Nothing about the repo changed, so
+   * nothing about the answer may either.
+   */
+  test("verdicts survive the ancestry cache expiring under them", () => {
+    setSystemTime(new Date(Date.now() + 60_000));
+    expect(of("squashed")?.mergedIntoTrunk).toBe(true);
+    expect(of("rebased")?.mergedIntoTrunk).toBe(true);
+  });
+
+  /**
+   * ...but only for the commit they were proved against. A remembered verdict
+   * that outlived its branch would be worse than the bug it fixes: the delete
+   * behind this flag is `-D`, so it would throw away work nothing has checked.
+   */
+  test("a remembered verdict is dropped when the branch moves", () => {
+    git("checkout", "-q", "rebased");
+    commit("rebase-c.txt", "c\n", "new work, after the merge");
+    git("checkout", "-q", "main");
+    setSystemTime(new Date(Date.now() + 60_000)); // still inside the sweep's TTL
+    expect(of("rebased")?.mergedIntoTrunk).toBe(false);
+  });
 });
+
+afterAll(() => setSystemTime());

--- a/server/test/gitlog.test.ts
+++ b/server/test/gitlog.test.ts
@@ -50,10 +50,14 @@ test("an unknown subcommand is treated as a read", () => {
 });
 
 test("records exit code, duration and the first stderr line on failure", () => {
-  const before = recent().length;
+  // Identify the new entry by its id, not by the list getting longer: the ring
+  // is capped (AGENTGLASS_GITLOG_SIZE, 400 by default) and the rest of the
+  // suite runs enough real git to fill it, after which recording one more
+  // evicts one more and the length never moves. The id is monotonic either way.
+  const before = recent().at(-1)?.id ?? 0;
   record("/repo", ["commit", "-m", "x"], 1, 12.5, "fatal: nothing to commit\nsecond line\n");
   const all = recent();
-  expect(all.length).toBe(before + 1);
+  expect(all.at(-1)!.id).toBe(before + 1);
   const e = all[all.length - 1];
   expect(e.args).toEqual(["commit", "-m", "x"]);
   expect(e.exitCode).toBe(1);

--- a/server/test/remote-branches.test.ts
+++ b/server/test/remote-branches.test.ts
@@ -75,6 +75,15 @@ describe("remoteBranches", () => {
     expect(g.hash).toMatch(/^[0-9a-f]{7,}$/);
   });
 
+  it("the count on the tab and the length of the list agree", () => {
+    // They came from two different filters and disagreed by one: `remotes()`
+    // counted `refs/remotes/origin/HEAD`, which `%(refname:short)` renders as
+    // the bare word "origin" — so a guard against names ending in "/HEAD"
+    // matched nothing and the tab claimed one branch more than the pane shows.
+    const r = gw.remotes(clone).find((x) => x.name === "origin")!;
+    expect(r.branches).toBe(gw.remoteBranches(clone, "origin").branches.length);
+  });
+
   it("drops origin/HEAD — it points at another row in the same list", () => {
     // A fresh clone always has one. Listed, it looks like a branch called HEAD
     // that you could check out.

--- a/server/test/remote-branches.test.ts
+++ b/server/test/remote-branches.test.ts
@@ -1,0 +1,264 @@
+// Browsing a remote, and pulling one of its branches down.
+//
+// Against a real remote (a bare repo) and a real clone, because everything
+// under test is about the difference between refs the clone HAS and refs it
+// merely KNOWS ABOUT — a distinction no fixture can fake. The repo this was
+// written for has 790 branches on origin and 45 locally, and the panel's whole
+// job is to keep those two facts apart on every row.
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string, origin: string, clone: string, gw: typeof import("../src/gitwork.ts");
+
+const run = (cwd: string, ...args: string[]) => spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+
+beforeAll(async () => {
+  // realpath: git records the resolved path in a worktree's .git file, and the
+  // worktree assertions below compare paths.
+  dir = realpathSync(mkdtempSync(join(tmpdir(), "agx-remote-")));
+  origin = join(dir, "origin.git");
+  clone = join(dir, "clone");
+  // The scope guard reads the running machine's real config; point it at the
+  // fixture before gitwork is imported, exactly as sync-base.test.ts does.
+  process.env.AGENTGLASS_ROOT = dir;
+
+  spawnSync("git", ["init", "-q", "--bare", "-b", "main", origin], { encoding: "utf8" });
+  const seed = join(dir, "seed");
+  spawnSync("git", ["init", "-q", "-b", "main", seed], { encoding: "utf8" });
+  run(seed, "config", "user.email", "t@example.com");
+  run(seed, "config", "user.name", "t");
+  // Explicit, distinct commit dates: `--sort=-committerdate` has nothing to
+  // sort by when four commits land in the same second, and a test that passes
+  // on git's tie-break order pins nothing.
+  let when = 0;
+  const commit = (f: string, msg: string) => {
+    writeFileSync(join(seed, f), `${msg}\n`);
+    run(seed, "add", "-A");
+    const date = `2024-01-0${++when} 12:00:00 +0000`;
+    spawnSync("git", ["-C", seed, "commit", "-qm", msg], {
+      encoding: "utf8",
+      env: { ...process.env, GIT_AUTHOR_DATE: date, GIT_COMMITTER_DATE: date },
+    });
+  };
+  commit("a.txt", "first");
+  run(seed, "remote", "add", "origin", origin);
+  run(seed, "push", "-q", "-u", "origin", "main");
+  // Three ticket branches on the remote, oldest first, so newest-first has
+  // something to be right or wrong about.
+  for (const b of ["WEB-1-alpha", "WEB-2-beta", "WEB-3-gamma"]) {
+    run(seed, "checkout", "-q", "-b", b, "main");
+    commit(`${b}.txt`, `work on ${b}`);
+    run(seed, "push", "-q", "origin", b);
+    run(seed, "checkout", "-q", "main");
+  }
+  spawnSync("git", ["clone", "-q", origin, clone], { encoding: "utf8" });
+  run(clone, "config", "user.email", "t@example.com");
+  run(clone, "config", "user.name", "t");
+
+  gw = await import("../src/gitwork.ts");
+});
+
+afterAll(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ } });
+
+describe("remoteBranches", () => {
+  it("lists what is on the remote, newest first", () => {
+    const r = gw.remoteBranches(clone, "origin");
+    expect(r.ok).toBe(true);
+    expect(r.remote).toBe("origin");
+    expect(r.branches.map((b) => b.name)).toEqual(["WEB-3-gamma", "WEB-2-beta", "WEB-1-alpha", "main"]);
+    const g = r.branches[0];
+    expect(g.ref).toBe("origin/WEB-3-gamma");
+    expect(g.subject).toBe("work on WEB-3-gamma");
+    expect(g.hash).toMatch(/^[0-9a-f]{7,}$/);
+  });
+
+  it("drops origin/HEAD — it points at another row in the same list", () => {
+    // A fresh clone always has one. Listed, it looks like a branch called HEAD
+    // that you could check out.
+    expect(run(clone, "symbolic-ref", "refs/remotes/origin/HEAD").stdout.trim()).toBe("refs/remotes/origin/main");
+    expect(gw.remoteBranches(clone, "origin").branches.some((b) => b.name === "HEAD")).toBe(false);
+  });
+
+  it("marks the ones you already have, and only those", () => {
+    // `main` is the clone's own branch; nothing else has been brought down.
+    const by = new Map(gw.remoteBranches(clone, "origin").branches.map((b) => [b.name, b]));
+    expect(by.get("main")!.local).toBe(true);
+    expect(by.get("main")!.tracking).toBe(true);
+    expect(by.get("WEB-1-alpha")!.local).toBe(false);
+    expect(by.get("WEB-1-alpha")!.tracking).toBe(false);
+  });
+
+  it("defaults to the repo's only remote when none is named", () => {
+    expect(gw.remoteBranches(clone, "").remote).toBe("origin");
+  });
+
+  it("answers nothing rather than everything for a remote that isn't there", () => {
+    // The refs/remotes/<name> namespace simply doesn't exist — the danger would
+    // be falling back to listing every remote's branches under one name.
+    expect(gw.remoteBranches(clone, "upstream").branches).toEqual([]);
+  });
+
+  it("refuses a remote name that is really a path", () => {
+    expect(gw.remoteBranches(clone, "origin/../../etc").ok).toBe(false);
+  });
+});
+
+describe("trackRemoteBranch", () => {
+  it("creates a local branch tracking the remote one, without moving the checkout", () => {
+    const head = run(clone, "rev-parse", "--abbrev-ref", "HEAD").stdout.trim();
+    expect(gw.trackRemoteBranch(clone, "origin/WEB-1-alpha").ok).toBe(true);
+    expect(run(clone, "rev-parse", "--verify", "--quiet", "refs/heads/WEB-1-alpha").status).toBe(0);
+    expect(run(clone, "config", "--get", "branch.WEB-1-alpha.merge").stdout.trim()).toBe("refs/heads/WEB-1-alpha");
+    expect(run(clone, "config", "--get", "branch.WEB-1-alpha.remote").stdout.trim()).toBe("origin");
+    // The working tree did NOT move: an agent may be mid-edit in it.
+    expect(run(clone, "rev-parse", "--abbrev-ref", "HEAD").stdout.trim()).toBe(head);
+  });
+
+  it("shows up as local on the very next listing", () => {
+    const b = gw.remoteBranches(clone, "origin").branches.find((x) => x.name === "WEB-1-alpha")!;
+    expect(b.local).toBe(true);
+    expect(b.tracking).toBe(true);
+  });
+
+  it("switches the checkout when asked to", () => {
+    expect(gw.trackRemoteBranch(clone, "origin/WEB-2-beta", { switch: true }).ok).toBe(true);
+    expect(run(clone, "rev-parse", "--abbrev-ref", "HEAD").stdout.trim()).toBe("WEB-2-beta");
+    run(clone, "checkout", "-q", "main");
+  });
+
+  it("refuses when the local name is taken", () => {
+    // The existing branch may be a different branch that happens to share a
+    // name; quietly reusing it is how you check out the wrong work.
+    const r = gw.trackRemoteBranch(clone, "origin/WEB-1-alpha");
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("already have a local");
+  });
+
+  it("refuses a ref whose prefix is not a remote", () => {
+    // Without this, a local branch literally called "origin/x" and a branch
+    // called "x" on the remote "origin" are indistinguishable.
+    expect(gw.trackRemoteBranch(clone, "nope/WEB-3-gamma").ok).toBe(false);
+    expect(gw.trackRemoteBranch(clone, "WEB-3-gamma").ok).toBe(false);
+  });
+
+  it("refuses a remote branch this clone has never seen", () => {
+    const r = gw.trackRemoteBranch(clone, "origin/never-fetched");
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("fetch first");
+  });
+});
+
+/** The sibling path the panel builds: `${root}-${branch}`. */
+const sibling = (branch: string) => `${clone}-${branch}`;
+
+describe("a remote branch as a worktree", () => {
+  it("cuts the new branch from the remote ref, not from HEAD", () => {
+    const path = sibling("WEB-3-gamma");
+    expect(gw.addWorktree(clone, path, "WEB-3-gamma", true, "origin/WEB-3-gamma").ok).toBe(true);
+    // The point of passing a start point at all: without it the worktree would
+    // hold a copy of main under the ticket's name.
+    expect(run(path, "rev-parse", "HEAD").stdout.trim())
+      .toBe(run(clone, "rev-parse", "origin/WEB-3-gamma").stdout.trim());
+    expect(run(path, "log", "-1", "--format=%s").stdout.trim()).toBe("work on WEB-3-gamma");
+  });
+
+  it("reports the checkout that has it, so the list can offer to open it", () => {
+    const b = gw.remoteBranches(clone, "origin").branches.find((x) => x.name === "WEB-3-gamma")!;
+    expect(b.local).toBe(true);
+    expect(b.worktree).toBe(sibling("WEB-3-gamma"));
+  });
+
+  it("refuses a start point that isn't here", () => {
+    const r = gw.addWorktree(clone, sibling("x"), "x", true, "origin/not-a-branch");
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("fetch first");
+  });
+});
+
+describe("where a worktree may be created", () => {
+  // The rule and its only caller disagreed from the first release: the panel
+  // sends `${root}-${branch}`, and this refused everything but
+  // `<repo>/.worktrees/`. Every press of "+ add worktree" failed.
+  it("accepts the sibling directory the panel actually asks for", () => {
+    expect(gw.addWorktree(clone, sibling("WEB-2-beta-wt"), "WEB-2-beta-wt", true).ok).toBe(true);
+  });
+
+  it("still accepts the nested layout", () => {
+    expect(gw.addWorktree(clone, join(clone, ".worktrees", "nested"), "nested", true).ok).toBe(true);
+  });
+
+  it("refuses anywhere else", () => {
+    // A full checkout planted in a served web root or an autostart directory is
+    // the thing the confinement exists to prevent.
+    for (const p of [join(dir, "elsewhere"), join(dir, "sub", "deep"), "/tmp/agx-not-here", join(clone, "inside")]) {
+      const r = gw.addWorktree(clone, p, "nope", true);
+      expect(r.ok).toBe(false);
+      expect(r.error).toContain("worktree path must be");
+    }
+  });
+
+  it("refuses a sibling that merely shares the parent", () => {
+    // `clone2` is next to `clone` and is not `clone-something`.
+    const r = gw.addWorktree(clone, join(dir, "clone2"), "nope", true);
+    expect(r.ok).toBe(false);
+  });
+
+  it("cannot climb out with ..", () => {
+    const r = gw.addWorktree(clone, join(clone, "..", "..", "escape"), "nope", true);
+    expect(r.ok).toBe(false);
+  });
+});
+
+describe("logGraph scope", () => {
+  // The complaint this comes from: standing in a worktree on a ticket branch
+  // and reading a log whose top commits belonged to other people's branches.
+  it("defaults to the history of the checkout you are in", () => {
+    run(clone, "checkout", "-q", "main");
+    const r = gw.logGraph(clone, 100);
+    expect(r.scope).toBe("head");
+    expect(r.branch).toBe("main");
+    const subjects = r.lines.map((l) => l.subject).filter(Boolean);
+    expect(subjects).toContain("first");
+    expect(subjects).not.toContain("work on WEB-3-gamma");
+  });
+
+  it("reads the whole graph when asked to", () => {
+    const subjects = gw.logGraph(clone, 100, "all").lines.map((l) => l.subject).filter(Boolean);
+    expect(subjects).toContain("work on WEB-3-gamma");
+    expect(subjects).toContain("first");
+  });
+
+  it("names the branch it read, from whichever checkout asked", () => {
+    // Each worktree is its own HEAD — the pane has to be able to say which one
+    // it is showing.
+    expect(gw.logGraph(sibling("WEB-3-gamma"), 20).branch).toBe("WEB-3-gamma");
+    expect(gw.logGraph(sibling("WEB-3-gamma"), 20).lines.map((l) => l.subject)).toContain("work on WEB-3-gamma");
+  });
+});
+
+describe("worktreesWithState", () => {
+  it("counts what is uncommitted in each checkout, one by one", async () => {
+    const wt = sibling("WEB-3-gamma");
+    writeFileSync(join(wt, "scratch.txt"), "untracked\n");
+    const by = new Map((await gw.worktreesWithState(clone)).map((w) => [w.path, w]));
+    // Per checkout, not repo-wide: the whole point is that one worktree being
+    // dirty says nothing about the next one.
+    expect(by.get(wt)!.dirty).toBe(1);
+    expect(by.get(sibling("WEB-2-beta-wt"))!.dirty).toBe(0);
+  });
+
+  it("agrees with what syncFromBase will actually do", async () => {
+    // The button is disabled off this number, so if the two ever disagree the
+    // panel either blocks a merge git would have allowed or offers one it
+    // won't.
+    const wt = sibling("WEB-3-gamma");
+    const dirty = (await gw.worktreesWithState(clone)).find((w) => w.path === wt)!.dirty!;
+    expect(dirty).toBeGreaterThan(0);
+    const r = gw.syncFromBase(wt, "main");
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("commit or stash");
+  });
+});

--- a/server/test/repo-order.test.ts
+++ b/server/test/repo-order.test.ts
@@ -1,0 +1,141 @@
+// The order every repo picker shows.
+//
+// Four dropdowns read the same list — Source control's, the terminal's, the
+// docked console's and the project picker — so the ordering is decided once,
+// here, on the server. The rule: the project itself first, then its checkouts
+// most recently worked in first. On a repo worked one-worktree-per-ticket that
+// is the difference between "the branch I am on today" being at the top and
+// being seventeen rows down, alphabetically, next to a ticket from March.
+//
+// Half of these tests exist because the cheap signals lie. `touchedAt` reads a
+// commit date and one file stamp, and every cheaper thing tried first turned
+// out to be rewritten by something that is not the user working — see
+// touchedAt() for the list, and the last two tests here for the two that were
+// written, measured against a real repo, and backed out.
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdtempSync, writeFileSync, rmSync, realpathSync, utimesSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string, repo: string, gw: typeof import("../src/gitwork.ts"), wtm: typeof import("../src/worktree.ts");
+const wt = (name: string) => join(dir, `orbit-${name}`);
+const TICKETS = ["WEB-1", "WEB-2", "WEB-3"];
+
+const run = (cwd: string, ...args: string[]) => spawnSync("git", ["-C", cwd, ...args], { encoding: "utf8" });
+
+/**
+ * Commit in `cwd`, dated, and age its HEAD to match.
+ *
+ * Both halves matter, because `touchedAt` is the later of the two. `git
+ * worktree add` stamps HEAD with the moment of creation, so three checkouts
+ * made in the same second all read "now" however old their commits are — which
+ * is right in life (a worktree you just made IS what you are working on) and
+ * useless in a fixture trying to order by commit date. Ageing HEAD alongside
+ * the commit is what a checkout made a day ago actually looks like.
+ */
+function commitAt(cwd: string, file: string, secondsAgo: number) {
+  writeFileSync(join(cwd, file), `${file}\n`);
+  run(cwd, "add", "-A");
+  const at = new Date(Date.now() - secondsAgo * 1000);
+  const when = at.toISOString();
+  spawnSync("git", ["-C", cwd, "commit", "-qm", file], {
+    encoding: "utf8",
+    env: { ...process.env, GIT_AUTHOR_DATE: when, GIT_COMMITTER_DATE: when },
+  });
+  const gd = wtm.gitDir(cwd);
+  if (gd) { try { utimesSync(join(gd, "HEAD"), at, at); } catch { /* mid-write */ } }
+}
+
+beforeAll(async () => {
+  dir = realpathSync(mkdtempSync(join(tmpdir(), "agx-order-")));
+  repo = join(dir, "orbit");
+  // Scope the cockpit at the fixture, so discoverRepos takes its "one project
+  // and its worktrees" path — the shape these dropdowns actually run in.
+  process.env.AGENTGLASS_ROOT = repo;
+
+  wtm = await import("../src/worktree.ts"); // commitAt below needs it
+  spawnSync("git", ["init", "-q", "-b", "main", repo], { encoding: "utf8" });
+  run(repo, "config", "user.email", "t@example.com");
+  run(repo, "config", "user.name", "t");
+  // The project itself is the STALEST of the four on purpose: position 0 is
+  // about what it is, not about when it was last touched.
+  commitAt(repo, "a.txt", 259_200); // three days ago
+  for (const t of TICKETS) run(repo, "worktree", "add", "-q", "-b", t, wt(t));
+
+  // Work lands on the three tickets in a deliberately non-alphabetical order:
+  // WEB-2 a minute ago, WEB-3 an hour, WEB-1 a day. Otherwise the assertion
+  // would pass on alphabetical order too and prove nothing.
+  commitAt(wt("WEB-1"), "one.txt", 86_400);
+  commitAt(wt("WEB-2"), "two.txt", 60);
+  commitAt(wt("WEB-3"), "three.txt", 3_600);
+
+  gw = await import("../src/gitwork.ts");
+});
+
+afterAll(() => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ } });
+
+/** The picker's list, cache bypassed — it is held for 5s and every assertion
+ *  here changes something. */
+const order = async () => {
+  gw.invalidateRepos();
+  return (await gw.discoverRepos([], [])).map((r) => r.name);
+};
+
+describe("repo picker order", () => {
+  it("puts the project first and the rest newest-worked-in first", async () => {
+    expect(await order()).toEqual(["orbit", "orbit-WEB-2", "orbit-WEB-3", "orbit-WEB-1"]);
+  });
+
+  it("keeps the project at the top even when it is the stalest thing there", async () => {
+    // The whole point of "position 0": it is the thing the others are worktrees
+    // OF, and hunting for it in a list of seventeen is not a thing anyone
+    // should have to do.
+    gw.invalidateRepos();
+    const repos = await gw.discoverRepos([], []);
+    expect(repos[0].name).toBe("orbit");
+    expect(repos[0].worktreeOf).toBeUndefined();
+    // …and it really is the oldest of the four, so this is not passing by luck.
+    expect(repos[0].touchedAt).toBeLessThan(Math.min(...repos.slice(1).map((r) => r.touchedAt)));
+  });
+
+  it("reorders when work lands in a checkout", async () => {
+    commitAt(wt("WEB-1"), "more.txt", 0);
+    expect((await order())[1]).toBe("orbit-WEB-1");
+  });
+
+  it("gives every checkout a timestamp", async () => {
+    // 0 means "nothing could be read", and those sort last. A fixture where
+    // they were all 0 would pass the ordering tests by accident.
+    gw.invalidateRepos();
+    const repos = await gw.discoverRepos([], []);
+    expect(repos.length).toBe(4);
+    for (const r of repos) expect(r.touchedAt).toBeGreaterThan(0);
+  });
+
+  it("survives the dirty-count sweep, which rewrites the index", async () => {
+    // The first version of this sorted on the index mtime. `git status` — which
+    // discoverRepos runs against every checkout to count changed files —
+    // refreshes the index and writes it back, so the timestamp became "when the
+    // picker last polled": identical everywhere, and the order came out as
+    // whichever parallel status happened to finish last.
+    const before = await order();
+    await order(); // a second full sweep: every status runs again
+    expect(await order()).toEqual(before);
+  });
+
+  it("survives git's housekeeping rewriting the reflogs", async () => {
+    // The second version sorted on `logs/HEAD`. Git's own `gc --auto` — which a
+    // fetch triggers — expires every worktree's reflog in one pass, stamping
+    // them all with the same millisecond. On the repo this was found on, that
+    // was sixteen of eighteen checkouts. Simulated directly here: the point is
+    // the timestamps, not what moved them.
+    const before = await order();
+    const now = new Date();
+    for (const t of TICKETS) {
+      const gd = wtm.gitDir(wt(t));
+      try { utimesSync(join(gd!, "logs", "HEAD"), now, now); } catch { /* no reflog is fine */ }
+    }
+    expect(await order()).toEqual(before);
+  });
+});

--- a/server/test/worktree-leftovers.test.ts
+++ b/server/test/worktree-leftovers.test.ts
@@ -205,6 +205,41 @@ describe("worktreeLeftovers", () => {
  *  removes them from what worktreeLeftovers() lists. Reorder the two describes
  *  and the first one starts failing for a reason that has nothing to do with
  *  it. */
+describe("foreignOwned", () => {
+  test("says nothing when every file is ours", () => {
+    // The normal case, and the one that must not cost anything: a false
+    // positive here refuses a removal that would have worked fine.
+    expect(gw.foreignOwned(WT)).toBeNull();
+  });
+
+  test("a directory nobody can read is not a directory full of strangers", () => {
+    expect(gw.foreignOwned(join(dir, "does-not-exist"))).toBeNull();
+  });
+});
+
+describe("fixWorktreeOwnership", () => {
+  test("refuses a path that is not a worktree of this repo", () => {
+    // This is the ONE call that reaches root. The path must come from git, not
+    // from the request, or a crafted call points chown at anything.
+    const r = gw.fixWorktreeOwnership(REPO, dir);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("not a worktree");
+  });
+
+  test("refuses the main checkout", () => {
+    const r = gw.fixWorktreeOwnership(REPO, REPO);
+    expect(r.ok).toBe(false);
+  });
+
+  test("does nothing, and elevates nothing, when the files are already ours", () => {
+    // No pkexec, no dialog, no root: there is nothing to hand back. If this
+    // ever starts prompting on a clean checkout, that is the bug.
+    const r = gw.fixWorktreeOwnership(REPO, WT);
+    expect(r.ok).toBe(true);
+    expect(r.output).toBe("already yours");
+  });
+});
+
 describe("rescueLeftovers", () => {
   test("copies into the main checkout at the same relative path", async () => {
     const r = await gw.rescueLeftovers(REPO, WT, ["notes-local.md"]);

--- a/server/test/worktree-leftovers.test.ts
+++ b/server/test/worktree-leftovers.test.ts
@@ -11,7 +11,7 @@
 // would bury it, and the two answers that must never read as "nothing to lose"
 // — a path that isn't ours, and a checkout we couldn't read at all.
 import { describe, expect, test, beforeAll } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, realpathSync, rmSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -23,6 +23,11 @@ const GHOST = join(dir, "repo-ghost");  // removed from under git
 
 process.env.XDG_CONFIG_HOME = dir; // never inherit the developer's own scope
 process.env.AGENTGLASS_DB = join(dir, "l.db");
+// Writes are scope-gated (guard() -> inScope()), and `bun test` runs every file
+// in ONE process — so without this the scope left behind by whichever file ran
+// before decides whether rescueLeftovers() is allowed to touch this temp repo.
+// Passing on its own and failing in the suite is the symptom.
+process.env.AGENTGLASS_ROOT = dir;
 
 function git(cwd: string, ...args: string[]) {
   const p = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
@@ -31,13 +36,19 @@ function git(cwd: string, ...args: string[]) {
 }
 
 let gw: typeof import("../src/gitwork.ts");
+/** The report lists entries now, not bare strings — each carries its size and
+ *  what the main checkout has at that path. These tests care about the names. */
+const paths = (r: { entries: { path: string }[] }) => r.entries.map((e) => e.path);
 
 beforeAll(async () => {
+  process.env.AGENTGLASS_ROOT = dir; // again here: another file may have moved it
   mkdirSync(REPO, { recursive: true });
   git(REPO, "init", "-q", "-b", "main");
   git(REPO, "config", "user.email", "t@example.com");
   git(REPO, "config", "user.name", "t");
-  writeFileSync(join(REPO, ".gitignore"), "*.env\n__pycache__/\nnode_modules/\n.mypy_cache/\nnotes-local.md\n");
+  // `.specs/` names the DIRECTORY, which is the common shape and the one that
+  // defeats git's own expansion — see the "whole directory" test below.
+  writeFileSync(join(REPO, ".gitignore"), "*.env\n__pycache__/\nnode_modules/\n.mypy_cache/\nnotes-local.md\n.specs/\n");
   writeFileSync(join(REPO, "README"), "x\n");
   git(REPO, "add", "-A");
   git(REPO, "commit", "-q", "-m", "root");
@@ -57,6 +68,22 @@ beforeAll(async () => {
   mkdirSync(join(WT, "cfg", "__pycache__"), { recursive: true });
   writeFileSync(join(WT, "cfg", "local.env"), "DB=here\n");
   writeFileSync(join(WT, "cfg", "__pycache__", "c.cpython-311.pyc"), "\x00");
+
+  // Both checkouts have a `.specs/`, ignored by a rule that names the whole
+  // directory. The main one holds an old note; the worktree holds one nobody
+  // else has. Only the second must be offered, and it can only BE offered if
+  // the directory gets broken open first.
+  mkdirSync(join(REPO, ".specs"), { recursive: true });
+  writeFileSync(join(REPO, ".specs", "older.md"), "from before\n");
+  mkdirSync(join(WT, ".specs"), { recursive: true });
+  writeFileSync(join(WT, ".specs", "findings.md"), "the notes I need\n");
+
+  // The three answers the main checkout can give about a path, which is what
+  // decides whether an entry is hidden, offered, or offered-with-a-warning.
+  writeFileSync(join(REPO, "shared.env"), "SAME=1\n");        // identical in both
+  writeFileSync(join(WT, "shared.env"), "SAME=1\n");
+  writeFileSync(join(REPO, "drifted.env"), "MAIN=1\n");       // exists in both, different
+  writeFileSync(join(WT, "drifted.env"), "WORKTREE=1\n");
 
   // Nothing but rebuildable output — the one case that IS safe to remove.
   git(REPO, "branch", "spare");
@@ -80,16 +107,16 @@ describe("worktreeLeftovers", () => {
 
     const r = await gw.worktreeLeftovers(REPO, WT);
     expect(r.error).toBeUndefined();
-    expect(r.files).toContain("secrets.env");
-    expect(r.files).toContain("notes-local.md");
+    expect(paths(r)).toContain("secrets.env");
+    expect(paths(r)).toContain("notes-local.md");
   });
 
   test("counts rebuildable output instead of listing it", async () => {
     const r = await gw.worktreeLeftovers(REPO, WT);
     // Four hundred `__pycache__/` lines would bury the one `.env` that matters,
     // and a dialog nobody reads to the end guards nothing.
-    expect(r.files.some((f) => f.includes("__pycache__"))).toBe(false);
-    expect(r.files.some((f) => f.includes("node_modules"))).toBe(false);
+    expect(paths(r).some((f: string) => f.includes("__pycache__"))).toBe(false);
+    expect(paths(r).some((f: string) => f.includes("node_modules"))).toBe(false);
     expect(r.skipped).toBeGreaterThanOrEqual(2);
   });
 
@@ -98,17 +125,17 @@ describe("worktreeLeftovers", () => {
     // git prints `cfg/` and stops, because nothing in it is tracked. Listing
     // that verbatim hides the env file and cries wolf about the cache; both
     // halves have to come out.
-    expect(r.files).toContain("cfg/local.env");
-    expect(r.files).not.toContain("cfg/");
+    expect(paths(r)).toContain("cfg/local.env");
+    expect(paths(r)).not.toContain("cfg/");
     // `src/` collapses the same way but holds only a cache — it must vanish
     // from the list entirely, not sit in it as an unexplained directory.
-    expect(r.files.some((f) => f.startsWith("src"))).toBe(false);
+    expect(paths(r).some((f: string) => f.startsWith("src"))).toBe(false);
   });
 
   test("an empty answer means empty — only when it really is", async () => {
     const r = await gw.worktreeLeftovers(REPO, BARE);
     expect(r.error).toBeUndefined();
-    expect(r.files).toEqual([]);
+    expect(paths(r)).toEqual([]);
     // Reported, so the UI can say "nothing but caches" rather than "empty" —
     // the two look identical in `files` alone.
     expect(r.skipped).toBeGreaterThan(0);
@@ -119,12 +146,111 @@ describe("worktreeLeftovers", () => {
     // "Couldn't look" and "nothing there" must never produce the same value:
     // the caller removes on the second and refuses on the first.
     expect(r.error).toBeTruthy();
-    expect(r.files).toEqual([]);
+    expect(paths(r)).toEqual([]);
   });
 
   test("refuses a path that is not a worktree of this repo", async () => {
     const r = await gw.worktreeLeftovers(REPO, dir);
     expect(r.error).toBeTruthy();
-    expect(r.files).toEqual([]);
+    expect(paths(r)).toEqual([]);
+  });
+
+  test("hides what the main checkout already has, byte for byte", async () => {
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    // A worktree is a second copy of the repo, so most of what looks alarming
+    // in it is a duplicate. Deleting a duplicate loses nothing, and listing it
+    // buries the entries that do matter.
+    expect(paths(r)).not.toContain("shared.env");
+    expect(r.identical).toBeGreaterThanOrEqual(1);
+  });
+
+  test("marks a path that exists in the main checkout but differs", async () => {
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    const e = r.entries.find((x) => x.path === "drifted.env");
+    // Offered — the worktree's copy may well be the newer one — but flagged,
+    // because copying it back OVERWRITES the main checkout's version.
+    expect(e?.vsMain).toBe("differs");
+    expect(r.entries.find((x) => x.path === "secrets.env")?.vsMain).toBe("absent");
+  });
+
+  test("breaks open a directory ignored as a whole directory", async () => {
+    // The case that nearly cost the whole feature. When .gitignore names the
+    // directory (`.specs/`), `git status --ignored=matching -- .specs/` answers
+    // `.specs/` again and never descends — so the list would offer one
+    // undivided `.specs/`, which is "differs" against the main checkout's own
+    // `.specs/` and therefore never pre-ticked and refused as already-existing.
+    // The one file nobody has a copy of would never be offered at all.
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    expect(paths(r)).toContain(".specs/findings.md");
+    expect(paths(r)).not.toContain(".specs/");
+    // And the file that only the main checkout has must not appear at all: it
+    // isn't in this worktree, so nothing about it is at risk.
+    expect(paths(r)).not.toContain(".specs/older.md");
+    expect(r.entries.find((e) => e.path === ".specs/findings.md")?.vsMain).toBe("absent");
+  });
+
+  test("sorts the safe ones first, smallest first", async () => {
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    const firstDiffers = r.entries.findIndex((e) => e.vsMain === "differs");
+    const lastAbsent = r.entries.map((e) => e.vsMain).lastIndexOf("absent");
+    // Otherwise a 708K directory of screenshots hides behind 22 MB of build
+    // output in a list that gets cut at twelve.
+    if (firstDiffers >= 0) expect(firstDiffers).toBeGreaterThan(lastAbsent);
+    expect(r.entries.every((e) => e.bytes >= 0)).toBe(true);
+  });
+});
+
+/** Runs after the block above ON PURPOSE: these copy `notes-local.md` and
+ *  `secrets.env` INTO the main checkout, which turns them into `identical` and
+ *  removes them from what worktreeLeftovers() lists. Reorder the two describes
+ *  and the first one starts failing for a reason that has nothing to do with
+ *  it. */
+describe("rescueLeftovers", () => {
+  test("copies into the main checkout at the same relative path", async () => {
+    const r = await gw.rescueLeftovers(REPO, WT, ["notes-local.md"]);
+    expect(r.ok).toBe(true);
+    expect(r.copied).toEqual(["notes-local.md"]);
+    expect(readFileSync(join(REPO, "notes-local.md"), "utf8")).toBe("what I found\n");
+    // And the worktree still has it — this is a copy, not a move. The removal
+    // that follows is what takes the original, and it must be able to fail
+    // without having already destroyed anything.
+    expect(existsSync(join(WT, "notes-local.md"))).toBe(true);
+  });
+
+  test("copies a directory whole", async () => {
+    const r = await gw.rescueLeftovers(REPO, WT, ["cfg/"]);
+    expect(r.ok).toBe(true);
+    expect(readFileSync(join(REPO, "cfg", "local.env"), "utf8")).toBe("DB=here\n");
+  });
+
+  test("REFUSES to overwrite what the main checkout already has", async () => {
+    // The whole safety property. `drifted.env` differs in the two checkouts, and
+    // a "rescue" that clobbers the main copy with the dying worktree's version
+    // is the exact accident this feature exists to prevent.
+    const before = readFileSync(join(REPO, "drifted.env"), "utf8");
+    const r = await gw.rescueLeftovers(REPO, WT, ["drifted.env"]);
+    expect(r.ok).toBe(false);
+    expect(r.copied).toEqual([]);
+    expect(r.skipped?.[0]?.why).toContain("already exists");
+    expect(readFileSync(join(REPO, "drifted.env"), "utf8")).toBe(before);
+  });
+
+  test("refuses to climb out of the worktree", async () => {
+    const r = await gw.rescueLeftovers(REPO, WT, ["../../../etc/passwd", "../repo/README"]);
+    expect(r.copied).toEqual([]);
+    expect(r.skipped).toHaveLength(2);
+    for (const s of r.skipped!) expect(s.why).toContain("outside");
+  });
+
+  test("refuses a path that is not a worktree of this repo", async () => {
+    const r = await gw.rescueLeftovers(REPO, dir, ["anything"]);
+    expect(r.ok).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+
+  test("reports each failure rather than stopping at the first", async () => {
+    const r = await gw.rescueLeftovers(REPO, WT, ["nope-does-not-exist", "secrets.env"]);
+    expect(r.copied).toEqual(["secrets.env"]);
+    expect(r.skipped?.[0]?.path).toBe("nope-does-not-exist");
   });
 });

--- a/server/test/worktree-leftovers.test.ts
+++ b/server/test/worktree-leftovers.test.ts
@@ -1,0 +1,130 @@
+// `git status` is not a safe answer to "is anything in this worktree?".
+//
+// The branches panel's bulk delete has to remove a worktree before it can
+// delete the branch checked out in it, and `git worktree remove` deletes the
+// whole directory — gitignored files included, with no `--force` needed and no
+// warning printed. A checkout holding `compose/envs/*.env` and a page of local
+// notes reports `status --porcelain` completely empty, so anything that asks
+// git "is it clean?" and acts on a yes has already lost that work.
+//
+// These pin the difference: the ignored file that git hides, the noise that
+// would bury it, and the two answers that must never read as "nothing to lose"
+// — a path that isn't ours, and a checkout we couldn't read at all.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, realpathSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = realpathSync(mkdtempSync(join(tmpdir(), "agx-leftovers-")));
+const REPO = join(dir, "repo");
+const WT = join(dir, "repo-feature");   // has ignored work in it
+const BARE = join(dir, "repo-empty");   // nothing but rebuildable noise
+const GHOST = join(dir, "repo-ghost");  // removed from under git
+
+process.env.XDG_CONFIG_HOME = dir; // never inherit the developer's own scope
+process.env.AGENTGLASS_DB = join(dir, "l.db");
+
+function git(cwd: string, ...args: string[]) {
+  const p = Bun.spawnSync(["git", ...args], { cwd, stdout: "pipe", stderr: "pipe" });
+  if (p.exitCode !== 0) throw new Error(`git ${args.join(" ")}: ${p.stderr.toString()}`);
+  return p.stdout.toString().trim();
+}
+
+let gw: typeof import("../src/gitwork.ts");
+
+beforeAll(async () => {
+  mkdirSync(REPO, { recursive: true });
+  git(REPO, "init", "-q", "-b", "main");
+  git(REPO, "config", "user.email", "t@example.com");
+  git(REPO, "config", "user.name", "t");
+  writeFileSync(join(REPO, ".gitignore"), "*.env\n__pycache__/\nnode_modules/\n.mypy_cache/\nnotes-local.md\n");
+  writeFileSync(join(REPO, "README"), "x\n");
+  git(REPO, "add", "-A");
+  git(REPO, "commit", "-q", "-m", "root");
+
+  // The checkout that matters: clean to git, holding real work on disk.
+  git(REPO, "branch", "feature");
+  git(REPO, "worktree", "add", "-q", WT, "feature");
+  writeFileSync(join(WT, "secrets.env"), "API_KEY=real\n");
+  writeFileSync(join(WT, "notes-local.md"), "what I found\n");
+  mkdirSync(join(WT, "src", "__pycache__"), { recursive: true });
+  writeFileSync(join(WT, "src", "__pycache__", "mod.cpython-311.pyc"), "\x00");
+  mkdirSync(join(WT, "node_modules", "left-pad"), { recursive: true });
+  writeFileSync(join(WT, "node_modules", "left-pad", "index.js"), "//\n");
+  // A directory holding nothing tracked collapses to one line in git's output.
+  // `cfg/` alone says nothing about which of these two it is, and they need
+  // opposite answers.
+  mkdirSync(join(WT, "cfg", "__pycache__"), { recursive: true });
+  writeFileSync(join(WT, "cfg", "local.env"), "DB=here\n");
+  writeFileSync(join(WT, "cfg", "__pycache__", "c.cpython-311.pyc"), "\x00");
+
+  // Nothing but rebuildable output — the one case that IS safe to remove.
+  git(REPO, "branch", "spare");
+  git(REPO, "worktree", "add", "-q", BARE, "spare");
+  mkdirSync(join(BARE, ".mypy_cache"), { recursive: true });
+  writeFileSync(join(BARE, ".mypy_cache", "cache.json"), "{}\n");
+
+  // Still registered with git, directory gone from disk.
+  git(REPO, "branch", "ghost");
+  git(REPO, "worktree", "add", "-q", GHOST, "ghost");
+  rmSync(GHOST, { recursive: true, force: true });
+
+  gw = await import("../src/gitwork.ts");
+});
+
+describe("worktreeLeftovers", () => {
+  test("names the ignored files git reports as clean", async () => {
+    // The premise. If this ever stops holding, the rest of this file is moot
+    // and `git status` would be a fine guard on its own.
+    expect(git(WT, "status", "--porcelain")).toBe("");
+
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    expect(r.error).toBeUndefined();
+    expect(r.files).toContain("secrets.env");
+    expect(r.files).toContain("notes-local.md");
+  });
+
+  test("counts rebuildable output instead of listing it", async () => {
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    // Four hundred `__pycache__/` lines would bury the one `.env` that matters,
+    // and a dialog nobody reads to the end guards nothing.
+    expect(r.files.some((f) => f.includes("__pycache__"))).toBe(false);
+    expect(r.files.some((f) => f.includes("node_modules"))).toBe(false);
+    expect(r.skipped).toBeGreaterThanOrEqual(2);
+  });
+
+  test("opens a collapsed directory rather than reporting its name", async () => {
+    const r = await gw.worktreeLeftovers(REPO, WT);
+    // git prints `cfg/` and stops, because nothing in it is tracked. Listing
+    // that verbatim hides the env file and cries wolf about the cache; both
+    // halves have to come out.
+    expect(r.files).toContain("cfg/local.env");
+    expect(r.files).not.toContain("cfg/");
+    // `src/` collapses the same way but holds only a cache — it must vanish
+    // from the list entirely, not sit in it as an unexplained directory.
+    expect(r.files.some((f) => f.startsWith("src"))).toBe(false);
+  });
+
+  test("an empty answer means empty — only when it really is", async () => {
+    const r = await gw.worktreeLeftovers(REPO, BARE);
+    expect(r.error).toBeUndefined();
+    expect(r.files).toEqual([]);
+    // Reported, so the UI can say "nothing but caches" rather than "empty" —
+    // the two look identical in `files` alone.
+    expect(r.skipped).toBeGreaterThan(0);
+  });
+
+  test("a checkout it cannot read reports an error, not an empty list", async () => {
+    const r = await gw.worktreeLeftovers(REPO, GHOST);
+    // "Couldn't look" and "nothing there" must never produce the same value:
+    // the caller removes on the second and refuses on the first.
+    expect(r.error).toBeTruthy();
+    expect(r.files).toEqual([]);
+  });
+
+  test("refuses a path that is not a worktree of this repo", async () => {
+    const r = await gw.worktreeLeftovers(REPO, dir);
+    expect(r.error).toBeTruthy();
+    expect(r.files).toEqual([]);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -535,6 +535,33 @@ export interface GitRemote {
   /** Branches on this remote, as short names ("main"), without the remote prefix. */
   branches: number;
 }
+/**
+ * One branch on a remote, as the local repository last saw it.
+ *
+ * These come from `refs/remotes/<remote>/*` — what the last fetch left behind,
+ * not a live call to the server. That distinction matters in the UI: a branch
+ * pushed by a colleague ten seconds ago is not here until you fetch.
+ *
+ * `local` and `worktree` are the whole point of the list. On a repo with 800
+ * remote branches the useful question is never "what exists" — it's "do I
+ * already have this one, and where".
+ */
+export interface GitRemoteBranch {
+  /** Short name, without the remote prefix — "WEB-1042-quota-banner". */
+  name: string;
+  /** Full short ref — "origin/WEB-1042-quota-banner", i.e. what you pass to git. */
+  ref: string;
+  hash: string;
+  subject: string;
+  author: string;
+  date: string; // relative
+  /** A local branch of the same name already exists. */
+  local: boolean;
+  /** …and it tracks this remote branch, rather than merely sharing its name. */
+  tracking: boolean;
+  /** A checkout that already has that local branch out, if any. */
+  worktree?: string;
+}
 export interface GitTag {
   name: string;
   /** Annotated tags carry their own message; lightweight ones borrow the commit's. */
@@ -564,6 +591,15 @@ export interface GitWorktree {
   base?: string | null;
   /** Commits the base has that this checkout does not. */
   behindBase?: number;
+  /**
+   * Uncommitted entries in that checkout (`git status --porcelain` lines).
+   *
+   * Costs one `git status` per worktree, and is worth it: a merge into a dirty
+   * checkout is refused by the server, so without this the panel offers a sync
+   * button that can only fail. Undefined means "not asked" — a bare worktree,
+   * or a caller that didn't want to pay for it.
+   */
+  dirty?: number;
 }
 
 // --- live docker panel (lazydocker replacement) ------------------------------

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -616,6 +616,30 @@ export interface GitWorktree {
   dirty?: number;
 }
 
+/**
+ * What removing a worktree would destroy, named before you agree to it.
+ *
+ * `git status` is not the answer to that question. It reports a checkout with a
+ * `.env` and a page of local notes in it as perfectly clean, because both are
+ * gitignored — and `git worktree remove` deletes the whole directory, ignored
+ * files included, without `--force` and without a word. So a caller about to
+ * offer "remove these worktrees" has to look at the disk itself.
+ */
+export interface WorktreeLeftovers {
+  path: string;
+  /** Repo-relative paths that would go: modified and untracked first, then the
+   *  ignored ones that don't look reproducible. Capped — see `more`. */
+  files: string[];
+  /** How many more there were beyond the ones listed. */
+  more: number;
+  /** Ignored entries dropped as rebuildable (`__pycache__/`, `node_modules/`).
+   *  Reported so the count in the UI can say what it chose not to show. */
+  skipped: number;
+  /** Set when the directory could not be read — treat as "assume work is
+   *  there", never as "nothing to lose". */
+  error?: string;
+}
+
 // --- live docker panel (lazydocker replacement) ------------------------------
 export interface DockerContainer {
   id: string;        // short id

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -458,6 +458,20 @@ export interface GitRepoRef {
   /** How many linked worktrees were folded into this project — what the picker
    *  shows so a dozen hidden checkouts aren't invisible. */
   worktrees?: number;
+  /**
+   * When this checkout was last worked in, as an epoch ms — what the pickers
+   * sort on, most recent first.
+   *
+   * Read from the mtime of the checkout's own `HEAD` and reflog, which git
+   * writes on every commit, checkout, merge, rebase, reset and pull. That makes
+   * it "when did I last do something here", which is the question a list of
+   * seventeen ticket worktrees is really being asked — and it costs two stats
+   * rather than a `git log` per checkout. See touchedAt() for why it is not the
+   * index.
+   *
+   * 0 when it could not be read; those sort last rather than first.
+   */
+  touchedAt: number;
 }
 /** One candidate directory from the project picker's path completion. Names and
  *  a `.git` flag only — the completion endpoint never reports files. */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -627,17 +627,52 @@ export interface GitWorktree {
  */
 export interface WorktreeLeftovers {
   path: string;
-  /** Repo-relative paths that would go: modified and untracked first, then the
-   *  ignored ones that don't look reproducible. Capped — see `more`. */
-  files: string[];
+  /** What would go, worst-first. Capped — see `more`. */
+  entries: LeftoverEntry[];
   /** How many more there were beyond the ones listed. */
   more: number;
   /** Ignored entries dropped as rebuildable (`__pycache__/`, `node_modules/`).
    *  Reported so the count in the UI can say what it chose not to show. */
   skipped: number;
+  /** Entries byte-identical to the same path in the main checkout. Counted and
+   *  NOT listed: deleting a copy loses nothing, and listing them buried the
+   *  four that mattered under twenty that didn't. */
+  identical: number;
   /** Set when the directory could not be read — treat as "assume work is
    *  there", never as "nothing to lose". */
   error?: string;
+}
+
+/**
+ * One thing that disappears with the worktree, and what the main checkout has
+ * to say about it.
+ *
+ * `vsMain` is the whole reason this can be offered as a rescue rather than just
+ * a warning. A worktree is a second copy of a repo, so most of what looks
+ * alarming in it — every `compose/envs/*.env`, every generated `reverse.js` —
+ * is byte-identical to the file already sitting in the main checkout. Those are
+ * dropped before they reach here (see `identical`). What remains is:
+ *
+ *   * `absent`  — the main checkout has nothing at this path. Copying it there
+ *                 is pure gain and cannot destroy anything, so these are the
+ *                 ones offered pre-selected.
+ *   * `differs` — a file exists there and is NOT the same. Copying OVERWRITES
+ *                 the main checkout's version, which is how a rescue turns into
+ *                 the thing it was meant to prevent. Never pre-selected, and
+ *                 the UI has to say "overwrites" out loud.
+ *
+ * A directory is reported `differs` whenever the main checkout has one at that
+ * path, without recursing to prove it: walking a 12 MB `dist/` to answer a
+ * question whose safe answer is already "don't pre-select it" is work spent to
+ * reach the same place.
+ */
+export interface LeftoverEntry {
+  /** Path relative to the worktree root. Trailing "/" when it's a directory. */
+  path: string;
+  /** Bytes, recursive for a directory. -1 when it could not be measured. */
+  bytes: number;
+  dir: boolean;
+  vsMain: "absent" | "differs";
 }
 
 // --- live docker panel (lazydocker replacement) ------------------------------

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -641,6 +641,25 @@ export interface WorktreeLeftovers {
   /** Set when the directory could not be read — treat as "assume work is
    *  there", never as "nothing to lose". */
   error?: string;
+  /** Files in this checkout owned by somebody else — almost always root,
+   *  written by a container that mounted the repo and ran as root. Present
+   *  means the removal CANNOT succeed and must not be attempted: git deletes
+   *  the worktree's registration before its files, so a half-done removal
+   *  leaves an orphan directory that no longer belongs to any repository. */
+  blocked?: BlockedByOwner;
+}
+
+/** Why a worktree cannot be deleted, and the one command that fixes it. */
+export interface BlockedByOwner {
+  /** How many foreign-owned paths were found before the walk gave up. */
+  count: number;
+  /** True when the count is a floor rather than a total. */
+  more: boolean;
+  /** Top-level directories to hand to chown — the useful unit, since these
+   *  come from a container writing a whole `tmp/` or `.mypy_cache/`. */
+  paths: string[];
+  /** Owner names seen, e.g. ["root"]. */
+  owners: string[];
 }
 
 /**

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -1,0 +1,137 @@
+import { useEffect, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Portal } from "./Portal.tsx";
+
+/**
+ * The app's own confirm/prompt, because the browser's belong to the browser.
+ *
+ * `window.confirm` renders in the OS chrome: a different typeface, a different
+ * button order per platform, no relationship to the panel that raised it. In a
+ * flow that then opens one of our own modals — pick what to keep, here is what
+ * it costs — the seam is the loudest thing on screen, and a dialog that reads
+ * as foreign is a dialog people click through without reading. That matters
+ * most for exactly the questions this app asks, which are about deleting
+ * things.
+ *
+ * It also blocks the JS thread, which is the second half of the same problem:
+ * nothing can show a spinner, disable a button, or repaint while it is up.
+ *
+ * So: same surface as the rest of the panel, resolved through a promise so the
+ * calling code keeps reading top to bottom.
+ *
+ *   if (!(await ask({ title: "Delete branch?", danger: true }))) return;
+ */
+
+export type ConfirmSpec = {
+  title: string;
+  /** Shown under the title, newlines preserved. */
+  body?: string;
+  confirmLabel?: string;
+  cancelLabel?: string;
+  /** Red confirm button — for anything that destroys work. */
+  danger?: boolean;
+  /** Turns this into a prompt: the resolved value is the typed string, or null
+   *  if cancelled. */
+  input?: { label?: string; initial?: string; placeholder?: string };
+};
+
+type Pending = ConfirmSpec & { resolve: (v: boolean | string | null) => void };
+
+export function ConfirmDialog({ pending }: { pending: Pending | null }) {
+  const [text, setText] = useState("");
+  const inputRef = useRef<HTMLInputElement>(null);
+  const isPrompt = !!pending?.input;
+
+  useEffect(() => {
+    if (!pending) return;
+    setText(pending.input?.initial ?? "");
+    // Focus after the entrance frame so the caret doesn't fight the animation.
+    const t = setTimeout(() => { inputRef.current?.focus(); inputRef.current?.select(); }, 40);
+    return () => clearTimeout(t);
+  }, [pending]);
+
+  useEffect(() => {
+    if (!pending) return;
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.preventDefault(); e.stopPropagation(); pending.resolve(isPrompt ? null : false); }
+      // Enter confirms, but not while a prompt's field is empty — that is the
+      // one case where the obvious keystroke would submit nothing.
+      else if (e.key === "Enter" && (!isPrompt || text.trim())) {
+        e.preventDefault(); e.stopPropagation();
+        pending.resolve(isPrompt ? text.trim() : true);
+      }
+    };
+    // Capture: the panel's own single-letter shortcuts listen on window too,
+    // and a dialog on screen owns the keyboard until it is answered.
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [pending, text, isPrompt]);
+
+  return (
+    <AnimatePresence>
+      {pending && (
+        <Portal>
+          <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+            className="fixed inset-0" style={{ zIndex: 10004, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+            onClick={() => pending.resolve(isPrompt ? null : false)} />
+          <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10005 }}>
+            <motion.div
+              initial={{ opacity: 0, scale: 0.98, y: 6 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.98 }}
+              className="pointer-events-auto w-full max-w-[520px] rounded-xl overflow-hidden"
+              style={{ background: "var(--bg2)", border: "1px solid var(--border)", boxShadow: "0 20px 60px rgba(0,0,0,0.5)" }}
+              role="dialog" aria-modal="true"
+            >
+              <div className="px-4 py-3.5">
+                <div className="text-[13px] font-medium" style={{ color: "var(--text)" }}>{pending.title}</div>
+                {pending.body && (
+                  <div className="text-[11.5px] mt-2 whitespace-pre-wrap leading-relaxed" style={{ color: "var(--text3)" }}>{pending.body}</div>
+                )}
+                {isPrompt && (
+                  <div className="mt-3">
+                    {pending.input!.label && <div className="text-[10.5px] mb-1" style={{ color: "var(--text3)" }}>{pending.input!.label}</div>}
+                    <input
+                      ref={inputRef} value={text} onChange={(e) => setText(e.target.value)}
+                      placeholder={pending.input!.placeholder}
+                      className="w-full text-[12px] px-2 py-1.5 rounded outline-none"
+                      style={{ background: "var(--bg)", border: "1px solid var(--border)", color: "var(--text)" }}
+                    />
+                  </div>
+                )}
+              </div>
+              <div className="px-4 py-2.5 flex items-center justify-end gap-2" style={{ borderTop: "1px solid var(--border)" }}>
+                <button onClick={() => pending.resolve(isPrompt ? null : false)}
+                  className="text-[11px] px-2.5 py-1 rounded"
+                  style={{ color: "var(--text2)", border: "1px solid var(--border)" }}>
+                  {pending.cancelLabel ?? "Cancel"}
+                </button>
+                <button onClick={() => pending.resolve(isPrompt ? text.trim() : true)}
+                  disabled={isPrompt && !text.trim()}
+                  className="text-[11px] px-2.5 py-1 rounded font-medium disabled:opacity-40"
+                  style={{ color: "var(--bg)", background: pending.danger ? "var(--error)" : "var(--primary)" }}>
+                  {pending.confirmLabel ?? (pending.danger ? "Delete" : "Ok")}
+                </button>
+              </div>
+            </motion.div>
+          </div>
+        </Portal>
+      )}
+    </AnimatePresence>
+  );
+}
+
+/**
+ * `const { ask, askText, dialog } = useDialogs()` — render `dialog`, await the
+ * rest. One pending question at a time, which is all any of these flows need.
+ */
+export function useDialogs() {
+  const [pending, setPending] = useState<Pending | null>(null);
+  const done = (resolve: (v: never) => void) => (v: never) => { setPending(null); resolve(v); };
+
+  const ask = (spec: ConfirmSpec): Promise<boolean> =>
+    new Promise<boolean>((resolve) => setPending({ ...spec, resolve: done(resolve as never) as never }));
+
+  const askText = (spec: ConfirmSpec & { input: NonNullable<ConfirmSpec["input"]> }): Promise<string | null> =>
+    new Promise<string | null>((resolve) => setPending({ ...spec, resolve: done(resolve as never) as never }));
+
+  return { ask, askText, dialog: <ConfirmDialog pending={pending} /> };
+}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -10,6 +10,7 @@ import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
 import { ConsoleStrip, lastTerminalRoot, runInConsole } from "./TerminalPanel.tsx";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
+import { useDialogs } from "./ConfirmDialog.tsx";
 
 // Strip ANSI CSI (colors, cursor moves, erases) + OSC sequences, not just SGR.
 const ANSI = /\x1b\[[0-9;?]*[A-Za-z]|\x1b\][^\x07]*(?:\x07|\x1b\\)/g; // eslint-disable-line no-control-regex
@@ -251,6 +252,7 @@ export function DockerView({ active }: { active: boolean }) {
   // keyed on the repo, not on the container, so selecting a different one
   // above never disturbs what is running below.
   const sidebarW = useSidebarWidth();
+  const { ask, dialog } = useDialogs();
   const [consoleOpen, setConsoleOpen] = useState(false);
   const [consoleH, setConsoleH] = useState<number>(() => {
     try { return Math.min(0.85, Math.max(0.08, Number(localStorage.getItem(CONSOLE_KEY)) || 0.1)); } catch { return 0.1; }
@@ -383,7 +385,7 @@ export function DockerView({ active }: { active: boolean }) {
     if (busy) return;
     const targets = cs.filter((c) => (verb === "start" ? c.state !== "running" : c.state === "running"));
     if (!targets.length) return;
-    if (verb !== "start" && !confirm(`${verb} ${targets.length} container${targets.length === 1 ? "" : "s"}?`)) return;
+    if (verb !== "start" && !(await ask({ title: `${verb} ${targets.length} container${targets.length === 1 ? "" : "s"}?`, confirmLabel: verb }))) return;
     setBusy(true);
     let ok = 0;
     const failed: string[] = [];
@@ -402,7 +404,7 @@ export function DockerView({ active }: { active: boolean }) {
 
   const doAction = async (id: string, verb: "start" | "stop" | "restart" | "rm") => {
     if (busy) return;
-    if ((verb === "rm" || verb === "stop") && !confirm(`${verb} this container?`)) return;
+    if ((verb === "rm" || verb === "stop") && !(await ask({ title: `${verb} this container?`, danger: verb === "rm", confirmLabel: verb }))) return;
     setBusy(true);
     try {
       const fn = verb === "start" ? api.dockerStart : verb === "stop" ? api.dockerStop : verb === "restart" ? api.dockerRestart : api.dockerRm;
@@ -654,6 +656,7 @@ export function DockerView({ active }: { active: boolean }) {
                 {toast && (
                   <div className="absolute bottom-4 left-1/2 -translate-x-1/2 px-3.5 py-2 rounded-lg text-[11px] shadow-xl" style={{ zIndex: 40, background: "var(--bg3)", border: `1px solid ${toast.ok ? "color-mix(in srgb, var(--success) 50%, transparent)" : "color-mix(in srgb, var(--error) 50%, transparent)"}`, color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</div>
                 )}
+                {dialog}
     </div>
   );
 }

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -7,6 +7,7 @@ import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
+import { partitionByWorktree, splitReadable, goneConfirmText, leftoversLine } from "../lib/goneCleanup.ts";
 import { api } from "../lib/api.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { newChat, update, setActiveChatId } from "../lib/chatStore.ts";
@@ -893,15 +894,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     let heldByWorktree: Map<string, string>;
     try { heldByWorktree = await heldByWorktreeNow(); }
     catch (e) { flash(false, `couldn't list this repo's worktrees: ${String(e)}`); return; }
-    const held = goneMerged.filter((b) => heldByWorktree.has(b.name));
-    const free = goneMerged.filter((b) => !heldByWorktree.has(b.name));
-    if (!confirm(
-      (free.length
-        ? `Delete ${free.length} branch${free.length === 1 ? "" : "es"} already merged into ${trunk}?`
-        : `None of the ${goneMerged.length} merged branches can be deleted on their own — every one is checked out in a worktree.`) +
-      (held.length ? `\n\n${held.length} more ${held.length === 1 ? "is" : "are"} checked out in a worktree. You'll be asked about those separately, with what removing them would delete.` : "") +
-      (goneUnmerged.length ? `\n\n${goneUnmerged.length} have no remote branch but are NOT in ${trunk} — those are kept.` : "")
-    )) return;
+    const { free, held } = partitionByWorktree(goneMerged, heldByWorktree);
+    if (!confirm(goneConfirmText(free, held, goneUnmerged.length, trunk))) return;
     setBusy(true);
     const failed: string[] = [];
     let done = 0;
@@ -940,23 +934,11 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     try { reports = (await api.gitWorktreeLeftovers(root, paths)).leftovers; }
     catch (e) { for (const b of held) failed.push(`${b.name} (couldn't inspect its worktree: ${String(e)})`); return 0; }
 
-    const byPath = new Map(reports.map((r) => [r.path, r] as const));
-    const unreadable = held.filter((b) => byPath.get(heldByWorktree.get(b.name)!)?.error ?? true);
-    const removable = held.filter((b) => !unreadable.includes(b));
-    for (const b of unreadable) {
-      const why = byPath.get(heldByWorktree.get(b.name)!)?.error ?? "no answer from the server";
-      failed.push(`${b.name} (${why})`);
-    }
+    const { removable, refused } = splitReadable(held, heldByWorktree, reports);
+    for (const { branch, why } of refused) failed.push(`${branch.name} (${why})`);
     if (!removable.length) return 0;
 
-    const detail = removable.map((b) => {
-      const r = byPath.get(heldByWorktree.get(b.name)!)!;
-      const shown = r.files.slice(0, 6).map((f) => `    ${f}`);
-      const rest = r.files.length - shown.length + r.more;
-      return `  ${wtName(r.path)}\n` + (r.files.length
-        ? shown.join("\n") + (rest > 0 ? `\n    …and ${rest} more` : "") + (r.skipped ? `\n    (+${r.skipped} rebuildable, e.g. caches — not listed)` : "")
-        : r.skipped ? `    nothing but ${r.skipped} rebuildable entries (caches, deps)` : "    empty");
-    }).join("\n\n");
+    const detail = removable.map(({ report }) => leftoversLine(report, wtName(report.path))).join("\n\n");
 
     if (!confirm(
       `Remove ${removable.length} worktree${removable.length === 1 ? "" : "s"} and delete their branches?\n\n` +
@@ -965,12 +947,13 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     )) return 0;
 
     let done = 0;
-    for (const b of removable) {
-      const path = heldByWorktree.get(b.name)!;
-      const rm = await api.gitWorktreeRemove(root, path, true).catch((e) => ({ ok: false, error: String(e) }));
-      if (!rm.ok) { failed.push(`${b.name} (${rm.error || "worktree remove failed"})`); continue; }
-      const r = await api.gitBranchDelete(root, b.name, true).catch((e) => ({ ok: false, error: String(e) }));
-      if (r.ok) done++; else failed.push(`${b.name} (${r.error || "branch delete failed"})`);
+    // `report.path` rather than another lookup: it is the path the server just
+    // confirmed it inspected, so the thing removed is the thing priced.
+    for (const { branch, report } of removable) {
+      const rm = await api.gitWorktreeRemove(root, report.path, true).catch((e) => ({ ok: false, error: String(e) }));
+      if (!rm.ok) { failed.push(`${branch.name} (${rm.error || "worktree remove failed"})`); continue; }
+      const r = await api.gitBranchDelete(root, branch.name, true).catch((e) => ({ ok: false, error: String(e) }));
+      if (r.ok) done++; else failed.push(`${branch.name} (${r.error || "branch delete failed"})`);
     }
     return done;
   };

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -746,6 +746,26 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   usePoll(open && !!root && !busy, loadView, 10_000);
 
   /**
+   * "still checking for squash merges…" has to be able to stop saying that.
+   *
+   * The sweep runs behind the response, so the panel shows that line and waits
+   * for a later poll to carry the finished answer. But the poll above is gated
+   * on `!busy` — one stuck flag and the line is frozen on screen forever,
+   * promising an update that will never arrive. Which is what happened: the
+   * server had been answering `sweeping: false` for minutes while the panel
+   * still claimed to be working.
+   *
+   * So the claim refreshes itself. One targeted re-read while it is true,
+   * ungated, and it stops as soon as the answer says so — nothing to leak,
+   * nothing to keep running once the line is gone.
+   */
+  useEffect(() => {
+    if (!open || !root || !branchData.sweeping) return;
+    const t = setTimeout(() => { reloadBranches(); }, 2500);
+    return () => clearTimeout(t);
+  }, [open, root, branchData.sweeping, branchData.branches]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  /**
    * Run a git action, and make sure the screen agrees with the repo afterwards.
    *
    * Two things this has to get right, both of which it used to get wrong:
@@ -1003,7 +1023,13 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
       if (!rels.length) continue;
       step(`keeping ${rels.length} file${rels.length === 1 ? "" : "s"} from ${wtName(path)}`);
       const res = await api.gitWorktreeRescue(root, path, rels).catch((e) => ({ ok: false, error: String(e), copied: [] as string[], skipped: [] as { path: string; why: string }[] }));
-      const lost = res.skipped ?? [];
+      // Every path asked for has to come back accounted for. Counting only
+      // `skipped` trusts the server to have reported its own omissions, and a
+      // request that silently returns fewer copies than it was given then
+      // reads as a clean success — which is how five screenshots were deleted
+      // after being "kept". Anything unaccounted for is a loss.
+      const missing = rels.filter((r) => !(res.copied ?? []).includes(r) && !(res.skipped ?? []).some((s) => s.path === r));
+      const lost = [...(res.skipped ?? []), ...missing.map((path) => ({ path, why: "never confirmed by the server" }))];
       if (lost.length) {
         // Anything we could not save is a reason to leave that worktree alone:
         // removing it now destroys the very file the user asked to keep.

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1224,7 +1224,13 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
 
   const COUNTS: Partial<Record<View, number>> = {
     changes: all.length, branches: branchData.branches.length, worktrees: worktrees.length,
-    stashes: stashes.length, remotes: remotes.length, tags: tags.length,
+    stashes: stashes.length, tags: tags.length,
+    // Branches on the remotes, not how many remotes there are. "1" over a pane
+    // listing 789 branches was the tab counting the wrong noun: every other tab
+    // counts the rows you are about to see, and this one counted the heading.
+    // Summed across remotes for the fork setup, where the answer is "everything
+    // you can reach", not "everything on whichever one is selected".
+    remotes: remotes.reduce((n, r) => n + r.branches, 0),
   };
   /**
    * One tab: the key that gets you there, the name, and the count *under* both.

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1233,74 +1233,75 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     remotes: remotes.reduce((n, r) => n + r.branches, 0),
   };
   /**
-   * One tab: the key that gets you there, the name, and the count *under* both.
+   * One tab: the key that gets you there, the name, and the count raised on the
+   * name as a footnote.
    *
-   * The count used to sit beside the name as a chip, which cost every counted
-   * tab ~28px of width. Eight tabs plus a 60-character branch name plus
-   * fetch/pull/push does not fit a laptop window, so the strip scrolled and the
-   * last tab ("Stashes") was permanently a sliver reading "8 S" behind the
-   * branch chip — a tab you cannot read is a tab you cannot use.
+   * Two problems, one shape. The count used to be a chip beside the label,
+   * which cost ~28px per counted tab — eight tabs plus a 60-character branch
+   * name plus fetch/pull/push did not fit, so the strip scrolled and "Stashes"
+   * was permanently a sliver reading "8 S" behind the branch chip. Moving the
+   * count onto a second line fixed the width and bought a different problem:
+   * eight bordered boxes, each with an outlined keycap and an internal rule,
+   * and a dead empty line under the two tabs that have no count. That read as
+   * a row of controls rather than a tab strip.
    *
-   * Stacking is the trade that costs nothing here: the header is a FIXED 48px
-   * (see VIEW_HEADER_H) and a two-line tab is ~31px, so the bar cannot grow
-   * vertically no matter what these say, while the strip gets ~150px back
-   * horizontally — enough for all eight to fit without scrolling.
+   * As a superscript the count is an attribute of the name instead of a second
+   * value competing with the jump key, so the box, the keycap outline and the
+   * rule can all go — and the tabs that have no count simply have no
+   * superscript, with nothing left for the absence to be a hole in. Measured
+   * against the previous design in a mock of the real 1900px header: 686px vs
+   * 746px, comfortably inside the ~890px the strip actually gets.
    *
-   * The rule separating the two lines is the tab's own, not a divider between
-   * tabs: it ties the number to the word above it rather than to its
-   * neighbours, which is what stops "45" and "125" from reading as one row of
-   * loose digits.
+   * The padding is deliberately top-heavy (7px over 4px): the raised digits
+   * need that room, or the active tab's tint clips through them.
    */
   const ViewTab = ({ id }: { id: View }) => {
     const n = COUNTS[id];
     const num = ALL_VIEWS.indexOf(id) + 1;
     const on = view === id;
     return (
-      <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]}${n != null ? ` (${n})` : ""} — press ${num}`}
+      <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]}${n ? ` (${n})` : ""} — press ${num}`}
         aria-keyshortcuts={String(num)}
-        className="text-[10.5px] px-2 py-[3px] rounded-md transition-colors flex flex-col items-stretch gap-[2px] whitespace-nowrap shrink-0"
-        style={{ background: on ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: on ? "var(--text)" : "var(--text3)", border: `1px solid color-mix(in srgb, var(--border) ${on ? 40 : 15}%, transparent)` }}>
-        <span className="flex items-center gap-1.5 leading-none">
-          {/* The key that gets you here. lazygit does the same in its panel
-              titles (gui.showPanelJumps) — a shortcut nothing advertises is a
-              shortcut nobody uses.
-
-              Drawn as a keycap rather than a bare digit. Bare, it read as a
-              count — "1 Changes" looked like one change. Now that the real
-              count is on the line below, the outline is what still tells the
-              two numbers apart at a glance. */}
-          <span
-            className="tabular-nums leading-none rounded-[3px] px-1 py-[1px]"
-            style={{ fontSize: 8.5, opacity: on ? 0.85 : 0.5, border: "1px solid color-mix(in srgb, var(--text3) 45%, transparent)" }}
-          >{num}</span>
+        className="text-[10.5px] leading-none rounded-[5px] transition-colors flex items-baseline gap-[5px] whitespace-nowrap shrink-0"
+        style={{
+          padding: "7px 7px 4px",
+          background: on ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent",
+          color: on ? "var(--text)" : "var(--text3)",
+          opacity: on ? 1 : 0.72,
+        }}>
+        {/* The key that gets you here. lazygit does the same in its panel titles
+            (gui.showPanelJumps) — a shortcut nothing advertises is a shortcut
+            nobody uses. A bare digit was ambiguous with the count while both
+            sat on the same line at the same size; raising the count settles it
+            without needing an outline around this one. */}
+        <span className="tabular-nums" style={{ fontSize: 8, opacity: on ? 0.9 : 0.5, color: on ? "var(--primary-hover)" : undefined }}>{num}</span>
+        <span className="relative">
           {VIEW_LABEL[id]}
+          {/* Zero is left off rather than drawn: these counts start at zero and
+              are only true once that tab has been visited, so a fresh panel
+              printing "0" on Tags would be stating something it never checked.
+              Every offset is explicit because the CSS reset gives `sup` its own
+              `top`, and inheriting that would put the digits somewhere other
+              than where this was designed and measured. */}
+          {!!n && (
+            <sup
+              className="tabular-nums"
+              style={{
+                fontSize: 7.5, lineHeight: 1, verticalAlign: "super",
+                position: "relative", top: -4.5, left: 1.5,
+                opacity: on ? 1 : 0.68, color: on ? "var(--primary-hover)" : undefined,
+              }}
+            >{n}</sup>
+          )}
         </span>
-        {/* Always rendered, count or not: an empty second line keeps every tab
-            the same height, and a strip of tabs that each stop at a different
-            place is worse than a blank half-line under "Log".
-
-            Zero is left blank rather than drawn. These counts start at zero and
-            are only true once that tab has been visited, so a fresh panel
-            printing "0" under Tags would be stating something it hasn't
-            checked. */}
-        <span
-          className="tabular-nums leading-none text-center pt-[2px]"
-          style={{
-            fontSize: 9,
-            minHeight: 10,
-            color: on ? "var(--primary-hover)" : "var(--text3)",
-            opacity: on ? 1 : 0.75,
-            borderTop: `1px solid color-mix(in srgb, var(--${on ? "primary" : "border"}) ${on ? 30 : 22}%, transparent)`,
-          }}
-        >{n ? n : ""}</span>
       </button>
     );
   };
-  /** One group's tabs. A single-view group renders as a plain button; a
-   *  multi-view one shows its siblings separated by a hairline, which is what
-   *  makes "these three are one panel" legible without a second row. */
+  /** One group's tabs. Held together by proximity alone — 1px between siblings
+   *  against the 9px between groups — which is enough to read "these three are
+   *  one panel" now that the tabs themselves carry no border to compete with. */
   const ViewGroup = ({ views }: { views: View[] }) => (
-    <div className="flex items-center gap-px rounded-md" style={views.length > 1 ? { background: "color-mix(in srgb, var(--border) 12%, transparent)" } : undefined}>
+    <div className="flex items-baseline gap-px">
       {views.map((v) => <ViewTab key={v} id={v} />)}
     </div>
   );
@@ -1377,7 +1378,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                       name will not fit a narrow window, and something has to
                       give — a strip you can flick is better than controls
                       pushed off the right edge. */}
-                  <div className="flex items-center gap-2 ml-1 min-w-0 overflow-x-auto agw-noscrollbar">
+                  <div className="flex items-center gap-[9px] ml-1 min-w-0 overflow-x-auto agw-noscrollbar">
                     {VIEW_GROUPS.map((g) => <ViewGroup key={g.label} views={g.views} />)}
                   </div>
                   <div className="ml-auto flex items-center gap-1.5 min-w-0">

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -7,7 +7,8 @@ import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
-import { partitionByWorktree, splitReadable, goneConfirmText, leftoversLine } from "../lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmText } from "../lib/goneCleanup.ts";
+import { RescueModal } from "./RescueModal.tsx";
 import { api } from "../lib/api.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { newChat, update, setActiveChatId } from "../lib/chatStore.ts";
@@ -463,6 +464,9 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const [graph, setGraph] = useState<GitGraphLine[]>([]);
   const [stashes, setStashes] = useState<GitStash[]>([]);
   const [worktrees, setWorktrees] = useState<GitWorktree[]>([]);
+  /** The rescue prompt, and the promise deleteHeldByWorktrees() is parked on
+   *  while it is open. Null means no prompt; resolving with null is a cancel. */
+  const [rescue, setRescue] = useState<{ reports: WorktreeLeftovers[]; resolve: (v: Map<string, string[]> | null) => void } | null>(null);
   const [remotes, setRemotes] = useState<GitRemote[]>([]);
   /** The remote whose branches the pane is listing, and that list. Empty until
    *  the first answer names one — the server picks the only/first remote when
@@ -938,18 +942,41 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     for (const { branch, why } of refused) failed.push(`${branch.name} (${why})`);
     if (!removable.length) return 0;
 
-    const detail = removable.map(({ report }) => leftoversLine(report, wtName(report.path))).join("\n\n");
+    // The modal replaces what used to be a confirm() listing the same files.
+    // Reading a list you then have to copy by hand is a step people skip at the
+    // exact moment they shouldn't, so the list is now the thing you act on.
+    const picked = await new Promise<Map<string, string[]> | null>((resolve) => {
+      setRescue({ reports: removable.map(({ report }) => report), resolve });
+    });
+    setRescue(null);
+    if (!picked) return 0; // cancelled — nothing removed, nothing copied
 
-    if (!confirm(
-      `Remove ${removable.length} worktree${removable.length === 1 ? "" : "s"} and delete their branches?\n\n` +
-      `git reports these checkouts clean, but removing one deletes its gitignored files too — silently. This is what goes:\n\n${detail}\n\n` +
-      `The branches are recoverable from the reflog for 30 days. These files are not recoverable at all.`
-    )) return 0;
+    // Copy first, remove second, and never the other way round. A failed rescue
+    // has to be able to stop the removal, which it cannot do once the directory
+    // is gone.
+    const keptBack = new Set<string>();
+    let rescued = 0;
+    for (const [path, rels] of picked) {
+      if (!rels.length) continue;
+      const res = await api.gitWorktreeRescue(root, path, rels).catch((e) => ({ ok: false, error: String(e), copied: [] as string[], skipped: [] as { path: string; why: string }[] }));
+      const lost = res.skipped ?? [];
+      if (lost.length) {
+        // Anything we could not save is a reason to leave that worktree alone:
+        // removing it now destroys the very file the user asked to keep.
+        const b = removable.find(({ report }) => report.path === path)?.branch;
+        if (b) failed.push(`${b.name} (kept — couldn't save ${lost.slice(0, 2).map((s) => `${s.path}: ${s.why}`).join("; ")})`);
+        keptBack.add(path);
+      }
+      if (res.copied?.length) rescued += res.copied.length;
+    }
+
+    if (rescued) flash(true, `kept ${rescued} file${rescued === 1 ? "" : "s"} in the main checkout`);
 
     let done = 0;
     // `report.path` rather than another lookup: it is the path the server just
     // confirmed it inspected, so the thing removed is the thing priced.
     for (const { branch, report } of removable) {
+      if (keptBack.has(report.path)) continue; // its rescue failed; already reported
       const rm = await api.gitWorktreeRemove(root, report.path, true).catch((e) => ({ ok: false, error: String(e) }));
       if (!rm.ok) { failed.push(`${branch.name} (${rm.error || "worktree remove failed"})`); continue; }
       const r = await api.gitBranchDelete(root, branch.name, true).catch((e) => ({ ok: false, error: String(e) }));
@@ -2113,6 +2140,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
           it's a drill-down from a row you clicked, not a place you navigate
           to — the rail's views are the destinations, this is a detour. */}
       <ChangesModal open={!!commitView} onClose={() => setCommitView(null)} onBack={() => setCommitView(null)} backLabel="Log" presetChanges={commitView?.changes} presetTitle={commitView?.title} />
+      {rescue && <RescueModal reports={rescue.reports} onCancel={() => rescue.resolve(null)} onConfirm={(picked) => rescue.resolve(picked)} />}
     </div>
   );
 }

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -955,7 +955,29 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     try { reports = (await api.gitWorktreeLeftovers(root, paths)).leftovers; }
     catch (e) { for (const b of held) failed.push(`${b.name} (couldn't inspect its worktree: ${String(e)})`); return 0; }
 
-    const { removable, refused } = splitReadable(held, heldByWorktree, reports);
+    let { removable, refused } = splitReadable(held, heldByWorktree, reports);
+
+    // A checkout blocked only by ownership is a checkout one dialog away from
+    // working, so offer that dialog instead of reporting a dead end. The
+    // elevation is the desktop's own (pkexec) and does chown, never rm — the
+    // removal still runs as the user, through every check below.
+    const blocked = reports.filter((r) => r.blocked && refused.some((f) => heldByWorktree.get(f.branch.name) === r.path));
+    if (blocked.length && await ask({
+      title: `${blocked.length} worktree${blocked.length === 1 ? " has" : "s have"} files owned by ${[...new Set(blocked.flatMap((r) => r.blocked!.owners))].join(", ")}`,
+      body: `A container wrote them, so nothing can delete them as you.\n\n${blocked.map((r) => `${wtName(r.path)} — ${r.blocked!.count}${r.blocked!.more ? "+" : ""} files`).join("\n")}\n\nHand them back? Your desktop will ask for your password. agentglass never sees it, and only runs chown — the deletion still happens as you.`,
+      confirmLabel: "Hand them back",
+    })) {
+      for (const r of blocked) {
+        setPending(`restoring ownership of ${wtName(r.path)}`);
+        const fix = await api.gitWorktreeChown(root, r.path).catch((e) => ({ ok: false, error: String(e) }));
+        if (!fix.ok) { flash(false, `${wtName(r.path)}: ${fix.error || "chown failed"}`); continue; }
+        r.blocked = undefined; // re-read below now that it can succeed
+      }
+      // Re-split against the repaired reports rather than trusting the old
+      // verdict: the whole point is that some of them are removable now.
+      ({ removable, refused } = splitReadable(held, heldByWorktree, reports));
+    }
+
     for (const { branch, why } of refused) failed.push(`${branch.name} (${why})`);
     if (!removable.length) return 0;
 

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
-import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
+import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { newChat, update, setActiveChatId } from "../lib/chatStore.ts";
@@ -844,6 +844,25 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const goneUnmerged = goneBranches.filter((b) => !b.mergedIntoTrunk);
 
   /**
+   * Branch name → the worktree holding it, excluding this checkout. `git branch
+   * -D` refuses outright on these, which is what made a bulk run report
+   * "deleted 0, 3 failed" with no hint that a worktree was the reason.
+   *
+   * Fetched here rather than read off the `worktrees` state, and that is not
+   * belt-and-braces: that state is only ever filled by the Worktrees tab
+   * (`view === "worktrees"`), so from the Branches tab it is an empty array and
+   * this map would find nothing — the partition below would send every branch
+   * down the "delete it directly" path and reproduce the exact failure this is
+   * fixing. Fresh is also the only correct answer for a destructive action:
+   * another agent adds or removes worktrees in this repo while the panel sits
+   * open.
+   */
+  const heldByWorktreeNow = async (): Promise<Map<string, string>> => {
+    const { worktrees: live } = await api.gitWorktrees(root);
+    return new Map(live.filter((w) => !w.current && w.branch && w.branch !== "(detached)").map((w) => [w.branch, w.path] as const));
+  };
+
+  /**
    * Delete the gone branches whose work is already in the trunk.
    *
    * Forced (`-D`), and that's safe *because* of the check above: we've verified
@@ -855,30 +874,105 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
    * genuinely dangerous case — a remote branch deleted without merging — and
    * it's the one case where an unrecoverable delete would actually cost you
    * something.
+   *
+   * The branches still held by a worktree are a second, separate question, and
+   * it gets its own confirmation *with the file list in it*. Not politeness:
+   * `git worktree remove` deletes gitignored files without `--force` and
+   * without a word, so a checkout that reports itself clean can still be
+   * holding every `compose/envs/*.env` and a page of local notes. `-D` on the
+   * branch is reversible for thirty days through the reflog; `rm -rf` on an
+   * ignored file is not reversible at all. So nothing is removed until the
+   * files that would go have been named on screen.
    */
   const deleteGone = async () => {
     if (!goneMerged.length || busy) return;
     const trunk = branchData.trunk ?? "the trunk";
+    // Before the first question, because the question's wording depends on it.
+    // A failure here is a reason to stop: without the map every branch looks
+    // free to delete, which is the wrong half of the fork to guess at.
+    let heldByWorktree: Map<string, string>;
+    try { heldByWorktree = await heldByWorktreeNow(); }
+    catch (e) { flash(false, `couldn't list this repo's worktrees: ${String(e)}`); return; }
+    const held = goneMerged.filter((b) => heldByWorktree.has(b.name));
+    const free = goneMerged.filter((b) => !heldByWorktree.has(b.name));
     if (!confirm(
-      `Delete ${goneMerged.length} branch${goneMerged.length === 1 ? "" : "es"} already merged into ${trunk}?` +
-      (goneUnmerged.length ? `\n\n${goneUnmerged.length} more have no remote branch but are NOT in ${trunk} — those are kept.` : "")
+      (free.length
+        ? `Delete ${free.length} branch${free.length === 1 ? "" : "es"} already merged into ${trunk}?`
+        : `None of the ${goneMerged.length} merged branches can be deleted on their own — every one is checked out in a worktree.`) +
+      (held.length ? `\n\n${held.length} more ${held.length === 1 ? "is" : "are"} checked out in a worktree. You'll be asked about those separately, with what removing them would delete.` : "") +
+      (goneUnmerged.length ? `\n\n${goneUnmerged.length} have no remote branch but are NOT in ${trunk} — those are kept.` : "")
     )) return;
     setBusy(true);
     const failed: string[] = [];
+    let done = 0;
     try {
-      for (const b of goneMerged) {
-        const r = await api.gitBranchDelete(root, b.name, true).catch(() => ({ ok: false }));
-        if (!r.ok) failed.push(b.name);
+      for (const b of free) {
+        const r = await api.gitBranchDelete(root, b.name, true).catch(() => ({ ok: false, error: "" }));
+        if (r.ok) done++; else failed.push(`${b.name}${r.error ? ` (${r.error})` : ""}`);
       }
-      const done = goneMerged.length - failed.length;
+      if (held.length) done += await deleteHeldByWorktrees(held, heldByWorktree, failed);
       flash(failed.length === 0,
         failed.length === 0
           ? `deleted ${done} merged branch${done === 1 ? "" : "es"}`
-          : `deleted ${done}, ${failed.length} failed: ${failed.slice(0, 3).join(", ")}${failed.length > 3 ? "…" : ""}`);
+          : `deleted ${done}, ${failed.length} kept: ${failed.slice(0, 2).join("; ")}${failed.length > 2 ? "…" : ""}`);
     } finally {
       setBusy(false);
       reloadBranches();
+      reloadWorktrees();
     }
+  };
+
+  /**
+   * The worktree half: price it, show the price, then charge it.
+   *
+   * One request covers the whole batch, and its answer is the dialog — every
+   * path that disappears, per checkout, with the rebuildable noise
+   * (`__pycache__/`, `node_modules/`) counted rather than listed so the lines
+   * that matter aren't buried under four hundred that don't.
+   *
+   * A checkout we could not read is not removed, whatever the user answers.
+   * "Could not list what's in there" and "there's nothing in there" produce the
+   * same empty list, and only one of them is safe to act on.
+   */
+  const deleteHeldByWorktrees = async (held: GitBranch[], heldByWorktree: Map<string, string>, failed: string[]): Promise<number> => {
+    const paths = held.map((b) => heldByWorktree.get(b.name)!);
+    let reports: WorktreeLeftovers[];
+    try { reports = (await api.gitWorktreeLeftovers(root, paths)).leftovers; }
+    catch (e) { for (const b of held) failed.push(`${b.name} (couldn't inspect its worktree: ${String(e)})`); return 0; }
+
+    const byPath = new Map(reports.map((r) => [r.path, r] as const));
+    const unreadable = held.filter((b) => byPath.get(heldByWorktree.get(b.name)!)?.error ?? true);
+    const removable = held.filter((b) => !unreadable.includes(b));
+    for (const b of unreadable) {
+      const why = byPath.get(heldByWorktree.get(b.name)!)?.error ?? "no answer from the server";
+      failed.push(`${b.name} (${why})`);
+    }
+    if (!removable.length) return 0;
+
+    const detail = removable.map((b) => {
+      const r = byPath.get(heldByWorktree.get(b.name)!)!;
+      const shown = r.files.slice(0, 6).map((f) => `    ${f}`);
+      const rest = r.files.length - shown.length + r.more;
+      return `  ${wtName(r.path)}\n` + (r.files.length
+        ? shown.join("\n") + (rest > 0 ? `\n    …and ${rest} more` : "") + (r.skipped ? `\n    (+${r.skipped} rebuildable, e.g. caches — not listed)` : "")
+        : r.skipped ? `    nothing but ${r.skipped} rebuildable entries (caches, deps)` : "    empty");
+    }).join("\n\n");
+
+    if (!confirm(
+      `Remove ${removable.length} worktree${removable.length === 1 ? "" : "s"} and delete their branches?\n\n` +
+      `git reports these checkouts clean, but removing one deletes its gitignored files too — silently. This is what goes:\n\n${detail}\n\n` +
+      `The branches are recoverable from the reflog for 30 days. These files are not recoverable at all.`
+    )) return 0;
+
+    let done = 0;
+    for (const b of removable) {
+      const path = heldByWorktree.get(b.name)!;
+      const rm = await api.gitWorktreeRemove(root, path, true).catch((e) => ({ ok: false, error: String(e) }));
+      if (!rm.ok) { failed.push(`${b.name} (${rm.error || "worktree remove failed"})`); continue; }
+      const r = await api.gitBranchDelete(root, b.name, true).catch((e) => ({ ok: false, error: String(e) }));
+      if (r.ok) done++; else failed.push(`${b.name} (${r.error || "branch delete failed"})`);
+    }
+    return done;
   };
   const mergeBranch = (name: string) => { if (confirm(`Merge ${name} into the current branch?`)) act(() => api.gitMerge(root, name), `merged ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
   const rebaseBranch = (name: string) => { if (confirm(`Rebase the current branch onto ${name}?`)) act(() => api.gitRebase(root, name), `rebased onto ${name}`).then((ok) => { if (ok) reloadBranches(); }); };

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -7,8 +7,9 @@ import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
-import { partitionByWorktree, splitReadable, goneConfirmText } from "../lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody } from "../lib/goneCleanup.ts";
 import { RescueModal } from "./RescueModal.tsx";
+import { useDialogs } from "./ConfirmDialog.tsx";
 import { api } from "../lib/api.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { newChat, update, setActiveChatId } from "../lib/chatStore.ts";
@@ -456,17 +457,21 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const [body, setBody] = useState("");
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
+  // The panel's own confirm/prompt. window.confirm renders in OS chrome, reads
+  // as somebody else's dialog next to our modals, and blocks the JS thread so
+  // nothing can show progress while it is up.
+  const { ask, askText, dialog } = useDialogs();
   const [repoOpen, setRepoOpen] = useState(false);
   const [repoQuery, setRepoQuery] = useState("");
   // branches / log / stashes / worktrees
-  const [branchData, setBranchData] = useState<{ current: string; branches: GitBranch[]; trunk?: string | null }>({ current: "", branches: [] });
+  const [branchData, setBranchData] = useState<{ current: string; branches: GitBranch[]; trunk?: string | null; sweeping?: boolean }>({ current: "", branches: [] });
   const [newBranch, setNewBranch] = useState("");
   const [graph, setGraph] = useState<GitGraphLine[]>([]);
   const [stashes, setStashes] = useState<GitStash[]>([]);
   const [worktrees, setWorktrees] = useState<GitWorktree[]>([]);
   /** The rescue prompt, and the promise deleteHeldByWorktrees() is parked on
    *  while it is open. Null means no prompt; resolving with null is a cancel. */
-  const [rescue, setRescue] = useState<{ reports: WorktreeLeftovers[]; resolve: (v: Map<string, string[]> | null) => void } | null>(null);
+  const [rescue, setRescue] = useState<{ reports: WorktreeLeftovers[]; resolve: (v: Map<string, string[]> | null) => void; progress?: string } | null>(null);
   const [remotes, setRemotes] = useState<GitRemote[]>([]);
   /** The remote whose branches the pane is listing, and that list. Empty until
    *  the first answer names one — the server picks the only/first remote when
@@ -771,7 +776,9 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   // working tree ops
   const stage = async (c: GitFileChange) => { if (await act(() => api.gitStage(root, [rel(c)]))) setSelKey("s:" + c.file_path); };
   const unstage = async (c: GitFileChange) => { if (await act(() => api.gitUnstage(root, [rel(c)]))) setSelKey("u:" + c.file_path); };
-  const discard = (c: GitFileChange) => { if (confirm(`Discard changes to ${baseName(c.file_path)}? This cannot be undone.`)) act(() => api.gitDiscard(root, [rel(c)]), "discarded"); };
+  const discard = async (c: GitFileChange) => {
+    if (await ask({ title: `Discard changes to ${baseName(c.file_path)}?`, body: "This cannot be undone.", danger: true, confirmLabel: "Discard" })) act(() => api.gitDiscard(root, [rel(c)]), "discarded");
+  };
   const doCommit = async () => {
     if (!title.trim()) { flash(false, "commit title required"); return; }
     if (await act(() => api.gitCommitStaged(root, title, body), "committed")) { setTitle(""); setBody(""); api.gitGraph(root, 500, logScope).then((r) => setGraph(r.lines)).catch(() => {}); }
@@ -804,20 +811,20 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
    * on *which* failure came back.
    */
   const deleteBranch = async (b: GitBranch) => {
-    if (busy || !confirm(`Delete branch ${b.name}?`)) return;
+    if (busy || !(await ask({ title: `Delete branch ${b.name}?`, danger: true }))) return;
     setBusy(true);
     setPending(`delete ${b.name}`);
     try {
       let r = await api.gitBranchDelete(root, b.name, false);
       const wt = r.ok ? null : /worktree at '([^']+)'/.exec(r.error || "")?.[1];
       if (wt) {
-        if (!confirm(`${b.name} is checked out in the worktree ${wtName(wt)}.\n\nRemove that worktree and delete the branch?`)) { flash(false, "kept"); return; }
+        if (!(await ask({ title: `${b.name} is checked out in a worktree`, body: `It lives in ${wtName(wt)}. Remove that worktree and delete the branch?`, danger: true, confirmLabel: "Remove & delete" }))) { flash(false, "kept"); return; }
         let rm = await api.gitWorktreeRemove(root, wt, false);
         // git refuses to drop a worktree holding work — modified tracked files
         // or, as often, a stray untracked scratch file. Name the cost, then let
         // them take it.
         if (!rm.ok && /modified|untracked|not clean/i.test(rm.error || "")) {
-          if (!confirm(`${wtName(wt)} still has uncommitted or untracked files.\n\nRemove it anyway? That work is gone.`)) { flash(false, rm.error || "kept"); return; }
+          if (!(await ask({ title: `${wtName(wt)} still has uncommitted or untracked files`, body: "Remove it anyway? That work is gone.", danger: true, confirmLabel: "Remove anyway" }))) { flash(false, rm.error || "kept"); return; }
           rm = await api.gitWorktreeRemove(root, wt, true);
         }
         if (!rm.ok) { flash(false, rm.error || "worktree remove failed"); return; }
@@ -826,7 +833,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
       }
       if (!r.ok && /not fully merged/i.test(r.error || "") && b.mergedIntoTrunk) {
         const trunk = branchData.trunk ?? "the trunk";
-        if (confirm(`git says ${b.name} isn't merged, but its commits are already in ${trunk} — a squash merge rewrites them, so the tip never becomes an ancestor.\n\nDelete it anyway?`)) {
+        if (await ask({ title: `git says ${b.name} isn't merged`, body: `Its commits are already in ${trunk} — a squash merge rewrites them, so the tip never becomes an ancestor of anything.\n\nDelete it anyway?`, danger: true })) {
           r = await api.gitBranchDelete(root, b.name, true);
         }
       }
@@ -892,19 +899,28 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const deleteGone = async () => {
     if (!goneMerged.length || busy) return;
     const trunk = branchData.trunk ?? "the trunk";
-    // Before the first question, because the question's wording depends on it.
-    // A failure here is a reason to stop: without the map every branch looks
-    // free to delete, which is the wrong half of the fork to guess at.
+    // Busy BEFORE the first await, not after the confirmation. `git worktree
+    // list` costs a status per checkout — on a repo with eighteen of them the
+    // press was followed by seconds of a button that looked untouched, and the
+    // first thing to appear was a dialog. A control that has been pressed has
+    // to say so on the same frame.
+    setBusy(true);
+    setPending("checking worktrees");
     let heldByWorktree: Map<string, string>;
+    // Without the map every branch looks free to delete, which is the wrong
+    // half of the fork to guess at — so a failure here stops the whole thing.
     try { heldByWorktree = await heldByWorktreeNow(); }
-    catch (e) { flash(false, `couldn't list this repo's worktrees: ${String(e)}`); return; }
+    catch (e) { flash(false, `couldn't list this repo's worktrees: ${String(e)}`); setBusy(false); setPending(null); return; }
     const { free, held } = partitionByWorktree(goneMerged, heldByWorktree);
-    if (!confirm(goneConfirmText(free, held, goneUnmerged.length, trunk))) return;
+    setPending(null);
+    setBusy(false); // the question is theirs to answer; nothing is running
+    if (!(await ask({ title: goneConfirmTitle(free, held, trunk), body: goneConfirmBody(free, held, goneUnmerged.length, trunk), confirmLabel: "Continue" }))) return;
     setBusy(true);
     const failed: string[] = [];
     let done = 0;
     try {
       for (const b of free) {
+        setPending(`deleting ${b.name}`);
         const r = await api.gitBranchDelete(root, b.name, true).catch(() => ({ ok: false, error: "" }));
         if (r.ok) done++; else failed.push(`${b.name}${r.error ? ` (${r.error})` : ""}`);
       }
@@ -915,6 +931,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
           : `deleted ${done}, ${failed.length} kept: ${failed.slice(0, 2).join("; ")}${failed.length > 2 ? "…" : ""}`);
     } finally {
       setBusy(false);
+      setPending(null);
       reloadBranches();
       reloadWorktrees();
     }
@@ -948,8 +965,12 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     const picked = await new Promise<Map<string, string[]> | null>((resolve) => {
       setRescue({ reports: removable.map(({ report }) => report), resolve });
     });
-    setRescue(null);
-    if (!picked) return 0; // cancelled — nothing removed, nothing copied
+    if (!picked) { setRescue(null); return 0; } // cancelled — nothing removed, nothing copied
+    // The modal STAYS UP for the rest of this, showing what is happening.
+    // Copying 700K and removing three checkouts is seconds of work, and closing
+    // the dialog first left the user staring at an unchanged panel, free to
+    // navigate away mid-delete with nothing on screen saying why.
+    const step = (progress: string) => setRescue((r) => (r ? { ...r, progress } : r));
 
     // Copy first, remove second, and never the other way round. A failed rescue
     // has to be able to stop the removal, which it cannot do once the directory
@@ -958,6 +979,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     let rescued = 0;
     for (const [path, rels] of picked) {
       if (!rels.length) continue;
+      step(`keeping ${rels.length} file${rels.length === 1 ? "" : "s"} from ${wtName(path)}`);
       const res = await api.gitWorktreeRescue(root, path, rels).catch((e) => ({ ok: false, error: String(e), copied: [] as string[], skipped: [] as { path: string; why: string }[] }));
       const lost = res.skipped ?? [];
       if (lost.length) {
@@ -977,23 +999,28 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     // confirmed it inspected, so the thing removed is the thing priced.
     for (const { branch, report } of removable) {
       if (keptBack.has(report.path)) continue; // its rescue failed; already reported
+      step(`removing ${wtName(report.path)}`);
       const rm = await api.gitWorktreeRemove(root, report.path, true).catch((e) => ({ ok: false, error: String(e) }));
       if (!rm.ok) { failed.push(`${branch.name} (${rm.error || "worktree remove failed"})`); continue; }
       const r = await api.gitBranchDelete(root, branch.name, true).catch((e) => ({ ok: false, error: String(e) }));
       if (r.ok) done++; else failed.push(`${branch.name} (${r.error || "branch delete failed"})`);
     }
+    setRescue(null);
     return done;
   };
-  const mergeBranch = (name: string) => { if (confirm(`Merge ${name} into the current branch?`)) act(() => api.gitMerge(root, name), `merged ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
-  const rebaseBranch = (name: string) => { if (confirm(`Rebase the current branch onto ${name}?`)) act(() => api.gitRebase(root, name), `rebased onto ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
-  const renameBranch = (name: string) => { const to = prompt(`Rename ${name} to:`, name); if (to && to.trim() && to !== name) act(() => api.gitBranchRename(root, name, to.trim()), `renamed → ${to.trim()}`).then((ok) => { if (ok) reloadBranches(); }); };
+  const mergeBranch = async (name: string) => { if (await ask({ title: `Merge ${name} into the current branch?`, confirmLabel: "Merge" })) act(() => api.gitMerge(root, name), `merged ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
+  const rebaseBranch = async (name: string) => { if (await ask({ title: `Rebase the current branch onto ${name}?`, confirmLabel: "Rebase" })) act(() => api.gitRebase(root, name), `rebased onto ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
+  const renameBranch = async (name: string) => {
+    const to = await askText({ title: `Rename ${name}`, input: { label: "New name", initial: name }, confirmLabel: "Rename" });
+    if (to && to !== name) act(() => api.gitBranchRename(root, name, to), `renamed → ${to}`).then((ok) => { if (ok) reloadBranches(); });
+  };
   // log
   const openCommit = async (hash: string, subject: string) => {
     try { const { changes } = await api.gitCommitDiff(root, hash); setCommitView({ changes, title: `${hash} · ${subject}` }); }
     catch (e) { flash(false, String(e)); }
   };
-  const resetTo = (hash: string, mode: "soft" | "mixed" | "hard") => {
-    if (mode === "hard" && !confirm(`Hard reset to ${hash}? This DISCARDS working-tree changes.`)) return;
+  const resetTo = async (hash: string, mode: "soft" | "mixed" | "hard") => {
+    if (mode === "hard" && !(await ask({ title: `Hard reset to ${hash}?`, body: "This DISCARDS working-tree changes.", danger: true, confirmLabel: "Reset --hard" }))) return;
     act(() => api.gitReset(root, hash, mode), `reset --${mode} ${hash}`).then((ok) => { if (ok) api.gitGraph(root, 500, logScope).then((r) => setGraph(r.lines)); });
   };
   // worktrees
@@ -1006,13 +1033,13 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   // Same shape as the worktree step inside deleteBranch: a dirty worktree is a
   // question ("that work is gone — still?"), not a dead end.
   const removeWorktree = async (w: GitWorktree) => {
-    if (busy || !confirm(`Remove worktree ${wtName(w.path)}?`)) return;
+    if (busy || !(await ask({ title: `Remove worktree ${wtName(w.path)}?`, danger: true, confirmLabel: "Remove" }))) return;
     setBusy(true);
     setPending(`remove ${wtName(w.path)}`);
     try {
       let r = await api.gitWorktreeRemove(root, w.path, false);
       if (!r.ok && /modified|untracked|not clean/i.test(r.error || "")) {
-        if (!confirm(`${wtName(w.path)} still has uncommitted or untracked files.\n\nRemove it anyway? That work is gone.`)) { flash(false, r.error || "kept"); return; }
+        if (!(await ask({ title: `${wtName(w.path)} still has uncommitted or untracked files`, body: "Remove it anyway? That work is gone.", danger: true, confirmLabel: "Remove anyway" }))) { flash(false, r.error || "kept"); return; }
         r = await api.gitWorktreeRemove(root, w.path, true);
       }
       flash(r.ok, r.ok ? "removed worktree" : r.error || "failed");
@@ -1058,7 +1085,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const reloadStashes = () => api.gitStashes(root).then((r) => setStashes(r.stashes)).catch(() => {});
   const stashPush = async () => { if (await act(() => api.gitStashPush(root, ""), "stashed")) reloadStashes(); };
   const stashOp = async (op: "apply" | "pop" | "drop", index: number) => {
-    if (op === "drop" && !confirm("Drop this stash?")) return;
+    if (op === "drop" && !(await ask({ title: "Drop this stash?", body: "The stashed changes are gone.", danger: true, confirmLabel: "Drop" }))) return;
     const fn = op === "apply" ? api.gitStashApply : op === "pop" ? api.gitStashPop : api.gitStashDrop;
     if (await act(() => fn(root, index), op + "ed")) reloadStashes();
   };
@@ -1189,9 +1216,9 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   }, [view]);
 
   // interactive hunk staging (unified view, modified files)
-  const applyHunk = (action: "stage" | "unstage" | "discard", i: number) => {
+  const applyHunk = async (action: "stage" | "unstage" | "discard", i: number) => {
     if (!selected || !writeEnabled) return;
-    if (action === "discard" && !confirm("Discard this hunk? This cannot be undone.")) return;
+    if (action === "discard" && !(await ask({ title: "Discard this hunk?", body: "This cannot be undone.", danger: true, confirmLabel: "Discard" }))) return;
     act(() => api.gitApplyHunk(root, selected.file_path, selected.staged, action, selected.hunks[i]), `${action}d hunk`);
   };
   const hunkBtn = (label: string, tint: string, onClick: () => void) => (
@@ -1498,8 +1525,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         the moment it exists for. */}
                     {branch?.canUndoMerge && (
                       <button
-                        onClick={() => {
-                          if (!confirm(`Undo the last merge on ${branch.name}?\n\nThe branch goes back to exactly where it was. Nothing has been pushed, so nothing anyone else has is affected.`)) return;
+                        onClick={async () => {
+                          if (!(await ask({ title: `Undo the last merge on ${branch.name}?`, body: "The branch goes back to exactly where it was. Nothing has been pushed, so nothing anyone else has is affected.", confirmLabel: "Undo merge" }))) return;
                           void act(() => api.gitUndoMerge(root), "merge undone", "undo");
                         }}
                         disabled={!writeEnabled || busy}
@@ -1817,7 +1844,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                           className={`flex items-center gap-2 px-3 whitespace-pre ${isCommit ? "cursor-pointer hover:brightness-125" : ""}`}
                           style={{ lineHeight: "1.55", ...(i === rowIdx ? rowProps(true).style : {}) }}
                           title={isCommit ? "View this commit's diff" : undefined}
-                          onContextMenu={isCommit ? (e) => { e.preventDefault(); const m = prompt(`reset current branch to ${l.hash} — type: soft, mixed, or hard`, "mixed"); if (m === "soft" || m === "mixed" || m === "hard") resetTo(l.hash!, m); } : undefined}>
+                          onContextMenu={isCommit ? async (e) => { e.preventDefault(); const m = await askText({ title: `Reset current branch to ${l.hash}`, input: { label: "Mode — soft, mixed or hard", initial: "mixed" }, confirmLabel: "Reset" }); if (m === "soft" || m === "mixed" || m === "hard") resetTo(l.hash!, m); } : undefined}>
                           <span style={{ color: "color-mix(in srgb, var(--primary) 75%, var(--text3))" }}>{l.graph}</span>
                           {isCommit && <>
                             <span className="shrink-0 tabular-nums" style={{ color: "var(--primary-hover)" }}>{l.hash}</span>
@@ -1858,12 +1885,13 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         {onlyGone && writeEnabled && goneMerged.length > 0 && (
                           <button onClick={deleteGone} disabled={busy} className="text-[10.5px] px-2.5 py-1 rounded-lg font-medium"
                             style={{ background: "color-mix(in srgb, var(--error) 18%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)", color: "var(--error)", opacity: busy ? 0.55 : 1 }}>
-                            {busy ? "deleting…" : `delete ${goneMerged.length} merged`}
+                            {busy ? `${pending ?? "working"}…` : `delete ${goneMerged.length} merged`}
                           </button>
                         )}
                         {onlyGone && (
                           <span className="text-[9.5px] t-dim2">
                             {goneMerged.length > 0 && <>{goneMerged.length} already in {branchData.trunk ?? "the trunk"}</>}
+                            {branchData.sweeping && <span title="Squash- and rebase-merged branches are recognised by replaying their diff, which runs behind the list. The count can still go up.">{goneMerged.length > 0 ? " · " : ""}still checking for squash merges…</span>}
                             {goneMerged.length > 0 && goneUnmerged.length > 0 && " · "}
                             {goneUnmerged.length > 0 && <span style={{ color: "var(--warning)" }}>{goneUnmerged.length} not merged — kept</span>}
                           </span>
@@ -2140,7 +2168,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
           it's a drill-down from a row you clicked, not a place you navigate
           to — the rail's views are the destinations, this is a detour. */}
       <ChangesModal open={!!commitView} onClose={() => setCommitView(null)} onBack={() => setCommitView(null)} backLabel="Log" presetChanges={commitView?.changes} presetTitle={commitView?.title} />
-      {rescue && <RescueModal reports={rescue.reports} onCancel={() => rescue.resolve(null)} onConfirm={(picked) => rescue.resolve(picked)} />}
+      {rescue && <RescueModal reports={rescue.reports} progress={rescue.progress} onCancel={() => rescue.resolve(null)} onConfirm={(picked) => rescue.resolve(picked)} />}
+      {dialog}
     </div>
   );
 }

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -6,7 +6,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
-import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
+import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { newChat, update, setActiveChatId } from "../lib/chatStore.ts";
@@ -134,7 +134,9 @@ const VIEW_KEYS: Record<View, [string, string][]> = {
   log: [["j/k", "commit"]],
   reflog: [["j/k", "entry"]],
   branches: [["j/k", "branch"], ["space", "checkout"], ["d", "delete"]],
-  remotes: [["j/k", "remote"]],
+  // `space` is the harmless one on purpose — see rowAction: checkout and
+  // worktree both move something on disk and stay mouse-only.
+  remotes: [["j/k", "branch"], ["space", "+ local"]],
   tags: [["j/k", "tag"]],
   stashes: [["j/k", "stash"], ["space", "apply"], ["d", "drop"]],
   worktrees: [["j/k", "worktree"], ["space", "open"], ["d", "remove"]],
@@ -461,8 +463,28 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const [stashes, setStashes] = useState<GitStash[]>([]);
   const [worktrees, setWorktrees] = useState<GitWorktree[]>([]);
   const [remotes, setRemotes] = useState<GitRemote[]>([]);
+  /** The remote whose branches the pane is listing, and that list. Empty until
+   *  the first answer names one — the server picks the only/first remote when
+   *  we ask without one, so there is no guess to make here. */
+  const [remoteSel, setRemoteSel] = useState("");
+  const [remoteRows, setRemoteRows] = useState<GitRemoteBranch[]>([]);
+  const [remoteQuery, setRemoteQuery] = useState("");
   const [tags, setTags] = useState<GitTag[]>([]);
   const [reflog, setReflog] = useState<GitReflogEntry[]>([]);
+  /**
+   * Whose history the Log shows: this checkout's own, or every branch.
+   *
+   * Remembered across sessions because it is a preference, not a mode you set
+   * per visit — and defaulted to the branch you are standing on, which is the
+   * answer to "what have I been doing" that the pane is usually asked.
+   */
+  const [logScope, setLogScope] = useState<"head" | "all">(() => {
+    try { return localStorage.getItem("agx_git_log_scope") === "all" ? "all" : "head"; } catch { return "head"; }
+  });
+  useEffect(() => { try { localStorage.setItem("agx_git_log_scope", logScope); } catch { /* private mode */ } }, [logScope]);
+  /** The branch the log was read from, as the server saw it — so the pane can
+   *  name it rather than leave you to infer it from the commits. */
+  const [graphBranch, setGraphBranch] = useState("");
   /** Which view has a request in flight, so "still loading" and "genuinely
    *  empty" stop rendering as the same blank pane. */
   const [busyView, setBusyView] = useState<View | null>(null);
@@ -659,13 +681,24 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
       });
     };
     if (view === "branches") track(api.gitBranches(root), setBranchData);
-    else if (view === "log") track(api.gitGraph(root, 500), (r) => setGraph(r.lines));
+    else if (view === "log") track(api.gitGraph(root, 500, logScope), (r) => { setGraph(r.lines); setGraphBranch(r.branch); });
     else if (view === "stashes") track(api.gitStashes(root), (r) => setStashes(r.stashes));
     else if (view === "worktrees") track(api.gitWorktrees(root), (r) => setWorktrees(r.worktrees));
-    else if (view === "remotes") track(api.gitRemotes(root), (r) => setRemotes(r.remotes));
+    else if (view === "remotes") {
+      // Two answers, because the pane asks two questions: which remotes there
+      // are (the picker) and what is on the selected one (the list). Asked
+      // together rather than chained, so the list doesn't wait on the picker.
+      api.gitRemotes(root).then((r) => setRemotes(r.remotes)).catch(() => {});
+      track(api.gitRemoteBranches(root, remoteSel), (r) => {
+        setRemoteRows(r.branches);
+        // Which remote the server actually read — how the picker gets its
+        // initial selection without this side guessing "origin".
+        if (r.remote) setRemoteSel(r.remote);
+      });
+    }
     else if (view === "tags") track(api.gitTags(root), (r) => setTags(r.tags));
     else if (view === "reflog") track(api.gitReflog(root), (r) => setReflog(r.entries));
-  }, [open, root, view]);
+  }, [open, root, view, logScope, remoteSel]);
   useEffect(() => { loadView(); }, [loadView]);
 
   // Any repository mutation, from anywhere — this panel, another window, or a
@@ -736,7 +769,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const discard = (c: GitFileChange) => { if (confirm(`Discard changes to ${baseName(c.file_path)}? This cannot be undone.`)) act(() => api.gitDiscard(root, [rel(c)]), "discarded"); };
   const doCommit = async () => {
     if (!title.trim()) { flash(false, "commit title required"); return; }
-    if (await act(() => api.gitCommitStaged(root, title, body), "committed")) { setTitle(""); setBody(""); api.gitGraph(root, 500).then((r) => setGraph(r.lines)).catch(() => {}); }
+    if (await act(() => api.gitCommitStaged(root, title, body), "committed")) { setTitle(""); setBody(""); api.gitGraph(root, 500, logScope).then((r) => setGraph(r.lines)).catch(() => {}); }
   };
   // branches
   const reloadBranches = () => api.gitBranches(root).then(setBranchData).catch(() => {});
@@ -857,7 +890,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   };
   const resetTo = (hash: string, mode: "soft" | "mixed" | "hard") => {
     if (mode === "hard" && !confirm(`Hard reset to ${hash}? This DISCARDS working-tree changes.`)) return;
-    act(() => api.gitReset(root, hash, mode), `reset --${mode} ${hash}`).then((ok) => { if (ok) api.gitGraph(root, 500).then((r) => setGraph(r.lines)); });
+    act(() => api.gitReset(root, hash, mode), `reset --${mode} ${hash}`).then((ok) => { if (ok) api.gitGraph(root, 500, logScope).then((r) => setGraph(r.lines)); });
   };
   // worktrees
   const reloadWorktrees = () => api.gitWorktrees(root).then((r) => setWorktrees(r.worktrees)).catch(() => {});
@@ -883,6 +916,34 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); setPending(null); }
   };
+  // remote branches
+  const reloadRemoteBranches = () => api.gitRemoteBranches(root, remoteSel).then((r) => setRemoteRows(r.branches)).catch(() => {});
+  /**
+   * Get a remote branch onto this machine, three ways.
+   *
+   * "local" makes the branch and stops — the safe one, and the one that fits a
+   * repo where the working tree belongs to an agent that is mid-edit. "checkout"
+   * also switches this checkout onto it. "worktree" gives it a directory of its
+   * own, which on a repo worked one-ticket-per-branch is usually what "add that
+   * branch to my local env" actually means.
+   */
+  const takeRemote = async (b: GitRemoteBranch, how: "local" | "checkout" | "worktree") => {
+    if (how === "worktree") {
+      const path = `${root}-${b.name.replace(/[\/\s]+/g, "-")}`; // sibling dir, same shape as the Worktrees tab uses
+      if (await act(() => api.gitWorktreeAdd(root, path, b.name, true, b.ref), `worktree ${wtName(path)}`, `take:${b.ref}`)) {
+        reloadRemoteBranches(); reloadWorktrees(); reloadBranches();
+      }
+      return;
+    }
+    const ok = await act(() => api.gitTrackRemote(root, b.ref, how === "checkout"),
+      how === "checkout" ? `on ${b.name}` : `${b.name} is local now`, `take:${b.ref}`);
+    if (!ok) return;
+    reloadRemoteBranches(); reloadBranches();
+    // Checking out moved the working tree — the Changes view is now the thing
+    // worth looking at, the same as it is after a checkout from the Branches tab.
+    if (how === "checkout") setView("changes");
+  };
+
   // Source control's picker never had this; the terminal's did. Same bug, one
   // file each, which is why it read as fixed.
   const repoPickerRef = useRef<HTMLDivElement | null>(null);
@@ -1091,13 +1152,31 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const incGraph = useIncremental(graph, root);
   const incReflog = useIncremental(reflog, root);
   const incTags = useIncremental(tags, root);
+  /**
+   * The remote's branches, filtered here rather than on the server.
+   *
+   * 790 of them arrive in one response and a repo's branch names are how people
+   * actually search — "20343", "phone", a colleague's prefix — so this is a
+   * substring match over name, subject and author, all terms having to hit. A
+   * round trip per keystroke would be slower and no more correct.
+   */
+  const shownRemoteBranches = useMemo(() => {
+    const q = remoteQuery.trim().toLowerCase();
+    if (!q) return remoteRows;
+    const terms = q.split(/\s+/);
+    return remoteRows.filter((b) => {
+      const hay = `${b.name} ${b.subject} ${b.author}`.toLowerCase();
+      return terms.every((t) => hay.includes(t));
+    });
+  }, [remoteRows, remoteQuery]);
+  const incRemoteBranches = useIncremental(shownRemoteBranches, `${root}:${remoteSel}:${remoteQuery}`);
 
   /** How many rows the focused view has, so j/k knows where the end is. */
   const rowCount =
     view === "branches" ? shownBranches.length :
     view === "reflog" ? reflog.length :
     view === "tags" ? tags.length :
-    view === "remotes" ? remotes.length :
+    view === "remotes" ? shownRemoteBranches.length :
     view === "stashes" ? stashes.length :
     view === "worktrees" ? worktrees.length :
     view === "log" ? graph.length : 0;
@@ -1106,6 +1185,9 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   // would otherwise leave it pointing past the end.
   useEffect(() => { setRowIdx((i) => (rowCount ? Math.min(i, rowCount - 1) : 0)); }, [rowCount]);
   useEffect(() => { setRowIdx(0); }, [view, root]);
+  // A different repo has different remotes: carrying the selection over asks for
+  // branches from a remote this one may not even have.
+  useEffect(() => { setRemoteSel(""); setRemoteRows([]); setRemoteQuery(""); }, [root]);
 
   /**
    * What `space` (the view's main action) and `d` (remove) do to the row under
@@ -1129,47 +1211,82 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
       const w = worktrees[rowIdx];
       if (!w || (kind === "delete" && w.current)) return;
       kind === "primary" ? openWorktree(w) : removeWorktree(w);
+    } else if (view === "remotes") {
+      // Only the harmless one gets a key. Checking out and creating a worktree
+      // both move something on disk, and neither should be one keystroke away
+      // from a list you scroll with j/k.
+      const b = shownRemoteBranches[rowIdx];
+      if (!b || b.local || kind === "delete") return;
+      takeRemote(b, "local");
     }
   };
-  const hasRowAction = view === "branches" || view === "stashes" || view === "worktrees";
+  const hasRowAction = view === "branches" || view === "stashes" || view === "worktrees" || view === "remotes";
 
   const COUNTS: Partial<Record<View, number>> = {
     changes: all.length, branches: branchData.branches.length, worktrees: worktrees.length,
     stashes: stashes.length, remotes: remotes.length, tags: tags.length,
   };
+  /**
+   * One tab: the key that gets you there, the name, and the count *under* both.
+   *
+   * The count used to sit beside the name as a chip, which cost every counted
+   * tab ~28px of width. Eight tabs plus a 60-character branch name plus
+   * fetch/pull/push does not fit a laptop window, so the strip scrolled and the
+   * last tab ("Stashes") was permanently a sliver reading "8 S" behind the
+   * branch chip — a tab you cannot read is a tab you cannot use.
+   *
+   * Stacking is the trade that costs nothing here: the header is a FIXED 48px
+   * (see VIEW_HEADER_H) and a two-line tab is ~31px, so the bar cannot grow
+   * vertically no matter what these say, while the strip gets ~150px back
+   * horizontally — enough for all eight to fit without scrolling.
+   *
+   * The rule separating the two lines is the tab's own, not a divider between
+   * tabs: it ties the number to the word above it rather than to its
+   * neighbours, which is what stops "45" and "125" from reading as one row of
+   * loose digits.
+   */
   const ViewTab = ({ id }: { id: View }) => {
     const n = COUNTS[id];
     const num = ALL_VIEWS.indexOf(id) + 1;
+    const on = view === id;
     return (
-      <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]} — press ${num}`}
+      <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]}${n != null ? ` (${n})` : ""} — press ${num}`}
         aria-keyshortcuts={String(num)}
-        className="text-[10.5px] px-2 py-1 rounded-md transition-colors flex items-center gap-1.5 whitespace-nowrap shrink-0"
-        style={{ background: view === id ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: view === id ? "var(--text)" : "var(--text3)", border: `1px solid color-mix(in srgb, var(--border) ${view === id ? 40 : 15}%, transparent)` }}>
-        {/* The key that gets you here. lazygit does the same in its panel titles
-            (gui.showPanelJumps) — a shortcut nothing advertises is a shortcut
-            nobody uses.
+        className="text-[10.5px] px-2 py-[3px] rounded-md transition-colors flex flex-col items-stretch gap-[2px] whitespace-nowrap shrink-0"
+        style={{ background: on ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: on ? "var(--text)" : "var(--text3)", border: `1px solid color-mix(in srgb, var(--border) ${on ? 40 : 15}%, transparent)` }}>
+        <span className="flex items-center gap-1.5 leading-none">
+          {/* The key that gets you here. lazygit does the same in its panel
+              titles (gui.showPanelJumps) — a shortcut nothing advertises is a
+              shortcut nobody uses.
 
-            Drawn as a keycap rather than a bare digit. Bare, it read as a
-            count — "1 Changes" looked like one change — and next to a real one
-            ("4 Branches 44") the row became two numbers with a word wedged
-            between them. An outlined cap says "press this"; the count beside
-            it is a filled chip, so the two are different kinds of object
-            before either is read. */}
-        <span
-          className="tabular-nums leading-none rounded-[3px] px-1 py-[1px]"
-          style={{
-            fontSize: 8.5,
-            opacity: view === id ? 0.85 : 0.5,
-            border: "1px solid color-mix(in srgb, var(--text3) 45%, transparent)",
-          }}
-        >{num}</span>
-        {VIEW_LABEL[id]}
-        {n != null && n > 0 && (
+              Drawn as a keycap rather than a bare digit. Bare, it read as a
+              count — "1 Changes" looked like one change. Now that the real
+              count is on the line below, the outline is what still tells the
+              two numbers apart at a glance. */}
           <span
-            className="tabular-nums leading-none rounded-full px-1.5 py-[1px]"
-            style={{ fontSize: 9, background: "color-mix(in srgb, var(--primary) 18%, transparent)", color: "var(--primary-hover)" }}
-          >{n}</span>
-        )}
+            className="tabular-nums leading-none rounded-[3px] px-1 py-[1px]"
+            style={{ fontSize: 8.5, opacity: on ? 0.85 : 0.5, border: "1px solid color-mix(in srgb, var(--text3) 45%, transparent)" }}
+          >{num}</span>
+          {VIEW_LABEL[id]}
+        </span>
+        {/* Always rendered, count or not: an empty second line keeps every tab
+            the same height, and a strip of tabs that each stop at a different
+            place is worse than a blank half-line under "Log".
+
+            Zero is left blank rather than drawn. These counts start at zero and
+            are only true once that tab has been visited, so a fresh panel
+            printing "0" under Tags would be stating something it hasn't
+            checked. */}
+        <span
+          className="tabular-nums leading-none text-center pt-[2px]"
+          style={{
+            fontSize: 9,
+            minHeight: 10,
+            color: on ? "var(--primary-hover)" : "var(--text3)",
+            opacity: on ? 1 : 0.75,
+            borderTop: `1px solid color-mix(in srgb, var(--${on ? "primary" : "border"}) ${on ? 30 : 22}%, transparent)`,
+          }}
+        >{n ? n : ""}</span>
       </button>
     );
   };
@@ -1549,6 +1666,37 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                     </div>
                   </div>
                 ) : view === "log" ? (
+                  <div className="flex-1 min-h-0 flex flex-col">
+                    {/*
+                      * Whose history this is.
+                      *
+                      * The pane used to run `--all` and say nothing about it,
+                      * so from a worktree on a ticket branch you got 500
+                      * commits belonging to every branch in the repo — your own
+                      * branch nowhere near the top — with no clue that was even
+                      * the question being answered. Naming the branch is half
+                      * the fix; the toggle is the other half, because "show me
+                      * the whole graph" is a real thing to want, just not the
+                      * default.
+                      */}
+                    <div className="shrink-0 px-3 pt-2.5 pb-2 flex items-center gap-2">
+                      <span className="text-[9.5px] uppercase tracking-wider t-dim2 shrink-0">history of</span>
+                      <span className="min-w-0 truncate text-[11px] px-2 py-0.5 rounded" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 12%, transparent)" }}
+                        title={logScope === "all" ? "every branch in this repository" : `${graphBranch || "HEAD"} — the branch this checkout is on`}>
+                        {logScope === "all" ? "every branch" : `⎇ ${graphBranch || branch?.name || "HEAD"}`}
+                      </span>
+                      <div className="flex items-center gap-px rounded-md ml-1" style={{ background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
+                        {([["head", "this branch"], ["all", "all branches"]] as const).map(([s, label]) => (
+                          <button key={s} onClick={() => setLogScope(s)}
+                            className="text-[10px] px-2 py-1 rounded-md whitespace-nowrap"
+                            style={{ background: logScope === s ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: logScope === s ? "var(--text)" : "var(--text3)", border: `1px solid color-mix(in srgb, var(--border) ${logScope === s ? 40 : 15}%, transparent)` }}
+                            title={s === "head" ? "Only the commits reachable from this checkout's HEAD" : "git log --all — every branch, which is a lot on a shared repo"}>
+                            {label}
+                          </button>
+                        ))}
+                      </div>
+                      <span className="ml-auto shrink-0 text-[9.5px] tabular-nums t-dim2">{graph.length ? `${graph.filter((l) => l.hash).length} commits` : ""}</span>
+                    </div>
                   <div onScroll={incGraph.onScroll} className="agx-scroll flex-1 min-h-0 overflow-auto py-1 text-[11.5px]" style={{ fontFamily: "var(--font-mono, ui-monospace), monospace" }}>
                     {incGraph.rows.map((l, i) => {
                       const isCommit = !!l.hash;
@@ -1572,6 +1720,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                     })}
                     {!graph.length && <PaneEmpty busy={busyView === "log"} what="commits" />}
                     <MoreRows shown={incGraph.rows.length} total={graph.length} onAll={incGraph.showAll} />
+                  </div>
                   </div>
                 ) : view === "branches" ? (
                   <div onScroll={incBranches.onScroll} className="agx-scroll flex-1 min-h-0 overflow-y-auto p-3">
@@ -1670,18 +1819,112 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                     {!stashes.length && <PaneEmpty busy={busyView === "stashes"} what="stashes" />}
                   </div>
                 ) : view === "remotes" ? (
-                  <div className="agx-scroll flex-1 min-h-0 overflow-y-auto p-3">
-                    {remotes.map((r, i) => (
-                      <div key={r.name} {...rowProps(i === rowIdx)} className="flex items-center gap-3 px-2.5 py-2 rounded-md" onClick={() => setRowIdx(i)}>
-                        <span className="shrink-0 text-[12px] font-medium" style={{ color: "var(--text)" }}>{r.name}</span>
-                        <span className="shrink-0 text-[9.5px] tabular-nums t-dim2">{r.branches} branch{r.branches === 1 ? "" : "es"}</span>
-                        <span className="min-w-0 flex-1 truncate text-[10px] t-dim2" title={r.fetchUrl}>{r.fetchUrl}</span>
-                        {/* Only worth showing when they differ — the fork setup,
-                            where you fetch from upstream and push to your own. */}
-                        {r.pushUrl && r.pushUrl !== r.fetchUrl && <span className="shrink-0 text-[9px] px-1 py-px rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 12%, transparent)" }} title={`pushes to ${r.pushUrl}`}>push ≠ fetch</span>}
+                  /*
+                   * The remote, and then what is actually on it.
+                   *
+                   * This tab used to be one row — "origin · 790 branches · url"
+                   * — which is a fact about the repository nobody needs twice.
+                   * The 790 were the interesting part and there was no way to
+                   * see them, so a branch a colleague pushed was reachable only
+                   * by typing git in a terminal. Now the remote line is a
+                   * header (a picker, when there is more than one) and the pane
+                   * below it is the branch list, searchable, with the one
+                   * action that matters: get it onto this machine.
+                   */
+                  <div className="flex-1 min-h-0 flex flex-col">
+                    <div className="px-3 pt-3 pb-2 shrink-0 flex flex-col gap-2">
+                      <div className="flex items-center gap-1.5 flex-wrap">
+                        {remotes.map((r) => {
+                          const on = r.name === remoteSel;
+                          return (
+                            <button key={r.name} onClick={() => { setRemoteSel(r.name); setRemoteQuery(""); }}
+                              className="flex items-center gap-2 px-2.5 py-1.5 rounded-lg text-[11px] max-w-full"
+                              style={{ background: on ? "color-mix(in srgb, var(--primary) 14%, transparent)" : "transparent", border: `1px solid color-mix(in srgb, var(--${on ? "primary" : "border"}) ${on ? 35 : 30}%, transparent)`, color: on ? "var(--text)" : "var(--text2)" }}
+                              title={`${r.fetchUrl}${r.pushUrl && r.pushUrl !== r.fetchUrl ? `\npushes to ${r.pushUrl}` : ""}`}>
+                              <span className="font-medium shrink-0">{r.name}</span>
+                              <span className="shrink-0 text-[9.5px] tabular-nums t-dim2">{r.branches}</span>
+                              <span className="min-w-0 truncate text-[9.5px] t-dim2">{r.fetchUrl}</span>
+                              {/* Only worth showing when they differ — the fork
+                                  setup, where you fetch from upstream and push
+                                  to your own. */}
+                              {r.pushUrl && r.pushUrl !== r.fetchUrl && <span className="shrink-0 text-[9px] px-1 py-px rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 12%, transparent)" }}>push ≠ fetch</span>}
+                            </button>
+                          );
+                        })}
                       </div>
-                    ))}
-                    {!remotes.length && <PaneEmpty busy={busyView === "remotes"} what="remotes" />}
+                      {!!remotes.length && (
+                        <div className="flex items-center gap-2">
+                          <input value={remoteQuery} onChange={(e) => { setRemoteQuery(e.target.value); setRowIdx(0); }}
+                            placeholder={`search ${remoteSel || "remote"} branches…`}
+                            className="flex-1 min-w-0 px-2.5 py-1.5 rounded-lg text-[11.5px] outline-none"
+                            style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }} />
+                          {/* Counted against the whole list, not the page: "36
+                              of 790" is the only way to know whether the search
+                              narrowed anything. */}
+                          <span className="shrink-0 text-[9.5px] tabular-nums t-dim2">
+                            {remoteQuery.trim() ? `${shownRemoteBranches.length} of ${remoteRows.length}` : `${remoteRows.length} branch${remoteRows.length === 1 ? "" : "es"}`}
+                          </span>
+                          {remoteQuery.trim() && (
+                            <button onClick={() => setRemoteQuery("")} className="shrink-0 text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>clear</button>
+                          )}
+                        </div>
+                      )}
+                      {/* These refs are the last fetch's answer, and every other
+                          number in this panel is measured against them. Saying
+                          so is cheaper than someone wondering why a branch
+                          pushed a minute ago isn't here. */}
+                      {!!remotes.length && <div className="text-[9.5px] t-dim2">as of the last fetch — press fetch above for anything newer</div>}
+                    </div>
+                    <div onScroll={incRemoteBranches.onScroll} className="agx-scroll flex-1 min-h-0 overflow-y-auto px-3 pb-3">
+                      {!shownRemoteBranches.length && (
+                        remoteQuery.trim() && remoteRows.length
+                          ? <div className="grid place-items-center py-10 t-dim2 text-[12px]">nothing on {remoteSel} matches “{remoteQuery.trim()}”</div>
+                          : <PaneEmpty busy={busyView === "remotes"} what={remotes.length ? "remote branches" : "remotes"} />
+                      )}
+                      {incRemoteBranches.rows.map((b, i) => {
+                        const sel = i === rowIdx;
+                        return (
+                          <div key={b.ref} onClick={() => setRowIdx(i)} {...rowProps(sel)}
+                            className="group flex items-center gap-2 px-2.5 py-1.5 rounded-md">
+                            <span className="shrink-0 text-[11.5px] font-medium truncate" style={{ maxWidth: 380, color: b.local ? "var(--text)" : "var(--text2)" }} title={b.ref}>{b.name}</span>
+                            {/* Whether you already have it is the whole reason
+                                this list is worth reading. A checkout that has
+                                it out is stronger still — that is where the
+                                work would go. */}
+                            {b.worktree
+                              ? <span className="shrink-0 text-[9px] px-1 py-px rounded" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }} title={`checked out in ${b.worktree}`}>▸ {wtName(b.worktree)}</span>
+                              : b.local
+                                ? <span className="shrink-0 text-[9px] px-1 py-px rounded" style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 12%, transparent)" }} title={b.tracking ? "you have this branch, tracking this remote one" : "you have a local branch of this name — it tracks something else"}>{b.tracking ? "local" : "local ≠"}</span>
+                                : null}
+                            <span className="shrink-0 text-[9.5px] tabular-nums t-dim2">{b.hash}</span>
+                            <span className="min-w-0 flex-1 truncate text-[10px] t-dim2" title={b.subject}>{b.subject}</span>
+                            <span className="shrink-0 text-[9.5px] t-dim2 truncate" style={{ maxWidth: 130 }}>{b.author}</span>
+                            <span className="shrink-0 text-[9.5px] t-dim2 w-20 text-right">{b.date}</span>
+                            {writeEnabled && !b.local && (
+                              <div className="shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                                {/* Three verbs, ordered by how much they move.
+                                    "+ local" touches nothing on disk; the other
+                                    two do, so they are never the default. */}
+                                <button onClick={() => takeRemote(b, "local")} disabled={busy} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}
+                                  title={`Create a local ${b.name} tracking ${b.ref}. Nothing is checked out — this working tree does not move.`}>+ local</button>
+                                <button onClick={() => takeRemote(b, "checkout")} disabled={busy} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}
+                                  title={`Create a local ${b.name} tracking ${b.ref} and switch this checkout onto it.`}>checkout</button>
+                                <button onClick={() => takeRemote(b, "worktree")} disabled={busy} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}
+                                  title={`Check ${b.name} out in its own directory beside this one — this working tree is untouched.`}>+ worktree</button>
+                              </div>
+                            )}
+                            {/* Already here: the useful action is going there,
+                                not making a second copy. */}
+                            {b.local && b.worktree && b.worktree !== root && (
+                              <button onClick={() => openWorktree({ path: b.worktree!, branch: b.name, head: b.hash, current: false, bare: false, locked: false })}
+                                className="shrink-0 text-[10px] px-1.5 py-0.5 rounded opacity-0 group-hover:opacity-100" style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}
+                                title={`Open ${b.worktree}`}>open</button>
+                            )}
+                          </div>
+                        );
+                      })}
+                      <MoreRows shown={incRemoteBranches.rows.length} total={shownRemoteBranches.length} onAll={incRemoteBranches.showAll} />
+                    </div>
                   </div>
                 ) : view === "tags" ? (
                   <div onScroll={incTags.onScroll} className="agx-scroll flex-1 min-h-0 overflow-y-auto p-3">
@@ -1730,6 +1973,10 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         <span className="shrink-0 text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 10%, transparent)" }}>⎇ {w.branch}</span>
                         <span className="shrink-0 text-[9.5px] tabular-nums t-dim2">{w.head}</span>
                         {w.locked && <span className="shrink-0 text-[9px]" style={{ color: "var(--warning)" }}>locked</span>}
+                        {/* Same reading as the repo picker's. It is also the
+                            reason the sync button below may be disabled, so it
+                            has to be visible on the row that carries it. */}
+                        {!!w.dirty && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--warning)" }} title={`${w.dirty} uncommitted change${w.dirty === 1 ? "" : "s"} in this checkout`}>●{w.dirty}</span>}
                         <span className="min-w-0 flex-1 truncate text-[9.5px] t-dim2">{w.path}</span>
                         {/* How far this checkout has drifted from what it was
                             branched off, and the one-click way to close the
@@ -1742,16 +1989,29 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                               title={`${w.behindBase} commit${w.behindBase === 1 ? "" : "s"} on ${w.base} that this branch does not have`}>
                               ↓{w.behindBase} behind {w.base}
                             </span>
-                            {writeEnabled && (
-                              <button
-                                onClick={() => act(() => api.gitSyncBase(w.path, w.base ?? undefined), `merged ${w.base}`, "sync")}
-                                disabled={busy}
-                                className="shrink-0 text-[10px] px-1.5 py-0.5 rounded"
-                                style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: busy ? 0.5 : 1 }}
-                                title={`Merge ${w.base} into ${w.branch}, in that worktree. A merge, not a rebase — nothing already pushed gets rewritten. Refused if that checkout has uncommitted changes.`}>
-                                {pending === "sync" ? "syncing…" : "sync"}
-                              </button>
-                            )}
+                            {/* Disabled on a dirty checkout, exactly like the
+                                header's sync button — syncFromBase refuses to
+                                merge over uncommitted work, so an enabled
+                                button here could only ever produce an error
+                                toast. The header got this right and this row
+                                did not, which is worse than either: the same
+                                action looked possible in one place and not the
+                                other. */}
+                            {writeEnabled && (() => {
+                              const blocked = !!w.dirty;
+                              return (
+                                <button
+                                  onClick={() => act(() => api.gitSyncBase(w.path, w.base ?? undefined), `merged ${w.base}`, `sync:${w.path}`)}
+                                  disabled={busy || blocked}
+                                  className="shrink-0 text-[10px] px-1.5 py-0.5 rounded"
+                                  style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: busy || blocked ? 0.45 : 1 }}
+                                  title={blocked
+                                    ? `Commit or stash the ${w.dirty} change${w.dirty === 1 ? "" : "s"} in ${wtName(w.path)} first — merging over uncommitted work is how you lose it`
+                                    : `Merge ${w.base} into ${w.branch}, in that worktree. A merge, not a rebase — nothing already pushed gets rewritten.`}>
+                                  {pending === `sync:${w.path}` ? "syncing…" : "sync"}
+                                </button>
+                              );
+                            })()}
                           </>
                         )}
                         {writeEnabled && !w.current && <button onClick={() => removeWorktree(w)} className="shrink-0 text-[10px] opacity-0 group-hover:opacity-100 px-1.5 py-0.5 rounded" style={{ color: "var(--error)" }} title="Remove worktree">remove</button>}

--- a/web/src/components/RescueModal.tsx
+++ b/web/src/components/RescueModal.tsx
@@ -1,0 +1,194 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import type { WorktreeLeftovers, LeftoverEntry } from "../../../shared/types.ts";
+import { Portal } from "./Portal.tsx";
+import { preselected, fmtBytes } from "../lib/goneCleanup.ts";
+
+/**
+ * The last thing between somebody's notes and `rm -rf`.
+ *
+ * Removing a worktree deletes its gitignored files with no --force and no
+ * warning, so the branches panel has to name them before it acts. Naming them
+ * was step one and it worked — but it left the user copying paths out by hand,
+ * which is a step people skip at exactly the moment they shouldn't. This turns
+ * the warning into an offer: tick what to keep, it goes into the MAIN checkout
+ * at the same relative path, then the worktree goes.
+ *
+ * The main checkout rather than an archive folder, because that is where these
+ * files already live — this repo's `.specs/` in the main checkout holds 157 of
+ * exactly these notes, and a worktree's three are the ones that never came
+ * back. Anything already there is refused, never overwritten (rescueLeftovers).
+ *
+ * Keyboard first, like the rest of this panel: j/k to move, space to toggle,
+ * a/n for all/none, enter to go. No entry is ticked by default unless copying
+ * it is provably safe — see preselected().
+ */
+
+const groupOf = (p: string) => p.split("/").pop() || p;
+
+function Tick({ on, dim }: { on: boolean; dim?: boolean }) {
+  return (
+    <span
+      className="shrink-0 w-3.5 h-3.5 rounded flex items-center justify-center text-[9px] leading-none"
+      style={{
+        color: on ? "var(--bg)" : "transparent",
+        background: on ? (dim ? "var(--warning)" : "var(--primary)") : "transparent",
+        border: `1px solid ${on ? (dim ? "var(--warning)" : "var(--primary)") : "color-mix(in srgb, var(--border) 60%, transparent)"}`,
+      }}
+    >{on ? "✓" : ""}</span>
+  );
+}
+
+/** A flat row list across every worktree, so j/k crosses group boundaries the
+ *  way a single list should. Headers are rendered from the same array. */
+type Row = { kind: "head"; report: WorktreeLeftovers } | { kind: "entry"; report: WorktreeLeftovers; entry: LeftoverEntry };
+const keyOf = (r: WorktreeLeftovers, e: LeftoverEntry) => `${r.path}\u0000${e.path}`;
+
+export function RescueModal({ reports, onCancel, onConfirm }: {
+  reports: WorktreeLeftovers[];
+  onCancel: () => void;
+  /** Chosen paths per worktree path. Empty map means "remove, rescue nothing". */
+  onConfirm: (picked: Map<string, string[]>) => void;
+}) {
+  const [on, setOn] = useState<Set<string>>(() => {
+    const s = new Set<string>();
+    for (const r of reports) for (const p of preselected(r)) s.add(`${r.path}\u0000${p}`);
+    return s;
+  });
+  const [cur, setCur] = useState(0);
+  const listRef = useRef<HTMLDivElement>(null);
+
+  const rows: Row[] = useMemo(() => {
+    const out: Row[] = [];
+    for (const report of reports) {
+      out.push({ kind: "head", report });
+      for (const entry of report.entries) out.push({ kind: "entry", report, entry });
+    }
+    return out;
+  }, [reports]);
+  const selectable = useMemo(() => rows.map((r, i) => (r.kind === "entry" ? i : -1)).filter((i) => i >= 0), [rows]);
+
+  // Land on the first real row, never on a header.
+  useEffect(() => { if (selectable.length && !selectable.includes(cur)) setCur(selectable[0]!); }, [selectable, cur]);
+
+  const totals = useMemo(() => {
+    let bytes = 0, n = 0, overwriteless = 0;
+    for (const r of rows) {
+      if (r.kind !== "entry") continue;
+      if (!on.has(keyOf(r.report, r.entry))) continue;
+      n++; bytes += Math.max(0, r.entry.bytes);
+      if (r.entry.vsMain === "differs") overwriteless++;
+    }
+    return { bytes, n, differs: overwriteless };
+  }, [rows, on]);
+
+  const toggle = (k: string) => setOn((s) => { const n = new Set(s); n.has(k) ? n.delete(k) : n.add(k); return n; });
+  const confirm = () => {
+    const picked = new Map<string, string[]>();
+    for (const r of rows) {
+      if (r.kind !== "entry" || !on.has(keyOf(r.report, r.entry))) continue;
+      picked.set(r.report.path, [...(picked.get(r.report.path) ?? []), r.entry.path]);
+    }
+    onConfirm(picked);
+  };
+
+  useEffect(() => {
+    const onKey = (e: KeyboardEvent) => {
+      if (e.key === "Escape") { e.preventDefault(); onCancel(); return; }
+      if (e.key === "Enter") { e.preventDefault(); confirm(); return; }
+      const at = selectable.indexOf(cur);
+      if (e.key === "j" || e.key === "ArrowDown") { e.preventDefault(); setCur(selectable[Math.min(selectable.length - 1, at + 1)] ?? cur); }
+      else if (e.key === "k" || e.key === "ArrowUp") { e.preventDefault(); setCur(selectable[Math.max(0, at - 1)] ?? cur); }
+      else if (e.key === " ") { e.preventDefault(); const r = rows[cur]; if (r?.kind === "entry") toggle(keyOf(r.report, r.entry)); }
+      // "all" means all, including the ones that would overwrite — it is an
+      // explicit keystroke, and the count of those is shown in the footer.
+      else if (e.key === "a") { e.preventDefault(); setOn(new Set(rows.flatMap((r) => (r.kind === "entry" ? [keyOf(r.report, r.entry)] : [])))); }
+      else if (e.key === "n") { e.preventDefault(); setOn(new Set()); }
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [rows, selectable, cur, on]);
+
+  useEffect(() => { listRef.current?.querySelector('[data-cur="1"]')?.scrollIntoView({ block: "nearest" }); }, [cur]);
+
+  const nothingToOffer = rows.every((r) => r.kind !== "entry");
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+          className="fixed inset-0" style={{ zIndex: 10002, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onCancel} />
+        <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10003 }}>
+          <motion.div
+            initial={{ opacity: 0, scale: 0.98, y: 6 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.98 }}
+            className="pointer-events-auto w-full max-w-[760px] max-h-[80vh] flex flex-col rounded-xl overflow-hidden"
+            style={{ background: "var(--bg2)", border: "1px solid var(--border)", boxShadow: "0 20px 60px rgba(0,0,0,0.5)" }}
+          >
+            <div className="px-4 py-3" style={{ borderBottom: "1px solid var(--border)" }}>
+              <div className="text-[13px] font-medium" style={{ color: "var(--text)" }}>
+                Keep anything before removing {reports.length} worktree{reports.length === 1 ? "" : "s"}?
+              </div>
+              <div className="text-[11px] mt-1" style={{ color: "var(--text3)" }}>
+                Ticked files are copied into the main checkout at the same path, then the worktrees are removed.
+                Nothing already there is overwritten.
+              </div>
+            </div>
+
+            <div ref={listRef} className="agx-scroll overflow-y-auto flex-1 px-2 py-2">
+              {nothingToOffer && (
+                <div className="px-3 py-6 text-[11.5px] text-center" style={{ color: "var(--text3)" }}>
+                  Nothing unique in these checkouts — everything in them is either a cache or already in the main checkout.
+                </div>
+              )}
+              {rows.map((r, i) => r.kind === "head" ? (
+                <div key={`h${i}`} className="px-2 pt-3 pb-1 text-[11px] font-medium flex items-baseline gap-2" style={{ color: "var(--text2)" }}>
+                  <span>{groupOf(r.report.path)}</span>
+                  <span className="text-[10px]" style={{ color: "var(--text3)" }}>
+                    {r.report.identical > 0 && `${r.report.identical} already in the main checkout`}
+                    {r.report.identical > 0 && r.report.skipped > 0 && " · "}
+                    {r.report.skipped > 0 && `${r.report.skipped} rebuildable`}
+                    {r.report.more > 0 && ` · ${r.report.more} more not shown`}
+                  </span>
+                </div>
+              ) : (
+                (() => {
+                  const k = keyOf(r.report, r.entry);
+                  const ticked = on.has(k);
+                  const risky = r.entry.vsMain === "differs";
+                  return (
+                    <button key={k} data-cur={i === cur ? "1" : undefined} onClick={() => { setCur(i); toggle(k); }}
+                      className="w-full flex items-center gap-2 px-2 py-1 rounded-md text-left"
+                      style={{ background: i === cur ? "color-mix(in srgb, var(--primary) 14%, transparent)" : "transparent" }}>
+                      <Tick on={ticked} dim={risky} />
+                      <span className="text-[11.5px] truncate" style={{ color: ticked ? "var(--text)" : "var(--text3)" }}>{r.entry.path}</span>
+                      {risky && (
+                        <span className="text-[9px] px-1 rounded shrink-0" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 15%, transparent)" }}>
+                          overwrites the main checkout
+                        </span>
+                      )}
+                      <span className="ml-auto text-[10px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{fmtBytes(r.entry.bytes)}</span>
+                    </button>
+                  );
+                })()
+              ))}
+            </div>
+
+            <div className="px-4 py-2.5 flex items-center gap-3" style={{ borderTop: "1px solid var(--border)" }}>
+              <span className="text-[11px]" style={{ color: "var(--text3)" }}>
+                <span className="t-dim2">j/k</span> move · <span className="t-dim2">space</span> toggle · <span className="t-dim2">a</span> all · <span className="t-dim2">n</span> none
+              </span>
+              <span className="ml-auto text-[11px] tabular-nums" style={{ color: totals.differs ? "var(--warning)" : "var(--text2)" }}>
+                {totals.n} selected · {fmtBytes(totals.bytes)}
+                {totals.differs > 0 && ` · ${totals.differs} would overwrite`}
+              </span>
+              <button onClick={onCancel} className="text-[11px] px-2.5 py-1 rounded" style={{ color: "var(--text2)", border: "1px solid var(--border)" }}>Cancel</button>
+              <button onClick={confirm} className="text-[11px] px-2.5 py-1 rounded font-medium" style={{ color: "var(--bg)", background: "var(--primary)" }}>
+                {totals.n ? `Keep ${totals.n} & remove` : "Remove, keep nothing"}
+              </button>
+            </div>
+          </motion.div>
+        </div>
+      </AnimatePresence>
+    </Portal>
+  );
+}

--- a/web/src/components/RescueModal.tsx
+++ b/web/src/components/RescueModal.tsx
@@ -2,7 +2,7 @@ import { useEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { WorktreeLeftovers, LeftoverEntry } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
-import { preselected, fmtBytes } from "../lib/goneCleanup.ts";
+import { preselected, fmtBytes, rescueKey, rescuePicks } from "../lib/goneCleanup.ts";
 
 /**
  * The last thing between somebody's notes and `rm -rf`.
@@ -42,7 +42,7 @@ function Tick({ on, dim }: { on: boolean; dim?: boolean }) {
 /** A flat row list across every worktree, so j/k crosses group boundaries the
  *  way a single list should. Headers are rendered from the same array. */
 type Row = { kind: "head"; report: WorktreeLeftovers } | { kind: "entry"; report: WorktreeLeftovers; entry: LeftoverEntry };
-const keyOf = (r: WorktreeLeftovers, e: LeftoverEntry) => `${r.path}\u0000${e.path}`;
+const keyOf = (r: WorktreeLeftovers, e: LeftoverEntry) => rescueKey(r.path, e.path);
 
 export function RescueModal({ reports, progress, onCancel, onConfirm }: {
   reports: WorktreeLeftovers[];
@@ -55,7 +55,7 @@ export function RescueModal({ reports, progress, onCancel, onConfirm }: {
 }) {
   const [on, setOn] = useState<Set<string>>(() => {
     const s = new Set<string>();
-    for (const r of reports) for (const p of preselected(r)) s.add(`${r.path}\u0000${p}`);
+    for (const r of reports) for (const p of preselected(r)) s.add(rescueKey(r.path, p));
     return s;
   });
   const [cur, setCur] = useState(0);
@@ -88,14 +88,10 @@ export function RescueModal({ reports, progress, onCancel, onConfirm }: {
   }, [rows, on]);
 
   const toggle = (k: string) => setOn((s) => { const n = new Set(s); n.has(k) ? n.delete(k) : n.add(k); return n; });
-  const submit = () => {
-    const picked = new Map<string, string[]>();
-    for (const r of rows) {
-      if (r.kind !== "entry" || !on.has(keyOf(r.report, r.entry))) continue;
-      picked.set(r.report.path, [...(picked.get(r.report.path) ?? []), r.entry.path]);
-    }
-    onConfirm(picked);
-  };
+  // Built from `reports` rather than from `rows`, and by a function with a test
+  // around it. The version that walked `rows` inline lost five screenshots and
+  // a `worktree.env` from a checkout that was deleted immediately afterwards.
+  const submit = () => onConfirm(rescuePicks(reports, on));
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {

--- a/web/src/components/RescueModal.tsx
+++ b/web/src/components/RescueModal.tsx
@@ -44,8 +44,11 @@ function Tick({ on, dim }: { on: boolean; dim?: boolean }) {
 type Row = { kind: "head"; report: WorktreeLeftovers } | { kind: "entry"; report: WorktreeLeftovers; entry: LeftoverEntry };
 const keyOf = (r: WorktreeLeftovers, e: LeftoverEntry) => `${r.path}\u0000${e.path}`;
 
-export function RescueModal({ reports, onCancel, onConfirm }: {
+export function RescueModal({ reports, progress, onCancel, onConfirm }: {
   reports: WorktreeLeftovers[];
+  /** Set once the user has committed: the dialog stays up and narrates instead
+   *  of vanishing into a panel that looks like nothing happened. */
+  progress?: string;
   onCancel: () => void;
   /** Chosen paths per worktree path. Empty map means "remove, rescue nothing". */
   onConfirm: (picked: Map<string, string[]>) => void;
@@ -57,6 +60,8 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
   });
   const [cur, setCur] = useState(0);
   const listRef = useRef<HTMLDivElement>(null);
+  /** Committed and running: the list stops taking input and the footer narrates. */
+  const working = !!progress;
 
   const rows: Row[] = useMemo(() => {
     const out: Row[] = [];
@@ -83,7 +88,7 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
   }, [rows, on]);
 
   const toggle = (k: string) => setOn((s) => { const n = new Set(s); n.has(k) ? n.delete(k) : n.add(k); return n; });
-  const confirm = () => {
+  const submit = () => {
     const picked = new Map<string, string[]>();
     for (const r of rows) {
       if (r.kind !== "entry" || !on.has(keyOf(r.report, r.entry))) continue;
@@ -94,8 +99,9 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
 
   useEffect(() => {
     const onKey = (e: KeyboardEvent) => {
+      if (working) return; // committed — the keyboard can't take it back
       if (e.key === "Escape") { e.preventDefault(); onCancel(); return; }
-      if (e.key === "Enter") { e.preventDefault(); confirm(); return; }
+      if (e.key === "Enter") { e.preventDefault(); submit(); return; }
       const at = selectable.indexOf(cur);
       if (e.key === "j" || e.key === "ArrowDown") { e.preventDefault(); setCur(selectable[Math.min(selectable.length - 1, at + 1)] ?? cur); }
       else if (e.key === "k" || e.key === "ArrowUp") { e.preventDefault(); setCur(selectable[Math.max(0, at - 1)] ?? cur); }
@@ -107,7 +113,7 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
     };
     window.addEventListener("keydown", onKey, true);
     return () => window.removeEventListener("keydown", onKey, true);
-  }, [rows, selectable, cur, on]);
+  }, [rows, selectable, cur, on, working]);
 
   useEffect(() => { listRef.current?.querySelector('[data-cur="1"]')?.scrollIntoView({ block: "nearest" }); }, [cur]);
 
@@ -134,7 +140,7 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
               </div>
             </div>
 
-            <div ref={listRef} className="agx-scroll overflow-y-auto flex-1 px-2 py-2">
+            <div ref={listRef} className="agx-scroll overflow-y-auto flex-1 px-2 py-2" style={{ opacity: working ? 0.45 : 1, pointerEvents: working ? "none" : "auto" }}>
               {nothingToOffer && (
                 <div className="px-3 py-6 text-[11.5px] text-center" style={{ color: "var(--text3)" }}>
                   Nothing unique in these checkouts — everything in them is either a cache or already in the main checkout.
@@ -174,6 +180,15 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
             </div>
 
             <div className="px-4 py-2.5 flex items-center gap-3" style={{ borderTop: "1px solid var(--border)" }}>
+              {working ? (
+                <>
+                  <span className="inline-block w-3 h-3 rounded-full shrink-0" style={{ border: "2px solid color-mix(in srgb, var(--primary) 35%, transparent)", borderTopColor: "var(--primary)", animation: "agx-spin 0.7s linear infinite" }} />
+                  <style>{"@keyframes agx-spin{to{transform:rotate(360deg)}}"}</style>
+                  <span className="text-[11.5px]" style={{ color: "var(--text2)" }}>{progress}…</span>
+                  <span className="ml-auto text-[10.5px]" style={{ color: "var(--text3)" }}>this can take a few seconds</span>
+                </>
+              ) : (
+              <>
               <span className="text-[11px]" style={{ color: "var(--text3)" }}>
                 <span className="t-dim2">j/k</span> move · <span className="t-dim2">space</span> toggle · <span className="t-dim2">a</span> all · <span className="t-dim2">n</span> none
               </span>
@@ -182,9 +197,11 @@ export function RescueModal({ reports, onCancel, onConfirm }: {
                 {totals.differs > 0 && ` · ${totals.differs} would overwrite`}
               </span>
               <button onClick={onCancel} className="text-[11px] px-2.5 py-1 rounded" style={{ color: "var(--text2)", border: "1px solid var(--border)" }}>Cancel</button>
-              <button onClick={confirm} className="text-[11px] px-2.5 py-1 rounded font-medium" style={{ color: "var(--bg)", background: "var(--primary)" }}>
+              <button onClick={submit} className="text-[11px] px-2.5 py-1 rounded font-medium" style={{ color: "var(--bg)", background: "var(--primary)" }}>
                 {totals.n ? `Keep ${totals.n} & remove` : "Remove, keep nothing"}
               </button>
+              </>
+              )}
             </div>
           </motion.div>
         </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -196,6 +196,12 @@ const realApi = {
   gitCommitDiff: (root: string, hash: string) => get<{ changes: FileChange[] }>(`/git/commit-diff?root=${encodeURIComponent(root)}&hash=${encodeURIComponent(hash)}`),
   gitStashes: (root: string) => get<{ stashes: GitStash[] }>(`/git/stashes?root=${encodeURIComponent(root)}`),
   gitRemotes: (root: string) => get<{ remotes: GitRemote[] }>(`/git/remotes?root=${encodeURIComponent(root)}`),
+  /** Every branch on one remote, as the last fetch left them — the whole list,
+   *  filtered and rendered progressively on this side. */
+  gitRemoteBranches: (root: string, remote: string) => get<{ ok: boolean; remote: string; branches: GitRemoteBranch[]; error?: string }>(`/git/remote-branches?root=${encodeURIComponent(root)}&remote=${encodeURIComponent(remote)}`),
+  /** Create a local branch tracking `ref` ("origin/WEB-1042"). `switch` also
+   *  moves this checkout onto it. */
+  gitTrackRemote: (root: string, ref: string, switchTo: boolean) => post<GitActionResult>("/git/track-remote", { root, ref, switch: switchTo }),
   gitTags: (root: string) => get<{ tags: GitTag[] }>(`/git/tags?root=${encodeURIComponent(root)}`),
   gitReflog: (root: string) => get<{ entries: GitReflogEntry[] }>(`/git/reflog?root=${encodeURIComponent(root)}`),
   gitCommandLog: (since = 0) => get<{ entries: GitLogEntry[] }>(`/git/commandlog?since=${since}`),
@@ -218,13 +224,18 @@ const realApi = {
   gitApplyHunk: (root: string, path: string, staged: boolean, action: "stage" | "unstage" | "discard", hunk: DiffHunk) => post<GitActionResult>("/git/apply-hunk", { root, path, staged, action, hunk }),
   gitConflictBlocks: (root: string, path: string) => get<{ ok: boolean; blocks: ConflictBlock[]; error?: string }>(`/git/conflict-blocks?root=${encodeURIComponent(root)}&path=${encodeURIComponent(path)}`),
   gitResolveBlocks: (root: string, path: string, choices: BlockChoice[]) => post<GitActionResult>("/git/resolve-blocks", { root, path, choices }),
-  gitGraph: (root: string, limit = 400) => get<{ lines: GitGraphLine[] }>(`/git/graph?root=${encodeURIComponent(root)}&limit=${limit}`),
+  /** `scope` is whose history: this checkout's own by default, the whole repo
+   *  on request. See logGraph() — the default used to be everything, which put
+   *  other people's branches at the top of your own log. */
+  gitGraph: (root: string, limit = 400, scope: "head" | "all" = "head") => get<{ lines: GitGraphLine[]; scope: "head" | "all"; branch: string }>(`/git/graph?root=${encodeURIComponent(root)}&limit=${limit}&scope=${scope}`),
   gitWorktrees: (root: string) => get<{ worktrees: GitWorktree[] }>(`/git/worktrees?root=${encodeURIComponent(root)}`),
   gitMerge: (root: string, name: string) => post<GitActionResult>("/git/merge", { root, name }),
   gitRebase: (root: string, name: string) => post<GitActionResult>("/git/rebase", { root, name }),
   gitBranchRename: (root: string, name: string, to: string) => post<GitActionResult>("/git/branch-rename", { root, name, to }),
   gitReset: (root: string, ref: string, mode: "soft" | "mixed" | "hard") => post<GitActionResult>("/git/reset", { root, ref, mode }),
-  gitWorktreeAdd: (root: string, path: string, branch: string, newBranch: boolean) => post<GitActionResult>("/git/worktree-add", { root, path, branch, newBranch }),
+  /** `startPoint` is what the new branch is cut from — a remote branch when the
+   *  Remotes tab asks; HEAD when omitted. */
+  gitWorktreeAdd: (root: string, path: string, branch: string, newBranch: boolean, startPoint?: string) => post<GitActionResult>("/git/worktree-add", { root, path, branch, newBranch, startPoint }),
   gitWorktreeRemove: (root: string, path: string, force: boolean) => post<GitActionResult>("/git/worktree-remove", { root, path, force }),
   /** Merge a checkout's base branch into it — "update from base". `root` is the
    *  checkout doing the updating, since the merge runs where the branch is. */
@@ -332,6 +343,8 @@ const demoApi: typeof realApi = {
   // The demo has no real repo behind it; empty lists render as "none yet"
   // rather than as an error, which is the right shape for a showcase.
   gitRemotes: (_root: string) => D({ remotes: [] as GitRemote[] }),
+  gitRemoteBranches: (_root: string, _remote: string) => D({ ok: true, remote: "", branches: [] as GitRemoteBranch[] }),
+  gitTrackRemote: (_root: string, _ref: string, _switchTo: boolean) => D(demo.gitActionUnavailable()),
   gitTags: (_root: string) => D({ tags: [] as GitTag[] }),
   gitReflog: (_root: string) => D({ entries: [] as GitReflogEntry[] }),
   gitCommandLog: (_since?: number) => D({ entries: [] as GitLogEntry[] }),
@@ -351,13 +364,13 @@ const demoApi: typeof realApi = {
   gitApplyHunk: (_root: string, _path: string, _staged: boolean, _action: "stage" | "unstage" | "discard", _hunk: DiffHunk) => D(demo.gitActionUnavailable()),
   gitConflictBlocks: (_root: string, _path: string) => D({ ok: false, blocks: [] as ConflictBlock[], error: "not available in the demo" }),
   gitResolveBlocks: (_root: string, _path: string, _choices: BlockChoice[]) => D(demo.gitActionUnavailable()),
-  gitGraph: (_root: string, _limit?: number) => D(demo.gitGraph()),
+  gitGraph: (_root: string, _limit?: number, _scope?: "head" | "all") => D({ ...demo.gitGraph(), scope: "head" as const, branch: "main" }),
   gitWorktrees: (_root: string) => D(demo.gitWorktrees()),
   gitMerge: (_root: string, _name: string) => D(demo.gitActionUnavailable()),
   gitRebase: (_root: string, _name: string) => D(demo.gitActionUnavailable()),
   gitBranchRename: (_root: string, _name: string, _to: string) => D(demo.gitActionUnavailable()),
   gitReset: (_root: string, _ref: string, _mode: "soft" | "mixed" | "hard") => D(demo.gitActionUnavailable()),
-  gitWorktreeAdd: (_root: string, _path: string, _branch: string, _newBranch: boolean) => D(demo.gitActionUnavailable()),
+  gitWorktreeAdd: (_root: string, _path: string, _branch: string, _newBranch: boolean, _startPoint?: string) => D(demo.gitActionUnavailable()),
   gitSyncBase: (_root: string, _base?: string) => D(demo.gitActionUnavailable()),
   gitSetBase: (_root: string, _branch: string, _base: string | null) => D(demo.gitActionUnavailable()),
   gitBaseCandidates: (_root: string) => D({ ok: true, refs: [] }),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -243,6 +243,9 @@ const realApi = {
    *  already there comes back in `skipped` with the reason. */
   gitWorktreeRescue: (root: string, path: string, paths: string[]) =>
     post<GitActionResult & { copied?: string[]; skipped?: { path: string; why: string }[] }>("/git/worktree-rescue", { root, path, paths }),
+  /** Hand a worktree's root-owned files back, via the desktop's own auth
+   *  dialog. chown only — the removal still runs as you. */
+  gitWorktreeChown: (root: string, path: string) => post<GitActionResult>("/git/worktree-chown", { root, path }),
   gitWorktreeLeftovers: (root: string, paths: string[]) =>
     get<{ leftovers: WorktreeLeftovers[] }>(`/git/worktree-leftovers?root=${encodeURIComponent(root)}${paths.map((p) => `&path=${encodeURIComponent(p)}`).join("")}`),
   /** Merge a checkout's base branch into it — "update from base". `root` is the
@@ -390,6 +393,7 @@ const demoApi: typeof realApi = {
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
   gitWorktreeLeftovers: (_root: string, _paths: string[]) => D({ leftovers: [] as WorktreeLeftovers[] }),
   gitWorktreeRescue: (_root: string, _path: string, _paths: string[]) => D(demo.gitActionUnavailable()),
+  gitWorktreeChown: (_root: string, _path: string) => D(demo.gitActionUnavailable()),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -237,6 +237,10 @@ const realApi = {
    *  Remotes tab asks; HEAD when omitted. */
   gitWorktreeAdd: (root: string, path: string, branch: string, newBranch: boolean, startPoint?: string) => post<GitActionResult>("/git/worktree-add", { root, path, branch, newBranch, startPoint }),
   gitWorktreeRemove: (root: string, path: string, force: boolean) => post<GitActionResult>("/git/worktree-remove", { root, path, force }),
+  /** What removing these worktrees would delete that git wouldn't warn about —
+   *  ask before offering the removal. One request for the whole batch. */
+  gitWorktreeLeftovers: (root: string, paths: string[]) =>
+    get<{ leftovers: WorktreeLeftovers[] }>(`/git/worktree-leftovers?root=${encodeURIComponent(root)}${paths.map((p) => `&path=${encodeURIComponent(p)}`).join("")}`),
   /** Merge a checkout's base branch into it — "update from base". `root` is the
    *  checkout doing the updating, since the merge runs where the branch is. */
   gitSyncBase: (root: string, base?: string) => post<GitActionResult>("/git/sync-base", { root, base }),
@@ -380,6 +384,7 @@ const demoApi: typeof realApi = {
   gitUndoMerge: (_root: string) => D(demo.gitActionUnavailable()),
   gitMergeContinue: (_root: string) => D(demo.gitActionUnavailable()),
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
+  gitWorktreeLeftovers: (_root: string, _paths: string[]) => D({ leftovers: [] as WorktreeLeftovers[] }),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -191,7 +191,7 @@ const realApi = {
   gitPush: (root: string) => post<GitActionResult>("/git/push", { root }),
   gitPull: (root: string) => post<GitActionResult>("/git/pull", { root }),
   gitFetch: (root: string) => post<GitActionResult>("/git/fetch", { root }),
-  gitBranches: (root: string) => get<{ current: string; branches: GitBranch[]; trunk?: string | null }>(`/git/branches?root=${encodeURIComponent(root)}`),
+  gitBranches: (root: string) => get<{ current: string; branches: GitBranch[]; trunk?: string | null; sweeping?: boolean }>(`/git/branches?root=${encodeURIComponent(root)}`),
   gitLog: (root: string, limit = 100) => get<{ commits: GitCommit[] }>(`/git/log?root=${encodeURIComponent(root)}&limit=${limit}`),
   gitCommitDiff: (root: string, hash: string) => get<{ changes: FileChange[] }>(`/git/commit-diff?root=${encodeURIComponent(root)}&hash=${encodeURIComponent(hash)}`),
   gitStashes: (root: string) => get<{ stashes: GitStash[] }>(`/git/stashes?root=${encodeURIComponent(root)}`),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -239,6 +239,10 @@ const realApi = {
   gitWorktreeRemove: (root: string, path: string, force: boolean) => post<GitActionResult>("/git/worktree-remove", { root, path, force }),
   /** What removing these worktrees would delete that git wouldn't warn about —
    *  ask before offering the removal. One request for the whole batch. */
+  /** Copy chosen leftovers into the main checkout. Never overwrites — anything
+   *  already there comes back in `skipped` with the reason. */
+  gitWorktreeRescue: (root: string, path: string, paths: string[]) =>
+    post<GitActionResult & { copied?: string[]; skipped?: { path: string; why: string }[] }>("/git/worktree-rescue", { root, path, paths }),
   gitWorktreeLeftovers: (root: string, paths: string[]) =>
     get<{ leftovers: WorktreeLeftovers[] }>(`/git/worktree-leftovers?root=${encodeURIComponent(root)}${paths.map((p) => `&path=${encodeURIComponent(p)}`).join("")}`),
   /** Merge a checkout's base branch into it — "update from base". `root` is the
@@ -385,6 +389,7 @@ const demoApi: typeof realApi = {
   gitMergeContinue: (_root: string) => D(demo.gitActionUnavailable()),
   gitWorktreeRemove: (_root: string, _path: string, _force: boolean) => D(demo.gitActionUnavailable()),
   gitWorktreeLeftovers: (_root: string, _paths: string[]) => D({ leftovers: [] as WorktreeLeftovers[] }),
+  gitWorktreeRescue: (_root: string, _path: string, _paths: string[]) => D(demo.gitActionUnavailable()),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -298,8 +298,10 @@ export function gitCommit(): CommitResult {
 // --- live git panel (demo is read-only) ---
 export function gitRepos(): { repos: GitRepoRef[] } {
   return { repos: [
-    { root: "/home/you/code/shop-api", name: "shop-api", branch: "main", dirty: 3, ahead: 2, behind: 0 },
-    { root: "/home/you/code/agentglass", name: "agentglass", branch: "feat/git-panel", dirty: 1, ahead: 0, behind: 1 },
+    // Fixed stamps, not Date.now(): a demo that reorders itself between two
+    // screenshots is a demo that looks broken.
+    { root: "/home/you/code/shop-api", name: "shop-api", branch: "main", dirty: 3, ahead: 2, behind: 0, touchedAt: 1_760_000_000_000 },
+    { root: "/home/you/code/agentglass", name: "agentglass", branch: "feat/git-panel", dirty: 1, ahead: 0, behind: 1, touchedAt: 1_759_000_000_000 },
   ] };
 }
 function gcf(id: number, path: string, status: GitFileChange["status"], staged: boolean, lines: string[]): GitFileChange {

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -148,6 +148,43 @@ export function preselected(report: WorktreeLeftovers, maxBytes = RESCUE_PRESELE
   return out;
 }
 
+/**
+ * The key a tick is stored under: which worktree, which path inside it.
+ *
+ * Two worktrees of the same repo hold the same relative paths — every one of
+ * them has a `worktree.env` — so the path alone cannot identify a row. The
+ * separator is NUL because no path contains one, written escaped because a raw
+ * one in a source file makes the whole file `data` to grep.
+ */
+export const rescueKey = (worktree: string, path: string) => `${worktree}\u0000${path}`;
+
+/**
+ * What the rescue request will actually ask for: worktree path → chosen paths.
+ *
+ * Lifted out of the modal and given a test, because the version that lived
+ * inside it silently dropped files. Five screenshots and a `worktree.env` were
+ * ticked, reported as copied, and were not on disk afterwards — and the
+ * checkout they were in got deleted straight after. Anything that decides what
+ * survives a deletion belongs somewhere it can be exercised without a browser.
+ *
+ * Order is preserved per worktree so the server's `copied` list can be lined up
+ * against what was asked for.
+ */
+export function rescuePicks(
+  reports: WorktreeLeftovers[],
+  ticked: ReadonlySet<string>,
+): Map<string, string[]> {
+  const picked = new Map<string, string[]>();
+  for (const report of reports) {
+    for (const entry of report.entries) {
+      if (!ticked.has(rescueKey(report.path, entry.path))) continue;
+      const list = picked.get(report.path);
+      if (list) list.push(entry.path); else picked.set(report.path, [entry.path]);
+    }
+  }
+  return picked;
+}
+
 /** Bytes as something a human reads at a glance in a list. */
 export function fmtBytes(n: number): string {
   if (n < 0) return "?";

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -104,20 +104,6 @@ export function goneConfirmBody(free: GitBranch[], held: GitBranch[], unmergedCo
   return parts.join("\n\n");
 }
 
-/** One worktree's entry in the "this is what goes" list. */
-export function leftoversLine(report: WorktreeLeftovers, name: string, shownMax = 6): string {
-  const shown = report.entries.slice(0, shownMax);
-  const rest = report.entries.length - shown.length + report.more;
-  const body = report.entries.length
-    ? shown.map((e) => `    ${e.path}${e.vsMain === "differs" ? "  (also in the main checkout, different)" : ""}`).join("\n")
-      + (rest > 0 ? `\n    …and ${rest} more` : "")
-      + (report.skipped ? `\n    (+${report.skipped} rebuildable, e.g. caches — not listed)` : "")
-    : report.skipped || report.identical
-      ? `    nothing unique — ${[report.identical && `${report.identical} already in the main checkout`, report.skipped && `${report.skipped} rebuildable`].filter(Boolean).join(", ")}`
-      : "    empty";
-  return `  ${name}\n${body}`;
-}
-
 /**
  * Which leftovers start out ticked in the rescue list.
  *

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -70,23 +70,23 @@ export function splitReadable(
  * touched — six, in a repo that has three. Each case gets its own sentence
  * rather than one sentence with a hole in it.
  */
-export function goneConfirmText(
-  free: GitBranch[],
-  held: GitBranch[],
-  unmergedCount: number,
-  trunk: string,
-): string {
+const s = (n: number, one: string, many: string) => (n === 1 ? one : many);
+
+/** The question itself — one line, the thing the dialog puts in bold. */
+export function goneConfirmTitle(free: GitBranch[], held: GitBranch[], trunk: string): string {
+  if (free.length) return `Delete ${free.length} ${s(free.length, "branch", "branches")} already merged into ${trunk}?`;
+  if (held.length) return `Remove ${held.length} ${s(held.length, "worktree", "worktrees")} and delete ${s(held.length, "its branch", "their branches")}?`;
+  return "Nothing to delete";
+}
+
+/** The detail under it. Everything the question can't carry on one line. */
+export function goneConfirmBody(free: GitBranch[], held: GitBranch[], unmergedCount: number, trunk: string): string {
   const parts: string[] = [];
-  const s = (n: number, one: string, many: string) => (n === 1 ? one : many);
-  if (free.length) {
-    parts.push(`Delete ${free.length} ${s(free.length, "branch", "branches")} already merged into ${trunk}?`);
-    if (held.length) {
-      parts.push(`${held.length} more ${s(held.length, "is", "are")} checked out in a worktree. You'll be asked about ${s(held.length, "it", "those")} separately, with what removing ${s(held.length, "it", "them")} would delete.`);
-    }
+  if (free.length && held.length) {
+    parts.push(`${held.length} more ${s(held.length, "is", "are")} checked out in a worktree. You'll be asked about ${s(held.length, "it", "those")} separately, with what removing ${s(held.length, "it", "them")} would delete.`);
   } else if (held.length) {
     // No "more" here: there is nothing for them to be more *than*.
-    parts.push(`All ${held.length} merged ${s(held.length, "branch is", "branches are")} checked out in a worktree, so ${s(held.length, "it", "they")} can't be deleted on ${s(held.length, "its", "their")} own.`);
-    parts.push(`Remove ${s(held.length, "that worktree", "those worktrees")} and delete ${s(held.length, "the branch", "the branches")}? You'll see exactly what removing ${s(held.length, "it", "them")} would delete before anything happens.`);
+    parts.push(`All ${held.length} merged ${s(held.length, "branch is", "branches are")} checked out in a worktree, so ${s(held.length, "it", "they")} can't be deleted on ${s(held.length, "its", "their")} own. You'll see exactly what removing ${s(held.length, "it", "them")} would delete, and can keep any of it, before anything happens.`);
   }
   if (unmergedCount) {
     parts.push(`${unmergedCount} ${s(unmergedCount, "has", "have")} no remote branch but ${s(unmergedCount, "is", "are")} NOT in ${trunk} — those are kept.`);

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -96,14 +96,53 @@ export function goneConfirmText(
 
 /** One worktree's entry in the "this is what goes" list. */
 export function leftoversLine(report: WorktreeLeftovers, name: string, shownMax = 6): string {
-  const shown = report.files.slice(0, shownMax);
-  const rest = report.files.length - shown.length + report.more;
-  const body = report.files.length
-    ? shown.map((f) => `    ${f}`).join("\n")
+  const shown = report.entries.slice(0, shownMax);
+  const rest = report.entries.length - shown.length + report.more;
+  const body = report.entries.length
+    ? shown.map((e) => `    ${e.path}${e.vsMain === "differs" ? "  (also in the main checkout, different)" : ""}`).join("\n")
       + (rest > 0 ? `\n    …and ${rest} more` : "")
       + (report.skipped ? `\n    (+${report.skipped} rebuildable, e.g. caches — not listed)` : "")
-    : report.skipped
-      ? `    nothing but ${report.skipped} rebuildable entries (caches, deps)`
+    : report.skipped || report.identical
+      ? `    nothing unique — ${[report.identical && `${report.identical} already in the main checkout`, report.skipped && `${report.skipped} rebuildable`].filter(Boolean).join(", ")}`
       : "    empty";
   return `  ${name}\n${body}`;
+}
+
+/**
+ * Which leftovers start out ticked in the rescue list.
+ *
+ * Two rules, and neither one knows what a `.specs` directory is — the repo this
+ * was built for keeps its notes there, the next one won't, and a heuristic that
+ * has to be told the folder name is a heuristic that only ever works once.
+ *
+ *   * `differs` is never pre-ticked. Copying it overwrites the main checkout's
+ *     own version, which is the accident this whole feature exists to avoid.
+ *     It stays offered — sometimes the worktree's copy IS the newer one — but
+ *     that has to be a deliberate tick.
+ *   * `absent` is pre-ticked while it stays small. Nothing can be lost by
+ *     copying it, and size is the one signal that separates notes from build
+ *     output without naming either: a page of findings is kilobytes, a `dist/`
+ *     is megabytes.
+ *
+ * On the repo this was built for that lands exactly on the four `.specs`
+ * entries and leaves 22 MB of `dist/` and a 5 MB `tmp/` unticked, without a
+ * single project-specific rule.
+ */
+export const RESCUE_PRESELECT_MAX_BYTES = 4 * 1024 * 1024;
+
+export function preselected(report: WorktreeLeftovers, maxBytes = RESCUE_PRESELECT_MAX_BYTES): Set<string> {
+  const out = new Set<string>();
+  for (const e of report.entries) {
+    if (e.vsMain === "absent" && e.bytes >= 0 && e.bytes <= maxBytes) out.add(e.path);
+  }
+  return out;
+}
+
+/** Bytes as something a human reads at a glance in a list. */
+export function fmtBytes(n: number): string {
+  if (n < 0) return "?";
+  if (n < 1024) return `${n}B`;
+  if (n < 1024 * 1024) return `${(n / 1024).toFixed(n < 10 * 1024 ? 1 : 0)}K`;
+  if (n < 1024 * 1024 * 1024) return `${(n / (1024 * 1024)).toFixed(n < 10 * 1024 * 1024 ? 1 : 0)}M`;
+  return `${(n / (1024 * 1024 * 1024)).toFixed(1)}G`;
 }

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -1,0 +1,109 @@
+/**
+ * The decisions behind "delete N merged", separated from the panel that asks
+ * them — because getting one wrong deletes somebody's work, and a decision
+ * buried in a component is a decision nobody can test.
+ *
+ * Two things live here: which branches can be deleted outright versus which are
+ * pinned by a worktree, and — once the server has reported what is inside those
+ * worktrees — which of them we are actually willing to remove.
+ *
+ * The second one shipped broken. It read
+ *
+ *     byPath.get(path)?.error ?? true
+ *
+ * to mean "unreadable", which is true whenever `error` is absent — that is,
+ * every time the server answered perfectly. Every branch with a worktree was
+ * refused with "no answer from the server" while the server was right there
+ * answering. Neither the type checker nor the server's own tests could see it:
+ * the expression is well-typed and the endpoint was correct. Only exercising
+ * this decision with a successful report catches it, which is why it is now a
+ * function that can be handed one.
+ */
+import type { GitBranch, WorktreeLeftovers } from "../../../shared/types.ts";
+
+/** Branches whose upstream is gone and whose work is in the trunk, split by
+ *  whether a worktree is holding them. `git branch -D` refuses on the held
+ *  ones no matter how hard it is forced. */
+export function partitionByWorktree(
+  goneMerged: GitBranch[],
+  heldByWorktree: Map<string, string>,
+): { free: GitBranch[]; held: GitBranch[] } {
+  return {
+    free: goneMerged.filter((b) => !heldByWorktree.has(b.name)),
+    held: goneMerged.filter((b) => heldByWorktree.has(b.name)),
+  };
+}
+
+/**
+ * Which held branches we are willing to act on, given what came back.
+ *
+ * A report with an `error`, or no report at all, means we could not see inside
+ * that checkout — and "couldn't look" must never take the same path as "nothing
+ * in there", because one of them ends in `rm -rf`. Those are refused with the
+ * reason attached, and the caller reports them as kept.
+ */
+export function splitReadable(
+  held: GitBranch[],
+  heldByWorktree: Map<string, string>,
+  reports: WorktreeLeftovers[],
+): { removable: { branch: GitBranch; report: WorktreeLeftovers }[]; refused: { branch: GitBranch; why: string }[] } {
+  const byPath = new Map(reports.map((r) => [r.path, r] as const));
+  const removable: { branch: GitBranch; report: WorktreeLeftovers }[] = [];
+  const refused: { branch: GitBranch; why: string }[] = [];
+  for (const branch of held) {
+    const path = heldByWorktree.get(branch.name);
+    const report = path ? byPath.get(path) : undefined;
+    // Explicit, in this order, so an absent `error` can never be mistaken for a
+    // failure the way `?.error ?? true` did.
+    if (!report) refused.push({ branch, why: "no answer from the server" });
+    else if (report.error) refused.push({ branch, why: report.error });
+    else removable.push({ branch, report });
+  }
+  return { removable, refused };
+}
+
+/**
+ * The first question, whose shape depends entirely on the split.
+ *
+ * With nothing free to delete, "3 more are checked out in a worktree" reads as
+ * three *additional* branches on top of the three it just said could not be
+ * touched — six, in a repo that has three. Each case gets its own sentence
+ * rather than one sentence with a hole in it.
+ */
+export function goneConfirmText(
+  free: GitBranch[],
+  held: GitBranch[],
+  unmergedCount: number,
+  trunk: string,
+): string {
+  const parts: string[] = [];
+  const s = (n: number, one: string, many: string) => (n === 1 ? one : many);
+  if (free.length) {
+    parts.push(`Delete ${free.length} ${s(free.length, "branch", "branches")} already merged into ${trunk}?`);
+    if (held.length) {
+      parts.push(`${held.length} more ${s(held.length, "is", "are")} checked out in a worktree. You'll be asked about ${s(held.length, "it", "those")} separately, with what removing ${s(held.length, "it", "them")} would delete.`);
+    }
+  } else if (held.length) {
+    // No "more" here: there is nothing for them to be more *than*.
+    parts.push(`All ${held.length} merged ${s(held.length, "branch is", "branches are")} checked out in a worktree, so ${s(held.length, "it", "they")} can't be deleted on ${s(held.length, "its", "their")} own.`);
+    parts.push(`Remove ${s(held.length, "that worktree", "those worktrees")} and delete ${s(held.length, "the branch", "the branches")}? You'll see exactly what removing ${s(held.length, "it", "them")} would delete before anything happens.`);
+  }
+  if (unmergedCount) {
+    parts.push(`${unmergedCount} ${s(unmergedCount, "has", "have")} no remote branch but ${s(unmergedCount, "is", "are")} NOT in ${trunk} — those are kept.`);
+  }
+  return parts.join("\n\n");
+}
+
+/** One worktree's entry in the "this is what goes" list. */
+export function leftoversLine(report: WorktreeLeftovers, name: string, shownMax = 6): string {
+  const shown = report.files.slice(0, shownMax);
+  const rest = report.files.length - shown.length + report.more;
+  const body = report.files.length
+    ? shown.map((f) => `    ${f}`).join("\n")
+      + (rest > 0 ? `\n    …and ${rest} more` : "")
+      + (report.skipped ? `\n    (+${report.skipped} rebuildable, e.g. caches — not listed)` : "")
+    : report.skipped
+      ? `    nothing but ${report.skipped} rebuildable entries (caches, deps)`
+      : "    empty";
+  return `  ${name}\n${body}`;
+}

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -19,7 +19,7 @@
  * this decision with a successful report catches it, which is why it is now a
  * function that can be handed one.
  */
-import type { GitBranch, WorktreeLeftovers } from "../../../shared/types.ts";
+import type { GitBranch, WorktreeLeftovers, BlockedByOwner } from "../../../shared/types.ts";
 
 /** Branches whose upstream is gone and whose work is in the trunk, split by
  *  whether a worktree is holding them. `git branch -D` refuses on the held
@@ -57,9 +57,19 @@ export function splitReadable(
     // failure the way `?.error ?? true` did.
     if (!report) refused.push({ branch, why: "no answer from the server" });
     else if (report.error) refused.push({ branch, why: report.error });
+    // Files owned by somebody else — a container that ran as root. The removal
+    // cannot finish, and git deletes the worktree's registration BEFORE its
+    // files, so attempting it is what leaves an orphaned directory behind.
+    // Refusing is the only outcome that keeps the checkout usable.
+    else if (report.blocked) refused.push({ branch, why: blockedReason(report.blocked) });
     else removable.push({ branch, report });
   }
   return { removable, refused };
+}
+
+/** One line for a toast, naming the fix rather than just the symptom. */
+export function blockedReason(b: BlockedByOwner): string {
+  return `${b.count}${b.more ? "+" : ""} files belong to ${b.owners.join(", ")} — run: sudo chown -R "$(id -un):$(id -gn)" ${b.paths.join(" ")}`;
 }
 
 /**

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "bun:test";
-import { partitionByWorktree, splitReadable, goneConfirmText, leftoversLine } from "../src/lib/goneCleanup.ts";
-import type { GitBranch, WorktreeLeftovers } from "../../shared/types.ts";
+import { partitionByWorktree, splitReadable, goneConfirmText, leftoversLine, preselected, fmtBytes } from "../src/lib/goneCleanup.ts";
+import type { GitBranch, WorktreeLeftovers, LeftoverEntry } from "../../shared/types.ts";
 
 /**
  * The bulk "delete N merged" path, pinned at the two points where it decides
@@ -17,8 +17,10 @@ const branch = (name: string): GitBranch => ({
   name, current: false, upstream: null, track: "[gone]", date: "", subject: "", mergedIntoTrunk: true,
 });
 const report = (path: string, over: Partial<WorktreeLeftovers> = {}): WorktreeLeftovers => ({
-  path, files: [], more: 0, skipped: 0, ...over,
+  path, entries: [], more: 0, skipped: 0, identical: 0, ...over,
 });
+const entry = (path: string, bytes: number, vsMain: "absent" | "differs" = "absent"): LeftoverEntry =>
+  ({ path, bytes, dir: path.endsWith("/"), vsMain });
 
 describe("partitionByWorktree", () => {
   it("puts a branch with a worktree on the held side", () => {
@@ -44,10 +46,10 @@ describe("splitReadable", () => {
 
   it("treats a successful report as removable", () => {
     // THE regression. A good report has no `error` field at all.
-    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1", { files: ["a.env"], skipped: 12 })]);
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1", { entries: [entry("a.env", 40)], skipped: 12 })]);
     expect(refused).toEqual([]);
     expect(removable).toHaveLength(1);
-    expect(removable[0]!.report.files).toEqual(["a.env"]);
+    expect(removable[0]!.report.entries.map((e) => e.path)).toEqual(["a.env"]);
   });
 
   it("an empty checkout is still removable", () => {
@@ -110,9 +112,56 @@ describe("goneConfirmText", () => {
   });
 });
 
+describe("preselected", () => {
+  it("ticks the small unique ones and leaves the big ones alone", () => {
+    // The shape of a real worktree: notes nobody else has, beside build output
+    // the main checkout also has a version of. No rule here knows what
+    // `.specs` is — only "absent" and "small".
+    const r = report("/code/repo-x", {
+      entries: [
+        entry(".specs/plan.md", 5340),
+        entry(".specs/pol-captures/", 725_000),
+        entry("tmp/", 5_500_000, "differs"),
+        entry("src/app/dist/", 12_000_000, "differs"),
+      ],
+    });
+    expect([...preselected(r)]).toEqual([".specs/plan.md", ".specs/pol-captures/"]);
+  });
+
+  it("never ticks something that would overwrite the main checkout", () => {
+    // Even a tiny one. Copying over a file that is already there is the exact
+    // accident the rescue exists to prevent, so it can only ever be deliberate.
+    const r = report("/x", { entries: [entry("worktree.env", 181, "differs")] });
+    expect(preselected(r).size).toBe(0);
+  });
+
+  it("does not tick something it could not measure", () => {
+    const r = report("/x", { entries: [entry("weird", -1)] });
+    expect(preselected(r).size).toBe(0);
+  });
+
+  it("leaves a large unique entry offered but unticked", () => {
+    // Unique and huge: still worth showing — it might be a capture directory —
+    // but not something to copy into the main checkout without being asked.
+    const r = report("/x", { entries: [entry("recordings/", 900_000_000)] });
+    expect(preselected(r).size).toBe(0);
+    expect(r.entries).toHaveLength(1);
+  });
+});
+
+describe("fmtBytes", () => {
+  it("reads at a glance", () => {
+    expect(fmtBytes(181)).toBe("181B");
+    expect(fmtBytes(5340)).toBe("5.2K");
+    expect(fmtBytes(725_000)).toBe("708K");
+    expect(fmtBytes(12_000_000)).toBe("11M");
+    expect(fmtBytes(-1)).toBe("?");
+  });
+});
+
 describe("leftoversLine", () => {
   it("caps the list and counts the rest, including the server's own overflow", () => {
-    const r = report("/code/repo-x", { files: ["1", "2", "3", "4", "5", "6", "7"], more: 21, skipped: 508 });
+    const r = report("/code/repo-x", { entries: ["1", "2", "3", "4", "5", "6", "7"].map((n) => entry(n, 10)), more: 21, skipped: 508 });
     const line = leftoversLine(r, "repo-x");
     expect(line).toContain("    1\n");
     expect(line).not.toContain("    7\n");
@@ -123,6 +172,7 @@ describe("leftoversLine", () => {
 
   it("distinguishes an empty checkout from one holding only caches", () => {
     expect(leftoversLine(report("/x"), "x")).toContain("empty");
-    expect(leftoversLine(report("/x", { skipped: 9 }), "x")).toContain("nothing but 9 rebuildable");
+    expect(leftoversLine(report("/x", { skipped: 9 }), "x")).toContain("9 rebuildable");
+    expect(leftoversLine(report("/x", { identical: 20 }), "x")).toContain("20 already in the main checkout");
   });
 });

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, leftoversLine, preselected, fmtBytes } from "../src/lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, leftoversLine, preselected, fmtBytes, rescueKey, rescuePicks } from "../src/lib/goneCleanup.ts";
 import type { GitBranch, WorktreeLeftovers, LeftoverEntry } from "../../shared/types.ts";
 
 /**
@@ -180,5 +180,56 @@ describe("leftoversLine", () => {
     expect(leftoversLine(report("/x"), "x")).toContain("empty");
     expect(leftoversLine(report("/x", { skipped: 9 }), "x")).toContain("9 rebuildable");
     expect(leftoversLine(report("/x", { identical: 20 }), "x")).toContain("20 already in the main checkout");
+  });
+});
+
+describe("rescuePicks", () => {
+  // The exact shape of the checkout that lost data: notes and screenshots that
+  // exist nowhere else, mixed with build output that also lives in the main
+  // checkout. Five of these were ticked, reported as copied, were not on disk
+  // afterwards — and the checkout was deleted next.
+  const WT = "/home/dev/orbit-WEB-1042";
+  const real = report(WT, {
+    entries: [
+      entry("worktree.env", 181),
+      entry(".specs/adversarial-findings-v11.md", 2902),
+      entry(".specs/adversarial-findings-local.md", 3300),
+      entry(".specs/implementation-plan.md", 5340),
+      entry(".specs/pol-captures/cap-01-air-dashboard.png", 12345),
+      entry(".specs/pol-captures/cap-03-dashboard-rendered.png", 137000),
+      entry(".specs/pol-captures/cap-02-profile-overlay.png", 151465),
+      entry(".specs/pol-captures/cap-05-console-table.png", 154278),
+      entry(".specs/pol-captures/cap-04-with-profile.png", 251903),
+      entry("tmp/pyrefly-exapi.txt", 103, "differs"),
+      entry("src/app/dist/bundle/", 12_000_000, "differs"),
+    ],
+    identical: 20, skipped: 508,
+  });
+
+  it("asks for every ticked path, nested ones included", () => {
+    // The regression. Nine entries pre-ticked, nine sent — not four.
+    const ticked = new Set([...preselected(real)].map((p) => rescueKey(WT, p)));
+    const picks = rescuePicks([real], ticked);
+    expect(picks.get(WT)).toHaveLength(9);
+    expect(picks.get(WT)).toContain(".specs/pol-captures/cap-04-with-profile.png");
+    expect(picks.get(WT)).toContain("worktree.env");
+    // And nothing that would overwrite the main checkout.
+    expect(picks.get(WT)).not.toContain("tmp/pyrefly-exapi.txt");
+  });
+
+  it("keys are per worktree, so identical paths don't collide", () => {
+    // Every worktree of a repo has a `worktree.env`. Ticking one must not tick
+    // the other, and must not drop it either.
+    const a = report("/w/a", { entries: [entry("worktree.env", 10)] });
+    const b = report("/w/b", { entries: [entry("worktree.env", 10)] });
+    const picks = rescuePicks([a, b], new Set([rescueKey("/w/b", "worktree.env")]));
+    expect(picks.has("/w/a")).toBe(false);
+    expect(picks.get("/w/b")).toEqual(["worktree.env"]);
+  });
+
+  it("an untouched worktree contributes nothing at all", () => {
+    // Not an empty array — the caller skips on `!rels.length`, and an entry
+    // with no paths would still print "keeping 0 files".
+    expect(rescuePicks([real], new Set()).size).toBe(0);
   });
 });

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "bun:test";
+import { partitionByWorktree, splitReadable, goneConfirmText, leftoversLine } from "../src/lib/goneCleanup.ts";
+import type { GitBranch, WorktreeLeftovers } from "../../shared/types.ts";
+
+/**
+ * The bulk "delete N merged" path, pinned at the two points where it decides
+ * something irreversible.
+ *
+ * The first version of `splitReadable` was written inline as
+ * `byPath.get(path)?.error ?? true`, which is `true` whenever the server
+ * succeeded — so every branch held by a worktree was refused with "no answer
+ * from the server" while the server was answering fine. The type checker was
+ * happy and the server's own tests all passed; the only thing that catches it
+ * is handing the decision a successful report and asking what it decided.
+ */
+const branch = (name: string): GitBranch => ({
+  name, current: false, upstream: null, track: "[gone]", date: "", subject: "", mergedIntoTrunk: true,
+});
+const report = (path: string, over: Partial<WorktreeLeftovers> = {}): WorktreeLeftovers => ({
+  path, files: [], more: 0, skipped: 0, ...over,
+});
+
+describe("partitionByWorktree", () => {
+  it("puts a branch with a worktree on the held side", () => {
+    const a = branch("PROJ-1"), b = branch("PROJ-2");
+    const { free, held } = partitionByWorktree([a, b], new Map([["PROJ-2", "/code/repo-PROJ-2"]]));
+    expect(free.map((x) => x.name)).toEqual(["PROJ-1"]);
+    expect(held.map((x) => x.name)).toEqual(["PROJ-2"]);
+  });
+
+  it("an empty map means nothing is held", () => {
+    // The state this map is built from is only populated by the Worktrees tab,
+    // so an empty one used to be the normal case from the Branches tab — and it
+    // silently sent every branch down the delete-directly path that fails.
+    const { free, held } = partitionByWorktree([branch("PROJ-1")], new Map());
+    expect(free).toHaveLength(1);
+    expect(held).toHaveLength(0);
+  });
+});
+
+describe("splitReadable", () => {
+  const b = branch("PROJ-1");
+  const map = new Map([["PROJ-1", "/code/repo-PROJ-1"]]);
+
+  it("treats a successful report as removable", () => {
+    // THE regression. A good report has no `error` field at all.
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1", { files: ["a.env"], skipped: 12 })]);
+    expect(refused).toEqual([]);
+    expect(removable).toHaveLength(1);
+    expect(removable[0]!.report.files).toEqual(["a.env"]);
+  });
+
+  it("an empty checkout is still removable", () => {
+    // No files and no error: nothing to lose, and it must not read as a failure
+    // just because the list is empty.
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1")]);
+    expect(refused).toEqual([]);
+    expect(removable).toHaveLength(1);
+  });
+
+  it("refuses a checkout that reported an error", () => {
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1", { error: "could not read that checkout" })]);
+    expect(removable).toEqual([]);
+    expect(refused[0]!.why).toBe("could not read that checkout");
+  });
+
+  it("refuses a branch with no report at all", () => {
+    // A path the server never answered for. Silence is not consent.
+    const { removable, refused } = splitReadable([b], map, []);
+    expect(removable).toEqual([]);
+    expect(refused[0]!.why).toBe("no answer from the server");
+  });
+
+  it("refuses a branch whose worktree path is unknown", () => {
+    const { removable, refused } = splitReadable([b], new Map(), [report("/code/repo-PROJ-1")]);
+    expect(removable).toEqual([]);
+    expect(refused).toHaveLength(1);
+  });
+});
+
+describe("goneConfirmText", () => {
+  const trunk = "origin/master";
+
+  it("does not call the held ones 'more' when none are free", () => {
+    // The shipped bug: "None of the 3 merged branches can be deleted on their
+    // own" followed by "3 more are checked out in a worktree" reads as six
+    // branches in a repo that has three.
+    const held = [branch("a"), branch("b"), branch("c")];
+    const text = goneConfirmText([], held, 5, trunk);
+    expect(text).not.toContain("more are checked out");
+    expect(text).toContain("All 3 merged branches are checked out in a worktree");
+    expect(text).toContain("5 have no remote branch");
+  });
+
+  it("uses 'more' only when there is something for them to be more than", () => {
+    const text = goneConfirmText([branch("a")], [branch("b")], 0, trunk);
+    expect(text).toContain("Delete 1 branch already merged into origin/master?");
+    expect(text).toContain("1 more is checked out in a worktree");
+  });
+
+  it("says nothing about worktrees when none are held", () => {
+    const text = goneConfirmText([branch("a"), branch("b")], [], 0, trunk);
+    expect(text).toBe("Delete 2 branches already merged into origin/master?");
+  });
+
+  it("agrees in number for a single held branch", () => {
+    const text = goneConfirmText([], [branch("a")], 0, trunk);
+    expect(text).toContain("All 1 merged branch is checked out in a worktree");
+    expect(text).toContain("Remove that worktree and delete the branch?");
+  });
+});
+
+describe("leftoversLine", () => {
+  it("caps the list and counts the rest, including the server's own overflow", () => {
+    const r = report("/code/repo-x", { files: ["1", "2", "3", "4", "5", "6", "7"], more: 21, skipped: 508 });
+    const line = leftoversLine(r, "repo-x");
+    expect(line).toContain("    1\n");
+    expect(line).not.toContain("    7\n");
+    // 7 files, 6 shown, 1 left over here plus the 21 the server had already cut.
+    expect(line).toContain("…and 22 more");
+    expect(line).toContain("(+508 rebuildable");
+  });
+
+  it("distinguishes an empty checkout from one holding only caches", () => {
+    expect(leftoversLine(report("/x"), "x")).toContain("empty");
+    expect(leftoversLine(report("/x", { skipped: 9 }), "x")).toContain("nothing but 9 rebuildable");
+  });
+});

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { partitionByWorktree, splitReadable, goneConfirmText, leftoversLine, preselected, fmtBytes } from "../src/lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, leftoversLine, preselected, fmtBytes } from "../src/lib/goneCleanup.ts";
 import type { GitBranch, WorktreeLeftovers, LeftoverEntry } from "../../shared/types.ts";
 
 /**
@@ -80,7 +80,7 @@ describe("splitReadable", () => {
   });
 });
 
-describe("goneConfirmText", () => {
+describe("goneConfirmTitle / goneConfirmBody", () => {
   const trunk = "origin/master";
 
   it("does not call the held ones 'more' when none are free", () => {
@@ -88,27 +88,33 @@ describe("goneConfirmText", () => {
     // own" followed by "3 more are checked out in a worktree" reads as six
     // branches in a repo that has three.
     const held = [branch("a"), branch("b"), branch("c")];
-    const text = goneConfirmText([], held, 5, trunk);
-    expect(text).not.toContain("more are checked out");
-    expect(text).toContain("All 3 merged branches are checked out in a worktree");
-    expect(text).toContain("5 have no remote branch");
+    expect(goneConfirmTitle([], held, trunk)).toBe("Remove 3 worktrees and delete their branches?");
+    const body = goneConfirmBody([], held, 5, trunk);
+    expect(body).not.toContain("more are checked out");
+    expect(body).toContain("All 3 merged branches are checked out in a worktree");
+    expect(body).toContain("5 have no remote branch");
   });
 
   it("uses 'more' only when there is something for them to be more than", () => {
-    const text = goneConfirmText([branch("a")], [branch("b")], 0, trunk);
-    expect(text).toContain("Delete 1 branch already merged into origin/master?");
-    expect(text).toContain("1 more is checked out in a worktree");
+    expect(goneConfirmTitle([branch("a")], [branch("b")], trunk)).toBe("Delete 1 branch already merged into origin/master?");
+    expect(goneConfirmBody([branch("a")], [branch("b")], 0, trunk)).toContain("1 more is checked out in a worktree");
   });
 
   it("says nothing about worktrees when none are held", () => {
-    const text = goneConfirmText([branch("a"), branch("b")], [], 0, trunk);
-    expect(text).toBe("Delete 2 branches already merged into origin/master?");
+    expect(goneConfirmTitle([branch("a"), branch("b")], [], trunk)).toBe("Delete 2 branches already merged into origin/master?");
+    expect(goneConfirmBody([branch("a"), branch("b")], [], 0, trunk)).toBe("");
   });
 
   it("agrees in number for a single held branch", () => {
-    const text = goneConfirmText([], [branch("a")], 0, trunk);
-    expect(text).toContain("All 1 merged branch is checked out in a worktree");
-    expect(text).toContain("Remove that worktree and delete the branch?");
+    expect(goneConfirmTitle([], [branch("a")], trunk)).toBe("Remove 1 worktree and delete its branch?");
+    expect(goneConfirmBody([], [branch("a")], 0, trunk)).toContain("All 1 merged branch is checked out in a worktree");
+  });
+
+  it("the title is one line — it is what the dialog bolds", () => {
+    // Body carries the rest. A title with newlines in it renders as a wall.
+    for (const t of [goneConfirmTitle([branch("a")], [branch("b")], trunk), goneConfirmTitle([], [branch("a")], trunk)]) {
+      expect(t).not.toContain("\n");
+    }
   });
 });
 

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, leftoversLine, preselected, fmtBytes, rescueKey, rescuePicks } from "../src/lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, preselected, fmtBytes, rescueKey, rescuePicks } from "../src/lib/goneCleanup.ts";
 import type { GitBranch, WorktreeLeftovers, LeftoverEntry } from "../../shared/types.ts";
 
 /**
@@ -162,24 +162,6 @@ describe("fmtBytes", () => {
     expect(fmtBytes(725_000)).toBe("708K");
     expect(fmtBytes(12_000_000)).toBe("11M");
     expect(fmtBytes(-1)).toBe("?");
-  });
-});
-
-describe("leftoversLine", () => {
-  it("caps the list and counts the rest, including the server's own overflow", () => {
-    const r = report("/code/repo-x", { entries: ["1", "2", "3", "4", "5", "6", "7"].map((n) => entry(n, 10)), more: 21, skipped: 508 });
-    const line = leftoversLine(r, "repo-x");
-    expect(line).toContain("    1\n");
-    expect(line).not.toContain("    7\n");
-    // 7 files, 6 shown, 1 left over here plus the 21 the server had already cut.
-    expect(line).toContain("…and 22 more");
-    expect(line).toContain("(+508 rebuildable");
-  });
-
-  it("distinguishes an empty checkout from one holding only caches", () => {
-    expect(leftoversLine(report("/x"), "x")).toContain("empty");
-    expect(leftoversLine(report("/x", { skipped: 9 }), "x")).toContain("9 rebuildable");
-    expect(leftoversLine(report("/x", { identical: 20 }), "x")).toContain("20 already in the main checkout");
   });
 });
 

--- a/web/test/no-native-dialogs.test.ts
+++ b/web/test/no-native-dialogs.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+/**
+ * The app asks its own questions.
+ *
+ * `window.confirm` and `window.prompt` render in the OS chrome: another
+ * typeface, another button order per platform, no relationship to the panel
+ * that raised them. Next to this app's own modals the seam is the loudest thing
+ * on screen — and a dialog that reads as foreign is one people click through
+ * without reading, which is the worst possible property for the questions here,
+ * all of which are about deleting somebody's work.
+ *
+ * They also block the JS thread, so nothing can show a spinner, disable a
+ * button or repaint while one is up. That is half of "I pressed it and nothing
+ * happened".
+ *
+ * Use `useDialogs()` from components/ConfirmDialog.tsx instead:
+ *
+ *   const { ask, askText, dialog } = useDialogs();   // render {dialog}
+ *   if (!(await ask({ title: "Delete branch?", danger: true }))) return;
+ *
+ * This is a lint, not a unit test, and it exists because the eighteen that were
+ * here got there one convenient call at a time.
+ */
+
+const SRC = new URL("../src", import.meta.url).pathname;
+const EXTS = [".ts", ".tsx"];
+
+/** `confirm(` / `prompt(` / `alert(` as a bare call — not `foo.confirm(`, not a
+ *  local named `confirm` being declared, and not the word inside a comment. */
+const NATIVE = /(?<![\w.$])(confirm|prompt|alert)\s*\(/g;
+
+function sources(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) { sources(p, out); continue; }
+    if (EXTS.some((e) => name.endsWith(e))) out.push(p);
+  }
+  return out;
+}
+
+/** Comment bodies and string literals, so prose about `confirm()` and a button
+ *  labelled "Confirm" don't fail the build. */
+function stripNoise(code: string): string {
+  return code
+    .replace(/\/\*[\s\S]*?\*\//g, " ")
+    .replace(/(^|[^:])\/\/[^\n]*/g, "$1 ")
+    .replace(/`(?:[^`\\]|\\.)*`/g, "``")
+    .replace(/"(?:[^"\\]|\\.)*"/g, '""')
+    .replace(/'(?:[^'\\]|\\.)*'/g, "''");
+}
+
+describe("no native dialogs", () => {
+  it("nothing calls window.confirm / prompt / alert", () => {
+    const hits: string[] = [];
+    for (const file of sources(SRC)) {
+      const code = stripNoise(readFileSync(file, "utf8"));
+      // The dialog component defines its own local `confirm` helper, which is
+      // the replacement, not an instance of the problem.
+      if (file.endsWith("ConfirmDialog.tsx")) continue;
+      for (const m of code.matchAll(NATIVE)) {
+        // `const confirm = () => …` inside a component is a local callback.
+        const before = code.slice(Math.max(0, m.index - 30), m.index);
+        if (/\b(const|let|function)\s+$/.test(before)) continue;
+        hits.push(`${file.slice(SRC.length + 1)}: ${m[1]}(`);
+      }
+    }
+    // Named in full: the point is that the failure tells you where to look.
+    expect(hits).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Thirteen fixes to the git panel, all of the same shape: the panel was confidently saying things that were not so.

**Branches.** A branch whose PR had merged still read "not merged — kept". Two causes. The sweep that recovers squash merges fills the Set the cache entry holds, but that entry expires on a 30s clock while the sweep declines to re-run for five minutes — so a rebuilt entry lost every verdict for four and a half minutes out of every five. And rebase merges were invisible to both checks we had: ancestry sees new hashes, and the squash probe compares one combined patch-id against the several separate ones a rebase leaves behind. `git cherry` is the check shaped for that, and it costs one spawn against the probe's five, so it now runs first.

**Worktrees.** The bulk delete refused every checkout it could read, and said nothing about which worktree was holding the branch. A worktree full of root-owned files was a trap with no way out. The rescue list hid rows you could have ticked.

**Remotes.** The tab counted remotes and called them branches. `origin`'s own HEAD shortens to just `origin` under `%(refname:short)`, so the obvious guard — skipping refs ending in `/HEAD` — matched nothing, and the tab claimed 790 over a list of 789.

**The tab strip** loses its boxes; counts become superscripts, which is what they are.

Also here: repo pickers sort by when you last worked there, the app asks its own questions instead of borrowing the OS dialog, and `leftoversLine` goes — dead since the rescue modal replaced it.

## How was it tested?

- `server/test/branch-merged.test.ts` grew the rebase-merge case and a regression for the cache gap. One fixture bug found while writing it: replayed straight onto the branch point, `git cherry-pick` reproduces byte-identical SHAs and the trunk fast-forwards, so plain ancestry answers and the test passed against the unfixed code. The trunk has to move first.
- `server/test/remote-branches.test.ts`, `gitlog.test.ts`, `repo-order.test.ts` and `worktree-leftovers.test.ts` cover the rest.
- `cd server && bun test`: 357 pass. `cd web && bun test`: 178 pass. Both typechecks clean, `vite build` clean.
- Exercised against a repository with 45 branches and 18 worktrees: 13 gone branches that previously reported 8 unmerged now report 4, and those four are genuinely ahead of the trunk.

First of a stack of six. Nothing below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
