### PR TITLE
fix(docker): put the cursor in the console the moment it opens

### DIFF
--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -292,6 +292,18 @@ export function DockerView({ active }: { active: boolean }) {
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
   const logRef = useRef<HTMLPreElement>(null);
   const frameRef = useRef<HTMLDivElement>(null);
+  /**
+   * Closing the console hands the keyboard back to the panel.
+   *
+   * The strip takes focus the moment it opens — opening a shell is asking to
+   * type in it, and it used to cost a click on the black area first. This is
+   * the other half of that: without it `j`/`k` would go on being swallowed by
+   * a shell that is no longer on screen.
+   */
+  const closeConsole = useCallback(() => {
+    setConsoleOpen(false);
+    requestAnimationFrame(() => frameRef.current?.focus());
+  }, []);
   const logSeq = useRef(0);          // guards stale log responses
   const stuckBottom = useRef(true);  // only auto-scroll when the user is at the bottom
 
@@ -624,7 +636,7 @@ export function DockerView({ active }: { active: boolean }) {
                   open={consoleOpen}
                   height={consoleH}
                   onHeight={setConsoleH}
-                  onClose={() => setConsoleOpen(false)}
+                  onClose={closeConsole}
                 />
 
                 {ov?.available && view === "containers" && (
@@ -637,7 +649,7 @@ export function DockerView({ active }: { active: boolean }) {
                         logs is the sort of thing you only use if you know it
                         is there. It reads as an action, not as a legend. */}
                     <button
-                      onClick={() => setConsoleOpen((v) => !v)}
+                      onClick={() => (consoleOpen ? closeConsole() : setConsoleOpen(true))}
                       className="ml-1 px-2.5 py-1 rounded-lg text-[10.5px] font-medium whitespace-nowrap transition-colors flex items-center gap-1.5"
                       title="A shell in this project, docked under the logs — run make targets, migrations or tests without leaving Docker. It keeps running while you look around."
                       style={{

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -501,6 +501,12 @@ export function ConsoleStrip({ root, open, height, onHeight, onClose }: {
     const doFit = () => { try { fitTerm(s); } catch { /* not measurable yet */ } };
     doFit();
     if (s.status === "idle") connect(s);
+    // Opening a shell is asking to type in it. The strip mounted focused on
+    // nothing, so every open cost a click on the black area before the first
+    // keystroke landed — and a click that does nothing visible is a click you
+    // forget you have to make. Same rAF as the terminal view's own focus: the
+    // element has to be attached and laid out first.
+    requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
     const ro = new ResizeObserver(doFit);
     ro.observe(el);
     return () => {


### PR DESCRIPTION
## What does this PR do?

Opening the console under a container left the cursor wherever it happened to be, so the first thing you typed went somewhere else. It takes focus on open now.

Small and self-contained. It sits in the stack only because it touches `DockerPanel.tsx` and `TerminalPanel.tsx`, which the branches below and above also move.

## How was it tested?

- `cd server && bun test`: 357 pass. `cd web && bun test`: 178 pass. Both typechecks clean, `vite build` clean.
- Opened the console on a running container and typed immediately.

Second of six. Reads on top of #1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
