### PR TITLE
feat(pr): review pull requests without leaving for the browser

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "electron": {
       "name": "agentglass-electron",
-      "version": "0.2.0",
+      "version": "0.4.0",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8",
@@ -32,6 +32,7 @@
       "dependencies": {
         "@number-flow/react": "^0.6.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "motion": "^12.42.2",
         "react": "^18.3.1",
@@ -341,6 +342,8 @@
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 
     "@xterm/xterm": ["@xterm/xterm@6.0.0", "", {}, "sha512-TQwDdQGtwwDt+2cgKDLn0IRaSxYu1tSUjgKarSDkUM0ZNiSRXFpjxEsvc/Zgc5kq5omJ+V0a8/kIM2WD3sMOYg=="],
 

--- a/electron/main.js
+++ b/electron/main.js
@@ -17,7 +17,7 @@
 // instance failing to bind). A custom scheme has neither problem: one stable
 // origin, no port, and any number of instances share it.
 
-const { app, BrowserWindow, ipcMain, protocol } = require("electron");
+const { app, BrowserWindow, ipcMain, protocol, shell } = require("electron");
 const { spawn } = require("child_process");
 const http = require("http");
 const fs = require("fs");
@@ -216,7 +216,40 @@ function createWindow() {
     webPreferences: { preload: path.join(__dirname, "preload.js") },
   });
   registerIpc(win);
+  openLinksOutside(win);
   win.loadURL(`${APP_ORIGIN}/`);
+}
+
+/**
+ * A link to GitHub belongs in the user's browser, not in this window.
+ *
+ * Without both handlers, `target="_blank"` opens a second, chrome-less Electron
+ * window with no way back, and an ordinary click navigates the app itself away
+ * from the renderer -- there is no address bar to return from, so the only fix
+ * is restarting the app.
+ *
+ * Only http(s) is ever handed to the OS. `shell.openExternal` will happily
+ * launch a `file://` or a custom-scheme URL, and the strings reaching here come
+ * out of pull request bodies and git remotes, which are written by other people.
+ */
+function openLinksOutside(win) {
+  const external = (url) => {
+    try {
+      const u = new URL(url);
+      if (u.protocol !== "http:" && u.protocol !== "https:") return false;
+      shell.openExternal(url);
+      return true;
+    } catch { return false; }
+  };
+  win.webContents.setWindowOpenHandler(({ url }) => {
+    external(url);
+    return { action: "deny" };
+  });
+  win.webContents.on("will-navigate", (e, url) => {
+    if (url.startsWith(APP_ORIGIN)) return; // the app navigating within itself
+    e.preventDefault();
+    external(url);
+  });
 }
 
 app.whenReady().then(async () => {

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -301,11 +301,11 @@ async function main() {
 
       await press("\\", true); // ⌘\ / Ctrl-\ opens it
       const railTabs = await evaluate(`document.querySelectorAll('${railSel} [role="tab"]').length`);
-      if (railTabs !== 5) failures.push(`[workspace] expected 5 rail tabs after Ctrl-\\, found ${railTabs}`);
+      if (railTabs !== 6) failures.push(`[workspace] expected 6 rail tabs after Ctrl-\\, found ${railTabs}`);
 
       // Every view mounts up front; only one is visible.
       const panes = await evaluate(`document.querySelectorAll('${railSel}')[0]?.parentElement?.querySelectorAll(':scope > div > [aria-hidden]').length ?? 0`);
-      if (panes !== 5) failures.push(`[workspace] expected all 5 views mounted, found ${panes}`);
+      if (panes !== 6) failures.push(`[workspace] expected all 6 views mounted, found ${panes}`);
 
       /**
        * Press a key and wait for the view to actually be the one expected.
@@ -327,9 +327,13 @@ async function main() {
       };
 
       // Inside the workspace, navigation carries a modifier. VIEWS order is
-      // git, diff, docker, term, chat — so ⌘2 and ⌘4.
+      // git, diff, pr, docker, term, chat — so ⌘2 is diff and ⌘5 is term.
+      // These numbers are deliberately literal rather than derived from the
+      // rail: a check that reads the app's own list would agree with it however
+      // wrong it got, and the point is to notice when the order moves. It moved
+      // here — `pr` was inserted third and pushed term from 4 to 5.
       if (!(await pressUntilView("2", "diff", true))) failures.push(`[workspace] Ctrl-2 should select diff, selected ${await selectedView()}`);
-      if (!(await pressUntilView("4", "term", true))) failures.push(`[workspace] Ctrl-4 should select term, selected ${await selectedView()}`);
+      if (!(await pressUntilView("5", "term", true))) failures.push(`[workspace] Ctrl-5 should select term, selected ${await selectedView()}`);
       if (!(await pressUntilView("1", "git", true))) failures.push(`[workspace] Ctrl-1 should select git, selected ${await selectedView()}`);
 
       // And the property this replaced a heuristic to guarantee: a bare letter
@@ -354,7 +358,7 @@ async function main() {
       }
       if (!closed) failures.push("[workspace] Escape did not close the workspace");
 
-      if (!failures.length) console.log("✓ smoke: workspace opens, all 5 views mount, keys switch and close");
+      if (!failures.length) console.log("✓ smoke: workspace opens, all 6 views mount, keys switch and close");
 
       // Chats have to outlive the page, which is a property no unit test can
       // reach: the store restores at module load, from real storage, in a real

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -47,6 +47,11 @@ import {
   overview as dockerOverview, stats as dockerStats, logs as dockerLogs, inspect as dockerInspect, top as dockerTop,
   startContainer, stopContainer, restartContainer, removeContainer,
 } from "./docker.ts";
+import {
+  listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
+  setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
+  rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi,
+} from "./prs.ts";
 import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, type PtyWsData } from "./terminal.ts";
 import { chatStream, CHAT_ENABLED, CHAT_BYPASS_ALLOWED } from "./chat.ts";
@@ -794,6 +799,67 @@ const server = Bun.serve<WsData>({
       if (res) return json(res, res.ok ? 200 : 400);
     }
 
+    // --- pull requests (gh-backed) ---
+    //
+    // Reads answer from a cache that refreshes behind them, so none of these
+    // waits on a subprocess. Writes are all POST and all origin-checked; the
+    // irreversible ones additionally carry the head sha the UI showed.
+    if (pathname === "/prs/capability") return json(await ghCapability(url.searchParams.get("force") === "1"));
+    if (pathname === "/prs/list") {
+      return json(await listPrs(
+        url.searchParams.get("root") || "",
+        url.searchParams.get("filter") || "mine",
+        url.searchParams.get("force") === "1",
+      ));
+    }
+    if (pathname === "/prs/detail") {
+      return json(await prDetail(
+        url.searchParams.get("root") || "",
+        url.searchParams.get("number") || "",
+        url.searchParams.get("force") === "1",
+      ));
+    }
+    if (pathname === "/prs/diff") {
+      return json(await prDiff(url.searchParams.get("root") || "", url.searchParams.get("number") || ""));
+    }
+    // Images in a PR body. Not JSON — it streams the bytes back, because
+    // GitHub's own attachment URLs 404 without the token this attaches.
+    if (pathname === "/prs/asset") return prAsset(url.searchParams.get("url") || "");
+    if (pathname === "/prs/branch-url") {
+      return json(await branchUrl(
+        url.searchParams.get("root") || "",
+        url.searchParams.get("branch") || "",
+        url.searchParams.get("gone") || "",
+      ));
+    }
+    if (pathname.startsWith("/prs/") && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: any = {};
+      try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const root = b.root ?? "";
+      const n = b.number;
+      let res;
+      switch (pathname) {
+        case "/prs/review": res = await submitReview(root, n, b.verb, b.body); break;
+        case "/prs/comment": res = await addComment(root, n, b.body); break;
+        case "/prs/reply": res = await replyToThread(root, n, b.commentId, b.body); break;
+        case "/prs/thread-resolved": res = await setThreadResolved(root, b.threadId, b.resolved); break;
+        case "/prs/react": res = await react(root, b.commentId, b.content); break;
+        case "/prs/edit": res = await editPr(root, n, { title: b.title, body: b.body, base: b.base }); break;
+        case "/prs/labels": res = await setLabels(root, n, b.add, b.remove); break;
+        case "/prs/reviewers": res = await setReviewers(root, n, b.add, b.remove); break;
+        case "/prs/draft": res = await setDraft(root, n, b.draft); break;
+        case "/prs/update-branch": res = await updateBranch(root, n); break;
+        case "/prs/rerun": res = await rerunFailedChecks(root, n); break;
+        case "/prs/merge": res = await mergePr(root, n, b.method, { deleteBranch: b.deleteBranch, auto: b.auto, headSha: b.headSha }); break;
+        case "/prs/close": res = await closePr(root, n, b.reopen === true); break;
+        case "/prs/local-review": res = await prepareLocalReview(root, n); break;
+        case "/prs/local-review-discard": res = await discardLocalReview(root, n); break;
+        default: res = null;
+      }
+      if (res) return json(res, res.ok ? 200 : 400);
+    }
+
     // --- in-browser terminal: ready-to-run project commands (make + scripts) ---
     if (pathname === "/terminal/commands") return json(projectCommands(url.searchParams.get("root") || ""));
 
@@ -1059,6 +1125,10 @@ const ws = workspaceRoot();
 console.log(ws ? `   Project     → ${ws} (this project only)` : "   Project     → every project on this machine");
 // Only meaningful once a project is open — see startAutoFetch().
 startAutoFetch();
+// A pull request's checks finished. The latch is on the server so the message
+// arrives once per verdict no matter how many browser tabs are watching, and
+// the frame carries the names of what failed rather than only a count.
+subscribeCi((v) => broadcast({ type: "ci", data: v }));
 // Watch our own event loop. Cheap (one timer, one subtraction) and the only
 // thing that turns "the terminal feels laggy" into a name and a number.
 watchLoop();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,7 +50,7 @@ import {
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
   setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
-  rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi, commitDiff as prCommitDiff,
+  rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi, commitDiff as prCommitDiff, submitReviewWith,
 } from "./prs.ts";
 import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, type PtyWsData } from "./terminal.ts";
@@ -844,6 +844,7 @@ const server = Bun.serve<WsData>({
       let res;
       switch (pathname) {
         case "/prs/review": res = await submitReview(root, n, b.verb, b.body); break;
+        case "/prs/review-with": res = await submitReviewWith(root, n, b.verb, b.body, b.comments); break;
         case "/prs/comment": res = await addComment(root, n, b.body); break;
         case "/prs/reply": res = await replyToThread(root, n, b.commentId, b.body); break;
         case "/prs/thread-resolved": res = await setThreadResolved(root, b.threadId, b.resolved); break;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -50,7 +50,7 @@ import {
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
   setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
-  rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi,
+  rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi, commitDiff as prCommitDiff,
 } from "./prs.ts";
 import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, type PtyWsData } from "./terminal.ts";
@@ -825,6 +825,9 @@ const server = Bun.serve<WsData>({
     // Images in a PR body. Not JSON — it streams the bytes back, because
     // GitHub's own attachment URLs 404 without the token this attaches.
     if (pathname === "/prs/asset") return prAsset(url.searchParams.get("url") || "");
+    if (pathname === "/prs/commit-diff") {
+      return json(await prCommitDiff(url.searchParams.get("root") || "", url.searchParams.get("sha") || ""));
+    }
     if (pathname === "/prs/branch-url") {
       return json(await branchUrl(
         url.searchParams.get("root") || "",

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -592,7 +592,7 @@ const DETAIL_QUERY = `query($owner:String!,$name:String!,$number:Int!){
     number title url state isDraft createdAt updatedAt
     additions deletions changedFiles
     baseRefName headRefName body
-    mergeable mergeStateStatus reviewDecision
+    mergeable mergeStateStatus reviewDecision viewerDidAuthor
     author{login}
     labels(first:20){nodes{name color}}
     assignees(first:10){nodes{login}}
@@ -635,6 +635,7 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
   const cap = await ghCapability();
   if (!cap.available || !cap.authed) return { ok: false, error: cap.reason };
 
+  const viewerLogin = cap.login || "";
   const data = await ghJson<any>([
     "api", "graphql",
     "-f", `query=${DETAIL_QUERY}`,
@@ -743,6 +744,12 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     assignees: (p.assignees?.nodes || []).map((n: any) => n.login),
     reviews, comments, threads, commits, files,
     forcePushedSinceReview,
+    // Who you are on this pull request. Offering "approve" on your own work is
+    // a control GitHub does not give you either, and a review button on every
+    // row makes the ones that are actually waiting on you invisible.
+    viewerDidAuthor: !!p.viewerDidAuthor,
+    viewerRequested: (p.reviewRequests?.nodes || [])
+      .some((n: any) => (n.requestedReviewer?.login || "") === viewerLogin && !!viewerLogin),
   };
 
   detailCache.set(key, { at: Date.now(), detail });

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -288,9 +288,22 @@ export function noteCi(repo: PrRepoId, pr: PrSummary): void {
 
 export type PrFilter = "mine" | "review" | "all";
 
-const LIST_FIELDS = "number,title,author,state,isDraft,headRefName,baseRefName,url,updatedAt,reviewDecision,additions,deletions,changedFiles,labels,statusCheckRollup";
+/**
+ * Two field sets, because one of them costs four times the other.
+ *
+ * Measured on a real repo, 50 open pull requests: 1.5s without
+ * `statusCheckRollup` and 5.5s with it. The rollup is a separate GraphQL walk
+ * per pull request, so it dominates — and it is also the part nobody is waiting
+ * for when they open the panel to find a title.
+ *
+ * So the list arrives in two passes. The cheap one lands first and the rows are
+ * usable immediately; the rollup fills the check states in behind it. A row
+ * whose checks have not landed says so rather than claiming "no checks", which
+ * is a different and wrong answer.
+ */
+const LIST_FIELDS_FAST = "number,title,author,state,isDraft,headRefName,baseRefName,url,updatedAt,reviewDecision,additions,deletions,changedFiles,labels";
 
-type Entry = { at: number; prs: PrSummary[]; loading: boolean; error?: string };
+type Entry = { at: number; prs: PrSummary[]; loading: boolean; checksPending: boolean; error?: string };
 const listCache = new Map<string, Entry>();
 const inflight = new Set<string>();
 const LIST_TTL_MS = 90_000;
@@ -300,8 +313,8 @@ const LIST_TTL_MS = 90_000;
 // same keys, still searchable.
 const cacheKey = (repo: PrRepoId, filter: PrFilter) => `${repo.key}\u0000${filter}`;
 
-function mapSummary(p: any): PrSummary {
-  const { rollup } = rollupChecks(p.statusCheckRollup);
+function mapSummary(p: any, withChecks: boolean): PrSummary {
+  const { rollup } = rollupChecks(withChecks ? p.statusCheckRollup : []);
   return {
     number: p.number,
     title: p.title || "",
@@ -318,22 +331,84 @@ function mapSummary(p: any): PrSummary {
     changedFiles: p.changedFiles ?? 0,
     labels: (p.labels || []).map((l: any) => ({ name: l.name, color: l.color })),
     checks: rollup,
+    // Absent is not zero: a row without this must say "checks loading", never
+    // "no checks", which is a claim about the repository rather than about us.
+    checksLoaded: withChecks,
   };
 }
 
 async function fetchList(repo: PrRepoId, filter: PrFilter): Promise<PrSummary[]> {
-  const R = ["-R", repo.nameWithOwner];
-  if (filter === "review") {
-    // `gh pr list --search` rather than `gh search prs`: the latter is a global
-    // search and would need its own repo filter anyway, and it rate-limits
-    // separately from the REST path everything else here uses.
-    const rows = await ghJson<any[]>(["pr", "list", ...R, "--search", "review-requested:@me", "--state", "open", "--limit", "50", "--json", LIST_FIELDS]);
-    return (rows || []).map(mapSummary);
-  }
-  const args = ["pr", "list", ...R, "--state", "open", "--limit", "50", "--json", LIST_FIELDS];
+  const args = ["pr", "list", "-R", repo.nameWithOwner, "--state", "open", "--limit", "50", "--json", LIST_FIELDS_FAST];
+  // `gh pr list --search` rather than `gh search prs`: the latter is a global
+  // search that would need its own repo filter anyway, and it rate-limits
+  // separately from the REST path everything else here uses.
+  if (filter === "review") args.push("--search", "review-requested:@me");
   if (filter === "mine") args.push("--author", "@me");
   const rows = await ghJson<any[]>(args);
-  return (rows || []).map(mapSummary);
+  return (rows || []).map((r) => mapSummary(r, false));
+}
+
+/**
+ * Check states, one pull request at a time.
+ *
+ * Asking for fifty rollups in one query does not work: GitHub answers
+ * `HTTP 504 — we couldn't respond to your request in time`. Measured on a real
+ * repo — 15 rollups in a batch take 3.2s, 50 in a batch time out on GitHub's
+ * side however long we are willing to wait. So they are fetched per pull
+ * request, ~0.8s each, newest first, and each one updates its own row as it
+ * lands. The list fills in visibly instead of arriving all at once or not at
+ * all.
+ *
+ * Keyed by `updatedAt`, so a poll that finds nothing changed costs nothing.
+ */
+/** Matched to the list's own limit on purpose. A lower cap leaves the rows past
+ *  it saying "checks…" for ever, which is a lie the UI has no way to correct.
+ *  Fifty probes is ~40s of background network — no CPU, nothing blocked — and
+ *  the per-PR cache keyed by `updatedAt` makes every later visit free. */
+const CHECK_PROBE_MAX = 50;
+const checkCache = new Map<string, { updatedAt: string; rollup: PrCheckRollup; all: PrCheck[] }>();
+const checkRunning = new Set<string>();
+
+function refreshChecks(repo: PrRepoId, filter: PrFilter, rows: PrSummary[]): void {
+  const key = cacheKey(repo, filter);
+  if (checkRunning.has(key)) return;
+  checkRunning.add(key);
+
+  void (async () => {
+    try {
+      let i = 0;
+      for (const pr of rows.slice(0, CHECK_PROBE_MAX)) {
+        const ck = `${repo.key}\u0000${pr.number}`;
+        const hit = checkCache.get(ck);
+        let rollup: PrCheckRollup, all: PrCheck[];
+        if (hit && hit.updatedAt === pr.updatedAt) {
+          ({ rollup, all } = hit);
+        } else {
+          const one = await ghJson<any>(["pr", "view", String(pr.number), "-R", repo.nameWithOwner, "--json", "statusCheckRollup"]);
+          if (!one) { i++; continue; }
+          ({ rollup, all } = rollupChecks(one.statusCheckRollup));
+          checkCache.set(ck, { updatedAt: pr.updatedAt, rollup, all });
+        }
+        i++;
+
+        // Update this row in place. Re-read the entry each time: a newer list
+        // may have replaced it while this walk was running, and overwriting it
+        // wholesale would undo that.
+        const cur = listCache.get(key);
+        if (!cur) return;
+        const next = cur.prs.map((p) => (p.number === pr.number ? { ...p, checks: rollup, checksLoaded: true } : p));
+        listCache.set(key, { ...cur, prs: next, checksPending: i < Math.min(rows.length, CHECK_PROBE_MAX) });
+        noteCi(repo, { ...pr, checks: rollup });
+      }
+      const cur = listCache.get(key);
+      if (cur) listCache.set(key, { ...cur, checksPending: false });
+    } catch {
+      const cur = listCache.get(key);
+      if (cur) listCache.set(key, { ...cur, checksPending: false });
+    } finally {
+      checkRunning.delete(key);
+    }
+  })();
 }
 
 /** Refresh behind the response. Never awaited by a request handler. */
@@ -342,19 +417,39 @@ function refreshList(repo: PrRepoId, filter: PrFilter): void {
   if (inflight.has(key)) return;
   inflight.add(key);
   const prev = listCache.get(key);
-  listCache.set(key, { at: prev?.at ?? 0, prs: prev?.prs ?? [], loading: true, error: prev?.error });
+  const keep = (over: Partial<Entry>): Entry => ({
+    at: prev?.at ?? 0, prs: prev?.prs ?? [], loading: true, checksPending: true, error: prev?.error, ...over,
+  });
+  listCache.set(key, keep({}));
+
   void (async () => {
     try {
       const cap = await ghCapability();
       if (!cap.available || !cap.authed) {
-        listCache.set(key, { at: Date.now(), prs: prev?.prs ?? [], loading: false, error: cap.reason });
+        listCache.set(key, keep({ at: Date.now(), loading: false, checksPending: false, error: cap.reason }));
         return;
       }
-      const prs = await fetchList(repo, filter);
-      listCache.set(key, { at: Date.now(), prs, loading: false });
-      for (const pr of prs) noteCi(repo, pr);
+
+      // One cheap query for the rows themselves — titles, authors, review
+      // decisions. Enough to choose a pull request, and it is what the panel
+      // is blocked on.
+      const rows = await fetchList(repo, filter);
+      if (!rows.length && prev?.prs.length) {
+        // An empty answer after a good one is far more likely to be a hiccup
+        // than a repository that lost every pull request. Keep what we had.
+        listCache.set(key, keep({ loading: false, checksPending: false }));
+        return;
+      }
+      // Carry over any check states already known, so switching back to a tab
+      // does not blank the states it had.
+      const merged = rows.map((r) => {
+        const hit = checkCache.get(`${repo.key}\u0000${r.number}`);
+        return hit && hit.updatedAt === r.updatedAt ? { ...r, checks: hit.rollup, checksLoaded: true } : r;
+      });
+      listCache.set(key, { at: Date.now(), prs: merged, loading: false, checksPending: merged.some((p) => !p.checksLoaded) });
+      refreshChecks(repo, filter, merged);
     } catch (e) {
-      listCache.set(key, { at: prev?.at ?? 0, prs: prev?.prs ?? [], loading: false, error: String(e) });
+      listCache.set(key, keep({ loading: false, checksPending: false, error: String(e) }));
     } finally {
       inflight.delete(key);
     }
@@ -403,6 +498,7 @@ export async function listPrs(rootIn: unknown, filterIn: unknown, force = false)
     fetchedAt: cur?.at ?? 0,
     stale: !cur?.at || Date.now() - (cur?.at ?? 0) > LIST_TTL_MS,
     loading: !!cur?.loading,
+    checksPending: !!cur?.checksPending,
     error: cur?.error,
     needsAuth: !cap.available || !cap.authed,
   };

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -1,0 +1,1086 @@
+// Pull requests, through the `gh` CLI the user is already logged into.
+//
+// Three rules shape everything here, and breaking any one of them makes the
+// panel worse than the browser it replaces:
+//
+// 1. NEVER on the poll path. A `gh` call costs 0.8-1.9s and this server has one
+//    thread. The panel polls; the fetches do not. Every read below answers from
+//    a cache and refreshes behind it, so a poll is a map lookup.
+//
+// 2. Keyed by the repo on the forge, not by the directory. Eighteen worktrees
+//    of one clone are one repo — keying by path would fetch the same list
+//    eighteen times.
+//
+// 3. Writes are public. A stray `gh pr merge` is not a UI bug, it is a deploy,
+//    so every mutation goes through `writeGuard` and the irreversible ones are
+//    named separately from the rest.
+import { gitAsync, safeAbs, repoRootOf } from "./git.ts";
+import { inScope } from "./config.ts";
+import type {
+  PrRepoId, PrSummary, PrDetail, PrListResponse, PrActionResult, PrCheck, PrCheckRollup,
+  PrCheckState, PrThread, PrReview, PrComment, PrCommit, PrFile, PrChecklistItem, PrMergeState, CiVerdict,
+} from "../../shared/types.ts";
+
+/** Same escape hatch the git writes use, so one variable disables both. */
+const WRITE_ENABLED = process.env.AGENTGLASS_GIT_WRITE_DISABLED !== "1";
+
+const GH_TIMEOUT_MS = 25_000;
+
+// ---------------------------------------------------------------------------
+// running gh
+// ---------------------------------------------------------------------------
+
+let ghPath: string | null | undefined;
+function ghBin(): string | null {
+  if (ghPath === undefined) ghPath = Bun.which("gh");
+  return ghPath ?? null;
+}
+
+export interface GhResult { code: number; stdout: string; stderr: string }
+
+/**
+ * Always async, always time-bounded.
+ *
+ * `gh` talks to the network, and a hung TLS handshake with no timeout is an
+ * agentglass that never answers again — the same failure mode as the sync git
+ * spawns that used to freeze the terminal socket.
+ */
+export async function gh(args: string[], cwd?: string, stdin?: string): Promise<GhResult> {
+  const bin = ghBin();
+  if (!bin) return { code: 127, stdout: "", stderr: "gh not found" };
+  try {
+    const proc = Bun.spawn([bin, ...args], {
+      cwd: cwd || undefined,
+      stdin: stdin === undefined ? "ignore" : new TextEncoder().encode(stdin),
+      stdout: "pipe",
+      stderr: "pipe",
+      env: { ...process.env, GH_PROMPT_DISABLED: "1", NO_COLOR: "1" },
+    });
+    const timer = setTimeout(() => { try { proc.kill(); } catch { /* already gone */ } }, GH_TIMEOUT_MS);
+    const [stdout, stderr, code] = await Promise.all([
+      new Response(proc.stdout).text(),
+      new Response(proc.stderr).text(),
+      proc.exited,
+    ]);
+    clearTimeout(timer);
+    return { code: code ?? 1, stdout, stderr };
+  } catch (e) {
+    return { code: 1, stdout: "", stderr: String(e) };
+  }
+}
+
+async function ghJson<T>(args: string[], cwd?: string): Promise<T | null> {
+  const r = await gh(args, cwd);
+  if (r.code !== 0) return null;
+  try { return JSON.parse(r.stdout) as T; } catch { return null; }
+}
+
+// ---------------------------------------------------------------------------
+// capability
+// ---------------------------------------------------------------------------
+
+export type GhCapability = { available: boolean; authed: boolean; login?: string; reason?: string };
+
+let capCache: { at: number; cap: GhCapability } | null = null;
+const CAP_TTL_MS = 60_000;
+
+/**
+ * Is `gh` here, and logged in?
+ *
+ * Cached, because the panel asks on every mount and `gh auth status` is a
+ * network round trip. Both answers are first-class UI states rather than
+ * errors: "install gh" and "run gh auth login" are things the user can act on,
+ * and a red toast saying "failed" is not.
+ */
+export async function ghCapability(force = false): Promise<GhCapability> {
+  if (!force && capCache && Date.now() - capCache.at < CAP_TTL_MS) return capCache.cap;
+  let cap: GhCapability;
+  if (!ghBin()) {
+    cap = { available: false, authed: false, reason: "the GitHub CLI (gh) is not installed" };
+  } else {
+    const r = await gh(["auth", "status", "--active"]);
+    if (r.code !== 0) {
+      cap = { available: true, authed: false, reason: "not logged in — run `gh auth login`" };
+    } else {
+      const m = (r.stdout + r.stderr).match(/account\s+(\S+)/i) || (r.stdout + r.stderr).match(/as\s+(\S+)\s/i);
+      cap = { available: true, authed: true, login: m?.[1] };
+    }
+  }
+  capCache = { at: Date.now(), cap };
+  return cap;
+}
+
+// ---------------------------------------------------------------------------
+// repo identity
+// ---------------------------------------------------------------------------
+
+/**
+ * `git@github.com:acme/orbit.git` and
+ * `https://github.com/acme/orbit.git` are the same repo.
+ *
+ * Returns null rather than guessing for anything that is not an obvious
+ * host/owner/name — a local path remote, a weird protocol. Guessing here would
+ * send `gh` at a repo that isn't yours.
+ */
+export function parseRemote(url: string): PrRepoId | null {
+  const raw = (url || "").trim();
+  if (!raw) return null;
+  let host = "", path = "";
+  const scp = raw.match(/^(?:([^@]+)@)?([^/:]+):(.+)$/);
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(raw)) {
+    try {
+      const u = new URL(raw);
+      if (u.protocol !== "http:" && u.protocol !== "https:" && u.protocol !== "ssh:") return null;
+      host = u.hostname;
+      path = u.pathname;
+    } catch { return null; }
+  } else if (scp) {
+    host = scp[2]!;
+    path = scp[3]!;
+  } else {
+    return null;
+  }
+  const parts = path.replace(/^\/+/, "").replace(/\.git$/i, "").split("/").filter(Boolean);
+  if (parts.length < 2 || !host) return null;
+  // Owner is the second-to-last segment: GHE can serve from a subpath.
+  const name = parts[parts.length - 1]!;
+  const owner = parts[parts.length - 2]!;
+  const nameWithOwner = `${owner}/${name}`;
+  return { key: `${host}/${nameWithOwner}`, host, owner, name, nameWithOwner };
+}
+
+const idCache = new Map<string, { at: number; id: PrRepoId | null }>();
+const ID_TTL_MS = 5 * 60_000;
+
+/**
+ * Which repo is this directory part of?
+ *
+ * `upstream` wins over `origin`: on a fork, the pull requests live on the
+ * upstream and a panel pointed at the fork shows an empty list forever. That is
+ * three lines here and confusing to retrofit later.
+ */
+export async function repoIdFor(rootIn: unknown): Promise<PrRepoId | null> {
+  const abs = safeAbs(rootIn);
+  if (!abs) return null;
+  const root = repoRootOf(abs);
+  if (!root) return null;
+  const hit = idCache.get(root);
+  if (hit && Date.now() - hit.at < ID_TTL_MS) return hit.id;
+  let id: PrRepoId | null = null;
+  for (const remote of ["upstream", "origin"]) {
+    const r = await gitAsync(root, ["remote", "get-url", remote]);
+    if (r.code !== 0) continue;
+    id = parseRemote(r.stdout.trim());
+    if (id) break;
+  }
+  idCache.set(root, { at: Date.now(), id });
+  return id;
+}
+
+// ---------------------------------------------------------------------------
+// checks
+// ---------------------------------------------------------------------------
+
+type RawCheck = {
+  __typename?: string;
+  name?: string; workflowName?: string; context?: string;
+  status?: string; conclusion?: string; state?: string; detailsUrl?: string; targetUrl?: string;
+};
+
+const TERMINAL_CONCLUSIONS = new Set([
+  "SUCCESS", "FAILURE", "CANCELLED", "TIMED_OUT", "ACTION_REQUIRED", "NEUTRAL", "SKIPPED", "STALE", "STARTUP_FAILURE",
+]);
+
+function checkState(c: RawCheck): { state: PrCheckState; done: boolean } {
+  // Two shapes come back in one array: CheckRun (status + conclusion) and
+  // StatusContext (state). Normalising here keeps every caller from re-learning
+  // GitHub's two vocabularies for the same idea.
+  if (c.__typename === "StatusContext" || (!c.status && c.state)) {
+    const s = (c.state || "").toUpperCase();
+    if (s === "SUCCESS") return { state: "success", done: true };
+    if (s === "FAILURE" || s === "ERROR") return { state: "failure", done: true };
+    return { state: "pending", done: false };
+  }
+  const status = (c.status || "").toUpperCase();
+  const concl = (c.conclusion || "").toUpperCase();
+  if (status !== "COMPLETED") return { state: "pending", done: false };
+  if (!TERMINAL_CONCLUSIONS.has(concl)) return { state: "pending", done: false };
+  if (concl === "SUCCESS") return { state: "success", done: true };
+  if (concl === "SKIPPED" || concl === "STALE") return { state: "skipped", done: true };
+  if (concl === "NEUTRAL") return { state: "neutral", done: true };
+  return { state: "failure", done: true };
+}
+
+export function rollupChecks(raw: RawCheck[] | null | undefined): { rollup: PrCheckRollup; all: PrCheck[] } {
+  const all: PrCheck[] = [];
+  let success = 0, failure = 0, skipped = 0, pending = 0;
+  for (const c of raw || []) {
+    const { state, done } = checkState(c);
+    const check: PrCheck = {
+      name: c.name || c.context || "check",
+      workflow: c.workflowName || "",
+      state, done,
+      url: c.detailsUrl || c.targetUrl || undefined,
+    };
+    all.push(check);
+    if (state === "success") success++;
+    else if (state === "failure") failure++;
+    else if (state === "skipped" || state === "neutral") skipped++;
+    else pending++;
+  }
+  const total = all.length;
+  const allDone = total > 0 && pending === 0;
+  return {
+    rollup: {
+      total, success, failure, skipped, pending, allDone,
+      // Skipped is not failure. Eighteen of a real PR's sixty-one checks are
+      // skipped and that PR is green.
+      verdict: allDone ? (failure > 0 ? "red" : "green") : null,
+      failing: all.filter((c) => c.state === "failure"),
+    },
+    all,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// CI notification latch
+// ---------------------------------------------------------------------------
+
+/** What we last told the user about each PR, so we tell them once. */
+const latch = new Map<string, "green" | "red">();
+const ciListeners = new Set<(v: CiVerdict) => void>();
+
+export function subscribeCi(fn: (v: CiVerdict) => void): () => void {
+  ciListeners.add(fn);
+  return () => { ciListeners.delete(fn); };
+}
+
+/**
+ * One notification per PR, at the end.
+ *
+ * A PR with sixty-one checks offers sixty-one chances to interrupt someone. The
+ * latch holds until every check is terminal and then reports the aggregate
+ * once. A re-run puts checks back to pending, which clears the latch, so a
+ * genuine second result still arrives — but a single green check inside a
+ * still-running suite never does.
+ *
+ * Exported so the latch can be tested without a network: it is the piece here
+ * whose failure mode — sixty-one notifications instead of one — the user would
+ * feel immediately.
+ */
+export function noteCi(repo: PrRepoId, pr: PrSummary): void {
+  const key = `${repo.key}#${pr.number}`;
+  if (!pr.checks.allDone) { latch.delete(key); return; }
+  const verdict = pr.checks.verdict;
+  if (!verdict) return;
+  if (latch.get(key) === verdict) return;
+  latch.set(key, verdict);
+  const v: CiVerdict = {
+    repo: repo.nameWithOwner, number: pr.number, title: pr.title, verdict,
+    failing: pr.checks.failing.map((c) => c.name), url: pr.url,
+  };
+  for (const fn of ciListeners) { try { fn(v); } catch { /* a listener must not break the poll */ } }
+}
+
+// ---------------------------------------------------------------------------
+// list
+// ---------------------------------------------------------------------------
+
+export type PrFilter = "mine" | "review" | "all";
+
+const LIST_FIELDS = "number,title,author,state,isDraft,headRefName,baseRefName,url,updatedAt,reviewDecision,additions,deletions,changedFiles,labels,statusCheckRollup";
+
+type Entry = { at: number; prs: PrSummary[]; loading: boolean; error?: string };
+const listCache = new Map<string, Entry>();
+const inflight = new Set<string>();
+const LIST_TTL_MS = 90_000;
+
+// `\u0000` written as an escape, never as the byte: a raw NUL makes the whole
+// file read as binary to grep, which then skips it in silence. Same separator,
+// same keys, still searchable.
+const cacheKey = (repo: PrRepoId, filter: PrFilter) => `${repo.key}\u0000${filter}`;
+
+function mapSummary(p: any): PrSummary {
+  const { rollup } = rollupChecks(p.statusCheckRollup);
+  return {
+    number: p.number,
+    title: p.title || "",
+    author: p.author?.login || "",
+    state: (p.state || "OPEN") as PrSummary["state"],
+    isDraft: !!p.isDraft,
+    headRefName: p.headRefName || "",
+    baseRefName: p.baseRefName || "",
+    url: p.url || "",
+    updatedAt: p.updatedAt || "",
+    reviewDecision: p.reviewDecision || null,
+    additions: p.additions ?? 0,
+    deletions: p.deletions ?? 0,
+    changedFiles: p.changedFiles ?? 0,
+    labels: (p.labels || []).map((l: any) => ({ name: l.name, color: l.color })),
+    checks: rollup,
+  };
+}
+
+async function fetchList(repo: PrRepoId, filter: PrFilter): Promise<PrSummary[]> {
+  const R = ["-R", repo.nameWithOwner];
+  if (filter === "review") {
+    // `gh pr list --search` rather than `gh search prs`: the latter is a global
+    // search and would need its own repo filter anyway, and it rate-limits
+    // separately from the REST path everything else here uses.
+    const rows = await ghJson<any[]>(["pr", "list", ...R, "--search", "review-requested:@me", "--state", "open", "--limit", "50", "--json", LIST_FIELDS]);
+    return (rows || []).map(mapSummary);
+  }
+  const args = ["pr", "list", ...R, "--state", "open", "--limit", "50", "--json", LIST_FIELDS];
+  if (filter === "mine") args.push("--author", "@me");
+  const rows = await ghJson<any[]>(args);
+  return (rows || []).map(mapSummary);
+}
+
+/** Refresh behind the response. Never awaited by a request handler. */
+function refreshList(repo: PrRepoId, filter: PrFilter): void {
+  const key = cacheKey(repo, filter);
+  if (inflight.has(key)) return;
+  inflight.add(key);
+  const prev = listCache.get(key);
+  listCache.set(key, { at: prev?.at ?? 0, prs: prev?.prs ?? [], loading: true, error: prev?.error });
+  void (async () => {
+    try {
+      const cap = await ghCapability();
+      if (!cap.available || !cap.authed) {
+        listCache.set(key, { at: Date.now(), prs: prev?.prs ?? [], loading: false, error: cap.reason });
+        return;
+      }
+      const prs = await fetchList(repo, filter);
+      listCache.set(key, { at: Date.now(), prs, loading: false });
+      for (const pr of prs) noteCi(repo, pr);
+    } catch (e) {
+      listCache.set(key, { at: prev?.at ?? 0, prs: prev?.prs ?? [], loading: false, error: String(e) });
+    } finally {
+      inflight.delete(key);
+    }
+  })();
+}
+
+/**
+ * The panel's read. Answers from cache and triggers a refresh if the copy is
+ * old — so the poll never waits on the network, and the age is shown rather
+ * than hidden behind a spinner that lies.
+ */
+export async function listPrs(rootIn: unknown, filterIn: unknown, force = false): Promise<PrListResponse> {
+  const filter: PrFilter = filterIn === "review" || filterIn === "all" ? filterIn : "mine";
+  const repo = await repoIdFor(rootIn);
+  if (!repo) {
+    const cap = await ghCapability();
+    return {
+      ok: true, repo: null, prs: [], fetchedAt: 0, stale: false, loading: false,
+      needsAuth: !cap.available || !cap.authed,
+      error: !cap.available || !cap.authed ? cap.reason : "no GitHub remote on this repository",
+    };
+  }
+  const key = cacheKey(repo, filter);
+  const hit = listCache.get(key);
+  const age = hit ? Date.now() - hit.at : Infinity;
+  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter);
+  const cur = listCache.get(key);
+
+  // "you are here" — the checkout's branch, matched against the PR heads. This
+  // is the branch/PR link, and it falls out of the dedupe rather than costing
+  // a call of its own.
+  let head = "";
+  const abs = safeAbs(rootIn);
+  const root = abs ? repoRootOf(abs) : null;
+  if (root) {
+    const r = await gitAsync(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
+    if (r.code === 0) head = r.stdout.trim();
+  }
+  const prs = (cur?.prs ?? []).map((p) => (p.headRefName && p.headRefName === head ? { ...p, isCurrentBranch: true } : p));
+
+  const cap = await ghCapability();
+  return {
+    ok: true,
+    repo,
+    prs,
+    fetchedAt: cur?.at ?? 0,
+    stale: !cur?.at || Date.now() - (cur?.at ?? 0) > LIST_TTL_MS,
+    loading: !!cur?.loading,
+    error: cur?.error,
+    needsAuth: !cap.available || !cap.authed,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// bot noise
+// ---------------------------------------------------------------------------
+
+const BOT_RE = /\[bot\]$|^(github-actions|dependabot|codecov|sonarcloud|claude)$/i;
+export const isBotLogin = (login: string): boolean => BOT_RE.test(login || "");
+
+/**
+ * Reduce a machine comment to the few numbers a person reads.
+ *
+ * A real coverage comment on a real PR is 46,551 characters — one table, 1,847
+ * rows, and about three figures anyone looks at. The raw text is kept; this
+ * only decides what is shown first.
+ */
+export function digestBotComment(body: string): string | null {
+  // These arrive as HTML tables, so tags and entities come off first — the
+  // fallback below otherwise reports `<a href=...><img alt="Coverage"` as if it
+  // were the summary.
+  const text = (body || "")
+    .replace(/<!--[\s\S]*?-->/g, " ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(/&nbsp;/g, " ")
+    .replace(/&ndash;/g, "-")
+    .replace(/&#46;/g, ".")
+    .replace(/&amp;/g, "&");
+
+  const bits: string[] = [];
+
+  // "Coverage (django) ... TOTAL 1829 315 82%" — the whole-project number, and
+  // the scope, which is the only reason two of these comments differ.
+  const scope = text.match(/Coverage\s*\(([^)]+)\)/i)?.[1]?.trim();
+  const total = text.match(/TOTAL[^%]*?(\d{1,3}(?:\.\d+)?)\s*%/i);
+  if (total) bits.push(`${scope ? `${scope} ` : ""}coverage ${total[1]}%`);
+
+  // "## Patch coverage . django" — the number that actually gates a review.
+  if (/Patch coverage/i.test(text)) {
+    const patchScope = text.match(/Patch coverage\s*[.·]\s*(\S+)/i)?.[1];
+    if (/No lines with coverage information/i.test(text)) {
+      bits.push(`${patchScope ? `${patchScope} ` : ""}patch: nothing measurable`);
+    } else {
+      const pcts = [...text.matchAll(/\((\d{1,3}(?:\.\d+)?)%\)/g)].map((m) => Number(m[1]));
+      if (pcts.length) {
+        const worst = Math.min(...pcts);
+        bits.push(`${patchScope ? `${patchScope} ` : ""}patch ${worst === 100 ? "100%" : `${worst}%..100%`} over ${pcts.length} file${pcts.length === 1 ? "" : "s"}`);
+      }
+    }
+  }
+
+  const failed = text.match(/(\d+)\s+failed/i);
+  if (failed) bits.push(`${failed[1]} failed`);
+
+  if (bits.length) return bits.join(" · ");
+
+  // Nothing recognised: the first line with words in it beats showing a table.
+  const first = text.split(/\r?\n/).map((l) => l.trim())
+    .find((l) => l && !l.startsWith("|") && !l.startsWith("#") && /[a-z]{3}/i.test(l));
+  return first ? first.replace(/\s+/g, " ").slice(0, 140) : null;
+}
+
+/**
+ * Checklist boxes out of a PR body. Unchecked ones are a merge signal on any
+ * repo whose template carries a real checklist.
+ *
+ * Split on `\r?\n`, and it matters: GitHub stores bodies with CRLF endings, and
+ * in a JavaScript regex `.` excludes every line terminator — `\r` among them.
+ * So `(.*)$` cannot match a line that ends in `\r`, and a naive split on `\n`
+ * finds exactly zero checkboxes in a real pull request while passing every test
+ * written with a `\n` fixture. Measured on a live PR: nine boxes, none found.
+ */
+export function parseChecklist(body: string): PrChecklistItem[] {
+  const out: PrChecklistItem[] = [];
+  for (const line of (body || "").split(/\r?\n/)) {
+    const m = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.*)$/);
+    if (!m) continue;
+    out.push({ checked: m[1]!.toLowerCase() === "x", text: m[2]!.trim() });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// detail
+// ---------------------------------------------------------------------------
+
+const DETAIL_QUERY = `query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){ pullRequest(number:$number){
+    number title url state isDraft createdAt updatedAt
+    additions deletions changedFiles
+    baseRefName headRefName body
+    mergeable mergeStateStatus reviewDecision
+    author{login}
+    labels(first:20){nodes{name color}}
+    assignees(first:10){nodes{login}}
+    reviewRequests(first:10){nodes{requestedReviewer{... on User{login} ... on Team{name}}}}
+    reviews(first:50){nodes{author{login} state body submittedAt}}
+    comments(first:50){nodes{databaseId author{login} body createdAt}}
+    commits(first:100){nodes{commit{oid messageHeadline parents{totalCount} author{user{login} name}}}}
+    files(first:100){nodes{path additions deletions changeType}}
+    reviewThreads(first:50){nodes{
+      id isResolved isOutdated path line
+      comments(first:20){nodes{id author{login} body createdAt}}
+    }}
+    timelineItems(last:30, itemTypes:[HEAD_REF_FORCE_PUSHED_EVENT]){nodes{... on HeadRefForcePushedEvent{createdAt}}}
+    statusCheckRollup:commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{
+      __typename
+      ... on CheckRun{name status conclusion detailsUrl checkSuite{workflowRun{workflow{name}}}}
+      ... on StatusContext{context state targetUrl}
+    }}}}}}
+  } } }`;
+
+const detailCache = new Map<string, { at: number; detail: PrDetail }>();
+const DETAIL_TTL_MS = 45_000;
+
+function mergeStateOf(s: string | undefined, isDraft: boolean): PrMergeState {
+  if (isDraft) return "DRAFT";
+  const v = (s || "").toUpperCase();
+  const known: PrMergeState[] = ["CLEAN", "BLOCKED", "BEHIND", "DIRTY", "UNSTABLE", "HAS_HOOKS"];
+  return (known as string[]).includes(v) ? (v as PrMergeState) : "UNKNOWN";
+}
+
+export async function prDetail(rootIn: unknown, numberIn: unknown, force = false): Promise<{ ok: boolean; detail?: PrDetail; error?: string }> {
+  const number = Number(numberIn);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "invalid pull request number" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const key = `${repo.key}#${number}`;
+  const hit = detailCache.get(key);
+  if (!force && hit && Date.now() - hit.at < DETAIL_TTL_MS) return { ok: true, detail: hit.detail };
+
+  const cap = await ghCapability();
+  if (!cap.available || !cap.authed) return { ok: false, error: cap.reason };
+
+  const data = await ghJson<any>([
+    "api", "graphql",
+    "-f", `query=${DETAIL_QUERY}`,
+    "-F", `owner=${repo.owner}`,
+    "-F", `name=${repo.name}`,
+    "-F", `number=${number}`,
+  ]);
+  const p = data?.data?.repository?.pullRequest;
+  if (!p) return { ok: false, error: "pull request not found, or gh could not reach the host" };
+
+  const rawChecks = p.statusCheckRollup?.nodes?.[0]?.commit?.statusCheckRollup?.contexts?.nodes ?? [];
+  const normalised = rawChecks.map((c: any) => ({
+    ...c,
+    workflowName: c.checkSuite?.workflowRun?.workflow?.name || "",
+  }));
+  const { rollup, all } = rollupChecks(normalised);
+
+  const reviews: PrReview[] = (p.reviews?.nodes || []).map((r: any) => ({
+    author: r.author?.login || "",
+    isBot: isBotLogin(r.author?.login || ""),
+    state: r.state,
+    body: r.body || "",
+    submittedAt: r.submittedAt || "",
+  }));
+
+  const comments: PrComment[] = (p.comments?.nodes || []).map((c: any) => {
+    const author = c.author?.login || "";
+    const bot = isBotLogin(author);
+    return {
+      id: c.databaseId,
+      author,
+      isBot: bot,
+      body: c.body || "",
+      createdAt: c.createdAt || "",
+      digest: bot ? digestBotComment(c.body || "") : null,
+    };
+  });
+
+  const threads: PrThread[] = (p.reviewThreads?.nodes || []).map((t: any) => ({
+    id: t.id,
+    path: t.path || "",
+    line: t.line ?? null,
+    isResolved: !!t.isResolved,
+    isOutdated: !!t.isOutdated,
+    comments: (t.comments?.nodes || []).map((c: any) => ({
+      id: c.id,
+      author: c.author?.login || "",
+      isBot: isBotLogin(c.author?.login || ""),
+      body: c.body || "",
+      createdAt: c.createdAt || "",
+    })),
+  }));
+
+  const commits: PrCommit[] = (p.commits?.nodes || []).map((n: any) => {
+    const c = n.commit || {};
+    return {
+      oid: c.oid || "",
+      short: (c.oid || "").slice(0, 8),
+      message: c.messageHeadline || "",
+      author: c.author?.user?.login || c.author?.name || "",
+      // A trunk catch-up merge is not work to review. Naming it lets the UI
+      // dim it instead of making you read it.
+      isMerge: (c.parents?.totalCount ?? 1) > 1,
+    };
+  });
+
+  const openByPath = new Map<string, number>();
+  for (const t of threads) if (!t.isResolved) openByPath.set(t.path, (openByPath.get(t.path) ?? 0) + 1);
+
+  const files: PrFile[] = (p.files?.nodes || []).map((f: any) => ({
+    path: f.path,
+    additions: f.additions ?? 0,
+    deletions: f.deletions ?? 0,
+    status: f.changeType || "",
+    comments: openByPath.get(f.path) ?? 0,
+  }));
+
+  // A force-push after a submitted review makes that review stale — the
+  // approval you are looking at was for code that no longer exists.
+  const pushes: string[] = (p.timelineItems?.nodes || []).map((n: any) => n?.createdAt).filter(Boolean);
+  const lastReviewAt = reviews.length ? reviews[reviews.length - 1]!.submittedAt : "";
+  const forcePushedSinceReview = !!lastReviewAt && pushes.some((at) => at > lastReviewAt);
+
+  const detail: PrDetail = {
+    number: p.number,
+    title: p.title || "",
+    author: p.author?.login || "",
+    state: p.state,
+    isDraft: !!p.isDraft,
+    headRefName: p.headRefName || "",
+    baseRefName: p.baseRefName || "",
+    url: p.url || "",
+    updatedAt: p.updatedAt || "",
+    reviewDecision: p.reviewDecision || null,
+    additions: p.additions ?? 0,
+    deletions: p.deletions ?? 0,
+    changedFiles: p.changedFiles ?? 0,
+    labels: (p.labels?.nodes || []).map((l: any) => ({ name: l.name, color: l.color })),
+    checks: rollup,
+    checksAll: all,
+    body: p.body || "",
+    mergeable: p.mergeable || "UNKNOWN",
+    mergeState: mergeStateOf(p.mergeStateStatus, !!p.isDraft),
+    checklist: parseChecklist(p.body || ""),
+    reviewers: (p.reviewRequests?.nodes || []).map((n: any) => n.requestedReviewer?.login || n.requestedReviewer?.name).filter(Boolean),
+    assignees: (p.assignees?.nodes || []).map((n: any) => n.login),
+    reviews, comments, threads, commits, files,
+    forcePushedSinceReview,
+  };
+
+  detailCache.set(key, { at: Date.now(), detail });
+  return { ok: true, detail };
+}
+
+/** The unified diff, straight into the diff renderer the app already has. */
+export async function prDiff(rootIn: unknown, numberIn: unknown): Promise<{ ok: boolean; text?: string; error?: string }> {
+  const number = Number(numberIn);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "invalid pull request number" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const r = await gh(["pr", "diff", String(number), "-R", repo.nameWithOwner]);
+  if (r.code !== 0) return { ok: false, error: r.stderr.trim() || "gh pr diff failed" };
+  return { ok: true, text: r.stdout };
+}
+
+// ---------------------------------------------------------------------------
+// asset proxy
+// ---------------------------------------------------------------------------
+
+/**
+ * Hosts we will fetch a PR-body image from.
+ *
+ * A PR body is text written by anyone who can open a pull request, and it
+ * reaches this server as a URL. Without an allowlist that is a request forger:
+ * `?url=http://169.254.169.254/…` is a metadata endpoint, `file:///…` is the
+ * disk. Only image hosts, only https.
+ */
+const ASSET_HOSTS = [
+  "github.com", "objects.githubusercontent.com", "user-images.githubusercontent.com",
+  "raw.githubusercontent.com", "avatars.githubusercontent.com", "media.githubusercontent.com",
+  "private-user-images.githubusercontent.com",
+];
+const ASSET_HOST_SUFFIXES = [".githubusercontent.com", ".clickup-attachments.com", ".githubassets.com"];
+
+export function assetAllowed(raw: string): URL | null {
+  let u: URL;
+  try { u = new URL(raw); } catch { return null; }
+  if (u.protocol !== "https:") return null;
+  const h = u.hostname.toLowerCase();
+  if (ASSET_HOSTS.includes(h)) return u;
+  if (ASSET_HOST_SUFFIXES.some((s) => h.endsWith(s))) return u;
+  return null;
+}
+
+let tokenCache: { at: number; token: string } | null = null;
+
+/** The token `gh` already holds. Never sent anywhere but the allowlisted host. */
+async function ghToken(): Promise<string> {
+  if (tokenCache && Date.now() - tokenCache.at < 5 * 60_000) return tokenCache.token;
+  const r = await gh(["auth", "token"]);
+  const token = r.code === 0 ? r.stdout.trim() : "";
+  tokenCache = { at: Date.now(), token };
+  return token;
+}
+
+/**
+ * Fetch an image in a PR body on the user's behalf.
+ *
+ * `https://github.com/user-attachments/assets/<uuid>` — which is what GitHub
+ * rewrites a pasted screenshot to — returns 404 without credentials. Measured:
+ * 404 raw, 200 image/png with the token attached. Since these are the
+ * before/after screenshots that carry the actual evidence in a review, without
+ * this every one of them is a broken box.
+ */
+export async function prAsset(rawUrl: unknown): Promise<Response> {
+  const u = assetAllowed(String(rawUrl || ""));
+  if (!u) return new Response("blocked", { status: 400 });
+  const token = await ghToken();
+  const headers: Record<string, string> = { accept: "image/*" };
+  // Only GitHub gets the credential. ClickUp is public and has no business
+  // receiving a GitHub token.
+  if (token && u.hostname.toLowerCase().endsWith("github.com")) headers.authorization = `token ${token}`;
+  let res: Response;
+  try {
+    res = await fetch(u.toString(), { headers, redirect: "follow", signal: AbortSignal.timeout(20_000) });
+  } catch (e) {
+    return new Response(`upstream: ${String(e)}`, { status: 502 });
+  }
+  if (!res.ok) return new Response(`upstream ${res.status}`, { status: res.status === 404 ? 404 : 502 });
+  const type = res.headers.get("content-type") || "application/octet-stream";
+  // Refuse to relay anything that is not an image: this endpoint must not
+  // become a general-purpose fetcher for whatever a body links to.
+  if (!/^image\//i.test(type)) return new Response("not an image", { status: 415 });
+  return new Response(res.body, {
+    headers: { "content-type": type, "cache-control": "private, max-age=600" },
+  });
+}
+
+// ---------------------------------------------------------------------------
+// writes
+// ---------------------------------------------------------------------------
+
+function writeGuard(rootIn: unknown): PrActionResult | null {
+  if (!WRITE_ENABLED) return { ok: false, error: "writes are disabled (AGENTGLASS_GIT_WRITE_DISABLED=1)" };
+  const abs = safeAbs(rootIn);
+  const root = abs ? repoRootOf(abs) : null;
+  if (!root) return { ok: false, error: "not a git repository" };
+  if (!inScope(root)) return { ok: false, error: "outside the open project — open the parent folder to work across repos" };
+  return null;
+}
+
+function invalidate(repo: PrRepoId, number?: number): void {
+  for (const k of listCache.keys()) if (k.startsWith(`${repo.key}\u0000`)) listCache.delete(k);
+  if (number !== undefined) detailCache.delete(`${repo.key}#${number}`);
+}
+
+async function runPr(rootIn: unknown, number: number, args: string[], stdin?: string): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "invalid pull request number" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const r = await gh([...args, "-R", repo.nameWithOwner], undefined, stdin);
+  invalidate(repo, number);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "gh failed" };
+  return { ok: true, detail: r.stdout.trim() || undefined };
+}
+
+const REVIEW_FLAG = { approve: "--approve", request_changes: "--request-changes", comment: "--comment" } as const;
+export type ReviewVerb = keyof typeof REVIEW_FLAG;
+
+/** Approve / request changes / comment. Body arrives on stdin so a review can
+ *  contain anything a shell would otherwise eat. */
+export async function submitReview(rootIn: unknown, number: unknown, verb: unknown, body: unknown): Promise<PrActionResult> {
+  const v = String(verb) as ReviewVerb;
+  if (!(v in REVIEW_FLAG)) return { ok: false, error: "invalid review type" };
+  const text = String(body ?? "");
+  if (v !== "approve" && !text.trim()) return { ok: false, error: "a comment or requested change needs a body" };
+  const args = ["pr", "review", String(Number(number)), REVIEW_FLAG[v]];
+  if (text.trim()) args.push("--body-file", "-");
+  return runPr(rootIn, Number(number), args, text.trim() ? text : undefined);
+}
+
+export async function addComment(rootIn: unknown, number: unknown, body: unknown): Promise<PrActionResult> {
+  const text = String(body ?? "").trim();
+  if (!text) return { ok: false, error: "empty comment" };
+  return runPr(rootIn, Number(number), ["pr", "comment", String(Number(number)), "--body-file", "-"], text);
+}
+
+/**
+ * Reply on a line thread.
+ *
+ * `gh pr comment` posts to the conversation, not to a thread — the reply has to
+ * go through the REST endpoint with `in_reply_to`, which is where the actual
+ * review conversation lives.
+ */
+export async function replyToThread(rootIn: unknown, number: unknown, commentId: unknown, body: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const n = Number(number), cid = Number(commentId);
+  const text = String(body ?? "").trim();
+  if (!Number.isInteger(n) || !Number.isInteger(cid)) return { ok: false, error: "invalid thread" };
+  if (!text) return { ok: false, error: "empty reply" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const r = await gh([
+    "api", "--method", "POST",
+    `repos/${repo.nameWithOwner}/pulls/${n}/comments/${cid}/replies`,
+    "-f", `body=${text}`,
+  ]);
+  invalidate(repo, n);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "reply failed" };
+  return { ok: true };
+}
+
+/**
+ * Resolve or unresolve a review thread.
+ *
+ * There is no `gh pr` subcommand for this — it is a GraphQL mutation and
+ * nothing else. Worth stating because the obvious search for one comes up
+ * empty and the feature looks impossible.
+ */
+export async function setThreadResolved(rootIn: unknown, threadId: unknown, resolved: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const id = String(threadId || "");
+  if (!id) return { ok: false, error: "invalid thread id" };
+  const want = resolved !== false && resolved !== "false";
+  const mutation = want
+    ? `mutation($id:ID!){resolveReviewThread(input:{threadId:$id}){thread{id isResolved}}}`
+    : `mutation($id:ID!){unresolveReviewThread(input:{threadId:$id}){thread{id isResolved}}}`;
+  const r = await gh(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${id}`]);
+  const repo = await repoIdFor(rootIn);
+  if (repo) invalidate(repo);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "could not change the thread" };
+  return { ok: true };
+}
+
+/** 👍 on a review comment — how most teams acknowledge without adding noise. */
+export async function react(rootIn: unknown, commentId: unknown, content: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const cid = Number(commentId);
+  const allowed = ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"];
+  const c = String(content || "+1");
+  if (!Number.isInteger(cid)) return { ok: false, error: "invalid comment" };
+  if (!allowed.includes(c)) return { ok: false, error: "invalid reaction" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const r = await gh(["api", "--method", "POST", `repos/${repo.nameWithOwner}/pulls/comments/${cid}/reactions`, "-f", `content=${c}`]);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "reaction failed" };
+  return { ok: true };
+}
+
+export async function editPr(rootIn: unknown, number: unknown, patch: { title?: unknown; body?: unknown; base?: unknown }): Promise<PrActionResult> {
+  const args = ["pr", "edit", String(Number(number))];
+  let stdin: string | undefined;
+  if (typeof patch.title === "string" && patch.title.trim()) args.push("--title", patch.title.trim());
+  if (typeof patch.body === "string") { args.push("--body-file", "-"); stdin = patch.body; }
+  if (typeof patch.base === "string" && patch.base.trim()) args.push("--base", patch.base.trim());
+  if (args.length === 3) return { ok: false, error: "nothing to change" };
+  return runPr(rootIn, Number(number), args, stdin);
+}
+
+/**
+ * Labels, which on some repos are not metadata but buttons.
+ *
+ * A "ready to review" label can start a CI review job; a style label can change
+ * what that job does. Treated as a real action for that reason, not as a tag
+ * edit.
+ */
+export async function setLabels(rootIn: unknown, number: unknown, add: unknown, remove: unknown): Promise<PrActionResult> {
+  const args = ["pr", "edit", String(Number(number))];
+  for (const l of Array.isArray(add) ? add : []) if (typeof l === "string" && l.trim()) args.push("--add-label", l.trim());
+  for (const l of Array.isArray(remove) ? remove : []) if (typeof l === "string" && l.trim()) args.push("--remove-label", l.trim());
+  if (args.length === 3) return { ok: false, error: "no labels given" };
+  return runPr(rootIn, Number(number), args);
+}
+
+export async function setReviewers(rootIn: unknown, number: unknown, add: unknown, remove: unknown): Promise<PrActionResult> {
+  const args = ["pr", "edit", String(Number(number))];
+  for (const l of Array.isArray(add) ? add : []) if (typeof l === "string" && l.trim()) args.push("--add-reviewer", l.trim());
+  for (const l of Array.isArray(remove) ? remove : []) if (typeof l === "string" && l.trim()) args.push("--remove-reviewer", l.trim());
+  if (args.length === 3) return { ok: false, error: "no reviewers given" };
+  return runPr(rootIn, Number(number), args);
+}
+
+export async function setDraft(rootIn: unknown, number: unknown, draft: unknown): Promise<PrActionResult> {
+  const args = ["pr", "ready", String(Number(number))];
+  if (draft === true || draft === "true") args.push("--undo");
+  return runPr(rootIn, Number(number), args);
+}
+
+/** Merge the base into the PR branch — the button whose absence is why half a
+ *  branch list carries hand-made "Merge origin/master into …" commits. */
+export async function updateBranch(rootIn: unknown, number: unknown): Promise<PrActionResult> {
+  return runPr(rootIn, Number(number), ["pr", "update-branch", String(Number(number))]);
+}
+
+/** Re-run the failed jobs on the PR's head — the usual answer to a red run,
+ *  and today the usual reason to leave the app. */
+export async function rerunFailedChecks(rootIn: unknown, number: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const n = Number(number);
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const detail = await prDetail(rootIn, n, true);
+  if (!detail.ok || !detail.detail) return { ok: false, error: detail.error || "could not read the pull request" };
+  const runIds = new Set<string>();
+  for (const c of detail.detail.checksAll) {
+    const m = (c.url || "").match(/\/actions\/runs\/(\d+)/);
+    if (m && c.state === "failure") runIds.add(m[1]!);
+  }
+  if (!runIds.size) return { ok: false, error: "no failed workflow run to re-run" };
+  const failures: string[] = [];
+  for (const id of runIds) {
+    const r = await gh(["run", "rerun", id, "--failed", "-R", repo.nameWithOwner]);
+    if (r.code !== 0) failures.push((r.stderr || "").trim().split("\n")[0] || id);
+  }
+  invalidate(repo, n);
+  if (failures.length) return { ok: false, error: `re-run failed: ${failures[0]}` };
+  return { ok: true, detail: `re-ran ${runIds.size} workflow run${runIds.size === 1 ? "" : "s"}` };
+}
+
+// --- irreversible ----------------------------------------------------------
+
+/**
+ * The merge itself.
+ *
+ * `--match-head-commit` is not optional. Between the moment the panel drew the
+ * diff and the moment you press the button, the author can push; without it you
+ * would merge a commit you never saw. The caller passes the head it showed you,
+ * and GitHub refuses if that is no longer the tip.
+ */
+export async function mergePr(rootIn: unknown, number: unknown, method: unknown, opts: { deleteBranch?: unknown; auto?: unknown; headSha?: unknown }): Promise<PrActionResult> {
+  const flag = method === "merge" ? "--merge" : method === "rebase" ? "--rebase" : method === "squash" ? "--squash" : null;
+  if (!flag) return { ok: false, error: "choose squash, merge or rebase" };
+  const args = ["pr", "merge", String(Number(number)), flag];
+  if (opts.auto === true || opts.auto === "true") args.push("--auto");
+  if (opts.deleteBranch === true || opts.deleteBranch === "true") args.push("--delete-branch");
+  if (typeof opts.headSha === "string" && /^[0-9a-f]{7,40}$/i.test(opts.headSha)) args.push("--match-head-commit", opts.headSha);
+  return runPr(rootIn, Number(number), args);
+}
+
+export async function closePr(rootIn: unknown, number: unknown, reopen = false): Promise<PrActionResult> {
+  return runPr(rootIn, Number(number), ["pr", reopen ? "reopen" : "close", String(Number(number))]);
+}
+
+// ---------------------------------------------------------------------------
+// local review
+// ---------------------------------------------------------------------------
+
+/**
+ * Where throwaway PR checkouts live. Under the repo's own git dir rather than
+ * /tmp, so they share the object store — checking out a 12-file PR against a
+ * large repo copies nothing.
+ */
+const REVIEW_WT_DIR = ".agentglass/pr-review";
+
+export interface LocalReviewPlan { ok: boolean; cwd?: string; prompt?: string; branch?: string; error?: string }
+
+/**
+ * Put a PR's head on disk and hand back the prompt to review it.
+ *
+ * Deliberately does not run Claude itself: the app already has a chat pipeline
+ * — `chatStream` in chat.ts, with streaming, an allowlist and a keepalive — and
+ * a second copy of that would rot. This returns a cwd and a prompt; the caller
+ * feeds them to the pipeline that already exists.
+ *
+ * The point of a worktree rather than the diff alone is context. A review that
+ * can only see `-` and `+` lines cannot follow a call site, check whether the
+ * helper being changed has another caller, or run the tests. That is the whole
+ * difference from the review the CI bot already posts.
+ *
+ * `pull/N/head` rather than the branch name: the branch may be on a fork you
+ * have no remote for, and this ref exists for every PR regardless.
+ */
+export async function prepareLocalReview(rootIn: unknown, numberIn: unknown): Promise<LocalReviewPlan> {
+  const g = writeGuard(rootIn);
+  // A worktree is a local write, so it takes the same gate — but the failure
+  // message should say that, not talk about pull requests.
+  if (g) return { ok: false, error: g.error };
+  const number = Number(numberIn);
+  if (!Number.isInteger(number) || number <= 0) return { ok: false, error: "invalid pull request number" };
+  const abs = safeAbs(rootIn);
+  const root = abs ? repoRootOf(abs) : null;
+  if (!root) return { ok: false, error: "not a git repository" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+
+  const detail = await prDetail(rootIn, number);
+  if (!detail.ok || !detail.detail) return { ok: false, error: detail.error || "could not read the pull request" };
+  const pr = detail.detail;
+
+  const ref = `refs/agentglass/pr-${number}`;
+  const fetched = await gitAsync(root, ["fetch", "--no-tags", "--force", "origin", `pull/${number}/head:${ref}`]);
+  if (fetched.code !== 0) return { ok: false, error: `could not fetch the pull request: ${fetched.stderr.trim().split("\n")[0]}` };
+
+  const dir = `${root}/${REVIEW_WT_DIR}/${number}`;
+  // Re-preparing the same PR is normal — you review, they push, you review
+  // again. Drop the old checkout rather than failing on "already exists".
+  await gitAsync(root, ["worktree", "remove", "--force", dir]);
+  const added = await gitAsync(root, ["worktree", "add", "--detach", dir, ref]);
+  if (added.code !== 0) return { ok: false, error: `could not create the review worktree: ${added.stderr.trim().split("\n")[0]}` };
+
+  const openThreads = pr.threads.filter((t) => !t.isResolved);
+  const prompt = [
+    `Review pull request #${pr.number} of ${repo.nameWithOwner}: "${pr.title}".`,
+    ``,
+    `This working directory is the PR's head commit, checked out in full — read whatever you need around the diff.`,
+    `Base branch: ${pr.baseRefName}. Head: ${pr.headRefName}. ${pr.changedFiles} files, +${pr.additions} −${pr.deletions}.`,
+    ``,
+    `Start with:  git diff ${pr.baseRefName}...HEAD`,
+    ``,
+    `## What the author says`,
+    pr.body.slice(0, 4000) || "(no description)",
+    ``,
+    openThreads.length ? `## Review comments still open\n${openThreads.map((t) => `- ${t.path}${t.line ? `:${t.line}` : ""} — ${t.comments[0]?.body.slice(0, 200) ?? ""}`).join("\n")}` : "",
+    ``,
+    `## What I want`,
+    `Find real defects: incorrect logic, unhandled cases, race conditions, missing test coverage for the behaviour being changed.`,
+    `Use the full checkout — check whether changed helpers have other callers, and whether the tests actually exercise the new path.`,
+    `Report each finding as: file:line, one sentence on the defect, and a concrete failure case. Say plainly if you find nothing serious.`,
+    `Do not post anything to GitHub, do not push, and do not change any files. This is a read-only review.`,
+  ].filter((l) => l !== "").join("\n");
+
+  return { ok: true, cwd: dir, prompt, branch: pr.headRefName };
+}
+
+/** Tear down a review checkout. Cheap, and leaving them around turns the
+ *  branches panel into a list of ghosts. */
+export async function discardLocalReview(rootIn: unknown, numberIn: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const number = Number(numberIn);
+  const abs = safeAbs(rootIn);
+  const root = abs ? repoRootOf(abs) : null;
+  if (!root || !Number.isInteger(number)) return { ok: false, error: "invalid request" };
+  const dir = `${root}/${REVIEW_WT_DIR}/${number}`;
+  const r = await gitAsync(root, ["worktree", "remove", "--force", dir]);
+  await gitAsync(root, ["update-ref", "-d", `refs/agentglass/pr-${number}`]);
+  if (r.code !== 0 && !/is not a working tree|No such file/i.test(r.stderr)) {
+    return { ok: false, error: r.stderr.trim().split("\n")[0] || "could not remove the review worktree" };
+  }
+  return { ok: true };
+}
+
+// ---------------------------------------------------------------------------
+// "open this branch on GitHub"
+// ---------------------------------------------------------------------------
+
+const branchUrlCache = new Map<string, { at: number; url: string }>();
+
+/**
+ * Where does this local branch live on the web?
+ *
+ * Two different answers, and which one you want depends on something the UI
+ * already knows. A branch that still exists on the remote has a tree page, and
+ * building that URL is string work — no network at all. A branch whose remote
+ * is gone has no tree page (that is what gone means); the only useful
+ * destination is the pull request, and finding it costs one `gh` call.
+ *
+ * So the cheap answer stays cheap and only the deleted-branch case pays, which
+ * is also the case where the answer is worth waiting for.
+ */
+export async function branchUrl(rootIn: unknown, branchIn: unknown, goneIn?: unknown): Promise<{ ok: boolean; url?: string; kind?: "tree" | "pr"; error?: string }> {
+  const branch = String(branchIn || "").trim();
+  if (!branch || /[\s]/.test(branch)) return { ok: false, error: "invalid branch name" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const web = `https://${repo.host}/${repo.nameWithOwner}`;
+  const gone = goneIn === true || goneIn === "true";
+
+  if (!gone) return { ok: true, url: `${web}/tree/${branch.split("/").map(encodeURIComponent).join("/")}`, kind: "tree" };
+
+  const key = `${repo.key}\u0000${branch}`;
+  const hit = branchUrlCache.get(key);
+  if (hit && Date.now() - hit.at < 30 * 60_000) return { ok: true, url: hit.url, kind: "pr" };
+
+  const cap = await ghCapability();
+  if (!cap.available || !cap.authed) return { ok: false, error: cap.reason };
+  const rows = await ghJson<any[]>([
+    "pr", "list", "-R", repo.nameWithOwner, "--head", branch, "--state", "all", "--limit", "5", "--json", "number,url,state,updatedAt",
+  ]);
+  if (!rows?.length) return { ok: false, error: `no pull request was ever opened from ${branch}` };
+  // Newest wins: a branch name gets reused, and the one you mean is the last.
+  const best = [...rows].sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)))[0];
+  branchUrlCache.set(key, { at: Date.now(), url: best.url });
+  return { ok: true, url: best.url, kind: "pr" };
+}

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -597,13 +597,13 @@ const DETAIL_QUERY = `query($owner:String!,$name:String!,$number:Int!){
     labels(first:20){nodes{name color}}
     assignees(first:10){nodes{login}}
     reviewRequests(first:10){nodes{requestedReviewer{... on User{login} ... on Team{name}}}}
-    reviews(first:50){nodes{author{login} state body submittedAt}}
-    comments(first:50){nodes{databaseId author{login} body createdAt}}
+    reviews(first:50){nodes{author{login} state body submittedAt url}}
+    comments(first:50){nodes{databaseId author{login} body createdAt url}}
     commits(first:100){nodes{commit{oid messageHeadline parents{totalCount} author{user{login} name}}}}
     files(first:100){nodes{path additions deletions changeType}}
     reviewThreads(first:50){nodes{
       id isResolved isOutdated path line
-      comments(first:20){nodes{id author{login} body createdAt}}
+      comments(first:20){nodes{id databaseId author{login} body createdAt url diffHunk originalLine}}
     }}
     timelineItems(last:30, itemTypes:[HEAD_REF_FORCE_PUSHED_EVENT]){nodes{... on HeadRefForcePushedEvent{createdAt}}}
     statusCheckRollup:commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{
@@ -659,6 +659,7 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     state: r.state,
     body: r.body || "",
     submittedAt: r.submittedAt || "",
+    url: r.url || "",
   }));
 
   const comments: PrComment[] = (p.comments?.nodes || []).map((c: any) => {
@@ -670,6 +671,7 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
       isBot: bot,
       body: c.body || "",
       createdAt: c.createdAt || "",
+      url: c.url || "",
       digest: bot ? digestBotComment(c.body || "") : null,
     };
   });
@@ -680,12 +682,22 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     line: t.line ?? null,
     isResolved: !!t.isResolved,
     isOutdated: !!t.isOutdated,
+    // The hunk GitHub stored with the comment, not one reconstructed from the
+    // pull request's diff. It arrives with the thread, so the code a comment is
+    // about is on screen without the diff having been fetched at all — and it
+    // is the same few lines GitHub shows, including on an outdated thread whose
+    // hunk no longer exists in the current diff.
+    diffHunk: t.comments?.nodes?.[0]?.diffHunk || "",
+    originalLine: t.comments?.nodes?.[0]?.originalLine ?? null,
+    url: t.comments?.nodes?.[0]?.url || "",
     comments: (t.comments?.nodes || []).map((c: any) => ({
       id: c.id,
+      databaseId: c.databaseId ?? null,
       author: c.author?.login || "",
       isBot: isBotLogin(c.author?.login || ""),
       body: c.body || "",
       createdAt: c.createdAt || "",
+      url: c.url || "",
     })),
   }));
 

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -1101,3 +1101,59 @@ export async function commitDiff(rootIn: unknown, shaIn: unknown): Promise<{ ok:
   if (r.code !== 0) return { ok: false, error: (r.stderr || "").trim().split("\n")[0] || "could not read that commit" };
   return { ok: true, text: r.stdout };
 }
+
+/**
+ * A whole review in one shot: a verdict, a body, and the line comments that
+ * were queued up while reading the diff.
+ *
+ * This is what GitHub calls a pending review, and it is a different endpoint
+ * from `gh pr review` — that one posts a verdict with a body and nothing else.
+ * Line comments have to ride along in the same request or they arrive as a
+ * scatter of separate notifications, which is exactly the noise a reviewer is
+ * trying not to create.
+ *
+ * `line` is the line in the file's NEW side. GitHub also accepts the older
+ * `position` (an offset within the diff), which is fragile the moment the
+ * branch moves; the line number survives a rebase.
+ */
+export async function submitReviewWith(
+  rootIn: unknown, numberIn: unknown, verb: unknown, body: unknown, commentsIn: unknown,
+): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const n = Number(numberIn);
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, error: "invalid pull request number" };
+  const event = verb === "approve" ? "APPROVE" : verb === "request_changes" ? "REQUEST_CHANGES" : verb === "comment" ? "COMMENT" : null;
+  if (!event) return { ok: false, error: "choose approve, request changes, or comment" };
+
+  const comments: { path: string; line: number; side: string; body: string }[] = [];
+  for (const c of Array.isArray(commentsIn) ? commentsIn : []) {
+    const path = typeof c?.path === "string" ? c.path : "";
+    const line = Number(c?.line);
+    const text = typeof c?.body === "string" ? c.body.trim() : "";
+    if (!path || !Number.isInteger(line) || line <= 0 || !text) continue;
+    comments.push({ path, line, side: c?.side === "LEFT" ? "LEFT" : "RIGHT", body: text });
+  }
+
+  const text = String(body ?? "").trim();
+  // GitHub refuses an empty COMMENT review, and a REQUEST_CHANGES with nothing
+  // said is unkind to whoever receives it.
+  if (event !== "APPROVE" && !text && !comments.length) {
+    return { ok: false, error: "say something, or leave at least one line comment" };
+  }
+
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+
+  const payload = JSON.stringify({ event, ...(text ? { body: text } : {}), ...(comments.length ? { comments } : {}) });
+  const r = await gh(
+    ["api", "--method", "POST", `repos/${repo.nameWithOwner}/pulls/${n}/reviews`, "--input", "-"],
+    undefined, payload,
+  );
+  invalidate(repo, n);
+  if (r.code !== 0) {
+    const msg = (r.stderr || r.stdout).trim().split("\n").find((l) => l.trim()) || "the review was not accepted";
+    return { ok: false, error: msg };
+  }
+  const count = comments.length;
+  return { ok: true, detail: `review submitted${count ? ` with ${count} line comment${count === 1 ? "" : "s"}` : ""}` };
+}

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -1084,3 +1084,20 @@ export async function branchUrl(rootIn: unknown, branchIn: unknown, goneIn?: unk
   branchUrlCache.set(key, { at: Date.now(), url: best.url });
   return { ok: true, url: best.url, kind: "pr" };
 }
+
+/**
+ * One commit's diff.
+ *
+ * Asked of GitHub rather than of the local checkout: the commit belongs to a
+ * pull request, which may be from a fork or simply not fetched here, and
+ * "review this commit" should not depend on whether you happen to have it.
+ */
+export async function commitDiff(rootIn: unknown, shaIn: unknown): Promise<{ ok: boolean; text?: string; error?: string }> {
+  const sha = String(shaIn || "").trim();
+  if (!/^[0-9a-f]{7,40}$/i.test(sha)) return { ok: false, error: "invalid commit" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const r = await gh(["api", `repos/${repo.nameWithOwner}/commits/${sha}`, "-H", "Accept: application/vnd.github.v3.diff"]);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || "").trim().split("\n")[0] || "could not read that commit" };
+  return { ok: true, text: r.stdout };
+}

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -480,7 +480,7 @@ export function makeCommands(root: string, dirs: CommandDir[] = commandDirs(root
     if (!makefile) continue;
     let text: string;
     try { text = readFileSync(join(root, rel, makefile), "utf8"); } catch { continue; }
-    for (const t of parseMakeTargets(text)) { // parseMakeTargets caps each file at 60
+    for (const t of parseMakeTargets(text)) { // capped per file — see MAKE_MAX_PER_FILE
       out.push({ name: t.name, cmd: rel ? `make -C ${rel} ${t.name}` : `make ${t.name}`, desc: t.desc, dir: rel });
     }
     if (out.length >= CMD_MAX_TOTAL) break;

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -289,6 +289,7 @@ export function ptyOpen(ws: PtyWs) {
     const reader = readable.getReader();
     let held: Uint8Array[] = [];
     let size = 0;
+    let backedUp = false;
     let timer: ReturnType<typeof setTimeout> | null = null;
     const flush = () => {
       if (timer) { clearTimeout(timer); timer = null; }
@@ -301,7 +302,11 @@ export function ptyOpen(ws: PtyWs) {
       })();
       held = []; size = 0;
       if (session.closed) return;
-      try { ws.send(out); } catch { /* socket gone; the read loop will notice */ }
+      // Bun answers with the bytes queued, or -1 when the socket is already
+      // backed up. That is a real backpressure signal from the transport
+      // itself — better than inferring it from a byte count — so remember it
+      // and let the read loop stop pulling on the pty until it clears.
+      try { if (ws.send(out) === -1) backedUp = true; } catch { /* socket gone; the read loop will notice */ }
     };
     try {
       for (;;) {
@@ -314,12 +319,18 @@ export function ptyOpen(ws: PtyWs) {
           if (size >= BIG) flush();
           else if (!timer) timer = setTimeout(flush, FRAME_MS);
         }
-        // Let the client catch up before pulling more out of the shell.
+        // Let the client catch up before pulling more out of the shell. Two
+        // ways to know it is behind: the transport said so on the last send, or
+        // the queue is deep. The wait is bounded — a client that never drains
+        // is a dead client, and holding the shell for it forever is worse than
+        // dropping behind.
         let waited = 0;
-        while (!session.closed && (ws.getBufferedAmount?.() ?? 0) > HIGH_WATER && waited < 10_000) {
+        while (!session.closed && waited < 10_000 &&
+               (backedUp || (ws.getBufferedAmount?.() ?? 0) > HIGH_WATER)) {
           flush();
           await Bun.sleep(4);
           waited += 4;
+          backedUp = (ws.getBufferedAmount?.() ?? 0) > HIGH_WATER;
         }
       }
     } catch { /* stream torn down */ }

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -257,16 +257,73 @@ export function ptyOpen(ws: PtyWs) {
   const tmuxPoll = setInterval(sweep, 500);
   session.tmuxPoll = tmuxPoll;
 
+  /**
+   * Shell output → socket, coalesced and back-pressured.
+   *
+   * It used to be one WebSocket frame per read off the pty. That is fine for a
+   * prompt and terrible for `cat` on a large file or a build log: the pty hands
+   * over whatever the kernel has, so a fast producer becomes thousands of tiny
+   * frames a second, each one a send here, a message event there, and a
+   * separate `term.write()` in the renderer. The cost is not the bytes, it is
+   * the per-frame overhead on both ends.
+   *
+   * Two things fix it, and they are the two the terminal actually needs:
+   *
+   *   * **Coalesce.** Hold what arrives for one frame's worth of time (8ms) and
+   *     send it as one message. A burst collapses into ~120 frames a second
+   *     instead of thousands. Typing is unaffected in any way a human can
+   *     perceive — 8ms is a third of the time it takes the key to travel — and
+   *     anything already large goes immediately rather than waiting.
+   *   * **Push back.** If the socket is behind, stop reading the pty. There is
+   *     no pause/resume call to make: not draining the stream lets the pipe
+   *     fill, and the kernel stops the producer for us — which is the whole
+   *     point of a pty being a pty. Without this, a runaway `yes` is buffered
+   *     in this process until something gives, and the something is memory.
+   */
+  const FRAME_MS = 8;
+  const BIG = 64 * 1024;          // send at once rather than waiting out the frame
+  const HIGH_WATER = 512 * 1024;  // socket queue past which we stop reading
+
   const pump = async (readable: ReadableStream<Uint8Array> | null | undefined) => {
     if (!readable) return;
     const reader = readable.getReader();
+    let held: Uint8Array[] = [];
+    let size = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+    const flush = () => {
+      if (timer) { clearTimeout(timer); timer = null; }
+      if (!held.length) return;
+      const out = held.length === 1 ? held[0] : (() => {
+        const all = new Uint8Array(size);
+        let at = 0;
+        for (const c of held) { all.set(c, at); at += c.length; }
+        return all;
+      })();
+      held = []; size = 0;
+      if (session.closed) return;
+      try { ws.send(out); } catch { /* socket gone; the read loop will notice */ }
+    };
     try {
       for (;;) {
         const { done, value } = await reader.read();
         if (done) break;
-        if (value && !session.closed) { try { ws.send(value); } catch { break; } }
+        if (session.closed) break;
+        if (value?.length) {
+          held.push(value);
+          size += value.length;
+          if (size >= BIG) flush();
+          else if (!timer) timer = setTimeout(flush, FRAME_MS);
+        }
+        // Let the client catch up before pulling more out of the shell.
+        let waited = 0;
+        while (!session.closed && (ws.getBufferedAmount?.() ?? 0) > HIGH_WATER && waited < 10_000) {
+          flush();
+          await Bun.sleep(4);
+          waited += 4;
+        }
       }
     } catch { /* stream torn down */ }
+    finally { flush(); }
   };
 
   (async () => {

--- a/server/test/prs.test.ts
+++ b/server/test/prs.test.ts
@@ -1,0 +1,275 @@
+// The pure parts of the pull-request panel, pinned.
+//
+// Everything that talks to `gh` is left to manual QA — it needs a network and a
+// login. What is tested here is the logic that decides what the panel *says*,
+// and each of these encodes something learned from a real pull request rather
+// than an invented case:
+//
+//  - eighteen worktrees of one clone must collapse to one repo, or the panel
+//    fetches the same list eighteen times;
+//  - skipped checks are not failures (a real PR: 43 success, 18 skipped, green);
+//  - the CI notification fires once at the end, not once per check;
+//  - the asset proxy is a URL taken from a pull request body, which is a string
+//    a stranger wrote.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-prs-"));
+process.env.XDG_CONFIG_HOME = dir;
+process.env.AGENTGLASS_DB = join(dir, "p.db");
+
+const prs = await import("../src/prs.ts");
+
+describe("repo identity", () => {
+  test("ssh and https forms of one repo produce one key", () => {
+    const a = prs.parseRemote("git@github.com:acme/orbit.git");
+    const b = prs.parseRemote("https://github.com/acme/orbit.git");
+    expect(a?.key).toBe("github.com/acme/orbit");
+    expect(b?.key).toBe(a?.key);
+    expect(a?.nameWithOwner).toBe("acme/orbit");
+  });
+
+  test("a trailing .git is optional, and ssh:// is understood", () => {
+    expect(prs.parseRemote("https://github.com/SirAllap/agentglass")?.key).toBe("github.com/SirAllap/agentglass");
+    expect(prs.parseRemote("ssh://git@github.com/SirAllap/agentglass.git")?.key).toBe("github.com/SirAllap/agentglass");
+  });
+
+  test("a self-hosted host keeps its own name", () => {
+    expect(prs.parseRemote("git@git.example.com:team/app.git")?.host).toBe("git.example.com");
+  });
+
+  /** Guessing here would point `gh` at somebody else's repository. */
+  test("anything that is not obviously a forge remote is refused", () => {
+    expect(prs.parseRemote("/srv/mirrors/thing.git")).toBeNull();
+    expect(prs.parseRemote("file:///srv/mirrors/thing.git")).toBeNull();
+    expect(prs.parseRemote("")).toBeNull();
+    expect(prs.parseRemote("git@github.com:noslash")).toBeNull();
+  });
+});
+
+describe("check rollup", () => {
+  const run = (status: string, conclusion: string, name = "c") =>
+    ({ __typename: "CheckRun", name, status, conclusion });
+
+  test("skipped is not failure — 43 green + 18 skipped is a green PR", () => {
+    const raw = [
+      ...Array.from({ length: 43 }, (_, i) => run("COMPLETED", "SUCCESS", `ok${i}`)),
+      ...Array.from({ length: 18 }, (_, i) => run("COMPLETED", "SKIPPED", `skip${i}`)),
+    ];
+    const { rollup } = prs.rollupChecks(raw);
+    expect(rollup.total).toBe(61);
+    expect(rollup.success).toBe(43);
+    expect(rollup.skipped).toBe(18);
+    expect(rollup.failure).toBe(0);
+    expect(rollup.allDone).toBe(true);
+    expect(rollup.verdict).toBe("green");
+  });
+
+  test("one running check means no verdict at all, however many have passed", () => {
+    const raw = [
+      ...Array.from({ length: 60 }, (_, i) => run("COMPLETED", "SUCCESS", `ok${i}`)),
+      run("IN_PROGRESS", "", "still-going"),
+    ];
+    const { rollup } = prs.rollupChecks(raw);
+    expect(rollup.pending).toBe(1);
+    expect(rollup.allDone).toBe(false);
+    expect(rollup.verdict).toBeNull();
+  });
+
+  test("failures are named, because a count alone sends you to the browser", () => {
+    const { rollup } = prs.rollupChecks([
+      run("COMPLETED", "SUCCESS", "lint"),
+      run("COMPLETED", "FAILURE", "pytest · vr/health"),
+    ]);
+    expect(rollup.verdict).toBe("red");
+    expect(rollup.failing.map((f) => f.name)).toEqual(["pytest · vr/health"]);
+  });
+
+  test("the older StatusContext shape is understood too", () => {
+    const { rollup } = prs.rollupChecks([
+      { __typename: "StatusContext", context: "ci/legacy", state: "SUCCESS" },
+      { __typename: "StatusContext", context: "ci/other", state: "PENDING" },
+    ]);
+    expect(rollup.success).toBe(1);
+    expect(rollup.pending).toBe(1);
+    expect(rollup.allDone).toBe(false);
+  });
+
+  test("no checks at all is not a green PR", () => {
+    const { rollup } = prs.rollupChecks([]);
+    expect(rollup.allDone).toBe(false);
+    expect(rollup.verdict).toBeNull();
+  });
+});
+
+describe("bot digest", () => {
+  /** The real one is 46,551 characters. Three numbers is what gets read. */
+  test("pulls the figures out of a coverage table", () => {
+    const body = [
+      "<!-- Pytest Coverage Comment: django-tests | django -->",
+      "| Name | Stmts | Miss | Cover |",
+      "|------|-------|------|-------|",
+      "| a.py | 412 | 31 | 92% |",
+      "Total coverage: 87.4%",
+      "Diff coverage: 100%",
+    ].join("\n");
+    const d = prs.digestBotComment(body);
+    // A decimal must survive: "87.4%" digested as "4%" once, because the
+    // percentage pattern only allowed whole numbers and matched the tail.
+    expect(d).toContain("87.4%");
+  });
+
+  test("falls back to the first real line rather than to nothing", () => {
+    const d = prs.digestBotComment("<!-- marker -->\n\n# Heading\n| table |\nDeployed to staging.");
+    expect(d).toBe("Deployed to staging.");
+  });
+
+  test("a comment with nothing in it digests to nothing, not to a lie", () => {
+    expect(prs.digestBotComment("")).toBeNull();
+  });
+
+  /** The real ones are HTML tables. Left as-is, the fallback reported
+   *  `<a href=...><img alt="Coverage"` as though that were the summary. */
+  test("HTML coverage tables reduce to the scope and the number", () => {
+    const body = '<a href="x"><img alt="Coverage" src="y"></a><table>' +
+      "<tr><td>Coverage (django)</td></tr><tr><td>TOTAL</td><td>1829</td><td>315</td><td>84%</td></tr></table>";
+    expect(prs.digestBotComment(body)).toBe("django coverage 84%");
+  });
+
+  test("a patch-coverage comment says which files, or says there were none", () => {
+    expect(prs.digestBotComment("## Patch coverage . exapi\n# Diff Coverage\nNo lines with coverage information in this diff."))
+      .toContain("nothing measurable");
+    const d = prs.digestBotComment("## Patch coverage . django\n- a&#46;py (100%)\n- b&#46;py (100%)");
+    expect(d).toContain("django patch");
+    expect(d).toContain("2 files");
+  });
+
+  test("tags never leak into the digest", () => {
+    expect(prs.digestBotComment("<div><b>Deployed</b> to staging.</div>")).toBe("Deployed to staging.");
+  });
+});
+
+describe("checklist", () => {
+  test("counts what is still open in a real template", () => {
+    const body = [
+      "## Checklist",
+      "- [x] I have followed the contributing document.",
+      "- [x] I have added the necessary tests.",
+      "- [ ] I have updated the documentation accordingly.",
+      "- [ ] If there are changes in prompts, I have added the `Evals` label.",
+      "",
+      "## Context",
+      "- a normal bullet, not a checkbox",
+    ].join("\n");
+    const items = prs.parseChecklist(body);
+    expect(items).toHaveLength(4);
+    expect(items.filter((i) => !i.checked)).toHaveLength(2);
+    expect(items[0]!.text).toContain("contributing document");
+  });
+
+  test("a body with no checklist yields none", () => {
+    expect(prs.parseChecklist("just prose\n\nand more prose")).toHaveLength(0);
+  });
+
+  /**
+   * The bug this pins found nothing on a live pull request while every test
+   * above passed.
+   *
+   * GitHub stores bodies with CRLF endings. In a JavaScript regex `.` matches
+   * no line terminator, and `\r` is one — so `(.*)$` cannot match a line that
+   * still carries its carriage return, and splitting on `\n` alone leaves one
+   * on every line. Nine real checkboxes, zero found, and a fixture written with
+   * `\n` would never have shown it.
+   */
+  test("CRLF bodies parse identically to LF ones", () => {
+    const lf = [
+      "## Checklist",
+      "- [x] I have followed the contributing document.",
+      "- [ ] I have updated the documentation accordingly.",
+      "- [x] When ready for review, add the label.",
+    ].join("\n");
+    const crlf = lf.replace(/\n/g, "\r\n");
+    expect(prs.parseChecklist(lf)).toHaveLength(3);
+    expect(prs.parseChecklist(crlf)).toEqual(prs.parseChecklist(lf));
+    expect(prs.parseChecklist(crlf).filter((c) => !c.checked)).toHaveLength(1);
+  });
+});
+
+describe("asset proxy allowlist", () => {
+  /**
+   * These URLs come out of pull request bodies. Without the allowlist this
+   * endpoint is a request forger with the server's network position — the
+   * cloud metadata endpoint and the local disk both being one string away.
+   */
+  test("admits the hosts that actually serve PR images", () => {
+    expect(prs.assetAllowed("https://github.com/user-attachments/assets/abc")).not.toBeNull();
+    expect(prs.assetAllowed("https://user-images.githubusercontent.com/1/x.png")).not.toBeNull();
+    expect(prs.assetAllowed("https://t14295188.p.clickup-attachments.com/t1/x.png")).not.toBeNull();
+  });
+
+  test("refuses anything else, and anything not https", () => {
+    expect(prs.assetAllowed("http://github.com/user-attachments/assets/abc")).toBeNull();
+    expect(prs.assetAllowed("file:///etc/passwd")).toBeNull();
+    expect(prs.assetAllowed("https://169.254.169.254/latest/meta-data/")).toBeNull();
+    expect(prs.assetAllowed("https://evil.example.com/x.png")).toBeNull();
+    expect(prs.assetAllowed("not a url")).toBeNull();
+  });
+
+  /** A suffix match written carelessly matches `evilgithubusercontent.com`. */
+  test("the suffix match cannot be spoofed by a lookalike domain", () => {
+    expect(prs.assetAllowed("https://evilgithubusercontent.com/x.png")).toBeNull();
+    expect(prs.assetAllowed("https://github.com.evil.example/x.png")).toBeNull();
+  });
+});
+
+describe("CI notification latch", () => {
+  const rollup = (over: Record<string, unknown> = {}) =>
+    ({ total: 61, success: 43, failure: 0, skipped: 18, pending: 0, allDone: true, verdict: "green", failing: [], ...over });
+
+  const pr = (n: number, checks: Record<string, unknown> = rollup()) => ({
+    number: n, title: `pr ${n}`, author: "x", state: "OPEN", isDraft: false,
+    headRefName: "h", baseRefName: "main", url: "u", updatedAt: "", reviewDecision: null,
+    additions: 0, deletions: 0, changedFiles: 0, labels: [], checks,
+  }) as unknown as Parameters<typeof prs.noteCi>[1];
+
+  const repo = prs.parseRemote("https://github.com/o/r")!;
+
+  test("sixty-one checks produce one notification, not sixty-one", () => {
+    const seen: string[] = [];
+    const off = prs.subscribeCi((v) => seen.push(`${v.number}:${v.verdict}`));
+    prs.noteCi(repo, pr(101));
+    prs.noteCi(repo, pr(101)); // the next poll, same answer
+    prs.noteCi(repo, pr(101));
+    off();
+    expect(seen).toEqual(["101:green"]);
+  });
+
+  test("a suite still running says nothing at all", () => {
+    const seen: string[] = [];
+    const off = prs.subscribeCi((v) => seen.push(String(v.number)));
+    prs.noteCi(repo, pr(102, rollup({ pending: 3, allDone: false, verdict: null })));
+    off();
+    expect(seen).toEqual([]);
+  });
+
+  /** A re-run puts checks back to pending; the second real result must arrive. */
+  test("a re-run clears the latch, so the next verdict is delivered", () => {
+    const seen: string[] = [];
+    const off = prs.subscribeCi((v) => seen.push(`${v.number}:${v.verdict}`));
+    prs.noteCi(repo, pr(103, rollup({ failure: 1, success: 42, verdict: "red", failing: [{ name: "pytest" }] })));
+    prs.noteCi(repo, pr(103, rollup({ pending: 5, allDone: false, verdict: null }))); // re-running
+    prs.noteCi(repo, pr(103));                                                        // green this time
+    off();
+    expect(seen).toEqual(["103:red", "103:green"]);
+  });
+
+  test("the failing check names ride along, so the message can name them", () => {
+    let got: string[] = [];
+    const off = prs.subscribeCi((v) => { got = v.failing; });
+    prs.noteCi(repo, pr(104, rollup({ failure: 1, verdict: "red", failing: [{ name: "pytest \u00b7 vr/health" }] })));
+    off();
+    expect(got).toEqual(["pytest \u00b7 vr/health"]);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -945,10 +945,15 @@ export type PrMergeState =
 
 export interface PrThreadComment {
   id: string;
+  /** The numeric id the REST reply endpoint wants; the `id` above is a GraphQL
+   *  node id and the two are not interchangeable. */
+  databaseId?: number | null;
   author: string;
   isBot: boolean;
   body: string;
   createdAt: string;
+  /** Straight to this comment on GitHub, for when you need the full thing. */
+  url?: string;
 }
 
 export interface PrThread {
@@ -959,6 +964,12 @@ export interface PrThread {
   isResolved: boolean;
   /** The code under it has changed since; usually safe to skip. */
   isOutdated: boolean;
+  /** The diff hunk GitHub kept with the comment. Present even when the thread
+   *  is outdated and those lines are gone from the current diff. */
+  diffHunk?: string;
+  /** The line in the file as it was when the comment was written. */
+  originalLine?: number | null;
+  url?: string;
   comments: PrThreadComment[];
 }
 
@@ -968,6 +979,7 @@ export interface PrReview {
   state: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING";
   body: string;
   submittedAt: string;
+  url?: string;
 }
 
 export interface PrComment {
@@ -976,6 +988,7 @@ export interface PrComment {
   isBot: boolean;
   body: string;
   createdAt: string;
+  url?: string;
   /** Bot noise reduced to its point — a 46KB coverage table is three numbers
    *  and 1,847 rows nobody reads. Null when nothing could be extracted. */
   digest?: string | null;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -931,6 +931,11 @@ export interface PrSummary {
   checks: PrCheckRollup;
   /** This checkout is on the PR's head branch — "you are here". */
   isCurrentBranch?: boolean;
+  /** Whether `checks` has actually been fetched. The list arrives in two
+   *  passes because the check rollup costs four times the rest of the row, and
+   *  a row that has not had its second pass must say "loading" rather than
+   *  "no checks" — those are different claims. */
+  checksLoaded?: boolean;
 }
 
 /** Why the merge button is grey. A disabled control that can't say why is the
@@ -1020,6 +1025,8 @@ export interface PrListResponse {
   fetchedAt: number;
   stale: boolean;
   loading: boolean;
+  /** The rows are here but their check states are still being fetched. */
+  checksPending?: boolean;
   error?: string;
   /** `gh` missing or not logged in — a first-class state, not an error toast. */
   needsAuth?: boolean;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1013,6 +1013,11 @@ export interface PrDetail extends PrSummary {
   /** The author force-pushed after a review was submitted: that review is
    *  stale and the reviewer should be told rather than left guessing. */
   forcePushedSinceReview: boolean;
+  /** You opened this one. GitHub will not let you review your own work, and
+   *  neither should the panel. */
+  viewerDidAuthor: boolean;
+  /** Somebody asked you for a review. This is what the review tab is for. */
+  viewerRequested: boolean;
 }
 
 export interface PrListResponse {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -370,7 +370,22 @@ export type WsFrame =
   /** Something mutated a repository. Carries no payload on purpose: the panels
    *  each need a different slice of git state, so they re-read what they show
    *  rather than the server guessing which of them cares about what. */
-  | { type: "git" };
+  | { type: "git" }
+  /** A pull request's checks all finished. One frame per PR per verdict — the
+   *  server holds the latch, so a suite of sixty-one checks sends one of these,
+   *  not sixty-one. */
+  | { type: "ci"; data: CiVerdict };
+
+/** The aggregate outcome of a PR's checks, once every one of them is terminal. */
+export interface CiVerdict {
+  repo: string;
+  number: number;
+  title: string;
+  verdict: "green" | "red";
+  /** Named, so the message can say what broke instead of just that something did. */
+  failing: string[];
+  url: string;
+}
 
 // --- commit composer (live git working-tree) ---------------------------------
 export interface GitFileStatus {
@@ -850,3 +865,164 @@ export type UpdateStatus = {
   blocked?: string;
   last?: { at: string; ok: boolean; tail: string };
 };
+
+// --- pull requests (gh-backed) ---------------------------------------------
+
+/**
+ * A repo's identity on the forge, not on disk.
+ *
+ * Eighteen worktrees of the same clone are one repo here. Keying PRs by path
+ * would fetch the same list eighteen times — at ~1.9s a call on a server with
+ * one thread, which is the stall this whole panel is written to avoid.
+ */
+export interface PrRepoId {
+  /** "github.com/acme/orbit" — the cache key, and what `gh -R` is given. */
+  key: string;
+  host: string;
+  owner: string;
+  name: string;
+  /** "acme/orbit" */
+  nameWithOwner: string;
+}
+
+export type PrCheckState = "success" | "failure" | "pending" | "skipped" | "neutral";
+
+export interface PrCheck {
+  name: string;
+  workflow: string;
+  state: PrCheckState;
+  /** Terminal means it will not change without a new push or a re-run. */
+  done: boolean;
+  url?: string;
+}
+
+export interface PrCheckRollup {
+  total: number;
+  success: number;
+  failure: number;
+  skipped: number;
+  pending: number;
+  /** Every check has reached a terminal state. The notification latch waits
+   *  for this, so 61 checks produce one message rather than 61. */
+  allDone: boolean;
+  /** Only meaningful with `allDone`. Skipped never counts as failure. */
+  verdict: "green" | "red" | null;
+  /** The failing ones, named — a count alone sends you to the browser. */
+  failing: PrCheck[];
+}
+
+export interface PrLabel { name: string; color?: string }
+
+export interface PrSummary {
+  number: number;
+  title: string;
+  author: string;
+  state: "OPEN" | "CLOSED" | "MERGED";
+  isDraft: boolean;
+  headRefName: string;
+  baseRefName: string;
+  url: string;
+  updatedAt: string;
+  reviewDecision: "APPROVED" | "CHANGES_REQUESTED" | "REVIEW_REQUIRED" | null;
+  additions: number;
+  deletions: number;
+  changedFiles: number;
+  labels: PrLabel[];
+  checks: PrCheckRollup;
+  /** This checkout is on the PR's head branch — "you are here". */
+  isCurrentBranch?: boolean;
+}
+
+/** Why the merge button is grey. A disabled control that can't say why is the
+ *  thing this panel exists to replace. */
+export type PrMergeState =
+  | "CLEAN" | "BLOCKED" | "BEHIND" | "DIRTY" | "UNSTABLE" | "DRAFT" | "HAS_HOOKS" | "UNKNOWN";
+
+export interface PrThreadComment {
+  id: string;
+  author: string;
+  isBot: boolean;
+  body: string;
+  createdAt: string;
+}
+
+export interface PrThread {
+  /** GraphQL node id — the only handle `resolveReviewThread` accepts. */
+  id: string;
+  path: string;
+  line: number | null;
+  isResolved: boolean;
+  /** The code under it has changed since; usually safe to skip. */
+  isOutdated: boolean;
+  comments: PrThreadComment[];
+}
+
+export interface PrReview {
+  author: string;
+  isBot: boolean;
+  state: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING";
+  body: string;
+  submittedAt: string;
+}
+
+export interface PrComment {
+  id: number;
+  author: string;
+  isBot: boolean;
+  body: string;
+  createdAt: string;
+  /** Bot noise reduced to its point — a 46KB coverage table is three numbers
+   *  and 1,847 rows nobody reads. Null when nothing could be extracted. */
+  digest?: string | null;
+}
+
+export interface PrCommit { oid: string; short: string; message: string; author: string; isMerge: boolean }
+
+export interface PrFile {
+  path: string;
+  additions: number;
+  deletions: number;
+  status: string;
+  /** Unresolved threads anchored to this file. */
+  comments: number;
+}
+
+export interface PrChecklistItem { checked: boolean; text: string }
+
+export interface PrDetail extends PrSummary {
+  body: string;
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  mergeState: PrMergeState;
+  /** Parsed out of the body — unchecked boxes are a merge signal on repos
+   *  whose template carries a real checklist. */
+  checklist: PrChecklistItem[];
+  reviewers: string[];
+  assignees: string[];
+  reviews: PrReview[];
+  comments: PrComment[];
+  threads: PrThread[];
+  commits: PrCommit[];
+  files: PrFile[];
+  checks: PrCheckRollup;
+  checksAll: PrCheck[];
+  /** The author force-pushed after a review was submitted: that review is
+   *  stale and the reviewer should be told rather than left guessing. */
+  forcePushedSinceReview: boolean;
+}
+
+export interface PrListResponse {
+  ok: boolean;
+  /** Null when this directory has no forge remote we understand. */
+  repo: PrRepoId | null;
+  prs: PrSummary[];
+  /** When the cached copy was taken. The UI shows this rather than pretending
+   *  to be live — every number here costs a subprocess. */
+  fetchedAt: number;
+  stale: boolean;
+  loading: boolean;
+  error?: string;
+  /** `gh` missing or not logged in — a first-class state, not an error toast. */
+  needsAuth?: boolean;
+}
+
+export interface PrActionResult { ok: boolean; error?: string; detail?: string }

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,7 @@
   "dependencies": {
     "@number-flow/react": "^0.6.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "motion": "^12.42.2",
     "react": "^18.3.1",

--- a/web/src/components/CommandBar.tsx
+++ b/web/src/components/CommandBar.tsx
@@ -1,0 +1,306 @@
+// The project-commands control, shared by both terminals.
+//
+// There are two shells in this app — the terminal view and the console docked
+// under Docker's logs — and they were not equals. The full view had a repo
+// picker and a searchable list of every Makefile target and package script;
+// the console, which is where migrations and container shells actually get
+// run, had nothing but a prompt. Same shell, same PTY, same session store,
+// half the affordances, because the controls were written inline in one panel's
+// JSX and could not be reached from the other.
+//
+// So the control lives here now and both mount the same one. The row it draws
+// is: the commands dropdown, then whatever the user has pinned.
+//
+// Pins are what make this more than a menu. A menu of 316 commands answers
+// "what can I run"; a pinned chip answers "run the thing I run twenty times a
+// day", which for a Django project is one migrate and one shell. Five is the
+// cap — enough for a day's work, few enough that the row can never grow into
+// the second scrolling strip this was meant to replace.
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import type { ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
+import { api, IS_DEMO } from "../lib/api.ts";
+import { useDismiss } from "../lib/useDismiss.ts";
+
+/**
+ * The four git one-liners this row used to hardcode as always-visible chips.
+ *
+ * They were a fixed 260px of the toolbar that nobody could remove, on a row
+ * that also has to hold a repo picker and a commands button. Now they are
+ * simply the first group in the dropdown — still one click away, pinnable like
+ * anything else, and costing nothing when you don't want them.
+ */
+export const GIT_COMMANDS: ProjectCommand[] = [
+  { name: "status", cmd: "git status", desc: "what is changed, staged and untracked", dir: "" },
+  { name: "log", cmd: "git log --oneline -15", desc: "the last 15 commits, one line each", dir: "" },
+  { name: "diff", cmd: "git diff --stat", desc: "which files changed, and by how much", dir: "" },
+  { name: "branches", cmd: "git branch -vv", desc: "local branches with their upstreams", dir: "" },
+];
+
+// --- pins --------------------------------------------------------------------
+
+export const MAX_PINS = 5;
+const PIN_KEY = "agentglass.commandPins";
+
+/**
+ * Pins are per repo, not global.
+ *
+ * A machine with seventeen checkouts of one project and a dozen other projects
+ * has no single set of five commands that is right everywhere — `make migrate`
+ * belongs to the Django repo and means nothing in the next one. Keyed by repo
+ * root, both terminals pointed at the same repo therefore show the same pins,
+ * which is the point: it is one setting, not one per panel.
+ */
+type PinMap = Record<string, string[]>;
+const EMPTY: string[] = [];
+
+function read(): PinMap {
+  try {
+    const raw = JSON.parse(localStorage.getItem(PIN_KEY) || "{}");
+    if (!raw || typeof raw !== "object" || Array.isArray(raw)) return {};
+    const out: PinMap = {};
+    for (const [k, v] of Object.entries(raw)) {
+      if (Array.isArray(v)) out[k] = v.filter((c): c is string => typeof c === "string").slice(0, MAX_PINS);
+    }
+    return out;
+  } catch { return {}; }
+}
+
+let pinned: PinMap = read();
+const subs = new Set<() => void>();
+
+function write(next: PinMap) {
+  pinned = next;
+  try { localStorage.setItem(PIN_KEY, JSON.stringify(next)); } catch { /* private mode — pins last the session */ }
+  for (const s of subs) s();
+}
+
+/** Pin, or unpin if it is already there. Returns false when the cap refused it,
+ *  so the caller can say why rather than looking broken. */
+export function togglePin(root: string, cmd: string): boolean {
+  if (!root || !cmd) return false;
+  const cur = pinned[root] ?? EMPTY;
+  if (cur.includes(cmd)) {
+    write({ ...pinned, [root]: cur.filter((c) => c !== cmd) });
+    return true;
+  }
+  if (cur.length >= MAX_PINS) return false;
+  write({ ...pinned, [root]: [...cur, cmd] });
+  return true;
+}
+
+/**
+ * The pins for one repo, live in every mounted bar at once.
+ *
+ * Both terminals can be on screen together — the Docker console under the logs
+ * while the terminal view holds the same repo — and pinning in one has to show
+ * up in the other immediately, or the two disagree about a setting they share.
+ * The snapshot is the stored array itself, which `write` replaces rather than
+ * mutates, so the identity check inside useSyncExternalStore stays honest.
+ */
+export function usePins(root: string): string[] {
+  return useSyncExternalStore(
+    useCallback((cb: () => void) => { subs.add(cb); return () => { subs.delete(cb); }; }, []),
+    useCallback(() => pinned[root] ?? EMPTY, [root]),
+    useCallback(() => EMPTY, []),
+  );
+}
+
+// --- the command list --------------------------------------------------------
+
+/**
+ * One fetch per repo, shared by every bar showing it.
+ *
+ * Two bars mounted on the same repo asked the server the same question twice,
+ * and that question walks the project for Makefiles and package.json files.
+ * Held briefly rather than forever: a Makefile does change, just not on the
+ * timescale of switching panels.
+ */
+const CMD_TTL_MS = 30_000;
+const cmdCache = new Map<string, { at: number; data: TerminalCommands }>();
+const cmdInflight = new Map<string, Promise<TerminalCommands>>();
+
+export function loadCommands(root: string): Promise<TerminalCommands> {
+  const hit = cmdCache.get(root);
+  if (hit && Date.now() - hit.at < CMD_TTL_MS) return Promise.resolve(hit.data);
+  const flying = cmdInflight.get(root);
+  if (flying) return flying;
+  const p = api.terminalCommands(root)
+    .then((data) => { cmdCache.set(root, { at: Date.now(), data }); return data; })
+    .catch(() => ({ enabled: true, make: [], scripts: [] } as TerminalCommands))
+    .finally(() => { cmdInflight.delete(root); });
+  cmdInflight.set(root, p);
+  return p;
+}
+
+export function useCommands(root: string): TerminalCommands | null {
+  const [cmds, setCmds] = useState<TerminalCommands | null>(null);
+  useEffect(() => {
+    if (!root || IS_DEMO) { setCmds(null); return; }
+    let live = true;
+    setCmds(null);
+    loadCommands(root).then((c) => { if (live) setCmds(c); });
+    return () => { live = false; };
+  }, [root]);
+  return cmds;
+}
+
+/**
+ * Filter the command list by name, description or folder.
+ *
+ * Description included deliberately: a Makefile names things like `infra.up`
+ * and `check.build_id`, so what you remember is usually what it *does*, not
+ * what it is called.
+ */
+export function matchCommands(list: ProjectCommand[], query: string): ProjectCommand[] {
+  const q = query.trim().toLowerCase();
+  if (!q) return list;
+  return list.filter((c) => `${c.name} ${c.desc ?? ""} ${c.dir ?? ""}`.toLowerCase().includes(q));
+}
+
+/** Bucket commands by the project folder they belong to, repo root first. */
+export function groupByDir(list: ProjectCommand[]): [string, ProjectCommand[]][] {
+  const by = new Map<string, ProjectCommand[]>();
+  for (const c of list) {
+    const dir = c.dir ?? "";
+    if (!by.has(dir)) by.set(dir, []);
+    by.get(dir)!.push(c);
+  }
+  return [...by.entries()].sort(([a], [b]) => (a === "" ? -1 : b === "" ? 1 : a.localeCompare(b)));
+}
+
+/**
+ * One row in the dropdown.
+ *
+ * A div rather than a button, because it holds two: running the command and
+ * pinning it are different actions and a button inside a button is not
+ * something a browser will lay out twice the same way.
+ */
+function CommandRow({ c, font, on, full, onRun, onPin }: {
+  c: ProjectCommand; font: string; on: boolean; full: boolean;
+  onRun: (cmd: string) => void; onPin: (cmd: string) => void;
+}) {
+  return (
+    <div className="group w-full px-3 py-1.5 flex items-baseline gap-2.5 hover:bg-[color-mix(in_srgb,var(--primary)_10%,transparent)]">
+      <button onClick={() => onRun(c.cmd)} title={c.cmd} className="min-w-0 flex-1 text-left flex items-baseline gap-2.5">
+        <span className="shrink-0 font-medium" style={{ color: "var(--primary-hover)", fontFamily: font }}>{c.cmd}</span>
+        <span className="min-w-0 flex-1 truncate t-dim2">{c.desc || "—"}</span>
+      </button>
+      {/* Pinned stars stay lit; the rest appear on hover, so a list of 300 rows
+          is not 300 competing controls. */}
+      <button
+        onClick={(e) => { e.stopPropagation(); onPin(c.cmd); }}
+        disabled={!on && full}
+        className={`shrink-0 text-[11px] leading-none px-1 ${on ? "" : "opacity-0 group-hover:opacity-100"}`}
+        style={{ color: on ? "var(--warning)" : "var(--text3)", opacity: !on && full ? 0.3 : undefined }}
+        title={on ? "unpin" : full ? `${MAX_PINS} pinned already — unpin one first` : `pin ${c.cmd} to the bar`}
+      >{on ? "★" : "☆"}</button>
+    </div>
+  );
+}
+
+/**
+ * The commands dropdown and the pinned chips.
+ *
+ * `font` is the terminal's own face: a command is a thing you type, and it
+ * reads as one when it is set in the face it will be typed in.
+ */
+export function CommandBar({ root, disabled, font, onRun, dropUp }: {
+  root: string;
+  disabled: boolean;
+  font: string;
+  onRun: (cmd: string) => void;
+  /** Open upwards — for the console strip, which sits at the bottom of a panel
+   *  and has nothing below it to open into. */
+  dropUp?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const wrap = useRef<HTMLDivElement>(null);
+  const cmds = useCommands(root);
+  const pins = usePins(root);
+  useDismiss(open, wrap, () => { setOpen(false); setQuery(""); });
+
+  const n = (cmds?.make.length ?? 0) + (cmds?.scripts.length ?? 0);
+  const full = pins.length >= MAX_PINS;
+  const run = (cmd: string) => { setOpen(false); setQuery(""); onRun(cmd); };
+  const pin = (cmd: string) => { togglePin(root, cmd); };
+
+  const groups: [string, ProjectCommand[]][] = [];
+  if (cmds) {
+    for (const [dir, list] of groupByDir(matchCommands(cmds.make, query))) groups.push([`make — ${dir ? `${dir}/Makefile` : "Makefile"}`, list]);
+    for (const [dir, list] of groupByDir(matchCommands(cmds.scripts, query))) groups.push([`scripts — ${dir ? `${dir}/package.json` : "package.json"}`, list]);
+  }
+  const gitMatches = matchCommands(GIT_COMMANDS, query);
+
+  return (
+    <>
+      <div className="relative shrink-0" ref={wrap}>
+        <button onClick={() => setOpen((o) => !o)} disabled={!root || IS_DEMO}
+          title="Ready-to-run project commands: Makefile targets & package scripts, with what each one does. Pin the ones you use."
+          className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg font-medium whitespace-nowrap"
+          style={{ color: n ? "var(--primary-hover)" : "var(--text2)", background: "color-mix(in srgb, var(--primary) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)", opacity: root && !IS_DEMO ? 1 : 0.5 }}>
+          ⚙ commands{n ? ` (${n})` : cmds ? " (none)" : " …"}<span className="t-dim2">▼</span>
+        </button>
+        {open && (
+          <div className="absolute left-0 rounded-lg text-[11px] shadow-2xl flex flex-col"
+            style={{ zIndex: 40, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", width: 460, maxHeight: 420, overflow: "hidden", ...(dropUp ? { bottom: "calc(100% + 4px)" } : { top: "calc(100% + 4px)" }) }}>
+            {/* A real project has more targets than fit on a screen — the repo
+                this was built against has 316 — so scrolling to find `migrate`
+                was the only way to run it. Matches the name and what the target
+                says it does, since half of them are only recognisable by their
+                description. */}
+            <input autoFocus value={query} onChange={(e) => setQuery(e.target.value)}
+              placeholder="filter commands…"
+              className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
+              style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
+            <div className="agx-scroll overflow-y-auto py-1" style={{ minHeight: 0 }}>
+              {!!gitMatches.length && (
+                <div>
+                  <div className="px-3 pt-1.5 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider">git — always available</div>
+                  {gitMatches.map((c) => <CommandRow key={"g:" + c.cmd} c={c} font={font} on={pins.includes(c.cmd)} full={full} onRun={run} onPin={pin} />)}
+                </div>
+              )}
+              {groups.map(([label, list]) => (
+                <div key={label}>
+                  <div className="px-3 pt-2 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider">{label}</div>
+                  {list.map((c) => <CommandRow key={label + ":" + c.cmd} c={c} font={font} on={pins.includes(c.cmd)} full={full} onRun={run} onPin={pin} />)}
+                </div>
+              ))}
+              {!gitMatches.length && !groups.length && (
+                <div className="px-3 py-2 t-dim2">{cmds ? `no command matches “${query.trim()}”` : "reading the project…"}</div>
+              )}
+            </div>
+            <div className="shrink-0 px-3 py-1.5 t-dim2 text-[9.5px] border-t" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
+              ☆ pins a command to the bar — {pins.length} of {MAX_PINS} used, per repo
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* The pinned row. Empty until something is pinned, and it says so once —
+          a bar with no affordance is a bar nobody discovers. */}
+      <div className="flex items-center gap-1 min-w-0 overflow-x-auto agx-scroll">
+        {pins.map((cmd) => (
+          <span key={cmd} className="group relative flex items-center shrink-0">
+            <button onClick={() => onRun(cmd)} disabled={disabled || !root || IS_DEMO}
+              className="text-[10px] pl-2 pr-2 py-1 rounded-md whitespace-nowrap"
+              style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", fontFamily: font }}
+              title={`run ${cmd}`}>{cmd}</button>
+            {/* Unpin from the chip itself: going back to the dropdown to find
+                the row you pinned is the long way round. */}
+            <button onClick={() => togglePin(root, cmd)}
+              className="absolute -top-1 -right-1 text-[9px] leading-none rounded-full px-[3px] py-[1px] opacity-0 group-hover:opacity-100"
+              style={{ background: "var(--bg3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}
+              title={`unpin ${cmd}`}>✕</button>
+          </span>
+        ))}
+        {!pins.length && !!root && (
+          <button onClick={() => setOpen(true)} className="text-[10px] px-2 py-1 rounded-md whitespace-nowrap shrink-0"
+            style={{ color: "var(--text3)", border: "1px dashed color-mix(in srgb, var(--border) 30%, transparent)" }}
+            title={`Pin up to ${MAX_PINS} commands here — they stay one click away, per repo`}>☆ pin a command</button>
+        )}
+      </div>
+    </>
+  );
+}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -7,7 +7,7 @@ import type { DockerOverview, DockerContainer, DockerStat } from "../../../share
 import { api } from "../lib/api.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
-import { ConsoleStrip, lastTerminalRoot, runInConsole } from "./TerminalPanel.tsx";
+import { ConsoleStrip, consoleRoot, runInConsole } from "./TerminalPanel.tsx";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
@@ -592,7 +592,7 @@ export function DockerView({ active }: { active: boolean }) {
                                   A second, container-only terminal would be a
                                   second set of bugs for no extra reach. */}
                               {writeEnabled && selected.state === "running" && (
-                                <button onClick={() => { setConsoleOpen(true); runInConsole(lastTerminalRoot(), `docker exec -it ${selected.id.slice(0, 12)} sh -c 'command -v bash >/dev/null && exec bash || exec sh'`); }}
+                                <button onClick={() => { setConsoleOpen(true); runInConsole(consoleRoot(), `docker exec -it ${selected.id.slice(0, 12)} sh -c 'command -v bash >/dev/null && exec bash || exec sh'`); }}
                                   className="text-[10px] px-2 py-0.5 rounded mr-1"
                                   style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" }}
                                   title={`Open a shell inside ${selected.name}`}>exec</button>
@@ -632,7 +632,7 @@ export function DockerView({ active }: { active: boolean }) {
                     else, so opening it takes room from the logs rather than
                     covering them. */}
                 <ConsoleStrip
-                  root={lastTerminalRoot()}
+                  root={consoleRoot()}
                   open={consoleOpen}
                   height={consoleH}
                   onHeight={setConsoleH}

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -844,6 +844,26 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     finally { setBusy(false); setPending(null); }
   };
 
+  /**
+   * Open a branch where it lives on the web.
+   *
+   * A live branch has a tree page and the URL is pure string work. A `gone` one
+   * has no tree page — that is what gone means — so the only useful destination
+   * is the pull request it came from, which costs a lookup. Resolved on click
+   * rather than prefetched for every row: thirteen gone branches would be
+   * thirteen network calls for a link nobody pressed.
+   */
+  const openBranchOnWeb = async (b: GitBranch) => {
+    if (busy) return;
+    setBusy(true);
+    try {
+      const r = await api.prBranchUrl(root, b.name, trackChip(b.track).gone);
+      if (!r.ok || !r.url) { flash(false, r.error || "could not work out where that branch lives"); return; }
+      window.open(r.url, "_blank", "noopener,noreferrer");
+    } catch (e) { flash(false, String(e)); }
+    finally { setBusy(false); }
+  };
+
   // Branches whose upstream is gone. Never the current one: git refuses to
   // delete a checked-out branch anyway, and offering it is just a failed call.
   const goneBranches = branchData.branches.filter((b) => !b.current && trackChip(b.track).gone);
@@ -1960,6 +1980,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                           <span className="shrink-0 text-[9.5px] t-dim2">{b.date}</span>
                           {writeEnabled && !b.current && (
                             <div className="shrink-0 flex items-center gap-1 opacity-0 group-hover:opacity-100">
+                              <button onClick={() => openBranchOnWeb(b)} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }} title={trackChip(b.track).gone ? "its remote branch is gone — find the pull request it came from" : "open this branch on GitHub"}>open ↗</button>
                               <button onClick={() => mergeBranch(b.name)} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }} title={`Merge ${b.name} into current`}>merge</button>
                               <button onClick={() => rebaseBranch(b.name)} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }} title={`Rebase current onto ${b.name}`}>rebase</button>
                               <button onClick={() => renameBranch(b.name)} className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text2)" }}>rename</button>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -399,7 +399,13 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
    * two the new list takes, and you are reading one pull request under a tab
    * that says you are looking at another.
    */
+  const lastScope = useRef<string>("");
   useEffect(() => {
+    const scope = `${root}\u0000${filter}`;
+    if (lastScope.current === scope) return; // re-render, not a switch
+    const first = lastScope.current === "";
+    lastScope.current = scope;
+    if (first) return; // nothing on screen yet to clear
     listReq.current++;
     setPrs([]);
     setSelected(null);
@@ -408,12 +414,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     setListState((st) => ({ ...st, loading: true, fetchedAt: 0 }));
   }, [filter, root]);
 
-  useEffect(() => {
-    if (!active || !root) return;
-    loadList();
-    const t = setInterval(() => loadList(), POLL_MS);
-    return () => clearInterval(t);
-  }, [active, root, filter, loadList]);
+  // Polling pauses while the view is hidden — no point spending requests on a
+  // pane nobody is looking at — and resumes on return. Resuming refreshes; it
+  // does not reset.
+
 
   /**
    * Warm the filters you are not looking at.
@@ -440,15 +444,49 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     api.prDetail(root, n, force).then((r) => {
       if (req !== detailReq.current) return; // a later selection already won
       if (r.ok && r.detail) setDetail(r.detail);
+      // A refresh that fails leaves what is on screen alone: the pull request
+      // you are reading is better than an error where it used to be.
+      else if (!force) setDetailErr(r.error || "");
       else { setDetail(null); setDetailErr(r.error || "could not load this pull request"); }
     }).catch((e) => { if (req === detailReq.current) setDetailErr(String(e)); });
   }, [root]);
 
   useEffect(() => {
-    if (!active || !root || selected == null) { setDetail(null); return; }
+    if (!active || !root) return;
+    loadList();
+    const t = setInterval(() => {
+      loadList();
+      // Keep the open pull request current too. This reads the server's cache,
+      // so it only reaches the network when that entry has actually aged out —
+      // without it, a comment left while you are reading never appears until
+      // you navigate away and back.
+      const n = selectedRef.current;
+      if (n != null) loadDetail(n);
+    }, POLL_MS);
+    return () => clearInterval(t);
+  }, [active, root, filter, loadList, loadDetail]);
+
+  /**
+   * Load a pull request when the SELECTION changes — never merely because the
+   * view became visible again.
+   *
+   * This effect used to list `active`, so stepping away to the terminal and
+   * coming back re-ran it: the open commit, the open file and the fetched diff
+   * were all thrown away and the pane went back to "loading". You lost your
+   * place for having looked somewhere else for a moment. The view stays mounted
+   * the whole time — only its visibility changes — so there is nothing to
+   * restore and nothing to reload.
+   */
+  const loadedFor = useRef<number | null>(null);
+  const selectedRef = useRef<number | null>(null);
+  useEffect(() => { selectedRef.current = selected; }, [selected]);
+  useEffect(() => {
+    if (!root || selected == null) { setDetail(null); loadedFor.current = null; return; }
+    if (loadedFor.current === selected) return; // same pull request, already here
+    loadedFor.current = selected;
     setDiff(""); setSelFile(null); setSelCommit(null); setCommitText("");
     loadDetail(selected);
-  }, [active, root, selected, loadDetail]);
+  }, [root, selected, loadDetail]);
 
   useEffect(() => {
     if ((tab !== "files" && tab !== "review") || !detail || diff || !root) return;

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -588,7 +588,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const canReview = !!d && !d.viewerDidAuthor;
 
   const TABS: { id: Tab; label: string; n?: number; warn?: boolean }[] = d ? [
-    { id: "overview", label: "overview", warn: d.checklist.some((c) => !c.checked) },
+    { id: "overview", label: "overview" },
     { id: "conversation", label: "conversation", n: lanes.humans.length + lanes.humanComments.length + d.threads.length + lanes.bots.length },
     { id: "commits", label: "commits", n: d.commits.length },
     { id: "files", label: "files", n: d.files.length },
@@ -711,12 +711,11 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                     onResolve={(t) => act(t.isResolved ? "unresolve" : "resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
                     onReply={async (t) => {
                       const first = t.comments[0];
-                      if (!first) return;
+                      if (typeof first?.databaseId !== "number") return;
                       const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply" } });
                       if (!body?.trim()) return;
-                      await act("reply", () => api.prReply(root, d.number, Number(first.id), body));
+                      await act("reply", () => api.prReply(root, d.number, first.databaseId as number, body));
                     }}
-                    fileOf={(p) => byPath.get(p)}
                   />
                 )}
 
@@ -797,8 +796,6 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
   onLocalReview: () => void; onMerge: () => void; onClose: () => void; onUpdateBranch: () => void;
   onRerun: () => void; onAutoMerge: () => void; onDraft: () => void; onGoThreads: () => void;
 }) {
-  const done = d.checklist.filter((c) => c.checked).length;
-  const open = d.checklist.length - done;
   const c = d.checks;
   const canMerge = d.mergeState === "CLEAN";
 
@@ -870,20 +867,6 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
           </span>
         </div>
       </section>
-
-      {d.checklist.length > 0 && (
-        <section>
-          <div className="flex items-center gap-2 text-[9.5px] uppercase tracking-wider mb-1" style={{ color: "var(--text3)" }}>
-            <span>checklist</span>
-            {open > 0 && <span style={{ color: "var(--warning)" }}>{open} open</span>}
-            <span className="ml-auto tabular-nums">{done}/{d.checklist.length}</span>
-          </div>
-          <Bar parts={[
-            { pct: (done / d.checklist.length) * 100, tint: "var(--success)" },
-            { pct: (open / d.checklist.length) * 100, tint: "var(--warning)" },
-          ]} />
-        </section>
-      )}
 
       <section>
         <div className="text-[9.5px] uppercase tracking-wider mb-2" style={{ color: "var(--text3)" }}>description</div>
@@ -1018,6 +1001,16 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
 // conversation
 // ---------------------------------------------------------------------------
 
+/** Out to GitHub, for the one thing the panel does not show — the full history
+ *  of an edit, a reaction, the blame behind a line. */
+function GhLink({ href, title }: { href: string; title: string }) {
+  return (
+    <a href={href} target="_blank" rel="noreferrer noopener" title={title}
+      className="shrink-0 text-[10px] px-1 rounded"
+      style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>↗</a>
+  );
+}
+
 function Lane({ label, extra }: { label: string; extra?: string }) {
   return (
     <div className="flex items-center gap-2 mt-4 mb-2 text-[9.5px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>
@@ -1027,8 +1020,8 @@ function Lane({ label, extra }: { label: string; extra?: string }) {
   );
 }
 
-function Card({ who, chip, when, tone, children }: {
-  who: string; chip?: React.ReactNode; when?: string; tone?: "chg" | "appr" | "bot"; children: React.ReactNode;
+function Card({ who, chip, when, tone, url, children }: {
+  who: string; chip?: React.ReactNode; when?: string; tone?: "chg" | "appr" | "bot"; url?: string; children: React.ReactNode;
 }) {
   const edge = tone === "chg" ? "var(--error)" : tone === "appr" ? "var(--success)" : tone === "bot" ? "var(--info)" : "var(--border)";
   return (
@@ -1039,60 +1032,81 @@ function Card({ who, chip, when, tone, children }: {
         <Avatar login={who} size={17} />
         <b style={{ color: "var(--text)", fontWeight: 500 }}>{who}</b>
         {chip}
-        {when && <span className="ml-auto text-[10px]" style={{ color: "var(--text3)" }}>{when}</span>}
+        <span className="ml-auto flex items-center gap-1.5 shrink-0">
+          {when && <span className="text-[10px]" style={{ color: "var(--text3)" }}>{when}</span>}
+          {url && <GhLink href={url} title="open on GitHub" />}
+        </span>
       </div>
       <div className="px-3 py-2.5">{children}</div>
     </div>
   );
 }
 
-/** The hunk a thread is anchored to, so the comment reads next to its code. */
-function ThreadSnippet({ file, line }: { file?: FileChange; line: number | null }) {
+/**
+ * The code a thread is about.
+ *
+ * Straight from the hunk GitHub stored with the comment. Reconstructing it from
+ * the pull request's diff meant the snippet only appeared on tabs that had
+ * already fetched that diff — so in the conversation, where the thread actually
+ * reads, there was never any code at all. It also survives an outdated thread,
+ * whose lines no longer exist in the current diff.
+ *
+ * Trimmed to the last few lines: a stored hunk runs thirty-odd lines and the
+ * comment is about the end of it.
+ */
+function ThreadSnippet({ hunk, line }: { hunk?: string; line?: number | null }) {
   const rows = useMemo(() => {
-    if (!file || !line) return null;
-    for (const h of file.hunks) {
-      let n = h.newStart;
-      const out: { text: string; no: number | null }[] = [];
-      for (const l of h.lines) {
-        const no = l.startsWith("-") ? null : n++;
-        out.push({ text: l, no });
-      }
-      if (out.some((r) => r.no === line)) {
-        const idx = out.findIndex((r) => r.no === line);
-        return out.slice(Math.max(0, idx - 3), idx + 1);
-      }
+    const all = (hunk || "").split(/\r?\n/).filter((l, i) => i > 0 || !l.startsWith("@@"));
+    const tail = all.slice(-5);
+    // Number the tail against the line the comment landed on, counting back
+    // over everything that occupies a line on the new side.
+    let n = typeof line === "number" ? line : NaN;
+    const nums: (number | null)[] = [];
+    for (let i = tail.length - 1; i >= 0; i--) {
+      if (tail[i]!.startsWith("-")) { nums[i] = null; continue; }
+      nums[i] = Number.isNaN(n) ? null : n--;
     }
-    return null;
-  }, [file, line]);
-  if (!rows?.length) return null;
+    return tail.map((text, i) => ({ text, no: nums[i] ?? null }));
+  }, [hunk, line]);
+
+  if (!hunk?.trim()) return null;
   return (
     <div className="text-[10.5px]" style={{ ...CODE_FONT_STYLE, borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
       {rows.map((r, i) => (
-        <div key={i} className="px-2.5 whitespace-pre overflow-hidden text-ellipsis" style={{
-          color: r.text.startsWith("+") ? "var(--success)" : r.text.startsWith("-") ? "var(--error)" : "var(--text3)",
+        <div key={i} className="flex" style={{
           background: r.text.startsWith("+") ? "color-mix(in srgb, var(--success) 10%, transparent)"
             : r.text.startsWith("-") ? "color-mix(in srgb, var(--error) 10%, transparent)" : undefined,
-        }}>{r.text || " "}</div>
+        }}>
+          <span className="shrink-0 text-right select-none tabular-nums px-2"
+            style={{ width: 46, color: "var(--text3)", opacity: .7 }}>{r.no ?? ""}</span>
+          <span className="min-w-0 flex-1 whitespace-pre overflow-x-auto pr-2 agx-scroll" style={{
+            color: r.text.startsWith("+") ? "var(--success)" : r.text.startsWith("-") ? "var(--error)" : "var(--text2)",
+          }}>{r.text || " "}</span>
+        </div>
       ))}
     </div>
   );
 }
 
-/** One review thread: where it is anchored, the code it sits on, the exchange,
- *  and the two things you can do about it. */
-function Thread({ t, fileOf, onResolve, onReply, busy }: {
-  t: PrThread; fileOf: (p: string) => FileChange | undefined;
-  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
+function Thread({ t, onResolve, onReply, busy }: {
+  t: PrThread; onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
 }) {
+  // The REST reply endpoint takes the numeric comment id. `id` is a GraphQL
+  // node id (`PRRC_kwDO…`) and `Number()` of that is NaN — which is why reply
+  // could never have worked before `databaseId` was asked for.
+  const canReply = typeof t.comments[0]?.databaseId === "number";
   return (
     <div className="rounded-md overflow-hidden mb-2" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
       <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
         style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
-        <span style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
+        <span className="truncate" style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
         {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="the code under this comment has changed since" />}
-        <span className="ml-auto">{t.isResolved ? <Chip text="resolved" tint="var(--success)" /> : <Chip text="open" tint="var(--warning)" />}</span>
+        <span className="ml-auto flex items-center gap-1.5 shrink-0">
+          {t.isResolved ? <Chip text="resolved" tint="var(--success)" /> : <Chip text="open" tint="var(--warning)" />}
+          {t.url && <GhLink href={t.url} title="open this thread on GitHub" />}
+        </span>
       </div>
-      <ThreadSnippet file={fileOf(t.path)} line={t.line} />
+      <ThreadSnippet hunk={t.diffHunk} line={t.originalLine ?? t.line} />
       {t.comments.map((c, i) => (
         <div key={c.id} className="px-3 py-2"
           style={{ paddingLeft: i ? 26 : 12, background: i ? "color-mix(in srgb, var(--border) 9%, transparent)" : undefined }}>
@@ -1100,25 +1114,28 @@ function Thread({ t, fileOf, onResolve, onReply, busy }: {
             <Avatar login={c.author} size={15} />
             <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
             {c.isBot && <Chip text="automation" tint="var(--info)" />}
-            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
+            <span className="ml-auto flex items-center gap-1.5" style={{ color: "var(--text3)" }}>
+              {ago(c.createdAt)}
+              {c.url && <GhLink href={c.url} title="open this comment on GitHub" />}
+            </span>
           </div>
           <Md body={c.body} />
         </div>
       ))}
       <div className="flex gap-1.5 px-3 py-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
-        <Btn onClick={() => onReply(t)} disabled={busy} small>reply</Btn>
+        <Btn onClick={() => onReply(t)} disabled={busy || !canReply} small
+          title={canReply ? undefined : "this thread has no comment to reply to"}>reply</Btn>
         <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "unresolve" : "resolve conversation"}</Btn>
       </div>
     </div>
   );
 }
 
-function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }: {
+function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy }: {
   d: PrDetail;
   lanes: { humans: PrReview[]; botReviews: PrReview[]; humanComments: PrComment[]; bots: PrComment[] };
   raw: boolean; onRaw: (v: boolean) => void;
   onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
-  fileOf: (path: string) => FileChange | undefined;
 }) {
   const kb = Math.round(lanes.bots.reduce((n, c) => n + c.body.length, 0) / 1024);
   // Threads whose author never submitted a review of their own — a bot's
@@ -1141,7 +1158,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }
         const mine = d.threads.filter((t) => t.comments[0]?.author === r.author);
         return (
           <div key={`r${i}`} className="mb-2">
-            <Card who={r.author} when={ago(r.submittedAt)}
+            <Card who={r.author} when={ago(r.submittedAt)} url={r.url}
               tone={r.state === "CHANGES_REQUESTED" ? "chg" : r.state === "APPROVED" ? "appr" : undefined}
               chip={r.state === "CHANGES_REQUESTED" ? <Chip text="requested changes" tint="var(--error)" />
                 : r.state === "APPROVED" ? <Chip text="approved" tint="var(--success)" /> : undefined}>
@@ -1149,26 +1166,26 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }
             </Card>
             {mine.length > 0 && (
               <div className="pl-3 ml-2" style={{ borderLeft: "2px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-                {mine.map((t) => <Thread key={t.id} t={t} fileOf={fileOf} onResolve={onResolve} onReply={onReply} busy={busy} />)}
+                {mine.map((t) => <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} busy={busy} />)}
               </div>
             )}
           </div>
         );
       })}
       {lanes.humanComments.map((c) => (
-        <Card key={c.id} who={c.author} when={ago(c.createdAt)}><Md body={c.body} /></Card>
+        <Card key={c.id} who={c.author} when={ago(c.createdAt)} url={c.url}><Md body={c.body} /></Card>
       ))}
 
       {orphanThreads.length > 0 && (
         <>
           <Lane label="line threads" extra={`${orphanThreads.filter((t) => !t.isResolved).length} open of ${orphanThreads.length}`} />
-          {orphanThreads.map((t) => <Thread key={t.id} t={t} fileOf={fileOf} onResolve={onResolve} onReply={onReply} busy={busy} />)}
+          {orphanThreads.map((t) => <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} busy={busy} />)}
         </>
       )}
 
       <Lane label="automation" extra={lanes.bots.length ? `${lanes.bots.length} comments · ${kb} KB` : undefined} />
       {lanes.botReviews.map((r, i) => (
-        <Card key={`br${i}`} who={r.author} when={ago(r.submittedAt)} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
+        <Card key={`br${i}`} who={r.author} when={ago(r.submittedAt)} url={r.url} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
           <Md body={r.body} />
         </Card>
       ))}
@@ -1180,7 +1197,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }
             {lanes.bots.length} machine comment{lanes.bots.length === 1 ? "" : "s"} · {kb} KB {raw ? "— hide raw" : "collapsed — show raw"}
           </button>
           {lanes.bots.map((c) => (
-            <Card key={c.id} who={c.author} when={ago(c.createdAt)} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
+            <Card key={c.id} who={c.author} when={ago(c.createdAt)} url={c.url} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
               {raw ? <pre className="overflow-x-auto text-[10px] max-h-72 agx-scroll" style={{ ...CODE_FONT_STYLE, color: "var(--text3)" }}>{c.body}</pre>
                 : <span style={{ color: "var(--text2)" }}>{c.digest || "(nothing worth pulling out)"}</span>}
             </Card>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -267,6 +267,32 @@ function DiffPane({ file, split, wrap, onComment }: {
 // list row
 // ---------------------------------------------------------------------------
 
+/** Placeholder rows while the list is on its way.
+ *
+ *  A spinner says "wait"; these say "a list is coming, roughly this shape",
+ *  which is the difference between a pane that feels slow and one that feels
+ *  broken. `prefers-reduced-motion` drops the shimmer, not the placeholder. */
+function Skeletons({ n = 6 }: { n?: number }) {
+  return (
+    <div aria-hidden>
+      <style>{`@keyframes agxpulse{0%,100%{opacity:.35}50%{opacity:.7}}
+@media (prefers-reduced-motion:reduce){.agx-sk{animation:none!important}}`}</style>
+      {Array.from({ length: n }, (_, i) => (
+        <div key={i} className="px-2.5 py-2 border-b" style={{ borderColor: "color-mix(in srgb, var(--border) 22%, transparent)" }}>
+          <div className="agx-sk rounded" style={{
+            height: 8, width: `${58 + ((i * 13) % 34)}%`, background: "color-mix(in srgb, var(--border) 55%, transparent)",
+            animation: `agxpulse 1.4s ease-in-out ${i * 0.09}s infinite`,
+          }} />
+          <div className="agx-sk rounded mt-1.5" style={{
+            height: 6, width: `${30 + ((i * 7) % 20)}%`, background: "color-mix(in srgb, var(--border) 38%, transparent)",
+            animation: `agxpulse 1.4s ease-in-out ${i * 0.09 + 0.2}s infinite`,
+          }} />
+        </div>
+      ))}
+    </div>
+  );
+}
+
 function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelect: () => void }) {
   const c = p.checks;
   return (
@@ -282,9 +308,15 @@ function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelec
         {p.isCurrentBranch && <Chip text="here" tint="var(--primary)" title="this checkout is on that branch" />}
       </div>
       <div className="flex items-center gap-1.5 mt-0.5 text-[10px]" style={{ color: "var(--text3)" }}>
-        <Dot tint={stateTint(p)} title={`${c.success} passed · ${c.failure} failed · ${c.skipped} skipped · ${c.pending} running`} />
+        <Dot tint={p.checksLoaded === false ? "var(--text3)" : stateTint(p)}
+          title={p.checksLoaded === false ? "check states are still loading" : `${c.success} passed · ${c.failure} failed · ${c.skipped} skipped · ${c.pending} running`} />
         <span className="tabular-nums">
-          {c.total === 0 ? "no checks" : c.pending > 0 ? `${c.total - c.pending}/${c.total}` : c.failure > 0 ? `${c.failure} failing` : "green"}
+          {/* Not yet fetched is not the same as none. Saying "no checks" here
+              would be a claim about the repository rather than about us. */}
+          {p.checksLoaded === false ? "checks…"
+            : c.total === 0 ? "no checks"
+            : c.pending > 0 ? `${c.total - c.pending}/${c.total}`
+            : c.failure > 0 ? `${c.failure} failing` : "green"}
         </span>
         {p.isDraft ? <Chip text="draft" tint="var(--text3)" /> : <ReviewChip d={p.reviewDecision} />}
         <span className="ml-auto shrink-0">{ago(p.updatedAt)}</span>
@@ -307,7 +339,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [filter, setFilter] = useState<Filter>("mine");
   const [prs, setPrs] = useState<PrSummary[]>([]);
   const [counts, setCounts] = useState<Partial<Record<Filter, number>>>({});
-  const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; error?: string; needsAuth?: boolean }>({ fetchedAt: 0, loading: false });
+  const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; checksPending?: boolean; error?: string; needsAuth?: boolean }>({ fetchedAt: 0, loading: false });
   const [selected, setSelected] = useState<number | null>(null);
   const [detail, setDetail] = useState<PrDetail | null>(null);
   const [detailErr, setDetailErr] = useState("");
@@ -326,6 +358,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [wrap, setWrap] = useState(false);
   const [reviewOpen, setReviewOpen] = useState(false);
   const detailReq = useRef(0);
+  /** Which list request is current. A filter's answer takes seconds, and
+   *  without this the slower reply from the filter you just left overwrites the
+   *  one you switched to — the old selection reappearing under the new tab. */
+  const listReq = useRef(0);
 
   const flash = useCallback((ok: boolean, msg: string) => {
     setToast({ ok, msg });
@@ -342,14 +378,36 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   const loadList = useCallback((force = false) => {
     if (!root) return;
+    const req = ++listReq.current;
+    const want = filter;
     api.prList(root, filter, force).then((r) => {
+      if (req !== listReq.current) return; // a newer request already won
       setRepo(r.repo);
       setPrs(r.prs);
-      setCounts((c) => ({ ...c, [filter]: r.prs.length }));
-      setListState({ fetchedAt: r.fetchedAt, loading: r.loading, error: r.error, needsAuth: r.needsAuth });
+      setCounts((c) => ({ ...c, [want]: r.prs.length }));
+      setListState({ fetchedAt: r.fetchedAt, loading: r.loading, checksPending: r.checksPending, error: r.error, needsAuth: r.needsAuth });
       setSelected((cur) => (cur && r.prs.some((p) => p.number === cur) ? cur : r.prs[0]?.number ?? null));
-    }).catch((e) => setListState({ fetchedAt: 0, loading: false, error: String(e) }));
+    }).catch((e) => {
+      if (req !== listReq.current) return;
+      setListState({ fetchedAt: 0, loading: false, error: String(e) });
+    });
   }, [root, filter]);
+
+  /**
+   * Switching filter empties the pane before anything is fetched.
+   *
+   * Otherwise the previous filter's selection stays on screen for the second or
+   * two the new list takes, and you are reading one pull request under a tab
+   * that says you are looking at another.
+   */
+  useEffect(() => {
+    listReq.current++;
+    setPrs([]);
+    setSelected(null);
+    setDetail(null);
+    setDetailErr("");
+    setListState((st) => ({ ...st, loading: true, fetchedAt: 0 }));
+  }, [filter, root]);
 
   useEffect(() => {
     if (!active || !root) return;
@@ -358,12 +416,23 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     return () => clearInterval(t);
   }, [active, root, filter, loadList]);
 
-  // The review queue's size, so the filter can carry it without being opened.
+  /**
+   * Warm the filters you are not looking at.
+   *
+   * Each is its own cache entry on the server, so the first visit to a tab
+   * always paid the whole fetch. Touching them once fills the counts and leaves
+   * a warm cache to switch into. Staggered, because the server has one thread
+   * and three `gh` calls at once is the stall this panel exists to avoid.
+   */
   useEffect(() => {
-    if (!active || !root || filter === "review") return;
-    api.prList(root, "review", false)
-      .then((r) => setCounts((c) => ({ ...c, review: r.prs.length })))
-      .catch(() => {});
+    if (!active || !root) return;
+    const others = (["mine", "review", "all"] as Filter[]).filter((f) => f !== filter);
+    const timers = others.map((f, i) => setTimeout(() => {
+      api.prList(root, f, false)
+        .then((r) => setCounts((c) => ({ ...c, [f]: r.prs.length })))
+        .catch(() => {});
+    }, 1200 + i * 2500));
+    return () => timers.forEach(clearTimeout);
   }, [active, root, filter]);
 
   const loadDetail = useCallback((n: number, force = false) => {
@@ -539,8 +608,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
         ) : repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>}
         <div className="ml-auto flex items-center gap-2 shrink-0">
           {toast && <span className="text-[10px] max-w-[380px] truncate" style={{ color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</span>}
-          <span className="text-[10px] tabular-nums" style={{ color: "var(--text3)" }}>
-            {listState.loading ? "refreshing…" : listState.fetchedAt ? `⟳ ${ago(new Date(listState.fetchedAt).toISOString())}` : ""}
+          <span className="text-[10px] tabular-nums" style={{ color: listState.loading || listState.checksPending ? "var(--warning)" : "var(--text3)" }}>
+            {listState.loading ? "loading pull requests…"
+              : listState.checksPending ? "loading check states…"
+              : listState.fetchedAt ? `⟳ ${ago(new Date(listState.fetchedAt).toISOString())}` : ""}
           </span>
           <Btn onClick={() => loadList(true)} disabled={busy} small>refresh</Btn>
         </div>
@@ -574,9 +645,11 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
             ) : !repo ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>{listState.error || "no GitHub remote on this repository"}</div>
             ) : prs.length === 0 ? (
-              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
-                {listState.loading ? "loading…" : filter === "mine" ? "no open pull requests of yours" : filter === "review" ? "nothing waiting on your review" : "no open pull requests"}
-              </div>
+              listState.loading ? <Skeletons /> : (
+                <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
+                  {filter === "mine" ? "no open pull requests of yours" : filter === "review" ? "nothing waiting on your review" : "no open pull requests"}
+                </div>
+              )
             ) : prs.map((p) => (
               <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
             ))}
@@ -587,7 +660,11 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
         <div className="flex-1 flex flex-col min-w-0 min-h-0">
           {!d ? (
-            <div className="p-4 text-[11.5px]" style={{ color: "var(--text3)" }}>{detailErr || (selected == null ? "select a pull request" : "loading…")}</div>
+            <div className="p-4 text-[11.5px]" style={{ color: "var(--text3)" }}>
+              {detailErr ? detailErr
+                : selected == null ? (listState.loading ? "loading pull requests…" : "select a pull request")
+                : `loading #${selected}…`}
+            </div>
           ) : (
             <>
               <div className="flex border-b shrink-0 overflow-x-auto items-center" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -1,0 +1,896 @@
+// Pull requests, so a review does not mean opening a browser.
+//
+// Two things shape this panel more than anything else, both learned from real
+// PRs rather than guessed:
+//
+// 1. The conversation is mostly machines. On a real review, four issue comments
+//    were all from CI and one coverage table alone was 46,551 characters, while
+//    the single human review that blocked the merge sat at the bottom. So the
+//    conversation is three lanes — humans, line threads, automation — and the
+//    machine lane collapses to its digest.
+//
+// 2. Nothing here waits on the network. `gh` costs a second or more per call
+//    and the server has one thread; every read is a cached answer with its age
+//    on screen, and a refresh happens behind it.
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import type {
+  PrSummary, PrDetail, PrRepoId, PrThread, PrComment, PrReview, PrCheck, GitRepoRef,
+} from "../../../shared/types.ts";
+import { api } from "../lib/api.ts";
+import { useSidebarWidth } from "../lib/sidebarWidth.ts";
+import { SidebarGrip } from "./SidebarGrip.tsx";
+import { useDialogs } from "./ConfirmDialog.tsx";
+import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
+
+type Filter = "mine" | "review" | "all";
+type Tab = "overview" | "conversation" | "commits" | "files" | "checks";
+
+const FILTERS: { id: Filter; label: string; hint: string }[] = [
+  { id: "mine", label: "mine", hint: "pull requests you opened" },
+  { id: "review", label: "review", hint: "waiting on your review" },
+  { id: "all", label: "all", hint: "every open pull request" },
+];
+
+const POLL_MS = 20_000;
+/** Per-file "I have read this" ticks. Twelve files is two sittings, so it has
+ *  to survive a reload — and it is a local opinion, not GitHub state. */
+const SEEN_KEY = "agentglass.pr.seen";
+
+function loadSeen(): Record<string, string[]> {
+  try { return JSON.parse(localStorage.getItem(SEEN_KEY) || "{}"); } catch { return {}; }
+}
+function saveSeen(v: Record<string, string[]>) {
+  try { localStorage.setItem(SEEN_KEY, JSON.stringify(v)); } catch { /* private mode */ }
+}
+
+function ago(iso: string): string {
+  if (!iso) return "";
+  const s = Math.max(0, (Date.now() - new Date(iso).getTime()) / 1000);
+  if (s < 90) return "just now";
+  if (s < 3600) return `${Math.round(s / 60)}m`;
+  if (s < 86400) return `${Math.round(s / 3600)}h`;
+  return `${Math.round(s / 86400)}d`;
+}
+
+const stateTint = (p: PrSummary): string => {
+  if (p.checks.pending > 0) return "var(--warning)";
+  if (p.checks.verdict === "red") return "var(--error)";
+  if (p.checks.verdict === "green") return "var(--success)";
+  return "var(--text3)";
+};
+
+function Dot({ tint, title }: { tint: string; title?: string }) {
+  return <span title={title} className="inline-block shrink-0 rounded-full" style={{ width: 6, height: 6, background: tint }} />;
+}
+
+function Chip({ text, tint, title }: { text: string; tint: string; title?: string }) {
+  return (
+    <span title={title} className="shrink-0 text-[9px] px-1 py-px rounded uppercase tracking-wide"
+      style={{ color: tint, background: `color-mix(in srgb, ${tint} 13%, transparent)` }}>{text}</span>
+  );
+}
+
+/** The human verdict, which is not the same question as whether CI is green. */
+function ReviewChip({ d }: { d: PrSummary["reviewDecision"] }) {
+  if (d === "APPROVED") return <Chip text="approved" tint="var(--success)" />;
+  if (d === "CHANGES_REQUESTED") return <Chip text="changes" tint="var(--error)" />;
+  if (d === "REVIEW_REQUIRED") return <Chip text="waiting" tint="var(--warning)" />;
+  return null;
+}
+
+function Bar({ parts }: { parts: { pct: number; tint: string }[] }) {
+  return (
+    <div className="flex-1 h-1.5 rounded-full overflow-hidden flex min-w-[60px]"
+      style={{ background: "color-mix(in srgb, var(--border) 35%, transparent)" }}>
+      {parts.map((p, i) => <div key={i} style={{ width: `${p.pct}%`, background: p.tint }} />)}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// markdown, enough of it
+// ---------------------------------------------------------------------------
+
+/**
+ * A PR body is markdown with links, checklists, code fences and screenshots,
+ * and the screenshots are the point — a review body here routinely carries
+ * before/after evidence. Rather than pull in a markdown library for one panel,
+ * this renders the subset those bodies actually use.
+ *
+ * Everything is escaped first and only the recognised constructs are put back,
+ * so a body containing raw HTML renders as text rather than as markup. The body
+ * is written by anyone who can open a pull request; it is not trusted input.
+ */
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+function renderInline(s: string): string {
+  let out = escapeHtml(s);
+  out = out.replace(/`([^`]+)`/g, '<code class="px-1 rounded" style="background:color-mix(in srgb,var(--border) 30%,transparent)">$1</code>');
+  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong style="color:var(--text)">$1</strong>');
+  // Links only to http(s) — a markdown link is a place to smuggle javascript:.
+  out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_m, text: string, href: string) => `<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${text}</a>`);
+  out = out.replace(/(^|[\s(])((?:https?:\/\/)[^\s<)]+)/g,
+    (_m, pre: string, href: string) => `${pre}<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${href}</a>`);
+  return out;
+}
+
+type MdBlock =
+  | { kind: "text"; html: string }
+  | { kind: "code"; text: string }
+  | { kind: "image"; src: string; alt: string };
+
+/** Split a body into what has to render differently: fenced code, images
+ *  (which need the proxy), and everything else. */
+export function parseBody(body: string): MdBlock[] {
+  const blocks: MdBlock[] = [];
+  let buf: string[] = [];
+  const flush = () => {
+    if (!buf.length) return;
+    const html = buf.map((line) => {
+      const h = line.match(/^(#{1,6})\s+(.*)$/);
+      if (h) return `<div style="color:var(--text);font-weight:600;margin-top:.7em">${renderInline(h[2]!)}</div>`;
+      const task = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.*)$/);
+      if (task) {
+        const done = task[1]!.toLowerCase() === "x";
+        return `<div style="display:flex;gap:.4em;color:${done ? "var(--text3)" : "var(--text)"}">` +
+          `<span style="color:${done ? "var(--success)" : "var(--warning)"}">${done ? "✔" : "☐"}</span>` +
+          `<span>${renderInline(task[2]!)}</span></div>`;
+      }
+      const li = line.match(/^\s*[-*]\s+(.*)$/);
+      if (li) return `<div style="display:flex;gap:.4em"><span style="color:var(--primary)">·</span><span>${renderInline(li[1]!)}</span></div>`;
+      if (!line.trim()) return "<div style='height:.5em'></div>";
+      return `<div>${renderInline(line)}</div>`;
+    }).join("");
+    blocks.push({ kind: "text", html });
+    buf = [];
+  };
+
+  // `\r?\n`, not `\n`: GitHub bodies are CRLF, and a JS regex `.` matches
+  // neither `\n` nor `\r`, so every `(.*)$` rule below silently fails on a line
+  // that still carries its carriage return — headings, task boxes and images
+  // all render as plain text.
+  const lines = (body || "").split(/\r?\n/);
+  let fence: string[] | null = null;
+  for (const line of lines) {
+    if (line.trim().startsWith("```")) {
+      if (fence) { blocks.push({ kind: "code", text: fence.join("\n") }); fence = null; }
+      else { flush(); fence = []; }
+      continue;
+    }
+    if (fence) { fence.push(line); continue; }
+
+    const md = line.match(/^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/);
+    const html = line.match(/<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i);
+    if (md) { flush(); blocks.push({ kind: "image", src: md[2]!, alt: md[1]! }); continue; }
+    if (html) {
+      flush();
+      const alt = line.match(/\balt="([^"]*)"/i)?.[1] ?? "";
+      blocks.push({ kind: "image", src: html[1]!, alt });
+      continue;
+    }
+    buf.push(line);
+  }
+  if (fence) blocks.push({ kind: "code", text: fence.join("\n") });
+  flush();
+  return blocks;
+}
+
+function Body({ body }: { body: string }) {
+  const blocks = useMemo(() => parseBody(body), [body]);
+  return (
+    <div className="text-[11.5px] leading-relaxed" style={{ color: "var(--text2)" }}>
+      {blocks.map((b, i) => {
+        if (b.kind === "code") {
+          return (
+            <pre key={i} className="my-1.5 p-2 rounded overflow-x-auto text-[10.5px]"
+              style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+              {b.text}
+            </pre>
+          );
+        }
+        if (b.kind === "image") {
+          // Through the server: GitHub's own attachment URLs answer 404 without
+          // the token, and these images are the evidence in a review.
+          return (
+            <figure key={i} className="my-2">
+              <img src={api.prAssetUrl(b.src)} alt={b.alt} loading="lazy"
+                className="max-w-full rounded" style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }} />
+              {b.alt && <figcaption className="text-[9.5px] mt-1" style={{ color: "var(--text3)" }}>{b.alt}</figcaption>}
+            </figure>
+          );
+        }
+        return <div key={i} dangerouslySetInnerHTML={{ __html: b.html }} />;
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// list row
+// ---------------------------------------------------------------------------
+
+function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelect: () => void }) {
+  const c = p.checks;
+  return (
+    <button onClick={onSelect}
+      className="w-full text-left px-2.5 py-1.5 border-b"
+      style={{
+        borderColor: "color-mix(in srgb, var(--border) 22%, transparent)",
+        background: active ? "color-mix(in srgb, var(--primary) 14%, transparent)" : "transparent",
+        boxShadow: active ? "inset 2px 0 0 var(--primary)" : undefined,
+      }}>
+      <div className="flex items-center gap-1.5">
+        <span className="text-[10px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>#{p.number}</span>
+        <span className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>{p.title}</span>
+        {p.isCurrentBranch && <Chip text="here" tint="var(--primary)" title="this checkout is on that branch" />}
+      </div>
+      <div className="flex items-center gap-1.5 mt-0.5 text-[10px]" style={{ color: "var(--text3)" }}>
+        <Dot tint={stateTint(p)} title={`${c.success} passed · ${c.failure} failed · ${c.skipped} skipped · ${c.pending} running`} />
+        <span className="tabular-nums">
+          {c.total === 0 ? "no checks"
+            : c.pending > 0 ? `${c.total - c.pending}/${c.total}`
+            : c.failure > 0 ? `${c.failure} failing` : "green"}
+        </span>
+        {p.isDraft ? <Chip text="draft" tint="var(--text3)" /> : <ReviewChip d={p.reviewDecision} />}
+        <span className="ml-auto shrink-0">{ago(p.updatedAt)}</span>
+      </div>
+    </button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// panel
+// ---------------------------------------------------------------------------
+
+export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChatWith?: (cwd: string, prompt: string) => void }) {
+  const sidebarW = useSidebarWidth();
+  const { ask, askText, dialog } = useDialogs();
+
+  const [repos, setRepos] = useState<GitRepoRef[]>([]);
+  const [root, setRoot] = useState("");
+  const [repo, setRepo] = useState<PrRepoId | null>(null);
+  const [filter, setFilter] = useState<Filter>("mine");
+  const [prs, setPrs] = useState<PrSummary[]>([]);
+  const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; error?: string; needsAuth?: boolean }>({ fetchedAt: 0, loading: false });
+  const [selected, setSelected] = useState<number | null>(null);
+  const [detail, setDetail] = useState<PrDetail | null>(null);
+  const [detailErr, setDetailErr] = useState("");
+  const [tab, setTab] = useState<Tab>("overview");
+  const [busy, setBusy] = useState(false);
+  const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
+  const [rawBots, setRawBots] = useState(false);
+  const [seen, setSeen] = useState<Record<string, string[]>>(loadSeen);
+  const [diff, setDiff] = useState<string>("");
+  const detailReq = useRef(0);
+
+  const flash = useCallback((ok: boolean, msg: string) => {
+    setToast({ ok, msg });
+    setTimeout(() => setToast(null), 4200);
+  }, []);
+
+  useEffect(() => {
+    if (!active) return;
+    api.gitRepos().then(({ repos }) => {
+      setRepos(repos);
+      setRoot((cur) => cur || repos[0]?.root || "");
+    }).catch(() => {});
+  }, [active]);
+
+  const loadList = useCallback((force = false) => {
+    if (!root) return;
+    api.prList(root, filter, force).then((r) => {
+      setRepo(r.repo);
+      setPrs(r.prs);
+      setListState({ fetchedAt: r.fetchedAt, loading: r.loading, error: r.error, needsAuth: r.needsAuth });
+      setSelected((cur) => (cur && r.prs.some((p) => p.number === cur) ? cur : r.prs[0]?.number ?? null));
+    }).catch((e) => setListState({ fetchedAt: 0, loading: false, error: String(e) }));
+  }, [root, filter]);
+
+  // Poll the cache, not GitHub. The server refreshes behind these calls, so a
+  // 20s tick is a map lookup and the age below the header is the honest answer
+  // to "how fresh is this".
+  useEffect(() => {
+    if (!active || !root) return;
+    loadList();
+    const t = setInterval(() => loadList(), POLL_MS);
+    return () => clearInterval(t);
+  }, [active, root, filter, loadList]);
+
+  const loadDetail = useCallback((n: number, force = false) => {
+    const req = ++detailReq.current;
+    setDetailErr("");
+    api.prDetail(root, n, force).then((r) => {
+      if (req !== detailReq.current) return; // a later selection already won
+      if (r.ok && r.detail) setDetail(r.detail);
+      else { setDetail(null); setDetailErr(r.error || "could not load this pull request"); }
+    }).catch((e) => { if (req === detailReq.current) setDetailErr(String(e)); });
+  }, [root]);
+
+  useEffect(() => {
+    if (!active || !root || selected == null) { setDetail(null); return; }
+    setDiff("");
+    loadDetail(selected);
+  }, [active, root, selected, loadDetail]);
+
+  useEffect(() => {
+    if (tab !== "files" || !detail || diff || !root) return;
+    api.prDiff(root, detail.number).then((r) => setDiff(r.ok ? (r.text || "") : "")).catch(() => {});
+  }, [tab, detail, diff, root]);
+
+  const act = useCallback(async (label: string, fn: () => Promise<{ ok: boolean; error?: string; detail?: string }>) => {
+    if (busy) return false;
+    setBusy(true);
+    try {
+      const r = await fn();
+      flash(r.ok, r.ok ? (r.detail || `${label} — done`) : (r.error || `${label} failed`));
+      if (r.ok) { loadList(true); if (selected != null) loadDetail(selected, true); }
+      return r.ok;
+    } catch (e) { flash(false, String(e)); return false; }
+    finally { setBusy(false); }
+  }, [busy, flash, loadList, selected, loadDetail]);
+
+  // --- conversation lanes -------------------------------------------------
+  const lanes = useMemo(() => {
+    if (!detail) return { humans: [] as PrReview[], bots: [] as PrComment[], botReviews: [] as PrReview[], humanComments: [] as PrComment[] };
+    return {
+      humans: detail.reviews.filter((r) => !r.isBot && (r.body.trim() || r.state !== "COMMENTED")),
+      botReviews: detail.reviews.filter((r) => r.isBot && r.body.trim()),
+      humanComments: detail.comments.filter((c) => !c.isBot),
+      bots: detail.comments.filter((c) => c.isBot),
+    };
+  }, [detail]);
+
+  const botBytes = useMemo(() => lanes.bots.reduce((n, c) => n + c.body.length, 0), [lanes.bots]);
+  const openThreads = useMemo(() => (detail?.threads ?? []).filter((t) => !t.isResolved), [detail]);
+
+  const seenKey = repo && detail ? `${repo.key}#${detail.number}` : "";
+  const seenFiles = seenKey ? (seen[seenKey] ?? []) : [];
+  const toggleSeen = (path: string) => {
+    if (!seenKey) return;
+    setSeen((cur) => {
+      const list = new Set(cur[seenKey] ?? []);
+      if (list.has(path)) list.delete(path); else list.add(path);
+      const next = { ...cur, [seenKey]: [...list] };
+      saveSeen(next);
+      return next;
+    });
+  };
+
+  // --- actions ------------------------------------------------------------
+  const doReview = async (verb: "approve" | "request_changes" | "comment") => {
+    if (!detail) return;
+    const noun = verb === "approve" ? "Approve" : verb === "request_changes" ? "Request changes on" : "Comment on";
+    const body = await askText({
+      title: `${noun} #${detail.number}`,
+      body: verb === "approve" ? "A note is optional for an approval." : "This is posted to GitHub and your team can see it.",
+      confirmLabel: "Submit review",
+      input: { label: "Review body", placeholder: verb === "approve" ? "optional" : "what needs to change…" },
+    });
+    if (body === null) return;
+    await act("review", () => api.prReview(root, detail.number, verb, body));
+  };
+
+  const doMerge = async () => {
+    if (!detail) return;
+    const head = detail.commits[detail.commits.length - 1]?.oid;
+    const ok = await ask({
+      title: `Merge #${detail.number} into ${detail.baseRefName}?`,
+      body: `${detail.title}\n\nSquash and merge, then delete the branch. This is public and cannot be undone from here.` +
+        (head ? `\n\nPinned to ${head.slice(0, 8)} — if anyone pushes before this lands, GitHub will refuse rather than merge a commit you have not seen.` : ""),
+      confirmLabel: "Squash & merge",
+      danger: true,
+    });
+    if (!ok) return;
+    await act("merge", () => api.prMerge(root, detail.number, "squash", { deleteBranch: true, headSha: head }));
+  };
+
+  const doClose = async () => {
+    if (!detail) return;
+    const ok = await ask({
+      title: `Close #${detail.number}?`,
+      body: `${detail.title}\n\nThe pull request is closed without merging. You can reopen it afterwards.`,
+      confirmLabel: "Close pull request",
+      danger: true,
+    });
+    if (!ok) return;
+    await act("close", () => api.prClose(root, detail.number));
+  };
+
+  const doLocalReview = async () => {
+    if (!detail) return;
+    setBusy(true);
+    try {
+      const r = await api.prLocalReview(root, detail.number);
+      if (!r.ok || !r.cwd || !r.prompt) { flash(false, r.error || "could not prepare the review"); return; }
+      if (onOpenChatWith) { onOpenChatWith(r.cwd, r.prompt); flash(true, `checked out #${detail.number} — review running in chat`); }
+      else flash(true, `checked out at ${r.cwd}`);
+    } catch (e) { flash(false, String(e)); }
+    finally { setBusy(false); }
+  };
+
+  // --- render -------------------------------------------------------------
+  const d = detail;
+  const checks = d?.checks;
+  const TABS: { id: Tab; label: string; n?: number; warn?: boolean }[] = d ? [
+    { id: "overview", label: "overview", warn: d.checklist.some((c) => !c.checked) },
+    { id: "conversation", label: "conversation", n: lanes.humans.length + lanes.humanComments.length + d.threads.length + lanes.bots.length },
+    { id: "commits", label: "commits", n: d.commits.length },
+    { id: "files", label: "files", n: d.files.length },
+    { id: "checks", label: "checks", n: d.checks.total, warn: d.checks.failure > 0 },
+  ] : [];
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <style>{SCROLLBAR_CSS}</style>
+      <div className={viewHeaderClass} style={viewHeaderStyle}>
+        <span className={viewTitleClass} style={{ color: "var(--text)" }}>pr</span>
+        {repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>}
+        {repos.length > 1 && (
+          <select value={root} onChange={(e) => { setRoot(e.target.value); setSelected(null); setDetail(null); }}
+            className="text-[10px] px-1 py-0.5 rounded bg-transparent max-w-[190px]"
+            style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+            {repos.map((r) => <option key={r.root} value={r.root} style={{ background: "var(--bg)" }}>{r.root.split("/").pop()}</option>)}
+          </select>
+        )}
+        <div className="ml-auto flex items-center gap-2 shrink-0">
+          {toast && (
+            <span className="text-[10px] max-w-[340px] truncate" style={{ color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</span>
+          )}
+          <span className="text-[10px] tabular-nums" style={{ color: "var(--text3)" }}>
+            {listState.loading ? "refreshing…" : listState.fetchedAt ? `⟳ ${ago(new Date(listState.fetchedAt).toISOString())}` : ""}
+          </span>
+          <button onClick={() => loadList(true)} disabled={busy}
+            className="text-[10px] px-1.5 py-0.5 rounded"
+            style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>refresh</button>
+        </div>
+      </div>
+
+      <div className="flex flex-1 min-h-0">
+        {/* ---- list ---- */}
+        <div className="flex flex-col min-h-0 shrink-0" style={{ width: sidebarW }}>
+          <div className="flex gap-1 px-2 py-1.5 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+            {FILTERS.map((f) => (
+              <button key={f.id} onClick={() => setFilter(f.id)} title={f.hint}
+                className="text-[10px] px-2 py-0.5 rounded-full"
+                style={{
+                  color: filter === f.id ? "var(--bg)" : "var(--text2)",
+                  background: filter === f.id ? "var(--primary)" : "transparent",
+                  border: `1px solid ${filter === f.id ? "var(--primary)" : "color-mix(in srgb, var(--border) 45%, transparent)"}`,
+                }}>{f.label}{filter === f.id && prs.length > 0 && <span className="ml-1 tabular-nums opacity-75">{prs.length}</span>}</button>
+            ))}
+          </div>
+          <div className="flex-1 overflow-y-auto min-h-0 ag-scroll">
+            {listState.needsAuth ? (
+              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
+                <div style={{ color: "var(--warning)" }}>{listState.error || "the GitHub CLI is not set up"}</div>
+                <div className="mt-2">Pull requests come from <code>gh</code>. Install it and run <code>gh auth login</code>, then hit refresh.</div>
+              </div>
+            ) : !repo ? (
+              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>{listState.error || "no GitHub remote on this repository"}</div>
+            ) : prs.length === 0 ? (
+              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
+                {listState.loading ? "loading…" : filter === "mine" ? "no open pull requests of yours" : filter === "review" ? "nothing waiting on your review" : "no open pull requests"}
+              </div>
+            ) : prs.map((p) => (
+              <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
+            ))}
+          </div>
+        </div>
+
+        <SidebarGrip />
+
+        {/* ---- detail ---- */}
+        <div className="flex-1 flex flex-col min-w-0 min-h-0">
+          {!d ? (
+            <div className="p-4 text-[11.5px]" style={{ color: "var(--text3)" }}>{detailErr || (selected == null ? "select a pull request" : "loading…")}</div>
+          ) : (
+            <>
+              <div className="flex gap-0 border-b shrink-0 overflow-x-auto" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+                {TABS.map((t) => (
+                  <button key={t.id} onClick={() => setTab(t.id)}
+                    className="text-[10.5px] px-3 py-1.5 whitespace-nowrap"
+                    style={{
+                      color: tab === t.id ? "var(--text)" : "var(--text3)",
+                      borderBottom: `2px solid ${tab === t.id ? "var(--primary)" : "transparent"}`,
+                      background: tab === t.id ? "color-mix(in srgb, var(--primary) 8%, transparent)" : "transparent",
+                    }}>
+                    {t.label}
+                    {t.n != null && <span className="ml-1 tabular-nums opacity-60">{t.n}</span>}
+                    {t.warn && <span className="ml-1" style={{ color: "var(--warning)" }}>●</span>}
+                  </button>
+                ))}
+              </div>
+
+              <div className="flex-1 overflow-y-auto min-h-0 ag-scroll p-3">
+                {tab === "overview" && <Overview d={d} onLocalReview={doLocalReview} busy={busy}
+                  onMerge={doMerge} onClose={doClose} onUpdateBranch={() => act("update branch", () => api.prUpdateBranch(root, d.number))}
+                  onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))}
+                  onAutoMerge={() => act("auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
+                  onDraft={() => act(d.isDraft ? "mark ready" : "convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
+                  openThreads={openThreads.length} />}
+
+                {tab === "conversation" && (
+                  <Conversation
+                    d={d} lanes={lanes} botBytes={botBytes} raw={rawBots} onRaw={setRawBots}
+                    onResolve={(t) => act(t.isResolved ? "unresolve" : "resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
+                    onReply={async (t) => {
+                      const first = t.comments[0];
+                      if (!first) return;
+                      const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply", placeholder: "…" } });
+                      if (body === null || !body.trim()) return;
+                      await act("reply", () => api.prReply(root, d.number, Number(first.id), body));
+                    }}
+                    onReview={doReview} busy={busy}
+                  />
+                )}
+
+                {tab === "commits" && (
+                  <div className="text-[11px]">
+                    {d.commits.map((c) => (
+                      <div key={c.oid} className="flex items-center gap-2 py-1 border-b" style={{ borderColor: "color-mix(in srgb, var(--border) 18%, transparent)", opacity: c.isMerge ? 0.5 : 1 }}>
+                        <span className="tabular-nums shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.short}</span>
+                        <span className="truncate" style={{ color: "var(--text2)" }}>{c.message}</span>
+                        {c.isMerge && <Chip text="merge" tint="var(--text3)" title="trunk catch-up, not work to review" />}
+                        <span className="ml-auto shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>{c.author}</span>
+                      </div>
+                    ))}
+                  </div>
+                )}
+
+                {tab === "files" && (
+                  <div className="text-[11px]">
+                    <div className="flex items-center gap-2 mb-2 text-[10px]" style={{ color: "var(--text3)" }}>
+                      <span className="tabular-nums">{seenFiles.length}/{d.files.length} reviewed</span>
+                      <Bar parts={[{ pct: d.files.length ? (seenFiles.length / d.files.length) * 100 : 0, tint: "var(--primary)" }]} />
+                    </div>
+                    {d.files.map((f) => {
+                      const done = seenFiles.includes(f.path);
+                      return (
+                        <label key={f.path} className="flex items-center gap-2 py-1 border-b cursor-pointer"
+                          style={{ borderColor: "color-mix(in srgb, var(--border) 18%, transparent)" }}>
+                          <input type="checkbox" checked={done} onChange={() => toggleSeen(f.path)} style={{ accentColor: "var(--primary)" }} />
+                          <span className="truncate" style={{ color: done ? "var(--text3)" : "var(--text2)", textDecoration: done ? "line-through" : undefined }}>{f.path}</span>
+                          {f.comments > 0 && <Chip text={`${f.comments} open`} tint="var(--warning)" />}
+                          <span className="ml-auto shrink-0 tabular-nums" style={{ color: "var(--success)" }}>+{f.additions}</span>
+                          <span className="shrink-0 tabular-nums" style={{ color: "var(--error)" }}>−{f.deletions}</span>
+                        </label>
+                      );
+                    })}
+                    {diff && (
+                      <pre className="mt-3 p-2 rounded overflow-x-auto text-[10.5px] leading-snug"
+                        style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)", maxHeight: 460 }}>
+                        {diff.split("\n").map((l, i) => (
+                          <div key={i} style={{
+                            color: l.startsWith("+") && !l.startsWith("+++") ? "var(--success)"
+                              : l.startsWith("-") && !l.startsWith("---") ? "var(--error)"
+                              : l.startsWith("@@") ? "var(--primary)" : "var(--text3)",
+                          }}>{l || " "}</div>
+                        ))}
+                      </pre>
+                    )}
+                  </div>
+                )}
+
+                {tab === "checks" && checks && <Checks d={d} onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))} busy={busy} />}
+              </div>
+            </>
+          )}
+        </div>
+      </div>
+      {dialog}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// overview
+// ---------------------------------------------------------------------------
+
+const MERGE_WHY: Record<string, string> = {
+  BLOCKED: "a required review or check has not passed",
+  BEHIND: "the base branch has moved — update the branch first",
+  DIRTY: "there are conflicts with the base branch",
+  UNSTABLE: "a check is failing",
+  DRAFT: "this is a draft",
+  HAS_HOOKS: "a repository hook is blocking the merge",
+  UNKNOWN: "GitHub has not finished working it out",
+};
+
+function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onDraft }: {
+  d: PrDetail; busy: boolean; openThreads: number;
+  onLocalReview: () => void; onMerge: () => void; onClose: () => void;
+  onUpdateBranch: () => void; onRerun: () => void; onAutoMerge: () => void; onDraft: () => void;
+}) {
+  const done = d.checklist.filter((c) => c.checked).length;
+  const open = d.checklist.length - done;
+  const c = d.checks;
+  const canMerge = d.mergeState === "CLEAN";
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div>
+        <div className="text-[13px]" style={{ color: "var(--text)" }}>{d.title}</div>
+        <div className="text-[10px] mt-0.5" style={{ color: "var(--text3)" }}>
+          #{d.number} · {d.author} · {d.headRefName} → {d.baseRefName} · +{d.additions} −{d.deletions} · {d.changedFiles} files
+        </div>
+        {d.labels.length > 0 && (
+          <div className="flex gap-1 flex-wrap mt-1.5">
+            {d.labels.map((l) => <Chip key={l.name} text={l.name} tint="var(--primary)" />)}
+          </div>
+        )}
+      </div>
+
+      {d.forcePushedSinceReview && (
+        <div className="text-[10.5px] px-2 py-1.5 rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 10%, transparent)" }}>
+          The author force-pushed after the last review — that review was for code that is no longer here.
+        </div>
+      )}
+
+      {/* merge, and why not */}
+      <section className="rounded" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
+        <div className="flex items-center gap-2 px-2 py-1 text-[9.5px] uppercase tracking-wider border-b"
+          style={{ color: "var(--text3)", borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+          <span>merge</span>
+          <span className="ml-auto" style={{ color: canMerge ? "var(--success)" : "var(--error)" }}>{canMerge ? "ready" : d.mergeState.toLowerCase()}</span>
+        </div>
+        <div className="p-2 text-[11px]" style={{ color: "var(--text2)" }}>
+          {!canMerge && (
+            <div className="flex gap-1.5 items-start mb-1">
+              <Dot tint="var(--error)" /><span>{MERGE_WHY[d.mergeState] ?? "not mergeable"}</span>
+            </div>
+          )}
+          {d.reviewDecision === "CHANGES_REQUESTED" && (
+            <div className="flex gap-1.5 items-start mb-1"><Dot tint="var(--error)" /><span>changes requested</span></div>
+          )}
+          {openThreads > 0 && (
+            <div className="flex gap-1.5 items-start mb-1">
+              <Dot tint="var(--warning)" />
+              <span>{openThreads} review thread{openThreads === 1 ? "" : "s"} still open — a reply is not a resolve</span>
+            </div>
+          )}
+          {c.failure > 0 && (
+            <div className="flex gap-1.5 items-start mb-1">
+              <Dot tint="var(--error)" />
+              <span>{c.failing.map((f) => f.name).slice(0, 3).join(", ")}{c.failing.length > 3 ? ` +${c.failing.length - 3}` : ""}</span>
+            </div>
+          )}
+          {canMerge && <div className="flex gap-1.5 items-start mb-1"><Dot tint="var(--success)" /><span>nothing is blocking this</span></div>}
+
+          <div className="flex gap-1.5 flex-wrap mt-2">
+            <Btn onClick={onMerge} disabled={busy || !canMerge} danger title={canMerge ? "squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>squash &amp; merge</Btn>
+            <Btn onClick={onAutoMerge} disabled={busy}>merge when green</Btn>
+            <Btn onClick={onUpdateBranch} disabled={busy} title="merge the base branch into this one">update branch</Btn>
+            {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
+            <Btn onClick={onDraft} disabled={busy}>{d.isDraft ? "mark ready" : "to draft"}</Btn>
+            <Btn onClick={onClose} disabled={busy} danger>close</Btn>
+          </div>
+        </div>
+      </section>
+
+      {d.checklist.length > 0 && (
+        <section>
+          <div className="flex items-center gap-2 text-[9.5px] uppercase tracking-wider mb-1" style={{ color: "var(--text3)" }}>
+            <span>checklist</span>
+            {open > 0 && <span style={{ color: "var(--warning)" }}>{open} open</span>}
+            <span className="ml-auto tabular-nums">{done}/{d.checklist.length}</span>
+          </div>
+          <Bar parts={[
+            { pct: (done / d.checklist.length) * 100, tint: "var(--success)" },
+            { pct: (open / d.checklist.length) * 100, tint: "var(--warning)" },
+          ]} />
+        </section>
+      )}
+
+      <section>
+        <div className="text-[9.5px] uppercase tracking-wider mb-1" style={{ color: "var(--text3)" }}>description</div>
+        <Body body={d.body} />
+      </section>
+
+      <div className="flex gap-1.5 flex-wrap">
+        <Btn onClick={onLocalReview} disabled={busy} primary
+          title="check the PR out into a throwaway worktree and review it with the full repo in context">review locally with Claude</Btn>
+        <a href={d.url} target="_blank" rel="noreferrer noopener"
+          className="text-[10px] px-2 py-1 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>open on GitHub ↗</a>
+      </div>
+    </div>
+  );
+}
+
+function Btn({ children, onClick, disabled, danger, primary, title }: {
+  children: React.ReactNode; onClick: () => void; disabled?: boolean; danger?: boolean; primary?: boolean; title?: string;
+}) {
+  const tint = danger ? "var(--error)" : primary ? "var(--primary)" : "var(--border)";
+  return (
+    <button onClick={onClick} disabled={disabled} title={title}
+      className="text-[10px] px-2 py-1 rounded disabled:opacity-40"
+      style={{
+        color: primary ? "var(--bg)" : danger ? "var(--error)" : "var(--text2)",
+        background: primary ? "var(--primary)" : "transparent",
+        border: `1px solid color-mix(in srgb, ${tint} ${primary ? 100 : 50}%, transparent)`,
+        cursor: disabled ? "not-allowed" : "pointer",
+      }}>{children}</button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// conversation
+// ---------------------------------------------------------------------------
+
+function Lane({ label, extra }: { label: string; extra?: string }) {
+  return (
+    <div className="flex items-center gap-2 mt-3 mb-1.5 text-[9.5px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>
+      <span>{label}</span>
+      {extra && <span>{extra}</span>}
+      <span className="flex-1 h-px" style={{ background: "color-mix(in srgb, var(--border) 30%, transparent)" }} />
+    </div>
+  );
+}
+
+function Conversation({ d, lanes, botBytes, raw, onRaw, onResolve, onReply, onReview, busy }: {
+  d: PrDetail;
+  lanes: { humans: PrReview[]; botReviews: PrReview[]; humanComments: PrComment[]; bots: PrComment[] };
+  botBytes: number; raw: boolean; onRaw: (v: boolean) => void;
+  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void;
+  onReview: (v: "approve" | "request_changes" | "comment") => void; busy: boolean;
+}) {
+  const kb = Math.round(botBytes / 1024);
+  return (
+    <div className="text-[11px]">
+      <Lane label="humans" />
+      {lanes.humans.length === 0 && lanes.humanComments.length === 0 && (
+        <div style={{ color: "var(--text3)" }}>Nobody has said anything yet.</div>
+      )}
+      {lanes.humans.map((r, i) => (
+        <div key={`r${i}`} className="mb-1.5 p-2 rounded"
+          style={{
+            background: "color-mix(in srgb, var(--border) 12%, transparent)",
+            borderLeft: `2px solid ${r.state === "CHANGES_REQUESTED" ? "var(--error)" : r.state === "APPROVED" ? "var(--success)" : "var(--primary)"}`,
+          }}>
+          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
+            <b style={{ color: "var(--text)", fontWeight: 500 }}>{r.author}</b>
+            {r.state === "CHANGES_REQUESTED" && <Chip text="changes requested" tint="var(--error)" />}
+            {r.state === "APPROVED" && <Chip text="approved" tint="var(--success)" />}
+            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(r.submittedAt)}</span>
+          </div>
+          {r.body && <Body body={r.body} />}
+        </div>
+      ))}
+      {lanes.humanComments.map((c) => (
+        <div key={c.id} className="mb-1.5 p-2 rounded" style={{ background: "color-mix(in srgb, var(--border) 12%, transparent)", borderLeft: "2px solid var(--primary)" }}>
+          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
+            <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
+            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
+          </div>
+          <Body body={c.body} />
+        </div>
+      ))}
+
+      <Lane label="line threads" extra={d.threads.length ? `${d.threads.filter((t) => !t.isResolved).length} open of ${d.threads.length}` : undefined} />
+      {d.threads.length === 0 && <div style={{ color: "var(--text3)" }}>No line comments.</div>}
+      {d.threads.map((t) => (
+        <div key={t.id} className="mb-1.5 rounded" style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+          <div className="flex items-center gap-1.5 px-2 py-1 border-b text-[10px]" style={{ borderColor: "color-mix(in srgb, var(--border) 22%, transparent)" }}>
+            <span style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
+            {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="the code under this comment has changed since" />}
+            <span className="ml-auto" style={{ color: t.isResolved ? "var(--success)" : "var(--warning)" }}>{t.isResolved ? "resolved" : "open"}</span>
+          </div>
+          {t.comments.map((c, i) => (
+            <div key={c.id} className="px-2 py-1.5" style={{ paddingLeft: i ? 18 : 8, background: i ? "color-mix(in srgb, var(--border) 10%, transparent)" : undefined }}>
+              <div className="flex items-center gap-1.5 mb-0.5 text-[10px]">
+                <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
+                {c.isBot && <Chip text="automation" tint="var(--info)" />}
+                <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
+              </div>
+              <Body body={c.body} />
+            </div>
+          ))}
+          <div className="flex gap-1.5 px-2 py-1.5">
+            <Btn onClick={() => onReply(t)} disabled={busy}>reply</Btn>
+            <Btn onClick={() => onResolve(t)} disabled={busy}>{t.isResolved ? "unresolve" : "resolve"}</Btn>
+          </div>
+        </div>
+      ))}
+
+      <Lane label="automation" extra={lanes.bots.length ? `${lanes.bots.length} comments · ${kb} KB` : undefined} />
+      {lanes.botReviews.map((r, i) => (
+        <div key={`br${i}`} className="mb-1.5 p-2 rounded" style={{ background: "color-mix(in srgb, var(--border) 10%, transparent)", borderLeft: "2px solid var(--info)" }}>
+          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
+            <b style={{ color: "var(--text)", fontWeight: 500 }}>{r.author}</b><Chip text="automation" tint="var(--info)" />
+            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(r.submittedAt)}</span>
+          </div>
+          <Body body={r.body} />
+        </div>
+      ))}
+      {lanes.bots.length > 0 && (
+        <>
+          {/* A real coverage comment is 46,551 characters and about three
+              numbers. Show the numbers; keep the rest one click away. */}
+          <button onClick={() => onRaw(!raw)} className="w-full text-left text-[10px] px-2 py-1 rounded mb-1.5"
+            style={{ color: "var(--text2)", border: "1px dashed color-mix(in srgb, var(--border) 50%, transparent)" }}>
+            <span style={{ color: "var(--primary)" }}>{raw ? "▾" : "▸"}</span>{" "}
+            {lanes.bots.length} machine comment{lanes.bots.length === 1 ? "" : "s"} · {kb} KB {raw ? "— hide raw" : "collapsed — show raw"}
+          </button>
+          {lanes.bots.map((c) => (
+            <div key={c.id} className="mb-1.5 p-2 rounded" style={{ background: "color-mix(in srgb, var(--border) 10%, transparent)", borderLeft: "2px solid var(--info)" }}>
+              <div className="flex items-center gap-1.5 mb-0.5 text-[10px]">
+                <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b><Chip text="automation" tint="var(--info)" />
+                <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
+              </div>
+              {raw
+                ? <pre className="overflow-x-auto text-[10px] max-h-64" style={{ ...CODE_FONT_STYLE, color: "var(--text3)" }}>{c.body}</pre>
+                : <div style={{ color: "var(--text2)" }}>{c.digest || "(nothing worth pulling out)"}</div>}
+            </div>
+          ))}
+        </>
+      )}
+
+      <div className="flex gap-1.5 flex-wrap mt-3">
+        <Btn onClick={() => onReview("comment")} disabled={busy}>comment</Btn>
+        <Btn onClick={() => onReview("approve")} disabled={busy}>approve</Btn>
+        <Btn onClick={() => onReview("request_changes")} disabled={busy} danger>request changes</Btn>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// checks
+// ---------------------------------------------------------------------------
+
+const CHECK_TINT: Record<PrCheck["state"], string> = {
+  success: "var(--success)", failure: "var(--error)", pending: "var(--warning)",
+  skipped: "var(--text3)", neutral: "var(--text3)",
+};
+
+function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: boolean }) {
+  const c = d.checks;
+  const pct = (n: number) => (c.total ? (n / c.total) * 100 : 0);
+  return (
+    <div className="text-[11px]">
+      <div className="flex items-center gap-2 mb-2 tabular-nums">
+        <span style={{ color: "var(--success)" }}>{c.success} ✓</span>
+        <span style={{ color: "var(--text3)" }}>{c.skipped} ⊘</span>
+        <span style={{ color: "var(--error)" }}>{c.failure} ✕</span>
+        {c.pending > 0 && <span style={{ color: "var(--warning)" }}>{c.pending} running</span>}
+        <Bar parts={[
+          { pct: pct(c.success), tint: "var(--success)" },
+          { pct: pct(c.failure), tint: "var(--error)" },
+          { pct: pct(c.pending), tint: "var(--warning)" },
+          { pct: pct(c.skipped), tint: "color-mix(in srgb, var(--text3) 40%, transparent)" },
+        ]} />
+      </div>
+
+      {c.failing.length > 0 && (
+        <div className="mb-2">
+          {c.failing.map((f, i) => (
+            <div key={i} className="flex items-center gap-1.5 py-1 px-2 mb-1 rounded"
+              style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 9%, transparent)" }}>
+              <Dot tint="var(--error)" />
+              <span style={{ color: "var(--text)" }}>{f.name}</span>
+              {f.workflow && <span className="text-[10px]" style={{ color: "var(--text3)" }}>{f.workflow}</span>}
+              {f.url && <a href={f.url} target="_blank" rel="noreferrer noopener" className="ml-auto text-[10px]" style={{ color: "var(--text2)" }}>log ↗</a>}
+            </div>
+          ))}
+          <Btn onClick={onRerun} disabled={busy}>re-run failed jobs</Btn>
+        </div>
+      )}
+
+      <div className="text-[10px] mb-2" style={{ color: "var(--text3)" }}>
+        {c.allDone
+          ? `all ${c.total} checks are done — ${c.verdict === "green" ? "green" : "red"}. One notification was sent, not ${c.total}.`
+          : `${c.pending} of ${c.total} still running — you will be told once, when the last one lands.`}
+      </div>
+
+      <div className="flex flex-wrap gap-0.5 mb-2">
+        {d.checksAll.map((k, i) => (
+          <span key={i} title={`${k.name}${k.workflow ? ` · ${k.workflow}` : ""} — ${k.state}`}
+            style={{ width: 11, height: 11, borderRadius: 2, background: CHECK_TINT[k.state], opacity: k.state === "skipped" || k.state === "neutral" ? 0.4 : 1 }} />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -1,28 +1,35 @@
 // Pull requests, so a review does not mean opening a browser.
 //
-// Two things shape this panel more than anything else, both learned from real
-// PRs rather than guessed:
+// What shapes this panel, all of it learned from real pull requests rather than
+// guessed:
 //
-// 1. The conversation is mostly machines. On a real review, four issue comments
+// 1. The conversation is mostly machines. On a live review, four issue comments
 //    were all from CI and one coverage table alone was 46,551 characters, while
-//    the single human review that blocked the merge sat at the bottom. So the
-//    conversation is three lanes — humans, line threads, automation — and the
-//    machine lane collapses to its digest.
+//    the single human review that blocked the merge sat last. So it reads in
+//    three lanes — humans, line threads, automation — and the machine lane
+//    collapses to its digest.
 //
-// 2. Nothing here waits on the network. `gh` costs a second or more per call
-//    and the server has one thread; every read is a cached answer with its age
-//    on screen, and a refresh happens behind it.
+// 2. A body is markdown, and prose set to the full width of a 2000px window is
+//    unreadable however correct the formatting. Everything written by a person
+//    renders through `Md`, which holds a reading measure and centres it.
+//
+// 3. Diffs are not re-implemented. `SplitDiff`/`UnifiedDiff` from ChangesModal
+//    are the app's diff viewer, keybindings and all; a pull request is
+//    translated into the `FileChange` they already speak.
+//
+// 4. Nothing waits on the network. `gh` costs a second or more per call and the
+//    server has one thread; every read is a cached answer with its age shown.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type {
-  PrSummary, PrDetail, PrRepoId, PrThread, PrComment, PrReview, PrCheck, GitRepoRef,
+  PrSummary, PrDetail, PrRepoId, PrThread, PrComment, PrReview, PrCheck, GitRepoRef, FileChange,
 } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
-import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
-import { parseBody, renderInline, splitDiff, lineTint, type MdBlock } from "../lib/prBody.ts";
+import { SCROLLBAR_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle } from "./ChangesModal.tsx";
+import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks";
@@ -34,16 +41,16 @@ const FILTERS: { id: Filter; label: string; hint: string }[] = [
 ];
 
 const POLL_MS = 20_000;
-/** Per-file "I have read this" ticks. Twelve files is two sittings, so it has
- *  to survive a reload — and it is a local opinion, not GitHub state. */
 const SEEN_KEY = "agentglass.pr.seen";
+const DRAFT_KEY = "agentglass.pr.drafts";
 
-function loadSeen(): Record<string, string[]> {
-  try { return JSON.parse(localStorage.getItem(SEEN_KEY) || "{}"); } catch { return {}; }
-}
-function saveSeen(v: Record<string, string[]>) {
-  try { localStorage.setItem(SEEN_KEY, JSON.stringify(v)); } catch { /* private mode */ }
-}
+/** A line comment written but not yet sent — GitHub's "pending review". */
+export interface DraftComment { path: string; line: number; body: string }
+
+const loadMap = <T,>(k: string): Record<string, T> => {
+  try { return JSON.parse(localStorage.getItem(k) || "{}"); } catch { return {}; }
+};
+const saveMap = (k: string, v: unknown) => { try { localStorage.setItem(k, JSON.stringify(v)); } catch { /* private mode */ } };
 
 function ago(iso: string): string {
   if (!iso) return "";
@@ -67,12 +74,11 @@ function Dot({ tint, title }: { tint: string; title?: string }) {
 
 function Chip({ text, tint, title }: { text: string; tint: string; title?: string }) {
   return (
-    <span title={title} className="shrink-0 text-[9px] px-1 py-px rounded uppercase tracking-wide"
-      style={{ color: tint, background: `color-mix(in srgb, ${tint} 13%, transparent)` }}>{text}</span>
+    <span title={title} className="shrink-0 text-[9px] px-1.5 py-px rounded-full uppercase tracking-wide"
+      style={{ color: tint, background: `color-mix(in srgb, ${tint} 14%, transparent)` }}>{text}</span>
   );
 }
 
-/** The human verdict, which is not the same question as whether CI is green. */
 function ReviewChip({ d }: { d: PrSummary["reviewDecision"] }) {
   if (d === "APPROVED") return <Chip text="approved" tint="var(--success)" />;
   if (d === "CHANGES_REQUESTED") return <Chip text="changes" tint="var(--error)" />;
@@ -89,103 +95,172 @@ function Bar({ parts }: { parts: { pct: number; tint: string }[] }) {
   );
 }
 
-// ---------------------------------------------------------------------------
-// markdown, enough of it
-// ---------------------------------------------------------------------------
-
-/**
- * A PR body is markdown with links, checklists, code fences and screenshots,
- * and the screenshots are the point — a review body here routinely carries
- * before/after evidence. Rather than pull in a markdown library for one panel,
- * this renders the subset those bodies actually use.
- *
- * Everything is escaped first and only the recognised constructs are put back,
- * so a body containing raw HTML renders as text rather than as markup. The body
- * is written by anyone who can open a pull request; it is not trusted input.
- */
-function Body({ body }: { body: string }) {
-  const blocks = useMemo(() => parseBody(body), [body]);
+/** GitHub's avatar for a login, through the server's allowlisted proxy. The
+ *  name is always beside it — the picture is recognition, not identification. */
+function Avatar({ login, size = 18 }: { login: string; size?: number }) {
+  const [failed, setFailed] = useState(false);
+  const initials = (login || "?").replace(/\[bot\]$/, "").slice(0, 2).toUpperCase();
+  if (failed || !login) {
+    return (
+      <span className="shrink-0 rounded-full inline-flex items-center justify-center"
+        style={{ width: size, height: size, background: "var(--primary)", color: "var(--bg)", fontSize: size * 0.42 }}>{initials}</span>
+    );
+  }
   return (
-    <div className="text-[11.5px] leading-relaxed" style={{ color: "var(--text2)" }}>
-      {blocks.map((b, i) => {
-        if (b.kind === "code") {
-          return (
-            <pre key={i} className="my-1.5 p-2 rounded overflow-x-auto text-[10.5px]"
-              style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-              {b.text}
-            </pre>
-          );
-        }
-        if (b.kind === "table") {
-          return (
-            <div key={i} className="my-2 overflow-x-auto ag-scroll">
-              <table className="text-[11px]" style={{ borderCollapse: "collapse" }}>
-                <thead>
-                  <tr>{b.head.map((h, j) => (
-                    <th key={j} className="text-left px-2 py-1 whitespace-nowrap"
-                      style={{ color: "var(--text)", fontWeight: 500, borderBottom: "1px solid color-mix(in srgb, var(--border) 55%, transparent)" }}
-                      dangerouslySetInnerHTML={{ __html: renderInline(h) }} />
-                  ))}</tr>
-                </thead>
-                <tbody>
-                  {b.rows.map((r, ri) => (
-                    <tr key={ri}>{r.map((c, ci) => (
-                      <td key={ci} className="px-2 py-1 align-top"
-                        style={{ color: "var(--text2)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}
-                        dangerouslySetInnerHTML={{ __html: renderInline(c) }} />
-                    ))}</tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          );
-        }
-        if (b.kind === "quote") {
-          return (
-            <blockquote key={i} className="my-1.5 pl-2 py-0.5"
-              style={{ borderLeft: "2px solid color-mix(in srgb, var(--primary) 55%, transparent)", color: "var(--text3)" }}
-              dangerouslySetInnerHTML={{ __html: b.html }} />
-          );
-        }
-        if (b.kind === "image") {
-          // Through the server: GitHub's own attachment URLs answer 404 without
-          // the token, and these images are the evidence in a review.
-          return (
-            <figure key={i} className="my-2">
-              <img src={api.prAssetUrl(b.src)} alt={b.alt} loading="lazy"
-                className="max-w-full rounded" style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }} />
-              {b.alt && <figcaption className="text-[9.5px] mt-1" style={{ color: "var(--text3)" }}>{b.alt}</figcaption>}
-            </figure>
-          );
-        }
-        return <div key={i} dangerouslySetInnerHTML={{ __html: b.html }} />;
-      })}
-    </div>
+    <img src={api.prAssetUrl(`https://avatars.githubusercontent.com/${encodeURIComponent(login.replace(/\[bot\]$/, ""))}?size=48`)}
+      alt="" aria-hidden width={size} height={size} onError={() => setFailed(true)}
+      className="shrink-0 rounded-full" style={{ width: size, height: size, objectFit: "cover" }} />
   );
 }
 
-/** A unified diff, coloured, with a background tint on the changed lines so a
- *  block of additions reads as a block rather than as green text. */
-function Diff({ text, empty }: { text: string; empty?: string }) {
-  const lines = useMemo(() => text.split(/\r?\n/), [text]);
-  if (!text.trim()) return <div className="text-[11px] p-2" style={{ color: "var(--text3)" }}>{empty ?? "no changes"}</div>;
+function Btn({ children, onClick, disabled, danger, primary, ok, title, small }: {
+  children: React.ReactNode; onClick?: () => void; disabled?: boolean;
+  danger?: boolean; primary?: boolean; ok?: boolean; title?: string; small?: boolean;
+}) {
+  const edge = danger ? "var(--error)" : ok ? "var(--success)" : primary ? "var(--primary)" : "var(--border)";
   return (
-    <pre className="overflow-x-auto text-[10.5px] leading-snug ag-scroll"
-      style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)", borderRadius: 4, margin: 0 }}>
-      {lines.map((l, i) => {
-        const add = l.startsWith("+") && !l.startsWith("+++");
-        const del = l.startsWith("-") && !l.startsWith("---");
-        return (
-          <div key={i} style={{
-            color: lineTint(l),
-            background: add ? "color-mix(in srgb, var(--success) 9%, transparent)"
-              : del ? "color-mix(in srgb, var(--error) 9%, transparent)" : undefined,
-            padding: "0 .5rem",
-          }}>{l || " "}</div>
-        );
-      })}
-    </pre>
+    <button onClick={onClick} disabled={disabled} title={title}
+      className={`rounded disabled:opacity-40 ${small ? "text-[10px] px-2 py-0.5" : "text-[10.5px] px-2.5 py-1"}`}
+      style={{
+        color: primary ? "var(--bg)" : danger ? "var(--error)" : ok ? "var(--success)" : "var(--text2)",
+        background: primary ? "var(--primary)" : "transparent",
+        border: `1px solid color-mix(in srgb, ${edge} ${primary ? 100 : 50}%, transparent)`,
+        cursor: disabled ? "not-allowed" : "pointer",
+        fontWeight: primary ? 500 : 400,
+      }}>{children}</button>
   );
+}
+
+// ---------------------------------------------------------------------------
+// markdown
+// ---------------------------------------------------------------------------
+
+/**
+ * The typography for rendered markdown.
+ *
+ * A stylesheet rather than inline styles because these rules are about
+ * descendants — a heading inside a comment, a cell inside a table — which
+ * inline styles cannot reach. `.agx-md` scopes every one of them.
+ */
+export const MD_CSS = `
+.agx-md{max-width:78ch;margin:0 auto;line-height:1.7;font-size:12.5px;color:var(--text2)}
+.agx-md>*:first-child{margin-top:0}
+.agx-md>*:last-child{margin-bottom:0}
+.agx-md p{margin:0 0 .85em}
+.agx-md h1,.agx-md h2,.agx-md h3,.agx-md h4,.agx-md h5,.agx-md h6{color:var(--text);font-weight:600;line-height:1.3;margin:1.5em 0 .5em}
+.agx-md h1{font-size:1.45em;padding-bottom:.25em;border-bottom:1px solid color-mix(in srgb,var(--border) 35%,transparent)}
+.agx-md h2{font-size:1.25em;padding-bottom:.25em;border-bottom:1px solid color-mix(in srgb,var(--border) 28%,transparent)}
+.agx-md h3{font-size:1.1em}
+.agx-md h4,.agx-md h5,.agx-md h6{font-size:1em;color:var(--text2)}
+.agx-md a{color:var(--primary);text-underline-offset:2px}
+.agx-md strong{color:var(--text);font-weight:600}
+.agx-md del{opacity:.6}
+.agx-md code{font-family:var(--diff-font,ui-monospace,monospace);font-size:.88em;background:color-mix(in srgb,var(--border) 30%,transparent);padding:.15em .4em;border-radius:4px;color:var(--text)}
+.agx-md pre{background:var(--bg);border:1px solid color-mix(in srgb,var(--border) 40%,transparent);border-radius:6px;padding:.7em .9em;overflow-x:auto;margin:0 0 .9em}
+.agx-md pre code{background:none;padding:0;font-size:.92em;line-height:1.55;color:var(--text2)}
+.agx-md blockquote{margin:0 0 .9em;padding:.15em 0 .15em .9em;border-left:3px solid color-mix(in srgb,var(--primary) 45%,transparent);color:var(--text3)}
+.agx-md ul,.agx-md ol{margin:0 0 .85em;padding-left:1.5em}
+.agx-md li{margin-bottom:.3em}
+.agx-md li::marker{color:var(--primary)}
+.agx-md .agx-task{list-style:none;padding-left:0}
+.agx-md .agx-task li{display:flex;gap:.55em;align-items:flex-start}
+.agx-md .agx-box{flex:none;width:13px;height:13px;margin-top:.28em;border-radius:3px;border:1px solid color-mix(in srgb,var(--border) 70%,transparent);display:inline-flex;align-items:center;justify-content:center;font-size:9px;line-height:1}
+.agx-md .agx-box[data-on="1"]{background:var(--primary);border-color:var(--primary);color:var(--bg)}
+.agx-md .agx-tw{overflow-x:auto;margin:0 0 .9em;max-width:100%}
+.agx-md table{border-collapse:collapse;font-size:.95em}
+.agx-md th{text-align:left;padding:.4em .8em;background:color-mix(in srgb,var(--border) 22%,transparent);color:var(--text);font-weight:600;border:1px solid color-mix(in srgb,var(--border) 40%,transparent);white-space:nowrap}
+.agx-md td{padding:.4em .8em;border:1px solid color-mix(in srgb,var(--border) 30%,transparent);vertical-align:top}
+.agx-md tbody tr:nth-child(even) td{background:color-mix(in srgb,var(--border) 10%,transparent)}
+.agx-md hr{border:0;border-top:1px solid color-mix(in srgb,var(--border) 40%,transparent);margin:1.2em 0}
+.agx-md figure{margin:0 0 .9em}
+.agx-md figure img{max-width:100%;border-radius:6px;border:1px solid color-mix(in srgb,var(--border) 40%,transparent);display:block}
+.agx-md figcaption{font-size:.85em;color:var(--text3);margin-top:.35em}
+`;
+
+/** One markdown block. Images go through the proxy — GitHub's own attachment
+ *  URLs answer 404 without the token, and those are the review's evidence. */
+function Block({ b }: { b: MdBlock }) {
+  if (b.kind === "heading") {
+    const H = (["h1", "h2", "h3", "h4", "h5", "h6"][b.level - 1] ?? "h6") as "h1";
+    return <H dangerouslySetInnerHTML={{ __html: b.html }} />;
+  }
+  if (b.kind === "para") return <p dangerouslySetInnerHTML={{ __html: b.html }} />;
+  if (b.kind === "rule") return <hr />;
+  if (b.kind === "code") return <pre><code>{b.text}</code></pre>;
+  if (b.kind === "quote") return <blockquote dangerouslySetInnerHTML={{ __html: b.html }} />;
+  if (b.kind === "image") {
+    return (
+      <figure>
+        <img src={api.prAssetUrl(b.src)} alt={b.alt} loading="lazy" />
+        {b.alt && <figcaption>{b.alt}</figcaption>}
+      </figure>
+    );
+  }
+  if (b.kind === "table") {
+    return (
+      <div className="agx-tw agx-scroll">
+        <table>
+          <thead><tr>{b.head.map((h, i) => <th key={i} dangerouslySetInnerHTML={{ __html: h }} />)}</tr></thead>
+          <tbody>{b.rows.map((r, i) => <tr key={i}>{r.map((c, j) => <td key={j} dangerouslySetInnerHTML={{ __html: c }} />)}</tr>)}</tbody>
+        </table>
+      </div>
+    );
+  }
+  const isTask = b.items.some((i) => i.checked !== undefined);
+  const List = b.ordered ? "ol" : "ul";
+  return (
+    <List className={isTask ? "agx-task" : undefined}>
+      {b.items.map((it, i) => (
+        <li key={i} style={it.depth ? { marginLeft: it.depth * 14 } : undefined}>
+          {it.checked !== undefined && <span className="agx-box" data-on={it.checked ? "1" : "0"}>{it.checked ? "✓" : ""}</span>}
+          <span dangerouslySetInnerHTML={{ __html: it.html }} />
+        </li>
+      ))}
+    </List>
+  );
+}
+
+export function Md({ body, className }: { body: string; className?: string }) {
+  const blocks = useMemo(() => parseBody(body), [body]);
+  if (!body?.trim()) return null;
+  return <div className={`agx-md ${className ?? ""}`}>{blocks.map((b, i) => <Block key={i} b={b} />)}</div>;
+}
+
+// ---------------------------------------------------------------------------
+// diff, through the app's own viewer
+// ---------------------------------------------------------------------------
+
+/** A parsed diff in the shape ChangesModal's viewer speaks. The synthetic
+ *  fields are inert — that component reads path, counts and hunks. */
+function toFileChange(f: ParsedFile, i: number): FileChange {
+  return {
+    id: i, timestamp: 0, source_app: "github", session_id: "pr", tool: "PullRequest",
+    file_path: f.path, additions: f.additions, deletions: f.deletions, hunks: f.hunks,
+  };
+}
+
+function DiffPane({ file, split, wrap, onComment }: {
+  file: FileChange; split: boolean; wrap: boolean;
+  onComment?: (line: number) => void;
+}) {
+  // `hunkAction` is the seam the viewer already offers. A comment anchors to
+  // the last added line of its hunk — the line you are almost always talking
+  // about — falling back to the hunk's last line when it only removes.
+  const action = onComment
+    ? (hi: number) => {
+        const h = file.hunks[hi];
+        if (!h) return null;
+        const nums = newLineNumbers(h);
+        let target = 0;
+        h.lines.forEach((l, i) => { if (l.startsWith("+") && nums[i]) target = nums[i]!; });
+        if (!target) for (let i = nums.length - 1; i >= 0; i--) if (nums[i]) { target = nums[i]!; break; }
+        if (!target) return null;
+        return <button onClick={() => onComment(target)} className="text-[10px] px-1.5 rounded"
+          style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" }}
+          title={`comment on line ${target}`}>+ comment</button>;
+      }
+    : undefined;
+  return split ? <SplitDiff c={file} wrap={wrap} /> : <UnifiedDiff c={file} wrap={wrap} hunkAction={action} />;
 }
 
 // ---------------------------------------------------------------------------
@@ -195,8 +270,7 @@ function Diff({ text, empty }: { text: string; empty?: string }) {
 function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelect: () => void }) {
   const c = p.checks;
   return (
-    <button onClick={onSelect}
-      className="w-full text-left px-2.5 py-1.5 border-b"
+    <button onClick={onSelect} className="w-full text-left px-2.5 py-1.5 border-b"
       style={{
         borderColor: "color-mix(in srgb, var(--border) 22%, transparent)",
         background: active ? "color-mix(in srgb, var(--primary) 14%, transparent)" : "transparent",
@@ -210,9 +284,7 @@ function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelec
       <div className="flex items-center gap-1.5 mt-0.5 text-[10px]" style={{ color: "var(--text3)" }}>
         <Dot tint={stateTint(p)} title={`${c.success} passed · ${c.failure} failed · ${c.skipped} skipped · ${c.pending} running`} />
         <span className="tabular-nums">
-          {c.total === 0 ? "no checks"
-            : c.pending > 0 ? `${c.total - c.pending}/${c.total}`
-            : c.failure > 0 ? `${c.failure} failing` : "green"}
+          {c.total === 0 ? "no checks" : c.pending > 0 ? `${c.total - c.pending}/${c.total}` : c.failure > 0 ? `${c.failure} failing` : "green"}
         </span>
         {p.isDraft ? <Chip text="draft" tint="var(--text3)" /> : <ReviewChip d={p.reviewDecision} />}
         <span className="ml-auto shrink-0">{ago(p.updatedAt)}</span>
@@ -234,6 +306,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [repo, setRepo] = useState<PrRepoId | null>(null);
   const [filter, setFilter] = useState<Filter>("mine");
   const [prs, setPrs] = useState<PrSummary[]>([]);
+  const [counts, setCounts] = useState<Partial<Record<Filter, number>>>({});
   const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; error?: string; needsAuth?: boolean }>({ fetchedAt: 0, loading: false });
   const [selected, setSelected] = useState<number | null>(null);
   const [detail, setDetail] = useState<PrDetail | null>(null);
@@ -242,19 +315,21 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [busy, setBusy] = useState(false);
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
   const [rawBots, setRawBots] = useState(false);
-  const [seen, setSeen] = useState<Record<string, string[]>>(loadSeen);
-  const [diff, setDiff] = useState<string>("");
-  /** Which file's diff is on screen. The whole-PR blob is never shown — it is
-   *  sliced by `splitDiff` and one file is rendered at a time. */
+  const [seen, setSeen] = useState<Record<string, string[]>>(() => loadMap<string[]>(SEEN_KEY));
+  const [drafts, setDrafts] = useState<Record<string, DraftComment[]>>(() => loadMap<DraftComment[]>(DRAFT_KEY));
+  const [diff, setDiff] = useState("");
   const [selFile, setSelFile] = useState<string | null>(null);
   const [selCommit, setSelCommit] = useState<string | null>(null);
-  const [commitText, setCommitText] = useState<string>("");
+  const [commitText, setCommitText] = useState("");
   const [commitBusy, setCommitBusy] = useState(false);
+  const [split, setSplit] = useState(true);
+  const [wrap, setWrap] = useState(false);
+  const [reviewOpen, setReviewOpen] = useState(false);
   const detailReq = useRef(0);
 
   const flash = useCallback((ok: boolean, msg: string) => {
     setToast({ ok, msg });
-    setTimeout(() => setToast(null), 4200);
+    setTimeout(() => setToast(null), 4500);
   }, []);
 
   useEffect(() => {
@@ -270,20 +345,26 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     api.prList(root, filter, force).then((r) => {
       setRepo(r.repo);
       setPrs(r.prs);
+      setCounts((c) => ({ ...c, [filter]: r.prs.length }));
       setListState({ fetchedAt: r.fetchedAt, loading: r.loading, error: r.error, needsAuth: r.needsAuth });
       setSelected((cur) => (cur && r.prs.some((p) => p.number === cur) ? cur : r.prs[0]?.number ?? null));
     }).catch((e) => setListState({ fetchedAt: 0, loading: false, error: String(e) }));
   }, [root, filter]);
 
-  // Poll the cache, not GitHub. The server refreshes behind these calls, so a
-  // 20s tick is a map lookup and the age below the header is the honest answer
-  // to "how fresh is this".
   useEffect(() => {
     if (!active || !root) return;
     loadList();
     const t = setInterval(() => loadList(), POLL_MS);
     return () => clearInterval(t);
   }, [active, root, filter, loadList]);
+
+  // The review queue's size, so the filter can carry it without being opened.
+  useEffect(() => {
+    if (!active || !root || filter === "review") return;
+    api.prList(root, "review", false)
+      .then((r) => setCounts((c) => ({ ...c, review: r.prs.length })))
+      .catch(() => {});
+  }, [active, root, filter]);
 
   const loadDetail = useCallback((n: number, force = false) => {
     const req = ++detailReq.current;
@@ -297,26 +378,32 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   useEffect(() => {
     if (!active || !root || selected == null) { setDetail(null); return; }
-    setDiff(""); setSelFile(null); setSelCommit(null); setCommitText("");
+    setDiff(""); setSelFile(null); setSelCommit(null); setCommitText(""); setReviewOpen(false);
     loadDetail(selected);
   }, [active, root, selected, loadDetail]);
 
   useEffect(() => {
-    if (tab !== "files" || !detail || diff || !root) return;
+    if ((tab !== "files" && !reviewOpen) || !detail || diff || !root) return;
     api.prDiff(root, detail.number).then((r) => setDiff(r.ok ? (r.text || "") : "")).catch(() => {});
-  }, [tab, detail, diff, root]);
+  }, [tab, reviewOpen, detail, diff, root]);
 
-  /** Per-file slices of the one diff we fetched. */
-  const byFile = useMemo(() => splitDiff(diff), [diff]);
+  const parsed = useMemo(() => parseUnifiedDiff(diff), [diff]);
+  const byPath = useMemo(() => {
+    const m = new Map<string, FileChange>();
+    parsed.forEach((f, i) => m.set(f.path, toFileChange(f, i)));
+    return m;
+  }, [parsed]);
 
   const openCommit = useCallback((sha: string) => {
-    if (!root) return;
+    if (!root || !sha) { setSelCommit(null); return; }
     setSelCommit(sha); setCommitText(""); setCommitBusy(true);
     api.prCommitDiff(root, sha)
-      .then((r) => setCommitText(r.ok ? (r.text || "") : `could not load this commit — ${r.error ?? ""}`))
-      .catch((e) => setCommitText(String(e)))
+      .then((r) => setCommitText(r.ok ? (r.text || "") : ""))
+      .catch(() => setCommitText(""))
       .finally(() => setCommitBusy(false));
   }, [root]);
+
+  const commitFiles = useMemo(() => parseUnifiedDiff(commitText).map(toFileChange), [commitText]);
 
   const act = useCallback(async (label: string, fn: () => Promise<{ ok: boolean; error?: string; detail?: string }>) => {
     if (busy) return false;
@@ -330,45 +417,53 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     finally { setBusy(false); }
   }, [busy, flash, loadList, selected, loadDetail]);
 
-  // --- conversation lanes -------------------------------------------------
-  const lanes = useMemo(() => {
-    if (!detail) return { humans: [] as PrReview[], bots: [] as PrComment[], botReviews: [] as PrReview[], humanComments: [] as PrComment[] };
-    return {
-      humans: detail.reviews.filter((r) => !r.isBot && (r.body.trim() || r.state !== "COMMENTED")),
-      botReviews: detail.reviews.filter((r) => r.isBot && r.body.trim()),
-      humanComments: detail.comments.filter((c) => !c.isBot),
-      bots: detail.comments.filter((c) => c.isBot),
-    };
-  }, [detail]);
+  const key = repo && detail ? `${repo.key}#${detail.number}` : "";
+  const seenFiles = key ? (seen[key] ?? []) : [];
+  const myDrafts = key ? (drafts[key] ?? []) : [];
 
-  const botBytes = useMemo(() => lanes.bots.reduce((n, c) => n + c.body.length, 0), [lanes.bots]);
-  const openThreads = useMemo(() => (detail?.threads ?? []).filter((t) => !t.isResolved), [detail]);
-
-  const seenKey = repo && detail ? `${repo.key}#${detail.number}` : "";
-  const seenFiles = seenKey ? (seen[seenKey] ?? []) : [];
   const toggleSeen = (path: string) => {
-    if (!seenKey) return;
+    if (!key) return;
     setSeen((cur) => {
-      const list = new Set(cur[seenKey] ?? []);
+      const list = new Set(cur[key] ?? []);
       if (list.has(path)) list.delete(path); else list.add(path);
-      const next = { ...cur, [seenKey]: [...list] };
-      saveSeen(next);
+      const next = { ...cur, [key]: [...list] };
+      saveMap(SEEN_KEY, next);
       return next;
     });
   };
 
-  // --- actions ------------------------------------------------------------
-  const doReview = async (verb: "approve" | "request_changes" | "comment") => {
-    if (!detail) return;
-    const noun = verb === "approve" ? "Approve" : verb === "request_changes" ? "Request changes on" : "Comment on";
+  const addDraft = async (path: string, line: number) => {
     const body = await askText({
-      title: `${noun} #${detail.number}`,
-      body: verb === "approve" ? "A note is optional for an approval." : "This is posted to GitHub and your team can see it.",
-      confirmLabel: "Submit review",
-      input: { label: "Review body", placeholder: verb === "approve" ? "optional" : "what needs to change…" },
+      title: `Comment on ${path.split("/").pop()}:${line}`,
+      body: "Queued with the rest of your review — nothing is sent until you submit.",
+      confirmLabel: "Add to review",
+      input: { label: "Comment", placeholder: "what needs to change here…" },
     });
-    if (body === null) return;
-    await act("review", () => api.prReview(root, detail.number, verb, body));
+    if (!body?.trim() || !key) return;
+    setDrafts((cur) => {
+      const next = { ...cur, [key]: [...(cur[key] ?? []), { path, line, body: body.trim() }] };
+      saveMap(DRAFT_KEY, next);
+      return next;
+    });
+    flash(true, `queued — ${(myDrafts.length + 1)} pending comment${myDrafts.length ? "s" : ""}`);
+  };
+
+  const dropDraft = (i: number) => {
+    if (!key) return;
+    setDrafts((cur) => {
+      const next = { ...cur, [key]: (cur[key] ?? []).filter((_, j) => j !== i) };
+      saveMap(DRAFT_KEY, next);
+      return next;
+    });
+  };
+
+  const submitReview = async (verb: "approve" | "request_changes" | "comment", body: string) => {
+    if (!detail) return;
+    const ok = await act("review", () => api.prReviewWith(root, detail.number, verb, body, myDrafts));
+    if (ok && key) {
+      setDrafts((cur) => { const next = { ...cur, [key]: [] }; saveMap(DRAFT_KEY, next); return next; });
+      setReviewOpen(false);
+    }
   };
 
   const doMerge = async () => {
@@ -377,9 +472,8 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     const ok = await ask({
       title: `Merge #${detail.number} into ${detail.baseRefName}?`,
       body: `${detail.title}\n\nSquash and merge, then delete the branch. This is public and cannot be undone from here.` +
-        (head ? `\n\nPinned to ${head.slice(0, 8)} — if anyone pushes before this lands, GitHub will refuse rather than merge a commit you have not seen.` : ""),
-      confirmLabel: "Squash & merge",
-      danger: true,
+        (head ? `\n\nPinned to ${head.slice(0, 8)} — if anyone pushes before this lands, GitHub refuses rather than merging a commit you have not seen.` : ""),
+      confirmLabel: "Squash & merge", danger: true,
     });
     if (!ok) return;
     await act("merge", () => api.prMerge(root, detail.number, "squash", { deleteBranch: true, headSha: head }));
@@ -389,9 +483,8 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (!detail) return;
     const ok = await ask({
       title: `Close #${detail.number}?`,
-      body: `${detail.title}\n\nThe pull request is closed without merging. You can reopen it afterwards.`,
-      confirmLabel: "Close pull request",
-      danger: true,
+      body: `${detail.title}\n\nClosed without merging. You can reopen it afterwards.`,
+      confirmLabel: "Close pull request", danger: true,
     });
     if (!ok) return;
     await act("close", () => api.prClose(root, detail.number));
@@ -403,15 +496,25 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     try {
       const r = await api.prLocalReview(root, detail.number);
       if (!r.ok || !r.cwd || !r.prompt) { flash(false, r.error || "could not prepare the review"); return; }
-      if (onOpenChatWith) { onOpenChatWith(r.cwd, r.prompt); flash(true, `checked out #${detail.number} — review running in chat`); }
+      if (onOpenChatWith) { onOpenChatWith(r.cwd, r.prompt); flash(true, `checked out #${detail.number} — review waiting in chat`); }
       else flash(true, `checked out at ${r.cwd}`);
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); }
   };
 
-  // --- render -------------------------------------------------------------
+  const lanes = useMemo(() => {
+    if (!detail) return { humans: [] as PrReview[], botReviews: [] as PrReview[], humanComments: [] as PrComment[], bots: [] as PrComment[] };
+    return {
+      humans: detail.reviews.filter((r) => !r.isBot && (r.body.trim() || r.state !== "COMMENTED")),
+      botReviews: detail.reviews.filter((r) => r.isBot && r.body.trim()),
+      humanComments: detail.comments.filter((c) => !c.isBot),
+      bots: detail.comments.filter((c) => c.isBot),
+    };
+  }, [detail]);
+
+  const openThreads = useMemo(() => (detail?.threads ?? []).filter((t) => !t.isResolved), [detail]);
   const d = detail;
-  const checks = d?.checks;
+
   const TABS: { id: Tab; label: string; n?: number; warn?: boolean }[] = d ? [
     { id: "overview", label: "overview", warn: d.checklist.some((c) => !c.checked) },
     { id: "conversation", label: "conversation", n: lanes.humans.length + lanes.humanComments.length + d.threads.length + lanes.bots.length },
@@ -422,53 +525,51 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <style>{SCROLLBAR_CSS}</style>
+      <style>{SCROLLBAR_CSS}{MD_CSS}</style>
+
       <div className={viewHeaderClass} style={viewHeaderStyle}>
         <span className={viewTitleClass} style={{ color: "var(--text)" }}>Pull Requests</span>
-        {/* The picker already says which checkout, and the checkout implies the
-            repo — showing `owner/name` next to it said the same thing twice. */}
         {repos.length > 1 ? (
           <select value={root} onChange={(e) => { setRoot(e.target.value); setSelected(null); setDetail(null); }}
-            title={repo ? repo.nameWithOwner : undefined}
+            title={repo?.nameWithOwner}
             className="text-[10px] px-1 py-0.5 rounded bg-transparent max-w-[220px]"
             style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
             {repos.map((r) => <option key={r.root} value={r.root} style={{ background: "var(--bg)" }}>{r.root.split("/").pop()}</option>)}
           </select>
-        ) : (
-          repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>
-        )}
+        ) : repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>}
         <div className="ml-auto flex items-center gap-2 shrink-0">
-          {toast && (
-            <span className="text-[10px] max-w-[340px] truncate" style={{ color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</span>
-          )}
+          {toast && <span className="text-[10px] max-w-[380px] truncate" style={{ color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</span>}
           <span className="text-[10px] tabular-nums" style={{ color: "var(--text3)" }}>
             {listState.loading ? "refreshing…" : listState.fetchedAt ? `⟳ ${ago(new Date(listState.fetchedAt).toISOString())}` : ""}
           </span>
-          <button onClick={() => loadList(true)} disabled={busy}
-            className="text-[10px] px-1.5 py-0.5 rounded"
-            style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>refresh</button>
+          <Btn onClick={() => loadList(true)} disabled={busy} small>refresh</Btn>
         </div>
       </div>
 
       <div className="flex flex-1 min-h-0">
-        {/* ---- list ---- */}
         <div className="flex flex-col min-h-0 shrink-0" style={{ width: sidebarW }}>
           <div className="flex gap-1 px-2 py-1.5 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
-            {FILTERS.map((f) => (
-              <button key={f.id} onClick={() => setFilter(f.id)} title={f.hint}
-                className="text-[10px] px-2 py-0.5 rounded-full"
-                style={{
-                  color: filter === f.id ? "var(--bg)" : "var(--text2)",
-                  background: filter === f.id ? "var(--primary)" : "transparent",
-                  border: `1px solid ${filter === f.id ? "var(--primary)" : "color-mix(in srgb, var(--border) 45%, transparent)"}`,
-                }}>{f.label}{filter === f.id && prs.length > 0 && <span className="ml-1 tabular-nums opacity-75">{prs.length}</span>}</button>
-            ))}
+            {FILTERS.map((f) => {
+              const n = counts[f.id];
+              return (
+                <button key={f.id} onClick={() => setFilter(f.id)} title={f.hint}
+                  className="text-[10px] px-2 py-0.5 rounded-full"
+                  style={{
+                    color: filter === f.id ? "var(--bg)" : "var(--text2)",
+                    background: filter === f.id ? "var(--primary)" : "transparent",
+                    border: `1px solid ${filter === f.id ? "var(--primary)" : "color-mix(in srgb, var(--border) 45%, transparent)"}`,
+                  }}>
+                  {f.label}
+                  {n ? <span className="ml-1 tabular-nums" style={{ opacity: filter === f.id ? .8 : 1, color: filter === f.id ? undefined : f.id === "review" ? "var(--warning)" : undefined }}>{n}</span> : null}
+                </button>
+              );
+            })}
           </div>
-          <div className="flex-1 overflow-y-auto min-h-0 ag-scroll">
+          <div className="flex-1 overflow-y-auto min-h-0 agx-scroll">
             {listState.needsAuth ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
                 <div style={{ color: "var(--warning)" }}>{listState.error || "the GitHub CLI is not set up"}</div>
-                <div className="mt-2">Pull requests come from <code>gh</code>. Install it and run <code>gh auth login</code>, then hit refresh.</div>
+                <div className="mt-2">Pull requests come from <code>gh</code>. Install it, run <code>gh auth login</code>, then refresh.</div>
               </div>
             ) : !repo ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>{listState.error || "no GitHub remote on this repository"}</div>
@@ -484,16 +585,14 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
         <SidebarGrip />
 
-        {/* ---- detail ---- */}
         <div className="flex-1 flex flex-col min-w-0 min-h-0">
           {!d ? (
             <div className="p-4 text-[11.5px]" style={{ color: "var(--text3)" }}>{detailErr || (selected == null ? "select a pull request" : "loading…")}</div>
           ) : (
             <>
-              <div className="flex gap-0 border-b shrink-0 overflow-x-auto" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+              <div className="flex border-b shrink-0 overflow-x-auto items-center" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
                 {TABS.map((t) => (
-                  <button key={t.id} onClick={() => setTab(t.id)}
-                    className="text-[10.5px] px-3 py-1.5 whitespace-nowrap"
+                  <button key={t.id} onClick={() => setTab(t.id)} className="text-[10.5px] px-3 py-1.5 whitespace-nowrap"
                     style={{
                       color: tab === t.id ? "var(--text)" : "var(--text3)",
                       borderBottom: `2px solid ${tab === t.id ? "var(--primary)" : "transparent"}`,
@@ -504,28 +603,37 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                     {t.warn && <span className="ml-1" style={{ color: "var(--warning)" }}>●</span>}
                   </button>
                 ))}
+                <div className="ml-auto flex items-center gap-1.5 px-2 shrink-0">
+                  {myDrafts.length > 0 && <Chip text={`${myDrafts.length} pending`} tint="var(--warning)" title="line comments queued but not sent" />}
+                  <Btn onClick={() => setReviewOpen(true)} primary small>review</Btn>
+                </div>
               </div>
 
-              <div className="flex-1 overflow-y-auto min-h-0 ag-scroll p-3">
-                {tab === "overview" && <Overview d={d} onLocalReview={doLocalReview} busy={busy}
-                  onMerge={doMerge} onClose={doClose} onUpdateBranch={() => act("update branch", () => api.prUpdateBranch(root, d.number))}
-                  onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))}
-                  onAutoMerge={() => act("auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
-                  onDraft={() => act(d.isDraft ? "mark ready" : "convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
-                  openThreads={openThreads.length} />}
+              <div className="flex-1 overflow-y-auto min-h-0 agx-scroll p-3">
+                {tab === "overview" && (
+                  <Overview
+                    d={d} busy={busy} openThreads={openThreads.length}
+                    onLocalReview={doLocalReview} onMerge={doMerge} onClose={doClose}
+                    onUpdateBranch={() => act("update branch", () => api.prUpdateBranch(root, d.number))}
+                    onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))}
+                    onAutoMerge={() => act("auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
+                    onDraft={() => act(d.isDraft ? "mark ready" : "convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
+                    onGoThreads={() => setTab("conversation")}
+                  />
+                )}
 
                 {tab === "conversation" && (
                   <Conversation
-                    d={d} lanes={lanes} botBytes={botBytes} raw={rawBots} onRaw={setRawBots}
+                    d={d} lanes={lanes} raw={rawBots} onRaw={setRawBots} busy={busy}
                     onResolve={(t) => act(t.isResolved ? "unresolve" : "resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
                     onReply={async (t) => {
                       const first = t.comments[0];
                       if (!first) return;
-                      const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply", placeholder: "…" } });
-                      if (body === null || !body.trim()) return;
+                      const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply" } });
+                      if (!body?.trim()) return;
                       await act("reply", () => api.prReply(root, d.number, Number(first.id), body));
                     }}
-                    onReview={doReview} busy={busy}
+                    fileOf={(p) => byPath.get(p)}
                   />
                 )}
 
@@ -534,23 +642,25 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                     {d.commits.map((c) => (
                       <div key={c.oid}>
                         <button onClick={() => openCommit(selCommit === c.oid ? "" : c.oid)}
-                          className="w-full text-left flex items-center gap-2 py-1 border-b"
+                          className="w-full text-left flex items-center gap-2 py-1.5 border-b"
                           style={{
                             borderColor: "color-mix(in srgb, var(--border) 18%, transparent)",
                             opacity: c.isMerge ? 0.55 : 1,
-                            background: selCommit === c.oid ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+                            background: selCommit === c.oid ? "color-mix(in srgb, var(--primary) 10%, transparent)" : "transparent",
                           }}>
                           <span className="shrink-0" style={{ color: "var(--text3)" }}>{selCommit === c.oid ? "▾" : "▸"}</span>
                           <span className="tabular-nums shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.short}</span>
                           <span className="truncate" style={{ color: "var(--text2)" }}>{c.message}</span>
                           {c.isMerge && <Chip text="merge" tint="var(--text3)" title="trunk catch-up, not work to review" />}
-                          <span className="ml-auto shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>{c.author}</span>
+                          <span className="ml-auto shrink-0 flex items-center gap-1.5 text-[10px]" style={{ color: "var(--text3)" }}>
+                            <Avatar login={c.author} size={14} />{c.author}
+                          </span>
                         </button>
                         {selCommit === c.oid && (
-                          <div className="my-1.5">
-                            {commitBusy
-                              ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>loading the diff…</div>
-                              : <Diff text={commitText} empty="this commit changed nothing" />}
+                          <div className="my-2">
+                            {commitBusy ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>loading the diff…</div>
+                              : commitFiles.length === 0 ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>this commit changed nothing textual</div>
+                              : <FileStack files={commitFiles} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap} />}
                           </div>
                         )}
                       </div>
@@ -559,50 +669,22 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 )}
 
                 {tab === "files" && (
-                  <div className="text-[11px]">
-                    <div className="flex items-center gap-2 mb-2 text-[10px]" style={{ color: "var(--text3)" }}>
-                      <span className="tabular-nums">{seenFiles.length}/{d.files.length} reviewed</span>
-                      <Bar parts={[{ pct: d.files.length ? (seenFiles.length / d.files.length) * 100 : 0, tint: "var(--primary)" }]} />
-                    </div>
-                    {d.files.map((f) => {
-                      const done = seenFiles.includes(f.path);
-                      const open = selFile === f.path;
-                      return (
-                        <div key={f.path}>
-                          <div className="flex items-center gap-2 py-1 border-b"
-                            style={{
-                              borderColor: "color-mix(in srgb, var(--border) 18%, transparent)",
-                              background: open ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
-                            }}>
-                            {/* The tick is "I have read this" and must not also
-                                open the file — two different intents on one row. */}
-                            <input type="checkbox" checked={done} onChange={() => toggleSeen(f.path)}
-                              onClick={(e) => e.stopPropagation()} style={{ accentColor: "var(--primary)" }}
-                              title="mark reviewed" aria-label={`mark ${f.path} reviewed`} />
-                            <button onClick={() => setSelFile(open ? null : f.path)}
-                              className="flex-1 min-w-0 text-left flex items-center gap-2">
-                              <span className="shrink-0" style={{ color: "var(--text3)" }}>{open ? "▾" : "▸"}</span>
-                              <span className="truncate" style={{ color: done ? "var(--text3)" : "var(--text2)", textDecoration: done ? "line-through" : undefined }}>{f.path}</span>
-                              {f.comments > 0 && <Chip text={`${f.comments} open`} tint="var(--warning)" />}
-                              <span className="ml-auto shrink-0 tabular-nums" style={{ color: "var(--success)" }}>+{f.additions}</span>
-                              <span className="shrink-0 tabular-nums" style={{ color: "var(--error)" }}>−{f.deletions}</span>
-                            </button>
-                          </div>
-                          {open && (
-                            <div className="my-1.5">
-                              {!diff
-                                ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>loading the diff…</div>
-                                : <Diff text={byFile.get(f.path) ?? ""} empty="no textual diff — binary, renamed, or too large to show" />}
-                            </div>
-                          )}
-                        </div>
-                      );
-                    })}
-                  </div>
+                  <FilesTab
+                    d={d} byPath={byPath} loaded={!!diff} seenFiles={seenFiles} onSeen={toggleSeen}
+                    sel={selFile} onSel={setSelFile} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap}
+                    drafts={myDrafts} onAddDraft={addDraft}
+                  />
                 )}
 
-                {tab === "checks" && checks && <Checks d={d} onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))} busy={busy} />}
+                {tab === "checks" && <Checks d={d} busy={busy} onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))} />}
               </div>
+
+              {reviewOpen && (
+                <ReviewSheet
+                  d={d} drafts={myDrafts} seen={seenFiles.length} busy={busy}
+                  onDrop={dropDraft} onCancel={() => setReviewOpen(false)} onSubmit={submitReview}
+                />
+              )}
             </>
           )}
         </div>
@@ -626,10 +708,10 @@ const MERGE_WHY: Record<string, string> = {
   UNKNOWN: "GitHub has not finished working it out",
 };
 
-function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onDraft }: {
+function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onDraft, onGoThreads }: {
   d: PrDetail; busy: boolean; openThreads: number;
-  onLocalReview: () => void; onMerge: () => void; onClose: () => void;
-  onUpdateBranch: () => void; onRerun: () => void; onAutoMerge: () => void; onDraft: () => void;
+  onLocalReview: () => void; onMerge: () => void; onClose: () => void; onUpdateBranch: () => void;
+  onRerun: () => void; onAutoMerge: () => void; onDraft: () => void; onGoThreads: () => void;
 }) {
   const done = d.checklist.filter((c) => c.checked).length;
   const open = d.checklist.length - done;
@@ -639,61 +721,69 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
   return (
     <div className="flex flex-col gap-3">
       <div>
-        <div className="text-[13px]" style={{ color: "var(--text)" }}>{d.title}</div>
-        <div className="text-[10px] mt-0.5" style={{ color: "var(--text3)" }}>
-          #{d.number} · {d.author} · {d.headRefName} → {d.baseRefName} · +{d.additions} −{d.deletions} · {d.changedFiles} files
+        <div className="text-[14px] leading-snug" style={{ color: "var(--text)" }}>{d.title}</div>
+        <div className="text-[10.5px] mt-1 flex items-center gap-1.5 flex-wrap" style={{ color: "var(--text3)" }}>
+          <Avatar login={d.author} size={15} />
+          <span>#{d.number} · {d.author} · {d.headRefName} → {d.baseRefName} ·</span>
+          <span style={{ color: "var(--success)" }}>+{d.additions}</span>
+          <span style={{ color: "var(--error)" }}>−{d.deletions}</span>
+          <span>· {d.changedFiles} files</span>
         </div>
         {d.labels.length > 0 && (
-          <div className="flex gap-1 flex-wrap mt-1.5">
-            {d.labels.map((l) => <Chip key={l.name} text={l.name} tint="var(--primary)" />)}
-          </div>
+          <div className="flex gap-1 flex-wrap mt-1.5">{d.labels.map((l) => <Chip key={l.name} text={l.name} tint="var(--primary)" />)}</div>
         )}
       </div>
 
       {d.forcePushedSinceReview && (
-        <div className="text-[10.5px] px-2 py-1.5 rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 10%, transparent)" }}>
+        <div className="text-[10.5px] px-2.5 py-2 rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 10%, transparent)" }}>
           The author force-pushed after the last review — that review was for code that is no longer here.
         </div>
       )}
 
       {/* merge, and why not */}
-      <section className="rounded" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
-        <div className="flex items-center gap-2 px-2 py-1 text-[9.5px] uppercase tracking-wider border-b"
-          style={{ color: "var(--text3)", borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
-          <span>merge</span>
-          <span className="ml-auto" style={{ color: canMerge ? "var(--success)" : "var(--error)" }}>{canMerge ? "ready" : d.mergeState.toLowerCase()}</span>
+      <section className="rounded-lg overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 38%, transparent)" }}>
+        <div className="flex gap-2.5 items-start p-3">
+          <span className="shrink-0 rounded-full flex items-center justify-center text-[13px]"
+            style={{ width: 26, height: 26, background: canMerge ? "var(--success)" : "var(--error)", color: "var(--bg)" }}>
+            {canMerge ? "✓" : "!"}
+          </span>
+          <span className="min-w-0">
+            <span className="block text-[13px] font-semibold leading-tight" style={{ color: "var(--text)" }}>
+              {canMerge ? "Ready to merge" : "Merging is blocked"}
+            </span>
+            <span className="block text-[11px] mt-0.5" style={{ color: "var(--text3)" }}>
+              {canMerge ? "nothing is standing in the way" : (MERGE_WHY[d.mergeState] ?? "not mergeable")}
+            </span>
+          </span>
         </div>
-        <div className="p-2 text-[11px]" style={{ color: "var(--text2)" }}>
-          {!canMerge && (
-            <div className="flex gap-1.5 items-start mb-1">
-              <Dot tint="var(--error)" /><span>{MERGE_WHY[d.mergeState] ?? "not mergeable"}</span>
-            </div>
-          )}
+
+        <div style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
           {d.reviewDecision === "CHANGES_REQUESTED" && (
-            <div className="flex gap-1.5 items-start mb-1"><Dot tint="var(--error)" /><span>changes requested</span></div>
+            <Reason tint="var(--error)" glyph="✕"><b style={{ color: "var(--text)", fontWeight: 500 }}>Changes requested</b> by a reviewer with write access</Reason>
           )}
           {openThreads > 0 && (
-            <div className="flex gap-1.5 items-start mb-1">
-              <Dot tint="var(--warning)" />
-              <span>{openThreads} review thread{openThreads === 1 ? "" : "s"} still open — a reply is not a resolve</span>
-            </div>
+            <Reason tint="var(--warning)" glyph="◯" action={<button onClick={onGoThreads} style={{ color: "var(--primary)" }}>go to thread</button>}>
+              {openThreads} review thread{openThreads === 1 ? "" : "s"} still open — <span style={{ color: "var(--text3)" }}>a reply is not a resolve</span>
+            </Reason>
           )}
           {c.failure > 0 && (
-            <div className="flex gap-1.5 items-start mb-1">
-              <Dot tint="var(--error)" />
-              <span>{c.failing.map((f) => f.name).slice(0, 3).join(", ")}{c.failing.length > 3 ? ` +${c.failing.length - 3}` : ""}</span>
-            </div>
+            <Reason tint="var(--error)" glyph="✕">{c.failing.slice(0, 2).map((f) => f.name).join(", ")}{c.failing.length > 2 ? ` +${c.failing.length - 2} more` : ""} failing</Reason>
           )}
-          {canMerge && <div className="flex gap-1.5 items-start mb-1"><Dot tint="var(--success)" /><span>nothing is blocking this</span></div>}
+          {c.failure === 0 && c.total > 0 && (
+            <Reason tint="var(--success)" glyph="✓">{c.total} checks passed{d.mergeable === "MERGEABLE" ? `, no conflicts with ${d.baseRefName}` : ""}</Reason>
+          )}
+        </div>
 
-          <div className="flex gap-1.5 flex-wrap mt-2">
-            <Btn onClick={onMerge} disabled={busy || !canMerge} danger title={canMerge ? "squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>squash &amp; merge</Btn>
-            <Btn onClick={onAutoMerge} disabled={busy}>merge when green</Btn>
-            <Btn onClick={onUpdateBranch} disabled={busy} title="merge the base branch into this one">update branch</Btn>
-            {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
-            <Btn onClick={onDraft} disabled={busy}>{d.isDraft ? "mark ready" : "to draft"}</Btn>
-            <Btn onClick={onClose} disabled={busy} danger>close</Btn>
-          </div>
+        <div className="flex items-center gap-1.5 flex-wrap px-3 py-2.5"
+          style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
+          <Btn onClick={onMerge} disabled={busy || !canMerge} primary title={canMerge ? "squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>squash &amp; merge</Btn>
+          <Btn onClick={onAutoMerge} disabled={busy} title="merge automatically once everything passes">merge when green</Btn>
+          <Btn onClick={onUpdateBranch} disabled={busy} title="merge the base branch into this one">update branch</Btn>
+          {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
+          <span className="ml-auto flex gap-1.5">
+            <Btn onClick={onDraft} disabled={busy} small>{d.isDraft ? "mark ready" : "to draft"}</Btn>
+            <Btn onClick={onClose} disabled={busy} danger small>close</Btn>
+          </span>
         </div>
       </section>
 
@@ -712,33 +802,131 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
       )}
 
       <section>
-        <div className="text-[9.5px] uppercase tracking-wider mb-1" style={{ color: "var(--text3)" }}>description</div>
-        <Body body={d.body} />
+        <div className="text-[9.5px] uppercase tracking-wider mb-2" style={{ color: "var(--text3)" }}>description</div>
+        {d.body.trim() ? <Md body={d.body} /> : <div className="text-[11px]" style={{ color: "var(--text3)" }}>No description.</div>}
       </section>
 
       <div className="flex gap-1.5 flex-wrap">
-        <Btn onClick={onLocalReview} disabled={busy} primary
-          title="check the PR out into a throwaway worktree and review it with the full repo in context">review locally with Claude</Btn>
-        <a href={d.url} target="_blank" rel="noreferrer noopener"
-          className="text-[10px] px-2 py-1 rounded" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>open on GitHub ↗</a>
+        <Btn onClick={onLocalReview} disabled={busy} primary title="check the PR out into a throwaway worktree and review it with the whole repo in context">review locally with Claude</Btn>
+        <a href={d.url} target="_blank" rel="noreferrer noopener" className="text-[10.5px] px-2.5 py-1 rounded"
+          style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>open on GitHub ↗</a>
       </div>
     </div>
   );
 }
 
-function Btn({ children, onClick, disabled, danger, primary, title }: {
-  children: React.ReactNode; onClick: () => void; disabled?: boolean; danger?: boolean; primary?: boolean; title?: string;
-}) {
-  const tint = danger ? "var(--error)" : primary ? "var(--primary)" : "var(--border)";
+function Reason({ tint, glyph, children, action }: { tint: string; glyph: string; children: React.ReactNode; action?: React.ReactNode }) {
   return (
-    <button onClick={onClick} disabled={disabled} title={title}
-      className="text-[10px] px-2 py-1 rounded disabled:opacity-40"
-      style={{
-        color: primary ? "var(--bg)" : danger ? "var(--error)" : "var(--text2)",
-        background: primary ? "var(--primary)" : "transparent",
-        border: `1px solid color-mix(in srgb, ${tint} ${primary ? 100 : 50}%, transparent)`,
-        cursor: disabled ? "not-allowed" : "pointer",
-      }}>{children}</button>
+    <div className="flex items-center gap-2 px-3 py-1.5 text-[11.5px]"
+      style={{ color: "var(--text2)", borderBottom: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" }}>
+      <span className="shrink-0 w-3.5 text-center" style={{ color: tint }}>{glyph}</span>
+      <span className="min-w-0">{children}</span>
+      {action && <span className="ml-auto shrink-0 text-[10px]">{action}</span>}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// files & commits
+// ---------------------------------------------------------------------------
+
+function DiffToolbar({ path, add, del, split, wrap, onSplit, onWrap, right }: {
+  path?: string; add?: number; del?: number; split: boolean; wrap: boolean;
+  onSplit: (v: boolean) => void; onWrap: (v: boolean) => void; right?: React.ReactNode;
+}) {
+  return (
+    <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px] shrink-0"
+      style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 10%, transparent)" }}>
+      {path && <span className="truncate" style={{ color: "var(--text)" }}>{path}</span>}
+      {add != null && <span className="tabular-nums shrink-0" style={{ color: "var(--success)" }}>+{add}</span>}
+      {del != null && <span className="tabular-nums shrink-0" style={{ color: "var(--error)" }}>−{del}</span>}
+      <span className="ml-auto flex items-center gap-1 shrink-0">
+        {right}
+        <Toggle on={split} onClick={() => onSplit(!split)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
+        <Toggle on={wrap} onClick={() => onWrap(!wrap)} title="Toggle line wrap">wrap</Toggle>
+      </span>
+    </div>
+  );
+}
+
+/** Several files, each with its own header — how a commit reads. */
+function FileStack({ files, split, wrap, onSplit, onWrap }: {
+  files: FileChange[]; split: boolean; wrap: boolean; onSplit: (v: boolean) => void; onWrap: (v: boolean) => void;
+}) {
+  return (
+    <div className="flex flex-col gap-2">
+      {files.map((f, i) => (
+        <div key={f.file_path} className="rounded overflow-hidden flex flex-col"
+          style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", maxHeight: 520 }}>
+          <DiffToolbar path={f.file_path} add={f.additions} del={f.deletions}
+            split={split} wrap={wrap} onSplit={i === 0 ? onSplit : onSplit} onWrap={onWrap} />
+          <div className="flex-1 min-h-0 flex">
+            <DiffPane file={f} split={split} wrap={wrap} />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wrap, onSplit, onWrap, drafts, onAddDraft }: {
+  d: PrDetail; byPath: Map<string, FileChange>; loaded: boolean;
+  seenFiles: string[]; onSeen: (p: string) => void;
+  sel: string | null; onSel: (p: string | null) => void;
+  split: boolean; wrap: boolean; onSplit: (v: boolean) => void; onWrap: (v: boolean) => void;
+  drafts: DraftComment[]; onAddDraft: (path: string, line: number) => void;
+}) {
+  const current = sel ? byPath.get(sel) : undefined;
+  const draftsFor = (p: string) => drafts.filter((x) => x.path === p).length;
+
+  return (
+    <div className="text-[11px] flex flex-col gap-2">
+      <div className="flex items-center gap-2 text-[10px]" style={{ color: "var(--text3)" }}>
+        <span className="tabular-nums">{seenFiles.length}/{d.files.length} reviewed</span>
+        <Bar parts={[{ pct: d.files.length ? (seenFiles.length / d.files.length) * 100 : 0, tint: "var(--primary)" }]} />
+      </div>
+
+      <div className="rounded overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
+        {d.files.map((f) => {
+          const done = seenFiles.includes(f.path);
+          const open = sel === f.path;
+          const nd = draftsFor(f.path);
+          return (
+            <div key={f.path} className="flex items-center gap-2 px-2 py-1"
+              style={{
+                borderBottom: "1px solid color-mix(in srgb, var(--border) 18%, transparent)",
+                background: open ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+                boxShadow: open ? "inset 2px 0 0 var(--primary)" : undefined,
+              }}>
+              {/* The tick means "I have read this" — a different intent from
+                  "show me this", so it is a different target. */}
+              <input type="checkbox" checked={done} onChange={() => onSeen(f.path)}
+                style={{ accentColor: "var(--primary)" }} title="mark reviewed" aria-label={`mark ${f.path} reviewed`} />
+              <button onClick={() => onSel(open ? null : f.path)} className="flex-1 min-w-0 text-left flex items-center gap-2">
+                <span className="shrink-0" style={{ color: "var(--text3)" }}>{open ? "▾" : "▸"}</span>
+                <span className="truncate" style={{ color: done ? "var(--text3)" : "var(--text2)", textDecoration: done ? "line-through" : undefined }}>{f.path}</span>
+                {f.comments > 0 && <Chip text={`${f.comments} open`} tint="var(--warning)" />}
+                {nd > 0 && <Chip text={`${nd} pending`} tint="var(--primary)" title="queued in your review" />}
+                <span className="ml-auto shrink-0 tabular-nums" style={{ color: "var(--success)" }}>+{f.additions}</span>
+                <span className="shrink-0 tabular-nums" style={{ color: "var(--error)" }}>−{f.deletions}</span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      {sel && (
+        <div className="rounded overflow-hidden flex flex-col" style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", height: 560 }}>
+          <DiffToolbar path={sel} add={current?.additions} del={current?.deletions} split={split} wrap={wrap} onSplit={onSplit} onWrap={onWrap}
+            right={<span className="text-[10px] mr-1" style={{ color: "var(--text3)" }}>unified shows “+ comment”</span>} />
+          <div className="flex-1 min-h-0 flex">
+            {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>loading the diff…</div>
+              : current ? <DiffPane file={current} split={split} wrap={wrap} onComment={(line) => onAddDraft(sel, line)} />
+              : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>no textual diff — binary, renamed, or too large to show</div>}
+          </div>
+        </div>
+      )}
+    </div>
   );
 }
 
@@ -748,22 +936,74 @@ function Btn({ children, onClick, disabled, danger, primary, title }: {
 
 function Lane({ label, extra }: { label: string; extra?: string }) {
   return (
-    <div className="flex items-center gap-2 mt-3 mb-1.5 text-[9.5px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>
-      <span>{label}</span>
-      {extra && <span>{extra}</span>}
+    <div className="flex items-center gap-2 mt-4 mb-2 text-[9.5px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>
+      <span>{label}</span>{extra && <span>{extra}</span>}
       <span className="flex-1 h-px" style={{ background: "color-mix(in srgb, var(--border) 30%, transparent)" }} />
     </div>
   );
 }
 
-function Conversation({ d, lanes, botBytes, raw, onRaw, onResolve, onReply, onReview, busy }: {
+function Card({ who, chip, when, tone, children }: {
+  who: string; chip?: React.ReactNode; when?: string; tone?: "chg" | "appr" | "bot"; children: React.ReactNode;
+}) {
+  const edge = tone === "chg" ? "var(--error)" : tone === "appr" ? "var(--success)" : tone === "bot" ? "var(--info)" : "var(--border)";
+  return (
+    <div className="rounded-md overflow-hidden mb-2"
+      style={{ border: `1px solid color-mix(in srgb, ${edge} ${tone ? 40 : 28}%, transparent)` }}>
+      <div className="flex items-center gap-2 px-2.5 py-1.5 text-[11px]"
+        style={{ background: `color-mix(in srgb, ${edge} ${tone ? 10 : 14}%, transparent)`, borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
+        <Avatar login={who} size={17} />
+        <b style={{ color: "var(--text)", fontWeight: 500 }}>{who}</b>
+        {chip}
+        {when && <span className="ml-auto text-[10px]" style={{ color: "var(--text3)" }}>{when}</span>}
+      </div>
+      <div className="px-3 py-2.5">{children}</div>
+    </div>
+  );
+}
+
+/** The hunk a thread is anchored to, so the comment reads next to its code. */
+function ThreadSnippet({ file, line }: { file?: FileChange; line: number | null }) {
+  const rows = useMemo(() => {
+    if (!file || !line) return null;
+    for (const h of file.hunks) {
+      let n = h.newStart;
+      const out: { text: string; no: number | null }[] = [];
+      for (const l of h.lines) {
+        const no = l.startsWith("-") ? null : n++;
+        out.push({ text: l, no });
+      }
+      if (out.some((r) => r.no === line)) {
+        const idx = out.findIndex((r) => r.no === line);
+        return out.slice(Math.max(0, idx - 3), idx + 1);
+      }
+    }
+    return null;
+  }, [file, line]);
+  if (!rows?.length) return null;
+  return (
+    <div className="text-[10.5px]" style={{ ...CODE_FONT_STYLE, borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
+      {rows.map((r, i) => (
+        <div key={i} className="px-2.5 whitespace-pre overflow-hidden text-ellipsis" style={{
+          color: r.text.startsWith("+") ? "var(--success)" : r.text.startsWith("-") ? "var(--error)" : "var(--text3)",
+          background: r.text.startsWith("+") ? "color-mix(in srgb, var(--success) 10%, transparent)"
+            : r.text.startsWith("-") ? "color-mix(in srgb, var(--error) 10%, transparent)" : undefined,
+        }}>{r.text || " "}</div>
+      ))}
+    </div>
+  );
+}
+
+function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }: {
   d: PrDetail;
   lanes: { humans: PrReview[]; botReviews: PrReview[]; humanComments: PrComment[]; bots: PrComment[] };
-  botBytes: number; raw: boolean; onRaw: (v: boolean) => void;
-  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void;
-  onReview: (v: "approve" | "request_changes" | "comment") => void; busy: boolean;
+  raw: boolean; onRaw: (v: boolean) => void;
+  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
+  fileOf: (path: string) => FileChange | undefined;
 }) {
-  const kb = Math.round(botBytes / 1024);
+  const kb = Math.round(lanes.bots.reduce((n, c) => n + c.body.length, 0) / 1024);
+  const openN = d.threads.filter((t) => !t.isResolved).length;
+
   return (
     <div className="text-[11px]">
       <Lane label="humans" />
@@ -771,94 +1011,68 @@ function Conversation({ d, lanes, botBytes, raw, onRaw, onResolve, onReply, onRe
         <div style={{ color: "var(--text3)" }}>Nobody has said anything yet.</div>
       )}
       {lanes.humans.map((r, i) => (
-        <div key={`r${i}`} className="mb-1.5 p-2 rounded"
-          style={{
-            background: "color-mix(in srgb, var(--border) 12%, transparent)",
-            borderLeft: `2px solid ${r.state === "CHANGES_REQUESTED" ? "var(--error)" : r.state === "APPROVED" ? "var(--success)" : "var(--primary)"}`,
-          }}>
-          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
-            <b style={{ color: "var(--text)", fontWeight: 500 }}>{r.author}</b>
-            {r.state === "CHANGES_REQUESTED" && <Chip text="changes requested" tint="var(--error)" />}
-            {r.state === "APPROVED" && <Chip text="approved" tint="var(--success)" />}
-            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(r.submittedAt)}</span>
-          </div>
-          {r.body && <Body body={r.body} />}
-        </div>
+        <Card key={`r${i}`} who={r.author} when={ago(r.submittedAt)}
+          tone={r.state === "CHANGES_REQUESTED" ? "chg" : r.state === "APPROVED" ? "appr" : undefined}
+          chip={r.state === "CHANGES_REQUESTED" ? <Chip text="changes requested" tint="var(--error)" />
+            : r.state === "APPROVED" ? <Chip text="approved" tint="var(--success)" /> : undefined}>
+          {r.body ? <Md body={r.body} /> : <span style={{ color: "var(--text3)" }}>({r.state.toLowerCase().replace("_", " ")}, no note)</span>}
+        </Card>
       ))}
       {lanes.humanComments.map((c) => (
-        <div key={c.id} className="mb-1.5 p-2 rounded" style={{ background: "color-mix(in srgb, var(--border) 12%, transparent)", borderLeft: "2px solid var(--primary)" }}>
-          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
-            <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
-            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
-          </div>
-          <Body body={c.body} />
-        </div>
+        <Card key={c.id} who={c.author} when={ago(c.createdAt)}><Md body={c.body} /></Card>
       ))}
 
-      <Lane label="line threads" extra={d.threads.length ? `${d.threads.filter((t) => !t.isResolved).length} open of ${d.threads.length}` : undefined} />
+      <Lane label="line threads" extra={d.threads.length ? `${openN} open of ${d.threads.length}` : undefined} />
       {d.threads.length === 0 && <div style={{ color: "var(--text3)" }}>No line comments.</div>}
       {d.threads.map((t) => (
-        <div key={t.id} className="mb-1.5 rounded" style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
-          <div className="flex items-center gap-1.5 px-2 py-1 border-b text-[10px]" style={{ borderColor: "color-mix(in srgb, var(--border) 22%, transparent)" }}>
+        <div key={t.id} className="rounded-md overflow-hidden mb-2" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
+          <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
+            style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
             <span style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
             {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="the code under this comment has changed since" />}
-            <span className="ml-auto" style={{ color: t.isResolved ? "var(--success)" : "var(--warning)" }}>{t.isResolved ? "resolved" : "open"}</span>
+            <span className="ml-auto">{t.isResolved ? <Chip text="resolved" tint="var(--success)" /> : <Chip text="open" tint="var(--warning)" />}</span>
           </div>
+          <ThreadSnippet file={fileOf(t.path)} line={t.line} />
           {t.comments.map((c, i) => (
-            <div key={c.id} className="px-2 py-1.5" style={{ paddingLeft: i ? 18 : 8, background: i ? "color-mix(in srgb, var(--border) 10%, transparent)" : undefined }}>
-              <div className="flex items-center gap-1.5 mb-0.5 text-[10px]">
+            <div key={c.id} className="px-3 py-2"
+              style={{ paddingLeft: i ? 26 : 12, background: i ? "color-mix(in srgb, var(--border) 9%, transparent)" : undefined }}>
+              <div className="flex items-center gap-1.5 mb-1 text-[10px]">
+                <Avatar login={c.author} size={15} />
                 <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
                 {c.isBot && <Chip text="automation" tint="var(--info)" />}
                 <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
               </div>
-              <Body body={c.body} />
+              <Md body={c.body} />
             </div>
           ))}
-          <div className="flex gap-1.5 px-2 py-1.5">
-            <Btn onClick={() => onReply(t)} disabled={busy}>reply</Btn>
-            <Btn onClick={() => onResolve(t)} disabled={busy}>{t.isResolved ? "unresolve" : "resolve"}</Btn>
+          <div className="flex gap-1.5 px-3 py-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
+            <Btn onClick={() => onReply(t)} disabled={busy} small>reply</Btn>
+            <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "unresolve" : "resolve conversation"}</Btn>
           </div>
         </div>
       ))}
 
       <Lane label="automation" extra={lanes.bots.length ? `${lanes.bots.length} comments · ${kb} KB` : undefined} />
       {lanes.botReviews.map((r, i) => (
-        <div key={`br${i}`} className="mb-1.5 p-2 rounded" style={{ background: "color-mix(in srgb, var(--border) 10%, transparent)", borderLeft: "2px solid var(--info)" }}>
-          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
-            <b style={{ color: "var(--text)", fontWeight: 500 }}>{r.author}</b><Chip text="automation" tint="var(--info)" />
-            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(r.submittedAt)}</span>
-          </div>
-          <Body body={r.body} />
-        </div>
+        <Card key={`br${i}`} who={r.author} when={ago(r.submittedAt)} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
+          <Md body={r.body} />
+        </Card>
       ))}
       {lanes.bots.length > 0 && (
         <>
-          {/* A real coverage comment is 46,551 characters and about three
-              numbers. Show the numbers; keep the rest one click away. */}
-          <button onClick={() => onRaw(!raw)} className="w-full text-left text-[10px] px-2 py-1 rounded mb-1.5"
+          <button onClick={() => onRaw(!raw)} className="w-full text-left text-[10px] px-2.5 py-1.5 rounded mb-2"
             style={{ color: "var(--text2)", border: "1px dashed color-mix(in srgb, var(--border) 50%, transparent)" }}>
             <span style={{ color: "var(--primary)" }}>{raw ? "▾" : "▸"}</span>{" "}
             {lanes.bots.length} machine comment{lanes.bots.length === 1 ? "" : "s"} · {kb} KB {raw ? "— hide raw" : "collapsed — show raw"}
           </button>
           {lanes.bots.map((c) => (
-            <div key={c.id} className="mb-1.5 p-2 rounded" style={{ background: "color-mix(in srgb, var(--border) 10%, transparent)", borderLeft: "2px solid var(--info)" }}>
-              <div className="flex items-center gap-1.5 mb-0.5 text-[10px]">
-                <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b><Chip text="automation" tint="var(--info)" />
-                <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
-              </div>
-              {raw
-                ? <pre className="overflow-x-auto text-[10px] max-h-64" style={{ ...CODE_FONT_STYLE, color: "var(--text3)" }}>{c.body}</pre>
-                : <div style={{ color: "var(--text2)" }}>{c.digest || "(nothing worth pulling out)"}</div>}
-            </div>
+            <Card key={c.id} who={c.author} when={ago(c.createdAt)} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
+              {raw ? <pre className="overflow-x-auto text-[10px] max-h-72 agx-scroll" style={{ ...CODE_FONT_STYLE, color: "var(--text3)" }}>{c.body}</pre>
+                : <span style={{ color: "var(--text2)" }}>{c.digest || "(nothing worth pulling out)"}</span>}
+            </Card>
           ))}
         </>
       )}
-
-      <div className="flex gap-1.5 flex-wrap mt-3">
-        <Btn onClick={() => onReview("comment")} disabled={busy}>comment</Btn>
-        <Btn onClick={() => onReview("approve")} disabled={busy}>approve</Btn>
-        <Btn onClick={() => onReview("request_changes")} disabled={busy} danger>request changes</Btn>
-      </div>
     </div>
   );
 }
@@ -875,67 +1089,201 @@ const CHECK_GLYPH: Record<PrCheck["state"], string> = {
   success: "✓", failure: "✕", pending: "•", skipped: "⊘", neutral: "⊘",
 };
 
+/** "CI / Tests / django-tests" — the workflow is the prefix, and grouping by
+ *  it turns fifty-nine rows into six things you can actually scan. */
+function groupOf(k: PrCheck): string {
+  if (k.workflow) return k.workflow;
+  const parts = k.name.split(" / ");
+  return parts.length > 1 ? parts.slice(0, -1).join(" / ") : "checks";
+}
+
 function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: boolean }) {
   const c = d.checks;
-  const pct = (n: number) => (c.total ? (n / c.total) * 100 : 0);
-  // Skipped checks are the bulk of a big suite and almost never what you came
-  // for, so they collapse — the same call GitHub makes, for the same reason.
+  const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   const [showSkipped, setShowSkipped] = useState(false);
 
-  const order: Record<PrCheck["state"], number> = { failure: 0, pending: 1, success: 2, neutral: 3, skipped: 4 };
-  const shown = useMemo(() => {
-    const list = d.checksAll.filter((k) => showSkipped || (k.state !== "skipped" && k.state !== "neutral"));
-    return [...list].sort((a, b) => order[a.state] - order[b.state] || a.name.localeCompare(b.name));
+  const groups = useMemo(() => {
+    const m = new Map<string, PrCheck[]>();
+    for (const k of d.checksAll) {
+      if (!showSkipped && (k.state === "skipped" || k.state === "neutral")) continue;
+      const g = groupOf(k);
+      if (!m.has(g)) m.set(g, []);
+      m.get(g)!.push(k);
+    }
+    const rank = (list: PrCheck[]) => (list.some((k) => k.state === "failure") ? 0 : list.some((k) => k.state === "pending") ? 1 : 2);
+    return [...m.entries()].sort((a, b) => rank(a[1]) - rank(b[1]) || a[0].localeCompare(b[0]));
   }, [d.checksAll, showSkipped]);
 
   const skippedCount = d.checksAll.filter((k) => k.state === "skipped" || k.state === "neutral").length;
+  const pct = (n: number) => (c.total ? (n / c.total) * 100 : 0);
 
   return (
-    <div className="text-[11px]">
-      <div className="flex items-center gap-2 mb-2 tabular-nums">
-        <span style={{ color: "var(--success)" }}>{c.success} ✓</span>
-        <span style={{ color: "var(--text3)" }}>{c.skipped} ⊘</span>
-        <span style={{ color: "var(--error)" }}>{c.failure} ✕</span>
-        {c.pending > 0 && <span style={{ color: "var(--warning)" }}>{c.pending} running</span>}
-        <Bar parts={[
-          { pct: pct(c.success), tint: "var(--success)" },
-          { pct: pct(c.failure), tint: "var(--error)" },
-          { pct: pct(c.pending), tint: "var(--warning)" },
-          { pct: pct(c.skipped), tint: "color-mix(in srgb, var(--text3) 40%, transparent)" },
-        ]} />
-        {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
+    <div className="text-[11px] flex flex-col gap-2">
+      <div className="flex items-center gap-3 p-3 rounded-lg" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
+        <span className="shrink-0 rounded-full flex items-center justify-center text-[13px]"
+          style={{ width: 26, height: 26, background: c.failure > 0 ? "var(--error)" : c.pending > 0 ? "var(--warning)" : "var(--success)", color: "var(--bg)" }}>
+          {c.failure > 0 ? "✕" : c.pending > 0 ? "•" : "✓"}
+        </span>
+        <span className="min-w-0">
+          <span className="block text-[13px] font-semibold leading-tight" style={{ color: "var(--text)" }}>
+            {c.failure > 0 ? `${c.failure} check${c.failure === 1 ? "" : "s"} failing` : c.pending > 0 ? `${c.pending} still running` : "All checks have passed"}
+          </span>
+          <span className="block text-[11px] mt-0.5 tabular-nums" style={{ color: "var(--text3)" }}>
+            {c.skipped} skipped · {c.success} successful · {c.failure} failing
+          </span>
+        </span>
+        <span className="ml-auto shrink-0 flex items-center gap-2">
+          {c.failure > 0 && <Btn onClick={onRerun} disabled={busy} small>re-run failed</Btn>}
+          <span className="text-[10px]" style={{ color: "var(--text3)" }}>{c.allDone ? "notified once, not " + c.total : "you will be told once, at the end"}</span>
+        </span>
       </div>
+      <Bar parts={[
+        { pct: pct(c.success), tint: "var(--success)" },
+        { pct: pct(c.failure), tint: "var(--error)" },
+        { pct: pct(c.pending), tint: "var(--warning)" },
+        { pct: pct(c.skipped), tint: "color-mix(in srgb, var(--text3) 40%, transparent)" },
+      ]} />
 
-      <div className="text-[10px] mb-2" style={{ color: "var(--text3)" }}>
-        {c.allDone
-          ? `all ${c.total} checks are done — ${c.verdict === "green" ? "green" : "red"}. One notification was sent, not ${c.total}.`
-          : `${c.pending} of ${c.total} still running — you will be told once, when the last one lands.`}
-      </div>
-
-      {/* Every check, by name. A grid of squares says something broke without
-          saying what, which is exactly the trip to the browser this replaces. */}
-      <div>
-        {shown.map((k, i) => (
-          <div key={`${k.name}-${i}`} className="flex items-center gap-2 py-1 border-b"
-            style={{ borderColor: "color-mix(in srgb, var(--border) 18%, transparent)" }}>
-            <span className="shrink-0 w-3 text-center" style={{ color: CHECK_TINT[k.state] }}>{CHECK_GLYPH[k.state]}</span>
-            <span className="truncate" style={{ color: k.state === "skipped" || k.state === "neutral" ? "var(--text3)" : "var(--text2)" }}>
-              {k.workflow ? <span style={{ color: "var(--text3)" }}>{k.workflow} / </span> : null}{k.name}
-            </span>
-            <span className="ml-auto shrink-0 text-[9.5px] uppercase tracking-wide" style={{ color: CHECK_TINT[k.state] }}>{k.state}</span>
-            {k.url && (
-              <a href={k.url} target="_blank" rel="noreferrer noopener" className="shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>log ↗</a>
-            )}
+      {groups.map(([name, list]) => {
+        const isOpen = openGroups[name] ?? list.some((k) => k.state === "failure" || k.state === "pending");
+        const bad = list.filter((k) => k.state === "failure").length;
+        const good = list.filter((k) => k.state === "success").length;
+        return (
+          <div key={name} className="rounded overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
+            <button onClick={() => setOpenGroups((o) => ({ ...o, [name]: !isOpen }))}
+              className="w-full text-left flex items-center gap-2 px-2.5 py-1.5"
+              style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)" }}>
+              <span style={{ color: "var(--text3)" }}>{isOpen ? "▾" : "▸"}</span>
+              <b style={{ color: "var(--text)", fontWeight: 500 }}>{name}</b>
+              {bad > 0 && <span style={{ color: "var(--error)" }}>{bad} ✕</span>}
+              {good > 0 && <span style={{ color: "var(--success)" }}>{good} ✓</span>}
+              <span className="ml-auto tabular-nums" style={{ color: "var(--text3)" }}>{list.length}</span>
+            </button>
+            {isOpen && list.map((k, i) => (
+              <div key={`${k.name}-${i}`} className="flex items-center gap-2 px-2.5 py-1"
+                style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 16%, transparent)" }}>
+                <span className="shrink-0 w-3 text-center" style={{ color: CHECK_TINT[k.state] }}>{CHECK_GLYPH[k.state]}</span>
+                <span className="truncate" style={{ color: k.state === "skipped" || k.state === "neutral" ? "var(--text3)" : "var(--text2)" }}>
+                  {k.name.startsWith(name) ? k.name.slice(name.length).replace(/^\s*\/\s*/, "") || k.name : k.name}
+                </span>
+                <span className="ml-auto shrink-0 text-[9.5px] uppercase tracking-wide" style={{ color: CHECK_TINT[k.state] }}>{k.state}</span>
+                {k.url && <a href={k.url} target="_blank" rel="noreferrer noopener" className="shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>log ↗</a>}
+              </div>
+            ))}
           </div>
-        ))}
-      </div>
+        );
+      })}
 
       {skippedCount > 0 && (
-        <button onClick={() => setShowSkipped((v) => !v)} className="mt-2 text-[10px] px-2 py-1 rounded"
+        <button onClick={() => setShowSkipped((v) => !v)} className="text-[10px] px-2.5 py-1.5 rounded self-start"
           style={{ color: "var(--text2)", border: "1px dashed color-mix(in srgb, var(--border) 50%, transparent)" }}>
           {showSkipped ? "hide" : "show"} {skippedCount} skipped
         </button>
       )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// review submission
+// ---------------------------------------------------------------------------
+
+/**
+ * Finishing a review: a verdict, a note, and everything queued while reading.
+ *
+ * The queued comments are the point. GitHub calls this a pending review, and it
+ * exists so a reviewer leaves one notification rather than a dozen — the
+ * comments and the verdict travel in a single request.
+ */
+function ReviewSheet({ d, drafts, seen, busy, onDrop, onCancel, onSubmit }: {
+  d: PrDetail; drafts: DraftComment[]; seen: number; busy: boolean;
+  onDrop: (i: number) => void; onCancel: () => void;
+  onSubmit: (verb: "approve" | "request_changes" | "comment", body: string) => void;
+}) {
+  const [verb, setVerb] = useState<"comment" | "approve" | "request_changes">("comment");
+  const [body, setBody] = useState("");
+  const [preview, setPreview] = useState(false);
+
+  return (
+    <div className="shrink-0 flex flex-col" style={{
+      borderTop: "1px solid color-mix(in srgb, var(--border) 45%, transparent)",
+      background: "color-mix(in srgb, var(--border) 8%, transparent)", maxHeight: "62%",
+    }}>
+      <div className="flex items-center gap-2 px-3 py-1.5 text-[11px]"
+        style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+        <b style={{ color: "var(--text)", fontWeight: 500 }}>Finish your review</b>
+        <span style={{ color: "var(--text3)" }}>#{d.number}</span>
+        <span className="ml-auto tabular-nums text-[10px]" style={{ color: "var(--text3)" }}>{seen}/{d.files.length} files viewed</span>
+      </div>
+
+      <div className="flex-1 overflow-y-auto min-h-0 agx-scroll p-3 flex flex-col gap-2">
+        {drafts.length > 0 && (
+          <div className="rounded overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)" }}>
+            <div className="px-2.5 py-1 text-[10px] uppercase tracking-wider"
+              style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 10%, transparent)" }}>
+              {drafts.length} pending comment{drafts.length === 1 ? "" : "s"} — sent with this review
+            </div>
+            {drafts.map((c, i) => (
+              <div key={i} className="flex items-start gap-2 px-2.5 py-1.5 text-[11px]"
+                style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" }}>
+                <span className="shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.path.split("/").pop()}:{c.line}</span>
+                <span className="min-w-0 flex-1" style={{ color: "var(--text2)" }}>{c.body}</span>
+                <button onClick={() => onDrop(i)} className="shrink-0 text-[10px]" style={{ color: "var(--error)" }}>drop</button>
+              </div>
+            ))}
+          </div>
+        )}
+
+        <div className="flex gap-0 text-[10.5px]" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+          {(["write", "preview"] as const).map((m) => (
+            <button key={m} onClick={() => setPreview(m === "preview")}
+              className="px-3 py-1"
+              style={{
+                color: (m === "preview") === preview ? "var(--text)" : "var(--text3)",
+                borderBottom: `2px solid ${(m === "preview") === preview ? "var(--primary)" : "transparent"}`,
+              }}>{m}</button>
+          ))}
+        </div>
+
+        {preview ? (
+          <div className="rounded p-2.5 min-h-[76px]" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
+            {body.trim() ? <Md body={body} /> : <span className="text-[11px]" style={{ color: "var(--text3)" }}>Nothing to preview.</span>}
+          </div>
+        ) : (
+          <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={4}
+            placeholder="Leave a comment — markdown works here."
+            className="w-full rounded p-2.5 text-[11.5px] bg-transparent resize-y"
+            style={{ color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }} />
+        )}
+
+        <div className="flex flex-col gap-1 text-[11.5px]" style={{ color: "var(--text2)" }}>
+          {([
+            ["comment", "Comment", "General feedback without explicit approval.", "var(--text)"],
+            ["approve", "Approve", "Submit feedback and approve merging these changes.", "var(--success)"],
+            ["request_changes", "Request changes", "Submit feedback that must be addressed first.", "var(--error)"],
+          ] as const).map(([id, label, hint, tint]) => (
+            <label key={id} className="flex items-start gap-2 cursor-pointer">
+              <input type="radio" name="agx-review-verb" checked={verb === id} onChange={() => setVerb(id)}
+                style={{ accentColor: "var(--primary)", marginTop: 3 }} />
+              <span>
+                <b style={{ color: tint, fontWeight: 500 }}>{label}</b>
+                <span className="block text-[10.5px]" style={{ color: "var(--text3)" }}>{hint}</span>
+              </span>
+            </label>
+          ))}
+        </div>
+      </div>
+
+      <div className="flex items-center gap-2 px-3 py-2 shrink-0"
+        style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+        <span className="text-[10px]" style={{ color: "var(--text3)" }}>
+          {verb === "approve" ? "Posted publicly to your team." : "Posted publicly. Say what needs to change."}
+        </span>
+        <span className="ml-auto flex gap-1.5">
+          <Btn onClick={onCancel} disabled={busy} small>cancel</Btn>
+          <Btn onClick={() => onSubmit(verb, body)} disabled={busy} primary>submit review</Btn>
+        </span>
+      </div>
     </div>
   );
 }

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -32,7 +32,7 @@ import { SCROLLBAR_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle } from "
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 
 type Filter = "mine" | "review" | "all";
-type Tab = "overview" | "conversation" | "commits" | "files" | "checks";
+type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
 
 const FILTERS: { id: Filter; label: string; hint: string }[] = [
   { id: "mine", label: "mine", hint: "pull requests you opened" },
@@ -356,7 +356,6 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [commitBusy, setCommitBusy] = useState(false);
   const [split, setSplit] = useState(true);
   const [wrap, setWrap] = useState(false);
-  const [reviewOpen, setReviewOpen] = useState(false);
   const detailReq = useRef(0);
   /** Which list request is current. A filter's answer takes seconds, and
    *  without this the slower reply from the filter you just left overwrites the
@@ -447,14 +446,14 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   useEffect(() => {
     if (!active || !root || selected == null) { setDetail(null); return; }
-    setDiff(""); setSelFile(null); setSelCommit(null); setCommitText(""); setReviewOpen(false);
+    setDiff(""); setSelFile(null); setSelCommit(null); setCommitText("");
     loadDetail(selected);
   }, [active, root, selected, loadDetail]);
 
   useEffect(() => {
-    if ((tab !== "files" && !reviewOpen) || !detail || diff || !root) return;
+    if ((tab !== "files" && tab !== "review") || !detail || diff || !root) return;
     api.prDiff(root, detail.number).then((r) => setDiff(r.ok ? (r.text || "") : "")).catch(() => {});
-  }, [tab, reviewOpen, detail, diff, root]);
+  }, [tab, detail, diff, root]);
 
   const parsed = useMemo(() => parseUnifiedDiff(diff), [diff]);
   const byPath = useMemo(() => {
@@ -531,7 +530,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     const ok = await act("review", () => api.prReviewWith(root, detail.number, verb, body, myDrafts));
     if (ok && key) {
       setDrafts((cur) => { const next = { ...cur, [key]: [] }; saveMap(DRAFT_KEY, next); return next; });
-      setReviewOpen(false);
+      setTab("conversation");
     }
   };
 
@@ -584,12 +583,17 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const openThreads = useMemo(() => (detail?.threads ?? []).filter((t) => !t.isResolved), [detail]);
   const d = detail;
 
+  // You cannot review your own pull request — GitHub does not offer it either,
+  // and a review control on every row buries the ones actually waiting on you.
+  const canReview = !!d && !d.viewerDidAuthor;
+
   const TABS: { id: Tab; label: string; n?: number; warn?: boolean }[] = d ? [
     { id: "overview", label: "overview", warn: d.checklist.some((c) => !c.checked) },
     { id: "conversation", label: "conversation", n: lanes.humans.length + lanes.humanComments.length + d.threads.length + lanes.bots.length },
     { id: "commits", label: "commits", n: d.commits.length },
     { id: "files", label: "files", n: d.files.length },
     { id: "checks", label: "checks", n: d.checks.total, warn: d.checks.failure > 0 },
+    ...(canReview ? [{ id: "review" as Tab, label: "review", n: myDrafts.length || undefined, warn: d.viewerRequested }] : []),
   ] : [];
 
   return (
@@ -682,7 +686,9 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 ))}
                 <div className="ml-auto flex items-center gap-1.5 px-2 shrink-0">
                   {myDrafts.length > 0 && <Chip text={`${myDrafts.length} pending`} tint="var(--warning)" title="line comments queued but not sent" />}
-                  <Btn onClick={() => setReviewOpen(true)} primary small>review</Btn>
+                  {d.viewerRequested && tab !== "review" && (
+                    <Btn onClick={() => setTab("review")} primary small>add your review</Btn>
+                  )}
                 </div>
               </div>
 
@@ -754,14 +760,15 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 )}
 
                 {tab === "checks" && <Checks d={d} busy={busy} onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))} />}
+
+                {tab === "review" && canReview && (
+                  <ReviewTab
+                    d={d} drafts={myDrafts} seen={seenFiles.length} busy={busy}
+                    onDrop={dropDraft} onSubmit={submitReview} onGoFiles={() => setTab("files")}
+                  />
+                )}
               </div>
 
-              {reviewOpen && (
-                <ReviewSheet
-                  d={d} drafts={myDrafts} seen={seenFiles.length} busy={busy}
-                  onDrop={dropDraft} onCancel={() => setReviewOpen(false)} onSubmit={submitReview}
-                />
-              )}
             </>
           )}
         </div>
@@ -1071,6 +1078,41 @@ function ThreadSnippet({ file, line }: { file?: FileChange; line: number | null 
   );
 }
 
+/** One review thread: where it is anchored, the code it sits on, the exchange,
+ *  and the two things you can do about it. */
+function Thread({ t, fileOf, onResolve, onReply, busy }: {
+  t: PrThread; fileOf: (p: string) => FileChange | undefined;
+  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
+}) {
+  return (
+    <div className="rounded-md overflow-hidden mb-2" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
+      <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
+        style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
+        <span style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
+        {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="the code under this comment has changed since" />}
+        <span className="ml-auto">{t.isResolved ? <Chip text="resolved" tint="var(--success)" /> : <Chip text="open" tint="var(--warning)" />}</span>
+      </div>
+      <ThreadSnippet file={fileOf(t.path)} line={t.line} />
+      {t.comments.map((c, i) => (
+        <div key={c.id} className="px-3 py-2"
+          style={{ paddingLeft: i ? 26 : 12, background: i ? "color-mix(in srgb, var(--border) 9%, transparent)" : undefined }}>
+          <div className="flex items-center gap-1.5 mb-1 text-[10px]">
+            <Avatar login={c.author} size={15} />
+            <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
+            {c.isBot && <Chip text="automation" tint="var(--info)" />}
+            <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
+          </div>
+          <Md body={c.body} />
+        </div>
+      ))}
+      <div className="flex gap-1.5 px-3 py-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
+        <Btn onClick={() => onReply(t)} disabled={busy} small>reply</Btn>
+        <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "unresolve" : "resolve conversation"}</Btn>
+      </div>
+    </div>
+  );
+}
+
 function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }: {
   d: PrDetail;
   lanes: { humans: PrReview[]; botReviews: PrReview[]; humanComments: PrComment[]; bots: PrComment[] };
@@ -1079,7 +1121,10 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }
   fileOf: (path: string) => FileChange | undefined;
 }) {
   const kb = Math.round(lanes.bots.reduce((n, c) => n + c.body.length, 0) / 1024);
-  const openN = d.threads.filter((t) => !t.isResolved).length;
+  // Threads whose author never submitted a review of their own — a bot's
+  // findings, or a comment left outside a review. They still need a home.
+  const reviewAuthors = new Set(lanes.humans.map((r) => r.author));
+  const orphanThreads = d.threads.filter((t) => !reviewAuthors.has(t.comments[0]?.author ?? ""));
 
   return (
     <div className="text-[11px]">
@@ -1087,47 +1132,39 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy, fileOf }
       {lanes.humans.length === 0 && lanes.humanComments.length === 0 && (
         <div style={{ color: "var(--text3)" }}>Nobody has said anything yet.</div>
       )}
-      {lanes.humans.map((r, i) => (
-        <Card key={`r${i}`} who={r.author} when={ago(r.submittedAt)}
-          tone={r.state === "CHANGES_REQUESTED" ? "chg" : r.state === "APPROVED" ? "appr" : undefined}
-          chip={r.state === "CHANGES_REQUESTED" ? <Chip text="changes requested" tint="var(--error)" />
-            : r.state === "APPROVED" ? <Chip text="approved" tint="var(--success)" /> : undefined}>
-          {r.body ? <Md body={r.body} /> : <span style={{ color: "var(--text3)" }}>({r.state.toLowerCase().replace("_", " ")}, no note)</span>}
-        </Card>
-      ))}
+      {lanes.humans.map((r, i) => {
+        // The line comments that belong to THIS review. GitHub nests them under
+        // the review they were submitted with, and that grouping is most of the
+        // meaning: a "requested changes" is a verdict, and the threads beneath
+        // it are the reasons. Split apart into separate lanes, you get a
+        // verdict with no reasons and a pile of reasons with no verdict.
+        const mine = d.threads.filter((t) => t.comments[0]?.author === r.author);
+        return (
+          <div key={`r${i}`} className="mb-2">
+            <Card who={r.author} when={ago(r.submittedAt)}
+              tone={r.state === "CHANGES_REQUESTED" ? "chg" : r.state === "APPROVED" ? "appr" : undefined}
+              chip={r.state === "CHANGES_REQUESTED" ? <Chip text="requested changes" tint="var(--error)" />
+                : r.state === "APPROVED" ? <Chip text="approved" tint="var(--success)" /> : undefined}>
+              {r.body ? <Md body={r.body} /> : <span style={{ color: "var(--text3)" }}>({r.state.toLowerCase().replace("_", " ")}, no note)</span>}
+            </Card>
+            {mine.length > 0 && (
+              <div className="pl-3 ml-2" style={{ borderLeft: "2px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                {mine.map((t) => <Thread key={t.id} t={t} fileOf={fileOf} onResolve={onResolve} onReply={onReply} busy={busy} />)}
+              </div>
+            )}
+          </div>
+        );
+      })}
       {lanes.humanComments.map((c) => (
         <Card key={c.id} who={c.author} when={ago(c.createdAt)}><Md body={c.body} /></Card>
       ))}
 
-      <Lane label="line threads" extra={d.threads.length ? `${openN} open of ${d.threads.length}` : undefined} />
-      {d.threads.length === 0 && <div style={{ color: "var(--text3)" }}>No line comments.</div>}
-      {d.threads.map((t) => (
-        <div key={t.id} className="rounded-md overflow-hidden mb-2" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
-          <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
-            style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
-            <span style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
-            {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="the code under this comment has changed since" />}
-            <span className="ml-auto">{t.isResolved ? <Chip text="resolved" tint="var(--success)" /> : <Chip text="open" tint="var(--warning)" />}</span>
-          </div>
-          <ThreadSnippet file={fileOf(t.path)} line={t.line} />
-          {t.comments.map((c, i) => (
-            <div key={c.id} className="px-3 py-2"
-              style={{ paddingLeft: i ? 26 : 12, background: i ? "color-mix(in srgb, var(--border) 9%, transparent)" : undefined }}>
-              <div className="flex items-center gap-1.5 mb-1 text-[10px]">
-                <Avatar login={c.author} size={15} />
-                <b style={{ color: "var(--text)", fontWeight: 500 }}>{c.author}</b>
-                {c.isBot && <Chip text="automation" tint="var(--info)" />}
-                <span className="ml-auto" style={{ color: "var(--text3)" }}>{ago(c.createdAt)}</span>
-              </div>
-              <Md body={c.body} />
-            </div>
-          ))}
-          <div className="flex gap-1.5 px-3 py-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
-            <Btn onClick={() => onReply(t)} disabled={busy} small>reply</Btn>
-            <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "unresolve" : "resolve conversation"}</Btn>
-          </div>
-        </div>
-      ))}
+      {orphanThreads.length > 0 && (
+        <>
+          <Lane label="line threads" extra={`${orphanThreads.filter((t) => !t.isResolved).length} open of ${orphanThreads.length}`} />
+          {orphanThreads.map((t) => <Thread key={t.id} t={t} fileOf={fileOf} onResolve={onResolve} onReply={onReply} busy={busy} />)}
+        </>
+      )}
 
       <Lane label="automation" extra={lanes.bots.length ? `${lanes.bots.length} comments · ${kb} KB` : undefined} />
       {lanes.botReviews.map((r, i) => (
@@ -1268,98 +1305,116 @@ function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: 
 /**
  * Finishing a review: a verdict, a note, and everything queued while reading.
  *
- * The queued comments are the point. GitHub calls this a pending review, and it
- * exists so a reviewer leaves one notification rather than a dozen — the
- * comments and the verdict travel in a single request.
+ * A tab rather than a sheet, because reviewing is a place you go, not a dialog
+ * you dismiss — and because it only exists on pull requests that are somebody
+ * else's. The queued comments are the point: GitHub calls this a pending
+ * review, and it exists so a reviewer leaves one notification rather than a
+ * dozen. The comments and the verdict travel in a single request.
  */
-function ReviewSheet({ d, drafts, seen, busy, onDrop, onCancel, onSubmit }: {
+function ReviewTab({ d, drafts, seen, busy, onDrop, onSubmit, onGoFiles }: {
   d: PrDetail; drafts: DraftComment[]; seen: number; busy: boolean;
-  onDrop: (i: number) => void; onCancel: () => void;
+  onDrop: (i: number) => void;
   onSubmit: (verb: "approve" | "request_changes" | "comment", body: string) => void;
+  onGoFiles: () => void;
 }) {
   const [verb, setVerb] = useState<"comment" | "approve" | "request_changes">("comment");
   const [body, setBody] = useState("");
   const [preview, setPreview] = useState(false);
+  const nothing = !body.trim() && drafts.length === 0;
 
   return (
-    <div className="shrink-0 flex flex-col" style={{
-      borderTop: "1px solid color-mix(in srgb, var(--border) 45%, transparent)",
-      background: "color-mix(in srgb, var(--border) 8%, transparent)", maxHeight: "62%",
-    }}>
-      <div className="flex items-center gap-2 px-3 py-1.5 text-[11px]"
-        style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
-        <b style={{ color: "var(--text)", fontWeight: 500 }}>Finish your review</b>
-        <span style={{ color: "var(--text3)" }}>#{d.number}</span>
-        <span className="ml-auto tabular-nums text-[10px]" style={{ color: "var(--text3)" }}>{seen}/{d.files.length} files viewed</span>
-      </div>
+    <div className="flex flex-col gap-3">
+      {d.viewerRequested && (
+        <div className="flex items-center gap-2 px-3 py-2 rounded-lg text-[11.5px]"
+          style={{ border: "1px solid color-mix(in srgb, var(--warning) 45%, transparent)", background: "color-mix(in srgb, var(--warning) 9%, transparent)" }}>
+          <Avatar login={d.author} size={18} />
+          <span style={{ color: "var(--text2)" }}>
+            <b style={{ color: "var(--text)", fontWeight: 500 }}>{d.author}</b> requested your review on this pull request
+          </span>
+        </div>
+      )}
 
-      <div className="flex-1 overflow-y-auto min-h-0 agx-scroll p-3 flex flex-col gap-2">
-        {drafts.length > 0 && (
-          <div className="rounded overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)" }}>
-            <div className="px-2.5 py-1 text-[10px] uppercase tracking-wider"
-              style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 10%, transparent)" }}>
-              {drafts.length} pending comment{drafts.length === 1 ? "" : "s"} — sent with this review
-            </div>
-            {drafts.map((c, i) => (
-              <div key={i} className="flex items-start gap-2 px-2.5 py-1.5 text-[11px]"
-                style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" }}>
-                <span className="shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.path.split("/").pop()}:{c.line}</span>
-                <span className="min-w-0 flex-1" style={{ color: "var(--text2)" }}>{c.body}</span>
-                <button onClick={() => onDrop(i)} className="shrink-0 text-[10px]" style={{ color: "var(--error)" }}>drop</button>
+      <div className="rounded-lg overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
+        <div className="flex items-center gap-2 px-3 py-1.5 text-[11px]"
+          style={{ background: "color-mix(in srgb, var(--border) 12%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+          <b style={{ color: "var(--text)", fontWeight: 500 }}>Finish your review</b>
+          <span style={{ color: "var(--text3)" }}>#{d.number}</span>
+          <button onClick={onGoFiles} className="ml-auto tabular-nums text-[10px]" style={{ color: seen < d.files.length ? "var(--primary)" : "var(--text3)" }}>
+            {seen}/{d.files.length} files viewed
+          </button>
+        </div>
+
+        <div className="p-3 flex flex-col gap-2">
+          {drafts.length > 0 ? (
+            <div className="rounded overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)" }}>
+              <div className="px-2.5 py-1 text-[10px] uppercase tracking-wider"
+                style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 10%, transparent)" }}>
+                {drafts.length} pending comment{drafts.length === 1 ? "" : "s"} — sent with this review
               </div>
+              {drafts.map((c, i) => (
+                <div key={i} className="flex items-start gap-2 px-2.5 py-1.5 text-[11px]"
+                  style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" }}>
+                  <span className="shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.path.split("/").pop()}:{c.line}</span>
+                  <span className="min-w-0 flex-1" style={{ color: "var(--text2)" }}>{c.body}</span>
+                  <button onClick={() => onDrop(i)} className="shrink-0 text-[10px]" style={{ color: "var(--error)" }}>drop</button>
+                </div>
+              ))}
+            </div>
+          ) : (
+            <div className="text-[10.5px]" style={{ color: "var(--text3)" }}>
+              No line comments queued. Open <button onClick={onGoFiles} style={{ color: "var(--primary)" }}>files</button> and
+              use “+ comment” on a hunk to attach one to a line.
+            </div>
+          )}
+
+          <div className="flex gap-0 text-[10.5px]" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+            {(["write", "preview"] as const).map((m) => (
+              <button key={m} onClick={() => setPreview(m === "preview")} className="px-3 py-1"
+                style={{
+                  color: (m === "preview") === preview ? "var(--text)" : "var(--text3)",
+                  borderBottom: `2px solid ${(m === "preview") === preview ? "var(--primary)" : "transparent"}`,
+                }}>{m}</button>
             ))}
           </div>
-        )}
 
-        <div className="flex gap-0 text-[10.5px]" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
-          {(["write", "preview"] as const).map((m) => (
-            <button key={m} onClick={() => setPreview(m === "preview")}
-              className="px-3 py-1"
-              style={{
-                color: (m === "preview") === preview ? "var(--text)" : "var(--text3)",
-                borderBottom: `2px solid ${(m === "preview") === preview ? "var(--primary)" : "transparent"}`,
-              }}>{m}</button>
-          ))}
-        </div>
+          {preview ? (
+            <div className="rounded p-2.5 min-h-[80px]" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
+              {body.trim() ? <Md body={body} /> : <span className="text-[11px]" style={{ color: "var(--text3)" }}>Nothing to preview.</span>}
+            </div>
+          ) : (
+            <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={5}
+              placeholder="Leave a comment — markdown works here."
+              className="w-full rounded p-2.5 text-[11.5px] bg-transparent resize-y"
+              style={{ color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }} />
+          )}
 
-        {preview ? (
-          <div className="rounded p-2.5 min-h-[76px]" style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
-            {body.trim() ? <Md body={body} /> : <span className="text-[11px]" style={{ color: "var(--text3)" }}>Nothing to preview.</span>}
+          <div className="flex flex-col gap-1 text-[11.5px]" style={{ color: "var(--text2)" }}>
+            {([
+              ["comment", "Comment", "General feedback without explicit approval.", "var(--text)"],
+              ["approve", "Approve", "Submit feedback and approve merging these changes.", "var(--success)"],
+              ["request_changes", "Request changes", "Submit feedback that must be addressed first.", "var(--error)"],
+            ] as const).map(([id, label, hint, tint]) => (
+              <label key={id} className="flex items-start gap-2 cursor-pointer">
+                <input type="radio" name="agx-review-verb" checked={verb === id} onChange={() => setVerb(id)}
+                  style={{ accentColor: "var(--primary)", marginTop: 3 }} />
+                <span>
+                  <b style={{ color: tint, fontWeight: 500 }}>{label}</b>
+                  <span className="block text-[10.5px]" style={{ color: "var(--text3)" }}>{hint}</span>
+                </span>
+              </label>
+            ))}
           </div>
-        ) : (
-          <textarea value={body} onChange={(e) => setBody(e.target.value)} rows={4}
-            placeholder="Leave a comment — markdown works here."
-            className="w-full rounded p-2.5 text-[11.5px] bg-transparent resize-y"
-            style={{ color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }} />
-        )}
 
-        <div className="flex flex-col gap-1 text-[11.5px]" style={{ color: "var(--text2)" }}>
-          {([
-            ["comment", "Comment", "General feedback without explicit approval.", "var(--text)"],
-            ["approve", "Approve", "Submit feedback and approve merging these changes.", "var(--success)"],
-            ["request_changes", "Request changes", "Submit feedback that must be addressed first.", "var(--error)"],
-          ] as const).map(([id, label, hint, tint]) => (
-            <label key={id} className="flex items-start gap-2 cursor-pointer">
-              <input type="radio" name="agx-review-verb" checked={verb === id} onChange={() => setVerb(id)}
-                style={{ accentColor: "var(--primary)", marginTop: 3 }} />
-              <span>
-                <b style={{ color: tint, fontWeight: 500 }}>{label}</b>
-                <span className="block text-[10.5px]" style={{ color: "var(--text3)" }}>{hint}</span>
-              </span>
-            </label>
-          ))}
+          <div className="flex items-center gap-2 pt-1">
+            <span className="text-[10px]" style={{ color: "var(--text3)" }}>
+              Posted publicly to your team{drafts.length ? `, with ${drafts.length} line comment${drafts.length === 1 ? "" : "s"}` : ""}.
+            </span>
+            <span className="ml-auto">
+              <Btn onClick={() => onSubmit(verb, body)} disabled={busy || (verb !== "approve" && nothing)} primary
+                title={verb !== "approve" && nothing ? "say something, or queue a line comment" : undefined}>submit review</Btn>
+            </span>
+          </div>
         </div>
-      </div>
-
-      <div className="flex items-center gap-2 px-3 py-2 shrink-0"
-        style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
-        <span className="text-[10px]" style={{ color: "var(--text3)" }}>
-          {verb === "approve" ? "Posted publicly to your team." : "Posted publicly. Say what needs to change."}
-        </span>
-        <span className="ml-auto flex gap-1.5">
-          <Btn onClick={onCancel} disabled={busy} small>cancel</Btn>
-          <Btn onClick={() => onSubmit(verb, body)} disabled={busy} primary>submit review</Btn>
-        </span>
       </div>
     </div>
   );

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -22,6 +22,7 @@ import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
+import { parseBody, renderInline, splitDiff, lineTint, type MdBlock } from "../lib/prBody.ts";
 
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks";
@@ -102,83 +103,6 @@ function Bar({ parts }: { parts: { pct: number; tint: string }[] }) {
  * so a body containing raw HTML renders as text rather than as markup. The body
  * is written by anyone who can open a pull request; it is not trusted input.
  */
-function escapeHtml(s: string): string {
-  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
-}
-
-function renderInline(s: string): string {
-  let out = escapeHtml(s);
-  out = out.replace(/`([^`]+)`/g, '<code class="px-1 rounded" style="background:color-mix(in srgb,var(--border) 30%,transparent)">$1</code>');
-  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong style="color:var(--text)">$1</strong>');
-  // Links only to http(s) — a markdown link is a place to smuggle javascript:.
-  out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
-    (_m, text: string, href: string) => `<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${text}</a>`);
-  out = out.replace(/(^|[\s(])((?:https?:\/\/)[^\s<)]+)/g,
-    (_m, pre: string, href: string) => `${pre}<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${href}</a>`);
-  return out;
-}
-
-type MdBlock =
-  | { kind: "text"; html: string }
-  | { kind: "code"; text: string }
-  | { kind: "image"; src: string; alt: string };
-
-/** Split a body into what has to render differently: fenced code, images
- *  (which need the proxy), and everything else. */
-export function parseBody(body: string): MdBlock[] {
-  const blocks: MdBlock[] = [];
-  let buf: string[] = [];
-  const flush = () => {
-    if (!buf.length) return;
-    const html = buf.map((line) => {
-      const h = line.match(/^(#{1,6})\s+(.*)$/);
-      if (h) return `<div style="color:var(--text);font-weight:600;margin-top:.7em">${renderInline(h[2]!)}</div>`;
-      const task = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.*)$/);
-      if (task) {
-        const done = task[1]!.toLowerCase() === "x";
-        return `<div style="display:flex;gap:.4em;color:${done ? "var(--text3)" : "var(--text)"}">` +
-          `<span style="color:${done ? "var(--success)" : "var(--warning)"}">${done ? "✔" : "☐"}</span>` +
-          `<span>${renderInline(task[2]!)}</span></div>`;
-      }
-      const li = line.match(/^\s*[-*]\s+(.*)$/);
-      if (li) return `<div style="display:flex;gap:.4em"><span style="color:var(--primary)">·</span><span>${renderInline(li[1]!)}</span></div>`;
-      if (!line.trim()) return "<div style='height:.5em'></div>";
-      return `<div>${renderInline(line)}</div>`;
-    }).join("");
-    blocks.push({ kind: "text", html });
-    buf = [];
-  };
-
-  // `\r?\n`, not `\n`: GitHub bodies are CRLF, and a JS regex `.` matches
-  // neither `\n` nor `\r`, so every `(.*)$` rule below silently fails on a line
-  // that still carries its carriage return — headings, task boxes and images
-  // all render as plain text.
-  const lines = (body || "").split(/\r?\n/);
-  let fence: string[] | null = null;
-  for (const line of lines) {
-    if (line.trim().startsWith("```")) {
-      if (fence) { blocks.push({ kind: "code", text: fence.join("\n") }); fence = null; }
-      else { flush(); fence = []; }
-      continue;
-    }
-    if (fence) { fence.push(line); continue; }
-
-    const md = line.match(/^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/);
-    const html = line.match(/<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i);
-    if (md) { flush(); blocks.push({ kind: "image", src: md[2]!, alt: md[1]! }); continue; }
-    if (html) {
-      flush();
-      const alt = line.match(/\balt="([^"]*)"/i)?.[1] ?? "";
-      blocks.push({ kind: "image", src: html[1]!, alt });
-      continue;
-    }
-    buf.push(line);
-  }
-  if (fence) blocks.push({ kind: "code", text: fence.join("\n") });
-  flush();
-  return blocks;
-}
-
 function Body({ body }: { body: string }) {
   const blocks = useMemo(() => parseBody(body), [body]);
   return (
@@ -190,6 +114,37 @@ function Body({ body }: { body: string }) {
               style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
               {b.text}
             </pre>
+          );
+        }
+        if (b.kind === "table") {
+          return (
+            <div key={i} className="my-2 overflow-x-auto ag-scroll">
+              <table className="text-[11px]" style={{ borderCollapse: "collapse" }}>
+                <thead>
+                  <tr>{b.head.map((h, j) => (
+                    <th key={j} className="text-left px-2 py-1 whitespace-nowrap"
+                      style={{ color: "var(--text)", fontWeight: 500, borderBottom: "1px solid color-mix(in srgb, var(--border) 55%, transparent)" }}
+                      dangerouslySetInnerHTML={{ __html: renderInline(h) }} />
+                  ))}</tr>
+                </thead>
+                <tbody>
+                  {b.rows.map((r, ri) => (
+                    <tr key={ri}>{r.map((c, ci) => (
+                      <td key={ci} className="px-2 py-1 align-top"
+                        style={{ color: "var(--text2)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}
+                        dangerouslySetInnerHTML={{ __html: renderInline(c) }} />
+                    ))}</tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          );
+        }
+        if (b.kind === "quote") {
+          return (
+            <blockquote key={i} className="my-1.5 pl-2 py-0.5"
+              style={{ borderLeft: "2px solid color-mix(in srgb, var(--primary) 55%, transparent)", color: "var(--text3)" }}
+              dangerouslySetInnerHTML={{ __html: b.html }} />
           );
         }
         if (b.kind === "image") {
@@ -206,6 +161,30 @@ function Body({ body }: { body: string }) {
         return <div key={i} dangerouslySetInnerHTML={{ __html: b.html }} />;
       })}
     </div>
+  );
+}
+
+/** A unified diff, coloured, with a background tint on the changed lines so a
+ *  block of additions reads as a block rather than as green text. */
+function Diff({ text, empty }: { text: string; empty?: string }) {
+  const lines = useMemo(() => text.split(/\r?\n/), [text]);
+  if (!text.trim()) return <div className="text-[11px] p-2" style={{ color: "var(--text3)" }}>{empty ?? "no changes"}</div>;
+  return (
+    <pre className="overflow-x-auto text-[10.5px] leading-snug ag-scroll"
+      style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)", borderRadius: 4, margin: 0 }}>
+      {lines.map((l, i) => {
+        const add = l.startsWith("+") && !l.startsWith("+++");
+        const del = l.startsWith("-") && !l.startsWith("---");
+        return (
+          <div key={i} style={{
+            color: lineTint(l),
+            background: add ? "color-mix(in srgb, var(--success) 9%, transparent)"
+              : del ? "color-mix(in srgb, var(--error) 9%, transparent)" : undefined,
+            padding: "0 .5rem",
+          }}>{l || " "}</div>
+        );
+      })}
+    </pre>
   );
 }
 
@@ -265,6 +244,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [rawBots, setRawBots] = useState(false);
   const [seen, setSeen] = useState<Record<string, string[]>>(loadSeen);
   const [diff, setDiff] = useState<string>("");
+  /** Which file's diff is on screen. The whole-PR blob is never shown — it is
+   *  sliced by `splitDiff` and one file is rendered at a time. */
+  const [selFile, setSelFile] = useState<string | null>(null);
+  const [selCommit, setSelCommit] = useState<string | null>(null);
+  const [commitText, setCommitText] = useState<string>("");
+  const [commitBusy, setCommitBusy] = useState(false);
   const detailReq = useRef(0);
 
   const flash = useCallback((ok: boolean, msg: string) => {
@@ -312,7 +297,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   useEffect(() => {
     if (!active || !root || selected == null) { setDetail(null); return; }
-    setDiff("");
+    setDiff(""); setSelFile(null); setSelCommit(null); setCommitText("");
     loadDetail(selected);
   }, [active, root, selected, loadDetail]);
 
@@ -320,6 +305,18 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (tab !== "files" || !detail || diff || !root) return;
     api.prDiff(root, detail.number).then((r) => setDiff(r.ok ? (r.text || "") : "")).catch(() => {});
   }, [tab, detail, diff, root]);
+
+  /** Per-file slices of the one diff we fetched. */
+  const byFile = useMemo(() => splitDiff(diff), [diff]);
+
+  const openCommit = useCallback((sha: string) => {
+    if (!root) return;
+    setSelCommit(sha); setCommitText(""); setCommitBusy(true);
+    api.prCommitDiff(root, sha)
+      .then((r) => setCommitText(r.ok ? (r.text || "") : `could not load this commit — ${r.error ?? ""}`))
+      .catch((e) => setCommitText(String(e)))
+      .finally(() => setCommitBusy(false));
+  }, [root]);
 
   const act = useCallback(async (label: string, fn: () => Promise<{ ok: boolean; error?: string; detail?: string }>) => {
     if (busy) return false;
@@ -427,14 +424,18 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     <div className="flex flex-col h-full min-h-0">
       <style>{SCROLLBAR_CSS}</style>
       <div className={viewHeaderClass} style={viewHeaderStyle}>
-        <span className={viewTitleClass} style={{ color: "var(--text)" }}>pr</span>
-        {repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>}
-        {repos.length > 1 && (
+        <span className={viewTitleClass} style={{ color: "var(--text)" }}>Pull Requests</span>
+        {/* The picker already says which checkout, and the checkout implies the
+            repo — showing `owner/name` next to it said the same thing twice. */}
+        {repos.length > 1 ? (
           <select value={root} onChange={(e) => { setRoot(e.target.value); setSelected(null); setDetail(null); }}
-            className="text-[10px] px-1 py-0.5 rounded bg-transparent max-w-[190px]"
+            title={repo ? repo.nameWithOwner : undefined}
+            className="text-[10px] px-1 py-0.5 rounded bg-transparent max-w-[220px]"
             style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
             {repos.map((r) => <option key={r.root} value={r.root} style={{ background: "var(--bg)" }}>{r.root.split("/").pop()}</option>)}
           </select>
+        ) : (
+          repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>
         )}
         <div className="ml-auto flex items-center gap-2 shrink-0">
           {toast && (
@@ -531,11 +532,27 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 {tab === "commits" && (
                   <div className="text-[11px]">
                     {d.commits.map((c) => (
-                      <div key={c.oid} className="flex items-center gap-2 py-1 border-b" style={{ borderColor: "color-mix(in srgb, var(--border) 18%, transparent)", opacity: c.isMerge ? 0.5 : 1 }}>
-                        <span className="tabular-nums shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.short}</span>
-                        <span className="truncate" style={{ color: "var(--text2)" }}>{c.message}</span>
-                        {c.isMerge && <Chip text="merge" tint="var(--text3)" title="trunk catch-up, not work to review" />}
-                        <span className="ml-auto shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>{c.author}</span>
+                      <div key={c.oid}>
+                        <button onClick={() => openCommit(selCommit === c.oid ? "" : c.oid)}
+                          className="w-full text-left flex items-center gap-2 py-1 border-b"
+                          style={{
+                            borderColor: "color-mix(in srgb, var(--border) 18%, transparent)",
+                            opacity: c.isMerge ? 0.55 : 1,
+                            background: selCommit === c.oid ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+                          }}>
+                          <span className="shrink-0" style={{ color: "var(--text3)" }}>{selCommit === c.oid ? "▾" : "▸"}</span>
+                          <span className="tabular-nums shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.short}</span>
+                          <span className="truncate" style={{ color: "var(--text2)" }}>{c.message}</span>
+                          {c.isMerge && <Chip text="merge" tint="var(--text3)" title="trunk catch-up, not work to review" />}
+                          <span className="ml-auto shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>{c.author}</span>
+                        </button>
+                        {selCommit === c.oid && (
+                          <div className="my-1.5">
+                            {commitBusy
+                              ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>loading the diff…</div>
+                              : <Diff text={commitText} empty="this commit changed nothing" />}
+                          </div>
+                        )}
                       </div>
                     ))}
                   </div>
@@ -549,29 +566,38 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                     </div>
                     {d.files.map((f) => {
                       const done = seenFiles.includes(f.path);
+                      const open = selFile === f.path;
                       return (
-                        <label key={f.path} className="flex items-center gap-2 py-1 border-b cursor-pointer"
-                          style={{ borderColor: "color-mix(in srgb, var(--border) 18%, transparent)" }}>
-                          <input type="checkbox" checked={done} onChange={() => toggleSeen(f.path)} style={{ accentColor: "var(--primary)" }} />
-                          <span className="truncate" style={{ color: done ? "var(--text3)" : "var(--text2)", textDecoration: done ? "line-through" : undefined }}>{f.path}</span>
-                          {f.comments > 0 && <Chip text={`${f.comments} open`} tint="var(--warning)" />}
-                          <span className="ml-auto shrink-0 tabular-nums" style={{ color: "var(--success)" }}>+{f.additions}</span>
-                          <span className="shrink-0 tabular-nums" style={{ color: "var(--error)" }}>−{f.deletions}</span>
-                        </label>
+                        <div key={f.path}>
+                          <div className="flex items-center gap-2 py-1 border-b"
+                            style={{
+                              borderColor: "color-mix(in srgb, var(--border) 18%, transparent)",
+                              background: open ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+                            }}>
+                            {/* The tick is "I have read this" and must not also
+                                open the file — two different intents on one row. */}
+                            <input type="checkbox" checked={done} onChange={() => toggleSeen(f.path)}
+                              onClick={(e) => e.stopPropagation()} style={{ accentColor: "var(--primary)" }}
+                              title="mark reviewed" aria-label={`mark ${f.path} reviewed`} />
+                            <button onClick={() => setSelFile(open ? null : f.path)}
+                              className="flex-1 min-w-0 text-left flex items-center gap-2">
+                              <span className="shrink-0" style={{ color: "var(--text3)" }}>{open ? "▾" : "▸"}</span>
+                              <span className="truncate" style={{ color: done ? "var(--text3)" : "var(--text2)", textDecoration: done ? "line-through" : undefined }}>{f.path}</span>
+                              {f.comments > 0 && <Chip text={`${f.comments} open`} tint="var(--warning)" />}
+                              <span className="ml-auto shrink-0 tabular-nums" style={{ color: "var(--success)" }}>+{f.additions}</span>
+                              <span className="shrink-0 tabular-nums" style={{ color: "var(--error)" }}>−{f.deletions}</span>
+                            </button>
+                          </div>
+                          {open && (
+                            <div className="my-1.5">
+                              {!diff
+                                ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>loading the diff…</div>
+                                : <Diff text={byFile.get(f.path) ?? ""} empty="no textual diff — binary, renamed, or too large to show" />}
+                            </div>
+                          )}
+                        </div>
                       );
                     })}
-                    {diff && (
-                      <pre className="mt-3 p-2 rounded overflow-x-auto text-[10.5px] leading-snug"
-                        style={{ ...CODE_FONT_STYLE, background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)", maxHeight: 460 }}>
-                        {diff.split("\n").map((l, i) => (
-                          <div key={i} style={{
-                            color: l.startsWith("+") && !l.startsWith("+++") ? "var(--success)"
-                              : l.startsWith("-") && !l.startsWith("---") ? "var(--error)"
-                              : l.startsWith("@@") ? "var(--primary)" : "var(--text3)",
-                          }}>{l || " "}</div>
-                        ))}
-                      </pre>
-                    )}
                   </div>
                 )}
 
@@ -845,10 +871,25 @@ const CHECK_TINT: Record<PrCheck["state"], string> = {
   success: "var(--success)", failure: "var(--error)", pending: "var(--warning)",
   skipped: "var(--text3)", neutral: "var(--text3)",
 };
+const CHECK_GLYPH: Record<PrCheck["state"], string> = {
+  success: "✓", failure: "✕", pending: "•", skipped: "⊘", neutral: "⊘",
+};
 
 function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: boolean }) {
   const c = d.checks;
   const pct = (n: number) => (c.total ? (n / c.total) * 100 : 0);
+  // Skipped checks are the bulk of a big suite and almost never what you came
+  // for, so they collapse — the same call GitHub makes, for the same reason.
+  const [showSkipped, setShowSkipped] = useState(false);
+
+  const order: Record<PrCheck["state"], number> = { failure: 0, pending: 1, success: 2, neutral: 3, skipped: 4 };
+  const shown = useMemo(() => {
+    const list = d.checksAll.filter((k) => showSkipped || (k.state !== "skipped" && k.state !== "neutral"));
+    return [...list].sort((a, b) => order[a.state] - order[b.state] || a.name.localeCompare(b.name));
+  }, [d.checksAll, showSkipped]);
+
+  const skippedCount = d.checksAll.filter((k) => k.state === "skipped" || k.state === "neutral").length;
+
   return (
     <div className="text-[11px]">
       <div className="flex items-center gap-2 mb-2 tabular-nums">
@@ -862,22 +903,8 @@ function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: 
           { pct: pct(c.pending), tint: "var(--warning)" },
           { pct: pct(c.skipped), tint: "color-mix(in srgb, var(--text3) 40%, transparent)" },
         ]} />
+        {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
       </div>
-
-      {c.failing.length > 0 && (
-        <div className="mb-2">
-          {c.failing.map((f, i) => (
-            <div key={i} className="flex items-center gap-1.5 py-1 px-2 mb-1 rounded"
-              style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 9%, transparent)" }}>
-              <Dot tint="var(--error)" />
-              <span style={{ color: "var(--text)" }}>{f.name}</span>
-              {f.workflow && <span className="text-[10px]" style={{ color: "var(--text3)" }}>{f.workflow}</span>}
-              {f.url && <a href={f.url} target="_blank" rel="noreferrer noopener" className="ml-auto text-[10px]" style={{ color: "var(--text2)" }}>log ↗</a>}
-            </div>
-          ))}
-          <Btn onClick={onRerun} disabled={busy}>re-run failed jobs</Btn>
-        </div>
-      )}
 
       <div className="text-[10px] mb-2" style={{ color: "var(--text3)" }}>
         {c.allDone
@@ -885,12 +912,30 @@ function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: 
           : `${c.pending} of ${c.total} still running — you will be told once, when the last one lands.`}
       </div>
 
-      <div className="flex flex-wrap gap-0.5 mb-2">
-        {d.checksAll.map((k, i) => (
-          <span key={i} title={`${k.name}${k.workflow ? ` · ${k.workflow}` : ""} — ${k.state}`}
-            style={{ width: 11, height: 11, borderRadius: 2, background: CHECK_TINT[k.state], opacity: k.state === "skipped" || k.state === "neutral" ? 0.4 : 1 }} />
+      {/* Every check, by name. A grid of squares says something broke without
+          saying what, which is exactly the trip to the browser this replaces. */}
+      <div>
+        {shown.map((k, i) => (
+          <div key={`${k.name}-${i}`} className="flex items-center gap-2 py-1 border-b"
+            style={{ borderColor: "color-mix(in srgb, var(--border) 18%, transparent)" }}>
+            <span className="shrink-0 w-3 text-center" style={{ color: CHECK_TINT[k.state] }}>{CHECK_GLYPH[k.state]}</span>
+            <span className="truncate" style={{ color: k.state === "skipped" || k.state === "neutral" ? "var(--text3)" : "var(--text2)" }}>
+              {k.workflow ? <span style={{ color: "var(--text3)" }}>{k.workflow} / </span> : null}{k.name}
+            </span>
+            <span className="ml-auto shrink-0 text-[9.5px] uppercase tracking-wide" style={{ color: CHECK_TINT[k.state] }}>{k.state}</span>
+            {k.url && (
+              <a href={k.url} target="_blank" rel="noreferrer noopener" className="shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>log ↗</a>
+            )}
+          </div>
         ))}
       </div>
+
+      {skippedCount > 0 && (
+        <button onClick={() => setShowSkipped((v) => !v)} className="mt-2 text-[10px] px-2 py-1 rounded"
+          style={{ color: "var(--text2)", border: "1px dashed color-mix(in srgb, var(--border) 50%, transparent)" }}>
+          {showSkipped ? "hide" : "show"} {skippedCount} skipped
+        </button>
+      )}
     </div>
   );
 }

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -335,7 +335,20 @@ function createSession(root: string): Sess {
     fontSize: 13,
     lineHeight: 1.2,
     cursorBlink: true,
-    scrollback: 10_000,
+    /*
+     * Scrollback, and why it is not ten thousand any more.
+     *
+     * xterm keeps every line as cell data, so a wide window at 10k lines is
+     * tens of megabytes per shell — and this app holds several open at once,
+     * deliberately, so a build in one keeps running while you work in another.
+     * It is also what a resize has to reflow: every line, on every fit, which
+     * is the multi-second freeze people report when dragging a pane.
+     *
+     * Four thousand lines is still more than a screenful of build output by two
+     * orders of magnitude, and it is what the scroll bar can realistically be
+     * dragged through.
+     */
+    scrollback: 4_000,
     theme: themeFromCss(),
     macOptionIsMeta: true,
   });
@@ -543,7 +556,13 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
     s.term.options.theme = themeFromCss();
     const unTheme = applyThemeLive(s);
     s.subs.add(redraw);
+    // Debounced: a ResizeObserver fires on every frame of a drag, and each fit
+    // reflows the entire scrollback *and* sends a resize ioctl to the shell.
+    // Undebounced that is the drag stuttering and the shell being told sixty
+    // different sizes on the way to the one that matters.
+    let fitTimer: ReturnType<typeof setTimeout> | null = null;
     const doFit = () => { try { fitTerm(s); } catch { /* not measurable yet */ } };
+    const fitSoon = () => { if (fitTimer) clearTimeout(fitTimer); fitTimer = setTimeout(doFit, 100); };
     doFit();
     if (s.status === "idle") connect(s);
     // Opening a shell is asking to type in it. The strip mounted focused on
@@ -552,9 +571,10 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
     // forget you have to make. Same rAF as the terminal view's own focus: the
     // element has to be attached and laid out first.
     requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
-    const ro = new ResizeObserver(doFit);
+    const ro = new ResizeObserver(fitSoon);
     ro.observe(el);
     return () => {
+      if (fitTimer) clearTimeout(fitTimer);
       ro.disconnect();
       unTheme();
       s.subs.delete(redraw);
@@ -714,7 +734,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   useEffect(() => {
     if (!open || IS_DEMO) return;
     panelClose = () => closeRef.current();
-    const mounted: { s: Sess; el: HTMLDivElement; ro: ResizeObserver; unTheme: () => void }[] = [];
+    const mounted: { s: Sess; el: HTMLDivElement; ro: ResizeObserver; unTheme: () => void; stopFit: () => void }[] = [];
     paneIds.forEach((id, i) => {
       const s = sessions.get(id);
       const el = paneRefs.current[i];
@@ -724,19 +744,25 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
       s.term.options.theme = themeFromCss(); // pick up theme switches between opens
       const unTheme = applyThemeLive(s);
       s.subs.add(force);
+      // Same debounce as the console strip: one fit when the drag settles, not
+      // one per frame of it — each costs a full reflow of the scrollback and a
+      // resize ioctl to the shell.
+      let fitTimer: ReturnType<typeof setTimeout> | null = null;
       const doFit = () => { try { fitTerm(s); } catch { /* not measurable yet */ } };
+      const fitSoon = () => { if (fitTimer) clearTimeout(fitTimer); fitTimer = setTimeout(doFit, 100); };
       doFit();
       if (s.status === "idle") connect(s);
-      const ro = new ResizeObserver(doFit);
+      const ro = new ResizeObserver(fitSoon);
       ro.observe(el);
-      mounted.push({ s, el, ro, unTheme });
+      mounted.push({ s, el, ro, unTheme, stopFit: () => { if (fitTimer) clearTimeout(fitTimer); } });
     });
     const focused = sessions.get(paneIds[focusIdx] ?? "");
     if (focused) requestAnimationFrame(() => focused.term.focus());
     return () => {
       panelClose = () => {};
-      for (const { s, el, ro, unTheme } of mounted) {
+      for (const { s, el, ro, unTheme, stopFit } of mounted) {
         ro.disconnect();
+        stopFit();
         unTheme();
         s.subs.delete(force);
         if (s.holder.parentElement === el) el.removeChild(s.holder);

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -9,6 +9,7 @@ import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
+import { WebglAddon } from "@xterm/addon-webgl";
 import "@xterm/xterm/css/xterm.css";
 import type { GitRepoRef, TerminalCommands, TmuxWindow } from "../../../shared/types.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
@@ -354,6 +355,28 @@ function createSession(root: string): Sess {
   });
   const fit = new FitAddon();
   term.loadAddon(fit);
+  /*
+   * Draw on the GPU when the machine will let us.
+   *
+   * xterm's default renderer builds DOM for every cell, which is the single
+   * biggest source of multi-second stalls when a shell is producing output
+   * quickly — a build log or `cat` on anything large. The WebGL renderer draws
+   * the same cells as textured quads and does not care how fast they arrive.
+   *
+   * Guarded twice, because a GPU is not a promise. The constructor throws where
+   * there is no WebGL2 context at all (a software-rendered session, a remote
+   * desktop, `--disable-gpu`), and a context can be lost *later* — a driver
+   * reset, the compositor reclaiming memory, waking from suspend. Both paths
+   * fall back to the DOM renderer, which is slower and always works; a terminal
+   * that renders slowly is a terminal, a terminal that renders nothing is a
+   * bug report. Neither case is worth a message: the shell keeps running and
+   * the user has nothing to decide.
+   */
+  try {
+    const gl = new WebglAddon();
+    gl.onContextLoss(() => { try { gl.dispose(); } catch { /* already gone */ } });
+    term.loadAddon(gl);
+  } catch { /* no WebGL2 here — the DOM renderer stays */ }
   // Shift+Esc closes the panel — plain Esc belongs to the shell (vim, fzf…).
   term.attachCustomKeyEventHandler((e) => {
     if (e.type === "keydown" && e.key === "Escape" && e.shiftKey) { panelClose(); return false; }

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -10,8 +10,9 @@ import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/Vi
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
-import type { GitRepoRef, ProjectCommand, TerminalCommands, TmuxWindow } from "../../../shared/types.ts";
+import type { GitRepoRef, TerminalCommands, TmuxWindow } from "../../../shared/types.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
+import { CommandBar, loadCommands } from "./CommandBar.tsx";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 
 const ROOT_KEY = "agentglass.terminalRoot";
@@ -24,6 +25,21 @@ export function lastTerminalRoot(): string {
 /** Marks the one shell per repo that belongs to a docked console strip. */
 const CONSOLE_TITLE = "console";
 
+/**
+ * Where the docked console is pointed, remembered separately from the terminal
+ * view's own repo.
+ *
+ * They are not the same question. The view is "where am I working"; the console
+ * under Docker's logs is "which checkout do I want to run migrations in", and
+ * on a machine with a worktree per ticket those are routinely different
+ * directories. Sharing one key made picking a repo in the console silently move
+ * the terminal view too.
+ */
+const CONSOLE_ROOT_KEY = "agentglass.consoleRoot";
+export function consoleRoot(): string {
+  try { return localStorage.getItem(CONSOLE_ROOT_KEY) || lastTerminalRoot(); } catch { return lastTerminalRoot(); }
+}
+
 /** Status dot, for anywhere that shows a shell's state. TermView builds a
  *  richer one that names the shell; this is the shared minimum. */
 const SESS_DOT: Record<SessStatus, { color: string; label: string }> = {
@@ -34,7 +50,6 @@ const SESS_DOT: Record<SessStatus, { color: string; label: string }> = {
   error: { color: "var(--error)", label: "disconnected" },
   unauthorized: { color: "var(--error)", label: "unauthorized ⚿" },
 };
-const QUICK = ["git status", "git log --oneline -15", "git diff --stat", "git branch -vv"];
 const repoName = (p: string) => p.split("/").pop() || p;
 
 // xterm draws in its own DOM — resolve theme vars to concrete colors for it.
@@ -471,12 +486,42 @@ export function runInConsole(root: string, cmd: string) {
  * value of a console under the logs is that it keeps its history and its
  * running job while you look around above it.
  */
-export function ConsoleStrip({ root, open, height, onHeight, onClose }: {
+export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClose }: {
   root: string; open: boolean; height: number; onHeight: (h: number) => void; onClose: () => void;
 }) {
   const slot = useRef<HTMLDivElement>(null);
   const [, redraw] = useReducer((x: number) => x + 1, 0);
   const [sid, setSid] = useState<string>("");
+  /**
+   * Which checkout this console is in — its own choice, falling back to the
+   * terminal view's repo until someone makes one. Changing it swaps which
+   * per-repo console session the strip is showing; the one you were in keeps
+   * running, which is the same promise the strip already makes when you close
+   * it.
+   */
+  const [picked, setPicked] = useState<string>(() => { try { return localStorage.getItem(CONSOLE_ROOT_KEY) || ""; } catch { return ""; } });
+  const root = picked || fallbackRoot;
+  const [repos, setRepos] = useState<GitRepoRef[]>([]);
+  const [repoOpen, setRepoOpen] = useState(false);
+  const [repoQuery, setRepoQuery] = useState("");
+  const pickerRef = useRef<HTMLDivElement>(null);
+  useDismiss(repoOpen, pickerRef, () => { setRepoOpen(false); setRepoQuery(""); });
+  // On demand: the Docker panel mounts this strip on every open, and most opens
+  // never touch the picker.
+  useEffect(() => {
+    if (!repoOpen || repos.length || IS_DEMO) return;
+    api.gitRepos().then(({ repos: r }) => setRepos(r)).catch(() => {});
+  }, [repoOpen, repos.length]);
+  const chooseRepo = (next: string) => {
+    setPicked(next);
+    try { localStorage.setItem(CONSOLE_ROOT_KEY, next); } catch { /* private mode — lasts the session */ }
+    setRepoOpen(false); setRepoQuery("");
+  };
+  const runHere = useCallback((cmd: string) => {
+    const s = sessions.get(sid);
+    if (!s || IS_DEMO) return;
+    runInShell(s, cmd);
+  }, [sid]);
 
   // One console shell per repo, reused. `sessionsFor` already orders by
   // creation, so the first console-tagged one is stable across remounts.
@@ -538,14 +583,62 @@ export function ConsoleStrip({ root, open, height, onHeight, onClose }: {
   if (!open) return null;
   return (
     <div className="shrink-0 flex flex-col" style={{ height: `${Math.round(height * 100)}%`, borderTop: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+      {/* The strip's own toolbar. Everything in it stops the drag from
+          starting — the whole bar is the resize handle, so a click that also
+          began a drag would move the console every time you opened a menu. */}
       <div onMouseDown={drag}
         className="shrink-0 flex items-center gap-2 px-3 py-1 cursor-row-resize select-none"
         style={{ background: "color-mix(in srgb, var(--bg3) 45%, transparent)" }}>
-        <span className="text-[10px] uppercase tracking-wider" style={{ color: "var(--primary-hover)" }}>console</span>
-        <span className="text-[9.5px] t-dim2 truncate">{root ? repoName(root) : "no repo"}</span>
-        {sess && <span className="text-[9px]" style={{ color: SESS_DOT[sess.status].color }}>● {SESS_DOT[sess.status].label}</span>}
-        <span className="ml-auto text-[9px] t-dim2">drag to resize</span>
-        <button onClick={(e) => { e.stopPropagation(); onClose(); }} className="text-[12px] leading-none px-1.5 t-dim2 hover:opacity-70" title="hide the console (the shell keeps running)">✕</button>
+        <span className="text-[10px] uppercase tracking-wider shrink-0" style={{ color: "var(--primary-hover)" }}>console</span>
+
+        {/* Which checkout this shell is in. The console is where migrations get
+            run, and on a worktree-per-ticket repo the right directory is rarely
+            the one the terminal view happens to be sitting in — so it picks its
+            own, and remembers it. */}
+        <div className="relative shrink-0" ref={pickerRef} onMouseDown={(e) => e.stopPropagation()}>
+          <button onClick={() => setRepoOpen((o) => !o)} disabled={IS_DEMO}
+            className="flex items-center gap-1.5 text-[10px] px-2 py-0.5 rounded-md max-w-[200px]"
+            style={{ background: "color-mix(in srgb, var(--bg3) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
+            title={root || "no repo"}>
+            <span className="truncate">{root ? repoName(root) : "no repo"}</span><span className="t-dim2">▼</span>
+          </button>
+          {repoOpen && (
+            <div className="absolute left-0 rounded-lg text-[11px] shadow-2xl flex flex-col"
+              style={{ zIndex: 40, bottom: "calc(100% + 4px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 360, overflow: "hidden" }}>
+              <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="filter repos…"
+                className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
+                style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
+              <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
+                {repos.filter((r) => { const q = repoQuery.trim().toLowerCase(); return !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q); }).map((r) => (
+                  <button key={r.root} onClick={() => chooseRepo(r.root)} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2"
+                    style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
+                    {/* Same badge and same name rule as every other picker: a
+                        worktree IS its branch, a project is its folder. */}
+                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                      style={r.worktreeOf
+                        ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
+                        : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>{r.worktreeOf ? "WT" : "REPO"}</span>
+                    <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.root}>{r.worktreeOf ? r.branch : r.name}</span>
+                    {r.dirty > 0 && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--warning)" }}>●{r.dirty}</span>}
+                  </button>
+                ))}
+                {!repos.length && <div className="px-3 py-2 t-dim2">reading repos…</div>}
+              </div>
+            </div>
+          )}
+        </div>
+
+        {sess && <span className="text-[9px] shrink-0" style={{ color: SESS_DOT[sess.status].color }}>● {SESS_DOT[sess.status].label}</span>}
+
+        {/* The same control the terminal view mounts — commands and pins, one
+            component, so the two shells cannot drift apart again. Opens upward:
+            there is nothing below this strip to open into. */}
+        <div className="flex items-center gap-2 min-w-0" onMouseDown={(e) => e.stopPropagation()}>
+          <CommandBar root={root} disabled={!sid} font={TERM_FONT} onRun={runHere} dropUp />
+        </div>
+
+        <span className="ml-auto text-[9px] t-dim2 shrink-0">drag to resize</span>
+        <button onClick={(e) => { e.stopPropagation(); onClose(); }} onMouseDown={(e) => e.stopPropagation()} className="text-[12px] leading-none px-1.5 t-dim2 hover:opacity-70 shrink-0" title="hide the console (the shell keeps running)">✕</button>
       </div>
       <div ref={slot} className="flex-1 min-h-0" style={{ background: "var(--bg)" }} onClick={() => sess?.term.focus()} />
     </div>
@@ -558,16 +651,16 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const [root, setRoot] = useState<string>(() => { try { return localStorage.getItem(ROOT_KEY) || ""; } catch { return ""; } });
   const [repoOpen, setRepoOpen] = useState(false);
   const [repoQuery, setRepoQuery] = useState("");
+  /** Only whether the server allows commands at all — the list, its dropdown
+   *  and the pins are the shared CommandBar's business now. */
   const [cmds, setCmds] = useState<TerminalCommands | null>(null);
-  const [cmdsOpen, setCmdsOpen] = useState(false);
-  const [cmdQuery, setCmdQuery] = useState("");
   /** Both dropdowns live in here, so one listener can tell "clicked outside"
    *  from "clicked a row". */
   const pickersRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const [, force] = useReducer((x: number) => x + 1, 0);
 
-  useDismiss(repoOpen || cmdsOpen, pickersRef, () => { setRepoOpen(false); setCmdsOpen(false); });
+  useDismiss(repoOpen, pickersRef, () => setRepoOpen(false));
 
   useEffect(() => {
     if (!open) return;
@@ -584,7 +677,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   useEffect(() => {
     if (!open || !root) return;
     setCmds(null);
-    api.terminalCommands(root).then(setCmds).catch(() => setCmds({ enabled: true, make: [], scripts: [] }));
+    loadCommands(root).then(setCmds);
   }, [open, root]);
 
   // Which shells are on screen. One id per visible pane: a single pane is the
@@ -763,7 +856,6 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     if (!root || IS_DEMO) return;
     const s = sessions.get(paneIds[focusIdx] ?? "") ?? createSession(root);
     runInShell(s, cmd);
-    setCmdsOpen(false);
   }, [root, paneIds, focusIdx]);
 
   const restart = useCallback(() => {
@@ -776,7 +868,6 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   }, [paneIds, focusIdx]);
 
   const repoRef = repos.find((r) => r.root === root);
-  const nCmds = (cmds?.make.length ?? 0) + (cmds?.scripts.length ?? 0);
   const disabled = cmds ? !cmds.enabled : false;
 
   const statusDot: Record<SessStatus, { color: string; label: string }> = {
@@ -814,7 +905,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   <span className={viewTitleClass} style={{ color: "var(--text)" }}>Terminal</span>
                   <div ref={pickersRef} className="flex items-center gap-3">
                   <div className="relative">
-                    <button onClick={() => { setRepoOpen((o) => !o); setCmdsOpen(false); }} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
+                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
                       <span className="font-medium">{repoRef ? repoName(repoRef.root) : "pick a repo"}</span><span className="t-dim2">▼</span>
                     </button>
                     {repoOpen && (
@@ -879,57 +970,13 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                     )}
                   </div>
 
-                  {/* project commands: Makefile targets + package scripts, explained */}
-                  <div className="relative">
-                    <button onClick={() => { setCmdsOpen((o) => !o); setRepoOpen(false); }} disabled={!nCmds}
-                      title="Ready-to-run project commands: Makefile targets & package scripts, with what each one does"
-                      className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg font-medium"
-                      style={{ color: nCmds ? "var(--primary-hover)" : "var(--text2)", background: "color-mix(in srgb, var(--primary) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)", opacity: nCmds ? 1 : 0.5 }}>
-                      ⚙ commands{nCmds ? ` (${nCmds})` : cmds ? " (none)" : " …"}<span className="t-dim2">▼</span>
-                    </button>
-                    {cmdsOpen && cmds && (
-                      <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", width: 460, maxHeight: 480, overflow: "hidden" }}>
-                        {/* A real project has more targets than fit on a screen
-                            — this repo's own reference monorepo has 150 in one
-                            Makefile — so scrolling to find `migrate` was the
-                            only way to run it. Matches the name and what the
-                            target says it does, since half of them are only
-                            recognisable by their description. */}
-                        <input autoFocus value={cmdQuery} onChange={(e) => setCmdQuery(e.target.value)}
-                          placeholder="filter commands…"
-                          className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
-                          style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
-                        <div className="agx-scroll overflow-y-auto py-1" style={{ minHeight: 0 }}>
-                          {/* commands come from the whole selected project — the
-                              root Makefile/package.json plus any in subfolders —
-                              so each folder gets its own labelled group */}
-                          {groupByDir(matchCommands(cmds.make, cmdQuery)).map(([dir, list]) => (
-                            <div key={"m:" + dir}>
-                              <div className="px-3 pt-1.5 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider">make — {dir ? `${dir}/Makefile` : "Makefile"}</div>
-                              {list.map((c) => <CommandRow key={"m:" + dir + ":" + c.name} c={c} onRun={run} />)}
-                            </div>
-                          ))}
-                          {groupByDir(matchCommands(cmds.scripts, cmdQuery)).map(([dir, list]) => (
-                            <div key={"s:" + dir}>
-                              <div className="px-3 pt-2 pb-0.5 t-dim2 text-[9.5px] uppercase tracking-wider">scripts — {dir ? `${dir}/package.json` : "package.json"}</div>
-                              {list.map((c) => <CommandRow key={"s:" + dir + ":" + c.name} c={c} onRun={run} />)}
-                            </div>
-                          ))}
-                          {!matchCommands(cmds.make, cmdQuery).length && !matchCommands(cmds.scripts, cmdQuery).length && (
-                            <div className="px-3 py-2 t-dim2">no command matches “{cmdQuery.trim()}”</div>
-                          )}
-                        </div>
-                      </div>
-                    )}
                   </div>
 
-                  </div>
-
-                  <div className="flex items-center gap-1 overflow-x-auto agx-scroll">
-                    {QUICK.map((q) => (
-                      <button key={q} onClick={() => run(q)} disabled={!root || IS_DEMO || disabled} className="text-[10px] px-2 py-1 rounded-md whitespace-nowrap" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>{q}</button>
-                    ))}
-                  </div>
+                  {/* Commands and pins — the same control the docked console
+                      mounts, so the two shells offer the same thing. Its own
+                      dropdown state lives inside it, which is why it sits
+                      outside the pickers group above. */}
+                  <CommandBar root={root} disabled={disabled} font={TERM_FONT} onRun={run} />
 
                   <div className="ml-auto flex items-center gap-1.5 shrink-0">
                     <span onClick={status === "unauthorized" ? reauthPrompt : undefined}
@@ -1106,35 +1153,3 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   );
 }
 
-/**
- * Filter the command list by name, description or folder.
- *
- * Description included deliberately: a Makefile names things like `infra.up`
- * and `check.build_id`, so what you remember is usually what it *does*, not
- * what it is called.
- */
-function matchCommands(list: ProjectCommand[], query: string): ProjectCommand[] {
-  const q = query.trim().toLowerCase();
-  if (!q) return list;
-  return list.filter((c) => `${c.name} ${c.desc ?? ""} ${c.dir ?? ""}`.toLowerCase().includes(q));
-}
-
-/** Bucket commands by the project folder they belong to, repo root first. */
-function groupByDir(list: ProjectCommand[]): [string, ProjectCommand[]][] {
-  const by = new Map<string, ProjectCommand[]>();
-  for (const c of list) {
-    const dir = c.dir ?? "";
-    if (!by.has(dir)) by.set(dir, []);
-    by.get(dir)!.push(c);
-  }
-  return [...by.entries()].sort(([a], [b]) => (a === "" ? -1 : b === "" ? 1 : a.localeCompare(b)));
-}
-
-function CommandRow({ c, onRun }: { c: ProjectCommand; onRun: (cmd: string) => void }) {
-  return (
-    <button onClick={() => onRun(c.cmd)} title={c.cmd} className="w-full text-left px-3 py-1.5 flex items-baseline gap-2.5 hover:bg-[color-mix(in_srgb,var(--primary)_10%,transparent)]">
-      <span className="shrink-0 font-medium" style={{ color: "var(--primary-hover)", fontFamily: TERM_FONT }}>{c.cmd}</span>
-      <span className="min-w-0 flex-1 truncate t-dim2">{c.desc || "—"}</span>
-    </button>
-  );
-}

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -3,9 +3,10 @@ import { AnimatePresence, motion } from "motion/react";
 import { Portal } from "../Portal.tsx";
 import { ViewRail, type RailPip } from "./ViewRail.tsx";
 import { VIEWS, saveLastView, type ViewId } from "./views.ts";
-import { subscribe as subscribeChats, attentionCount } from "../../lib/chatStore.ts";
+import { subscribe as subscribeChats, attentionCount, newChat, setActiveChatId, update as updateChat } from "../../lib/chatStore.ts";
 import { GitView } from "../GitPanel.tsx";
 import { DiffView } from "../ChangesModal.tsx";
+import { PrView } from "../PrPanel.tsx";
 import { DockerView } from "../DockerPanel.tsx";
 import { TermView, subscribeSessions, liveSessionCount } from "../TerminalPanel.tsx";
 import { ChatView } from "../ChatPanel.tsx";
@@ -14,12 +15,13 @@ import { DynamicIsland, NOTCH_BAND } from "./DynamicIsland.tsx";
 const BODY = {
   git: GitView,
   diff: DiffView,
+  pr: PrView,
   docker: DockerView,
   term: TermView,
   chat: ChatView,
 } as const;
 
-/** One overlay, five views.
+/** One overlay, six views.
  *
  *  Every view mounts as soon as the workspace opens and stays mounted until it
  *  closes — switching only flips visibility. That is the whole point: the old
@@ -40,6 +42,20 @@ export function Workspace({
   // Same reason as App's onClose: this reaches a view's effect dependencies,
   // and a fresh arrow each render is a remount nobody asked for.
   const openChat = useCallback(() => onView("chat"), [onView]);
+
+  /**
+   * Start a chat already pointed at a directory, with a prompt waiting.
+   *
+   * The prompt lands in the composer rather than being sent: a local PR review
+   * is a real Claude run against a real checkout, and it should not begin
+   * because you clicked a button one pane over. You read it, then you send it.
+   */
+  const openChatWith = useCallback((cwd: string, prompt: string) => {
+    const chat = newChat(cwd);
+    updateChat(chat.id, (c) => { c.draft = prompt; c.title = "pr review"; });
+    setActiveChatId(chat.id);
+    onView("chat");
+  }, [onView]);
   const frameRef = useRef<HTMLDivElement>(null);
 
   const chatWaiting = useSyncExternalStore(subscribeChats, attentionCount, attentionCount);
@@ -140,6 +156,7 @@ export function Workspace({
                           active={active}
                           {...(v.id === "chat" ? { focusId: chatFocusId, onClose } : {})}
                           {...(v.id === "git" ? { onOpenChat: openChat } : {})}
+                          {...(v.id === "pr" ? { onOpenChatWith: openChatWith } : {})}
                           {...(v.id === "term" ? { onClose } : {})}
                         />
                       </div>

--- a/web/src/components/workspace/icons.tsx
+++ b/web/src/components/workspace/icons.tsx
@@ -1,4 +1,4 @@
-/** The five workspace glyphs, shared by the rail and the header button.
+/** The workspace glyphs, shared by the rail and the header button.
  *  They used to live in Header.tsx, where the rail couldn't reach them. */
 
 const svg = {
@@ -21,6 +21,17 @@ export function DiffIcon({ size = 15 }: P) {
     <svg {...svg} width={size} height={size}>
       <path d="M6 3v12" /><circle cx="6" cy="18" r="2.2" /><path d="M6 15a6 6 0 0 0 6 6" />
       <circle cx="18" cy="6" r="2.2" /><path d="M18 8v3a6 6 0 0 1-6 6" />
+    </svg>
+  );
+}
+
+/** Two commits reconciling into one line — a pull request, not a branch. */
+export function PrIcon({ size = 15 }: P) {
+  return (
+    <svg {...svg} width={size} height={size}>
+      <circle cx="6" cy="6" r="2.2" /><path d="M6 8.2V18" /><circle cx="6" cy="20" r="2" />
+      <circle cx="18" cy="18" r="2.2" /><path d="M18 15.8V10a4 4 0 0 0-4-4h-2.5" />
+      <path d="M13 3.5 10.5 6 13 8.5" />
     </svg>
   );
 }

--- a/web/src/components/workspace/views.ts
+++ b/web/src/components/workspace/views.ts
@@ -17,7 +17,7 @@ export type ViewDef = {
 export const VIEWS: ViewDef[] = [
   { id: "git", label: "git", key: "g", icon: GitIcon, hint: "stage, commit, push/pull the working tree" },
   { id: "diff", label: "diff", key: "d", icon: DiffIcon, hint: "review & commit every diff the fleet made" },
-  { id: "pr", label: "pr", key: "p", icon: PrIcon, hint: "review pull requests without leaving for the browser" },
+  { id: "pr", label: "pull requests", key: "p", icon: PrIcon, hint: "review pull requests without leaving for the browser" },
   { id: "docker", label: "docker", key: "o", icon: DockerIcon, hint: "containers, logs, stats & actions" },
   { id: "term", label: "term", key: "t", icon: TerminalIcon, hint: "a real shell in any repo/worktree" },
   { id: "chat", label: "chat", key: "c", icon: ChatIcon, hint: "drive a Claude session in any repo/worktree" },

--- a/web/src/components/workspace/views.ts
+++ b/web/src/components/workspace/views.ts
@@ -1,7 +1,7 @@
 import type { ComponentType } from "react";
-import { GitIcon, DiffIcon, DockerIcon, TerminalIcon, ChatIcon } from "./icons.tsx";
+import { GitIcon, DiffIcon, DockerIcon, TerminalIcon, ChatIcon, PrIcon } from "./icons.tsx";
 
-export type ViewId = "git" | "diff" | "docker" | "term" | "chat";
+export type ViewId = "git" | "diff" | "pr" | "docker" | "term" | "chat";
 
 export type ViewDef = {
   id: ViewId;
@@ -13,10 +13,11 @@ export type ViewDef = {
   hint: string;
 };
 
-/** Order is the rail's order, and ⌘1..⌘5 index into it. */
+/** Order is the rail's order, and ⌘1..⌘6 index into it. */
 export const VIEWS: ViewDef[] = [
   { id: "git", label: "git", key: "g", icon: GitIcon, hint: "stage, commit, push/pull the working tree" },
   { id: "diff", label: "diff", key: "d", icon: DiffIcon, hint: "review & commit every diff the fleet made" },
+  { id: "pr", label: "pr", key: "p", icon: PrIcon, hint: "review pull requests without leaving for the browser" },
   { id: "docker", label: "docker", key: "o", icon: DockerIcon, hint: "containers, logs, stats & actions" },
   { id: "term", label: "term", key: "t", icon: TerminalIcon, hint: "a real shell in any repo/worktree" },
   { id: "chat", label: "chat", key: "c", icon: ChatIcon, hint: "drive a Claude session in any repo/worktree" },

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -125,6 +125,7 @@ async function post<T>(path: string, body: unknown): Promise<T> {
 }
 
 const D = <T,>(v: T) => Promise.resolve(v); // demo helper
+const demoPrAction = (): PrActionResult => ({ ok: false, error: "the demo is read-only" });
 
 const realApi = {
   recent: (limit = 300) => get<WatchEvent[]>(`/events/recent?limit=${limit}`),
@@ -270,6 +271,41 @@ const realApi = {
   updateLog: () => get<{ ok: boolean; text: string }>("/update/log"),
   dockerInspect: (id: string) => get<{ ok: boolean; env: string[]; config: string; error?: string }>(`/docker/inspect?id=${encodeURIComponent(id)}`),
   dockerTop: (id: string) => get<{ ok: boolean; text: string; error?: string }>(`/docker/top?id=${encodeURIComponent(id)}`),
+  // --- pull requests (gh-backed) ---
+  prCapability: (force = false) => get<{ available: boolean; authed: boolean; login?: string; reason?: string }>(`/prs/capability${force ? "?force=1" : ""}`),
+  prList: (root: string, filter: "mine" | "review" | "all", force = false) =>
+    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}${force ? "&force=1" : ""}`),
+  prDetail: (root: string, number: number, force = false) =>
+    get<{ ok: boolean; detail?: PrDetail; error?: string }>(`/prs/detail?root=${encodeURIComponent(root)}&number=${number}${force ? "&force=1" : ""}`),
+  prDiff: (root: string, number: number) =>
+    get<{ ok: boolean; text?: string; error?: string }>(`/prs/diff?root=${encodeURIComponent(root)}&number=${number}`),
+  /** Images in a PR body go through the server, which attaches the gh token —
+   *  GitHub's own attachment URLs 404 without it. */
+  prAssetUrl: (raw: string) => `${SERVER}/prs/asset?url=${encodeURIComponent(raw)}`,
+  prReview: (root: string, number: number, verb: "approve" | "request_changes" | "comment", body: string) =>
+    post<PrActionResult>("/prs/review", { root, number, verb, body }),
+  prComment: (root: string, number: number, body: string) => post<PrActionResult>("/prs/comment", { root, number, body }),
+  prReply: (root: string, number: number, commentId: number, body: string) => post<PrActionResult>("/prs/reply", { root, number, commentId, body }),
+  prSetThreadResolved: (root: string, threadId: string, resolved: boolean) => post<PrActionResult>("/prs/thread-resolved", { root, threadId, resolved }),
+  prReact: (root: string, commentId: number, content = "+1") => post<PrActionResult>("/prs/react", { root, commentId, content }),
+  prEdit: (root: string, number: number, patch: { title?: string; body?: string; base?: string }) => post<PrActionResult>("/prs/edit", { root, number, ...patch }),
+  prLabels: (root: string, number: number, add: string[], remove: string[]) => post<PrActionResult>("/prs/labels", { root, number, add, remove }),
+  prReviewers: (root: string, number: number, add: string[], remove: string[]) => post<PrActionResult>("/prs/reviewers", { root, number, add, remove }),
+  prDraft: (root: string, number: number, draft: boolean) => post<PrActionResult>("/prs/draft", { root, number, draft }),
+  prUpdateBranch: (root: string, number: number) => post<PrActionResult>("/prs/update-branch", { root, number }),
+  prRerun: (root: string, number: number) => post<PrActionResult>("/prs/rerun", { root, number }),
+  prMerge: (root: string, number: number, method: "squash" | "merge" | "rebase", opts: { deleteBranch?: boolean; auto?: boolean; headSha?: string }) =>
+    post<PrActionResult>("/prs/merge", { root, number, method, ...opts }),
+  prClose: (root: string, number: number, reopen = false) => post<PrActionResult>("/prs/close", { root, number, reopen }),
+  prLocalReview: (root: string, number: number) =>
+    post<{ ok: boolean; cwd?: string; prompt?: string; branch?: string; error?: string }>("/prs/local-review", { root, number }),
+  prLocalReviewDiscard: (root: string, number: number) => post<PrActionResult>("/prs/local-review-discard", { root, number }),
+  /** Where a local branch lives on the web. A live branch resolves to its tree
+   *  with no network at all; a gone one resolves to the PR it came from. */
+  prBranchUrl: (root: string, branch: string, gone: boolean) =>
+    get<{ ok: boolean; url?: string; kind?: "tree" | "pr"; error?: string }>(
+      `/prs/branch-url?root=${encodeURIComponent(root)}&branch=${encodeURIComponent(branch)}&gone=${gone ? "true" : "false"}`),
+
   // --- in-browser terminal: ready-to-run project commands (make + scripts) ---
   terminalCommands: (root: string) => get<TerminalCommands>(`/terminal/commands?root=${encodeURIComponent(root)}`),
   // --- multi-chat: drive a claude session from the browser ---
@@ -414,6 +450,33 @@ const demoApi: typeof realApi = {
   dockerStop: (_id: string) => D(demo.dockerActionUnavailable()),
   dockerRestart: (_id: string) => D(demo.dockerActionUnavailable()),
   dockerRm: (_id: string) => D(demo.dockerActionUnavailable()),
+
+  // The demo has no GitHub behind it, and pretending otherwise would put a
+  // fake PR list in front of someone evaluating the app. It reports the same
+  // "gh isn't set up" state a real machine without gh would, which is honest
+  // and is a screen worth showing anyway.
+  prCapability: (_force?: boolean) => D({ available: false, authed: false, reason: "pull requests need the GitHub CLI — not available in the demo" }),
+  prList: (_root: string, _filter: "mine" | "review" | "all", _force?: boolean) =>
+    D<PrListResponse>({ ok: true, repo: null, prs: [], fetchedAt: 0, stale: false, loading: false, needsAuth: true, error: "not available in the demo" }),
+  prDetail: (_root: string, _number: number, _force?: boolean) => D({ ok: false, error: "not available in the demo" }),
+  prDiff: (_root: string, _number: number) => D({ ok: false, error: "not available in the demo" }),
+  prAssetUrl: (raw: string) => raw,
+  prReview: (_r: string, _n: number, _v: "approve" | "request_changes" | "comment", _b: string) => D(demoPrAction()),
+  prComment: (_r: string, _n: number, _b: string) => D(demoPrAction()),
+  prReply: (_r: string, _n: number, _c: number, _b: string) => D(demoPrAction()),
+  prSetThreadResolved: (_r: string, _t: string, _v: boolean) => D(demoPrAction()),
+  prReact: (_r: string, _c: number, _content?: string) => D(demoPrAction()),
+  prEdit: (_r: string, _n: number, _p: { title?: string; body?: string; base?: string }) => D(demoPrAction()),
+  prLabels: (_r: string, _n: number, _a: string[], _rm: string[]) => D(demoPrAction()),
+  prReviewers: (_r: string, _n: number, _a: string[], _rm: string[]) => D(demoPrAction()),
+  prDraft: (_r: string, _n: number, _d: boolean) => D(demoPrAction()),
+  prUpdateBranch: (_r: string, _n: number) => D(demoPrAction()),
+  prRerun: (_r: string, _n: number) => D(demoPrAction()),
+  prMerge: (_r: string, _n: number, _m: "squash" | "merge" | "rebase", _o: { deleteBranch?: boolean; auto?: boolean; headSha?: string }) => D(demoPrAction()),
+  prClose: (_r: string, _n: number, _reopen?: boolean) => D(demoPrAction()),
+  prLocalReview: (_r: string, _n: number) => D({ ok: false, error: "not available in the demo" }),
+  prLocalReviewDiscard: (_r: string, _n: number) => D(demoPrAction()),
+  prBranchUrl: (_r: string, _b: string, _g: boolean) => D({ ok: false, error: "not available in the demo" }),
 };
 
 export const api = IS_DEMO ? demoApi : realApi;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -284,6 +284,12 @@ const realApi = {
   prAssetUrl: (raw: string) => `${SERVER}/prs/asset?url=${encodeURIComponent(raw)}`,
   prReview: (root: string, number: number, verb: "approve" | "request_changes" | "comment", body: string) =>
     post<PrActionResult>("/prs/review", { root, number, verb, body }),
+  /** A verdict plus every line comment queued while reading the diff, in one
+   *  request — GitHub's "pending review", which arrives as one notification
+   *  instead of a scatter. */
+  prReviewWith: (root: string, number: number, verb: "approve" | "request_changes" | "comment", body: string,
+    comments: { path: string; line: number; side?: "LEFT" | "RIGHT"; body: string }[]) =>
+    post<PrActionResult>("/prs/review-with", { root, number, verb, body, comments }),
   prComment: (root: string, number: number, body: string) => post<PrActionResult>("/prs/comment", { root, number, body }),
   prReply: (root: string, number: number, commentId: number, body: string) => post<PrActionResult>("/prs/reply", { root, number, commentId, body }),
   prSetThreadResolved: (root: string, threadId: string, resolved: boolean) => post<PrActionResult>("/prs/thread-resolved", { root, threadId, resolved }),
@@ -464,6 +470,7 @@ const demoApi: typeof realApi = {
   prDiff: (_root: string, _number: number) => D({ ok: false, error: "not available in the demo" }),
   prAssetUrl: (raw: string) => raw,
   prReview: (_r: string, _n: number, _v: "approve" | "request_changes" | "comment", _b: string) => D(demoPrAction()),
+  prReviewWith: (_r: string, _n: number, _v: "approve" | "request_changes" | "comment", _b: string, _c: unknown[]) => D(demoPrAction()),
   prComment: (_r: string, _n: number, _b: string) => D(demoPrAction()),
   prReply: (_r: string, _n: number, _c: number, _b: string) => D(demoPrAction()),
   prSetThreadResolved: (_r: string, _t: string, _v: boolean) => D(demoPrAction()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -302,6 +302,8 @@ const realApi = {
   prLocalReviewDiscard: (root: string, number: number) => post<PrActionResult>("/prs/local-review-discard", { root, number }),
   /** Where a local branch lives on the web. A live branch resolves to its tree
    *  with no network at all; a gone one resolves to the PR it came from. */
+  prCommitDiff: (root: string, sha: string) =>
+    get<{ ok: boolean; text?: string; error?: string }>(`/prs/commit-diff?root=${encodeURIComponent(root)}&sha=${encodeURIComponent(sha)}`),
   prBranchUrl: (root: string, branch: string, gone: boolean) =>
     get<{ ok: boolean; url?: string; kind?: "tree" | "pr"; error?: string }>(
       `/prs/branch-url?root=${encodeURIComponent(root)}&branch=${encodeURIComponent(branch)}&gone=${gone ? "true" : "false"}`),
@@ -476,6 +478,7 @@ const demoApi: typeof realApi = {
   prClose: (_r: string, _n: number, _reopen?: boolean) => D(demoPrAction()),
   prLocalReview: (_r: string, _n: number) => D({ ok: false, error: "not available in the demo" }),
   prLocalReviewDiscard: (_r: string, _n: number) => D(demoPrAction()),
+  prCommitDiff: (_r: string, _s: string) => D({ ok: false, error: "not available in the demo" }),
   prBranchUrl: (_r: string, _b: string, _g: boolean) => D({ ok: false, error: "not available in the demo" }),
 };
 

--- a/web/src/lib/prBody.ts
+++ b/web/src/lib/prBody.ts
@@ -1,0 +1,155 @@
+// The pure text logic behind the pull-request panel: a PR body is markdown, and
+// `gh pr diff` returns the whole request in one blob.
+//
+// Kept out of the component so it can be tested without a DOM — the panel
+// imports `api.ts`, which reads `location` while its module body runs.
+
+function escapeHtml(s: string): string {
+  return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
+}
+
+export function renderInline(s: string): string {
+  let out = escapeHtml(s);
+  out = out.replace(/`([^`]+)`/g, '<code class="px-1 rounded" style="background:color-mix(in srgb,var(--border) 30%,transparent)">$1</code>');
+  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong style="color:var(--text)">$1</strong>');
+  // Links only to http(s) — a markdown link is a place to smuggle javascript:.
+  out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_m, text: string, href: string) => `<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${text}</a>`);
+  out = out.replace(/(^|[\s(])((?:https?:\/\/)[^\s<)]+)/g,
+    (_m, pre: string, href: string) => `${pre}<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${href}</a>`);
+  return out;
+}
+
+export type MdBlock =
+  | { kind: "text"; html: string }
+  | { kind: "code"; text: string }
+  | { kind: "image"; src: string; alt: string }
+  /** A real table, not the pipes. PR bodies use these for before/after
+   *  evidence — a RED/GREEN comparison is a table, and rendering it as raw
+   *  pipes is the difference between reading the proof and squinting at it. */
+  | { kind: "table"; head: string[]; rows: string[][] }
+  | { kind: "quote"; html: string };
+
+/** Split a body into what has to render differently: fenced code, images
+ *  (which need the proxy), and everything else. */
+export function parseBody(body: string): MdBlock[] {
+  const blocks: MdBlock[] = [];
+  let buf: string[] = [];
+  const flush = () => {
+    if (!buf.length) return;
+    const html = buf.map((line) => {
+      const h = line.match(/^(#{1,6})\s+(.*)$/);
+      if (h) return `<div style="color:var(--text);font-weight:600;margin-top:.7em">${renderInline(h[2]!)}</div>`;
+      const task = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.*)$/);
+      if (task) {
+        const done = task[1]!.toLowerCase() === "x";
+        return `<div style="display:flex;gap:.4em;color:${done ? "var(--text3)" : "var(--text)"}">` +
+          `<span style="color:${done ? "var(--success)" : "var(--warning)"}">${done ? "✔" : "☐"}</span>` +
+          `<span>${renderInline(task[2]!)}</span></div>`;
+      }
+      const li = line.match(/^\s*[-*]\s+(.*)$/);
+      if (li) return `<div style="display:flex;gap:.4em"><span style="color:var(--primary)">·</span><span>${renderInline(li[1]!)}</span></div>`;
+      if (!line.trim()) return "<div style='height:.5em'></div>";
+      return `<div>${renderInline(line)}</div>`;
+    }).join("");
+    blocks.push({ kind: "text", html });
+    buf = [];
+  };
+
+  // `\r?\n`, not `\n`: GitHub bodies are CRLF, and a JS regex `.` matches
+  // neither `\n` nor `\r`, so every `(.*)$` rule below silently fails on a line
+  // that still carries its carriage return — headings, task boxes and images
+  // all render as plain text.
+  const lines = (body || "").split(/\r?\n/);
+  let fence: string[] | null = null;
+
+  /** `| a | b |` -> ["a","b"], tolerating the optional outer pipes. */
+  const cells = (l: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim());
+  const isDivider = (l: string) => /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(l);
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i]!;
+    if (line.trim().startsWith("```")) {
+      if (fence) { blocks.push({ kind: "code", text: fence.join("\n") }); fence = null; }
+      else { flush(); fence = []; }
+      continue;
+    }
+    if (fence) { fence.push(line); continue; }
+
+    // A table is a header row, a divider, then rows — checked ahead rather
+    // than line by line, because a lone `|` line is not a table.
+    if (line.includes("|") && i + 1 < lines.length && isDivider(lines[i + 1]!)) {
+      flush();
+      const head = cells(line);
+      const rows: string[][] = [];
+      i += 2;
+      while (i < lines.length && lines[i]!.includes("|") && lines[i]!.trim()) { rows.push(cells(lines[i]!)); i++; }
+      i--;
+      blocks.push({ kind: "table", head, rows });
+      continue;
+    }
+
+    if (/^\s*>\s?/.test(line)) {
+      flush();
+      const quoted: string[] = [];
+      while (i < lines.length && /^\s*>\s?/.test(lines[i]!)) { quoted.push(lines[i]!.replace(/^\s*>\s?/, "")); i++; }
+      i--;
+      blocks.push({ kind: "quote", html: quoted.map((q) => `<div>${renderInline(q)}</div>`).join("") });
+      continue;
+    }
+
+    const md = line.match(/^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/);
+    const html = line.match(/<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i);
+    if (md) { flush(); blocks.push({ kind: "image", src: md[2]!, alt: md[1]! }); continue; }
+    if (html) {
+      flush();
+      const alt = line.match(/\balt="([^"]*)"/i)?.[1] ?? "";
+      blocks.push({ kind: "image", src: html[1]!, alt });
+      continue;
+    }
+    buf.push(line);
+  }
+  if (fence) blocks.push({ kind: "code", text: fence.join("\n") });
+  flush();
+  return blocks;
+}
+
+// ---------------------------------------------------------------------------
+// diffs
+// ---------------------------------------------------------------------------
+
+/**
+ * One unified diff, cut into per-file pieces.
+ *
+ * `gh pr diff` returns the whole pull request in one blob, and dumping that
+ * under the file list is how you get a review nobody can navigate. One fetch
+ * still, sliced here, so picking a file is instant and costs nothing.
+ */
+export function splitDiff(text: string): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!text) return out;
+  let path = "";
+  let buf: string[] = [];
+  const flush = () => { if (path) out.set(path, buf.join("\n")); };
+  for (const line of text.split(/\r?\n/)) {
+    const m = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (m) {
+      flush();
+      // The b-side name: a rename shows its destination, which is the path the
+      // file list is keyed by.
+      path = m[2]!;
+      buf = [line];
+      continue;
+    }
+    if (path) buf.push(line);
+  }
+  flush();
+  return out;
+}
+
+export const lineTint = (l: string): string =>
+  l.startsWith("+") && !l.startsWith("+++") ? "var(--success)"
+    : l.startsWith("-") && !l.startsWith("---") ? "var(--error)"
+    : l.startsWith("@@") ? "var(--primary)"
+    : l.startsWith("diff --git") || l.startsWith("index ") || l.startsWith("--- ") || l.startsWith("+++ ") ? "var(--text3)"
+    : "var(--text2)";

--- a/web/src/lib/prBody.ts
+++ b/web/src/lib/prBody.ts
@@ -1,130 +1,196 @@
-// The pure text logic behind the pull-request panel: a PR body is markdown, and
-// `gh pr diff` returns the whole request in one blob.
+// A pull request body is markdown, and the parts people actually write are a
+// small, knowable set: headings, lists, task lists, tables, fenced code,
+// blockquotes, links and screenshots. This renders those properly rather than
+// almost-properly.
 //
-// Kept out of the component so it can be tested without a DOM — the panel
-// imports `api.ts`, which reads `location` while its module body runs.
+// Two rules run through it:
+//
+// 1. Everything is escaped first and only recognised constructs are put back.
+//    A body is written by anyone who can open a pull request, so it is never
+//    trusted input — no raw HTML survives except the images lifted out
+//    deliberately, which go through the server's allowlisted proxy.
+//
+// 2. Every line rule splits on `\r?\n`. GitHub stores bodies with CRLF, and a
+//    JavaScript regex `.` matches no line terminator — `\r` included — so a
+//    naive split leaves a carriage return on every line and each `(.*)$` rule
+//    silently matches nothing. That shipped once already: zero of nine
+//    checkboxes found on a live pull request, with every `\n` fixture passing.
 
 function escapeHtml(s: string): string {
   return s.replace(/&/g, "&amp;").replace(/</g, "&lt;").replace(/>/g, "&gt;").replace(/"/g, "&quot;");
 }
 
-export function renderInline(s: string): string {
-  let out = escapeHtml(s);
-  out = out.replace(/`([^`]+)`/g, '<code class="px-1 rounded" style="background:color-mix(in srgb,var(--border) 30%,transparent)">$1</code>');
-  out = out.replace(/\*\*([^*]+)\*\*/g, '<strong style="color:var(--text)">$1</strong>');
-  // Links only to http(s) — a markdown link is a place to smuggle javascript:.
-  out = out.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
-    (_m, text: string, href: string) => `<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${text}</a>`);
-  out = out.replace(/(^|[\s(])((?:https?:\/\/)[^\s<)]+)/g,
-    (_m, pre: string, href: string) => `${pre}<a href="${href}" target="_blank" rel="noreferrer noopener" style="color:var(--primary)">${href}</a>`);
-  return out;
+/** The handful of entities GitHub emits in bodies it has round-tripped. */
+function decodeEntities(s: string): string {
+  return s
+    .replace(/&nbsp;/g, " ").replace(/&ndash;/g, "–").replace(/&mdash;/g, "—")
+    .replace(/&#(\d+);/g, (_m, d: string) => { try { return String.fromCodePoint(Number(d)); } catch { return _m; } })
+    .replace(/&quot;/g, '"').replace(/&#39;|&apos;/g, "'")
+    .replace(/&lt;/g, "<").replace(/&gt;/g, ">").replace(/&amp;/g, "&");
 }
 
+/**
+ * Inline marks.
+ *
+ * Order matters: code spans come out first and go back last, so a `**` inside
+ * backticks is never mistaken for bold. The placeholder is a private-use
+ * codepoint rather than a digit — a bare index would collide with any number in
+ * the prose around it, which is how "1" became a code span once.
+ */
+const SLOT = "";
+
+export function renderInline(raw: string): string {
+  const spans: string[] = [];
+  let s = decodeEntities(raw).replace(/`([^`]+)`/g, (_m, code: string) => {
+    spans.push(`<code>${escapeHtml(code)}</code>`);
+    return `${SLOT}${spans.length - 1}${SLOT}`;
+  });
+
+  s = escapeHtml(s);
+  s = s.replace(/\*\*([^*]+)\*\*/g, "<strong>$1</strong>");
+  s = s.replace(/(^|[\s(])\*([^*\n]+)\*/g, "$1<em>$2</em>");
+  s = s.replace(/~~([^~]+)~~/g, "<del>$1</del>");
+
+  // http(s) only — a markdown link is a fine place to hide `javascript:`.
+  s = s.replace(/\[([^\]]+)\]\((https?:\/\/[^\s)]+)\)/g,
+    (_m, text: string, href: string) => `<a href="${href}" target="_blank" rel="noreferrer noopener">${text}</a>`);
+  s = s.replace(/(^|[\s(])((?:https?:\/\/)[^\s<)]+)/g,
+    (_m, pre: string, href: string) => `${pre}<a href="${href}" target="_blank" rel="noreferrer noopener">${href}</a>`);
+
+  return s.replace(new RegExp(`${SLOT}(\\d+)${SLOT}`, "g"), (_m, i: string) => spans[Number(i)] ?? "");
+}
+
+export type MdListItem = { html: string; checked?: boolean; depth: number };
+
 export type MdBlock =
-  | { kind: "text"; html: string }
-  | { kind: "code"; text: string }
-  | { kind: "image"; src: string; alt: string }
-  /** A real table, not the pipes. PR bodies use these for before/after
-   *  evidence — a RED/GREEN comparison is a table, and rendering it as raw
-   *  pipes is the difference between reading the proof and squinting at it. */
+  | { kind: "heading"; level: number; html: string }
+  | { kind: "para"; html: string }
+  | { kind: "list"; ordered: boolean; items: MdListItem[] }
+  | { kind: "code"; text: string; lang?: string }
   | { kind: "table"; head: string[]; rows: string[][] }
-  | { kind: "quote"; html: string };
+  | { kind: "quote"; html: string }
+  | { kind: "image"; src: string; alt: string }
+  | { kind: "rule" };
 
-/** Split a body into what has to render differently: fenced code, images
- *  (which need the proxy), and everything else. */
+const cells = (l: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim());
+const isDivider = (l: string) => /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(l);
+const IMG_MD = /^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/;
+const IMG_HTML = /<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i;
+
 export function parseBody(body: string): MdBlock[] {
-  const blocks: MdBlock[] = [];
-  let buf: string[] = [];
-  const flush = () => {
-    if (!buf.length) return;
-    const html = buf.map((line) => {
-      const h = line.match(/^(#{1,6})\s+(.*)$/);
-      if (h) return `<div style="color:var(--text);font-weight:600;margin-top:.7em">${renderInline(h[2]!)}</div>`;
-      const task = line.match(/^\s*[-*]\s+\[([ xX])\]\s+(.*)$/);
-      if (task) {
-        const done = task[1]!.toLowerCase() === "x";
-        return `<div style="display:flex;gap:.4em;color:${done ? "var(--text3)" : "var(--text)"}">` +
-          `<span style="color:${done ? "var(--success)" : "var(--warning)"}">${done ? "✔" : "☐"}</span>` +
-          `<span>${renderInline(task[2]!)}</span></div>`;
-      }
-      const li = line.match(/^\s*[-*]\s+(.*)$/);
-      if (li) return `<div style="display:flex;gap:.4em"><span style="color:var(--primary)">·</span><span>${renderInline(li[1]!)}</span></div>`;
-      if (!line.trim()) return "<div style='height:.5em'></div>";
-      return `<div>${renderInline(line)}</div>`;
-    }).join("");
-    blocks.push({ kind: "text", html });
-    buf = [];
-  };
-
-  // `\r?\n`, not `\n`: GitHub bodies are CRLF, and a JS regex `.` matches
-  // neither `\n` nor `\r`, so every `(.*)$` rule below silently fails on a line
-  // that still carries its carriage return — headings, task boxes and images
-  // all render as plain text.
+  const out: MdBlock[] = [];
   const lines = (body || "").split(/\r?\n/);
-  let fence: string[] | null = null;
+  let para: string[] = [];
 
-  /** `| a | b |` -> ["a","b"], tolerating the optional outer pipes. */
-  const cells = (l: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim());
-  const isDivider = (l: string) => /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(l);
+  const flushPara = () => {
+    if (!para.length) return;
+    out.push({ kind: "para", html: para.map(renderInline).join(" ") });
+    para = [];
+  };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
-    if (line.trim().startsWith("```")) {
-      if (fence) { blocks.push({ kind: "code", text: fence.join("\n") }); fence = null; }
-      else { flush(); fence = []; }
+
+    const fence = line.match(/^\s*```+\s*(\S*)/);
+    if (fence) {
+      flushPara();
+      const lang = fence[1] || undefined;
+      const buf: string[] = [];
+      i++;
+      while (i < lines.length && !/^\s*```/.test(lines[i]!)) { buf.push(lines[i]!); i++; }
+      out.push({ kind: "code", text: buf.join("\n"), lang });
       continue;
     }
-    if (fence) { fence.push(line); continue; }
 
-    // A table is a header row, a divider, then rows — checked ahead rather
-    // than line by line, because a lone `|` line is not a table.
+    if (!line.trim()) { flushPara(); continue; }
+
+    if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(line)) { flushPara(); out.push({ kind: "rule" }); continue; }
+
+    const h = line.match(/^(#{1,6})\s+(.*)$/);
+    if (h) { flushPara(); out.push({ kind: "heading", level: h[1]!.length, html: renderInline(h[2]!) }); continue; }
+
+    const img = line.match(IMG_MD);
+    if (img) { flushPara(); out.push({ kind: "image", src: img[2]!, alt: img[1]! }); continue; }
+    const ihtml = line.match(IMG_HTML);
+    if (ihtml) {
+      flushPara();
+      out.push({ kind: "image", src: ihtml[1]!, alt: line.match(/\balt="([^"]*)"/i)?.[1] ?? "" });
+      continue;
+    }
+
+    // A table needs a header AND a divider, looked ahead: a lone pipe in prose
+    // is not a table, and treating it as one ate the sentence.
     if (line.includes("|") && i + 1 < lines.length && isDivider(lines[i + 1]!)) {
-      flush();
+      flushPara();
       const head = cells(line);
       const rows: string[][] = [];
       i += 2;
       while (i < lines.length && lines[i]!.includes("|") && lines[i]!.trim()) { rows.push(cells(lines[i]!)); i++; }
       i--;
-      blocks.push({ kind: "table", head, rows });
+      out.push({ kind: "table", head, rows });
       continue;
     }
 
     if (/^\s*>\s?/.test(line)) {
-      flush();
+      flushPara();
       const quoted: string[] = [];
       while (i < lines.length && /^\s*>\s?/.test(lines[i]!)) { quoted.push(lines[i]!.replace(/^\s*>\s?/, "")); i++; }
       i--;
-      blocks.push({ kind: "quote", html: quoted.map((q) => `<div>${renderInline(q)}</div>`).join("") });
+      out.push({ kind: "quote", html: quoted.map(renderInline).join(" ") });
       continue;
     }
 
-    const md = line.match(/^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/);
-    const html = line.match(/<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i);
-    if (md) { flush(); blocks.push({ kind: "image", src: md[2]!, alt: md[1]! }); continue; }
-    if (html) {
-      flush();
-      const alt = line.match(/\balt="([^"]*)"/i)?.[1] ?? "";
-      blocks.push({ kind: "image", src: html[1]!, alt });
+    const li = line.match(/^(\s*)([-*+]|\d+[.)])\s+(.*)$/);
+    if (li) {
+      flushPara();
+      const ordered = /\d/.test(li[2]!);
+      const items: MdListItem[] = [];
+      while (i < lines.length) {
+        const m = lines[i]!.match(/^(\s*)([-*+]|\d+[.)])\s+(.*)$/);
+        if (!m) {
+          // An indented continuation belongs to the item above it — GitHub's
+          // own checklist wraps this way and it read as a stray paragraph.
+          if (items.length && lines[i]!.trim() && /^\s{2,}\S/.test(lines[i]!)) {
+            items[items.length - 1]!.html += " " + renderInline(lines[i]!.trim());
+            i++;
+            continue;
+          }
+          break;
+        }
+        const depth = Math.min(4, Math.floor(m[1]!.replace(/\t/g, "  ").length / 2));
+        const task = m[3]!.match(/^\[([ xX])\]\s+(.*)$/);
+        items.push(task
+          ? { html: renderInline(task[2]!), checked: task[1]!.toLowerCase() === "x", depth }
+          : { html: renderInline(m[3]!), depth });
+        i++;
+      }
+      i--;
+      out.push({ kind: "list", ordered, items });
       continue;
     }
-    buf.push(line);
+
+    para.push(line);
   }
-  if (fence) blocks.push({ kind: "code", text: fence.join("\n") });
-  flush();
-  return blocks;
+  flushPara();
+  return out;
+}
+
+/** Checklist boxes, for the merge-readiness signal on the overview. */
+export function parseChecklist(body: string): { checked: boolean; text: string }[] {
+  const out: { checked: boolean; text: string }[] = [];
+  for (const line of (body || "").split(/\r?\n/)) {
+    const m = line.match(/^\s*[-*+]\s+\[([ xX])\]\s+(.*)$/);
+    if (!m) continue;
+    out.push({ checked: m[1]!.toLowerCase() === "x", text: m[2]!.trim() });
+  }
+  return out;
 }
 
 // ---------------------------------------------------------------------------
 // diffs
 // ---------------------------------------------------------------------------
 
-/**
- * One unified diff, cut into per-file pieces.
- *
- * `gh pr diff` returns the whole pull request in one blob, and dumping that
- * under the file list is how you get a review nobody can navigate. One fetch
- * still, sliced here, so picking a file is instant and costs nothing.
- */
+/** One unified diff, cut into per-file pieces. */
 export function splitDiff(text: string): Map<string, string> {
   const out = new Map<string, string>();
   if (!text) return out;
@@ -135,8 +201,8 @@ export function splitDiff(text: string): Map<string, string> {
     const m = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
     if (m) {
       flush();
-      // The b-side name: a rename shows its destination, which is the path the
-      // file list is keyed by.
+      // The b-side: a rename shows its destination, which is how the file list
+      // is keyed.
       path = m[2]!;
       buf = [line];
       continue;
@@ -147,9 +213,61 @@ export function splitDiff(text: string): Map<string, string> {
   return out;
 }
 
-export const lineTint = (l: string): string =>
-  l.startsWith("+") && !l.startsWith("+++") ? "var(--success)"
-    : l.startsWith("-") && !l.startsWith("---") ? "var(--error)"
-    : l.startsWith("@@") ? "var(--primary)"
-    : l.startsWith("diff --git") || l.startsWith("index ") || l.startsWith("--- ") || l.startsWith("+++ ") ? "var(--text3)"
-    : "var(--text2)";
+export interface ParsedHunk { oldStart: number; oldLines: number; newStart: number; newLines: number; lines: string[] }
+export interface ParsedFile { path: string; additions: number; deletions: number; hunks: ParsedHunk[] }
+
+/**
+ * A unified diff, in the shape the app's own diff viewer already speaks.
+ *
+ * This is the whole trick behind files and commits looking like the rest of
+ * agentglass: `SplitDiff`/`UnifiedDiff` take a `FileChange` carrying `hunks`,
+ * so a pull request only has to be translated into that. No second diff
+ * renderer, no second set of keybindings, and no drift between the two.
+ */
+export function parseUnifiedDiff(text: string): ParsedFile[] {
+  const files: ParsedFile[] = [];
+  let cur: ParsedFile | null = null;
+  let hunk: ParsedHunk | null = null;
+
+  for (const line of (text || "").split(/\r?\n/)) {
+    const g = line.match(/^diff --git a\/(.+?) b\/(.+)$/);
+    if (g) {
+      cur = { path: g[2]!, additions: 0, deletions: 0, hunks: [] };
+      files.push(cur);
+      hunk = null;
+      continue;
+    }
+    if (!cur) continue;
+    const h = line.match(/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/);
+    if (h) {
+      hunk = {
+        oldStart: Number(h[1]), oldLines: h[2] === undefined ? 1 : Number(h[2]),
+        newStart: Number(h[3]), newLines: h[4] === undefined ? 1 : Number(h[4]),
+        lines: [],
+      };
+      cur.hunks.push(hunk);
+      continue;
+    }
+    if (!hunk) continue;
+    // "\ No newline at end of file" is metadata about the file, not a line of it.
+    if (line.startsWith("\\")) continue;
+    if (line.startsWith("+")) { cur.additions++; hunk.lines.push(line); continue; }
+    if (line.startsWith("-")) { cur.deletions++; hunk.lines.push(line); continue; }
+    if (line.startsWith(" ")) { hunk.lines.push(line); continue; }
+    // A truly empty line inside a hunk is a context line whose single leading
+    // space some tools trim. Dropping it shifts every line number after it.
+    if (line === "") { hunk.lines.push(" "); continue; }
+  }
+  return files;
+}
+
+/**
+ * The line number a diff line lands on in the new file.
+ *
+ * Needed to anchor a review comment: GitHub's API wants the line in the file,
+ * and what the viewer has is a position inside a hunk.
+ */
+export function newLineNumbers(hunk: ParsedHunk): (number | null)[] {
+  let n = hunk.newStart;
+  return hunk.lines.map((l) => (l.startsWith("-") ? null : n++));
+}

--- a/web/src/lib/prBody.ts
+++ b/web/src/lib/prBody.ts
@@ -72,7 +72,10 @@ export type MdBlock =
   | { kind: "image"; src: string; alt: string }
   | { kind: "rule" };
 
-const cells = (l: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => c.trim());
+/** A table cell is markdown too. Returning the raw text put `**Drift**` on
+ *  screen with its asterisks — the bold that a RED/GREEN comparison leans on
+ *  was exactly what stopped rendering. */
+const cells = (l: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => renderInline(c.trim()));
 const isDivider = (l: string) => /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(l);
 const IMG_MD = /^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/;
 const IMG_HTML = /<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i;

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -3,6 +3,7 @@ import type { WatchEvent, WsFrame, OpenToolCall } from "../../../shared/types.ts
 import { WS_URL, IS_DEMO, hasToken, probeAuth } from "./api.ts";
 import * as demo from "./demo.ts";
 import { gitChanged } from "./gitBus.ts";
+import { recordNote } from "./sysNotify.ts";
 
 const MAX_EVENTS = 2000;
 const FLUSH_MS = 220; // coalesce bursts into ~5 renders/sec
@@ -126,6 +127,21 @@ export function useLive(): LiveData {
       if (frame.type === "git") {
         // Not our data — a nudge for whoever is showing git state.
         gitChanged();
+        return;
+      }
+      if (frame.type === "ci") {
+        // The server holds the latch, so this arrives once per verdict for a
+        // whole suite. Naming the failures is the point: "1 failing" without a
+        // name is what sends you to the browser.
+        const v = frame.data;
+        recordNote({
+          app: "agentglass",
+          summary: `${v.repo}#${v.number} — checks ${v.verdict}`,
+          body: v.verdict === "red" && v.failing.length
+            ? `${v.failing.slice(0, 3).join(", ")}${v.failing.length > 3 ? ` +${v.failing.length - 3} more` : ""}\n${v.title}`
+            : v.title,
+          urgency: v.verdict === "red" ? 2 : 1,
+        });
         return;
       }
       if (frame.type === "initial") {

--- a/web/test/pr-panel.test.ts
+++ b/web/test/pr-panel.test.ts
@@ -242,3 +242,24 @@ describe("markdown, the parts a PR body actually uses", () => {
     expect(b!.html).not.toContain("<script>");
   });
 });
+
+describe("table cells are markdown", () => {
+  /** A RED/GREEN comparison leans on bold inside the cells, and returning the
+   *  raw text put `**Drift**` on screen with its asterisks. */
+  test("bold and code inside a cell render", () => {
+    const blocks = parseBody("| a | b |\n|---|---|\n| **Drift** | `150 s` |\n");
+    const t = blocks.find((b) => b.kind === "table");
+    if (t?.kind !== "table") throw new Error("no table");
+    expect(t.rows[0]![0]).toContain("<strong>Drift</strong>");
+    expect(t.rows[0]![1]).toContain("<code>150 s</code>");
+    expect(t.rows[0]![0]).not.toContain("**");
+  });
+
+  test("a header cell renders too, and is escaped", () => {
+    const blocks = parseBody("| **RED** | <b>x</b> |\n|---|---|\n| 1 | 2 |\n");
+    const t = blocks.find((b) => b.kind === "table");
+    if (t?.kind !== "table") throw new Error("no table");
+    expect(t.head[0]).toContain("<strong>RED</strong>");
+    expect(t.head[1]).toContain("&lt;b&gt;");
+  });
+});

--- a/web/test/pr-panel.test.ts
+++ b/web/test/pr-panel.test.ts
@@ -1,0 +1,117 @@
+// The two pure functions behind the pull-request panel's readability.
+//
+// Both exist because of a specific complaint after using it for real: the whole
+// pull request's diff was being dumped under the file list with no way to reach
+// one file, and a body's tables rendered as raw pipes when a table is exactly
+// how a before/after comparison gets written.
+import { describe, expect, test } from "bun:test";
+import { splitDiff, parseBody } from "../src/lib/prBody.ts";
+
+describe("splitDiff", () => {
+  const DIFF = [
+    "diff --git a/src/app/views.py b/src/app/views.py",
+    "index f10c7ce..f9d6c1e 100644",
+    "--- a/src/app/views.py",
+    "+++ b/src/app/views.py",
+    "@@ -1,3 +1,4 @@",
+    " context",
+    "-gone",
+    "+added",
+    "diff --git a/src/app/utils.py b/src/app/utils.py",
+    "index aaa..bbb 100644",
+    "--- a/src/app/utils.py",
+    "+++ b/src/app/utils.py",
+    "@@ -10,2 +10,2 @@",
+    "-old",
+    "+new",
+  ].join("\n");
+
+  test("cuts one blob into per-file pieces", () => {
+    const m = splitDiff(DIFF);
+    expect([...m.keys()]).toEqual(["src/app/views.py", "src/app/utils.py"]);
+    expect(m.get("src/app/utils.py")).toContain("+new");
+    // Each piece keeps its own header, so it renders as a complete diff.
+    expect(m.get("src/app/utils.py")!.startsWith("diff --git")).toBe(true);
+  });
+
+  test("a file's piece does not leak into the next", () => {
+    const m = splitDiff(DIFF);
+    expect(m.get("src/app/views.py")).not.toContain("+new");
+    expect(m.get("src/app/utils.py")).not.toContain("+added");
+  });
+
+  /** The panel keys files by the b-side path, which is where a rename lands. */
+  test("a rename is keyed by its destination", () => {
+    const m = splitDiff("diff --git a/old/name.py b/new/name.py\n--- a/old/name.py\n+++ b/new/name.py\n");
+    expect([...m.keys()]).toEqual(["new/name.py"]);
+  });
+
+  test("empty and header-less input yield nothing rather than throwing", () => {
+    expect(splitDiff("").size).toBe(0);
+    expect(splitDiff("just some text\nwith no header").size).toBe(0);
+  });
+
+  test("CRLF diffs split the same as LF ones", () => {
+    expect([...splitDiff(DIFF.replace(/\n/g, "\r\n")).keys()]).toEqual([...splitDiff(DIFF).keys()]);
+  });
+});
+
+describe("parseBody", () => {
+  const kinds = (b: string) => parseBody(b).map((x) => x.kind);
+
+  test("a markdown table becomes a table, not a wall of pipes", () => {
+    const body = [
+      "Proof of life",
+      "",
+      "| | RED (master) | GREEN (this PR) |",
+      "|---|---|---|",
+      "| Rows written | 1 | 2 |",
+      "| Drift | 150 s | 0 s |",
+      "",
+      "after",
+    ].join("\n");
+    const blocks = parseBody(body);
+    const table = blocks.find((b) => b.kind === "table");
+    expect(table).toBeDefined();
+    if (table?.kind !== "table") throw new Error("not a table");
+    expect(table.head).toEqual(["", "RED (master)", "GREEN (this PR)"]);
+    expect(table.rows).toHaveLength(2);
+    expect(table.rows[1]).toEqual(["Drift", "150 s", "0 s"]);
+  });
+
+  /** A lone pipe in prose is not a table, and treating it as one ate the line. */
+  test("a pipe without a divider row stays prose", () => {
+    expect(kinds("a | b is not a table\nand nor is this")).toEqual(["text"]);
+  });
+
+  test("blockquotes are quoted rather than printed with their >", () => {
+    const blocks = parseBody("> **Note:** if you modify critical files\n> the CI will post a checklist\n\nnormal");
+    expect(blocks[0]!.kind).toBe("quote");
+    if (blocks[0]!.kind !== "quote") throw new Error("not a quote");
+    expect(blocks[0]!.html).not.toContain("&gt;");
+    expect(blocks[0]!.html).toContain("Note:");
+  });
+
+  test("fenced code is kept verbatim, pipes and all", () => {
+    const blocks = parseBody("text\n```\n| not | a | table |\n```\nmore");
+    const code = blocks.find((b) => b.kind === "code");
+    expect(code).toBeDefined();
+    if (code?.kind !== "code") throw new Error("not code");
+    expect(code.text).toBe("| not | a | table |");
+  });
+
+  test("images are lifted out so they can go through the proxy", () => {
+    const blocks = parseBody('![RED before](https://user-images.githubusercontent.com/1/a.png)\ntext\n<img alt="GREEN" src="https://github.com/user-attachments/assets/x">');
+    const imgs = blocks.filter((b) => b.kind === "image");
+    expect(imgs).toHaveLength(2);
+    if (imgs[0]!.kind !== "image" || imgs[1]!.kind !== "image") throw new Error("not images");
+    expect(imgs[0]!.alt).toBe("RED before");
+    expect(imgs[1]!.src).toContain("user-attachments");
+  });
+
+  /** Bodies arrive CRLF from GitHub; every rule here is line-anchored. */
+  test("CRLF bodies parse identically to LF ones", () => {
+    const body = "## Head\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\n> quoted\n";
+    expect(kinds(body.replace(/\n/g, "\r\n"))).toEqual(kinds(body));
+  });
+});

--- a/web/test/pr-panel.test.ts
+++ b/web/test/pr-panel.test.ts
@@ -5,7 +5,7 @@
 // one file, and a body's tables rendered as raw pipes when a table is exactly
 // how a before/after comparison gets written.
 import { describe, expect, test } from "bun:test";
-import { splitDiff, parseBody } from "../src/lib/prBody.ts";
+import { splitDiff, parseBody, parseUnifiedDiff, newLineNumbers } from "../src/lib/prBody.ts";
 
 describe("splitDiff", () => {
   const DIFF = [
@@ -81,7 +81,7 @@ describe("parseBody", () => {
 
   /** A lone pipe in prose is not a table, and treating it as one ate the line. */
   test("a pipe without a divider row stays prose", () => {
-    expect(kinds("a | b is not a table\nand nor is this")).toEqual(["text"]);
+    expect(kinds("a | b is not a table\nand nor is this")).toEqual(["para"]);
   });
 
   test("blockquotes are quoted rather than printed with their >", () => {
@@ -113,5 +113,132 @@ describe("parseBody", () => {
   test("CRLF bodies parse identically to LF ones", () => {
     const body = "## Head\n\n| a | b |\n|---|---|\n| 1 | 2 |\n\n> quoted\n";
     expect(kinds(body.replace(/\n/g, "\r\n"))).toEqual(kinds(body));
+  });
+});
+
+describe("parseUnifiedDiff", () => {
+  const DIFF = [
+    "diff --git a/app/views.py b/app/views.py",
+    "index f10c7ce..f9d6c1e 100644",
+    "--- a/app/views.py",
+    "+++ b/app/views.py",
+    "@@ -10,4 +10,5 @@ def handler(request):",
+    " context line",
+    "-removed",
+    "+added one",
+    "+added two",
+    " trailing",
+    "@@ -40 +41,2 @@",
+    "-only",
+    "+replaced",
+    "+extra",
+    "diff --git a/app/utils.py b/app/utils.py",
+    "@@ -1,2 +1,2 @@",
+    "-old",
+    "+new",
+  ].join("\n");
+
+  test("counts additions and deletions per file, not per pull request", () => {
+    const files = parseUnifiedDiff(DIFF);
+    expect(files.map((f) => f.path)).toEqual(["app/views.py", "app/utils.py"]);
+    expect(files[0]!.additions).toBe(4);
+    expect(files[0]!.deletions).toBe(2);
+    expect(files[1]!.additions).toBe(1);
+    expect(files[1]!.deletions).toBe(1);
+  });
+
+  test("hunk headers parse, including the single-line form without a comma", () => {
+    const [views] = parseUnifiedDiff(DIFF);
+    expect(views!.hunks).toHaveLength(2);
+    expect(views!.hunks[0]).toMatchObject({ oldStart: 10, oldLines: 4, newStart: 10, newLines: 5 });
+    // "@@ -40 +41,2 @@" — an omitted count means one line, not zero.
+    expect(views!.hunks[1]).toMatchObject({ oldStart: 40, oldLines: 1, newStart: 41, newLines: 2 });
+  });
+
+  test("no-newline markers are dropped but blank context lines survive", () => {
+    const [f] = parseUnifiedDiff([
+      "diff --git a/a.txt b/a.txt",
+      "@@ -1,3 +1,3 @@",
+      " one",
+      "",
+      "+two",
+      "\\ No newline at end of file",
+    ].join("\n"));
+    // A blank context line that lost its leading space still occupies a line;
+    // dropping it shifts every line number after it.
+    expect(f!.hunks[0]!.lines).toEqual([" one", " ", "+two"]);
+  });
+
+  test("nothing parseable yields no files rather than throwing", () => {
+    expect(parseUnifiedDiff("")).toEqual([]);
+    expect(parseUnifiedDiff("not a diff at all")).toEqual([]);
+  });
+
+  test("CRLF diffs parse identically to LF ones", () => {
+    expect(parseUnifiedDiff(DIFF.replace(/\n/g, "\r\n"))).toEqual(parseUnifiedDiff(DIFF));
+  });
+});
+
+describe("newLineNumbers", () => {
+  test("removed lines have no line in the new file; the rest count up", () => {
+    const [f] = parseUnifiedDiff([
+      "diff --git a/a.py b/a.py",
+      "@@ -5,3 +5,3 @@",
+      " keep",
+      "-gone",
+      "+fresh",
+    ].join("\n"));
+    expect(newLineNumbers(f!.hunks[0]!)).toEqual([5, null, 6]);
+  });
+});
+
+describe("markdown, the parts a PR body actually uses", () => {
+  test("ordered lists stay ordered, and nesting keeps its depth", () => {
+    const blocks = parseBody("1. first\n2. second\n   - nested\n");
+    const list = blocks.find((b) => b.kind === "list");
+    if (list?.kind !== "list") throw new Error("no list");
+    expect(list.ordered).toBe(true);
+    expect(list.items[2]!.depth).toBeGreaterThan(0);
+  });
+
+  test("a wrapped checklist line joins the item above it", () => {
+    const blocks = parseBody("- [ ] If there are changes in prompts, add the label\n      and push a commit afterwards.\n");
+    const list = blocks.find((b) => b.kind === "list");
+    if (list?.kind !== "list") throw new Error("no list");
+    expect(list.items).toHaveLength(1);
+    expect(list.items[0]!.html).toContain("push a commit");
+  });
+
+  test("headings carry their level", () => {
+    const levels = parseBody("# one\n\n## two\n\n#### four\n").filter((b) => b.kind === "heading").map((b) => (b.kind === "heading" ? b.level : 0));
+    expect(levels).toEqual([1, 2, 4]);
+  });
+
+  test("bold inside a code span is left alone", () => {
+    const [b] = parseBody("use `--all**` carefully");
+    expect(b!.kind).toBe("para");
+    if (b!.kind !== "para") throw new Error("not a para");
+    expect(b!.html).toContain("<code>");
+    expect(b!.html).not.toContain("<strong>");
+  });
+
+  test("strikethrough and entities render", () => {
+    const [b] = parseBody("~~dropped~~ and &amp; and &#39;quoted&#39;");
+    if (b!.kind !== "para") throw new Error("not a para");
+    expect(b!.html).toContain("<del>dropped</del>");
+    expect(b!.html).toContain("&amp;");
+  });
+
+  test("a javascript: link is never turned into an anchor", () => {
+    const [b] = parseBody("[click](javascript:alert(1))");
+    if (b!.kind !== "para") throw new Error("not a para");
+    expect(b!.html).not.toContain("<a ");
+  });
+
+  test("raw HTML in a body is shown, never executed", () => {
+    const [b] = parseBody("<script>alert(1)</script>");
+    if (b!.kind !== "para") throw new Error("not a para");
+    expect(b!.html).toContain("&lt;script&gt;");
+    expect(b!.html).not.toContain("<script>");
   });
 });

--- a/web/test/view-order.test.ts
+++ b/web/test/view-order.test.ts
@@ -48,13 +48,17 @@ describe("view order", () => {
     expect(ids).toContain("term");
     expect(ids).toContain("docker");
     expect(ids).toContain("diff");
-    expect(ids.length).toBe(5);
+    expect(ids).toContain("pr");
+    // Against the module's own list, not a number: the point is that nothing
+    // is dropped, and hardcoding a count means every view added later fails a
+    // test about something else.
+    expect(ids.length).toBe(v.VIEWS.length);
   });
 
   it("ignores a corrupt saved order rather than throwing", async () => {
     store.set("agentglass.workspace.order", "{not json");
     const v = await load();
-    expect(v.loadViewOrder().length).toBe(5);
+    expect(v.loadViewOrder().length).toBe(v.VIEWS.length);
   });
 
   it("drops an id that no longer exists", async () => {


### PR DESCRIPTION
## What does this PR do?

A sixth workspace view. Reviewing a colleague's code should not mean opening a browser.

It is built from what a real pull request actually contains rather than from what GitHub's own layout implies. On a live review, four issue comments were all from CI and one coverage table alone was 46,551 characters, while the single human review that blocked the merge sat last. So the conversation reads in three lanes — humans, line threads, automation — the machine lane collapses to its digest, and threads sit under the review they were submitted with, because a verdict without its reasons is not worth reading.

**Diffs are not re-implemented.** `SplitDiff`/`UnifiedDiff` from `ChangesModal` are the app's diff viewer, and a pull request is translated into the `FileChange` they already speak. Split/unified, wrap, line numbers, syntax highlighting and the keybindings all arrive for free, and there is one diff renderer in the app rather than two drifting apart.

**Evidence images need a proxy.** GitHub's `user-attachments` URLs answer 404 without credentials — measured — so bodies go through a server proxy that attaches the token `gh` already holds, over a host allowlist, because those URLs come out of text a stranger wrote.

**One CI notification per pull request, at the end.** Sixty-one checks is sixty-one chances to interrupt someone; a latch holds until every check has reached a terminal state and reports the aggregate once. Skipped is not failure, and a re-run clears the latch so a genuine second result still arrives.

**Repos are keyed by their identity on the forge, never by directory.** Eighteen worktrees of one clone are one repo — keying by path would fetch the same list eighteen times, at ~1.9s a call on a server with one thread.

**Reviews can be finished properly.** Line comments queue while you read — GitHub's pending review — and go out with the verdict in a single POST, so the author gets one notification instead of a dozen. The review tab exists only on somebody else's work: `viewerDidAuthor` comes from GraphQL, and GitHub does not let you approve your own pull request either.

Nothing waits on the network. Every read answers from a cache that refreshes behind it, with its age on screen.

## How was it tested?

- New `server/test/prs.test.ts` (25 tests) over repo identity, the check rollup, the bot digest, the checklist parser, the asset allowlist and the CI latch. New `web/test/pr-panel.test.ts` (26 tests) over the markdown block model, the diff splitter and the unified-diff parser.
- Two bugs those tests now pin. GitHub bodies are CRLF, and a JavaScript regex `.` excludes every line terminator including `\r`, so `(.*)$` matched nothing and a real nine-item checklist parsed as zero — while every `\n` fixture passed. And a percentage pattern that allowed only whole numbers digested "87.4%" as "4%".
- **Every write path exercised end to end against a throwaway private repository**: comment, labels, edit, draft toggle, the pending review with two line comments in a single POST, reply, react, resolve and unresolve, update-branch, close, reopen, and a real squash merge. The error paths too — approving your own pull request, an unknown reviewer, and a merge with a stale head sha, which GitHub refuses exactly as it should.
- `cd server && bun test`: 400 pass. `cd web && bun test`: 204 pass. Both typechecks clean, `vite build` clean.

Fifth of six, on top of #4. It needs the diff viewer and `gitAsync` below it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
