### PR TITLE
Open the release notes from About, not only after an update

### DIFF
--- a/web/src/components/ReleaseNotesModal.tsx
+++ b/web/src/components/ReleaseNotesModal.tsx
@@ -1,0 +1,96 @@
+import { motion, AnimatePresence } from "motion/react";
+import { useEffect } from "react";
+import { Portal } from "./Portal.tsx";
+import { Markdown } from "../lib/markdown.tsx";
+
+/**
+ * The notes for one release, in a dialog.
+ *
+ * Split out of WhatsNew because the notes now have two ways in, and only one of
+ * them is automatic. WhatsNew decides *whether* to interrupt; About opens the
+ * same thing because somebody asked. Neither decision belongs in the chrome, so
+ * this component holds none of it — it renders what it is handed.
+ *
+ * Presentational on purpose, including the loading and error states. The
+ * automatic caller never shows either (it stays silent rather than opening an
+ * empty modal), but the manual one must: a button that opens nothing reads as
+ * broken, and "could not reach github for the notes" is an answer.
+ *
+ * Above the settings dialog rather than beside it, since that is where the
+ * manual route opens from. Equal z-index would leave the winner decided by DOM
+ * order, which is not a thing to rely on.
+ *
+ * Shaped like SettingsModal — always mounted, `open` toggled — so the Portal
+ * node is stable and AnimatePresence still gets to run the exit.
+ */
+export function ReleaseNotesModal({ open, tag, notes, title = "What's new", loading, error, footnote, onClose }: {
+  open: boolean;
+  tag: string;
+  notes: string;
+  title?: string;
+  loading?: boolean;
+  error?: string;
+  /** Shown under the notes — e.g. that this build is some commits past the tag. */
+  footnote?: string;
+  onClose: () => void;
+}) {
+  // Captured, so Escape closes these notes and not whatever they opened over:
+  // the settings dialog listens on the same window, in the bubble phase.
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); onClose(); } };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, onClose]);
+
+  return (
+    <Portal>
+      <AnimatePresence>
+        {open && (
+          <>
+            <motion.div
+              initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
+              className="fixed inset-0" style={{ zIndex: 10010, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+              onClick={onClose} />
+            <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none" style={{ zIndex: 10011 }}>
+              <motion.div
+                role="dialog" aria-modal="true" aria-label={tag ? `${title} in ${tag}` : title}
+                initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}
+                transition={{ type: "spring", stiffness: 340, damping: 30 }}
+                className="w-[720px] max-w-[95vw] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
+                style={{ maxHeight: "min(78vh, 640px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+
+                <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                  <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>{title}</span>
+                  {tag && <span className="chip" style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }}>{tag}</span>}
+                  <button onClick={onClose} className="ml-auto text-[18px] leading-none px-2 t-dim2 hover:opacity-70" aria-label="Close">✕</button>
+                </div>
+
+                <div className="px-5 py-4 overflow-y-auto agx-scroll text-[12.5px]" style={{ color: "var(--text2)" }}>
+                  {loading
+                    ? <div className="text-[11px] t-dim2">reading the notes…</div>
+                    : error
+                      ? <div className="text-[11px]" style={{ color: "var(--warning)" }}>{error}</div>
+                      : <Markdown text={notes} />}
+                  {footnote && !loading && !error && (
+                    <div className="mt-4 pt-3 border-t text-[10px] t-dim2" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                      {footnote}
+                    </div>
+                  )}
+                </div>
+
+                <div className="px-5 py-3 border-t shrink-0 flex justify-end" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                  <button onClick={onClose} autoFocus
+                    className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
+                    style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)" }}>
+                    got it
+                  </button>
+                </div>
+              </motion.div>
+            </div>
+          </>
+        )}
+      </AnimatePresence>
+    </Portal>
+  );
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -13,10 +13,12 @@ import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { ingestUpdate } from "../lib/updateStore.ts";
+import { ReleaseNotesModal } from "./ReleaseNotesModal.tsx";
+import { installedNotes, type NotesTarget } from "../lib/whatsNew.ts";
 import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESKTOP } from "../lib/desktop.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
-import type { UpdateStatus } from "../../../shared/types.ts";
+import type { UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
 import { sysNotifyMode, setSysNotifyMode, notifyCapability, notifyQuiet, setNotifyQuiet, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
 import { clock24, setClock24 } from "../lib/clockPref.ts";
 import { bindings, rebind, resetBindings, subscribeBindings, isCustomised, LABELS, DEFAULTS, type ActionId,
@@ -211,6 +213,23 @@ function AboutPane({ open }: { open: boolean }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [started, setStarted] = useState(false);
+  // Which release's notes are being read, and what came back. Fetched here
+  // because the modal is presentational — the automatic caller has to see the
+  // answer before it can decide whether to open at all, so neither of them can
+  // let the dialog do its own loading. The server holds these for an hour, so
+  // reopening the same release is not a round trip that reaches github twice.
+  const [want, setWant] = useState<NotesTarget | null>(null);
+  const [notes, setNotes] = useState<ReleaseNotes | null>(null);
+
+  useEffect(() => {
+    if (!want) return;
+    let live = true;
+    setNotes(null);
+    api.updateNotes(want.tag)
+      .then((r) => { if (live) setNotes(r); })
+      .catch(() => { if (live) setNotes({ ok: false, tag: want.tag, notes: "", source: "", error: "could not reach the server" }); });
+    return () => { live = false; };
+  }, [want]);
 
   useEffect(() => {
     if (!open) return;
@@ -236,6 +255,7 @@ function AboutPane({ open }: { open: boolean }) {
   if (!st) return <Section title="About"><div className="px-3 py-2 text-[11px] t-dim2">reading version…</div></Section>;
 
   const short = st.info.commit ? st.info.commit.slice(0, 7) : "unknown";
+  const mine = installedNotes(st.info.baseTag, st.info.distance, st.branch);
   return (
     <Section title="About">
       <div className="px-3 py-2 flex flex-col gap-3">
@@ -243,6 +263,16 @@ function AboutPane({ open }: { open: boolean }) {
           <span className="text-[12.5px]" style={{ color: "var(--text)" }}>agentglass {st.info.version}</span>
           <span className="text-[10.5px] t-dim2 tabular-nums" title={st.info.commit}>{short}</span>
           {st.info.builtAt && <span className="text-[10px] t-dim2">built {new Date(st.info.builtAt).toLocaleString()}</span>}
+          {/* The notes used to appear once, on the launch after an update, and
+              were unreachable ever after — dismiss it, or update before it
+              existed, and the only copy was on the release page. */}
+          {mine && (
+            <button onClick={() => setWant(mine)}
+              className="ml-auto text-[10.5px] px-2 py-0.5 rounded-md hover:opacity-80"
+              style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}>
+              release notes
+            </button>
+          )}
         </div>
 
         {/* The outcome of the previous run, which finished after the app it was
@@ -288,17 +318,41 @@ function AboutPane({ open }: { open: boolean }) {
               ))}
             </div>
             {err && <div className="text-[10.5px]" style={{ color: "var(--error)" }}>{err}</div>}
-            <button onClick={run} disabled={busy}
-              className="self-start text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
-              style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)", opacity: busy ? 0.5 : 1 }}>
-              {busy ? "starting…" : `install ${st.branch} & restart`}
-            </button>
+            <div className="flex items-center gap-2">
+              <button onClick={run} disabled={busy}
+                className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
+                style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)", opacity: busy ? 0.5 : 1 }}>
+                {busy ? "starting…" : `install ${st.branch} & restart`}
+              </button>
+              {/* Read before you install, rather than after the app has
+                  restarted into it. The tag list above says which releases are
+                  coming; this says what is in them. */}
+              <button onClick={() => setWant({ tag: st.branch, title: "What's in this update" })}
+                className="text-[11.5px] px-3 py-1.5 rounded-lg hover:opacity-80"
+                style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}>
+                what's in {st.branch}
+              </button>
+            </div>
             <span className="text-[9.5px] t-dim2">
               Builds the tagged release in its own clone under ~/.cache, then reinstalls and restarts. Your working checkout is never touched, and only published tags are ever offered — commits pushed after a tag stay out until you tag them.
             </span>
           </>
         )}
       </div>
+
+      <ReleaseNotesModal
+        open={!!want}
+        tag={want?.tag ?? ""}
+        title={want?.title}
+        footnote={want?.footnote}
+        loading={!!want && !notes}
+        // A release with no annotation, an origin github knows nothing about,
+        // a laptop on a train: all of them end here. Saying which is the whole
+        // point of a button you pressed on purpose.
+        error={notes && !notes.ok ? (notes.error || "no notes for that release") : undefined}
+        notes={notes?.notes ?? ""}
+        onClose={() => setWant(null)}
+      />
     </Section>
   );
 }

--- a/web/src/components/WhatsNew.tsx
+++ b/web/src/components/WhatsNew.tsx
@@ -1,7 +1,6 @@
 import { useEffect, useState } from "react";
-import { motion, AnimatePresence } from "motion/react";
 import { api, IS_DEMO } from "../lib/api.ts";
-import { Markdown } from "../lib/markdown.tsx";
+import { ReleaseNotesModal } from "./ReleaseNotesModal.tsx";
 import { markSeen, releaseToAnnounce } from "../lib/whatsNew.ts";
 
 /**
@@ -13,9 +12,14 @@ import { markSeen, releaseToAnnounce } from "../lib/whatsNew.ts";
  * nobody does.
  *
  * Once. `releaseToAnnounce` decides, and it deliberately stays quiet on a fresh
- * install and on a downgrade; this component only renders what it is told.
- * Dismissing marks the version seen, and so does failing to load the notes: an
- * empty modal on every launch would be worse than no modal at all.
+ * install and on a downgrade; this component only decides *whether*, and hands
+ * the rendering to ReleaseNotesModal. Dismissing marks the version seen, and so
+ * does failing to load the notes: an empty modal on every launch would be worse
+ * than no modal at all.
+ *
+ * Missing the interruption is no longer the same as missing the notes: Settings
+ * › About opens them on demand, which is the one thing this cannot do — it
+ * fires once, on a version boundary, and never again.
  */
 export function WhatsNew() {
   const [tag, setTag] = useState<string | null>(null);
@@ -43,50 +47,5 @@ export function WhatsNew() {
 
   const close = () => { if (tag) markSeen(tag); setTag(null); };
 
-  useEffect(() => {
-    if (!tag) return;
-    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
-    window.addEventListener("keydown", onKey, true);
-    return () => window.removeEventListener("keydown", onKey, true);
-  }, [tag]);
-
-  return (
-    <AnimatePresence>
-      {tag && (
-        <>
-          <motion.div
-            initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-            className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
-            onClick={close} />
-          <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none" style={{ zIndex: 10001 }}>
-            <motion.div
-              role="dialog" aria-modal="true" aria-label={`What's new in ${tag}`}
-              initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}
-              transition={{ type: "spring", stiffness: 340, damping: 30 }}
-              className="w-[720px] max-w-[95vw] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
-              style={{ maxHeight: "min(78vh, 640px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
-
-              <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
-                <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>What's new</span>
-                <span className="chip" style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }}>{tag}</span>
-                <button onClick={close} className="ml-auto text-[18px] leading-none px-2 t-dim2 hover:opacity-70" aria-label="Close">✕</button>
-              </div>
-
-              <div className="px-5 py-4 overflow-y-auto agx-scroll text-[12.5px]" style={{ color: "var(--text2)" }}>
-                <Markdown text={notes} />
-              </div>
-
-              <div className="px-5 py-3 border-t shrink-0 flex justify-end" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
-                <button onClick={close} autoFocus
-                  className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
-                  style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)" }}>
-                  got it
-                </button>
-              </div>
-            </motion.div>
-          </div>
-        </>
-      )}
-    </AnimatePresence>
-  );
+  return <ReleaseNotesModal open={!!tag} tag={tag ?? ""} notes={notes} onClose={close} />;
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -266,7 +266,10 @@ const realApi = {
   dockerStats: () => get<{ stats: DockerStat[] }>("/docker/stats"),
   dockerLogs: (id: string, tail = 400) => get<{ ok: boolean; text: string; error?: string }>(`/docker/logs?id=${encodeURIComponent(id)}&tail=${tail}`),
   updateStatus: () => get<UpdateStatus>("/update/status"),
-  updateNotes: () => get<ReleaseNotes>("/update/notes"),
+  // The tag is optional because the automatic modal wants "whatever this build
+  // came from", while About asks for a named release — the update it is about
+  // to install, say, which is not the one running.
+  updateNotes: (tag?: string) => get<ReleaseNotes>(`/update/notes${tag ? `?tag=${encodeURIComponent(tag)}` : ""}`),
   updateRun: () => post<{ ok: boolean; error?: string }>("/update/run", {}),
   updateLog: () => get<{ ok: boolean; text: string }>("/update/log"),
   dockerInspect: (id: string) => get<{ ok: boolean; env: string[]; config: string; error?: string }>(`/docker/inspect?id=${encodeURIComponent(id)}`),
@@ -441,7 +444,7 @@ const demoApi: typeof realApi = {
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),
-  updateNotes: () => D({ ok: false, tag: "", notes: "", source: "", error: "not available in the demo" } as ReleaseNotes),
+  updateNotes: (_tag?: string) => D({ ok: false, tag: "", notes: "", source: "", error: "not available in the demo" } as ReleaseNotes),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),
   updateRun: () => D({ ok: false, error: "not available in the demo" }),
   updateLog: () => D({ ok: true, text: "" }),

--- a/web/src/lib/whatsNew.ts
+++ b/web/src/lib/whatsNew.ts
@@ -42,6 +42,38 @@ export function releaseToAnnounce(tag: string, seen = read()): string | null {
   return tag;
 }
 
+/** Which release About's notes button opens, and what it must admit to. */
+export type NotesTarget = { tag: string; title: string; footnote?: string };
+
+/**
+ * The notes reachable on demand, rather than only on a version boundary.
+ *
+ * The announcement above fires once and never again, so anyone who dismissed it
+ * — or updated before it existed — had no way back to the notes at all. About
+ * needs to answer "what is in the thing I am running", which is a different
+ * question with two honest answers:
+ *
+ *  - **Built from a release.** Show that release. If the build is some commits
+ *    past the tag, say so: the notes describe the tag, not the build, and a
+ *    72-commit gap presented as "what's new" is a lie by omission.
+ *  - **Built from no release** — a dev checkout, or provenance too old to
+ *    judge. Nothing truthful can be said about this build, but the newest
+ *    published release is still worth being able to read, labelled as what it
+ *    is rather than as yours.
+ */
+export function installedNotes(baseTag: string, distance: number, latest: string): NotesTarget | null {
+  if (baseTag) {
+    return {
+      tag: baseTag,
+      title: "What's new",
+      footnote: distance > 0
+        ? `This build is ${distance} commit${distance === 1 ? "" : "s"} past ${baseTag} — those changes are not in these notes.`
+        : undefined,
+    };
+  }
+  return latest ? { tag: latest, title: "Latest release" } : null;
+}
+
 /** Compare v-prefixed release tags numerically. String order gets v0.10.0 wrong
  *  against v0.9.0, which is the one comparison that has to survive a year. */
 function rank(tag: string): number {

--- a/web/test/whats-new.test.ts
+++ b/web/test/whats-new.test.ts
@@ -71,3 +71,42 @@ describe("what's new", () => {
     expect(wn.releaseToAnnounce("v0.4.0")).toBeNull();
   });
 });
+
+/**
+ * The notes About offers, which is a different question: not "has this changed
+ * since last launch" but "what is in the thing I am running".
+ */
+describe("notes on demand", () => {
+  it("offers the release this build came from", () => {
+    expect(wn.installedNotes("v0.4.0", 0, "v0.4.0")).toEqual({ tag: "v0.4.0", title: "What's new", footnote: undefined });
+  });
+
+  it("admits when the build is past the tag it is named after", () => {
+    // The whole reason this is not just `tag`: notes for v0.4.0 shown against a
+    // build 72 commits past it describe a fraction of what is running.
+    const t = wn.installedNotes("v0.4.0", 72, "v0.4.0");
+    expect(t?.tag).toBe("v0.4.0");
+    expect(t?.footnote).toContain("72 commits past v0.4.0");
+  });
+
+  it("counts one commit in the singular", () => {
+    expect(wn.installedNotes("v0.4.0", 1, "v0.4.0")?.footnote).toContain("1 commit past");
+  });
+
+  it("falls back to the newest published release when the build descends from none", () => {
+    // A dev checkout. There is nothing truthful to say about this build, so the
+    // latest release is offered as itself rather than as yours.
+    expect(wn.installedNotes("", 0, "v0.4.0")).toEqual({ tag: "v0.4.0", title: "Latest release" });
+  });
+
+  it("offers nothing when there is no release to point at", () => {
+    // No tag published anywhere: a button here could only ever open an error.
+    expect(wn.installedNotes("", 0, "")).toBeNull();
+  });
+
+  it("never offers the latest release as the installed one", () => {
+    // Being on v0.3.0 with v0.4.0 published must show v0.3.0 — the button sits
+    // beside the version, and showing someone else's notes there is a lie.
+    expect(wn.installedNotes("v0.3.0", 0, "v0.4.0")?.tag).toBe("v0.3.0");
+  });
+});


### PR DESCRIPTION
## The gap

The notes were reachable exactly once: the launch after an update, on a version boundary. `releaseToAnnounce` fires on a version it has not run before and never again — so dismissing the modal, or updating from a build older than the feature, left the GitHub release page as the only copy. Nobody goes there, which is the problem the modal was written to solve.

The endpoint already took a `?tag=`, the notes were already cached for an hour, and nothing in the UI ever called either on purpose.

## What this adds

- **`release notes`** beside the version in Settings › About — what is in the build you are running.
- **`what's in <tag>`** beside the install button — read the update before taking it, rather than after the app has restarted into it.

## Three things it had to get right

- **The notes describe a tag; a build is usually past one.** This checkout's `build-info.json` says `baseTag: v0.4.0, distance: 72`. Presenting v0.4.0's notes as "what's new" there is a lie by omission, so `installedNotes` returns a footnote — *"This build is 72 commits past v0.4.0 — those changes are not in these notes."*
- **A dev checkout descends from no release.** Nothing truthful can be said about that build, so it offers the newest published release labelled `Latest release`, never as yours.
- **The automatic modal stays silent on failure; a button must not.** A button that opens nothing reads as broken, so the dialog now renders loading and error states — `could not reach github for the notes` is an answer.

## Shape

`ReleaseNotesModal` is the chrome, presentational, at z-index 10010/10011 so it lands above the settings dialog rather than beside it — equal z-index would have left the winner to DOM order. Escape is captured, so it closes the notes and not the settings dialog underneath. `WhatsNew` keeps the only part with judgement in it: whether to interrupt.

## Verified

- `make typecheck`, `make test` (400 pass), `web` suite (210 pass, 6 new for `installedNotes`), `make smoke` — all green.
- Against a running server: `?tag=v0.3.0` and `?tag=v0.4.0` each return their own annotation from the update clone; no tag on a dev build returns `this build descends from no release` (the error the modal now shows); a malformed tag is refused; a browser origin is still `cross-origin write blocked` by the desktop gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)