### PR TITLE
A lightweight tag has no notes, so stop publishing its commit message

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -30,5 +30,17 @@ jobs:
           # so %(contents) yields the commit message and the annotation — the
           # actual release notes — is lost. Re-fetch to get the tag object.
           git fetch --force --tags origin "refs/tags/$GITHUB_REF_NAME:refs/tags/$GITHUB_REF_NAME"
+
+          # And refuse if it is lightweight for real, rather than publishing a
+          # commit message as the release notes. %(contents) never fails and
+          # never comes back empty on such a tag — it just answers with the
+          # wrong thing, which is how a merge subject becomes a release body.
+          kind="$(git for-each-ref --format='%(objecttype)' "refs/tags/$GITHUB_REF_NAME")"
+          if [ "$kind" != "tag" ]; then
+            echo "::error::$GITHUB_REF_NAME is a lightweight tag ($kind) — it carries no annotation to publish." >&2
+            echo "Cut it with: git tag -a --cleanup=verbatim $GITHUB_REF_NAME -F notes.md" >&2
+            exit 1
+          fi
+
           git tag -l --format='%(contents)' "$GITHUB_REF_NAME" > /tmp/notes.md
           gh release create "$GITHUB_REF_NAME" --repo "$GITHUB_REPOSITORY" --title "$GITHUB_REF_NAME" --notes-file /tmp/notes.md

--- a/server/src/selfupdate.ts
+++ b/server/src/selfupdate.ts
@@ -258,9 +258,19 @@ export async function releaseNotes(tagIn?: string): Promise<{ ok: boolean; tag: 
 
   // The tag object may be there without its annotation if the clone fetched it
   // shallowly, hence the emptiness check rather than trusting exit status.
+  //
+  // `%(objecttype)` first, because a LIGHTWEIGHT tag has no annotation and
+  // `%(contents)` silently answers with the *commit message* instead. It never
+  // returns empty, so the check above cannot catch it and the fallback below
+  // never runs. That is not hypothetical: v0.3.0 and v0.1.0 are lightweight —
+  // publishing a release from the GitHub UI creates the tag that way — and this
+  // function reported v0.3.0's release notes as "Merge pull request #123 from
+  // SirAllap/docs/refresh-assets-and-docs", while the real, hand-written notes
+  // sat on the release the fallback would have fetched.
   if (existsSync(join(SRC, ".git"))) {
-    const r = git(SRC, ["tag", "-l", "--format=%(contents)", tag]);
-    const local = r.status === 0 ? r.stdout.trim() : "";
+    const r = git(SRC, ["for-each-ref", "--format=%(objecttype)%0a%(contents)", `refs/tags/${tag}`]);
+    const [kind, ...rest] = (r.status === 0 ? r.stdout : "").split("\n");
+    const local = kind?.trim() === "tag" ? rest.join("\n").trim() : "";
     if (local) return keep(local, "clone");
   }
 

--- a/server/test/release-notes.test.ts
+++ b/server/test/release-notes.test.ts
@@ -31,6 +31,9 @@ beforeAll(async () => {
   run(clone, "add", "-A");
   run(clone, "commit", "-qm", "first");
   spawnSync("git", ["-C", clone, "tag", "-a", "--cleanup=verbatim", "v9.9.9", "-F", "-"], { input: NOTES, encoding: "utf8" });
+  // A lightweight tag, the shape `gh release create` leaves behind: no
+  // annotation at all, so `%(contents)` falls through to the commit message.
+  run(clone, "tag", "v9.9.8");
   su = await import("../src/selfupdate.ts");
 });
 
@@ -49,6 +52,30 @@ describe("release notes", () => {
     expect(r.ok).toBe(true);
     expect(r.source).toBe("clone");
     expect(r.notes).toContain("tmux windows are the panel's own tabs");
+  });
+
+  it("keeps the markdown headings a release body is made of", async () => {
+    // `git tag -a -F` strips every line starting with `#` unless it is told
+    // not to — which silently deletes every `### Section` from the notes and
+    // leaves a flat list. The fixture is cut with --cleanup=verbatim, and this
+    // is the assertion that notices if that ever stops being true.
+    const r = await su.releaseNotes("v9.9.9");
+    expect(r.notes).toContain("### Terminal");
+  });
+
+  it("refuses to read a lightweight tag, whose 'annotation' is a commit message", async () => {
+    // The bug this replaced: %(contents) on a tag with no annotation answers
+    // with the commit message and never comes back empty, so the old emptiness
+    // check passed it straight through as release notes. v0.3.0 is lightweight
+    // — publishing from the GitHub UI creates the tag that way — and the app
+    // showed "Merge pull request #123 from …" as its release notes.
+    //
+    // Correct behaviour is to decline the clone and fall through to the API,
+    // which here has no reachable origin, so the answer is an honest failure
+    // rather than a plausible-looking wrong one.
+    const r = await su.releaseNotes("v9.9.8");
+    expect(r.source).not.toBe("clone");
+    expect(r.notes).not.toContain("first");
   });
 
   it("answers with a shape the client can always read", async () => {


### PR DESCRIPTION
## The bug

`%(contents)` on a tag with **no annotation** answers with the *commit message*. It never fails and never comes back empty — so the emptiness check that was meant to catch a missing annotation waved it straight through as release notes.

Not hypothetical. `v0.3.0` and `v0.1.0` are lightweight (publishing a release from the GitHub UI creates the tag that way), and against a running server the app reports v0.3.0's release notes as:

```
$ curl -H "Origin: agentglass://app" ".../update/notes?tag=v0.3.0"
{"ok":true,"tag":"v0.3.0","notes":"Merge pull request #123 from SirAllap/docs/refresh-assets-and-docs\n\nReshoot the screenshots and hero GIF, and document the workspace","source":"clone"}
```

The real, hand-written v0.3.0 notes are on the GitHub release the whole time — on the fallback path that could never be reached, because the clone had already "succeeded".

This is worse than an error. A merge subject looks enough like a release note to be believed.

## The fix

`releaseNotes()` asks `%(objecttype)` first and only reads the clone when the tag is annotated. Anything else falls through to the releases API, where a UI-published release keeps its body.

`release.yml` gets the same guard from the other side. It already re-fetches the tag object *because* a lightweight ref loses the annotation — then trusted `%(contents)` anyway, so a tag cut without `-a` would have published a commit subject as the release body. It now refuses, and says how to cut the tag properly.

## The other way a release body breaks

`git tag -a -F notes.md` **strips every line beginning with `#`** unless given `--cleanup=verbatim` — git treats them as comments. Every `### Section` heading vanishes and the notes become a flat list of bullets. Demonstrated:

```
$ git tag -a vTEST-default -F notes.md      # headings gone
Opening line.
- a bullet (#177).
- another (#173).

$ git tag -a vTEST-verbatim --cleanup=verbatim -F notes.md
Opening line.
### Pull requests
- a bullet (#177).
### Git
- another (#173).
```

The fixture in `release-notes.test.ts` was already cut with `--cleanup=verbatim`; there was no assertion that would notice if that stopped being true. There is one now.

## Verified

- New test fails against the old code (`expect(r.source).not.toBe("clone")` → received `"clone"`) and passes with the fix — checked by stashing the source change and re-running.
- `bun test` on `release-notes` + `selfupdate`: 19 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)