### PR TITLE
The workspace has six views, and one of them was undocumented

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,13 +86,13 @@ config file:
 
 Watching is only half of it. agentglass grew a set of **lazygit / lazydocker-style panels** — plus a real terminal and a Claude chat — that live right in the cockpit, so you can go from *seeing* what the fleet did to *acting* on it without leaving the tab. Keyboard-driven, and they wear the same 22 themes.
 
-They live in one **workspace**: `Ctrl+\` (`⌘\`) opens it over the dashboard, a rail down the left switches between the five views, and `Esc` puts you back. Every view has the same fixed-height title bar and the same list width, so switching changes the panel and nothing else moves.
+They live in one **workspace**: `Ctrl+\` (`⌘\`) opens it over the dashboard, a rail down the left switches between the six views, and `Esc` puts you back. Every view has the same fixed-height title bar and the same list width, so switching changes the panel and nothing else moves.
 
-**Two kinds of shortcut, because they answer different questions.** On the dashboard, bare letters jump straight in — `g` `d` `o` `t` `c`. Inside the workspace every keystroke belongs to whatever has focus, usually a shell, so navigation there carries a modifier: `Ctrl+1`–`Ctrl+5` for the rail in order, `Ctrl+[` / `Ctrl+]` to cycle. Both sets are rebindable in **Settings ▸ Shortcuts**, and the modified one takes any combination you like — `Ctrl+Alt+J` is recorded exactly as you hold it.
+**Two kinds of shortcut, because they answer different questions.** On the dashboard, bare letters jump straight in — `g` `d` `p` `o` `t` `c`. Inside the workspace every keystroke belongs to whatever has focus, usually a shell, so navigation there carries a modifier: `Ctrl+1`–`Ctrl+6` for the rail in order, `Ctrl+[` / `Ctrl+]` to cycle. Both sets are rebindable in **Settings ▸ Shortcuts**, and the modified one takes any combination you like — `Ctrl+Alt+J` is recorded exactly as you hold it.
 
 ![settings — every shortcut, rebindable, with the key that works anywhere beside the one that works on the dashboard](.github/assets/settings-shortcuts.png)
 
-**Drag the rail to reorder it.** Put the terminal at the bottom if that is where your thumb goes; `Ctrl+1`–`5` follow your arrangement, so the tooltips never start lying. Drag the seam beside any list to resize it — every view shares that width, and it is remembered.
+**Drag the rail to reorder it.** Put the terminal at the bottom if that is where your thumb goes; `Ctrl+1`–`6` follow your arrangement, so the tooltips never start lying. Drag the seam beside any list to resize it — every view shares that width, and it is remembered.
 
 ### 🔔 The notch — what is happening, above everything
 
@@ -121,6 +121,18 @@ It also does the three things you would otherwise drop to a terminal for:
 **Undo the merge**, while that is still exactly reversible — only when nothing is committed on top and nothing is pushed. If either is true the button explains why instead of offering you a lie.
 
 ![source control panel](.github/assets/git.png)
+
+### 🔀 Pull requests — review one without opening a browser &nbsp;`p`
+
+Every open pull request across the repos the fleet touches, filtered by **mine** / **waiting on your review** / **all**, each row carrying its checks rolled into one dot (hover for `passed · failed · skipped · running`) and a `here` chip when this checkout is on that branch.
+
+Open one and it has **overview · conversation · commits · files · checks · review**. The diff is the app's own viewer — the same `SplitDiff` / `UnifiedDiff` the file-changes panel uses, keybindings and all, rather than a second implementation that drifts — and it reads **per file or per commit**, with merge commits marked as the trunk catch-ups they are so you do not review them as work.
+
+**The conversation is mostly machines, so it is not one list.** On a real review, four issue comments were all from CI, one coverage table alone was 46,551 characters, and the single human review that actually blocked the merge sat last, under all of it. It reads in three lanes instead — humans, line threads, automation — and the machine lane collapses to a digest. Everything a person wrote renders as real markdown at a reading measure, because prose set to the full width of a 2000px window is unreadable however correctly it is formatted.
+
+**Reviews work the way GitHub's do.** Line comments queue as drafts (a `pending` chip counts them) and go up together as one review — approve, request changes or comment — so a half-finished review never lands in someone's inbox a line at a time. Threads belong to the review that opened them, are anchored to the code they are about, link out when you do want the browser, and the app declines to let you approve your own pull request.
+
+Nothing blocks on the network: `gh` costs a second or more per call and the server has one thread, so every read is a cached answer that shows its own age.
 
 ### 🐳 Docker — lazydocker, in the dashboard &nbsp;`o`
 
@@ -647,6 +659,7 @@ Where this is going — themes, not dates. The living version is the issue track
 - Voice input in chat — [#92](https://github.com/SirAllap/agentglass/issues/92)
 
 **Recently shipped** — see the [releases](https://github.com/SirAllap/agentglass/releases) for the full record.
+- **v0.5.0** — pull request review inside the cockpit, and the freeze is gone: the event loop is watched, and every expensive git, docker and database read left the thread that carries the terminal
 - **v0.4.0** — evidence-of-life signal for open tool calls; the shell no longer adopts a stranger's server on `:4000`
 - **v0.3.0** — in-app merge-conflict resolution, whole-project docker controls, a rearrangeable workspace, and an in-app updater
 - **v0.2.x** — downloadable installers for Linux / macOS / Windows, the Electron desktop shell, and a real chat panel


### PR DESCRIPTION
The PR review view shipped in #177. The README never mentioned it.

**What was stale**

| README said | Reality (`web/src/components/workspace/views.ts`) |
|---|---|
| "the **five** views" | six: `git, diff, pr, docker, term, chat` |
| `Ctrl+1`–`Ctrl+5` | `⌘1`–`⌘6` |
| bare letters `g` `d` `o` `t` `c` | `g` `d` `p` `o` `t` `c` |
| a section per panel — `d`, `g`, `o`, `t`, `c` | no section for `p` |

The smoke test has asserted six rail tabs since #177 (`scripts/smoke.ts:303`), so the docs were the only thing still claiming five.

**The new section** covers what the panel does and the two decisions that are not visible in a screenshot — both taken from `PrPanel.tsx`'s own header comment, which recorded why:

- The conversation reads in **three lanes** (humans, line threads, automation) because on a real review four issue comments were CI, one coverage table was 46,551 characters, and the single human review that blocked the merge sat underneath all of it.
- Line comments **queue as drafts** and go up as one review, so a half-finished review does not arrive in somebody's inbox a line at a time.

Also notes that the diff is the app's existing `SplitDiff`/`UnifiedDiff` rather than a second implementation, that merge commits are marked as trunk catch-ups, that you cannot approve your own PR, and that every read is cached with its age shown because `gh` costs a second per call on a single-threaded server.

**Roadmap** gets a v0.5.0 line under "recently shipped".

🤖 Generated with [Claude Code](https://claude.com/claude-code)