### PR TITLE
fix(terminal): follow the tmux client when the session moves under it

### DIFF
--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -81,16 +81,27 @@ type Session = {
   /** Cleared on close — a stray interval would keep reading /proc for a pty
    *  that no longer exists, once per session, forever. */
   tmuxPoll?: ReturnType<typeof setInterval> | null;
-  /** The tmux session this shell is attached to, once one is found. */
+  /** The tmux client in this shell, once one is found. Survives a session
+   *  switch, which is the whole reason it is kept apart from the target. */
+  tmuxClient?: TmuxClient | null;
+  /** The tmux session that client is showing, re-read every poll. */
   tmux?: TmuxTarget | null;
+  /** tmux's prefix keys, re-read whenever the session changes rather than every
+   *  tick: it is a config value, not a live one. */
+  tmuxPrefix?: string[];
   /** Re-read tmux and push if anything moved. Held so an action can refresh
    *  immediately instead of leaving the strip stale until the next tick. */
   tmuxSweep?: () => void;
-  /** Whether we hid tmux's own status line, so it can be given back on the way
-   *  out. Restoring is not optional: a session left with `status off` after the
-   *  panel closed would look broken in the user's real terminal, and they would
-   *  have no reason to connect it to us. */
-  tmuxStatusHidden?: boolean;
+  /** Whether the panel wants tmux's own status line drawn. Remembered rather
+   *  than applied and forgotten, so the answer can be re-applied to whatever
+   *  session the client moves to next. Undefined until the panel says. */
+  tmuxStatusVisible?: boolean;
+  /** The session we actually hid it on, so it can be given back on the way out.
+   *  Restoring is not optional: a session left with `status off` after the panel
+   *  closed would look broken in the user's real terminal, and they would have
+   *  no reason to connect it to us. It is the session and not a boolean because
+   *  the one we borrowed from is not always the one we end up on. */
+  tmuxStatusHiddenOn?: TmuxTarget | null;
 };
 const sessions = new Map<PtyWs, Session>();
 
@@ -119,7 +130,7 @@ function killGroup(s: Session, sigNum: number) {
   } catch { /* already gone */ }
 }
 
-import { resolveTarget, listWindows, runAction, setStatusLine, prefixKeys, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
+import { resolveClient, readFrame, runAction, setStatusLine, prefixKeys, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 
 const enc = new TextEncoder();
 const ctl = (ws: PtyWs, frame: Record<string, unknown>) => { try { ws.send(JSON.stringify(frame)); } catch { /* closed */ } };
@@ -205,43 +216,85 @@ export function ptyOpen(ws: PtyWs) {
   sessions.set(ws, session);
   ctl(ws, { t: "ready", mode, shell: basename(shell), cwd, resize: !!sizeDir });
 
-  /*
-   * Watch for tmux coming and going.
+  /**
+   * The client moved to a different session — follow it there.
    *
-   * Polled rather than detected once at startup, because the interesting case
-   * is exactly the one that changes: you open a plain shell, type `tmux`, and
-   * the panel's tabs and split button should stand down at that moment — and
-   * come back when you detach. Two seconds is well under the threshold where a
-   * stale layout is noticeable, and the check is a couple of small /proc reads.
+   * Everything we hold about a session is about *that* session: the prefix we
+   * advertise, and the status line we borrowed. Hand the old one its status line
+   * back before borrowing the next one's, so a user who switches away with `^b s`
+   * finds their other session exactly as their config left it.
+   */
+  const followSession = (t: TmuxTarget) => {
+    const borrowed = session.tmuxStatusHiddenOn;
+    if (borrowed && borrowed.id !== t.id) {
+      setStatusLine(borrowed, true);
+      session.tmuxStatusHiddenOn = null;
+    }
+    session.tmux = t;
+    session.tmuxPrefix = prefixKeys(t);
+    // Re-apply the panel's answer to the new session. Without this a restored
+    // session comes up with tmux's own status line on top of our tabs, and
+    // nothing in the panel changed to make the browser re-ask for it.
+    if (session.tmuxStatusVisible === false && !session.tmuxStatusHiddenOn) {
+      if (setStatusLine(t, false)) session.tmuxStatusHiddenOn = t;
+    }
+  };
+
+  /*
+   * Watch for tmux coming and going, and for the session under it moving.
+   *
+   * Polled rather than detected once at startup, because the interesting cases
+   * are exactly the ones that change: you open a plain shell, type `tmux`, and
+   * the panel's split button should stand down at that moment — and come back
+   * when you detach. The same is true one level down, for which session that
+   * client is showing.
    */
   let sawTmux = false;
-  let sentWindows = "";
+  let sent = "";
   const sweep = () => {
     if (session.closed || session.exited) return;
     const now = tmuxRunning(proc.pid);
     if (now !== sawTmux) {
       sawTmux = now;
       if (!now) {
-        // Detached. Forget the session rather than keep polling a target that
+        // Detached. Forget the client rather than keep polling a target that
         // is no longer ours, and stop describing windows nobody is looking at.
+        session.tmuxClient = null;
         session.tmux = null;
-        session.tmuxStatusHidden = false;
-        sentWindows = "";
+        session.tmuxPrefix = [];
+        session.tmuxStatusHiddenOn = null;
+        sent = "";
         ctl(ws, { t: "tmux", active: false, windows: [] });
         return;
       }
     }
     if (!now) return;
-    // Resolved once per attach: the join walks /proc and shells out to
-    // list-clients, and neither answer changes while the same client is up.
-    if (!session.tmux) session.tmux = resolveTarget(proc.pid);
-    const windows = session.tmux ? listWindows(session.tmux) : [];
+    // The client is resolved once per attach — that walk is /proc and it does
+    // not change while the same client is up. Which session it is *showing* is
+    // read every tick, because that does change: `^b s`, and every continuum
+    // restore, which switches the client to the restored session and kills the
+    // one it attached to. A target cached at attach time points at that dead
+    // session for the rest of the shell's life.
+    if (!session.tmuxClient) session.tmuxClient = resolveClient(proc.pid);
+    const frame = session.tmuxClient ? readFrame(session.tmuxClient) : null;
+    if (frame) {
+      if (frame.target.id !== session.tmux?.id) followSession(frame.target);
+      else session.tmux = frame.target; // a rename keeps the id and changes the name
+    } else {
+      // Unreachable: the server went away, or the client is mid-attach. Drop it
+      // and resolve again next tick rather than answer from something stale.
+      session.tmuxClient = null;
+      session.tmux = null;
+    }
+    const windows = frame?.windows ?? [];
     // Only speak when something changed. A tab strip that re-renders on every
-    // tick is a tab strip that drops the click you were halfway through.
-    const shape = JSON.stringify(windows);
-    if (shape === sentWindows && sawTmux === now) return;
-    sentWindows = shape;
-    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, prefix: session.tmux ? prefixKeys(session.tmux) : [], windows });
+    // tick is a tab strip that drops the click you were halfway through. The
+    // session is part of "changed": switching between two sessions with the
+    // same window names is still a switch, and the panel says which one it is.
+    const shape = JSON.stringify([session.tmux?.id ?? null, windows]);
+    if (shape === sent) return;
+    sent = shape;
+    ctl(ws, { t: "tmux", active: true, session: session.tmux?.session ?? null, prefix: session.tmuxPrefix ?? [], windows });
   };
   session.tmuxSweep = sweep;
   /*
@@ -383,12 +436,17 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
      * /proc, never one the client names, so a page cannot address somebody
      * else's tmux by asking nicely.
      */
-    if (!s.tmux) return;
     if (msg.cmd === "status") {
       const visible = msg.visible !== false;
-      if (setStatusLine(s.tmux, visible)) s.tmuxStatusHidden = !visible;
+      // Remembered before it is applied, and remembered even with no session
+      // resolved yet: this is a preference about tmux's chrome, not about one
+      // session, and it has to survive the client being switched to another.
+      s.tmuxStatusVisible = visible;
+      if (!s.tmux) return;
+      if (setStatusLine(s.tmux, visible)) s.tmuxStatusHiddenOn = visible ? null : s.tmux;
       return;
     }
+    if (!s.tmux) return;
     const action = msg.cmd as TmuxAction;
     if (!["select", "new", "kill", "rename"].includes(action)) return;
     if (!runAction(s.tmux, action, msg.window, msg.name)) return;
@@ -420,7 +478,7 @@ function cleanup(ws: PtyWs, s: Session) {
   // Give the status line back before letting go. The panel borrowed it; a
   // session left with `status off` after the panel closed looks broken in the
   // user's real terminal, and nothing there would point back at us.
-  if (s.tmuxStatusHidden && s.tmux) { setStatusLine(s.tmux, true); s.tmuxStatusHidden = false; }
+  if (s.tmuxStatusHiddenOn) { setStatusLine(s.tmuxStatusHiddenOn, true); s.tmuxStatusHiddenOn = null; }
   if (s.sizeDir) { try { rmSync(s.sizeDir, { recursive: true, force: true }); } catch { /* tmp reaper will get it */ } s.sizeDir = null; }
 }
 

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -25,13 +25,33 @@ import type { TmuxWindow } from "../../shared/types.ts";
  *  socket, and short enough that a wedged tmux server cannot stall the poll. */
 const TMUX_TIMEOUT_MS = 2000;
 
+/**
+ * The tmux client itself: everything about it that /proc knows and tmux does
+ * not need to be asked about.
+ *
+ * Held separately from the session because they change on different clocks. A
+ * client lives as long as the shell has tmux in it; the session it is *showing*
+ * can change underneath it at any moment, and does — `^b s`, `^b (`, and every
+ * tmux-continuum restore, which attaches you to a scratch session and then
+ * switches you to the restored one before you have finished blinking.
+ */
+export interface TmuxClient {
+  /** The tmux client process inside our shell. */
+  pid: number;
+  /** `-S <path>` / `-L <name>` as the client itself was invoked, so we reach the
+   *  same server rather than the default one. Empty for the default socket. */
+  socket: string[];
+  /** The terminal it is attached to, which is how tmux names it back to us. */
+  tty: string;
+}
+
 export interface TmuxTarget {
   /** The tmux client process inside our shell. */
   pid: number;
   /** `-S <path>` / `-L <name>` as the client itself was invoked, so we reach the
    *  same server rather than the default one. Empty for the default socket. */
   socket: string[];
-  /** The session that client is attached to, for display. */
+  /** The session that client is attached to *right now*, for display. */
   session: string;
   /** tmux's own id for it (`$0`), which is what every command below targets.
    *  Names are matched by prefix unless you fight the syntax for it, and even
@@ -116,26 +136,19 @@ function tmux(socket: string[], args: string[]): string | null {
 }
 
 /**
- * Resolve the pid of a tmux client to the session it is showing.
+ * The tmux client under this shell, and how to reach its server.
  *
- * The join is the terminal: our pty is that client's controlling tty, and tmux
- * will name it back to us in `client_tty`. Guessing instead — taking the most
- * recent session, say — is wrong the moment a user has two sessions open, which
- * is the normal case for the people who use tmux at all.
+ * Only the /proc half. Which session it is showing is deliberately not part of
+ * this: that answer goes stale, and an interface that hands both back at once
+ * invites a caller to cache the pair, which is the bug this shape exists to
+ * prevent.
  */
-export function resolveTarget(shellPid: number): TmuxTarget | null {
+export function resolveClient(shellPid: number): TmuxClient | null {
   const pid = tmuxClientPid(shellPid);
   if (!pid) return null;
   const tty = ttyOf(pid);
   if (!tty) return null;
-  const socket = socketOf(pid);
-  const out = tmux(socket, ["list-clients", "-F", "#{client_tty}\t#{session_name}\t#{session_id}"]);
-  if (!out) return null;
-  for (const line of out.split("\n")) {
-    const [clientTty, session, id] = line.split("\t");
-    if (clientTty === tty && session && id) return { pid, socket, session, id };
-  }
-  return null;
+  return { pid, socket: socketOf(pid), tty };
 }
 
 /** tmux window ids are `@` and digits, and nothing a client sends is trusted to
@@ -164,13 +177,72 @@ export function parseWindows(out: string): TmuxWindow[] {
   return windows;
 }
 
-export function listWindows(t: TmuxTarget): TmuxWindow[] {
-  const out = tmux(t.socket, [
-    "list-windows",
-    "-t", t.id,
-    "-F", "#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}",
+export interface TmuxFrame {
+  target: TmuxTarget;
+  windows: TmuxWindow[];
+}
+
+/**
+ * Which session this client is on, and what is in it — asked together, every
+ * time.
+ *
+ * The join is the terminal: our pty is that client's controlling tty, and tmux
+ * names it back to us in `client_tty`. Guessing instead — taking the most recent
+ * session, say — is wrong the moment a user has two sessions open, which is the
+ * normal case for the people who use tmux at all.
+ *
+ * The session has to be re-read rather than resolved once and kept, because a
+ * client outlives the session it is showing. `^b s` moves it. So does
+ * tmux-continuum's restore, which is worse than a move: it attaches you to a
+ * scratch session, restores the saved ones, switches you across and kills the
+ * scratch one behind you. A target cached at attach time then names a session
+ * that no longer exists, `list-windows` answers nothing, and the tab strip
+ * silently empties out while tmux carries on drawing its own status line
+ * underneath — which is exactly what it did.
+ *
+ * One tmux invocation for both halves: `list-clients` cannot tell us the windows
+ * and `list-windows` cannot tell us the client, but tmux takes a command list,
+ * so this costs the same one spawn per poll the old single-session read did. The
+ * lines are tagged because they come back concatenated.
+ */
+export function readFrame(c: TmuxClient): TmuxFrame | null {
+  const out = tmux(c.socket, [
+    "list-clients", "-F", "c\t#{client_tty}\t#{session_name}\t#{session_id}",
+    ";",
+    "list-windows", "-a",
+    "-F", "w\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}",
   ]);
-  return out ? parseWindows(out) : [];
+  if (!out) return null;
+  const f = parseFrame(out, c.tty);
+  return f ? { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows } : null;
+}
+
+/**
+ * Pick our client's session out of the server's answer, and its windows out of
+ * every session's windows.
+ *
+ * Windows are filtered by session id and not by anything friendlier: session
+ * *names* are not unique enough to bet a `kill-window` on — resurrect happily
+ * restores a second session called `main` — and the id is what tmux itself uses.
+ */
+export function parseFrame(out: string, tty: string): { session: string; id: string; windows: TmuxWindow[] } | null {
+  let session: string | null = null;
+  let id: string | null = null;
+  const windowRows: string[] = [];
+  for (const line of out.split("\n")) {
+    if (line.startsWith("c\t")) {
+      const [, clientTty, name, sid] = line.split("\t");
+      if (clientTty === tty && name && sid) { session = name; id = sid; }
+    } else if (line.startsWith("w\t")) {
+      windowRows.push(line);
+    }
+  }
+  if (!session || !id) return null;
+  const mine = windowRows
+    .filter((r) => r.startsWith(`w\t${id}\t`))
+    // Drop the tag and the session id; what is left is what parseWindows reads.
+    .map((r) => r.split("\t").slice(2).join("\t"));
+  return { session, id, windows: parseWindows(mine.join("\n")) };
 }
 
 /**

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -8,7 +8,7 @@
 // What is unit-tested is everything that turns tmux's text into our shapes, and
 // everything that decides whether a command is allowed to run at all.
 import { describe, expect, test } from "bun:test";
-import { parseWindows, socketFromArgv, runAction, sanitizeWindowName, prefixKeys, type TmuxTarget } from "../src/tmuxctl.ts";
+import { parseWindows, parseFrame, socketFromArgv, runAction, sanitizeWindowName, prefixKeys, type TmuxTarget } from "../src/tmuxctl.ts";
 
 describe("reading tmux's window list", () => {
   test("id, index, name, active flag and tmux's own marks", () => {
@@ -44,6 +44,55 @@ describe("reading tmux's window list", () => {
     const [bell, activity] = parseWindows("@0\t1\tbuild\t0\t!\n@1\t2\ttest\t0\t#\n");
     expect(bell!.flags).toBe("!");
     expect(activity!.flags).toBe("#");
+  });
+});
+
+describe("which session the client is on", () => {
+  // Read fresh every poll rather than once at attach, because a client outlives
+  // the session it shows. tmux-continuum's restore is the case that broke: it
+  // attaches you to a scratch session, restores the saved ones, switches you
+  // across and kills the scratch one — so a session resolved at attach time
+  // names something that no longer exists, and the tab strip empties out while
+  // tmux keeps drawing its own status line where our tabs should have been.
+  const frame = [
+    "c\t/dev/pts/3\tother\t$1",
+    "c\t/dev/pts/0\tmain\t$2",
+    "w\t$1\t@0\t1\tnot-ours\t1\t*",
+    "w\t$2\t@3\t1\tAI01\t1\t*",
+    "w\t$2\t@4\t2\tAI02\t0\t-",
+  ].join("\n");
+
+  test("our client's session, and only our session's windows", () => {
+    const f = parseFrame(frame, "/dev/pts/0");
+    expect(f!.session).toBe("main");
+    expect(f!.id).toBe("$2");
+    expect(f!.windows.map((w) => w.name)).toEqual(["AI01", "AI02"]);
+  });
+
+  test("windows are matched by session id, not by name", () => {
+    // resurrect will happily restore a second session called `main`, and a
+    // kill-window aimed at the wrong one of those is unrecoverable.
+    const twoMains = "c\t/dev/pts/0\tmain\t$2\nw\t$9\t@1\t1\tmain\t1\t*\nw\t$2\t@2\t1\tours\t1\t*";
+    expect(parseFrame(twoMains, "/dev/pts/0")!.windows.map((w) => w.name)).toEqual(["ours"]);
+  });
+
+  test("a session with no windows of its own reads as empty, not as somebody else's", () => {
+    expect(parseFrame("c\t/dev/pts/0\tmain\t$2\nw\t$1\t@0\t1\tnot-ours\t1\t*", "/dev/pts/0")!.windows).toEqual([]);
+  });
+
+  test("no client on our terminal is no answer at all", () => {
+    // Mid-attach, or the client detached between the /proc walk and the ask.
+    // Answering with the first session in the list would put somebody else's
+    // windows in the strip, and a click there kills somebody else's window.
+    expect(parseFrame(frame, "/dev/pts/9")).toBeNull();
+    expect(parseFrame("", "/dev/pts/0")).toBeNull();
+  });
+
+  test("window names with tabs in them do not smuggle a session id", () => {
+    // The name is the last-but-two field and is not re-split, so this is a
+    // window called what it says, in $2, and not one in $7.
+    const f = parseFrame("c\t/dev/pts/0\tmain\t$2\nw\t$2\t@1\t1\tnpm run dev\t1\t*", "/dev/pts/0");
+    expect(f!.windows).toEqual([{ id: "@1", index: 1, name: "npm run dev", active: true, flags: "*" }]);
   });
 });
 


### PR DESCRIPTION
## What broke

Open the terminal panel on a machine running tmux-continuum and the tabs never show up. You get the empty strip, the "panel chrome hidden — tmux owns the panes" line, and tmux's own status bar still painted across the top — the exact bar our tabs exist to replace.


## Why

`resolveTarget()` resolved a client to a session once, at attach, and the session was kept for the life of the shell. But a client outlives the session it is showing. `^b s` moves it, and continuum's restore moves it by design: it attaches you to a scratch session, restores the saved ones, switches the client across, and kills the scratch session behind you.

So the cached target names a session that no longer exists. Reproduced against a real tmux server:

```
resolved:  A $0  windows: [ "winA" ]     # at attach
STALE target windows: [ "winA" ]         # after switch-client -t B: wrong session
fresh resolve: B $1 [ "winB", "winB2" ]  # what it should have said
after the old session is killed, stale target windows: []   # what the screenshot is
```

Empty windows is also why the status line survived: the panel only asks for it to be hidden once it has tabs to put there, so both halves of the bug come from the same stale answer.

## The fix

- `resolveTarget` splits into `resolveClient` (the /proc half, still resolved once — it does not change) and `readFrame` (which session, and its windows, re-read every poll).
- `readFrame` asks `list-clients` and `list-windows -a` in one tmux command list, so it is still one spawn per 500ms tick, same as the single-session read it replaces.
- On a session change we follow it: re-read the prefix, hand the old session its status line back, and re-apply the panel's preference to the new one. That last part has to be server-side — nothing changes in the browser when a session is restored underneath it, so nothing there would re-ask.
- Windows are matched by session id, never by name. resurrect will restore a second session called `main` without blinking, and a `kill-window` aimed at the wrong one is not recoverable.

## Verified

Against a live tmux server, walking the full continuum sequence (attach to scratch → restore → switch-client → kill scratch):

```
on attach:      scratch $0 [ "scratch" ]      scratch status: off
after restore:  restored $1 [ "AI01", "AI02" ] restored status: off
given back:     (status restored on close)
```

`bun test`: 20 pass in the tmux suite, including new cases for picking our client out of several, matching windows by id when two sessions share a name, and refusing to answer with somebody else's session when no client is on our tty. The 28 failures elsewhere in the suite are present on `main` untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
