### PR TITLE
docs: the way in is the app, not a dev server

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
 
 Point any AI coding agent at agentglass — via Claude Code hooks or any OpenTelemetry GenAI exporter (OpenAI Codex, Gemini CLI, Bedrock, LangChain, LiteLLM…) — and watch every agent, tool call, token, and dollar move in real time. Cost tracking, tool-latency percentiles, error timelines, session lifecycles, a filter-the-whole-cockpit-by-provider switch, and 22 themes. It persists across reloads (unlike a pure in-browser stream).
 
-And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Runs in the browser or as a **native desktop app**.
+And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Ships as a **native desktop app**, server included.
 
 ### ▶ [**Live demo →**](https://sirallap.github.io/agentglass/demo/)
 
@@ -244,23 +244,54 @@ Every dark palette has a matching light twin — e.g. Midnight Purple Light:
 
 ## Quickstart
 
-Requires [Bun](https://bun.sh) ≥ 1.1 and Python 3 (for the hook forwarder).
+agentglass is a **desktop app**. Grab the installer for your platform from
+[**Releases**](https://github.com/SirAllap/agentglass/releases/latest), launch
+it, and the cockpit opens with its own server bundled inside. Nothing to run in
+a terminal, no port to open in a browser.
+
+| Linux | macOS |
+| --- | --- |
+| `.AppImage` (chmod +x, run it) or `.deb` | `.dmg`, Apple Silicon and Intel |
+
+That alone already shows you everything: the built-in **transcript scanner**
+reads `~/.claude/projects`, so every Claude Code session on the machine is
+there on first open, with no wiring at all.
+
+To also get live streaming and `PreToolUse` gating, wire the hooks once
+(opt-in, details [below](#wire-the-hooks-globally--one-command-opt-in)). The
+forwarder lives in the repo, so this step wants a clone and Python 3; it needs
+nothing else:
 
 ```bash
 git clone https://github.com/SirAllap/agentglass.git && cd agentglass
-bun install
-bun run setup        # wire the global Claude Code hooks — opt-in, see below
-bun run dev          # server :4000  +  UI :6180
+python3 hooks/install_hooks.py        # global Claude Code hooks
+python3 hooks/seed_demo.py            # optional: streams demo agents for ~30s
 ```
 
-Open **http://localhost:6180**. Then see it move without wiring a real project:
+> Want to look before installing? The [**live demo**](https://sirallap.github.io/agentglass/demo/)
+> is this exact UI, built from the same source on every push, running on
+> fabricated data.
+
+### Running from source
+
+For hacking on agentglass, or for a headless box. Requires
+[Bun](https://bun.sh) ≥ 1.1 and Python 3 (for the hook forwarder).
 
 ```bash
-python3 hooks/seed_demo.py            # streams demo agents for ~30s
+bun install
+bun run dev          # server :4000  +  UI :6180  (vite dev server)
+make desktop         # or: build the UI and launch the real shell
 ```
 
+`bun run dev` gives you the same UI in a browser tab at
+**http://localhost:6180**, minus what only the shell can do (fullscreen, zoom,
+launch-at-login, and the self-update route, which refuses a browser by design).
+It is the development path, not the way to run the app. If something else on
+your machine already owns `:4000`, the tab will talk to *that* server, so check
+the port before believing an empty dashboard.
+
 **Single-port deploys** (a headless box, a systemd unit): build the UI once and
-the server serves it itself — one process, one port, API and dashboard on the
+the server serves it itself, one process, one port, API and dashboard on the
 same origin:
 
 ```bash
@@ -268,12 +299,13 @@ bun run build                         # web/dist
 cd server && bun run src/index.ts     # dashboard AND API on :4000
 ```
 
-When `web/dist` doesn't exist (plain `bun run dev`), nothing changes — the
-server is API-only and the vite dev server owns the UI as before.
+When `web/dist` doesn't exist (plain `bun run dev`, or the packaged app's
+bundled server), nothing is served over HTTP: the server is API-only and no
+dashboard is reachable on that port at all.
 
-Prefer `make`? Every entry point is a described Makefile target — `make help`
-lists them all (`make dev`, `make setup`, `make demo-feed`, `make desktop`, …),
-and the in-app terminal (`t` → **⚙ commands**) surfaces the same list, ready to
+Prefer `make`? Every entry point is a described Makefile target, and `make help`
+lists them all (`make dev`, `make setup`, `make demo-feed`, `make desktop`, …).
+The in-app terminal (`t` → **⚙ commands**) surfaces the same list, ready to
 click-run.
 
 ### Wire the hooks globally — one command, opt-in
@@ -326,6 +358,13 @@ run in a terminal. Launch it from your app menu and the cockpit opens; close it
 and the server goes with it. The UI is the same web app, run in Chromium so it
 composites on the GPU.
 
+Installers for every release are published on
+[**Releases**](https://github.com/SirAllap/agentglass/releases/latest):
+`.AppImage` and `.deb` for Linux, `.dmg` for macOS (Apple Silicon and Intel).
+That is the way to install it.
+
+Building it yourself, from a clone:
+
 ```bash
 make desktop            # build the UI and launch Electron + the sidecar
 make desktop-dist       # package installable binaries (electron-builder)
@@ -333,6 +372,10 @@ make desktop-install    # install for this user (no root)
 ```
 
 Then launch **agentglass** from your desktop menu, or `agentglass` from a shell.
+
+The packaged app's bundled server serves the API and nothing else: the UI is
+loaded from the shell's own `agentglass://` origin, which a browser cannot
+reach, so an install never exposes a dashboard on a port.
 
 - **Attaches, never duplicates** — if a server is already listening on `:4000`
   (e.g. a `bun run dev` you left running), the app attaches to it instead of

--- a/landing/index.html
+++ b/landing/index.html
@@ -543,13 +543,13 @@
       <b>hold a risky tool call until you approve it</b>, from any device, and it survives a
       restart. And the cockpit acts — review diffs, stage &amp; push, drive docker, drop into
       a <b>real terminal</b> (with your tmux windows as native tabs), chat with Claude —
-      without leaving the glass. Runs in the browser, or as a desktop app.
+      without leaving the glass. A desktop app, with its server built in.
     </p>
 
     <div class="ctas">
       <a class="btn-a" href="./demo/">▶ Enter the live demo</a>
       <a class="btn-b" data-dl="any" href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener">⬇ Download <span data-agx="version">the desktop app</span></a>
-      <button class="btn-b" id="copy-npx" data-copy="git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev" title="Copy: git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev"><span class="c">$</span> <span id="npx-txt">git clone … &amp;&amp; bun install &amp;&amp; bun run dev</span></button>
+      <button class="btn-b" id="copy-npx" data-copy="git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run setup" title="Copy: git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run setup"><span class="c">$</span> <span id="npx-txt">git clone … &amp;&amp; bun run setup</span></button>
     </div>
 
     <div class="keys" aria-label="Workspace panels, one keystroke away">
@@ -832,9 +832,9 @@ sudo apt install ./agentglass_*.deb</code>
   <div class="txgrid">
     <div class="txlog rv">
       <div><span class="who p">pilot ▸</span> request startup.</div>
-      <div><span class="who">tower ▸</span> cleared. two ways in —</div>
+      <div><span class="who">tower ▸</span> cleared. one way in —</div>
       <div class="dim">◇ <a href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener" style="text-decoration:underline">download the desktop app</a> · macOS, Linux, Windows</div>
-      <div class="dim">◇ or <span class="cmd">git clone</span> · <span class="cmd">bun install</span> · <span class="cmd">bun run dev</span></div>
+      <div class="dim">◇ launch it — the server ships inside, nothing to run</div>
       <div class="dim">◇ scanning ~/.claude/projects … 18 sessions found</div>
       <div class="dim">◇ <span class="cmd">bun run setup</span> wires the Claude Code hooks — opt-in</div>
       <div><span class="who p">pilot ▸</span> tower in sight. <span class="caret"></span></div>
@@ -864,7 +864,7 @@ sudo apt install ./agentglass_*.deb</code>
   <div class="rv">
     <span class="stamp">Cleared for takeoff</span>
     <h2>Your agents are already flying.<br><em>Get a tower.</em></h2>
-    <button class="cmdline" id="copy-npx2" data-copy="git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev" title="Copy: git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run dev"><span class="p">$</span> <span id="npx-txt2">git clone … &amp;&amp; bun install &amp;&amp; bun run dev</span></button>
+    <button class="cmdline" id="copy-npx2" data-copy="git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run setup" title="Copy: git clone https://github.com/SirAllap/agentglass.git &amp;&amp; cd agentglass &amp;&amp; bun install &amp;&amp; bun run setup"><span class="p">$</span> <span id="npx-txt2">git clone … &amp;&amp; bun run setup</span></button>
     <div class="row">
       <a class="btn-a" href="./demo/">▶ Live demo — no install</a>
       <a class="btn-b" data-dl="mac" href="https://github.com/SirAllap/agentglass/releases/latest" target="_blank" rel="noopener">⬇ macOS</a>


### PR DESCRIPTION
## Why

Quickstart opened with `git clone && bun install && bun run dev` and told the reader to open `localhost:6180`. That is the **vite dev server**. It is the right entry point for someone changing the code, and the wrong one for everyone else, who then met the project through a browser tab that is missing fullscreen, zoom, launch-at-login and the self-update route (all of which live behind `window.agentglass`, `electron/preload.js`).

Releases have shipped installers for every platform since v0.2.0 (`.AppImage`, `.deb`, `.dmg` for both Apple Silicon and Intel). Nothing pointed a newcomer at them first.

## What changed

- **Quickstart** now leads with the installer, and says plainly that the scanner already shows every session with no wiring at all.
- **Running from source** is a new subsection directly below it, holding `bun run dev` and the single-port deploy notes unchanged. Contributors lose nothing, and it now says out loud that it is the development path and what a browser tab does not get.
- The hook step drops `bun run setup` for `python3 hooks/install_hooks.py`. Someone who installed a binary has no reason to have Bun; the installer only ever needed Python.
- The Desktop app section points at Releases first, building from a clone second, and records that the packaged server serves the API only. The UI comes from the shell's `agentglass://` origin, so an install never exposes a dashboard on a port.
- Landing: hero and footer copy-buttons now copy the hook-wiring command instead of `bun run dev`, and the quickstart log stops offering the dev server as a second "way in". The "run it from source" note stays, framed as what it is.

## Notes

Docs and landing only, no code touched. Browser serving (`server/src/webui.ts`) is untouched, since headless and single-port deploys depend on it.

Found while writing this: the packaged app ships `web` and the compiled server but **not** `hooks/` (`electron/package.json:27-30`), and there is no hook-install endpoint, so a binary user who wants hooks has to clone anyway. Worth a follow-up issue, out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)