### PR TITLE
fix(tmux): give tmux back a row to draw its prompts in

### DIFF
--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -131,6 +131,7 @@ function killGroup(s: Session, sigNum: number) {
 }
 
 import { resolveClient, readFrame, runAction, setStatusLine, prefixKeys, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
+import { applyThemeTo } from "./themesync.ts";
 
 const enc = new TextEncoder();
 const ctl = (ws: PtyWs, frame: Record<string, unknown>) => { try { ws.send(JSON.stringify(frame)); } catch { /* closed */ } };
@@ -232,6 +233,13 @@ export function ptyOpen(ws: PtyWs) {
     }
     session.tmux = t;
     session.tmuxPrefix = prefixKeys(t);
+    // Repaint this server in the cockpit's palette. A tmux that started after
+    // the last theme switch — a reboot, or a continuum restore — has never
+    // heard of it, and the parts the panel does not draw itself (the message
+    // row, the prompt, the pane borders) come up in tmux's own colours in the
+    // middle of a themed panel. Best-effort, and silent when there is no theme
+    // file yet: this is a repaint, not a precondition.
+    applyThemeTo(t.socket);
     // Re-apply the panel's answer to the new session. Without this a restored
     // session comes up with tmux's own status line on top of our tabs, and
     // nothing in the panel changed to make the browser re-ask for it.

--- a/server/src/themesync.ts
+++ b/server/src/themesync.ts
@@ -474,10 +474,56 @@ export const SNIPPETS = {
   tmux: `source-file -q ~/.config/agentglass/theme.tmux.conf`,
 };
 
+/**
+ * Where this machine's tmux config actually lives.
+ *
+ * tmux reads `~/.tmux.conf` *and* `$XDG_CONFIG_HOME/tmux/tmux.conf`, and the
+ * second one is where a config written this decade tends to be. Looking only at
+ * the first told anyone on the XDG path that they had not added the snippet
+ * when they had, and offered to have them paste it into a file they do not
+ * keep — so the theme quietly stopped applying every time their tmux server
+ * restarted, which for anyone running tmux-continuum is every reboot.
+ *
+ * The one that exists wins; the XDG one wins if both do, because that is the
+ * one being maintained. With neither, `~/.tmux.conf` is the answer, since tmux
+ * reads it and it is the path every tmux answer on the internet names.
+ */
+export function tmuxConfPath(): string {
+  const xdg = join(CONFIG_HOME, "tmux", "tmux.conf");
+  const dot = join(homedir(), ".tmux.conf");
+  if (existsSync(xdg)) return xdg;
+  return existsSync(dot) ? dot : xdg;
+}
+
+/**
+ * Push the generated theme into one specific tmux server.
+ *
+ * `syncTheme` already does this on the default socket when the palette changes,
+ * which covers "the user picked a new theme". It does not cover the other
+ * direction: a tmux *server* that started after the last sync — a reboot, a
+ * `kill-server`, or a tmux-continuum restore — comes up with none of it, and
+ * everything the panel does not draw itself (the message row, the prompt, the
+ * pane borders) falls back to whatever tmux ships with. That is a black bar in
+ * the middle of a themed panel, and nothing in the app explains why.
+ *
+ * Sourcing our own generated file is the same act the theme switch already
+ * performs, at the moment it is actually needed, and `-q` makes it silent when
+ * the file is not there yet.
+ */
+export function applyThemeTo(socket: string[]): boolean {
+  if (!existsSync(TMUX_THEME)) return false;
+  try {
+    const p = Bun.spawnSync(["tmux", ...socket, "source-file", "-q", TMUX_THEME], {
+      stdout: "ignore", stderr: "ignore", timeout: 2000,
+    });
+    return p.exitCode === 0;
+  } catch { return false; }
+}
+
 /** Has the user already opted in? Read-only — this never edits their files. */
 export function snippetStatus(): { nvim: boolean; tmux: boolean; nvimPath: string; tmuxPath: string } {
   const nvimPath = join(CONFIG_HOME, "nvim", "lua", "plugins", "theme.lua");
-  const tmuxPath = join(homedir(), ".tmux.conf");
+  const tmuxPath = tmuxConfPath();
   const has = (p: string, needle: string) => {
     try { return existsSync(p) && readFileSync(p, "utf8").includes(needle); } catch { return false; }
   };

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -327,18 +327,66 @@ export function runAction(t: TmuxTarget, action: TmuxAction, window?: string, na
   }
 }
 
+/** The options the panel borrows when it takes the status line over. Restored
+ *  together, in the same breath, so a half-restored bar cannot outlive us. */
+const BORROWED = ["status", "status-format[0]", "status-style"];
+
 /**
- * Hide or restore tmux's own status line for this session.
+ * What `status` this session actually resolves to, set on the session or
+ * inherited from the global options.
  *
- * Opt-in, and it has to be: `status` is a session option, not a client one, so a
- * second client attached to the same session from a real terminal loses its
- * status line too. Nobody should have that happen to them because they opened a
- * panel. `set-option -u` puts it back exactly as their config had it, rather
- * than guessing at "on".
+ * Needed because "already off" is a real answer and a different one from "on":
+ * a user who runs tmux with no status line has nothing for us to hide, and
+ * turning one *on* to blank it would cost them a row for no reason.
+ */
+function effectiveStatus(t: TmuxTarget): string {
+  const own = (tmux(t.socket, ["show-options", "-t", t.id, "-v", "status"]) || "").trim();
+  return own || (tmux(t.socket, ["show-options", "-gv", "status"]) || "").trim();
+}
+
+/**
+ * Take tmux's status line over for this session, or give it back.
+ *
+ * Taking it over used to mean `status off`, which is not the same thing as
+ * taking it over — it is removing it, and tmux still needs somewhere to put a
+ * prompt. With no status row allocated, `prefix ,`, `prefix .`, `prefix :` and
+ * every `display-message` (continuum's "Tmux environment saved!", say) are
+ * drawn *over the top line of the shell*, because that is the row where the
+ * status line would have been. The pane's own content is untouched underneath
+ * and comes back when the message clears, so nothing is lost — it just looks
+ * like the terminal is being scribbled on, and the line you were reading is
+ * gone while you answer.
+ *
+ * So the row is blanked rather than removed: `status on` with an empty
+ * `status-format[0]`, styled in the terminal's own default colours so an empty
+ * bar is invisible against the panel. tmux keeps a row it can draw prompts and
+ * messages into, the tab strip stays the only window list on screen, and the
+ * shell keeps every line it had. The cost is honest and small: one row, which
+ * is what the status line was costing anyway.
+ *
+ * Opt-in, and it has to be: these are session options, not client ones, so a
+ * second client attached to the same session from a real terminal is affected
+ * too. `set-option -u` puts each one back exactly as their config had it,
+ * rather than guessing at a default.
  */
 export function setStatusLine(t: TmuxTarget, visible: boolean): boolean {
-  const args = visible
-    ? ["set-option", "-t", t.id, "-u", "status"]
-    : ["set-option", "-t", t.id, "status", "off"];
-  return tmux(t.socket, args) !== null;
+  if (visible) {
+    // Give everything back, and do not stop at the first failure: a session that
+    // kept `status-format[0]` blank because `status` failed to restore is a
+    // session with an invisible status line and no way to know why.
+    return BORROWED.map((opt) => tmux(t.socket, ["set-option", "-t", t.id, "-u", opt]) !== null).every(Boolean);
+  }
+  // Nothing to borrow from someone who runs without one. They already live with
+  // prompts drawing over their shell in every other terminal they use, and
+  // adding a row here would be the panel deciding it knows better.
+  if (effectiveStatus(t) === "off") return false;
+  const set = (opt: string, val: string) => tmux(t.socket, ["set-option", "-t", t.id, opt, val]) !== null;
+  const on = set("status", "on");
+  // `bg=default` is the terminal's background, which is the panel's background,
+  // so the row reads as part of the app rather than as a bar with nothing in it.
+  const styled = set("status-style", "bg=default,fg=default");
+  const blank = set("status-format[0]", "");
+  // The blanking is the part that matters; if it took, we borrowed the bar and
+  // the caller must remember to give it back.
+  return blank && (on || styled);
 }

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -8,7 +8,7 @@
 // What is unit-tested is everything that turns tmux's text into our shapes, and
 // everything that decides whether a command is allowed to run at all.
 import { describe, expect, test } from "bun:test";
-import { parseWindows, parseFrame, socketFromArgv, runAction, sanitizeWindowName, prefixKeys, type TmuxTarget } from "../src/tmuxctl.ts";
+import { parseWindows, parseFrame, socketFromArgv, runAction, sanitizeWindowName, prefixKeys, setStatusLine, type TmuxTarget } from "../src/tmuxctl.ts";
 
 describe("reading tmux's window list", () => {
   test("id, index, name, active flag and tmux's own marks", () => {
@@ -164,6 +164,26 @@ describe("window names", () => {
 
   test("absurdly long names are cut, not passed on", () => {
     expect(sanitizeWindowName("x".repeat(500))!.length).toBe(64);
+  });
+});
+
+describe("borrowing the status line", () => {
+  // The panel takes tmux's status row over rather than turning it off, because
+  // tmux needs somewhere to draw `prefix ,`, `prefix :` and every
+  // `display-message` — with no row allocated it draws them over the top line
+  // of the shell instead. What is unit-testable without a tmux server is the
+  // bookkeeping: whether we claim to have borrowed something we did not.
+  const t: TmuxTarget = { pid: 1, socket: ["-L", "nonexistent-agx-test"], session: "s", id: "$0" };
+
+  test("an unreachable server is not reported as borrowed", () => {
+    // The caller remembers what it borrowed so it can give it back on the way
+    // out. A false claim here leaves a restore aimed at a session we never
+    // touched, and — worse — swallows the real one.
+    expect(setStatusLine(t, false)).toBe(false);
+  });
+
+  test("giving it back reports failure rather than pretending", () => {
+    expect(setStatusLine(t, true)).toBe(false);
   });
 });
 

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -1163,7 +1163,9 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                     })}
                     <button onClick={() => tmuxCmd("new")} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title={`new tmux window (${px} c puts it next to this one)`}>+</button>
                     <button onClick={() => setTmuxBar((v) => !v)} className="ml-auto shrink-0 px-2 py-1 rounded-md text-[10px]" style={{ color: "var(--text3)" }}
-                      title={tmuxBar ? "hide tmux's own status line for this session" : "show tmux's own status line again"}>
+                      title={tmuxBar
+                        ? "blank tmux's own status line for this session — it keeps the row, so its prompts and messages still have somewhere to draw"
+                        : "give tmux's own status line back"}>
                       {tmuxBar ? "hide tmux bar" : "show tmux bar"}
                     </button>
                   </div>


### PR DESCRIPTION
Reported from the panel: `(rename-window)`, `(move-window)` and "Tmux environment saved!" appearing as a raw black bar over the first line of the shell.

## What is happening

Hiding tmux's status line with `status off` does not hand the row to the panel. It removes it — and tmux still has prompts to draw. `prefix ,`, `prefix .`, `prefix :` and every `display-message` then get painted over the top line of the pane, because that is where the status line would have been.

Measured with a real client on a pty, message triggered while the pane held a known line:

```
status off (today)      pane rows=24   message drawn=True    pane still holds its text: True
blank row (this PR)     pane rows=23   message drawn=True    pane still holds its text: True
```

The content is never actually lost — the pane's buffer is intact underneath and repaints when the message clears. It just looks like the terminal is being scribbled on, and the line you were reading is covered while you answer a prompt you did not see coming.

## The fix

Borrow the row instead of removing it: `status on`, `status-format[0]` empty, `status-style bg=default,fg=default` so an empty bar takes the terminal's background and is invisible against the panel. tmux keeps somewhere to put a prompt, the tab strip stays the only window list on screen, and the shell keeps every line it had. Restored with `set-option -u` on all three, and it does not stop at the first failure — a session left with a blank format because `status` failed to restore is a session with an invisible status line and no way to know why.

A session that already runs `status off` is left alone: nothing to hide, and turning one on to blank it would cost a row to solve a problem that user does not have.

```
start:       rows=24  status=(inherits global)
borrow:      true     status=on  format0=[]  style=bg=default,fg=default
give back:   true     status=(inherits global)  style=[]

a user who runs without a status line:
borrow:      false    status=off   (nothing taken)
```

## Two things found chasing the same screenshots

**The row was black, not themed.** The tmux server had never heard of the palette. `syncTheme` sources the generated file when the *theme* changes; it does not cover the case where the *tmux server* starts afterwards — a reboot, a `kill-server`, or a tmux-continuum restore. Verified on the reporting machine: `message-style` was `bg=#020007,fg=#ffffff` live while the generated file said `bg=#2d1b4e`, and sourcing the file by hand fixed it. The panel now repaints the server it finds, when it finds it, with the file the theme switch already writes.

**And the reason it never persisted:** `snippetStatus` looked only at `~/.tmux.conf`. tmux also reads `$XDG_CONFIG_HOME/tmux/tmux.conf`, which is where the reporting machine's config lives — so agentglass reported the snippet as missing when the user had never been offered the right file to put it in. It now finds the XDG path and prefers it when both exist.

## Verified

`bun test` tmux + themesync suites: 34 pass. `bun run build` clean. Borrow/restore and the already-off case run against a live tmux server (output above); the row measurements come from a pty-attached client, not from reading options.

🤖 Generated with [Claude Code](https://claude.com/claude-code)