### PR TITLE
feat(desktop): reopen the app the install had to close

### DIFF
--- a/electron/appctl.sh
+++ b/electron/appctl.sh
@@ -87,6 +87,69 @@ _wait_gone() {
   [ -z "$(app_pids)" ]
 }
 
+# How the instance we are about to stop was started, so it can be put back the
+# same way. Empty means nothing was running, which is the difference between
+# "reopen it" and "open something the user had deliberately closed".
+#
+# One argument per line rather than the NUL-separated bytes /proc hands over,
+# because a shell variable cannot hold a NUL. The assumption that costs is an
+# argument containing a newline, which no way of launching this app produces.
+APPCTL_RESTART_ARGV=""
+APPCTL_RESTART_ENV=""
+
+# Read a stopped instance's command line and the environment that scoped it.
+#
+# Only AGENTGLASS_* is carried over. Restoring the whole environment would put
+# back whatever session the app happened to be launched from — stale sockets,
+# a dead SSH agent, a display that has since gone away — while the variables
+# that actually change what the app *is* are ours: `make desktop-open` scopes a
+# window to one repo with AGENTGLASS_PROJECT, and reopening it unscoped would
+# silently be a different app than the one that was closed.
+_capture_restart() {
+  local pid=$1
+  APPCTL_RESTART_ARGV=$(tr '\0' '\n' < "/proc/$pid/cmdline" 2>/dev/null) || APPCTL_RESTART_ARGV=""
+  APPCTL_RESTART_ENV=$(tr '\0' '\n' < "/proc/$pid/environ" 2>/dev/null | grep '^AGENTGLASS_[A-Za-z0-9_]*=' || true)
+  # An instance we could not read is one we must not claim to be able to
+  # restore: reopening with the wrong arguments is worse than not reopening.
+  [ -n "$APPCTL_RESTART_ARGV" ] || return 0
+}
+
+# Reopen what stop_app took down, if it took anything down.
+#
+# Deliberately not "launch the app": an install run while nothing was open
+# leaves nothing open, because the person who closed it meant to. This only
+# puts back the instance that was there a moment ago, with the arguments and the
+# scoping it had.
+start_app() {
+  [ -n "$APPCTL_RESTART_ARGV" ] || return 0
+  [ -x "$APP/agentglass" ] || return 1
+
+  local args=() env=() line
+  # argv[0] is dropped: it may be the ~/.local/bin symlink, or a path into an
+  # install directory that has just been replaced. The binary to run is the one
+  # we installed, by definition.
+  while IFS= read -r line; do
+    [ -n "$line" ] && args+=("$line")
+  done <<< "$APPCTL_RESTART_ARGV"
+  args=("${args[@]:1}")
+  while IFS= read -r line; do
+    [ -n "$line" ] && env+=("$line")
+  done <<< "$APPCTL_RESTART_ENV"
+
+  echo "==> reopening (${#args[@]} arg(s)${env:+, scoped})"
+  # Detached from this shell in its own session, so the app outlives the install
+  # script rather than dying with the terminal it was rebuilt from. `setsid`
+  # where there is one; a plain background job is the fallback, and the `disown`
+  # keeps a hangup from reaching it.
+  if command -v setsid >/dev/null 2>&1; then
+    setsid env "${env[@]}" "$APP/agentglass" "${args[@]}" </dev/null >/dev/null 2>&1 &
+  else
+    env "${env[@]}" "$APP/agentglass" "${args[@]}" </dev/null >/dev/null 2>&1 &
+    disown 2>/dev/null || true
+  fi
+  return 0
+}
+
 # Stop the running instance, politely first. Returns 1 if anything survives,
 # because the caller's next move is rm -rf over these very files.
 stop_app() {
@@ -97,6 +160,9 @@ stop_app() {
   mains=$(main_pids)
   if [ -n "$mains" ]; then
     echo "==> stopping the running instance (main: $(echo "$mains" | tr '\n' ' '))"
+    # Read it before signalling it. A process that has exited has no command
+    # line left to read, and this is the only moment the answer exists.
+    _capture_restart "$(echo "$mains" | head -n 1)"
     kill $mains 2>/dev/null || true
   else
     # No main process: helpers that outlived their parent, or a sidecar left

--- a/electron/install-local.sh
+++ b/electron/install-local.sh
@@ -119,3 +119,10 @@ echo "installed:"
 echo "  app      $APP/agentglass"
 echo "  command  agentglass"
 echo "  launcher $DESKTOP/agentglass.desktop"
+
+# Put back what we took down. An install has to close the running app — it is
+# replacing the files underneath it — and leaving it closed made the normal
+# loop (merge, `make desktop-update`, look at the change) end with the window
+# gone and no sign that reopening it was the next step. Nothing happens here if
+# nothing was running.
+start_app

--- a/node_modules
+++ b/node_modules
@@ -1,0 +1,1 @@
+/home/serallap/code/agentglass/node_modules

--- a/server/test/install-stop.test.ts
+++ b/server/test/install-stop.test.ts
@@ -167,3 +167,74 @@ describe("stopping it", () => {
     rmSync(app, { recursive: true, force: true });
   });
 });
+
+describe("putting back what the install took down", () => {
+  // An install has to close the running app — it is replacing the files
+  // underneath it. Leaving it closed made the normal loop (merge, rebuild,
+  // look at the change) end with the window gone, which reads as the rebuild
+  // having broken something.
+  //
+  // The stub here blocks on a fifo rather than on stdin, because start_app
+  // hands the app /dev/null — as it must, since the reopened app outlives the
+  // shell that installed it. A stub reading stdin would see EOF and exit
+  // instantly, and the test would be measuring its own harness.
+  const blocker = (app: string) => {
+    const fifo = join(app, "block");
+    Bun.spawnSync(["mkfifo", fifo]);
+    return `read x < ${fifo}`;
+  };
+  const ourPids = (app: string) =>
+    Bun.spawnSync(["bash", "-c", `APP="${app}"; . "${APPCTL}"; app_pids`], { stdout: "pipe" })
+      .stdout.toString().trim().split("\n").filter(Boolean);
+  const cleanup = (app: string) => {
+    for (const pid of ourPids(app)) { try { process.kill(Number(pid), 9); } catch { /* gone */ } }
+    rmSync(app, { recursive: true, force: true });
+  };
+
+  test("the instance comes back with the flags it had", async () => {
+    const app = fakeInstall();
+    // A main process started the ordinary way for this app: with a flag.
+    launch(join(app, "agentglass"), blocker(app), "--ozone-platform=wayland");
+    await Bun.sleep(200);
+
+    const { code, out } = await appctl(app, 'stop_app && start_app && sleep 0.5 && tr "\\0" " " < /proc/$(main_pids | head -n1)/cmdline');
+    expect(code).toBe(0);
+    expect(out).toContain("reopening");
+    // The same binary, and the flag it was carrying — not a bare relaunch that
+    // silently drops the way this app is started.
+    expect(out).toContain(`${app}/agentglass`);
+    expect(out).toContain("--ozone-platform=wayland");
+    cleanup(app);
+  });
+
+  test("AGENTGLASS_ scoping survives, and nothing else is carried over", async () => {
+    // `make desktop-open DIR=…` scopes a window to one repo through the
+    // environment. Reopening it unscoped would be a different app than the one
+    // that was closed. Everything else about that environment is a dead session
+    // by the time we get here, so it is deliberately left behind.
+    const app = fakeInstall();
+    const p = Bun.spawn([join(app, "agentglass"), "-c", blocker(app)], {
+      stdio: ["pipe", "ignore", "ignore"],
+      env: { ...process.env, AGENTGLASS_PROJECT: "/tmp/scoped-repo", SOME_DEAD_SESSION: "nope" },
+    });
+    p.unref();
+    spawned.push(p.pid);
+    await Bun.sleep(200);
+
+    const { out } = await appctl(app, 'stop_app >/dev/null && start_app >/dev/null && sleep 0.5 && tr "\\0" "\\n" < /proc/$(main_pids | head -n1)/environ');
+    expect(out).toContain("AGENTGLASS_PROJECT=/tmp/scoped-repo");
+    expect(out).not.toContain("SOME_DEAD_SESSION");
+    cleanup(app);
+  });
+
+  test("an install with nothing running opens nothing", async () => {
+    // The person who closed it meant to. A rebuild is not a reason to reopen
+    // an app that was not there.
+    const app = fakeInstall();
+    const { code, out } = await appctl(app, "stop_app && start_app");
+    expect(code).toBe(0);
+    expect(out).not.toContain("reopening");
+    expect(ourPids(app)).toEqual([]);
+    rmSync(app, { recursive: true, force: true });
+  });
+});


### PR DESCRIPTION
Asked for directly: "after that success binary rebuild should reopen the app.. its annoying".

## Why it closes it in the first place

That part is deliberate and stays. The install replaces the files underneath a running app, and an instance left alive on deleted inodes keeps running the old code while its sidecar holds the port, so the next launch adopts a stale server. `stop_app` exists for exactly that.

What was missing is the other half. The loop is: merge, `make desktop-update`, look at the change — and it ended with the window gone and nothing saying that reopening it was the next step.

## What this adds

`start_app`, called at the end of a successful install, putting back the instance that was there a moment ago:

- **With the arguments it had.** `agentglass --ozone-platform=wayland` (or `--no-sandbox`) is an ordinary way to start this app, and a bare relaunch silently drops it.
- **With its scoping.** `make desktop-open DIR=…` scopes a window to one repo through `AGENTGLASS_PROJECT`. Reopening it unscoped would be a different app than the one that was closed. Only `AGENTGLASS_*` is carried over — the rest of that environment is a dead session by the time the install finishes.
- **Read before the kill.** An exited process has no command line left to read; that moment is the only time the answer exists. An instance we could not read is one we do not claim to be able to restore.
- **Detached**, in its own session, so the reopened app outlives the terminal it was rebuilt from.
- **Nothing running, nothing opened.** An install run with the app closed leaves it closed. The person who closed it meant to.

## Tests

Three added to `server/test/install-stop.test.ts`, driven against a fake install with real processes the way that file already works: the flags survive a stop/start round trip, `AGENTGLASS_PROJECT` survives while an unrelated variable does not, and an install with nothing running opens nothing.

One harness note in the code: the stub blocks on a fifo rather than on stdin, because `start_app` hands the app `/dev/null` (as it must, since the reopened app outlives the installing shell). A stub reading stdin sees EOF and exits instantly, and the test would be measuring itself.

`bun test server/test/install-stop.test.ts`: 10 pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)