### PR TITLE
fix: untrack the node_modules symlink that slipped into the tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# Both forms: a trailing slash matches a directory only, and a `node_modules`
+# that is a *symlink* (a worktree pointed at the main checkout's copy, say) is a
+# file — so `node_modules/` alone let one be committed.
+node_modules
 node_modules/
 dist/
 *.db

--- a/node_modules
+++ b/node_modules
@@ -1,1 +1,0 @@
-/home/serallap/code/agentglass/node_modules


### PR DESCRIPTION
`node_modules` is committed at the repo root as a symlink pointing at an absolute path on one machine. It came in with #197 and is meaningless — worse than meaningless — for anyone else: a checkout gets a dangling link where their dependencies should be, and `bun install` fails with `ELOOP: too many levels of symbolic links` on every package.

## How it got past .gitignore

The rule was `node_modules/`. A trailing slash matches a **directory only**, and the thing added here was a *symlink* — a file as far as git is concerned — so it was never ignored and a `git add -A` swept it in.

Both forms are listed now, so the next one is ignored whichever shape it takes.

## Repro of the damage

```
$ bun install
ELOOP: Too many levels of symbolic links: failed to link package: ansi-regex@6.2.2 (link)
... 569 packages
Failed to install 569 packages
```

Removing the link and re-running installs 1135 packages cleanly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)