### PR TITLE
fix(web): say so when :4000 is answering and it isn't us

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -29,6 +29,7 @@ import { StatsModal } from "./components/StatsModal.tsx";
 import { SkillsModal } from "./components/SkillsModal.tsx";
 import { Workspace } from "./components/workspace/Workspace.tsx";
 import { VIEW_IDS, loadViewOrder, loadLastView, type ViewId } from "./components/workspace/views.ts";
+import ServerBanner from "./components/ServerBanner.tsx";
 import { chordFromEvent, viewForChord } from "./lib/keybindings.ts";
 import { newChat, chatResuming, applyLiveEvent } from "./lib/chatStore.ts";
 import { sessionCwd } from "./lib/worktree.ts";
@@ -413,6 +414,9 @@ export default function App() {
     <div className="h-screen overflow-hidden flex flex-col relative">
       <div className="aurora" />
       <div className="aurora-grid" />
+
+      {/* Above everything, because when it shows, nothing below it is real. */}
+      <ServerBanner />
 
       <Header
         conn={conn}

--- a/web/src/components/ServerBanner.tsx
+++ b/web/src/components/ServerBanner.tsx
@@ -1,0 +1,83 @@
+// Says out loud what the UI is talking to, when what it is talking to is wrong.
+//
+// The dashboard's API origin is configured three ways and guessed a fourth:
+// `VITE_CW_SERVER`, the origin the desktop shell verified and handed over, the
+// server having served the page itself — and, failing all three,
+// `http://<host>:4000`. That last one is a guess, and nothing used to check it.
+//
+// When the guess is wrong the app does not fail, which is the problem. Requests
+// go to whoever owns the port, come back as 404s or shapes we do not
+// understand, and the cockpit renders exactly as it would with no agents: empty
+// panels, "no repos found", no error anywhere. The honest reading of that
+// screen is "this project is broken".
+//
+// Only the run-from-source path can get here. The desktop shell has probed the
+// port since #126, and a single-port deploy is talking to itself by definition.
+import { useEffect, useState } from "react";
+import { IS_DEMO, SERVER, SERVER_GUESSED, probeServer, type ServerIdentity } from "../lib/api.ts";
+
+/** How often to look again while the answer is wrong. Often enough that
+ *  starting the server clears the banner without a reload, rare enough that a
+ *  machine with nothing listening is not hammering a closed port. */
+const RECHECK_MS = 4000;
+
+export default function ServerBanner() {
+  const [identity, setIdentity] = useState<ServerIdentity>("ours");
+
+  useEffect(() => {
+    // Nothing to warn about when the origin was configured rather than guessed,
+    // and the demo has no server at all by design.
+    if (!SERVER_GUESSED || IS_DEMO) return;
+    let stop = false;
+    let timer: ReturnType<typeof setTimeout>;
+    const look = async () => {
+      const now = await probeServer();
+      if (stop) return;
+      setIdentity(now);
+      // Stop asking once it is us: the socket takes over from here, and a
+      // healthy app should not be polling /health forever.
+      if (now !== "ours") timer = setTimeout(look, RECHECK_MS);
+    };
+    void look();
+    return () => { stop = true; clearTimeout(timer); };
+  }, []);
+
+  if (identity === "ours") return null;
+
+  // Two different problems, two different fixes. Telling them apart is most of
+  // the value here — "start the server" and "something else owns this port"
+  // have looked identical from this screen until now.
+  const foreign = identity === "foreign";
+  return (
+    <div
+      role="alert"
+      className="shrink-0 px-4 py-2 text-[11px] flex items-center gap-2 flex-wrap border-b"
+      style={{
+        background: foreign
+          ? "color-mix(in srgb, var(--error) 14%, transparent)"
+          : "color-mix(in srgb, var(--warning) 12%, transparent)",
+        borderColor: foreign
+          ? "color-mix(in srgb, var(--error) 35%, transparent)"
+          : "color-mix(in srgb, var(--warning) 30%, transparent)",
+        color: "var(--text)",
+      }}
+    >
+      <span className="font-semibold" style={{ color: foreign ? "var(--error)" : "var(--warning)" }}>
+        {foreign ? "wrong server" : "no server"}
+      </span>
+      {foreign ? (
+        <span>
+          Something is listening on <code>{SERVER}</code>, but it isn’t agentglass — everything below is empty because
+          that server has nothing to say about your agents.
+        </span>
+      ) : (
+        <span>
+          Nothing is answering at <code>{SERVER}</code>.
+        </span>
+      )}
+      <span style={{ color: "var(--text3)" }}>
+        Start it with <code>bun run dev</code>, or point the UI elsewhere with <code>VITE_CW_SERVER</code>.
+      </span>
+    </div>
+  );
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -25,6 +25,67 @@ export const SERVER: string =
   DESKTOP_API?.replace(/\/$/, "") ||
   (SERVED_BY_API ? location.origin : `http://${location.hostname}:4000`);
 
+/**
+ * Whether the line above *guessed* the origin rather than being told it.
+ *
+ * The three configured paths are known-good: `VITE_CW_SERVER` was typed by
+ * someone, the desktop shell probes and hands over the origin it verified, and
+ * a page the server itself served is the server by definition. Only the last
+ * fallback is a guess, and it is the one worth checking.
+ */
+export const SERVER_GUESSED: boolean =
+  !(import.meta.env.VITE_CW_SERVER as string | undefined) && !DESKTOP_API && !SERVED_BY_API;
+
+/** What is answering at `SERVER`. `foreign` is the interesting one: something
+ *  is there, it is not us, and every panel is about to ask it for data. */
+export type ServerIdentity = "ours" | "foreign" | "down";
+
+/**
+ * Ask the origin who it is.
+ *
+ * A 200 is not proof of identity, and treating it as proof is a bug with teeth:
+ * `:4000` is a common default (Phoenix ships on it, and any number of local
+ * observability servers pick it), so a machine with one of those running hands
+ * the dashboard a stranger. Every request then gets a 404 or a shape we do not
+ * understand, and the cockpit renders exactly as it would with no agents at
+ * all. The conclusion a reasonable person draws is "this project is broken".
+ *
+ * The desktop shell has checked this since #126 — it walks eight ports and
+ * reads the body of `/health` rather than its status. This is the same check on
+ * the side that never had it: run from source, which is contributors.
+ *
+ * The `ok`/`clients` shape is accepted alongside the name so that a server
+ * built before `service` existed still identifies as ours rather than as an
+ * impostor.
+ */
+export async function probeServer(timeoutMs = 2500): Promise<ServerIdentity> {
+  const ctl = new AbortController();
+  const bail = setTimeout(() => ctl.abort(), timeoutMs);
+  try {
+    const r = await fetch(`${SERVER}/health`, { headers: authHeaders(), signal: ctl.signal });
+    // A server that needs a token is still ours, and the header we just sent
+    // may simply be missing — that is the auth banner's problem, not this one.
+    if (r.status === 401 || r.status === 403) return "ours";
+    if (!r.ok) return "foreign";
+    // A body we cannot read is still a body: something is listening and it is
+    // not us. Letting the parse failure fall through to the catch below would
+    // report "nothing is there" about a server that just answered, which is the
+    // exact confusion this function exists to end — a Phoenix app on :4000
+    // serves HTML from every path, including this one.
+    let j: { service?: unknown; ok?: unknown; clients?: unknown };
+    try { j = await r.json(); } catch { return "foreign"; }
+    return j.service === "agentglass" || (j.ok === true && typeof j.clients === "number") ? "ours" : "foreign";
+  } catch (e) {
+    // Refused, DNS, CORS, or the abort above: nothing usable is there. Told
+    // apart from `foreign` deliberately — "start the server" and "something
+    // else owns this port" are different problems with different fixes, and
+    // today they look identical.
+    return (e as Error)?.name === "AbortError" ? "foreign" : "down";
+  } finally {
+    clearTimeout(bail);
+  }
+}
+
 /** Auth token for a server that requires one (exposed / multi-user box). Read
  *  once from `?token=` — then stripped from the URL bar so it isn't shoulder-
  *  surfed or copied around — or from a prior localStorage save. Empty on the

--- a/web/test/server-identity.test.ts
+++ b/web/test/server-identity.test.ts
@@ -1,0 +1,80 @@
+// Who is answering at the API origin.
+//
+// The origin is a guess on the run-from-source path (`http://<host>:4000`), and
+// :4000 is a popular default — Phoenix ships on it, and local observability
+// servers pick it. When the guess is wrong the app does not fail: it renders
+// empty panels and "no repos found", which reads as a broken project rather
+// than as a busy port. These cover the identification, which is the part that
+// turns an hour of confusion into a sentence.
+import { describe, expect, test, afterAll } from "bun:test";
+
+/** The logic under test, as `probeServer` runs it. Kept parameterised by origin
+ *  because the module reads its own at import time, and a test that can only
+ *  ask about one origin cannot cover the interesting cases. */
+async function identify(origin: string, timeoutMs = 2500): Promise<string> {
+  const ctl = new AbortController();
+  const bail = setTimeout(() => ctl.abort(), timeoutMs);
+  try {
+    const r = await fetch(`${origin}/health`, { signal: ctl.signal });
+    if (r.status === 401 || r.status === 403) return "ours";
+    if (!r.ok) return "foreign";
+    let j: { service?: unknown; ok?: unknown; clients?: unknown };
+    try { j = await r.json(); } catch { return "foreign"; }
+    return j.service === "agentglass" || (j.ok === true && typeof j.clients === "number") ? "ours" : "foreign";
+  } catch (e) {
+    return (e as Error)?.name === "AbortError" ? "foreign" : "down";
+  } finally { clearTimeout(bail); }
+}
+
+const json = (body: unknown, status = 200) => () =>
+  new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
+
+const servers: Array<{ stop: (force?: boolean) => void }> = [];
+const serve = (fetchFn: () => Response) => {
+  const s = Bun.serve({ port: 0, fetch: fetchFn });
+  servers.push(s);
+  return `http://127.0.0.1:${s.port}`;
+};
+afterAll(() => { for (const s of servers) s.stop(true); });
+
+describe("identifying what owns the API port", () => {
+  test("a server that names itself is ours", async () => {
+    expect(await identify(serve(json({ ok: true, service: "agentglass", clients: 0 })))).toBe("ours");
+  });
+
+  test("a build from before the name existed is still ours", async () => {
+    // The shape check keeps an older sidecar adoptable rather than orphaned —
+    // reporting "wrong server" at someone's own server would be worse than the
+    // silence it replaces.
+    expect(await identify(serve(json({ ok: true, clients: 2 })))).toBe("ours");
+  });
+
+  test("another JSON server on the port is a stranger, not us", async () => {
+    // The case that caused this: an observability server holding :4000. It
+    // answers 200 with valid JSON, which is why status alone cannot decide.
+    expect(await identify(serve(json({ ok: true, service: "obs", uptime: 3 })))).toBe("foreign");
+  });
+
+  test("a server that answers HTML is a stranger, not an absence", async () => {
+    // Phoenix serves HTML from every path including this one. The body fails to
+    // parse, and calling that "nothing is listening" would send the reader off
+    // to start a server that is already running — on a port that is taken.
+    expect(await identify(serve(() => new Response("<!doctype html><h1>Phoenix</h1>", { headers: { "content-type": "text/html" } })))).toBe("foreign");
+  });
+
+  test("an error status is a stranger too", async () => {
+    expect(await identify(serve(json({ error: "nope" }, 500)))).toBe("foreign");
+  });
+
+  test("a server asking for a token is ours", async () => {
+    // It answered like us and refused us; that is an auth problem with its own
+    // banner, and claiming "wrong server" here would point at the wrong fix.
+    expect(await identify(serve(json({ error: "unauthorized" }, 401)))).toBe("ours");
+  });
+
+  test("nothing listening is told apart from a stranger", async () => {
+    // Different problems, different fixes, and until now they looked identical
+    // from this screen.
+    expect(await identify("http://127.0.0.1:1")).toBe("down");
+  });
+});


### PR DESCRIPTION
Closes #191.

## What happens today

`SERVER` falls back to `http://<host>:4000` when nothing configured it, and nothing checks the guess. When another program owns that port, every panel fetches from it, gets 404s or shapes we don't understand, and the cockpit renders exactly as it would with no agents at all: empty panels, "no repos found", no error anywhere.

You reported it from the other end: `:4000` held by an unrelated observability server, and the app looked half-finished. The conclusion a reasonable person draws is "this project is broken", not "check your ports".

Only the run-from-source path can reach this. The desktop shell has probed the port since #126, and a single-port deploy talks to itself by definition.

## The fix

Verify the guess the way the shell already does — read the body of `/health`, not its status, because a stranger answers 200 too — and put a banner above everything when the answer is wrong. It distinguishes the two problems, which have different fixes and have looked identical from this screen:

> **wrong server** — Something is listening on `http://localhost:4000`, but it isn't agentglass. Start it with `bun run dev`, or point the UI elsewhere with `VITE_CW_SERVER`.

> **no server** — Nothing is answering at `http://localhost:4000`. Start it with `bun run dev`, or point the UI elsewhere with `VITE_CW_SERVER`.

It re-checks every 4s while wrong and stops the moment it is right, so starting the server clears it without a reload.

## Cases, all tested against real servers

| What is on the port | Verdict |
|---|---|
| a server naming itself `agentglass` | ours |
| a build from before `/health` carried a name (`ok` + `clients`) | ours |
| an observability server answering valid JSON | **foreign** |
| something serving HTML (Phoenix serves it from every path) | **foreign** |
| a 500 | foreign |
| a server demanding a token (401) | ours, and an auth problem |
| nothing listening | down |

The HTML row is a bug my first draft had: an unparseable body fell through to the "nothing is there" branch, which would have sent the reader off to start a server that is already running, on a port that is taken. `web/test/server-identity.test.ts` covers all seven.

`bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)