### PR TITLE
feat(workspace): reach the skills catalog from the rail

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -133,6 +133,11 @@ export default function App() {
   wsOpenRef.current = wsOpen;
   const wsViewRef = useRef(wsView);
   wsViewRef.current = wsView;
+  // The catalog is the one panel that can open *over* the workspace, from the
+  // rail. Escape has to be able to tell the two apart, or one keystroke closes
+  // both and you lose the shell you were looking at to read a description.
+  const skillsOpenRef = useRef(skillsOpen);
+  skillsOpenRef.current = skillsOpen;
 
   // The workspace covers the dashboard, so the dashboard's ambient loops are
   // animating for nobody. The stylesheet freezes them on `data-ws`, the same way
@@ -330,6 +335,9 @@ export default function App() {
       // because a focused textarea can swallow it before it reaches here.
       if (e.key === "Escape") {
         if ((e.target as HTMLElement)?.closest?.(".xterm")) return;
+        // Peel one layer at a time: the catalog opened from the rail sits on
+        // top of the workspace, so it goes first and the workspace stays.
+        if (wsOpenRef.current && skillsOpenRef.current) { setSkillsOpen(false); return; }
         setSelected(null);
         setPaletteOpen(false);
         setHelpOpen(false);
@@ -485,7 +493,7 @@ export default function App() {
       <EventModal event={selected} onClose={() => setSelected(null)} />
       <StatsModal open={statsOpen} onClose={() => setStatsOpen(false)} stats={stats} windowMs={windowMs} />
       <SkillsModal open={skillsOpen} onClose={() => setSkillsOpen(false)} />
-      <Workspace open={wsOpen} view={wsView} onView={setWsView} onClose={closeWorkspace} chatFocusId={chatFocus} />
+      <Workspace open={wsOpen} view={wsView} onView={setWsView} onClose={closeWorkspace} onSkills={() => setSkillsOpen(true)} chatFocusId={chatFocus} />
       <SearchModal open={searchOpen} onClose={() => setSearchOpen(false)} onSelectApp={(app) => setFilter((f) => ({ ...f, app }))} />
       {/* Shows once when the app first runs a version it has not run before —
           the update button restarts into a new build and otherwise says nothing

--- a/web/src/components/Portal.tsx
+++ b/web/src/components/Portal.tsx
@@ -1,16 +1,23 @@
 import { useEffect, useState, type ReactNode } from "react";
 import { createPortal } from "react-dom";
 
-/** Renders children into document.body so they escape panel stacking contexts. */
-export function Portal({ children }: { children: ReactNode }) {
+/** Renders children into document.body so they escape panel stacking contexts.
+ *
+ *  Every portal lands as a sibling of every other, all at the same z, so which
+ *  one wins is decided by the order the effects happened to append them in —
+ *  fine while only one is ever open, wrong the moment one overlay opens another.
+ *  `z` is the escape hatch for that case: a layer that must sit above the
+ *  workspace says so, instead of hoping it mounted late enough.
+ */
+export function Portal({ children, z = 9999 }: { children: ReactNode; z?: number }) {
   const [el] = useState(() => document.createElement("div"));
   useEffect(() => {
     el.style.position = "relative";
-    el.style.zIndex = "9999";
+    el.style.zIndex = String(z);
     document.body.appendChild(el);
     return () => {
       document.body.removeChild(el);
     };
-  }, [el]);
+  }, [el, z]);
   return createPortal(children, el);
 }

--- a/web/src/components/SkillsModal.tsx
+++ b/web/src/components/SkillsModal.tsx
@@ -192,7 +192,10 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
   const used = all.filter((s) => s.calls > 0).length;
 
   return (
-    <Portal>
+    // Above the workspace's portal, not merely after it: the rail opens this
+    // from inside the workspace, and at equal z the frame — which mounts later
+    // — would paint straight over the catalog.
+    <Portal z={10100}>
       <AnimatePresence>
         {open && (
           <>

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -1,6 +1,7 @@
 import { useSyncExternalStore, useState } from "react";
 import { VIEWS, loadViewOrder, saveViewOrder, subscribeViewOrder, type ViewId } from "./views.ts";
 import { chordFor, chordLabel, chords, subscribeBindings } from "../../lib/keybindings.ts";
+import { SkillsIcon } from "./icons.tsx";
 
 const EMPTY_CHORDS = {};
 
@@ -15,11 +16,12 @@ export type RailPip = { dot?: boolean; count?: number };
  *  replied) rides as a corner pip so it costs no width at all.
  */
 export function ViewRail({
-  view, onSelect, onClose, pips,
+  view, onSelect, onClose, onSkills, pips,
 }: {
   view: ViewId;
   onSelect: (v: ViewId) => void;
   onClose: () => void;
+  onSkills: () => void;
   pips?: Partial<Record<ViewId, RailPip>>;
 }) {
   // Arrow keys move between tabs, matching the tablist pattern. Without this
@@ -114,7 +116,19 @@ export function ViewRail({
         );
       })}
 
-      <div className="mt-auto pt-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--primary) 10%, transparent)" }}>
+      <div className="mt-auto pt-2 flex flex-col gap-[3px]" style={{ borderTop: "1px solid color-mix(in srgb, var(--primary) 10%, transparent)" }}>
+        {/* The catalog is reference, not a view: it opens over the workspace and
+            hands it straight back, so it belongs down here with close rather
+            than among the tabs, where it would imply state you can return to. */}
+        <button
+          onClick={onSkills}
+          aria-label="Skills catalog"
+          data-tip="skills catalog · what this fleet can do"
+          className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+          style={{ color: "var(--text4)" }}
+        >
+          <SkillsIcon size={16} />
+        </button>
         <button
           onClick={onClose}
           aria-label="Close workspace"

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -31,12 +31,13 @@ const BODY = {
  *  aren't looking at keep their state without costing anything on the network.
  */
 export function Workspace({
-  open, view, onView, onClose, chatFocusId,
+  open, view, onView, onClose, onSkills, chatFocusId,
 }: {
   open: boolean;
   view: ViewId;
   onView: (v: ViewId) => void;
   onClose: () => void;
+  onSkills: () => void;
   chatFocusId?: string | null;
 }) {
   // Same reason as App's onClose: this reaches a view's effect dependencies,
@@ -126,7 +127,7 @@ export function Workspace({
                   boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)",
                 }}
               >
-                <ViewRail view={view} onSelect={onView} onClose={onClose} pips={pips} />
+                <ViewRail view={view} onSelect={onView} onClose={onClose} onSkills={onSkills} pips={pips} />
 
                 <div className="relative flex-1 min-w-0">
                   {VIEWS.map((v) => {

--- a/web/src/components/workspace/icons.tsx
+++ b/web/src/components/workspace/icons.tsx
@@ -53,6 +53,17 @@ export function WorkspaceIcon({ size = 15 }: P) {
   return <svg {...svg} width={size} height={size}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M9 4v16" /></svg>;
 }
 
+/** The skills catalog: a reference you open, not a view you work in — which is
+ *  why it sits with close at the foot of the rail rather than among the tabs. */
+export function SkillsIcon({ size = 15 }: P) {
+  return (
+    <svg {...svg} width={size} height={size}>
+      <path d="M4 19.5A2.5 2.5 0 0 1 6.5 17H20" />
+      <path d="M6.5 3H20v18H6.5A2.5 2.5 0 0 1 4 18.5v-13A2.5 2.5 0 0 1 6.5 3z" />
+    </svg>
+  );
+}
+
 export function CloseIcon({ size = 15 }: P) {
   return <svg {...svg} width={size} height={size}><path d="M6 6l12 12M18 6L6 18" /></svg>;
 }


### PR DESCRIPTION
The skills explorer was only reachable from the dashboard header. Inside the workspace — where you are actually working — there was no way to it: you had to close the frame, open the catalog, read, then find your way back to the view and shell you left.

It now sits at the foot of the view rail, directly above close.

- **Not a tab.** It opens over the workspace and hands it straight back, so it belongs with the frame's own controls rather than among the views, where it would imply state you can return to.
- **Escape peels one layer.** With the catalog open over the workspace, Escape dismisses the catalog alone; the shell or diff underneath stays exactly as it was.
- **`Portal` grew a `z` prop.** Every overlay lands as a body-level sibling at the same z-index, so which one paints on top was decided by the order the effects happened to append them in. That is fine while only one is ever open, and wrong the moment one overlay opens another — the workspace mounts later, so it covered the catalog. The layer that must sit above now says so.

No new state, no new fetch: it reuses the App-level `skillsOpen` and the same modal the header opens.

## Testing

- `tsc --noEmit` clean.
- Not yet exercised in a running build — the stacking fix and the Escape ordering are the two things to look at when it is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)