### PR TITLE
feat(landing): rebuild the workspace section as a bento, with pull requests

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -35,6 +35,11 @@
     --success:#34d399; --warning:#facc15; --error:#f87171; --info:#60a5fa;
     --shadow:rgba(0,0,0,.8);
     --glow:rgba(251,146,60,.22);
+    /* the app sets panel titles in its sans; the rest of this page is mono */
+    --sans:ui-sans-serif,system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;
+    /* workspace bento motion, in one place so it stays consistent */
+    --wsease:cubic-bezier(.22,.9,.24,1);
+    --wsdwell:10s;
   }
   *{box-sizing:border-box; margin:0; padding:0;}
   html{scroll-behavior:smooth;}
@@ -243,37 +248,108 @@
   .card .read .r{color:var(--error);} .card .read .w{color:var(--warning);}
 
 
-  /* ============ workspace showcase — press a key, switch a panel ============ */
-  .ws-body{display:grid; grid-template-columns:210px 1fr; min-height:430px;}
-  @media(max-width:760px){.ws-body{grid-template-columns:1fr;}}
-  .ws-tabs{
-    display:flex; flex-direction:column; gap:6px; padding:14px;
-    border-right:1px solid color-mix(in srgb, var(--border) 55%, transparent);
+  /* ============ workspace bento — all six panels at once ============
+     Built from the app's own recipe (web/src/index.css): the panel gradient,
+     the primary-12% hairline, the 1rem radius and the eyebrow + sentence title
+     header every panel in the app wears. Token-only, so it survives all 22
+     themes.
+
+     The active tile grows by interpolating flex-grow — grid `span` is not
+     animatable, and a FLIP/scale trick would squash the type. Flex means every
+     tile keeps its home cell forever, so the eye follows one box swelling
+     instead of chasing a reshuffle.
+     ============================================================== */
+  .bento{display:flex; gap:11px; padding:0 12px 12px; height:560px;}
+  .bento .bcol{
+    display:flex; flex-direction:column; gap:11px; min-width:0; flex:1 1 0;
+    transition:flex-grow .64s var(--wsease);
   }
-  @media(max-width:760px){
-    .ws-tabs{flex-direction:row; overflow-x:auto; border-right:none;
-      border-bottom:1px solid color-mix(in srgb, var(--border) 55%, transparent);}
+  .bt{
+    position:relative; flex:1 1 0; min-height:0; overflow:hidden; text-align:left;
+    background:color-mix(in srgb, var(--bg2) 60%, transparent);
+    border:1px solid color-mix(in srgb, var(--border) 40%, transparent);
+    border-radius:.85rem; color:var(--text3);
+    transition:flex-grow .64s var(--wsease), border-color .64s var(--wsease),
+               background .64s var(--wsease), box-shadow .64s var(--wsease);
   }
-  .wtab{
-    display:flex; align-items:center; gap:10px; text-align:left;
-    background:transparent; border:1px solid transparent; border-radius:10px;
-    padding:10px 12px; color:var(--text3); font-size:13px; font-weight:600;
-    transition:background .15s, border-color .15s, color .15s; white-space:nowrap;
+  .bt::after{
+    content:""; position:absolute; inset:0; pointer-events:none;
+    background:linear-gradient(180deg, color-mix(in srgb, var(--primary) 10%, transparent), transparent 60%);
   }
-  .wtab b{
-    color:var(--primary); font-weight:700; font-size:12px;
-    border:1px solid var(--border2); border-radius:5px; padding:0 7px; line-height:1.7;
-    background:color-mix(in srgb, var(--bg) 60%, transparent); flex:none;
+  .bt:hover{border-color:color-mix(in srgb, var(--primary) 35%, transparent);}
+  .bt.on{
+    background:color-mix(in srgb, var(--bg2) 84%, transparent);
+    border-color:color-mix(in srgb, var(--primary) 45%, transparent);
+    box-shadow:0 18px 40px -28px var(--shadow), inset 0 1px 0 0 rgba(255,255,255,.05);
   }
-  .wtab:hover{background:color-mix(in srgb, var(--primary) 8%, transparent); color:var(--text);}
-  .wtab.on{
-    background:color-mix(in srgb, var(--primary) 14%, transparent);
-    border-color:var(--border2); color:var(--text);
+  .bt .pad{position:relative; z-index:1; padding:11px 14px 12px; height:100%; display:flex; flex-direction:column; min-height:0;}
+  .bt .bh{display:flex; align-items:flex-start; justify-content:space-between; gap:10px; flex:none;}
+  .bt .eyebrow{
+    font-size:9.5px; letter-spacing:.2em; text-transform:uppercase; font-weight:700;
+    color:color-mix(in srgb, var(--primary) 85%, var(--text));
+    display:flex; align-items:center; gap:6px;
   }
-  .ws-view{position:relative; padding:16px 18px; overflow-x:auto;}
-  .wpane{display:none; animation:wfade .3s ease;}
-  .wpane.on{display:block;}
-  @keyframes wfade{from{opacity:0; transform:translateY(8px)} to{opacity:1; transform:none}}
+  .bt .eyebrow .new{
+    font-size:8.5px; font-weight:800; letter-spacing:.1em; padding:1px 6px;
+    background:var(--primary); color:var(--bg); border-radius:20px;
+  }
+  .bt .btitle{
+    font-family:var(--sans); font-size:13.5px; font-weight:600; color:var(--text);
+    letter-spacing:-.01em; margin-top:2px; line-height:1.25; opacity:.82;
+    transition:opacity .64s var(--wsease);
+  }
+  .bt.on .btitle{opacity:1;}
+  .bt .kchip{
+    flex:none; color:var(--primary); font-size:10.5px; font-weight:700; padding:0 6px;
+    border:1px solid color-mix(in srgb, var(--primary) 35%, transparent); border-radius:5px;
+    background:color-mix(in srgb, var(--bg) 45%, transparent);
+  }
+  /* mini and full share one cell, so the swap is a crossfade, not a jump */
+  .bt .bc{position:relative; display:grid; flex:1; min-height:0; margin-top:9px;}
+  .bt .bc > *{grid-area:1/1; min-width:0;}
+  .bt .mini{
+    font-size:11.5px; line-height:1.65; color:var(--text4);
+    transition:opacity .22s var(--wsease), transform .22s var(--wsease);
+  }
+  .bt .mini s{text-decoration:none; color:var(--text3);}
+  .bt .mini em{display:block; margin-top:6px; font-style:normal; font-size:10.5px; color:color-mix(in srgb, var(--text4) 75%, transparent);}
+  .bt .mini em b{color:var(--text3); border:1px solid color-mix(in srgb, var(--border) 70%, transparent); border-radius:4px; padding:0 4px;}
+  .bt .full{
+    overflow:hidden; opacity:0; transform:translateY(7px); pointer-events:none;
+    transition:opacity .24s var(--wsease) .17s, transform .3s var(--wsease) .17s;
+    -webkit-mask-image:linear-gradient(180deg,#000 90%,transparent);
+    mask-image:linear-gradient(180deg,#000 90%,transparent);
+  }
+  .bt.on .full{opacity:1; transform:none; pointer-events:auto;}
+  .bt.on .mini{opacity:0; transform:translateY(-6px);}
+  /* a tile is a third of the panel even when it is the big one, so the mock
+     rows have to wrap here where the old full-width pane let them run */
+  .bt .full .m-row{flex-wrap:wrap; white-space:normal; row-gap:4px;}
+  .bt .full .m-code{overflow-x:auto;}
+  /* the dwell line: how long this tile keeps the floor */
+  .bt .prog{position:absolute; left:0; bottom:0; height:2px; width:0; z-index:2; opacity:0;
+    background:linear-gradient(90deg, transparent, var(--primary));}
+  .bt.on .prog{opacity:.85; animation:bfill var(--wsdwell) linear;}
+  @keyframes bfill{from{width:0} to{width:100%}}
+  .ws-meter{position:relative; width:110px; height:3px; border-radius:3px; overflow:hidden;
+    background:color-mix(in srgb, var(--border) 55%, transparent);}
+  .ws-meter i{position:absolute; inset:0 auto 0 0; width:0; border-radius:3px; background:var(--primary);}
+  .ws-meter.run i{animation:bfill var(--wsdwell) linear;}
+  /* hover, hidden tab and off-screen all park the lap where it stands */
+  .panel.wspaused .ws-meter i, .panel.wspaused .bt.on .prog{animation-play-state:paused;}
+  /* once the visitor takes the controls the timer is gone for good */
+  .panel.wsmanual .prog{display:none;}
+  .panel.wsmanual .ws-meter{opacity:.2;}
+
+  /* Phones: no growth, no rotation, no timer — six readable cards. The whole
+     point of the bento is peripheral vision, and a phone has none. */
+  @media(max-width:820px){
+    .bento{flex-direction:column; height:auto; padding:0 10px 10px; gap:9px;}
+    .bento .bcol{flex:none; gap:9px;}
+    .bt{flex:none;}
+    .bt .full, .bt .prog, .ws-meter, #ws-mode{display:none;}
+    .bt .mini{opacity:1 !important; transform:none !important;}
+  }
   /* shared mock bits */
   .m-row{display:flex; align-items:center; gap:10px; padding:6px 8px; border-radius:7px; font-size:12.5px; color:var(--text3); white-space:nowrap;}
   .m-row:hover{background:color-mix(in srgb, var(--primary) 5%, transparent);}
@@ -314,6 +390,36 @@
   .m-typing i{display:inline-block; width:5px; height:5px; border-radius:50%; background:var(--text4); margin-right:3px; animation:mty 1.1s infinite;}
   .m-typing i:nth-child(2){animation-delay:.18s} .m-typing i:nth-child(3){animation-delay:.36s}
   @keyframes mty{0%,100%{opacity:.25; transform:translateY(0)} 50%{opacity:1; transform:translateY(-3px)}}
+  /* pull request bits — the three lanes the real panel reads in */
+  .m-chip.ok{color:var(--success); border-color:color-mix(in srgb, var(--success) 45%, transparent);}
+  .m-chip.bad{color:var(--error); border-color:color-mix(in srgb, var(--error) 45%, transparent);}
+  .m-chip.warn{color:var(--warning); border-color:color-mix(in srgb, var(--warning) 45%, transparent);}
+  .m-btn.ok{color:var(--success); border-color:color-mix(in srgb, var(--success) 55%, transparent);}
+  .m-btn.bad{color:var(--error); border-color:color-mix(in srgb, var(--error) 55%, transparent);}
+  .pr-lane{display:flex; gap:6px; margin-top:8px; flex-wrap:wrap;}
+  .pr-lane span{
+    font-size:10.5px; border-radius:20px; padding:3px 10px; color:var(--text4);
+    border:1px solid color-mix(in srgb, var(--border) 70%, transparent);
+  }
+  .pr-lane span.on{color:var(--bg); background:var(--primary); border-color:transparent; font-weight:700;}
+  .pr-thread{
+    margin:8px 0; padding:8px 10px; font-size:11.5px; line-height:1.6; color:var(--text3);
+    border:1px solid color-mix(in srgb, var(--border) 45%, transparent); border-radius:10px;
+  }
+  .pr-thread .who{display:flex; align-items:center; gap:7px; font-size:11px; color:var(--text2); margin-bottom:4px;}
+  .pr-thread b{color:var(--text2);}
+  .av{
+    width:17px; height:17px; border-radius:50%; flex:none; display:inline-flex;
+    align-items:center; justify-content:center; font-size:8.5px; font-weight:700;
+    background:var(--primary); color:var(--bg);
+  }
+  .av.bot{background:var(--info);}
+  .pr-bots{
+    margin:7px 0; padding:7px 10px; font-size:10.5px; color:var(--text4);
+    display:flex; align-items:center; gap:8px; flex-wrap:wrap;
+    border:1px dashed color-mix(in srgb, var(--border) 60%, transparent); border-radius:10px;
+  }
+  .pr-acts{display:flex; gap:6px; flex-wrap:wrap; margin-top:9px;}
   /* reveals */
   .rv{opacity:0; transform:translateY(22px); transition:opacity .55s ease, transform .55s ease;}
   .rv.in{opacity:1; transform:none;}
@@ -484,10 +590,8 @@
     .pfoot span[style]{margin-left:0 !important;}
     thead th{padding:10px 12px;}
     tbody td{padding:11px 12px; font-size:12.5px;}
-    .ws-tabs{padding:10px; gap:5px;}
-    .wtab{padding:9px 11px; font-size:12.5px;}
-    .ws-view{padding:14px 12px;}
-    .ws-body{min-height:0;}
+    .bt .pad{padding:11px 12px 12px;}
+    .bt .btitle{font-size:13px;}
     .m-row{font-size:12px; gap:8px;}
     .m-bar{width:56px;}
     .m-keys{font-size:10.5px; line-height:1.8; margin-top:10px;}
@@ -541,9 +645,10 @@
       But <b>agentglass</b> is not a viewer: it's mission control <b>and a full workspace</b>.
       The dashboard watches every tool call, token and dollar live. The control plane can
       <b>hold a risky tool call until you approve it</b>, from any device, and it survives a
-      restart. And the cockpit acts — review diffs, stage &amp; push, drive docker, drop into
-      a <b>real terminal</b> (with your tmux windows as native tabs), chat with Claude —
-      without leaving the glass. A desktop app, with its server built in.
+      restart. And the cockpit acts — review diffs, stage &amp; push, <b>review a pull request
+      and merge it</b> without opening a browser, drive docker, drop into a <b>real terminal</b>
+      (with your tmux windows as native tabs), chat with Claude — without leaving the glass.
+      A desktop app, with its server built in.
     </p>
 
     <div class="ctas">
@@ -554,8 +659,9 @@
 
     <div class="keys" aria-label="Workspace panels, one keystroke away">
       <span class="klbl">the whole workspace, one keystroke away —</span>
-      <a class="key" href="#workspace" data-panel="d"><b>d</b> diff</a>
       <a class="key" href="#workspace" data-panel="g"><b>g</b> git</a>
+      <a class="key" href="#workspace" data-panel="d"><b>d</b> diff</a>
+      <a class="key" href="#workspace" data-panel="p"><b>p</b> pull requests</a>
       <a class="key" href="#workspace" data-panel="o"><b>o</b> docker</a>
       <a class="key" href="#workspace" data-panel="t"><b>t</b> terminal</a>
       <a class="key" href="#workspace" data-panel="c"><b>c</b> chat</a>
@@ -577,6 +683,8 @@
       <span><b>c</b> claude replied · shop-web chat</span>
       <span>✓ approved · gate restored after restart, agent still held</span>
       <span><b>t</b> tmux · 3 windows as native tabs · C-f listening</span>
+      <span><b>p</b> #482 · 1 review waiting · checks 3 ✓ 1 ✗</span>
+      <span><b>p</b> review handed to claude · branch checked out locally</span>
       <span>◷ AG-5F6D open 9m · transcript still growing — working, not stuck</span>
       <span>⬇ <span data-agx="version">a new release</span> available · release notes in Settings ▸ About</span>
     </div>
@@ -588,68 +696,126 @@
   <div class="rv">
     <span class="plabel">Workspace</span>
     <h2>Press a key. Fly the cockpit.</h2>
-    <p class="note">Each panel below is the real layout of the app — and the keys are real too. Try it: press <b>d</b>, <b>g</b>, <b>o</b>, <b>t</b> or <b>c</b> on your keyboard right now.</p>
+    <p class="note">Every panel of the real app, all six at once — and the keys are real. Press <b>g</b>, <b>d</b>, <b>p</b>, <b>o</b>, <b>t</b> or <b>c</b> on your keyboard right now. Leave it alone and it flies itself.</p>
   </div>
-  <div class="panel rv d1">
+  <div class="panel rv d1" id="ws-panel">
     <div class="phead">
       <span class="live"><span class="lamp"></span>WORKSPACE</span>
-      <span class="t" id="ws-title">Diff — everything the fleet changed</span>
+      <span class="t" id="ws-title">Pull requests — review without the browser</span>
       <span class="sp"></span>
-      <span class="t">one keystroke away</span>
+      <span class="t" id="ws-mode">auto · one lap a minute</span>
+      <span class="ws-meter" id="ws-meter" aria-hidden="true"><i></i></span>
     </div>
-    <div class="ws-body">
-      <div class="ws-tabs" role="tablist" aria-label="Workspace panels">
-        <button class="wtab on" data-panel="d" role="tab"><b>d</b> Diff &amp; review</button>
-        <button class="wtab" data-panel="g" role="tab"><b>g</b> Source control</button>
-        <button class="wtab" data-panel="o" role="tab"><b>o</b> Docker</button>
-        <button class="wtab" data-panel="t" role="tab"><b>t</b> Terminal</button>
-        <button class="wtab" data-panel="c" role="tab"><b>c</b> Chat</button>
+    <div class="bento" role="tablist" aria-label="Workspace panels">
+
+      <div class="bcol" data-col="gp">
+        <button class="bt" data-panel="g" role="tab" aria-selected="false">
+          <span class="pad">
+            <span class="bh">
+              <span>
+                <span class="eyebrow">
+                  <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" aria-hidden="true"><path d="M5 3v10M5 6h4a2 2 0 0 1 2 2v5"/><circle cx="5" cy="2.6" r="1.6"/><circle cx="5" cy="13.4" r="1.6"/><circle cx="11" cy="13.4" r="1.6"/></svg>
+                  git
+                </span>
+                <span class="btitle">Stage, commit, push</span>
+              </span>
+              <span class="kchip">g</span>
+            </span>
+            <span class="bc">
+              <span class="mini"><s>shop-api · main</s> ↑2 ahead · 2 staged, 1 unstaged<em><b>s</b> stage · <b>u</b> unstage · <b>x</b> discard · hunk staging</em></span>
+              <span class="full">
+                <div class="m-row"><span class="m-status"><i></i>shop-api · main</span><span class="m-chip">↑2 ahead</span><span style="margin-left:auto"></span><span class="m-btn">Pull</span><span class="m-btn pri">Push ↑2</span></div>
+                <div class="m-hd">Staged (2)</div>
+                <div class="m-row"><span style="color:var(--warning)">M</span> src/services/pricing.ts</div>
+                <div class="m-row"><span style="color:var(--warning)">M</span> src/routes/checkout.ts</div>
+                <div class="m-hd">Unstaged (1)</div>
+                <div class="m-row"><span style="color:var(--warning)">M</span> web/src/components/Cart.tsx</div>
+                <div class="m-keys">lazygit-style, write-gated · <b>s</b> stage · <b>u</b> unstage · <b>x</b> discard · interactive hunk staging · branches, log, stashes, worktrees · resolve conflicts, or hand them to a chat</div>
+              </span>
+            </span>
+          </span>
+          <span class="prog"></span>
+        </button>
+
+        <button class="bt on" data-panel="p" role="tab" aria-selected="true">
+          <span class="pad">
+            <span class="bh">
+              <span>
+                <span class="eyebrow">
+                  <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="4.6" cy="3.4" r="1.7"/><circle cx="4.6" cy="12.6" r="1.7"/><circle cx="11.4" cy="12.6" r="1.7"/><path d="M4.6 5.1v5.8M11.4 10.9V6.4a2 2 0 0 0-2-2H7.6"/><path d="M9.2 2.8 7.4 4.4l1.8 1.6"/></svg>
+                  pull requests <span class="new">new</span>
+                </span>
+                <span class="btitle">Review without the browser</span>
+              </span>
+              <span class="kchip">p</span>
+            </span>
+            <span class="bc">
+              <span class="mini"><s>#482 · 1 review waiting</s> checks 3 ✓ 1 ✗<em>approve, request changes, merge — or hand it to claude</em></span>
+              <span class="full">
+                <div class="m-row" style="padding-left:0"><span class="m-status"><i style="background:var(--warning); box-shadow:0 0 7px var(--warning)"></i>#482 round prices at checkout</span><span class="m-chip">shop-api ← fix/rounding</span><span style="margin-left:auto"></span><span class="m-chip ok">3 ✓</span><span class="m-chip bad">1 ✗</span><span class="m-chip warn">review required</span></div>
+                <div class="pr-lane"><span class="on">humans 1</span><span>line threads 2</span><span>automation 12 ▸ digest</span></div>
+                <div class="pr-thread"><div class="who"><span class="av">RC</span> richard · requested changes · 2h</div>Rounding at the boundary is right, but <b>assertRounded</b> throws on legacy carts. Guard it?</div>
+                <div class="pr-bots"><span class="av bot">CI</span> 12 automation comments collapsed · coverage table 46,551 chars · expand</div>
+                <div class="m-code">
+                  <div class="ln add"><span class="no">18</span><span>+   <span class="fn">assertRounded</span>(cart.total)</span></div>
+                  <div class="ln"><span class="no">19</span><span>    <span class="kw">return</span> pay(cart) }</span></div>
+                  <div class="ln"><span class="no"> </span><span class="cm">  ⤷ your pending comment · sends with the review</span></div>
+                </div>
+                <div class="pr-acts"><span class="m-btn ok">✓ Approve</span><span class="m-btn bad">Request changes</span><span class="m-btn">Squash &amp; merge</span><span class="m-btn pri">→ hand to claude</span></div>
+                <div class="m-keys">review a pull request without opening a browser · humans, line threads and CI in separate lanes, machines collapsed to a digest · line comments queue as a pending review · merge is pinned to the head SHA, so a push you have not seen makes GitHub refuse · <b>→ claude</b> checks the branch out locally and opens a chat with the review prompt loaded</div>
+              </span>
+            </span>
+          </span>
+          <span class="prog"></span>
+        </button>
       </div>
-      <div class="ws-view">
 
-        <div class="wpane on" id="wp-d" role="tabpanel">
-          <div class="m-row"><span class="m-status"><i></i>src/services/pricing.ts</span><span class="m-chip">M · 2 chunks</span><span style="margin-left:auto"></span><button class="m-btn">✦ Explain</button><button class="m-btn pri">Commit…</button></div>
-          <div class="m-code" style="margin-top:8px">
-            <div class="ln"><span class="no">41</span><span>  <span class="kw">const</span> rate = taxRate(region)</span></div>
-            <div class="ln del"><span class="no">42</span><span>- <span class="kw">const</span> price = subtotal * rate</span></div>
-            <div class="ln add"><span class="no">42</span><span>+ <span class="kw">const</span> price = <span class="tok"><span class="fn">round</span>(</span>subtotal * rate<span class="tok">)</span></span></div>
-            <div class="ln"><span class="no">43</span><span>  cart.total = price <span class="cm">// word-level diff, shiki-highlighted</span></span></div>
-          </div>
-          <div class="m-code" style="margin-top:8px">
-            <div class="ln"><span class="no">17</span><span>  <span class="kw">export</span> <span class="kw">function</span> <span class="fn">checkout</span>(cart: Cart) {</span></div>
-            <div class="ln add"><span class="no">18</span><span>+   <span class="fn">assertRounded</span>(cart.total)</span></div>
-            <div class="ln"><span class="no">19</span><span>    <span class="kw">return</span> pay(cart) }</span></div>
-          </div>
-          <div class="m-keys">every Edit/Write the fleet made, chaptered per session · <b>j/k</b> move · <b>v</b> split/unified · check off reviewed files</div>
-        </div>
+      <div class="bcol" data-col="dt">
+        <button class="bt" data-panel="d" role="tab" aria-selected="false">
+          <span class="pad">
+            <span class="bh">
+              <span>
+                <span class="eyebrow">
+                  <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" aria-hidden="true"><rect x="2.2" y="2.2" width="11.6" height="11.6" rx="2.4"/><path d="M5 6.2h6M5 9.8h6"/></svg>
+                  diff
+                </span>
+                <span class="btitle">Everything the fleet changed</span>
+              </span>
+              <span class="kchip">d</span>
+            </span>
+            <span class="bc">
+              <span class="mini"><s>3 files</s> chaptered per session · word-level diff<em><b>j/k</b> move · <b>v</b> split or unified · check off reviewed</em></span>
+              <span class="full">
+                <div class="m-row" style="padding-left:0"><span class="m-status"><i></i>src/services/pricing.ts</span><span class="m-chip">M · 2 chunks</span><span style="margin-left:auto"></span><span class="m-btn">✦ Explain</span><span class="m-btn pri">Commit…</span></div>
+                <div class="m-code" style="margin-top:8px">
+                  <div class="ln"><span class="no">41</span><span>  <span class="kw">const</span> rate = taxRate(region)</span></div>
+                  <div class="ln del"><span class="no">42</span><span>- <span class="kw">const</span> price = subtotal * rate</span></div>
+                  <div class="ln add"><span class="no">42</span><span>+ <span class="kw">const</span> price = <span class="tok"><span class="fn">round</span>(</span>subtotal * rate<span class="tok">)</span></span></div>
+                  <div class="ln"><span class="no">43</span><span>  cart.total = price <span class="cm">// word-level diff, shiki-highlighted</span></span></div>
+                </div>
+                <div class="m-keys">every Edit/Write the fleet made, chaptered per session · <b>j/k</b> move · <b>v</b> split/unified · check off reviewed files</div>
+              </span>
+            </span>
+          </span>
+          <span class="prog"></span>
+        </button>
 
-        <div class="wpane" id="wp-g" role="tabpanel">
-          <div class="m-row"><span class="m-status"><i></i>shop-api · main</span><span class="m-chip">↑2 ahead</span><span style="margin-left:auto"></span><button class="m-btn">Pull</button><button class="m-btn pri">Push ↑2</button></div>
-          <div class="m-hd">Staged (2)</div>
-          <div class="m-row"><span style="color:var(--warning)">M</span> src/services/pricing.ts</div>
-          <div class="m-row"><span style="color:var(--warning)">M</span> src/routes/checkout.ts</div>
-          <div class="m-hd">Unstaged (1)</div>
-          <div class="m-row"><span style="color:var(--warning)">M</span> web/src/components/Cart.tsx</div>
-          <div class="m-hd">Commit</div>
-          <div class="m-row" style="border:1px solid color-mix(in srgb, var(--border) 60%, transparent); border-radius:8px; color:var(--text2)">fix: round prices at checkout<span style="margin-left:auto"></span><button class="m-btn pri">Commit</button></div>
-          <div class="m-keys">lazygit-style, write-gated · <b>s</b> stage · <b>u</b> unstage · <b>x</b> discard · interactive hunk staging · branches, log, stashes, worktrees · resolve conflicts, or hand them to a chat</div>
-        </div>
-
-        <div class="wpane" id="wp-o" role="tabpanel">
-          <div class="m-hd" style="margin-top:0">compose: shop</div>
-          <div class="m-row"><span class="m-status"><i></i>api-worker</span><span class="m-chip">running</span><span class="m-bar"><i style="width:34%"></i></span><span>cpu 34%</span><span class="m-chip">212 MB</span></div>
-          <div class="m-row"><span class="m-status"><i></i>postgres</span><span class="m-chip">running</span><span class="m-bar"><i style="width:12%"></i></span><span>cpu 12%</span><span class="m-chip">148 MB</span></div>
-          <div class="m-row"><span class="m-status"><i></i>redis</span><span class="m-chip">running</span><span class="m-bar"><i style="width:3%"></i></span><span>cpu 3%</span><span class="m-chip">18 MB</span></div>
-          <div class="m-hd" style="margin-top:14px">logs — api-worker</div>
-          <div class="m-log"><span class="t">13:46:02</span> <span class="ok">INFO</span>  worker started · queue=payments
-<span class="t">13:46:04</span> <span class="ok">INFO</span>  processed 14 jobs in 412ms
-<span class="t">13:46:07</span> <span class="wr">WARN</span>  retry #1 · stripe timeout (2.1s)
-<span class="t">13:46:08</span> <span class="ok">INFO</span>  ok · job 8842 settled $129.00</div>
-          <div class="m-keys">lazydocker-style, write-gated · <b>r</b> restart · <b>l</b> logs · <b>s</b> stop · images, volumes, networks</div>
-        </div>
-
-        <div class="wpane" id="wp-t" role="tabpanel">
-          <div class="m-log"><span style="color:var(--success)">dev@machine</span> <span style="color:var(--info)">shop-api</span> % make test
+        <button class="bt" data-panel="t" role="tab" aria-selected="false">
+          <span class="pad">
+            <span class="bh">
+              <span>
+                <span class="eyebrow">
+                  <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="1.8" y="2.6" width="12.4" height="10.8" rx="2.2"/><path d="M4.6 6.4 6.8 8l-2.2 1.6M8.4 10.2h3"/></svg>
+                  terminal
+                </span>
+                <span class="btitle">A real PTY on your machine</span>
+              </span>
+              <span class="kchip">t</span>
+            </span>
+            <span class="bc">
+              <span class="mini"><s>3 pass · 0 fail</s> real PTY · tmux windows as native tabs<em>your login shell, per repo, persistent across reloads</em></span>
+              <span class="full">
+                <div class="m-log"><span style="color:var(--success)">dev@machine</span> <span style="color:var(--info)">shop-api</span> % make test
 bun test v1.2.19
 <span class="ok">✓</span> pricing rounds correctly <span class="t">(12ms)</span>
 <span class="ok">✓</span> checkout asserts rounded totals <span class="t">(8ms)</span>
@@ -657,21 +823,74 @@ bun test v1.2.19
 
  <span class="ok">3 pass</span> · 0 fail · 41 expect() calls
 <span style="color:var(--success)">dev@machine</span> <span style="color:var(--info)">shop-api</span> % <span class="caret"></span></div>
-          <div class="m-keys">a real PTY — your login shell over a WebSocket, not an emulation · per-repo, persistent · <b>⚙</b> discovers Makefile targets &amp; package.json scripts · run <b>tmux</b> and its windows become native tabs, keybindings untouched</div>
-        </div>
-
-        <div class="wpane" id="wp-c" role="tabpanel">
-          <div class="m-row" style="padding:2px 8px"><span class="m-status"><i></i>shop-web</span><span class="m-chip">Opus</span><span class="m-chip">acceptEdits</span></div>
-          <div class="m-msg user">fix the cart rounding bug</div>
-          <div class="m-msg ai">
-            <div class="tools"><span>Read Cart.tsx</span><span>Grep pricing</span><span>Edit pricing.ts</span></div>
-            Found it — totals were summed before rounding. Patched <b>round()</b> into <b>pricing.ts</b> and added a guard in checkout. Running the tests now.
-          </div>
-          <div class="m-msg ai m-typing"><i></i><i></i><i></i></div>
-          <div class="m-keys">drives your local <b>claude</b> CLI · pick repo, model, permission mode · queue a message mid-turn · chats survive a crash or a project switch · sessions join the fleet like any other agent</div>
-        </div>
-
+                <div class="m-keys">a real PTY — your login shell over a WebSocket, not an emulation · per-repo, persistent · <b>⚙</b> discovers Makefile targets &amp; package.json scripts · run <b>tmux</b> and its windows become native tabs, keybindings untouched</div>
+              </span>
+            </span>
+          </span>
+          <span class="prog"></span>
+        </button>
       </div>
+
+      <div class="bcol" data-col="oc">
+        <button class="bt" data-panel="o" role="tab" aria-selected="false">
+          <span class="pad">
+            <span class="bh">
+              <span>
+                <span class="eyebrow">
+                  <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><rect x="2" y="7.4" width="3" height="3"/><rect x="5.5" y="7.4" width="3" height="3"/><rect x="9" y="7.4" width="3" height="3"/><rect x="5.5" y="4" width="3" height="3"/><path d="M1.6 10.6c1.8 3.4 10.6 3.6 12.8-2.2"/></svg>
+                  docker
+                </span>
+                <span class="btitle">Containers, logs, stats</span>
+              </span>
+              <span class="kchip">o</span>
+            </span>
+            <span class="bc">
+              <span class="mini"><s>3 running</s> api-worker · postgres · redis<em><b>r</b> restart · <b>l</b> logs · <b>s</b> stop · images, volumes</em></span>
+              <span class="full">
+                <div class="m-hd" style="margin-top:0">compose: shop</div>
+                <div class="m-row"><span class="m-status"><i></i>api-worker</span><span class="m-chip">running</span><span class="m-bar"><i style="width:34%"></i></span><span>cpu 34%</span><span class="m-chip">212 MB</span></div>
+                <div class="m-row"><span class="m-status"><i></i>postgres</span><span class="m-chip">running</span><span class="m-bar"><i style="width:12%"></i></span><span>cpu 12%</span><span class="m-chip">148 MB</span></div>
+                <div class="m-row"><span class="m-status"><i></i>redis</span><span class="m-chip">running</span><span class="m-bar"><i style="width:3%"></i></span><span>cpu 3%</span><span class="m-chip">18 MB</span></div>
+                <div class="m-hd">logs — api-worker</div>
+                <div class="m-log"><span class="t">13:46:04</span> <span class="ok">INFO</span>  processed 14 jobs in 412ms
+<span class="t">13:46:07</span> <span class="wr">WARN</span>  retry #1 · stripe timeout (2.1s)
+<span class="t">13:46:08</span> <span class="ok">INFO</span>  ok · job 8842 settled $129.00</div>
+                <div class="m-keys">lazydocker-style, write-gated · <b>r</b> restart · <b>l</b> logs · <b>s</b> stop · images, volumes, networks</div>
+              </span>
+            </span>
+          </span>
+          <span class="prog"></span>
+        </button>
+
+        <button class="bt" data-panel="c" role="tab" aria-selected="false">
+          <span class="pad">
+            <span class="bh">
+              <span>
+                <span class="eyebrow">
+                  <svg viewBox="0 0 16 16" width="13" height="13" fill="none" stroke="currentColor" stroke-width="1.4" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M2 4.4a2 2 0 0 1 2-2h8a2 2 0 0 1 2 2v4.6a2 2 0 0 1-2 2H7l-3.4 2.6V11H4a2 2 0 0 1-2-2z"/></svg>
+                  chat
+                </span>
+                <span class="btitle">Drive Claude in any repo</span>
+              </span>
+              <span class="kchip">c</span>
+            </span>
+            <span class="bc">
+              <span class="mini"><s>shop-web · Opus</s> queue a message mid-turn<em>pick repo, model and permission mode · survives a crash</em></span>
+              <span class="full">
+                <div class="m-row" style="padding:2px 8px"><span class="m-status"><i></i>shop-web</span><span class="m-chip">Opus</span><span class="m-chip">acceptEdits</span></div>
+                <div class="m-msg user">fix the cart rounding bug</div>
+                <div class="m-msg ai">
+                  <div class="tools"><span>Read Cart.tsx</span><span>Grep pricing</span><span>Edit pricing.ts</span></div>
+                  Found it — totals were summed before rounding. Patched <b>round()</b> into <b>pricing.ts</b> and added a guard in checkout.
+                </div>
+                <div class="m-keys">drives your local <b>claude</b> CLI · pick repo, model, permission mode · queue a message mid-turn · chats survive a crash or a project switch · sessions join the fleet like any other agent</div>
+              </span>
+            </span>
+          </span>
+          <span class="prog"></span>
+        </button>
+      </div>
+
     </div>
   </div>
 </section>
@@ -1178,50 +1397,116 @@ sudo apt install ./agentglass_*.deb</code>
     });
   });
 
-  /* ── workspace showcase: tabs, real keyboard shortcuts, auto-rotate ── */
+  /* ── workspace bento: the six panels, real keys, a lap a minute ──
+     Motion is flex-grow interpolating on the tile and its column; the CSS owns
+     the curve, this only sets the numbers. Everything about the rotation is
+     built to yield: it stops for good the first time the visitor touches it,
+     and parks itself on hover, on a hidden tab, and once it scrolls away.
+     Phones never rotate — there is no peripheral vision on a phone, so the
+     bento is a plain stack there and a timer would only burn battery. */
   (function(){
-    var order = ['d','g','o','t','c'];
+    var panel = document.getElementById('ws-panel');
+    if(!panel) return;
+    var bento = panel.querySelector('.bento');
+    var meter = document.getElementById('ws-meter');
+    var titleEl = document.getElementById('ws-title');
+    var modeEl = document.getElementById('ws-mode');
+    var tiles = [].slice.call(panel.querySelectorAll('.bt'));
+    var cols = [].slice.call(panel.querySelectorAll('.bcol'));
+
+    /* the lap, fixed and never random: it opens on pull requests because that
+       is the newest thing here, then walks the rest of the workspace */
+    var order = ['p','t','g','d','o','c'];
     var titles = {
-      d:'Diff — everything the fleet changed',
       g:'Source control — stage, commit, push',
+      d:'Diff — everything the fleet changed',
+      p:'Pull requests — review without the browser',
       o:'Docker — containers, logs, stats',
       t:'Terminal — a real PTY on your machine',
       c:'Chat — drive local Claude sessions'
     };
-    var interacted = false;
-    function activate(k){
-      document.querySelectorAll('.wtab').forEach(function(b){ b.classList.toggle('on', b.dataset.panel===k); });
-      document.querySelectorAll('.wpane').forEach(function(p2){ p2.classList.toggle('on', p2.id==='wp-'+k); });
-      var t = document.getElementById('ws-title'); if(t) t.textContent = titles[k];
+    /* one source of truth for the dwell, read off the stylesheet so the CSS
+       progress line and this timer can never drift apart */
+    function dwellMs(){
+      var v = getComputedStyle(document.documentElement).getPropertyValue('--wsdwell');
+      var n = parseFloat(v) || 10;
+      return /ms\s*$/.test(v) ? n : n * 1000;
     }
-    document.querySelectorAll('.wtab').forEach(function(b){
-      b.addEventListener('click', function(){ interacted = true; activate(b.dataset.panel); });
+    var phone = matchMedia('(max-width: 820px)');
+    var i = 0, timer = null, manual = false, hovered = false, onScreen = true;
+
+    function activate(k){
+      i = Math.max(0, order.indexOf(k));
+      tiles.forEach(function(t){
+        var on = t.dataset.panel === k;
+        t.classList.toggle('on', on);
+        t.setAttribute('aria-selected', on ? 'true' : 'false');
+        t.style.flexGrow = on ? '3.4' : '1';
+      });
+      cols.forEach(function(c){ c.style.flexGrow = c.dataset.col.indexOf(k) === -1 ? '1' : '2.15'; });
+      if(titleEl) titleEl.textContent = titles[k];
+      /* restart the header meter from zero; removing the class and forcing a
+         reflow is the only reliable way to replay a CSS animation */
+      if(meter){
+        meter.classList.remove('run');
+        void meter.offsetWidth;
+        if(!manual && !reduced && !phone.matches) meter.classList.add('run');
+      }
+    }
+    function schedule(){
+      clearTimeout(timer);
+      if(manual || reduced || phone.matches || hovered || !onScreen || document.hidden) return;
+      timer = setTimeout(function(){ activate(order[(i+1) % order.length]); schedule(); }, dwellMs());
+    }
+    function park(on){
+      panel.classList.toggle('wspaused', on);
+      if(on) clearTimeout(timer); else schedule();
+    }
+    /* a carousel that fights the visitor is worse than no carousel */
+    function takeOver(k){
+      manual = true;
+      clearTimeout(timer);
+      panel.classList.add('wsmanual');
+      if(modeEl) modeEl.textContent = 'you have the controls';
+      activate(k);
+    }
+
+    tiles.forEach(function(t){
+      t.addEventListener('click', function(){ takeOver(t.dataset.panel); });
     });
     /* hero keycaps jump to the section AND open their panel */
     document.querySelectorAll('.keys .key[data-panel]').forEach(function(a){
-      a.addEventListener('click', function(){ interacted = true; activate(a.dataset.panel); });
+      a.addEventListener('click', function(){ takeOver(a.dataset.panel); });
     });
-    /* the real thing: press d/g/o/t/c anywhere on the page */
+    /* the real thing: press g/d/p/o/t/c anywhere on the page */
     document.addEventListener('keydown', function(e){
       if(e.metaKey || e.ctrlKey || e.altKey) return;
       var tag = (e.target && e.target.tagName) || '';
       if(tag === 'INPUT' || tag === 'TEXTAREA') return;
       var k = e.key.toLowerCase();
       if(order.indexOf(k) === -1) return;
-      interacted = true; activate(k);
+      takeOver(k);
       var sec = document.getElementById('workspace');
       var r = sec.getBoundingClientRect();
       if(r.bottom < 80 || r.top > innerHeight - 80) sec.scrollIntoView({behavior:'smooth', block:'nearest'});
     });
-    /* gentle auto-rotate until the visitor touches it */
-    if(!reduced){
-      var i = 0;
-      var iv = setInterval(function(){
-        if(interacted){ clearInterval(iv); return; }
-        i = (i+1) % order.length;
-        activate(order[i]);
-      }, 5000);
+
+    if(bento){
+      bento.addEventListener('mouseenter', function(){ hovered = true; park(true); });
+      bento.addEventListener('mouseleave', function(){ hovered = false; park(false); });
     }
+    document.addEventListener('visibilitychange', function(){ park(document.hidden || hovered); });
+    if('IntersectionObserver' in window){
+      new IntersectionObserver(function(entries){
+        onScreen = entries[0].isIntersecting;
+        park(!onScreen || hovered);
+      }, {threshold:.2}).observe(panel);
+    }
+    /* rotating in a phone layout would grow nothing and time nothing */
+    if(phone.addEventListener) phone.addEventListener('change', function(){ clearTimeout(timer); activate(order[i]); schedule(); });
+
+    activate(order[0]);
+    schedule();
   })();
 
   /* ── reveals ── */


### PR DESCRIPTION
The workspace section showed **five** panels in a text tab list that looks like nothing in the app, behind a `430px` min-height that left a void under every short panel. Meanwhile the app grew a sixth view — **pull requests** — and the landing never mentioned it.

### What it is now

All six visible at once: `g` git, `d` diff, `p` **pull requests**, `o` docker, `t` terminal, `c` chat. The active tile grows in place; the rest stay one-line summaries with the keys they answer to. Nothing is hidden, and the panel is exactly as tall as its content.

Pull requests gets the room it earns: the three lanes the real panel reads in (humans, line threads, CI collapsed to a digest), a pending line comment, the check counts, and the actions — approve, request changes, squash-merge pinned to the head SHA, and handing the whole review to Claude.

### Why flex-grow and not a grid span

Grid `span` is not animatable, and a scale-based FLIP would squash the type. So growth is `flex-grow` interpolating 1 → 3.4 on the tile and 1 → 2.15 on its column. Every tile keeps its home cell, so the eye follows one box swelling instead of chasing a reshuffle, and it animates in every browser with no View Transitions and no JS layout math.

### The rotation, and how it yields

Left alone the panel flies itself on a fixed lap — `p → t → g → d → o → c`, ten seconds each, opening on pull requests. It gets out of the way immediately:

- the first click or keystroke ends it **for good**
- parks on hover, on a hidden tab, and once it scrolls off screen
- phones never rotate — no peripheral vision on a phone, so the bento is a plain stack there with no growth and no timer
- `prefers-reduced-motion` turns the whole thing off

### Style

The chrome is the app's own recipe from `web/src/index.css`: the panel gradient, the `primary 12%` hairline, the `1rem` radius, and the eyebrow + sentence-title header every panel in the app wears. Token-only, so it still reads right in all 22 themes.

Also: `p` joins the hero keycaps, the hero copy mentions reviewing and merging a pull request without a browser, and the ticker gained two PR lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)