### PR TITLE
feat(repos): give a fresh install somewhere to look, and say so when there is nowhere

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -6,6 +6,7 @@
 
 import { resolve, basename, relative, dirname, sep, join } from "node:path";
 import { statSync, readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs";
+import { homedir } from "node:os";
 import { git, gitAsync, safeAbs, repoRootOf, currentBranch } from "./git.ts";
 import { configuredRepoDirs, workspaceRoot, inScope } from "./config.ts";
 import { worktreeParent, gitDir } from "./worktree.ts";
@@ -305,6 +306,39 @@ function reposUnder(baseDir: string, depth = REPO_SCAN_DEPTH): string[] {
  * directly in one of those (a home directory that is itself a repo) still gets
  * listed on its own — it just doesn't drag its neighbours in.
  */
+/**
+ * Where code tends to live, for an install that has nothing else to go on.
+ *
+ * Every other source of roots describes a machine that has already been used:
+ * the cwd the app was launched from (a shortcut, so not a repo), projects the
+ * transcript scan found (no sessions yet), the parents of those projects, repos
+ * seen in telemetry (no events yet), and configured directories (unset). On a
+ * fresh install all five are empty, so the picker offered "Whole machine" and
+ * nothing else — which reads as discovery being broken, when it is discovery
+ * working exactly as written.
+ *
+ * The list is short and conventional on purpose. This is a guess, and a guess
+ * that walks somewhere surprising is worse than no guess at all: each of these
+ * is a directory whose name says "my code is in here", and one `readdir` is the
+ * whole cost of trying. Anything more exotic is what `repoDirs` is for, which
+ * the empty state now names.
+ */
+const CODE_HOMES = ["code", "src", "projects", "dev", "repos", "workspace", "Developer", "Documents/GitHub"];
+
+export function firstRunRoots(): string[] {
+  // `$HOME` first, `homedir()` behind it. On POSIX the variable is the user's
+  // own statement about where their home is, and honouring it is also what
+  // makes this testable against a fixture rather than against the machine the
+  // test happens to run on.
+  const home = process.env.HOME || homedir();
+  const out: string[] = [];
+  for (const name of CODE_HOMES) {
+    const dir = resolve(home, name);
+    try { if (statSync(dir).isDirectory()) out.push(dir); } catch { /* not on this machine */ }
+  }
+  return out;
+}
+
 function codeRootsOf(knownRoots: string[]): string[] {
   const TOO_BROAD = new Set(["/", "/home", "/mnt", "/media", "/run", "/usr", "/opt", "/var", "/tmp", "/etc", "/srv"]);
   const out = new Set<string>();
@@ -528,7 +562,13 @@ export async function discoverRepos(paths: string[], knownRoots: string[] = [], 
   // them and, more to the point, predictable. Inference is only the fallback
   // for an unconfigured install, and it can do no better than guess from the
   // directories that happen to hold existing projects.
-  const bases = only.length ? only : codeRootsOf(knownRoots);
+  // Inferred parents first, then the conventional homes — and the homes only
+  // when inference came back with nothing, which is exactly the fresh-install
+  // case. A machine that has been used has better information about itself than
+  // this list does, and adding `~/code` to it would put back projects the user
+  // has never opened here alongside the ones they work in daily.
+  const inferred = codeRootsOf(knownRoots);
+  const bases = only.length ? only : (inferred.length ? inferred : firstRunRoots());
   for (const base of bases) for (const r of reposUnder(base)) roots.add(r);
   // env overrides for repos that live elsewhere
   for (const p of (process.env.AGENTGLASS_REPOS || "").split(":").filter(Boolean)) { const r = repoRootOf(p); if (r) roots.add(r); }

--- a/server/test/first-run-repos.test.ts
+++ b/server/test/first-run-repos.test.ts
@@ -1,0 +1,54 @@
+// On a fresh install the project picker offered "Whole machine" and nothing
+// else, however many repos were on disk. Not a bug in discovery: every source
+// of roots describes a machine that has already been used (a cwd inside a repo,
+// projects with transcripts, their parents, repos seen in telemetry, configured
+// directories), and on first run all five are empty. So the first screen a new
+// user sees could only work after they had already used the thing.
+//
+// The fix is a short list of conventional code homes, which is a guess — and a
+// guess that walks somewhere surprising is worse than no guess. These pin what
+// it will and will not look at.
+import { describe, expect, test, afterEach, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { firstRunRoots } from "../src/gitwork.ts";
+
+let home = "";
+const realHome = process.env.HOME;
+beforeEach(() => { home = mkdtempSync(join(tmpdir(), "agx-home-")); process.env.HOME = home; });
+afterEach(() => { process.env.HOME = realHome; rmSync(home, { recursive: true, force: true }); });
+
+const make = (...dirs: string[]) => { for (const d of dirs) mkdirSync(join(home, d), { recursive: true }); };
+
+describe("where to look on a machine that has never been used", () => {
+  test("the conventional code homes, when they exist", () => {
+    make("code", "src", "projects");
+    expect(firstRunRoots().map((r) => r.replace(home + "/", ""))).toEqual(["code", "src", "projects"]);
+  });
+
+  test("nothing is invented for a home that has none of them", () => {
+    // Better to offer nothing than to walk somewhere surprising: the empty
+    // state names `repoDirs`, which is the answer for an unconventional layout.
+    make("Music", "Downloads", "Desktop");
+    expect(firstRunRoots()).toEqual([]);
+  });
+
+  test("a file named like a code home is not a code home", () => {
+    Bun.write(join(home, "code"), "not a directory");
+    expect(firstRunRoots()).toEqual([]);
+  });
+
+  test("the nested one is found where macOS puts it", () => {
+    make("Documents/GitHub");
+    expect(firstRunRoots()).toEqual([join(home, "Documents/GitHub")]);
+  });
+
+  test("the list stays short", () => {
+    // This is a guess, and every entry is a directory tree somebody's install
+    // will walk on boot. Growing it is a decision, not a reflex — the escape
+    // hatch for an unusual layout is `repoDirs`, which costs nothing to nobody.
+    make("code", "src", "projects", "dev", "repos", "workspace", "Developer", "Documents/GitHub");
+    expect(firstRunRoots().length).toBeLessThanOrEqual(8);
+  });
+});

--- a/web/src/components/ProjectPicker.tsx
+++ b/web/src/components/ProjectPicker.tsx
@@ -172,7 +172,25 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                   </button>
 
                   {repos === null && <div className="px-3 py-3 text-[11px] t-dim2">looking for repos…</div>}
-                  {repos !== null && !shown.length && <div className="px-3 py-3 text-[11px] t-dim2">no repos found{terms.length ? " for that filter" : ""}</div>}
+                  {/* Two different empty states. A filter that matches nothing
+                      is about the filter; an empty list with no filter is about
+                      configuration, and saying "no repos found" there states a
+                      fact about the machine ("you have no code") when the true
+                      statement is about this app ("nothing is configured to
+                      look in"). The first reads as a bug in discovery, which is
+                      how it was reported. */}
+                  {repos !== null && !shown.length && (terms.length ? (
+                    <div className="px-3 py-3 text-[11px] t-dim2">no repos match that filter</div>
+                  ) : (
+                    <div className="px-3 py-3 text-[11px] t-dim2 leading-relaxed">
+                      <div style={{ color: "var(--text2)" }}>nothing to look in yet</div>
+                      <div className="mt-1">
+                        agentglass sweeps the folders your projects already live in, and the usual ones
+                        (<code>~/code</code>, <code>~/src</code>, <code>~/projects</code>…). If yours are somewhere else,
+                        name them with <code>repoDirs</code> in your config, or <code>AGENTGLASS_REPO_DIRS</code>.
+                      </div>
+                    </div>
+                  ))}
                   {shown.map((r) => (
                     <button key={r.root} onClick={() => choose(r.root)} disabled={busy}
                       className="w-full text-left px-3 py-2 rounded-lg flex items-center gap-2.5 hover:bg-[color-mix(in_srgb,var(--primary)_10%,transparent)]"


### PR DESCRIPTION
Closes #194.

On a fresh install the project picker offers "Whole machine" and nothing else, however many repos are on disk. It reads as broken discovery. It is not: `discoverRepos()` draws roots from five sources and on first run all five are empty — the cwd is a shortcut rather than a repo, no sessions have been ingested, so no known roots and no parents derived from them, `repoDirs` is unset, and no telemetry has arrived. The discovery story only starts working after you have already used the thing, which is backwards for the first screen you see.

## The fix

A short list of conventional code homes, used **only** when inference came back with nothing:

```
~/code  ~/src  ~/projects  ~/dev  ~/repos  ~/workspace  ~/Developer  ~/Documents/GitHub
```

Simulated fresh install (no config, no history, cwd outside a repo):

```
before:  (nothing — the picker offers only "Whole machine")
after:   ~/code/agentglass, ~/code/obs, ~/code/lazyagent, ~/src/PywalZen, …
```

A machine that has been used knows better about itself than this list does, so the homes are a fallback rather than an addition: adding `~/code` to a user with real history would put projects they have never opened here alongside the ones they work in daily.

## And the floor, since it is the same bug

The empty state said "no repos found", which states a fact about the world ("you have no code") when the true statement is about configuration ("nothing is configured to look in"). It now says the second thing and names `repoDirs` / `AGENTGLASS_REPO_DIRS`. A filter that matches nothing gets its own, separate message — that one really is about the filter.

## Tests

`server/test/first-run-repos.test.ts`, against a fixture home: the conventional directories are found, a home with none of them yields nothing rather than inventing somewhere to walk, a *file* named `code` is not a code home, the nested macOS one is found, and the list is pinned short — every entry is a tree that somebody's install walks on boot, so growing it should be a decision rather than a reflex.

Server suite: 417 pass. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)