### PR TITLE
feat(fleet): let the evidence decide stuck vs slow, not the clock

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -683,7 +683,11 @@ const OPEN_TOOL_MAX_MS = 30 * 60_000;
 const openToolSql = (scoped: string) =>
   `SELECT p.session_id AS session_id, p.source_app AS source_app,
           COALESCE(p.tool_name, 'tool') AS tool_name, p.timestamp AS since,
-          json_extract(p.payload, '$.tool_input.file_path') AS target
+          json_extract(p.payload, '$.tool_input.file_path') AS target,
+          -- Where the call is running, for the tools whose only possible
+          -- evidence is that something moved in it: the turn's cwd when it ran
+          -- somewhere other than the repo root, the project path otherwise.
+          COALESCE(json_extract(p.payload, '$.cwd'), json_extract(p.payload, '$.project_path')) AS dir
      FROM events p
     WHERE p.hook_event_type = 'PreToolUse'
       AND p.timestamp >= ?

--- a/server/src/evidence.ts
+++ b/server/src/evidence.ts
@@ -9,26 +9,83 @@
  * genuinely long job vanishes from the fleet while it is still working.
  *
  * So ask a different question: not "how long has this been open" but "when did
- * this session last produce evidence that it is alive". Two sources, both local
- * and both independent of the hook stream that has gone quiet:
+ * this session last produce evidence that it is alive". Every source is local
+ * and independent of the hook stream, which by definition has gone quiet.
  *
- *  - the transcript file, which the CLI appends to as a turn streams. Growth
- *    there is the strongest signal available and costs one stat.
- *  - the file a write tool named in its own input. If Edit said it would touch
- *    src/foo.ts, then src/foo.ts changing is that tool doing its job.
+ * ## What the transcript actually does, measured
  *
- * This module only *reports* freshness; nothing here classifies a session. That
- * is deliberate: the numbers want watching against real runs — including a real
- * hang — before any state machine is moved onto them.
+ * The obvious source is the transcript file, and the obvious rule — "it stopped
+ * growing, so the session is hung" — is wrong. Measured against a real Claude
+ * Code run with a 43-second Bash call:
+ *
+ *     command starts   22:18:07
+ *     transcript mtime 22:18:10     <- the tool_use record being written
+ *     command ends     22:18:50
+ *     transcript mtime 22:18:10     <- unchanged for the whole call
+ *
+ * The CLI writes the call at the start and the result at the end, and nothing
+ * in between. A quiet transcript during a tool call is therefore the *normal*
+ * state, and a rule built on it would flag every long build as hung — the exact
+ * false positive this is meant to retire.
+ *
+ * That measurement turns the transcript into a different and more useful
+ * signal. If it grows *well after* a call opened, the CLI has moved on: the
+ * call finished and the Post event never reached us. That is a lost pair, not a
+ * hang, and today it is indistinguishable from one for a full thirty minutes.
+ *
+ * ## What each tool class can be held to
+ *
+ * A single rule cannot work, because tools differ in what they are expected to
+ * leave behind:
+ *
+ *  - Edit / Write / NotebookEdit name the file they will touch, so that file
+ *    not changing is a real absence.
+ *  - Bash may write anywhere or nowhere, so movement under its working
+ *    directory is evidence *for* life and its absence proves nothing.
+ *  - Read / Grep / Glob finish in moments and leave nothing behind, so minutes
+ *    of open call with the CLI silent is a genuine stall.
+ *  - WebFetch, WebSearch and MCP tools leave nothing local at all.
+ *
+ * Which is why `unknown` is a first-class answer here and is rendered as one.
+ * Claiming a hang we cannot see is how the current thresholds lost trust, and
+ * repeating that with better wording would be no improvement.
  */
-import { statSync } from "node:fs";
-import type { OpenToolCall } from "../../shared/types.ts";
+import { readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import type { OpenToolCall, Liveness } from "../../shared/types.ts";
 import { transcriptPathOf } from "./transcripts.ts";
 
 /** Tools whose own input names a file they are about to change. Bash is absent
  *  on purpose: its command may write anywhere, or nowhere, and guessing a path
  *  for it would manufacture evidence rather than find it. */
 const WRITES_A_FILE = new Set(["Edit", "MultiEdit", "Write", "NotebookEdit"]);
+
+/** Tools that finish in moments and leave nothing behind but their result. An
+ *  open call here is not a long job — there is no such thing as a long Glob. */
+const LEAVES_NOTHING = new Set(["Read", "Grep", "Glob", "LS", "TodoWrite"]);
+
+/** Tools whose work happens somewhere we cannot watch. Named rather than
+ *  inferred, so a new local tool defaults to being checked rather than excused. */
+const WATCHES_NOTHING = new Set(["WebFetch", "WebSearch", "Task"]);
+
+/**
+ * How long after a call opens the transcript may still be describing *it*.
+ *
+ * Measured at about three seconds for the tool_use record. Twenty is generous
+ * enough that a loaded machine is not called a lost pair, and short enough to
+ * catch a real one within a poll or two.
+ */
+const SETTLE_MS = 20_000;
+
+/**
+ * How long expected evidence may be absent before that absence means something.
+ *
+ * This is a threshold, which is what #134 set out to retire — but it is a
+ * threshold on *silence where noise was expected*, not on how long a job is
+ * allowed to take. A three-minute Edit that never touched its file is stuck
+ * whatever the machine's speed; a three-hour build that keeps writing is not.
+ */
+const QUIET_MS = 3 * 60_000;
 
 /** mtime in ms, or null when the path is gone, unreadable, or was never given.
  *  A tool that has not created its target yet is not evidence of anything. */
@@ -41,17 +98,111 @@ function mtimeOf(path: string | null | undefined): number | null {
   }
 }
 
+/** Bounded so a home directory pointed at by mistake cannot turn into a
+ *  thousand stats on every poll. */
+const DIR_ENTRY_MAX = 400;
+
 /**
- * Attach the freshest evidence found for each open call.
+ * The freshest thing to have happened in a directory, one level down.
+ *
+ * For Bash this is the only signal there is. A directory's mtime moves when an
+ * entry is created or removed inside it, so a build writing objects, a test run
+ * dropping a cache, a `git` command touching `.git` — all of it shows up here
+ * without walking a tree. Nothing is skipped: `node_modules`, `dist` and
+ * `target` are exactly where a build proves it is alive, which is the opposite
+ * of what those directories mean to the repo scanner.
+ */
+function newestUnder(dir: string | null | undefined): number | null {
+  if (!dir) return null;
+  let newest: number | null = null;
+  try {
+    newest = statSync(dir).mtimeMs;
+    let seen = 0;
+    for (const name of readdirSync(dir)) {
+      if (++seen > DIR_ENTRY_MAX) break;
+      const at = mtimeOf(join(dir, name));
+      if (at !== null && (newest === null || at > newest)) newest = at;
+    }
+  } catch { /* unreadable or gone — no evidence, which is not a verdict */ }
+  return newest;
+}
+
+/** Whether a name is an MCP tool, which by definition runs somewhere else. */
+const isMcp = (tool: string) => tool.startsWith("mcp__");
+
+/** Which sources this tool can be held to. Exported so the collector below and
+ *  the classifier cannot drift apart about what a Bash call is. */
+export const watchesDirectory = (tool: string): boolean =>
+  !WRITES_A_FILE.has(tool) && !LEAVES_NOTHING.has(tool) && !WATCHES_NOTHING.has(tool) && !isMcp(tool);
+
+export interface EvidenceSources {
+  transcriptAt: number | null;
+  targetAt: number | null;
+  dirAt: number | null;
+}
+
+/**
+ * Turn the evidence into a verdict, for one call.
+ *
+ * Exported for the tests, which is the point: this decides what the fleet says
+ * about a session, and it should be arguable against fixtures rather than only
+ * against whatever a live machine happens to be doing.
+ */
+export function classify(
+  call: Pick<OpenToolCall, "tool_name" | "since">,
+  src: EvidenceSources,
+  now: number,
+): Liveness {
+  const { tool_name, since } = call;
+  const open = now - since;
+
+  // The CLI moved on. The transcript only grows when a call is recorded or a
+  // result arrives, so growth this long after the call opened means the result
+  // landed and our Post event never did. A bookkeeping failure, and
+  // specifically not a hang — today the two are indistinguishable for half an
+  // hour, and both are reported as a running tool.
+  if (open > SETTLE_MS && src.transcriptAt !== null && src.transcriptAt > since + SETTLE_MS) return "lost";
+
+  if (isMcp(tool_name) || WATCHES_NOTHING.has(tool_name)) return "unknown";
+
+  if (WRITES_A_FILE.has(tool_name)) {
+    // The file it named is the whole point of the call.
+    if (src.targetAt !== null && src.targetAt >= since) return "working";
+    // No readable target at all — an input we could not parse, or a file the
+    // tool has not created yet — is not the same as a target that failed to
+    // move. Only the second is a claim we are entitled to make.
+    if (src.targetAt === null) return open > QUIET_MS ? "unknown" : "working";
+    return open > QUIET_MS ? "stuck" : "working";
+  }
+
+  if (LEAVES_NOTHING.has(tool_name)) {
+    // There is no such thing as a slow Glob. Minutes of open call with nothing
+    // written anywhere is the one case where silence really is the answer.
+    return open > QUIET_MS ? "stuck" : "working";
+  }
+
+  // Bash, and anything else local we have not named. Movement under the working
+  // directory is evidence for life; its absence is not evidence against it,
+  // because plenty of legitimate commands compute for minutes writing nothing.
+  // Saying "I cannot tell" is the honest answer, and it is what the UI shows.
+  if (src.dirAt !== null && src.dirAt >= since) return "working";
+  return open > QUIET_MS ? "unknown" : "working";
+}
+
+/**
+ * Attach the freshest evidence found for each open call, and the verdict it
+ * supports.
  *
  * Kept out of db.ts because it reaches the filesystem and the transcript index,
  * and a query module that quietly stats files is a query module nobody can
- * reason about. Two stats per open call, and the list is capped at 200.
+ * reason about. Work is deduplicated per session and per directory, and the
+ * call list is capped at 200 upstream.
  */
-export function withEvidence(calls: OpenToolCall[]): OpenToolCall[] {
-  // One transcript stat per session, not per call: a session with four tools
-  // open would otherwise stat the same file four times for one answer.
+export function withEvidence(calls: OpenToolCall[], now = Date.now()): OpenToolCall[] {
+  // One transcript stat per session, and one scan per directory: a session with
+  // four tools open would otherwise pay for the same answer four times over.
   const perSession = new Map<string, number | null>();
+  const perDir = new Map<string, number | null>();
 
   return calls.map((c) => {
     if (!perSession.has(c.session_id)) {
@@ -60,25 +211,35 @@ export function withEvidence(calls: OpenToolCall[]): OpenToolCall[] {
     const transcriptAt = perSession.get(c.session_id) ?? null;
     const targetAt = WRITES_A_FILE.has(c.tool_name) ? mtimeOf(c.target) : null;
 
-    // Freshest wins, and which one it was is reported: "the transcript grew"
-    // and "the file it promised to touch changed" are different claims, and a
-    // reader deciding whether to trust the number wants to know which was made.
-    let evidenceAt: number | undefined;
-    let evidenceKind: OpenToolCall["evidenceKind"];
-    if (transcriptAt !== null && (targetAt === null || transcriptAt >= targetAt)) {
-      evidenceAt = transcriptAt;
-      evidenceKind = "transcript";
-    } else if (targetAt !== null) {
-      evidenceAt = targetAt;
-      evidenceKind = "target";
-    } else {
-      // Nothing to read. Not the same as "nothing happened": a tool with no
-      // expected artifact and a session whose transcript we cannot find both
-      // land here, and calling either of them stuck would be the old mistake
-      // in a new place.
-      evidenceKind = "none";
+    // The directory is only scanned for the tools it can say anything about.
+    // Reading a project directory to decide whether a WebFetch is alive would
+    // be work spent to learn nothing.
+    let dirAt: number | null = null;
+    if (watchesDirectory(c.tool_name) && c.dir) {
+      if (!perDir.has(c.dir)) perDir.set(c.dir, newestUnder(c.dir));
+      dirAt = perDir.get(c.dir) ?? null;
     }
 
-    return { ...c, ...(evidenceAt === undefined ? {} : { evidenceAt }), evidenceKind };
+    // Freshest wins, and which one it was is reported: "the transcript grew",
+    // "the file it promised to touch changed" and "something moved in the
+    // working directory" are different claims, and a reader deciding whether to
+    // trust the verdict wants to know which was made.
+    const candidates: Array<[number, NonNullable<OpenToolCall["evidenceKind"]>]> = [];
+    if (transcriptAt !== null) candidates.push([transcriptAt, "transcript"]);
+    if (targetAt !== null) candidates.push([targetAt, "target"]);
+    if (dirAt !== null) candidates.push([dirAt, "dir"]);
+    candidates.sort((a, b) => b[0] - a[0]);
+    const best = candidates[0];
+
+    return {
+      ...c,
+      ...(best ? { evidenceAt: best[0] } : {}),
+      // Nothing to read. Not the same as "nothing happened": a tool with no
+      // expected artifact and a session whose transcript we cannot find both
+      // land here, and calling either of them stuck would be the old mistake in
+      // a new place.
+      evidenceKind: best ? best[1] : "none",
+      liveness: classify(c, { transcriptAt, targetAt, dirAt }, now),
+    };
   });
 }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -295,12 +295,47 @@ function broadcast(frame: WsFrame) {
   }
 }
 
+/**
+ * Push the open-tool list, with evidence read at this moment.
+ *
+ * Evidence is a claim about *now* — "the file it promised to touch has not
+ * changed since the call opened" — and one taken when a client connected is
+ * worth nothing a minute later. It used to be sent only in the `initial` frame,
+ * which was fine while nothing depended on it and is not fine now that it
+ * decides whether a session is reported as stuck.
+ *
+ * Silent when nothing is open and when nobody is listening, so an idle machine
+ * pays for one SQL query on a four-second tick and no filesystem work at all.
+ */
+function pushOpenTools() {
+  if (!clients.size) return;
+  const open = openToolCalls();
+  if (!open.length && !lastOpenCount) return;
+  lastOpenCount = open.length;
+  broadcast({ type: "openTools", data: withEvidence(open) });
+}
+let lastOpenCount = 0;
+/**
+ * How often the verdict is re-read.
+ *
+ * Fast enough that "stuck" appears while the user is still looking at the
+ * session, slow enough that the filesystem work — one stat per session, one
+ * shallow directory scan per working directory — is nothing. The classifier's
+ * own thresholds are in minutes, so a tighter tick would buy no accuracy.
+ */
+const OPEN_TOOL_TICK_MS = 4000;
+setInterval(pushOpenTools, OPEN_TOOL_TICK_MS).unref?.();
+
 /** Normalize → persist → broadcast → alert. Shared by /ingest and /v1/traces. */
 function ingestBody(body: IngestBody) {
   const n = normalize(body);
   const { event, session } = insertEvent(n);
   broadcast({ type: "event", data: event });
   broadcast({ type: "session", data: session });
+  // A Pre opens a call and a Post closes one, so the list the fleet is drawing
+  // from just changed. Pushed now rather than up to a tick later, because the
+  // moment a tool starts is exactly when the card should say so.
+  if (event.hook_event_type === "PreToolUse" || event.hook_event_type.startsWith("PostToolUse")) pushOpenTools();
   maybeAlert(event);
   return event;
 }
@@ -1086,6 +1121,10 @@ setInterval(prune, 3_600_000);
 startScanner(({ event, session }) => {
   broadcast({ type: "event", data: event });
   broadcast({ type: "session", data: session });
+  // A Pre opens a call and a Post closes one, so the list the fleet is drawing
+  // from just changed. Pushed now rather than up to a tick later, because the
+  // moment a tool starts is exactly when the card should say so.
+  if (event.hook_event_type === "PreToolUse" || event.hook_event_type.startsWith("PostToolUse")) pushOpenTools();
   maybeAlert(event);
 });
 

--- a/server/test/evidence.test.ts
+++ b/server/test/evidence.test.ts
@@ -1,142 +1,113 @@
-import { afterAll, beforeAll, describe, expect, it } from "bun:test";
-import { mkdtempSync, writeFileSync, rmSync, utimesSync } from "node:fs";
-import { tmpdir } from "node:os";
-import { join } from "node:path";
-import type { OpenToolCall } from "../../shared/types.ts";
+// What the evidence says about a running tool call.
+//
+// The old rule was elapsed time alone: warn at five minutes, write the pair off
+// at thirty. It is wrong in both directions — half the warnings were healthy
+// builds, and a genuinely long job vanished from the fleet while it was still
+// working — because slow and hung look identical from the input side.
+//
+// These pin the replacement. The classifier is pure and takes its sources as
+// numbers, so every case below is a claim that can be argued with rather than a
+// machine that happened to behave.
+import { describe, expect, test } from "bun:test";
+import { classify, watchesDirectory } from "../src/evidence.ts";
 
-/**
- * Evidence of life, against real files with real mtimes.
- *
- * The whole point of the signal is that it reads something the hook stream
- * cannot fake, so mocking the filesystem here would test the opposite of what
- * matters.
- */
-let dir: string, transcript: string, target: string, ev: typeof import("../src/evidence.ts");
+const NOW = 1_700_000_000_000;
+const ago = (ms: number) => NOW - ms;
+const min = (n: number) => n * 60_000;
+const none = { transcriptAt: null, targetAt: null, dirAt: null };
 
-/**
- * The session the fixture transcript belongs to, registered in the same table
- * the scanner writes, since that is what the lookup reads.
- *
- * Minted per run rather than fixed. db.ts binds its file at import and the
- * first suite to import it decides that file for the whole process, so in a
- * full `bun test` this one can land on the developer's real database — where
- * every previous run of this test has left a row pointing at a temp directory
- * that no longer exists. The lookup takes the newest row for the session, hands
- * back a deleted path, and the evidence this file is about reads as "none".
- * A fresh id cannot collide with its own history.
- */
-const SESSION = `sess-alive-${crypto.randomUUID().slice(0, 8)}`;
+describe("a tool that names the file it will touch", () => {
+  test("the file changed since the call opened: working", () => {
+    expect(classify({ tool_name: "Edit", since: ago(min(8)) }, { ...none, targetAt: ago(min(1)) }, NOW)).toBe("working");
+  });
 
-const call = (over: Partial<OpenToolCall> = {}): OpenToolCall => ({
-  session_id: SESSION,
-  source_app: "claude-code",
-  tool_name: "Bash",
-  since: Date.now() - 60_000,
-  ...over,
+  test("eight minutes and the file has not moved: stuck", () => {
+    // The case the elapsed-time rule could not see. Nothing about the duration
+    // decides this — a file that was going to change would have changed.
+    expect(classify({ tool_name: "Write", since: ago(min(8)) }, { ...none, targetAt: ago(min(30)) }, NOW)).toBe("stuck");
+  });
+
+  test("a call younger than the quiet window is not accused", () => {
+    // An Edit that opened four seconds ago has not failed to do anything yet.
+    expect(classify({ tool_name: "Edit", since: ago(4000) }, { ...none, targetAt: ago(min(30)) }, NOW)).toBe("working");
+  });
+
+  test("a target we cannot read at all is `unknown`, not `stuck`", () => {
+    // A file the tool has not created yet, or an input we could not parse.
+    // "The file did not move" and "there is no file to look at" are different
+    // claims and only the first accuses anybody.
+    expect(classify({ tool_name: "Write", since: ago(min(8)) }, none, NOW)).toBe("unknown");
+  });
 });
 
-beforeAll(async () => {
-  dir = mkdtempSync(join(tmpdir(), "agx-evidence-"));
-  process.env.AGENTGLASS_ROOT = dir;
-  // A database of its own, and a config directory of its own. Without them this
-  // suite reads whatever the machine already has: on a fresh CI checkout that is
-  // nothing and every assertion holds, while on any developer's machine the real
-  // database answers first and the same three tests fail. A test that only passes
-  // where there is no history is not testing what it claims to.
-  process.env.AGENTGLASS_DB = join(dir, "evidence.db");
-  process.env.XDG_CONFIG_HOME = dir;
-  transcript = join(dir, "session.jsonl");
-  target = join(dir, "target.ts");
-  writeFileSync(transcript, "{}\n");
-  writeFileSync(target, "export const x = 1;\n");
+describe("a tool that leaves nothing behind", () => {
+  test("minutes of open Glob is stuck", () => {
+    // There is no such thing as a slow Glob, so silence really is the answer.
+    expect(classify({ tool_name: "Glob", since: ago(min(6)) }, none, NOW)).toBe("stuck");
+  });
 
-  const { db } = await import("../src/db.ts");
-  await import("../src/transcripts.ts"); // creates transcript_files
-  db.query(
-    `INSERT INTO transcript_files (path, session_id, source_app, project_path, lines_done, size, mtime)
-     VALUES (?, ?, 'claude-code', ?, 1, 2, 0)`
-  ).run(transcript, SESSION, dir);
-
-  ev = await import("../src/evidence.ts");
+  test("a Read that just started is fine", () => {
+    expect(classify({ tool_name: "Read", since: ago(2000) }, none, NOW)).toBe("working");
+  });
 });
 
-afterAll(async () => {
-  // Take the fixture row out again. On a machine where the temp database above
-  // did not win, this row lands in the real one, and a test that leaves debris
-  // in the database it borrowed is a test that breaks the next run.
-  try {
-    const { db } = await import("../src/db.ts");
-    db.query("DELETE FROM transcript_files WHERE session_id = ?").run(SESSION);
-  } catch { /* nothing to clean */ }
-  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+describe("Bash, which may write anywhere or nowhere", () => {
+  test("something moved in its working directory: working", () => {
+    expect(classify({ tool_name: "Bash", since: ago(min(20)) }, { ...none, dirAt: ago(1000) }, NOW)).toBe("working");
+  });
+
+  test("a twenty-minute build that has written nothing is `unknown`, not `stuck`", () => {
+    // The honest answer. A command can legitimately compute for a long time
+    // writing nothing — a query, a fetch, a test run held on stdout — and
+    // claiming a hang we cannot see is exactly how the five-minute warning lost
+    // its credibility.
+    expect(classify({ tool_name: "Bash", since: ago(min(20)) }, none, NOW)).toBe("unknown");
+  });
+
+  test("directory movement from before the call started is not evidence for it", () => {
+    // The build output that was already there when the command began says
+    // nothing about whether the command is running.
+    expect(classify({ tool_name: "Bash", since: ago(min(20)) }, { ...none, dirAt: ago(min(40)) }, NOW)).toBe("unknown");
+  });
 });
 
-/** Backdate a file, so "fresh" and "stale" are facts rather than timing luck. */
-const age = (path: string, secondsAgo: number) => {
-  const t = Date.now() / 1000 - secondsAgo;
-  utimesSync(path, t, t);
-};
-
-describe("evidence of life", () => {
-  it("reports the transcript growing, which is evidence the hooks cannot give", () => {
-    age(transcript, 3);
-    const [r] = ev.withEvidence([call()]);
-    expect(r!.evidenceKind).toBe("transcript");
-    expect(Date.now() - r!.evidenceAt!).toBeLessThan(10_000);
+describe("tools whose work happens somewhere we cannot watch", () => {
+  test("a WebFetch is never accused", () => {
+    expect(classify({ tool_name: "WebFetch", since: ago(min(45)) }, none, NOW)).toBe("unknown");
   });
 
-  it("reports the file a write tool named, when that is the fresher signal", () => {
-    // The shape that matters: a long Edit whose transcript went quiet, but
-    // whose target is being written right now.
-    age(transcript, 600);
-    age(target, 2);
-    const [r] = ev.withEvidence([call({ tool_name: "Edit", target })]);
-    expect(r!.evidenceKind).toBe("target");
-    expect(Date.now() - r!.evidenceAt!).toBeLessThan(10_000);
+  test("an MCP tool is never accused", () => {
+    expect(classify({ tool_name: "mcp__figma__get_design", since: ago(min(45)) }, none, NOW)).toBe("unknown");
   });
 
-  it("prefers the freshest of the two rather than a fixed order", () => {
-    age(transcript, 2);
-    age(target, 600);
-    const [r] = ev.withEvidence([call({ tool_name: "Edit", target })]);
-    expect(r!.evidenceKind).toBe("transcript");
+  test("and neither is asked for a directory scan", () => {
+    // Reading a project directory to decide whether a WebFetch is alive is work
+    // spent to learn nothing.
+    expect(watchesDirectory("WebFetch")).toBe(false);
+    expect(watchesDirectory("mcp__x__y")).toBe(false);
+    expect(watchesDirectory("Edit")).toBe(false);
+    expect(watchesDirectory("Bash")).toBe(true);
+  });
+});
+
+describe("telling a lost pair from a hang", () => {
+  // Measured against a real run: the CLI writes the tool_use record about three
+  // seconds after a call opens and then nothing until the result. So transcript
+  // growth well after the call began means the result landed and our Post event
+  // did not — our bookkeeping failed, the session is fine.
+  test("the transcript grew long after the call opened: lost, not stuck", () => {
+    expect(classify({ tool_name: "Bash", since: ago(min(10)) }, { ...none, transcriptAt: ago(min(2)) }, NOW)).toBe("lost");
   });
 
-  it("ignores a target for tools that write nowhere in particular", () => {
-    // Bash may write anywhere or nowhere. Reading a path off it would be
-    // manufacturing evidence, which is worse than having none.
-    age(transcript, 900);
-    age(target, 1);
-    const [r] = ev.withEvidence([call({ tool_name: "Bash", target })]);
-    expect(r!.evidenceKind).toBe("transcript");
-    expect(Date.now() - r!.evidenceAt!).toBeGreaterThan(800_000 / 1000);
+  test("growth inside the settle window is the call being recorded, not the CLI moving on", () => {
+    // Three seconds after the call opened is the tool_use record. Reading that
+    // as "the CLI moved on" would mark every call lost the moment it started.
+    expect(classify({ tool_name: "Bash", since: ago(min(10)) }, { ...none, transcriptAt: ago(min(10)) + 3000 }, NOW)).toBe("unknown");
   });
 
-  it("says `none` rather than guessing when nothing is readable", () => {
-    // An unknown session and a target that does not exist: the honest answer is
-    // that we cannot tell, and it must not read as "stuck".
-    const [r] = ev.withEvidence([
-      call({ session_id: "sess-unknown", tool_name: "Edit", target: join(dir, "never-created.ts") }),
-    ]);
-    expect(r!.evidenceKind).toBe("none");
-    expect(r!.evidenceAt).toBeUndefined();
-  });
-
-  it("stats a session's transcript once however many of its calls are open", () => {
-    // Four open tools on one session is one question about that session.
-    const calls = [call(), call({ tool_name: "Grep" }), call({ tool_name: "Read" }), call({ tool_name: "Glob" })];
-    const out = ev.withEvidence(calls);
-    expect(out).toHaveLength(4);
-    expect(new Set(out.map((r) => r.evidenceAt)).size).toBe(1);
-  });
-
-  it("leaves every field it was given alone", () => {
-    // It enriches; it must not become a place where open-call data is rewritten.
-    const c = call({ tool_name: "Edit", target, since: 123 });
-    const [r] = ev.withEvidence([c]);
-    expect(r!.session_id).toBe(c.session_id);
-    expect(r!.tool_name).toBe("Edit");
-    expect(r!.since).toBe(123);
-    expect(r!.target).toBe(target);
+  test("a quiet transcript during a long Bash is normal and accuses nobody", () => {
+    // The measurement that shaped all of this: the transcript does not grow
+    // while a command runs. A rule built on it would call every long build hung.
+    expect(classify({ tool_name: "Bash", since: ago(min(15)) }, { ...none, transcriptAt: ago(min(16)) }, NOW)).toBe("unknown");
   });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -359,12 +359,35 @@ export interface OpenToolCall {
   evidenceAt?: number;
   /** Which evidence the timestamp came from. `none` means no source was
    *  readable — deliberately not the same claim as "nothing happened". */
-  evidenceKind?: "transcript" | "target" | "none";
+  evidenceKind?: "transcript" | "target" | "dir" | "none";
+  /** The directory this call is running in, for tools whose only possible
+   *  evidence is that something moved in it. */
+  dir?: string | null;
+  /** What the evidence supports. Absent from a server too old to send it, which
+   *  the client reads as `unknown` rather than as good news. */
+  liveness?: Liveness;
 }
+
+/**
+ * What the evidence says about a running tool call.
+ *
+ * `unknown` is a real answer and is rendered as one: a WebFetch and a `curl`
+ * leave nothing local behind, and claiming a hang we cannot see is how a
+ * five-minute timer lost its credibility in the first place.
+ *
+ * `lost` is not a hang either — it is our own bookkeeping failing. The CLI
+ * wrote more transcript after this call opened, so the result arrived and the
+ * Post event did not.
+ */
+export type Liveness = "working" | "stuck" | "lost" | "unknown";
 
 /** WebSocket frames. */
 export type WsFrame =
   | { type: "initial"; data: WatchEvent[]; openTools?: OpenToolCall[] }
+  /** The open-tool list again, with fresh evidence. Pushed on a timer while any
+   *  call is open: evidence is a claim about *now*, and one taken at connect
+   *  time is worth nothing thirty seconds later. */
+  | { type: "openTools"; data: OpenToolCall[] }
   | { type: "event"; data: WatchEvent }
   | { type: "session"; data: SessionRollup }
   /** Something mutated a repository. Carries no payload on purpose: the panels

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, OpenToolCall } from "../../../shared/types.ts";
+import type { WatchEvent, OpenToolCall, Liveness } from "../../../shared/types.ts";
 import { agentKey, fmtMs, sessionTitle } from "./format.ts";
 import { sessionWorktree } from "./worktree.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
@@ -56,7 +56,11 @@ export interface AgentCard {
    *  and reported only: nothing here decides `status` yet. The point of showing
    *  it first is to find out where it lies before anything depends on it. */
   evidenceAt: number | null;
-  evidenceKind: "transcript" | "target" | "none" | null;
+  evidenceKind: "transcript" | "target" | "dir" | "none" | null;
+  /** What that evidence supports. `unknown` is a real answer — a WebFetch
+   *  leaves nothing local behind — and is rendered as one rather than being
+   *  rounded up to "fine" or down to "stuck". */
+  liveness: Liveness;
   /** Context-window estimate: the latest turn's full prompt size (input +
    *  cache read + cache write — each API call re-sends the conversation, so
    *  that sum IS the context). 0 = no turn seen yet. */
@@ -72,11 +76,16 @@ export interface AgentCard {
 
 const STALL_MS = 20_000;
 const IDLE_MS = 5 * 60_000;
-// An open tool call older than this is a lost pair (crashed session, dropped
-// event), not a genuinely long build — stop vouching for it as "working".
+// The backstop for an open call nothing can vouch for. It used to be the whole
+// answer — "open for thirty minutes, therefore lost" — which dropped genuinely
+// long jobs off the fleet while they were still working. Now it only applies
+// when the evidence has nothing better to say: a call the server can see making
+// progress is not written off however long it runs.
 const TOOL_RUN_MAX_MS = 30 * 60_000;
-// An open tool call this old is worth a heads-up: probably a long build,
-// possibly a hang — either way the user wants to know it's still open.
+// How long an open call runs before it is worth mentioning at all. It is no
+// longer a verdict, only the point past which the evidence is worth reporting:
+// at five minutes, "still writing files" and "has touched nothing" are
+// different sentences, and this used to say the same thing for both.
 const TOOL_RUN_WARN_MS = 5 * 60_000;
 // An error this close to a session's final event is the note it ended on, rather
 // than one it hit and recovered from. Wide enough to cover the Stop that
@@ -107,6 +116,7 @@ function blankCard(key: string, source_app: string, session_id: string, model_na
     runningSince: 0,
     evidenceAt: null,
     evidenceKind: null,
+    liveness: "working",
     ctxTokens: 0,
     ctxTs: 0,
     ctxLimit: 200_000,
@@ -234,11 +244,12 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
     if (s.since >= a.runningSince) {
       a.runningTool = s.tool_name;
       a.runningSince = s.since;
-      // Carried through untouched. The classifier below still runs on elapsed
-      // time alone; this rides alongside it so the two can be compared against
-      // real runs before either replaces the other.
       a.evidenceAt = s.evidenceAt ?? null;
       a.evidenceKind = s.evidenceKind ?? null;
+      // A server too old to send a verdict says nothing, which is `unknown` —
+      // not good news. Reading a missing field as "working" would let an old
+      // server silently vouch for every session on the fleet.
+      a.liveness = s.liveness ?? "unknown";
     }
   }
 
@@ -254,7 +265,15 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
     const since = now - a.lastSeen;
     // A session that ended can't still be running a tool, whatever pair we
     // think is open; and an open pair past the ceiling is lost, not long.
-    if (a.lastType === "Stop" || a.lastType === "SessionEnd" || (a.runningTool && now - a.runningSince >= TOOL_RUN_MAX_MS)) {
+    // A session that ended cannot still be running a tool, whatever pair we
+    // think is open. `lost` says the same thing with evidence behind it: the
+    // transcript grew after this call opened, so its result arrived and our
+    // Post event did not. The thirty-minute ceiling stays as the backstop for
+    // calls the evidence cannot speak to, and no longer applies to one we can
+    // see making progress.
+    const unvouched = a.liveness !== "working";
+    if (a.lastType === "Stop" || a.lastType === "SessionEnd" || a.liveness === "lost"
+      || (a.runningTool && unvouched && now - a.runningSince >= TOOL_RUN_MAX_MS)) {
       a.runningTool = null;
     }
     const running = !!a.runningTool;
@@ -273,7 +292,17 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
     a.outcome = deriveOutcome(a);
     // While a tool call is open, its live duration is the most informative
     // thing the card can say — better than the stale "PreToolUse · Bash".
-    if (a.status === "working" && running) a.lastAction = `running ${a.runningTool} · ${fmtMs(now - a.runningSince)}`;
+    if (a.status === "working" && running) {
+      // Past the point where a reader starts to wonder, say which of the two
+      // things it is. Before that the duration speaks for itself and a verdict
+      // on a ten-second call is noise.
+      const openFor = now - a.runningSince;
+      const note = openFor < TOOL_RUN_WARN_MS ? ""
+        : a.liveness === "stuck" ? " · no sign of life"
+        : a.liveness === "unknown" ? " · can't tell"
+        : " · still working";
+      a.lastAction = `running ${a.runningTool} · ${fmtMs(openFor)}${note}`;
+    }
 
     a.ctxLimit = ctxLimitOf(a.model_name, a.ctxTokens);
 
@@ -331,6 +360,14 @@ export function deriveOutcome(a: AgentCard): AgentOutcome {
   return "unclear";
 }
 
+/** Why a call was called stuck, in the reader's terms. The verdict is only
+ *  useful if the sentence under it can be argued with. */
+function stuckBecause(a: AgentCard): string {
+  if (a.evidenceKind === "target") return "the file it named has not changed since it started";
+  if (a.evidenceKind === "dir") return "nothing has moved in its working directory";
+  return "the session has written nothing since it started";
+}
+
 export function deriveAlerts(agents: AgentCard[]): Alert[] {
   const now = Date.now();
   const out: Alert[] = [];
@@ -339,11 +376,20 @@ export function deriveAlerts(agents: AgentCard[]): Alert[] {
       out.push({ id: "wait:" + a.key, level: "warn", agent: a.key, text: "waiting for approval / input", ts: a.lastSeen });
     if (a.status === "errored")
       out.push({ id: "err:" + a.key, level: "error", agent: a.key, text: `${a.errors} error(s) — last action ${a.lastAction}`, ts: a.lastSeen });
-    // A tool call open this long deserves eyes: could be a fat build, could be
-    // a hang — the alert says which tool and for how long, and the user knows
-    // which of the two their project makes plausible.
-    if (a.status === "working" && a.runningTool && now - a.runningSince >= TOOL_RUN_WARN_MS)
-      out.push({ id: "long:" + a.key, level: "warn", agent: a.key, text: `${a.runningTool} running for ${fmtMs(now - a.runningSince)} — long job or stuck?`, ts: a.runningSince });
+    // A long tool call used to raise the same warning whatever it was doing,
+    // and asked the reader to guess: "long job or stuck?". Half of those were
+    // healthy builds, which is how the warning stopped being read at all. The
+    // evidence answers it now, and where it cannot, it says so instead of
+    // pretending. A call that is visibly working raises nothing.
+    if (a.status === "working" && a.runningTool && now - a.runningSince >= TOOL_RUN_WARN_MS) {
+      const openFor = fmtMs(now - a.runningSince);
+      if (a.liveness === "stuck")
+        out.push({ id: "stuck:" + a.key, level: "error", agent: a.key, ts: a.runningSince,
+          text: `${a.runningTool} open ${openFor} with nothing to show for it — ${stuckBecause(a)}` });
+      else if (a.liveness === "unknown")
+        out.push({ id: "long:" + a.key, level: "warn", agent: a.key, ts: a.runningSince,
+          text: `${a.runningTool} running ${openFor} — nothing local to check, so this could be either` });
+    }
     const rate = a.tools > 3 ? a.errors / a.tools : 0;
     if (rate > 0.25)
       out.push({ id: "rate:" + a.key, level: "error", agent: a.key, text: `high failure rate ${(rate * 100).toFixed(0)}%`, ts: a.lastSeen });

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -151,6 +151,11 @@ export function useLive(): LiveData {
         setEvents(initial);
         setLastEvent(initial[initial.length - 1] ?? null);
         setOpenTools(frame.openTools ?? []);
+      } else if (frame.type === "openTools") {
+        // The whole list, re-read with fresh evidence. Replaces rather than
+        // merges: the server's answer is authoritative about what is open, and
+        // a call missing from it has closed.
+        setOpenTools(frame.data);
       } else if (frame.type === "event") {
         if (seen.current.has(frame.data.id)) return; // duplicate delivery
         seen.current.add(frame.data.id);


### PR DESCRIPTION
Closes #134. Roadmap: top of **Now**.

The evidence signal shipped in v0.4.0 as reported-only, with a note in `derive.ts` that it "rides alongside so the two can be compared against real runs before either replaces the other". This is that step.

## The measurement that changed the design

#134's table has Bash falling back to transcript growth. Measured against a real Claude Code run with a 43-second Bash call:

```
command starts   22:18:07
transcript mtime 22:18:10     <- the tool_use record being written
command ends     22:18:50
transcript mtime 22:18:10     <- unchanged for the whole call
```

The CLI writes the call at the start and the result at the end, and nothing in between. **A quiet transcript during a tool call is the normal state**, so a rule built on it would flag every long build as hung — precisely the false positive the issue exists to retire.

What the transcript *does* say is the opposite thing. Growth well after a call opened means the CLI moved on: the result arrived and our Post event did not. That is a **lost pair**, not a hang — and today the two are indistinguishable for a full thirty minutes, with both reported as a running tool.

## The rules

| Tool class | Evidence | Absence means |
|---|---|---|
| Edit / Write / NotebookEdit | the file it named moved | **stuck** (only when the file is readable and did not move) |
| Bash | movement in its working directory | **unknown** — a command may compute for minutes writing nothing |
| Read / Grep / Glob | nothing written for minutes | **stuck** — there is no such thing as a slow Glob |
| WebFetch / Task / MCP | nothing local to read | **unknown**, always |

`unknown` is a first-class answer and is rendered as one. Claiming a hang we cannot see is how the five-minute warning lost its credibility.

## Against real rows

Synthetic open calls in a copy of the real database, so the SQL and the filesystem work are both exercised:

```
Bash  open 12m  evidence=dir      -> working    (old code: "long job or stuck?" at 5m)
Edit  open  7m  evidence=target   -> stuck      (file it named exists, has not moved)
Edit  open  9m  evidence=none     -> unknown    (target unreadable — not an accusation)
```

## What changes in the fleet

- The thirty-minute ceiling no longer drops a call the evidence can see making progress, so a genuinely long job stays on the fleet instead of vanishing mid-run.
- `lost` retires the pair immediately and for a stated reason, rather than after half an hour of claiming a tool is running.
- The "long job or stuck?" warning — which asked the reader to guess, and was a healthy build half the time — becomes an error that says what is missing ("the file it named has not changed since it started"), a warning that admits it cannot tell, or nothing at all when the call is visibly working.
- Evidence is now pushed on a 4s tick while anything is open, and immediately when a Pre/Post moves the list. It was only in the `initial` frame, which was fine while nothing depended on it; a verdict about *now*, taken at connect time, is worth nothing a minute later.

## Tests

`server/test/evidence.test.ts`, 15 cases against a pure classifier — including the three that encode the measurement above: growth inside the settle window is the call being recorded (not the CLI moving on), a quiet transcript during a long Bash accuses nobody, and directory movement from *before* the call started is not evidence for it.

Server suite: 425 pass. `bun run build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)