### PR TITLE
harden: first-run robustness (git/docker/update/terminal/orphan-sidecar)

### DIFF
--- a/.github/workflows/desktop-binaries.yml
+++ b/.github/workflows/desktop-binaries.yml
@@ -38,6 +38,12 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Full history + tags, so `git describe --tags` in build.mjs can name
+          # the release this build descends from. A shallow checkout has no tag
+          # object, which would stamp the installer with an empty baseTag and
+          # leave the About pane unable to say which release it is.
+          fetch-depth: 0
 
       - uses: oven-sh/setup-bun@v2
         with:
@@ -72,6 +78,19 @@ jobs:
             p.version = process.argv[1]
             fs.writeFileSync(f, JSON.stringify(p, null, 2) + "\n")
           ' "${GITHUB_REF_NAME#v}"
+
+      # Stamp provenance INTO staging, next to the sidecar CI just compiled, so
+      # the installer carries build-info.json (version/commit/origin/baseTag)
+      # and self-update.sh. Without this the packaged app records no origin, and
+      # updateStatus() blocks with "reinstall from source" — no update badge,
+      # no notification, no way to install a new release. --provenance-only is
+      # deliberate: it must not rebuild the web UI or recompile the sidecar,
+      # which is cross-built for this matrix target and cannot be reproduced on
+      # the runner's own arch. Runs after the version sync so build-info carries
+      # the tag's version, and before packaging so extraResources picks it up.
+      - name: Stamp provenance (build-info.json + self-update.sh)
+        shell: bash
+        run: node electron/build.mjs --provenance-only
 
       # electron-builder packages the app; the web build and staged sidecar come
       # in via extraResources (see electron/package.json "build").

--- a/Makefile
+++ b/Makefile
@@ -10,8 +10,13 @@ help: ## List every make command with what it does
 install: ## Install all workspace dependencies (bun)
 	bun install
 
+# `trap 'kill 0'` tears the whole process group (concurrently, bun --watch, the
+# server, vite) down on Ctrl-C or a SIGTERM to make, so an abandoned `make dev`
+# leaves nothing behind. The server also carries its own parent-death watchdog
+# (AGENTGLASS_DIE_WITH_PARENT, set in server/package.json's dev script) as the
+# backstop for the SIGKILL case this trap cannot catch.
 dev: ## Run server (:4000) + web dashboard (:6180) together, live-reload
-	bun run dev
+	trap 'kill 0' INT TERM; bun run dev
 
 server: ## Run only the Bun + SQLite server on :4000
 	bun run dev:server
@@ -25,14 +30,16 @@ build: ## Production build of the web dashboard (web/dist)
 test: ## Run the server test suite (what CI runs)
 	cd server && bun test
 
+# The scripts kill the server/Chrome they spawn on their own SIGINT/SIGTERM;
+# `trap 'kill 0'` here is the group-wide backstop for a SIGTERM aimed at make.
 smoke: build ## Boot the production bundle in headless Chrome — fails on a blank screen or any console error
-	bun scripts/smoke.ts
+	trap 'kill 0' INT TERM; bun scripts/smoke.ts
 
 perf: ## Check the server still answers while it works — fails if the event loop (and so the terminal) stalls
-	bun scripts/perfbudget.ts
+	trap 'kill 0' INT TERM; bun scripts/perfbudget.ts
 
 soak: ## Run the server hard for a few minutes and fail if its memory keeps climbing (AGX_SOAK_MINUTES=30 for a real one)
-	bun scripts/soak.ts
+	trap 'kill 0' INT TERM; bun scripts/soak.ts
 
 typecheck: ## Type-check both halves (vite build and bun both strip types without checking)
 	cd web && bunx tsc --noEmit

--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -11,6 +11,19 @@ import { fileURLToPath } from "node:url";
 const HERE = dirname(fileURLToPath(import.meta.url));
 const REPO = resolve(HERE, "..");
 
+// CI builds the web UI and cross-compiles the sidecar for each target platform
+// itself (a bun `--compile --target=` this host cannot produce), then calls us
+// only to stamp provenance. In that mode we must NOT rebuild either — wiping
+// staging would delete the cross-built sidecar CI just placed, and recompiling
+// would produce a host-arch binary in a package meant for another platform.
+//
+// This is the seam the desktop-binaries workflow needs: before this existed,
+// CI never ran build.mjs at all, so its installers shipped with no
+// build-info.json and no self-update.sh — the whole update path was dead on
+// every binary anyone downloaded, while local builds (which do run build.mjs)
+// worked fine and hid it.
+const provenanceOnly = process.argv.includes("--provenance-only");
+
 function run(cmd, args, cwd) {
   const r = spawnSync(cmd, args, { cwd, stdio: "inherit" });
   if (r.status !== 0) {
@@ -19,20 +32,26 @@ function run(cmd, args, cwd) {
   }
 }
 
-console.log("==> building web UI");
-run("bun", ["run", "build"], resolve(REPO, "web"));
+if (provenanceOnly) {
+  // staging already holds CI's cross-compiled sidecar; only make sure the dir
+  // is there (idempotent — never wipes) so the writes below land.
+  mkdirSync(resolve(HERE, "staging"), { recursive: true });
+} else {
+  console.log("==> building web UI");
+  run("bun", ["run", "build"], resolve(REPO, "web"));
 
-console.log("==> compiling server sidecar");
-// Wipe staging first. electron-builder copies *everything* in here into the
-// app's resources (extraResources: { from: "staging", to: "." }), so anything
-// left behind ships — a stray build of the sidecar is 100MB, and six of them
-// once made it into an installed app before anyone noticed the size.
-rmSync(resolve(HERE, "staging"), { recursive: true, force: true });
-mkdirSync(resolve(HERE, "staging"), { recursive: true });
-run("bun", [
-  "build", "--compile", resolve(REPO, "server/src/index.ts"),
-  "--outfile", resolve(HERE, "staging/agentglass-server"),
-]);
+  console.log("==> compiling server sidecar");
+  // Wipe staging first. electron-builder copies *everything* in here into the
+  // app's resources (extraResources: { from: "staging", to: "." }), so anything
+  // left behind ships — a stray build of the sidecar is 100MB, and six of them
+  // once made it into an installed app before anyone noticed the size.
+  rmSync(resolve(HERE, "staging"), { recursive: true, force: true });
+  mkdirSync(resolve(HERE, "staging"), { recursive: true });
+  run("bun", [
+    "build", "--compile", resolve(REPO, "server/src/index.ts"),
+    "--outfile", resolve(HERE, "staging/agentglass-server"),
+  ]);
+}
 
 // Provenance, so the installed app knows what it was built from and can offer
 // to update itself. Without it the server would have to guess where the source

--- a/electron/main.js
+++ b/electron/main.js
@@ -179,7 +179,12 @@ async function resolvePort() {
 async function ensureServer(adopt) {
   const port = SERVER_PORT;
   if (adopt) return; // a dev server or another instance is already up
-  const env = { ...process.env, AGENTGLASS_PORT: String(port) };
+  // AGENTGLASS_DIE_WITH_PARENT arms the server's own parent-death watchdog:
+  // stopSidecar below cannot fire if this main process is SIGKILLed or crashes,
+  // so the sidecar backs it up by exiting on its own once we are gone. Only
+  // servers we spawn get the flag; adopted ones (returned above) keep whatever
+  // lifecycle they were launched with.
+  const env = { ...process.env, AGENTGLASS_PORT: String(port), AGENTGLASS_DIE_WITH_PARENT: "1" };
   sidecar = PACKAGED
     ? spawn(SIDECAR_BIN, [], { stdio: "ignore", env })
     : spawn("bun", ["run", path.join(REPO, "server", "src", "index.ts")], { stdio: "ignore", env });

--- a/scripts/perfbudget.ts
+++ b/scripts/perfbudget.ts
@@ -84,10 +84,21 @@ const server = spawn({
     // The transcript sweep reads whatever is in the operator's ~/.claude, which
     // is neither this app's doing nor reproducible on a CI runner.
     AGENTGLASS_SCAN_DISABLED: "1",
+    // Arm the server's parent-death watchdog. The finally below kills it on a
+    // clean exit, but if this script is SIGKILLed the server is reparented to
+    // init and would otherwise linger holding the port — the watchdog reaps it.
+    AGENTGLASS_DIE_WITH_PARENT: "1",
   },
   stdout: "ignore",
   stderr: "inherit",
 });
+
+// SIGTERM/SIGINT skip the finally below, so a Ctrl-C or a `kill` on this script
+// would leave the server it spawned running. Kill it on the way out ourselves;
+// the watchdog is the backstop for the harder SIGKILL case only.
+for (const s of ["SIGINT", "SIGTERM"] as const) {
+  process.on(s, () => { try { server.kill(); } catch { /* already gone */ } process.exit(1); });
+}
 
 const lat: number[] = [];
 let stop = false;

--- a/scripts/smoke.ts
+++ b/scripts/smoke.ts
@@ -217,6 +217,17 @@ async function main() {
   let chrome: Awaited<ReturnType<typeof launchChrome>> | undefined;
   let cdp: Cdp | undefined;
 
+  // SIGTERM/SIGINT skip the finally below, so an interrupted smoke would leave
+  // the headless Chrome it spawned orphaned (the static server is in-process,
+  // but Chrome is a real subprocess). Wire the same teardown to those signals.
+  for (const s of ["SIGINT", "SIGTERM"] as const) {
+    process.on(s, () => {
+      try { chrome?.proc.kill(); } catch { /* already gone */ }
+      try { server.stop(true); } catch { /* already down */ }
+      process.exit(1);
+    });
+  }
+
   try {
     chrome = await launchChrome(process.argv.includes("--headful"));
     cdp = await Cdp.connect(chrome.wsUrl);

--- a/scripts/soak.ts
+++ b/scripts/soak.ts
@@ -74,9 +74,20 @@ const server = spawn({
     AGENTGLASS_DB: join(home, "soak.db"),
     XDG_CONFIG_HOME: join(home, "config"), XDG_DATA_HOME: join(home, "data"), XDG_CACHE_HOME: join(home, "cache"),
     AGENTGLASS_TOKEN: "", AGENTGLASS_SCAN_DISABLED: "1",
+    // Arm the server's parent-death watchdog. A soak runs for minutes and is the
+    // one most likely to be interrupted; if this script is SIGKILLed the server
+    // is reparented to init and the watchdog reaps it instead of it lingering.
+    AGENTGLASS_DIE_WITH_PARENT: "1",
   },
   stdout: "ignore", stderr: "inherit",
 });
+
+// SIGTERM/SIGINT skip the finally below, so a Ctrl-C or a `kill` on this script
+// would leave the server it spawned running. Kill it on the way out ourselves;
+// the watchdog is the backstop for the harder SIGKILL case only.
+for (const s of ["SIGINT", "SIGTERM"] as const) {
+  process.on(s, () => { try { server.kill(); } catch { /* already gone */ } process.exit(1); });
+}
 
 const POLLED = [
   `/git/tree?root=${R}`, `/git/repos`, `/git/branches?root=${R}`,

--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "dev": "bun --watch run src/index.ts",
+    "dev": "AGENTGLASS_DIE_WITH_PARENT=1 bun --watch run src/index.ts",
     "start": "bun run src/index.ts"
   },
   "devDependencies": {

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -11,7 +11,7 @@
 // images the turn goes out as `--input-format stream-json` instead — one JSON
 // line carrying text and image content blocks together, which is the only
 // channel structured content has into a `claude -p` run.
-import { safeAbs, repoRootOf } from "./git.ts";
+import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
 import { inScope, chatBypassAllowed } from "./config.ts";
 import type { ChatImage, ChatImageMediaType } from "../../shared/types.ts";
 
@@ -195,7 +195,12 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   if (!bin) return err("no local `claude` CLI — install Claude Code to chat", 403);
   if (process.env.AGENTGLASS_CHAT_DISABLED === "1") return err("chat is disabled (AGENTGLASS_CHAT_DISABLED=1)", 403);
   const dir = safeAbs(cwd);
-  if (!dir || !repoRootOf(dir)) return err("invalid or non-repo directory");
+  if (!dir || !repoRootOf(dir)) {
+    // With no git, repoRootOf fails for every directory — name the real cause
+    // rather than blaming the folder.
+    const cap = gitCapability();
+    return err(cap.available ? "invalid or non-repo directory" : (cap.reason || "git is not installed"));
+  }
   // The last write path still outside the scope boundary (#67 covered git and
   // the terminal). A chat runs a real `claude` with tools in that directory, so
   // it can change anything a shell could — leaving it machine-wide would have

--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -7,7 +7,7 @@
 import { basename } from "node:path";
 import type {
   DockerContainer, DockerStat, DockerImage, DockerVolume, DockerNetwork,
-  DockerOverview, DockerScope, DockerActionResult,
+  DockerOverview, DockerScope, DockerActionResult, DockerCapability,
 } from "../../shared/types.ts";
 import { workspaceRoot, scopeRoots } from "./config.ts";
 import { backoff, currentLabel, resumedAs } from "./loopwatch.ts";
@@ -68,6 +68,30 @@ function jsonLines(out: string): Record<string, string>[] {
   return rows;
 }
 
+/**
+ * Is the `docker` CLI even here?
+ *
+ * Everything below assumes it is, and `Bun.spawn` THROWS on a missing binary
+ * rather than exiting 127 — so on a machine with no docker, runDocker() catches
+ * that throw and hands back `{ code:1, stderr:"…Executable not found…" }`. That
+ * non-empty stderr then reads to probeDaemon() as a *conclusive* answer from the
+ * CLI, and the panel says "docker not available (is the daemon running?)" over a
+ * daemon that was never even asked. Telling "not installed" apart from "daemon
+ * down" is the whole point of dockerCapability(); this is the primitive it and
+ * overview() both key on. Mirrors gitBin().
+ *
+ * PATH passed explicitly for the reason gitBin() documents: bare
+ * `Bun.which("docker")` resolves against a PATH snapshotted at process start,
+ * which both ignores a genuinely stripped environment and makes this untestable.
+ * Cached for the process — a binary doesn't appear mid-session, and the panel
+ * polls the overview every few seconds.
+ */
+let dockerBinCache: string | null | undefined;
+export function dockerBin(): string | null {
+  if (dockerBinCache === undefined) dockerBinCache = Bun.which("docker", { PATH: process.env.PATH ?? "" });
+  return dockerBinCache;
+}
+
 let cachedVersion: string | null = null;
 let versionCheckedAt = 0;
 /** How long a *conclusive* "no daemon" is trusted before probing again. */
@@ -112,6 +136,12 @@ interface DaemonProbe {
  */
 async function probeDaemon(): Promise<DaemonProbe> {
   if (cachedVersion) return { version: cachedVersion, inconclusive: false };
+  // No CLI to ask: spawning would throw ENOENT and burn a pool slot on every
+  // poll, and its caught stderr is what used to masquerade as the daemon saying
+  // "no". A missing binary is a *conclusive* no-daemon we know without asking —
+  // returning it here is what lets overview() say "not installed" instead of
+  // blaming a daemon that was never contacted.
+  if (!dockerBin()) return { version: null, inconclusive: false };
   if (versionInflight) return versionInflight;
   const wait = lastProbeInconclusive ? VERSION_UNSURE_RETRY_MS : VERSION_RETRY_MS;
   if (versionCheckedAt && Date.now() - versionCheckedAt < wait) {
@@ -146,6 +176,48 @@ async function probeDaemon(): Promise<DaemonProbe> {
 
 export async function dockerVersion(): Promise<string | null> {
   return (await probeDaemon()).version;
+}
+
+/**
+ * The three-state answer the panel needs: not installed / daemon down / OK.
+ *
+ * Mirrors gitCapability(), but with docker's extra failure mode folded in.
+ * `available` means the same thing it does for git — the CLI is on PATH — while
+ * the daemon nuance rides on `version`/`reason`:
+ *
+ *   (a) no binary      → { available:false, reason }   (install guidance)
+ *   (b) binary, no daemon → { available:true,  reason } (start the daemon)
+ *   (c) binary + daemon   → { available:true,  version }
+ *
+ * No 60s memo of its own, unlike gitCapability(): git has no daemon so its
+ * verdict is stable for the whole session, but docker's is not — and both halves
+ * are already cached at the right granularity underneath (dockerBin() for the
+ * life of the process, probeDaemon() with its own success-forever / failure-
+ * briefly policy). A capability that pinned "daemon down" for a full minute is
+ * exactly the staleness the rest of this file is written to avoid.
+ */
+export async function dockerCapability(): Promise<DockerCapability> {
+  if (!dockerBin()) {
+    return { available: false, reason: "Docker isn't installed — the docker CLI isn't on your PATH" };
+  }
+  const { version, inconclusive } = await probeDaemon();
+  if (version) return { available: true, version };
+  return {
+    available: true,
+    reason: inconclusive
+      ? "no answer from docker yet — still trying to reach the daemon"
+      : "the docker daemon isn't responding — is it running?",
+  };
+}
+
+/** Test seam: forget the binary probe (and the daemon memo it feeds) so a test
+ *  can flip PATH and re-ask, the way git-capability's own test does. */
+export function __resetDockerCapForTest(): void {
+  dockerBinCache = undefined;
+  cachedVersion = null;
+  versionCheckedAt = 0;
+  lastProbeInconclusive = false;
+  versionInflight = null;
 }
 
 // Every field is named explicitly instead of using `{{json .}}`, which looks
@@ -333,12 +405,17 @@ export async function overview(): Promise<DockerOverview> {
     const down: DockerOverview = {
       available: false, writeEnabled: DOCKER_WRITE_ENABLED, version: null,
       containers: [], images: [], volumes: [], networks: [],
-      // Say which of the two it is. Claiming the daemon is down when all we did
-      // was run out of patience sends the user to `systemctl status` for
-      // nothing — and it was, on a machine where docker was fine.
-      error: inconclusive
-        ? "no answer from docker yet — still trying"
-        : "docker not available (is the daemon running?)",
+      // Say which of the THREE it is. The daemon message must not be shown for a
+      // machine that has no docker at all — that binary-absent case is checked
+      // first, so "is the daemon running?" only ever names a daemon we actually
+      // tried to reach. Then the old split: a refusal is a fact, a timeout is
+      // only us running out of patience (which used to send the user to
+      // `systemctl status` for nothing, on a machine where docker was fine).
+      error: !dockerBin()
+        ? "Docker isn't installed — the docker CLI isn't on your PATH"
+        : inconclusive
+          ? "no answer from docker yet — still trying"
+          : "docker not available (is the daemon running?)",
     };
     // A guess is not worth caching for as long as a fact. Holding an
     // inconclusive verdict for the full window is what kept the error on screen

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -17,7 +17,7 @@ import { inScope } from "./config.ts";
 import { record } from "./gitlog.ts";
 import { currentLabel, resumedAs } from "./loopwatch.ts";
 import { withSpawnSlot } from "./spawnpool.ts";
-import type { GitFileStatus, RepoStatus, CommitResult } from "../../shared/types.ts";
+import type { GitFileStatus, RepoStatus, CommitResult, GitCapability } from "../../shared/types.ts";
 
 export const COMMIT_ENABLED = process.env.AGENTGLASS_COMMIT_DISABLED !== "1";
 
@@ -49,6 +49,59 @@ export async function gitAsync(cwd: string, args: string[]): Promise<GitResult> 
   // Queued behind the process cap — see spawnpool. A sweep of eighteen
   // checkouts is eighteen of these, and several sweeps can overlap.
   return withSpawnSlot(() => runGit(cwd, args));
+}
+
+/**
+ * Is `git` even here?
+ *
+ * The whole file assumes it is, and `Bun.spawn` THROWS on a missing binary
+ * rather than returning exit 127 — so without this probe, a machine with no git
+ * turns every call above into a caught `{ code: 1 }`, and the panels invent a
+ * cause: the repo picker shows an empty "no repos found", and the terminal and
+ * chat reject a perfectly good directory with "invalid or non-repo directory"
+ * (blaming the folder for a tool that isn't installed). This is the same
+ * first-class-state treatment `ghCapability` already gives the PR panel: "git
+ * is not installed" is something the user can act on, not an error to bury.
+ *
+ * `Bun.which` is cached for the process — a binary does not appear mid-session,
+ * and the repo picker asks on every mount.
+ */
+let gitBinCache: string | null | undefined;
+export function gitBin(): string | null {
+  // PATH passed explicitly: bare `Bun.which("git")` resolves against a PATH
+  // captured at process start and ignores later changes to process.env.PATH,
+  // which both hides a genuinely stripped environment and makes this untestable.
+  if (gitBinCache === undefined) gitBinCache = Bun.which("git", { PATH: process.env.PATH ?? "" });
+  return gitBinCache;
+}
+
+let gitCapCache: { at: number; cap: GitCapability } | null = null;
+const GIT_CAP_TTL_MS = 60_000;
+
+export function gitCapability(): GitCapability {
+  if (gitCapCache && Date.now() - gitCapCache.at < GIT_CAP_TTL_MS) return gitCapCache.cap;
+  const bin = gitBin();
+  let cap: GitCapability;
+  if (!bin) {
+    cap = { available: false, reason: "git is not installed — the source-control, terminal and pull-request panels need it" };
+  } else {
+    let version: string | undefined;
+    try {
+      // Not through git()/record(): a capability probe must not land in the git
+      // activity log. `git --version` needs no repo and cannot hang meaningfully.
+      const r = Bun.spawnSync([bin, "--version"], { stdout: "pipe", stderr: "ignore", timeout: 5_000 });
+      version = r.exitCode === 0 ? (r.stdout?.toString().trim().replace(/^git version /, "") || undefined) : undefined;
+    } catch { /* vanished between which and spawn — treat as present, callers still guard */ }
+    cap = { available: true, version };
+  }
+  gitCapCache = { at: Date.now(), cap };
+  return cap;
+}
+
+/** Test seam: forget the probe so a test can flip PATH and re-ask. */
+export function __resetGitCapForTest(): void {
+  gitBinCache = undefined;
+  gitCapCache = null;
 }
 
 /**

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -45,7 +45,7 @@ import { syncTheme, snippetStatus, SNIPPETS } from "./themesync.ts";
 import { completePath, FS_BROWSE_ENABLED } from "./fsbrowse.ts";
 import {
   overview as dockerOverview, stats as dockerStats, logs as dockerLogs, inspect as dockerInspect, top as dockerTop,
-  startContainer, stopContainer, restartContainer, removeContainer,
+  startContainer, stopContainer, restartContainer, removeContainer, dockerCapability,
 } from "./docker.ts";
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
@@ -796,6 +796,12 @@ const server = Bun.serve<WsData>({
     }
 
     // --- live docker panel (lazydocker-style) ---
+    // Is docker even installed, as opposed to the daemon being down? A plain
+    // read like the rest of /docker/*, so the surface-wide origin/rebinding gate
+    // is the whole authorisation story. Lets the panel show install guidance for
+    // a missing binary instead of the overview's daemon message. Mirrors
+    // /git/capability.
+    if (pathname === "/docker/capability") return json(await dockerCapability());
     if (pathname === "/docker/overview") return json(await dockerOverview());
     if (pathname === "/docker/stats") {
       // Sample what the panel is showing. The overview is cached and scoped, so

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1151,6 +1151,42 @@ for (const sig of ["SIGINT", "SIGTERM"] as const) {
   process.on(sig, () => { shutdownTerminals(); process.exit(0); });
 }
 
+// Parent-death watchdog: a server must never outlive whoever launched it.
+//
+// The signal handlers above only cover a clean SIGINT/SIGTERM. They do nothing
+// when the launcher is SIGKILLed or crashes, and there is no launcher-side
+// cleanup at all for `make dev`, the perf/soak scripts, or a server an agent
+// left running inside a worktree that was later deleted (cwd `(deleted)`). The
+// only other thing that stops a sidecar is Electron's in-process stopSidecar
+// handler, which likewise cannot survive its own SIGKILL. The observed result:
+// a dozen servers reparented to init, each holding a port and a fistful of
+// shells, still running ~18h later and saturating the box. This gives the
+// server its own defence — it remembers the pid it was born under and, every
+// few seconds, checks that pid is still both its parent and alive. Reparented
+// to init (ppid 1), handed to a different parent, or the original gone → hang
+// up the shells and exit under its own power, within ~3s of losing its parent.
+//
+// Gated behind a flag the launcher opts into, so a deliberately daemonized
+// `make start` is never self-terminated. Every launcher that expects the
+// server to die with it sets the flag (the electron spawn, the dev script, the
+// perf/soak spawns); the 432-test suite never sets it, so the watchdog stays
+// dormant under `make test` — which is why the interval is not even registered
+// unless the flag is present. `process.ppid === 1` is the robust signal: a
+// crash of an intermediate wrapper (`bun --watch`, `concurrently`) reparents
+// the whole subtree to init, which a bare `!== bornUnder` on a still-live
+// wrapper would miss; `!== bornUnder` in turn catches the immediate parent
+// alone going away and the pid being recycled under a new owner.
+if (process.env.AGENTGLASS_DIE_WITH_PARENT === "1") {
+  const bornUnder = process.ppid;
+  const alive = (pid: number) => { try { process.kill(pid, 0); return true; } catch { return false; } };
+  setInterval(() => {
+    if (process.ppid === 1 || process.ppid !== bornUnder || !alive(bornUnder)) {
+      shutdownTerminals();
+      process.exit(0);
+    }
+  }, 3000).unref?.();
+}
+
 console.log(`🛰  agentglass server on http://${LOOPBACK_ONLY ? "localhost" : BIND}:${server.port}`);
 if (!LOOPBACK_ONLY) {
   const posture = AUTH_TOKEN ? "token-protected" : "UNAUTHENTICATED";

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,7 +26,7 @@ import { getUsage } from "./usage.ts";
 import { submitGate, decideGate, pendingGates, awaitGate, restoreGates, GATE_MAX_MS } from "./gate.ts";
 import { otlpTracesToEvents, otlpLogsToEvents } from "./otlp.ts";
 import { decodeOtlpTraces, decodeOtlpLogs } from "./otlp_pb.ts";
-import { statusForPaths, commit as gitCommit, COMMIT_ENABLED, git } from "./git.ts";
+import { statusForPaths, commit as gitCommit, COMMIT_ENABLED, git, gitCapability } from "./git.ts";
 import {
   workingTree, discoverRepos, stage, unstage, stageAll, unstageAll, discard,
   commitStaged, push as gitPush, pull as gitPull, fetch as gitFetch,
@@ -633,6 +633,9 @@ const server = Bun.serve<WsData>({
     }
 
     // --- live git panel (lazygit-style working tree) ---
+    // Is git even installed? A plain read like the rest of /git/*, so the
+    // surface-wide origin/rebinding gate is the whole authorisation story.
+    if (pathname === "/git/capability") return json(gitCapability());
     if (pathname === "/git/repos") {
       const paths = getChanges(300).map((c) => c.file_path);
       // `all=1` is the project picker: it needs the whole machine even when the
@@ -1175,3 +1178,12 @@ subscribeCi((v) => broadcast({ type: "ci", data: v }));
 // Watch our own event loop. Cheap (one timer, one subtraction) and the only
 // thing that turns "the terminal feels laggy" into a name and a number.
 watchLoop();
+
+// Say it once at boot if git is missing. Every git/diff/PR panel and the
+// terminal need it, and without this the only symptom is empty panels that
+// blame the repo — the log line is where an installer user finds the real
+// cause without opening devtools.
+{
+  const gc = gitCapability();
+  if (!gc.available) console.warn(`⚠  git not found on PATH — the git, diff, pull-request and terminal panels will not work. Install git to enable them.`);
+}

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -20,7 +20,7 @@ import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import type { ServerWebSocket } from "bun";
 import type { ProjectCommand, TerminalCommands } from "../../shared/types.ts";
-import { safeAbs, repoRootOf } from "./git.ts";
+import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
 import { terminalActive } from "./loopwatch.ts";
 import { inScope } from "./config.ts";
 import { SKIP_DIRS } from "./gitwork.ts";
@@ -173,7 +173,14 @@ export function ptyOpen(ws: PtyWs) {
   const d = ws.data as PtyWsData;
   if (!TERMINAL_ENABLED) { ctl(ws, { t: "fatal", error: "terminal is disabled (AGENTGLASS_TERMINAL_DISABLED=1)" }); ws.close(1008, "disabled"); return; }
   const cwd = safeAbs(d.root);
-  if (!cwd || !repoRootOf(cwd)) { ctl(ws, { t: "fatal", error: "invalid or non-repo directory" }); ws.close(1008, "bad root"); return; }
+  if (!cwd || !repoRootOf(cwd)) {
+    // repoRootOf runs `git rev-parse`, so with no git it fails for every path.
+    // Say which — "invalid directory" for a real bad root, but "git is not
+    // installed" when that is the actual cause, or the fix looks unrelated.
+    const cap = gitCapability();
+    ctl(ws, { t: "fatal", error: cap.available ? "invalid or non-repo directory" : (cap.reason || "git is not installed") });
+    ws.close(1008, "bad root"); return;
+  }
   // A shell is the widest capability here — anything it can reach, it can
   // change. An instance opened for one project must not hand one out anywhere
   // else, or "open a project" narrows the view while leaving the blast radius

--- a/server/test/docker-capability.test.ts
+++ b/server/test/docker-capability.test.ts
@@ -1,0 +1,55 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { dockerCapability, dockerBin, __resetDockerCapForTest } from "../src/docker.ts";
+
+/**
+ * Whether docker is on this machine, told apart from "the daemon is down".
+ *
+ * The whole docker panel assumes the CLI exists, and Bun.spawn *throws* on a
+ * missing binary rather than returning 127 — so without dockerBin() the caught
+ * ENOENT stderr masquerades as the daemon answering "no", and the panel blames a
+ * daemon it never contacted. These flip PATH the way git-capability's own test
+ * does, which is exactly what an installer user with no docker hits.
+ */
+const realPath = process.env.PATH;
+
+afterEach(() => {
+  process.env.PATH = realPath;
+  __resetDockerCapForTest();
+});
+
+describe("docker capability", () => {
+  it("reports docker as MISSING when it is not on PATH, and does NOT blame the daemon", async () => {
+    // The installer-user case: docker simply is not installed. Bun.which returns
+    // null against an empty PATH, and the reason must send them to *install*,
+    // never to check a daemon that was never there — that conflation is the bug.
+    process.env.PATH = "";
+    __resetDockerCapForTest();
+    const cap = await dockerCapability();
+    expect(cap.available).toBe(false);
+    expect(cap.version).toBeUndefined();
+    expect(cap.reason && cap.reason.length).toBeGreaterThan(0);
+    expect(cap.reason?.toLowerCase()).not.toContain("daemon");
+    expect(dockerBin()).toBeNull();
+  });
+
+  it("always answers with a shape the client can read", async () => {
+    __resetDockerCapForTest();
+    const cap = await dockerCapability();
+    expect(typeof cap.available).toBe("boolean");
+    if (!cap.available) expect(typeof cap.reason).toBe("string");
+  });
+
+  it("when docker IS installed, available is decided by the binary, not the daemon", async () => {
+    // Conditional on this box actually having docker — unlike git, it may not.
+    // When it does, `available` is true whether or not the daemon answers: the
+    // (b) daemon-down and (c) OK states both mean "installed", and differ only
+    // in version/reason.
+    __resetDockerCapForTest();
+    const bin = dockerBin();
+    if (!bin) return; // no docker here — the MISSING test covers that path
+    const cap = await dockerCapability();
+    expect(cap.available).toBe(true);
+    if (cap.version) expect(cap.reason).toBeUndefined();      // (c) OK
+    else expect(typeof cap.reason).toBe("string");            // (b) daemon down
+  });
+});

--- a/server/test/git-capability.test.ts
+++ b/server/test/git-capability.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it } from "bun:test";
+import { gitCapability, gitBin, __resetGitCapForTest } from "../src/git.ts";
+
+/**
+ * Whether git is on this machine, told apart from "no repos here".
+ *
+ * The whole git/diff/PR/terminal story assumes git exists, and Bun.spawn
+ * *throws* on a missing binary rather than returning 127 — so without this
+ * probe the panels silently blame the repo. These drive both answers by
+ * flipping PATH, which is exactly what an installer user without git hits.
+ */
+const realPath = process.env.PATH;
+
+afterEach(() => {
+  process.env.PATH = realPath;
+  __resetGitCapForTest();
+});
+
+describe("git capability", () => {
+  it("reports git as available on a machine that has it (the CI runner does)", () => {
+    __resetGitCapForTest();
+    const cap = gitCapability();
+    expect(cap.available).toBe(true);
+    // A version string when we could read one; never a reason, since nothing is wrong.
+    expect(cap.reason).toBeUndefined();
+    expect(typeof gitBin()).toBe("string");
+  });
+
+  it("caches within the window, so the repo picker asking on every mount is one probe", () => {
+    __resetGitCapForTest();
+    const a = gitCapability();
+    const b = gitCapability();
+    expect(a).toBe(b); // same object identity — served from cache
+  });
+
+  it("reports git as MISSING when it is not on PATH, with an actionable reason", () => {
+    // The installer-user case: git simply is not installed. Bun.which("git")
+    // returns null against an empty PATH.
+    process.env.PATH = "";
+    __resetGitCapForTest();
+    const cap = gitCapability();
+    expect(cap.available).toBe(false);
+    expect(cap.version).toBeUndefined();
+    expect(cap.reason && cap.reason.length).toBeGreaterThan(0);
+    expect(gitBin()).toBeNull();
+  });
+
+  it("always answers with a shape the client can read", () => {
+    __resetGitCapForTest();
+    const cap = gitCapability();
+    expect(typeof cap.available).toBe("boolean");
+    if (!cap.available) expect(typeof cap.reason).toBe("string");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -787,6 +787,32 @@ export interface DockerOverview {
 }
 export interface DockerActionResult { ok: boolean; error?: string; output?: string; }
 
+/**
+ * Whether docker is usable, told apart into the three states that need three
+ * different answers on screen.
+ *
+ * The overview carries a single `available: false` + `error` for any failure,
+ * which conflated the two that matter: a *missing binary* and a *downed daemon*
+ * are different problems with different fixes ("install Docker" vs "start the
+ * daemon"), and the panel used to send everyone to the daemon message — even on
+ * a machine with no docker at all. This is the docker counterpart to
+ * GitCapability, and `available` here means the same thing it does there: the
+ * CLI is on PATH.
+ *
+ *   (a) not installed → available:false, reason names it (install guidance)
+ *   (b) installed, daemon down → available:true, reason (no version)
+ *   (c) OK → available:true, version (no reason)
+ */
+export interface DockerCapability {
+  /** The `docker` CLI is on this machine. False → not installed at all. */
+  available: boolean;
+  /** The daemon's version, present only when it answered — i.e. state (c). */
+  version?: string;
+  /** Why docker isn't usable: the binary is missing (a), or the daemon isn't
+   *  responding (b). Absent in the healthy case. */
+  reason?: string;
+}
+
 // --- LLM walkthrough (AI-authored review itinerary) --------------------------
 export interface WalkthroughInputFile {
   path: string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -837,6 +837,15 @@ export interface TerminalCommands {
   scripts: ProjectCommand[]; // package.json scripts, runner-aware
 }
 
+/** Whether `git` is on this machine at all. `available: false` is a first-class
+ *  UI state — the git/diff/PR panels and the terminal all need git — not an
+ *  error to bury behind an empty "no repos found". */
+export interface GitCapability {
+  available: boolean;
+  version?: string;
+  reason?: string;
+}
+
 /** One `<<<<<<< / ======= / >>>>>>>` region of a conflicted file. */
 export type ConflictBlock = {
   index: number;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -30,6 +30,7 @@ import { SkillsModal } from "./components/SkillsModal.tsx";
 import { Workspace } from "./components/workspace/Workspace.tsx";
 import { VIEW_IDS, loadViewOrder, loadLastView, type ViewId } from "./components/workspace/views.ts";
 import ServerBanner from "./components/ServerBanner.tsx";
+import GitMissingBanner from "./components/GitMissingBanner.tsx";
 import { chordFromEvent, viewForChord } from "./lib/keybindings.ts";
 import { newChat, chatResuming, applyLiveEvent } from "./lib/chatStore.ts";
 import { sessionCwd } from "./lib/worktree.ts";
@@ -425,6 +426,7 @@ export default function App() {
 
       {/* Above everything, because when it shows, nothing below it is real. */}
       <ServerBanner />
+      <GitMissingBanner />
 
       <Header
         conn={conn}

--- a/web/src/components/CommandBar.tsx
+++ b/web/src/components/CommandBar.tsx
@@ -21,6 +21,7 @@ import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "
 import type { ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
 import { api, IS_DEMO } from "../lib/api.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
+import { keepTermFocus } from "../lib/keepFocus.ts";
 
 /**
  * The four git one-liners this row used to hardcode as always-visible chips.
@@ -205,11 +206,19 @@ function CommandRow({ c, font, on, full, onRun, onPin }: {
  * `font` is the terminal's own face: a command is a thing you type, and it
  * reads as one when it is set in the face it will be typed in.
  */
-export function CommandBar({ root, disabled, font, onRun, dropUp }: {
+export function CommandBar({ root, disabled, font, onRun, onClose, dropUp }: {
   root: string;
   disabled: boolean;
   font: string;
   onRun: (cmd: string) => void;
+  /** Put the cursor back where it belongs once the dropdown closes.
+   *
+   *  The filter input has to take focus off the terminal while it is open (you
+   *  came here to type in it), so closing it — by Escape, an outside click, or
+   *  the toggle — has to hand the focus back, or the shell sits there ignoring
+   *  keys until you click into it again. Running a command already refocuses
+   *  through `onRun`; this covers every other way out. */
+  onClose?: () => void;
   /** Open upwards — for the console strip, which sits at the bottom of a panel
    *  and has nothing below it to open into. */
   dropUp?: boolean;
@@ -219,10 +228,13 @@ export function CommandBar({ root, disabled, font, onRun, dropUp }: {
   const wrap = useRef<HTMLDivElement>(null);
   const cmds = useCommands(root);
   const pins = usePins(root);
-  useDismiss(open, wrap, () => { setOpen(false); setQuery(""); });
+  const dismiss = useCallback(() => { setOpen(false); setQuery(""); onClose?.(); }, [onClose]);
+  useDismiss(open, wrap, dismiss);
 
   const n = (cmds?.make.length ?? 0) + (cmds?.scripts.length ?? 0);
   const full = pins.length >= MAX_PINS;
+  // Selecting a command hands focus back through onRun (it types into the
+  // shell), so it closes without going through `dismiss`'s own refocus.
   const run = (cmd: string) => { setOpen(false); setQuery(""); onRun(cmd); };
   const pin = (cmd: string) => { togglePin(root, cmd); };
 
@@ -236,14 +248,22 @@ export function CommandBar({ root, disabled, font, onRun, dropUp }: {
   return (
     <>
       <div className="relative shrink-0" ref={wrap}>
-        <button onClick={() => setOpen((o) => !o)} disabled={!root || IS_DEMO}
+        {/* onMouseDown keeps the shell's cursor: the trigger is a button, and a
+            press on it would otherwise blur the terminal. Opening reveals the
+            filter input, which autofocuses on its own; closing routes through
+            `dismiss` so the focus goes back to the shell rather than nowhere. */}
+        <button onMouseDown={keepTermFocus} onClick={() => (open ? dismiss() : setOpen(true))} disabled={!root || IS_DEMO}
           title="Ready-to-run project commands: Makefile targets & package scripts, with what each one does. Pin the ones you use."
           className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg font-medium whitespace-nowrap"
           style={{ color: n ? "var(--primary-hover)" : "var(--text2)", background: "color-mix(in srgb, var(--primary) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)", opacity: root && !IS_DEMO ? 1 : 0.5 }}>
           ⚙ commands{n ? ` (${n})` : cmds ? " (none)" : " …"}<span className="t-dim2">▼</span>
         </button>
         {open && (
-          <div className="absolute left-0 rounded-lg text-[11px] shadow-2xl flex flex-col"
+          // keepTermFocus on the whole popover: a click on its padding, a
+          // border, or a command row must not blur the filter input (it stays
+          // yours to type in while the menu is open). The input itself is
+          // excluded by the handler, so it can still be clicked into.
+          <div onMouseDown={keepTermFocus} className="absolute left-0 rounded-lg text-[11px] shadow-2xl flex flex-col"
             style={{ zIndex: 40, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", width: 460, maxHeight: 420, overflow: "hidden", ...(dropUp ? { bottom: "calc(100% + 4px)" } : { top: "calc(100% + 4px)" }) }}>
             {/* A real project has more targets than fit on a screen — the repo
                 this was built against has 316 — so scrolling to find `migrate`
@@ -283,20 +303,25 @@ export function CommandBar({ root, disabled, font, onRun, dropUp }: {
       <div className="flex items-center gap-1 min-w-0 overflow-x-auto agx-scroll">
         {pins.map((cmd) => (
           <span key={cmd} className="group relative flex items-center shrink-0">
-            <button onClick={() => onRun(cmd)} disabled={disabled || !root || IS_DEMO}
+            {/* onMouseDown keeps the shell focused; running the chip refocuses
+                it anyway through onRun, but unpinning does not, so both carry
+                the guard rather than only one. */}
+            <button onMouseDown={keepTermFocus} onClick={() => onRun(cmd)} disabled={disabled || !root || IS_DEMO}
               className="text-[10px] pl-2 pr-2 py-1 rounded-md whitespace-nowrap"
               style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", fontFamily: font }}
               title={`run ${cmd}`}>{cmd}</button>
             {/* Unpin from the chip itself: going back to the dropdown to find
                 the row you pinned is the long way round. */}
-            <button onClick={() => togglePin(root, cmd)}
+            <button onMouseDown={keepTermFocus} onClick={() => togglePin(root, cmd)}
               className="absolute -top-1 -right-1 text-[9px] leading-none rounded-full px-[3px] py-[1px] opacity-0 group-hover:opacity-100"
               style={{ background: "var(--bg3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}
               title={`unpin ${cmd}`}>✕</button>
           </span>
         ))}
         {!pins.length && !!root && (
-          <button onClick={() => setOpen(true)} className="text-[10px] px-2 py-1 rounded-md whitespace-nowrap shrink-0"
+          // Opens the dropdown (whose input then autofocuses), so it must not
+          // steal the shell's cursor on the way there — see the trigger above.
+          <button onMouseDown={keepTermFocus} onClick={() => setOpen(true)} className="text-[10px] px-2 py-1 rounded-md whitespace-nowrap shrink-0"
             style={{ color: "var(--text3)", border: "1px dashed color-mix(in srgb, var(--border) 30%, transparent)" }}
             title={`Pin up to ${MAX_PINS} commands here — they stay one click away, per repo`}>☆ pin a command</button>
         )}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -3,7 +3,7 @@
 // stop/restart/rm actions. Images / volumes / networks get their own tabs.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
-import type { DockerOverview, DockerContainer, DockerStat } from "../../../shared/types.ts";
+import type { DockerOverview, DockerContainer, DockerStat, DockerCapability } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
@@ -246,6 +246,32 @@ function DetailPane({ tab, env, config, top, error }: {
   );
 }
 
+/**
+ * The binary-missing empty state: install guidance, not the daemon message.
+ *
+ * The overview reports `available:false` for BOTH a downed daemon and a docker
+ * that was never installed, and those two need different words because they need
+ * different fixes — "start Docker" versus "install it". When dockerCapability()
+ * says the CLI is absent we render this in place of the daemon error; it is the
+ * docker sibling of GitMissingBanner.
+ */
+function DockerMissing({ reason }: { reason?: string }) {
+  return (
+    <div className="flex-1 grid place-items-center px-6 text-center">
+      <div className="max-w-md flex flex-col items-center gap-2">
+        <span className="text-[13px] font-semibold" style={{ color: "var(--warning)" }}>Docker isn't installed</span>
+        <span className="text-[11.5px]" style={{ color: "var(--text2)" }}>
+          {reason || "the docker CLI isn't on your PATH"}. Containers, images, volumes and logs stay empty until it is.
+        </span>
+        <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>
+          Get it from <code>docker.com/get-started</code> (Docker Desktop), or your package manager:{" "}
+          <code>apt install docker.io</code>, <code>brew install docker</code> — then reopen.
+        </span>
+      </div>
+    </div>
+  );
+}
+
 export function DockerView({ active }: { active: boolean }) {
   // A shell docked under the logs, for the `make migrate` you always end up
   // needing while watching a container. Its height is remembered and it is
@@ -259,6 +285,11 @@ export function DockerView({ active }: { active: boolean }) {
   });
   useEffect(() => { try { localStorage.setItem(CONSOLE_KEY, String(consoleH)); } catch { /* non-fatal */ } }, [consoleH]);
   const [ov, setOv] = useState<DockerOverview | null>(null);
+  // Installed vs daemon-down. Only consulted for the missing-binary case, which
+  // is stable for the session — the daemon's own up/down still rides on the
+  // overview's error. Lets the empty state offer install guidance instead of
+  // sending someone to check a daemon they never had.
+  const [cap, setCap] = useState<DockerCapability | null>(null);
   const [stats, setStats] = useState<Record<string, DockerStat>>({});
   const [view, setView] = useState<View>("containers");
   const [openSections, setOpenSections] = useState<Record<View, boolean>>(() => {
@@ -337,6 +368,16 @@ export function DockerView({ active }: { active: boolean }) {
     requestAnimationFrame(() => frameRef.current?.focus());
     return () => clearInterval(t);
   }, [active, loadOverview]);
+
+  // Is docker even installed? Asked once per activation, not on the 5s poll —
+  // a binary doesn't come and go mid-session, and all we take from it is the
+  // absent-CLI verdict that swaps the daemon message for install guidance.
+  useEffect(() => {
+    if (!active) return;
+    let live = true;
+    api.dockerCapability().then((c) => { if (live) setCap(c); }).catch(() => { /* origin gate / offline — the overview's error still shows */ });
+    return () => { live = false; };
+  }, [active]);
 
   // stats: only poll the (slow) `docker stats` sample while viewing containers.
   useEffect(() => {
@@ -490,7 +531,14 @@ export function DockerView({ active }: { active: boolean }) {
                 </div>
 
                 {!ov?.available ? (
-                  <div className="flex-1 grid place-items-center t-dim2 text-[12px] px-6 text-center">{ov?.error || "connecting to docker…"}</div>
+                  // A missing binary and a downed daemon both land here; the
+                  // capability tells them apart so the former gets install
+                  // guidance rather than "is the daemon running?".
+                  cap && !cap.available ? (
+                    <DockerMissing reason={cap.reason} />
+                  ) : (
+                    <div className="flex-1 grid place-items-center t-dim2 text-[12px] px-6 text-center">{ov?.error || "connecting to docker…"}</div>
+                  )
                 ) : (
                   <div className="flex-1 min-h-0 flex">
                     {/* Everything at once down the left, the way lazydocker

--- a/web/src/components/GitMissingBanner.tsx
+++ b/web/src/components/GitMissingBanner.tsx
@@ -1,0 +1,50 @@
+// Says out loud when the reason the panels are empty is that git isn't here.
+//
+// git is the one external tool the workspace was built assuming — the source
+// control, diff and pull-request panels all shell out to it, and the terminal
+// validates its working directory with `git rev-parse`. When it is missing,
+// `Bun.spawn` throws, the server catches it, and the symptom is the same blank
+// screen a broken origin gives: empty panels, "no repos found", no error. This
+// is the git counterpart to ServerBanner, and to the in-panel guidance the PR
+// panel already shows for a missing `gh`.
+//
+// Asked once. A binary does not get installed mid-session, and unlike the
+// server-origin check there is nothing to poll back to health.
+import { useEffect, useState } from "react";
+import { api, IS_DEMO } from "../lib/api.ts";
+import type { GitCapability } from "../../../shared/types.ts";
+
+export default function GitMissingBanner() {
+  const [cap, setCap] = useState<GitCapability | null>(null);
+
+  useEffect(() => {
+    if (IS_DEMO) return;
+    let live = true;
+    api.gitCapability().then((c) => { if (live) setCap(c); }).catch(() => { /* origin gate, offline — ServerBanner owns that story */ });
+    return () => { live = false; };
+  }, []);
+
+  if (!cap || cap.available) return null;
+
+  return (
+    <div
+      role="alert"
+      className="shrink-0 px-4 py-2 text-[11px] flex items-center gap-2 flex-wrap border-b"
+      style={{
+        background: "color-mix(in srgb, var(--warning) 12%, transparent)",
+        borderColor: "color-mix(in srgb, var(--warning) 30%, transparent)",
+        color: "var(--text)",
+      }}
+    >
+      <span className="font-semibold" style={{ color: "var(--warning)" }}>git not found</span>
+      <span>
+        {cap.reason || "git is not installed"}. The source-control, diff and pull-request panels stay empty, and the
+        terminal cannot open, until it is on your <code>PATH</code>.
+      </span>
+      <span style={{ color: "var(--text3)" }}>
+        Install it from <code>git-scm.com/downloads</code> (or your package manager: <code>apt install git</code>,{" "}
+        <code>brew install git</code>), then reopen.
+      </span>
+    </div>
+  );
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -318,6 +318,13 @@ function AboutPane({ open }: { open: boolean }) {
               ))}
             </div>
             {err && <div className="text-[10.5px]" style={{ color: "var(--error)" }}>{err}</div>}
+            {/* The install compiles the release on this machine, so the
+                toolchain has to be here before it starts — said up front
+                rather than left to fail the build and report it in the panel
+                above, after the app has already gone down to restart. */}
+            <div className="text-[10.5px] px-2.5 py-1.5 rounded-lg" style={{ color: "var(--text2)", background: "color-mix(in srgb, var(--warning) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)" }}>
+              Built on your machine from source — needs <span style={{ color: "var(--warning)" }}>git</span> and <span style={{ color: "var(--warning)" }}>bun</span> installed, and is Linux-only for now.
+            </div>
             <div className="flex items-center gap-2">
               <button onClick={run} disabled={busy}
                 className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
@@ -334,7 +341,7 @@ function AboutPane({ open }: { open: boolean }) {
               </button>
             </div>
             <span className="text-[9.5px] t-dim2">
-              Builds the tagged release in its own clone under ~/.cache, then reinstalls and restarts. Your working checkout is never touched, and only published tags are ever offered — commits pushed after a tag stay out until you tag them.
+              Compiles the tagged release in its own clone under ~/.cache, then reinstalls and restarts. Your working checkout is never touched, and only published tags are ever offered — commits pushed after a tag stay out until you tag them.
             </span>
           </>
         )}

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -6,6 +6,7 @@
 // running job — reopening reattaches to the live session, scrollback intact.
 import { Fragment, useCallback, useEffect, useReducer, useRef, useState } from "react";
 import { useDismiss } from "../lib/useDismiss.ts";
+import { keepTermFocus } from "../lib/keepFocus.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
@@ -551,7 +552,15 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
   const [repoOpen, setRepoOpen] = useState(false);
   const [repoQuery, setRepoQuery] = useState("");
   const pickerRef = useRef<HTMLDivElement>(null);
-  useDismiss(repoOpen, pickerRef, () => { setRepoOpen(false); setRepoQuery(""); });
+  /** Put the cursor back in the console after a menu that had to borrow the
+   *  focus (the repo filter, the commands filter) closes again. Deferred a
+   *  frame so it lands after the menu's own input has finished unmounting —
+   *  otherwise the browser moves focus to <body> right after we set it. */
+  const focusConsole = useCallback(() => {
+    const s = sessions.get(sid);
+    if (s) requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
+  }, [sid]);
+  useDismiss(repoOpen, pickerRef, () => { setRepoOpen(false); setRepoQuery(""); focusConsole(); });
   // On demand: the Docker panel mounts this strip on every open, and most opens
   // never touch the picker.
   useEffect(() => {
@@ -562,6 +571,7 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
     setPicked(next);
     try { localStorage.setItem(CONSOLE_ROOT_KEY, next); } catch { /* private mode — lasts the session */ }
     setRepoOpen(false); setRepoQuery("");
+    focusConsole();
   };
   const runHere = useCallback((cmd: string) => {
     const s = sessions.get(sid);
@@ -649,7 +659,10 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
             the one the terminal view happens to be sitting in — so it picks its
             own, and remembers it. */}
         <div className="relative shrink-0" ref={pickerRef} onMouseDown={(e) => e.stopPropagation()}>
-          <button onClick={() => setRepoOpen((o) => !o)} disabled={IS_DEMO}
+          {/* keepTermFocus so opening the picker does not blur the console; the
+              filter input inside autofocuses on its own, and closing hands the
+              cursor back (see chooseRepo / the useDismiss above). */}
+          <button onMouseDown={keepTermFocus} onClick={() => setRepoOpen((o) => !o)} disabled={IS_DEMO}
             className="flex items-center gap-1.5 text-[10px] px-2 py-0.5 rounded-md max-w-[200px]"
             style={{ background: "color-mix(in srgb, var(--bg3) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
             title={root || "no repo"}>
@@ -687,7 +700,7 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
             component, so the two shells cannot drift apart again. Opens upward:
             there is nothing below this strip to open into. */}
         <div className="flex items-center gap-2 min-w-0" onMouseDown={(e) => e.stopPropagation()}>
-          <CommandBar root={root} disabled={!sid} font={TERM_FONT} onRun={runHere} dropUp />
+          <CommandBar root={root} disabled={!sid} font={TERM_FONT} onRun={runHere} onClose={focusConsole} dropUp />
         </div>
 
         <span className="ml-auto text-[9px] t-dim2 shrink-0">drag to resize</span>
@@ -713,8 +726,6 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const containerRef = useRef<HTMLDivElement>(null);
   const [, force] = useReducer((x: number) => x + 1, 0);
 
-  useDismiss(repoOpen, pickersRef, () => setRepoOpen(false));
-
   useEffect(() => {
     if (!open) return;
     api.gitRepos().then(({ repos }) => {
@@ -739,6 +750,20 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const [paneIds, setPaneIds] = useState<string[]>([]);
   const [focusIdx, setFocusIdx] = useState(0);
   const paneRefs = useRef<(HTMLDivElement | null)[]>([]);
+
+  /** Put the cursor back in the pane you were in. Called when a menu that had
+   *  to borrow the focus for its own input — the repo filter, the commands
+   *  filter, a window rename — closes again: the terminal is where typing
+   *  should resume. Deferred a frame so it lands after the menu's input has
+   *  unmounted, or the browser moves focus to <body> straight after we set it. */
+  const focusTerm = useCallback(() => {
+    const s = sessions.get(paneIds[focusIdx] ?? "");
+    if (s) requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
+  }, [paneIds, focusIdx]);
+  // The repo picker's filter takes focus off the shell while it is open, so
+  // dismissing it (Escape, an outside click) has to give the shell its cursor
+  // back — see focusTerm.
+  useDismiss(repoOpen, pickersRef, () => { setRepoOpen(false); focusTerm(); });
 
   const tabs = !IS_DEMO && root ? sessionsFor(root) : [];
 
@@ -974,9 +999,13 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                 {/* header: repo picker + command launcher + actions */}
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
                   <span className={viewTitleClass} style={{ color: "var(--text)" }}>Terminal</span>
-                  <div ref={pickersRef} className="flex items-center gap-3">
+                  {/* keepTermFocus on the picker group so pressing the trigger
+                      or a repo row never blurs the shell; the filter input is
+                      excluded by the handler and still takes focus, and every
+                      way out of the menu below hands the cursor back. */}
+                  <div ref={pickersRef} className="flex items-center gap-3" onMouseDown={keepTermFocus}>
                   <div className="relative">
-                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
+                    <button onClick={() => { if (repoOpen) { setRepoOpen(false); focusTerm(); } else setRepoOpen(true); }} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
                       <span className="font-medium">{repoRef ? repoName(repoRef.root) : "pick a repo"}</span><span className="t-dim2">▼</span>
                     </button>
                     {repoOpen && (
@@ -995,7 +1024,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                           {repos.filter((r) => { const q = repoQuery.trim().toLowerCase(); return !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q); }).map((r) => {
                             const live = sessionsFor(r.root).some((s) => s.status === "live");
                             return (
-                              <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); setRepoQuery(""); }} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2" style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
+                              <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); setRepoQuery(""); focusTerm(); }} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2" style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
                                 {/* Indented under its project — a shell in a
                                     worktree is a shell in that branch, not in
                                     some unrelated repo that looks similar. */}
@@ -1047,9 +1076,12 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       mounts, so the two shells offer the same thing. Its own
                       dropdown state lives inside it, which is why it sits
                       outside the pickers group above. */}
-                  <CommandBar root={root} disabled={disabled} font={TERM_FONT} onRun={run} />
+                  <CommandBar root={root} disabled={disabled} font={TERM_FONT} onRun={run} onClose={focusTerm} />
 
-                  <div className="ml-auto flex items-center gap-1.5 shrink-0">
+                  {/* keepTermFocus so none of these buttons — split, restart,
+                      clear, the status pill — steals the shell's cursor on
+                      press; they act and the terminal keeps the keyboard. */}
+                  <div className="ml-auto flex items-center gap-1.5 shrink-0" onMouseDown={keepTermFocus}>
                     <span onClick={status === "unauthorized" ? reauthPrompt : undefined}
                       className={`flex items-center gap-1.5 text-[10px] t-dim2 mr-1 ${status === "unauthorized" ? "cursor-pointer" : ""}`}
                       title={status === "unauthorized" ? "this server needs an access token — click to enter it" : "shell status"}>
@@ -1061,9 +1093,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   </div>
                 </div>
 
-                {/* shells open in this repo — scrolls, so the count can grow */}
+                {/* shells open in this repo — scrolls, so the count can grow.
+                    keepTermFocus on the strip so switching, closing or adding a
+                    shell by click doesn't blur the terminal underneath. */}
                 {!IS_DEMO && !disabled && !tmuxActive && (
-                  <div className="shrink-0 flex items-center gap-1 px-3 py-1 border-b overflow-x-auto agw-noscrollbar" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                  <div onMouseDown={keepTermFocus} className="shrink-0 flex items-center gap-1 px-3 py-1 border-b overflow-x-auto agw-noscrollbar" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
                     {tabs.map((t) => {
                       const shown = paneIds.includes(t.id);
                       const focused = t.id === paneIds[focusIdx];
@@ -1090,7 +1124,12 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                     user's side this is the same control, and which program is
                     behind it should not change how the workspace looks. */}
                 {tmuxActive && tmuxWindows.length > 0 && (
-                  <div className="shrink-0 flex items-center gap-1 px-3 py-1 border-b overflow-x-auto agw-noscrollbar" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                  // keepTermFocus so switching tmux windows by click (and the +,
+                  // kill, hide-bar buttons) never blurs the pane — tmux keeps
+                  // owning the keyboard the instant the tab changes. The rename
+                  // input is excluded by the handler, so it can still be typed
+                  // in; it hands focus back on close (see below).
+                  <div onMouseDown={keepTermFocus} className="shrink-0 flex items-center gap-1 px-3 py-1 border-b overflow-x-auto agw-noscrollbar" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
                     <span
                       title={prefixLive ? "tmux is waiting for the rest of the sequence" : `tmux prefix: ${(sess?.tmuxPrefix ?? []).join(" or ") || "unknown"}`}
                       className="shrink-0 px-1.5 py-1 rounded-md text-[10px] font-semibold tabular-nums transition-colors duration-75"
@@ -1141,11 +1180,16 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                               onClick={(e) => e.stopPropagation()}
                               onBlur={() => setRenaming(null)}
                               onKeyDown={(e) => {
-                                if (e.key === "Escape") { setRenaming(null); return; }
+                                // Escape and Enter close the rename box on
+                                // purpose, so both hand the keyboard back to the
+                                // pane rather than leaving it on the vanishing
+                                // input.
+                                if (e.key === "Escape") { setRenaming(null); focusTerm(); return; }
                                 if (e.key !== "Enter") return;
                                 const name = (e.target as HTMLInputElement).value.trim();
                                 if (name && name !== w.name) tmuxCmd("rename", { window: w.id, name });
                                 setRenaming(null);
+                                focusTerm();
                               }}
                               className="bg-transparent outline-none w-20 text-[10.5px]"
                               style={{ color: "var(--text)", borderBottom: "1px solid color-mix(in srgb, var(--primary) 60%, transparent)" }}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -240,6 +240,7 @@ const realApi = {
   /** Subdirectories matching a half-typed path — the picker's completion. */
   fsComplete: (prefix: string) => get<FsCompletion>(`/fs/complete?prefix=${encodeURIComponent(prefix)}`),
   // --- live git panel (lazygit-style) ---
+  gitCapability: () => get<GitCapability>("/git/capability"),
   gitRepos: () => get<{ repos: GitRepoRef[] }>("/git/repos"),
   /** Every repo on the machine — for the project picker, even when scoped. */
   gitReposAll: () => get<{ repos: GitRepoRef[] }>("/git/repos?all=1"),
@@ -446,6 +447,7 @@ const demoApi: typeof realApi = {
   setWorkspace: (_root: string | null) => D({ ok: false, workspace: null, persisted: false, error: "unavailable in the demo" }),
   // The demo has no filesystem to browse, so completion is simply always empty.
   fsComplete: (_prefix: string) => D({ base: "", entries: [], truncated: false }),
+  gitCapability: () => D({ available: true } as GitCapability),
   gitRepos: () => D(demo.gitRepos()),
   gitReposAll: () => D(demo.gitRepos()),
   gitTree: (root: string) => D(demo.gitTree(root)),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -324,6 +324,9 @@ const realApi = {
   gitUndoMerge: (root: string) => post<GitActionResult>("/git/undo-merge", { root }),
   gitMergeContinue: (root: string) => post<GitActionResult>("/git/merge-continue", { root }),
   // --- live docker panel (lazydocker-style) ---
+  /** Installed / daemon-down / OK — so the panel can show install guidance for a
+   *  missing binary instead of the overview's daemon message. Mirrors gitCapability. */
+  dockerCapability: () => get<DockerCapability>("/docker/capability"),
   dockerOverview: () => get<DockerOverview>("/docker/overview"),
   dockerStats: () => get<{ stats: DockerStat[] }>("/docker/stats"),
   dockerLogs: (id: string, tail = 400) => get<{ ok: boolean; text: string; error?: string }>(`/docker/logs?id=${encodeURIComponent(id)}&tail=${tail}`),
@@ -504,6 +507,7 @@ const demoApi: typeof realApi = {
   gitWorktreeLeftovers: (_root: string, _paths: string[]) => D({ leftovers: [] as WorktreeLeftovers[] }),
   gitWorktreeRescue: (_root: string, _path: string, _paths: string[]) => D(demo.gitActionUnavailable()),
   gitWorktreeChown: (_root: string, _path: string) => D(demo.gitActionUnavailable()),
+  dockerCapability: () => D({ available: true, version: "27.0.3" } as DockerCapability),
   dockerOverview: () => D(demo.dockerOverview()),
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),

--- a/web/src/lib/keepFocus.ts
+++ b/web/src/lib/keepFocus.ts
@@ -1,0 +1,22 @@
+import type { MouseEvent } from "react";
+
+/**
+ * Keep the terminal focused when the panel's own chrome is clicked.
+ *
+ * A mousedown on a button, a tab or a menu's own padding blurs whatever held
+ * focus — here the xterm textarea — and nothing puts it back, so the next
+ * keystroke lands nowhere until you click into the terminal a second time. It
+ * is the same annoyance a text editor's toolbar has, and the same fix:
+ * preventDefault on the *mousedown* stops the browser moving focus, while the
+ * click still fires, so the button does its job and the shell keeps the cursor.
+ *
+ * The one thing it must not swallow is a real text field — the rename box, a
+ * filter input — which is asking for the focus on purpose. Those are left
+ * alone so they can be clicked into and their cursor placed; when they close
+ * again the caller hands the focus back to the terminal itself.
+ */
+export function keepTermFocus(e: MouseEvent) {
+  const t = e.target as HTMLElement;
+  if (t.closest("input, textarea, select, [contenteditable='true']")) return;
+  e.preventDefault();
+}


### PR DESCRIPTION
## What does this PR do?

Split 1/4 of #209. First-run robustness: provenance stamped into CI installers so downloaded updates work at all, missing-git detection, git+bun+Linux requirements flagged before the build, docker "not installed" told apart from "daemon down", terminal focus kept on a panel-chrome click, and a parent-death watchdog so a server never outlives its launcher (orphan-sidecar P0).

## How was it tested?

`bun test` (server) and `cd web && bun test`, `bunx tsc --noEmit`, and `make smoke` (headless mount of all six views). New tests cover git-missing and docker capability states.