### PR TITLE
fix(gitwork): resolveBlocks no longer injects blank lines at conflict boundaries

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -2478,9 +2478,13 @@ const C_END = /^>>>>>>> ?(.*)$/;
  * shown, whereas patching the original by line number can if anything touched
  * the file in between.
  */
-function splitConflicts(text: string): { segments: (string | ConflictBlock)[]; blocks: ConflictBlock[] } {
+function splitConflicts(text: string): { segments: (string[] | ConflictBlock)[]; blocks: ConflictBlock[] } {
   const lines = text.split("\n");
-  const segments: (string | ConflictBlock)[] = [];
+  // Plain runs are kept as line arrays, not joined strings: an empty run (a
+  // conflict at the very start or end of the file, or two adjacent conflicts)
+  // must contribute zero lines on reassembly. Joining "" with "\n" instead
+  // injected a spurious blank line and silently corrupted the staged file.
+  const segments: (string[] | ConflictBlock)[] = [];
   const blocks: ConflictBlock[] = [];
   let plain: string[] = [];
 
@@ -2522,12 +2526,12 @@ function splitConflicts(text: string): { segments: (string | ConflictBlock)[]; b
       ...(base ? { base } : {}),
       ourLabel: m[1] || "ours", theirLabel: theirLabel || "theirs",
     };
-    segments.push(plain.join("\n"));
+    segments.push(plain);
     plain = [];
     segments.push(block);
     blocks.push(block);
   }
-  segments.push(plain.join("\n"));
+  segments.push(plain);
   return { segments, blocks };
 }
 
@@ -2574,15 +2578,22 @@ export function resolveBlocks(rootIn: unknown, relIn: unknown, choicesIn: unknow
   }
   if (!blocks.length) return { ok: false, error: "no conflicts left in that file" };
 
-  const out = segments.map((seg) => {
-    if (typeof seg === "string") return seg;
+  // Reassemble by flattening line arrays, not by joining segment strings: the
+  // markers occupied whole lines, so a resolved block simply substitutes its
+  // chosen lines for the marker region. An empty plain run adds no line and so
+  // no newline — which is exactly what a boundary conflict needs.
+  const outLines: string[] = [];
+  for (const seg of segments) {
+    if (Array.isArray(seg)) { outLines.push(...seg); continue; }
     const c = choices[seg.index]!;
-    const lines = c === "ours" ? seg.ours
+    outLines.push(...(
+      c === "ours" ? seg.ours
       : c === "theirs" ? seg.theirs
       : c === "both" ? [...seg.ours, ...seg.theirs]
-      : [...seg.theirs, ...seg.ours];
-    return lines.join("\n");
-  }).join("\n");
+      : [...seg.theirs, ...seg.ours]
+    ));
+  }
+  const out = outLines.join("\n");
 
   try { writeFileSync(abs, out); } catch { return { ok: false, error: "cannot write that file" }; }
   return run(root, ["add", "--", rels[0]!]);

--- a/server/test/conflict-blocks.test.ts
+++ b/server/test/conflict-blocks.test.ts
@@ -133,6 +133,30 @@ describe("conflict blocks", () => {
     expect(r.error).toContain("binary");
   });
 
+  // The reassembly bug: an empty plain run at a file boundary or between two
+  // adjacent conflicts used to be joined with "\n" and inject a blank line into
+  // the staged file — a silent drift from what the user resolved.
+  it("does not add a blank line for a conflict at the very start of the file", () => {
+    write(["<<<<<<< HEAD", "mine", "=======", "yours", ">>>>>>> feature", "after"].join("\n"));
+    expect(resolveBlocks(dir, "a.txt", ["ours"]).ok).toBe(true);
+    expect(read()).toBe(["mine", "after"].join("\n")); // no leading blank
+  });
+
+  it("does not add a blank line for a conflict at the very end of the file", () => {
+    write(["before", "<<<<<<< HEAD", "mine", "=======", "yours", ">>>>>>> feature"].join("\n"));
+    expect(resolveBlocks(dir, "a.txt", ["theirs"]).ok).toBe(true);
+    expect(read()).toBe(["before", "yours"].join("\n")); // no trailing blank
+  });
+
+  it("does not add a blank line between two adjacent conflicts", () => {
+    write([
+      "<<<<<<< HEAD", "a1", "=======", "b1", ">>>>>>> feature",
+      "<<<<<<< HEAD", "a2", "=======", "b2", ">>>>>>> feature",
+    ].join("\n"));
+    expect(resolveBlocks(dir, "a.txt", ["ours", "theirs"]).ok).toBe(true);
+    expect(read()).toBe(["a1", "b2"].join("\n")); // no blank at start or between
+  });
+
   it("survives a real merge conflict end to end", () => {
     writeFileSync(join(dir, "a.txt"), "one\ntwo\nthree\n");
     git("add", "-A"); git("commit", "-qm", "base");


### PR DESCRIPTION
## What does this PR do?

Audit HIGH (correctness) in `gitwork.ts`. splitConflicts stored each plain run as a joined string, so an empty run (a conflict at the very start or end of a file, or two adjacent conflicts) became "", and resolveBlocks reassembled with a "\n" join that injected a spurious blank line — silently corrupting the resolved file it staged. Fix: keep plain runs as line arrays and reassemble by flattening lines; an empty run adds no line and no newline.

## How was it tested?

`bun test` (server, 472 pass) and `bunx tsc --noEmit`. New tests cover a conflict at the start, at the end, and two adjacent conflicts.