### PR TITLE
fix(gitwork): reject prunable worktrees in the pkexec ownership gate (priv-esc)

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1532,7 +1532,7 @@ function parseWorktreeList(stdout: string, root: string): GitWorktree[] {
   const out: GitWorktree[] = [];
   let cur: Partial<GitWorktree> | null = null;
   const flush = () => {
-    if (cur && cur.path) out.push({ path: cur.path, branch: cur.branch || "(detached)", head: cur.head || "", current: cur.path === root, bare: !!cur.bare, locked: !!cur.locked });
+    if (cur && cur.path) out.push({ path: cur.path, branch: cur.branch || "(detached)", head: cur.head || "", current: cur.path === root, bare: !!cur.bare, locked: !!cur.locked, prunable: !!cur.prunable });
     cur = null;
   };
   for (const line of stdout.split("\n")) {
@@ -1544,6 +1544,9 @@ function parseWorktreeList(stdout: string, root: string): GitWorktree[] {
     else if (line === "bare") cur.bare = true;
     else if (line === "detached") cur.branch = "(detached)";
     else if (line.startsWith("locked")) cur.locked = true;
+    // A gitdir that points nowhere valid — including one an attacker fabricated
+    // to name an arbitrary path. Captured so privileged callers can refuse it.
+    else if (line.startsWith("prunable")) cur.prunable = true;
   }
   flush();
   return out;
@@ -2117,7 +2120,13 @@ export function fixWorktreeOwnership(rootIn: string, pathIn: unknown): GitAction
   const abs = safeAbs(pathIn); if (!abs) return { ok: false, error: "invalid path" };
   // Only a path git itself vouches for, and never the checkout we are in.
   if (abs === root) return { ok: false, error: "that is the main checkout" };
-  if (!worktreeList(root).some((w) => w.path === abs)) return { ok: false, error: "not a worktree of this repository" };
+  // Must be a *live* worktree, not a prunable one: a prunable entry is a broken
+  // registration whose gitdir points nowhere valid, and an attacker with write
+  // access to the repo can fabricate one aimed at an arbitrary root-owned path.
+  // Trusting it here would point `pkexec chown -R` at that path — a privilege
+  // escalation. `git worktree list` flags such entries prunable, so we require a
+  // non-prunable match before handing the path to root.
+  if (!worktreeList(root).some((w) => w.path === abs && !w.prunable)) return { ok: false, error: "not a worktree of this repository" };
   if (!foreignOwned(abs)) return { ok: true, output: "already yours" };
 
   const uid = typeof process.getuid === "function" ? process.getuid() : -1;

--- a/server/test/worktree-ownership.test.ts
+++ b/server/test/worktree-ownership.test.ts
@@ -1,0 +1,62 @@
+// fixWorktreeOwnership hands a path to `pkexec chown -R`, so the gate that
+// decides "this is really a worktree of this repo" is the only thing standing
+// between a local user and chowning an arbitrary root-owned directory to
+// themselves. A prunable entry — a broken registration whose gitdir points
+// nowhere valid — can be fabricated by anyone with write access to the repo to
+// name any path, so it must not count as a real worktree here.
+import { describe, expect, it, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { fixWorktreeOwnership } from "../src/gitwork.ts";
+
+let dir = "";
+const git = (...a: string[]) => spawnSync("git", ["-C", dir, ...a], { encoding: "utf8" });
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "agx-wtown-"));
+  process.env.AGENTGLASS_ROOT = dir;
+  git("init", "-q", "-b", "main");
+  git("config", "user.email", "t@example.com");
+  git("config", "user.name", "T");
+  writeFileSync(join(dir, "a.txt"), "seed\n");
+  git("add", "-A"); git("commit", "-qm", "seed");
+});
+afterEach(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("fixWorktreeOwnership gate", () => {
+  it("refuses a fabricated prunable worktree, so pkexec can't be aimed at an arbitrary path", () => {
+    // Stands in for a root-owned directory the attacker wants chowned to them.
+    const target = mkdtempSync(join(tmpdir(), "agx-target-"));
+    // The attack: write a worktree registration whose gitdir names `target`.
+    // git cannot verify the back-reference (target has no .git pointing here),
+    // so it lists the entry as prunable.
+    const wt = join(dir, ".git", "worktrees", "evil");
+    mkdirSync(wt, { recursive: true });
+    writeFileSync(join(wt, "gitdir"), join(target, ".git") + "\n");
+    writeFileSync(join(wt, "HEAD"), "ref: refs/heads/main\n");
+    writeFileSync(join(wt, "commondir"), "../..\n");
+
+    // Sanity: git really does surface `target` as a prunable worktree.
+    const listed = git("worktree", "list", "--porcelain").stdout;
+    expect(listed).toContain(target);
+    expect(listed).toContain("prunable");
+
+    const r = fixWorktreeOwnership(dir, target);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("not a worktree");
+
+    rmSync(target, { recursive: true, force: true });
+  });
+
+  it("still accepts a real, live worktree", () => {
+    const wtPath = join(mkdtempSync(join(tmpdir(), "agx-wt-")), "feature");
+    expect(git("worktree", "add", "-q", "-b", "feature", wtPath).status).toBe(0);
+    // Its files are ours, so the gate passes and there is nothing to chown.
+    const r = fixWorktreeOwnership(dir, wtPath);
+    expect(r.ok).toBe(true);
+    expect(r.output).toContain("already yours");
+    rmSync(wtPath, { recursive: true, force: true });
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -638,6 +638,11 @@ export interface GitWorktree {
   current: boolean;
   bare: boolean;
   locked: boolean;
+  /** Git reports the registration as broken — its gitdir points nowhere valid.
+   *  A fabricated entry (an attacker-written .git/worktrees/<x>/gitdir aimed at
+   *  an arbitrary path) surfaces as prunable, so any privileged action must not
+   *  trust a prunable path as a real worktree of this repo. */
+  prunable?: boolean;
   /** The branch this one was cut from — trunk unless overridden per branch.
    *  Null on the trunk checkout itself, which has no base. */
   base?: string | null;


### PR DESCRIPTION
## What does this PR do?

Audit HIGH (privilege escalation) in `gitwork.ts`. fixWorktreeOwnership hands a path to `pkexec chown -R`, gated only by a path match against `git worktree list`. The porcelain parser accepted prunable entries (broken registrations), and a local user with repo write access can fabricate one (writing .git/worktrees/<x>/gitdir at an arbitrary root-owned path). Fix: parse the porcelain `prunable` flag and require a non-prunable match in the privileged gate.

## How was it tested?

`bun test` (server, 471 pass) and `bunx tsc --noEmit`. A new test fabricates the exact prunable registration (git confirms it lists as prunable) and asserts the gate refuses it, while a real live worktree is still accepted.