### PR TITLE
fix(db): scope skillUsageDetail so top_skills can't leak other projects

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1106,15 +1106,19 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
  */
 export function skillUsageDetail(since = 0, bucketCount = 12, provider?: string): SkillUsage[] {
   const { clause: pf, args: pa } = providerScope(provider);
+  // Project scope, same as every other aggregation in computeStatsSummary. Its
+  // absence here leaked top_skills — and the cost charged to them — from every
+  // other project on the machine into a cockpit opened for one.
+  const { clause: sc, args: sa } = scopeClause();
   const invocations = db
     .query<{ session_id: string; timestamp: number; skill: string }, any[]>(
       `SELECT session_id, timestamp, json_extract(payload, '$.tool_input.skill') AS skill
        FROM events
        WHERE hook_event_type = 'PreToolUse' AND tool_name = 'Skill'
-         AND json_extract(payload, '$.tool_input.skill') IS NOT NULL AND timestamp >= ?${pf}
+         AND json_extract(payload, '$.tool_input.skill') IS NOT NULL AND timestamp >= ?${pf}${sc}
        ORDER BY session_id, timestamp`
     )
-    .all(since, ...pa);
+    .all(since, ...pa, ...sa);
   if (!invocations.length) return [];
 
   const bySession = new Map<string, { timestamp: number; skill: string }[]>();
@@ -1144,12 +1148,14 @@ export function skillUsageDetail(since = 0, bucketCount = 12, provider?: string)
     a.buckets[idx]++;
   }
 
-  // Charge each cost-bearing event to the running skill at that moment.
+  // Charge each cost-bearing event to the running skill at that moment — scoped
+  // too, or an out-of-project session's spend is attributed to an in-project
+  // skill it never ran.
   const costRows = db
-    .query<{ session_id: string; timestamp: number; cost_usd: number }, [number]>(
-      `SELECT session_id, timestamp, cost_usd FROM events WHERE cost_usd > 0 AND timestamp >= ?`
+    .query<{ session_id: string; timestamp: number; cost_usd: number }, any[]>(
+      `SELECT session_id, timestamp, cost_usd FROM events WHERE cost_usd > 0 AND timestamp >= ?${sc}`
     )
-    .all(since);
+    .all(since, ...sa);
   for (const c of costRows) {
     const invs = bySession.get(c.session_id);
     if (!invs) continue;

--- a/server/test/skill-scope.test.ts
+++ b/server/test/skill-scope.test.ts
@@ -1,0 +1,50 @@
+// top_skills is a scoped read, like every other stat. skillUsageDetail forgot
+// the project filter, so a cockpit opened for one project listed skills — and
+// charged their cost — from every other project on the machine.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-skillscope-"));
+const SCOPED = join(dir, "scoped");
+const OTHER = join(dir, "other");
+for (const p of [SCOPED, OTHER]) mkdirSync(p, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "skill.db");
+process.env.AGENTGLASS_ROOT = SCOPED;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const skillEvent = (project: string, session: string, skill: string) => ({
+  source_app: project.split("/").pop()!,
+  session_id: session,
+  hook_event_type: "PreToolUse",
+  tool_name: "Skill",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 20, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "ran a skill",
+  timestamp: Date.now(),
+  payload: { project_path: project, tool_input: { skill } },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  db.insertEvent(skillEvent(SCOPED, "s-in", "alpha") as any);
+  db.insertEvent(skillEvent(OTHER, "s-out", "beta") as any);
+});
+
+describe("skillUsageDetail scoping", () => {
+  test("lists only skills run in the open project", () => {
+    const skills = db.skillUsageDetail(0).map((s) => s.skill);
+    expect(skills).toContain("alpha");
+    expect(skills).not.toContain("beta"); // the other project's skill must not leak in
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Audit MEDIUM (scope-leak) in `db.ts`. skillUsageDetail applied only providerScope, never scopeClause, so statsSummary's top_skills (and the cost charged to each) listed invocations from every other project on the machine in a cockpit opened for one; the cost query had no scope at all. Both queries now fold the same project filter as every other aggregation.

## How was it tested?

`bun test` (server, 478 pass) and `bunx tsc --noEmit`. A new test asserts a Skill run in another project does not appear in the scoped top_skills.