### PR TITLE
fix(terminal): restore tmux's status line on detach, and actually clear the blank

### DIFF
--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -287,8 +287,15 @@ export function ptyOpen(ws: PtyWs) {
     if (now !== sawTmux) {
       sawTmux = now;
       if (!now) {
-        // Detached. Forget the client rather than keep polling a target that
-        // is no longer ours, and stop describing windows nobody is looking at.
+        // Detached. Hand the session its status line back before forgetting we
+        // borrowed it — a detach ends the client, not the server: the session
+        // stays alive, so a status left hidden here comes up blank on every
+        // future attach. Same restore followSession() does when the client
+        // moves on with `^b s`; the sweep missing it was the leak.
+        const borrowed = session.tmuxStatusHiddenOn;
+        if (borrowed) setStatusLine(borrowed, true);
+        // Forget the client rather than keep polling a target that is no longer
+        // ours, and stop describing windows nobody is looking at.
         session.tmuxClient = null;
         session.tmux = null;
         session.tmuxPrefix = [];

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -329,7 +329,13 @@ export function runAction(t: TmuxTarget, action: TmuxAction, window?: string, na
 
 /** The options the panel borrows when it takes the status line over. Restored
  *  together, in the same breath, so a half-restored bar cannot outlive us. */
-const BORROWED = ["status", "status-format[0]", "status-style"];
+// Restored by unsetting. `status-format[0]` is the one we blank when borrowing,
+// but `set-option -u status-format[0]` does NOT clear an array element on tmux
+// 3.7 — the override lingers as "" and the bar stays invisible even after a
+// restore ran. Unsetting the whole `status-format` array is what actually
+// returns it to the user's config default; we only ever set index 0, so nothing
+// else of theirs is lost.
+const BORROWED = ["status", "status-format", "status-style"];
 
 /**
  * Whether this user's tmux normally has a status line at all, read from the


### PR DESCRIPTION
## What does this PR do?

Audit MEDIUM (state-corruption) in `terminal.ts`, plus a second bug in `tmuxctl.ts` found while verifying. The detach sweep nulled the borrowed status-line record without restoring it — a detach ends the client, not the server, so the borrowed, blanked status stayed blank on every future attach; it now restores before forgetting, like followSession on `^b s`. And that restore was itself incomplete: `set-option -u status-format[0]` does not clear an array element on tmux 3.7, so BORROWED now unsets the whole `status-format` array.

## How was it tested?

`bun test` (server, 478 pass) and `bunx tsc --noEmit`. The live tmux half (which this file's tests deliberately leave out) was verified against a real tmux 3.7 server: borrow -> blank -> restore returns status-format[0] to its default.