### PR TITLE
fix(transcripts): stop lines_done drifting on a newline-less record

### DIFF
--- a/server/src/transcripts.ts
+++ b/server/src/transcripts.ts
@@ -465,6 +465,12 @@ interface Tail {
   bytes: number;
   /** Complete lines processed — must stay equal to transcript_files.lines_done. */
   lines: number;
+  /** Whether `bytes` sits right after a newline. False when the last record was
+   *  taken before its terminating newline landed (a live write caught mid-write,
+   *  accepted by the restIsWholeRecord branch): the newline is then the head of
+   *  the next chunk and must be consumed as that record's terminator, not split
+   *  into a phantom empty line that drifts `lines` past the true record count. */
+  endedWithNewline: boolean;
   toolCalls: Map<string, { name: string; input: unknown }>;
   seenUsage: Set<string>;
   customTitle: string | null;
@@ -527,9 +533,24 @@ async function ingestFile(
   const tail = cached && cached.lines === from && cached.bytes <= file.size ? cached : undefined;
   if (!tail) tails.delete(path);
 
-  const baseByte = tail?.bytes ?? 0;
+  let baseByte = tail?.bytes ?? 0;
   const baseLine = tail?.lines ?? 0;
-  const chunk = tail ? await file.slice(baseByte).text() : await file.text();
+  let chunk = tail ? await file.slice(baseByte).text() : await file.text();
+
+  // The previous sweep committed a record whose terminating newline hadn't
+  // landed yet (a live write caught between the record's bytes and its "\n",
+  // taken by the restIsWholeRecord branch below), so it left the byte offset
+  // just before that newline. The newline is now the head of this chunk:
+  // consume it as the record's terminator here. Splitting it into a line
+  // instead would add a phantom empty record, drift lines_done one past the
+  // true count, and make a later cold re-read over-skip — dropping the newest
+  // records for good.
+  let strippedNewline = false;
+  if (tail && !tail.endedWithNewline && chunk.startsWith("\n")) {
+    chunk = chunk.slice(1);
+    baseByte += 1;
+    strippedNewline = true;
+  }
 
   // Cut at the last newline. An active session is appended record by record and
   // a sweep lands mid-write often enough to matter: parsing the half-flushed
@@ -643,9 +664,17 @@ async function ingestFile(
 
   // The tail row we hand the next sweep, updated to match each committed batch.
   const saveTail = (bytes: number, doneLines: number): void => {
+    // At a newline boundary unless we stopped on the file's newline-less final
+    // line. When no line was processed this sweep, the offset either advanced by
+    // exactly the newline we stripped (now at a boundary) or did not move at all
+    // (carry the prior tail's answer forward).
+    const endedWithNewline = lines.length === 0
+      ? (strippedNewline || (tail?.endedWithNewline ?? true))
+      : (i >= lines.length ? endsWithNewline : true);
     tails.set(path, {
       bytes,
       lines: doneLines,
+      endedWithNewline,
       toolCalls,
       seenUsage,
       customTitle,

--- a/server/test/transcript-batching.test.ts
+++ b/server/test/transcript-batching.test.ts
@@ -36,7 +36,7 @@ beforeAll(async () => {
   mkdirSync(CWD, { recursive: true });
 });
 
-const FIXTURES = ["b-many", "b-usage", "b-oversize"];
+const FIXTURES = ["b-many", "b-usage", "b-oversize", "b-drift"];
 afterAll(() => {
   process.env.AGENTGLASS_SCAN_BATCH_LINES = priorBatchLines;
   process.env.AGENTGLASS_SCAN_BATCH_BYTES = priorBatchBytes;
@@ -100,6 +100,31 @@ describe("batched transcript sweep", () => {
     // Unchanged file: no manufacturing on a re-run.
     await sweep();
     expect(prompts(sid).length).toBe(19);
+  });
+
+  test("a newline-less record doesn't drift lines_done and drop the next one", async () => {
+    const sid = "b-drift";
+    // A, then B: a complete record whose terminating newline hasn't landed yet
+    // — a live write caught between the record's bytes and its "\n". Raw writes,
+    // because the helpers always append a newline.
+    writeFileSync(path("drift"), prompt(sid, "A") + "\n" + prompt(sid, "B"));
+    await sweep();
+    expect(prompts(sid)).toEqual(["A", "B"]); // B is taken now, not held forever
+
+    // B's newline lands. This must NOT be counted as a new (empty) line: the
+    // record was already ingested, and drifting lines_done past the true count
+    // is what makes a later cold re-read over-skip.
+    appendFileSync(path("drift"), "\n");
+    await sweep();
+    expect(prompts(sid)).toEqual(["A", "B"]); // no duplicate
+    expect(progress("drift")?.lines_done).toBe(2); // two records, not three
+
+    // A restart drops the byte offsets but keeps lines_done. A new record C then
+    // arrives; with a drifted lines_done the from-zero re-read would skip it.
+    scan.__dropTailCache();
+    appendFileSync(path("drift"), prompt(sid, "C") + "\n");
+    await sweep();
+    expect(prompts(sid)).toEqual(["A", "B", "C"]); // C must survive
   });
 
   test("one reply's usage survives the batch boundary and is not double counted", async () => {


### PR DESCRIPTION
## What does this PR do?

Audit MEDIUM (offset-drift) in `transcripts.ts`. When a sweep accepts a complete record whose terminating newline hasn't landed yet (the restIsWholeRecord branch — a live write caught mid-record), it commits the record but leaves the byte offset just before the newline. The next sweep's chunk was that lone "\n"; split into lines it became a phantom empty record that advanced lines_done one past the true count, and a later cold re-read (a restart) over-skipped and dropped the newest record(s). Fix: the tail remembers whether its offset sits after a newline and consumes a pending leading "\n" as the record's terminator.

## How was it tested?

`bun test` (server, 479 pass) and `bunx tsc --noEmit`. A new test drives real scanOnce sweeps: a record taken before its newline, the newline landing, then a restart and a new record — the new record survives and lines_done reads two, not three.