### PR TITLE
fix(security): close three LOW-severity holes from the audit

### DIFF
--- a/server/src/gate.ts
+++ b/server/src/gate.ts
@@ -157,7 +157,13 @@ export function restoreGates(): { restored: number; expired: number } {
   for (const row of undecidedGates()) {
     if (row.expires <= now) {
       const out = timeoutOutcome();
-      resolveGateRow(row.id, out.decision, out.reason || `gate expired while the server was down (${out.decision})`, "restart", now);
+      // out.reason verbatim — never backfilled. timeoutOutcome() leaves the
+      // reason EMPTY on a fail-open allow on purpose, so the re-attaching hook
+      // falls through to Claude Code's own permission prompt; a non-empty reason
+      // makes the hook force-allow and skip that prompt. The live-timeout path
+      // (finish → resolveGateRow) preserves the empty reason too, and a restart
+      // must not silently turn a pending gate into a prompt-skipping auto-allow.
+      resolveGateRow(row.id, out.decision, out.reason, "restart", now);
       expired++;
       continue;
     }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -90,7 +90,13 @@ const TRUST_LAN = process.env.AGENTGLASS_TRUST_LAN === "1";
 // Optional shared-secret auth. Null on a loopback-only box with no token set
 // (unchanged zero-config UX); required otherwise. Exposing without a token
 // mints and prints one rather than running unauthenticated.
-const AUTH = resolveToken(LOOPBACK_ONLY);
+// TRUST_LAN widens the CSRF origin gate to trust any private-IP page, so it must
+// bring a token with it — otherwise a loopback instance (token skipped because
+// the bind is local) would let a LAN-origin page drive token-less destructive
+// writes through the victim's own loopback. Treating TRUST_LAN as "not loopback
+// only" for the token decision forces a token exactly when one is needed; net.ts
+// already documents TRUST_LAN as something used on top of a token.
+const AUTH = resolveToken(LOOPBACK_ONLY && !TRUST_LAN);
 const AUTH_TOKEN = AUTH.token;
 /** One socket, three roles: the live event stream, PTY terminal shells, and
  *  the desktop-notification mirror. */

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -745,10 +745,14 @@ const cmdCache = new Map<string, { at: number; data: TerminalCommands }>();
  *  cached — see commandDirsAsync and cmdCache for why. */
 export async function projectCommands(root: unknown): Promise<TerminalCommands> {
   const cwd = safeAbs(root);
+  // inScope, like the shell-spawn path: without it a cockpit opened for one
+  // project answers /terminal/commands?root=/any/other/repo, handing back that
+  // repo's Makefile targets and script names — the file contents of a project
+  // outside the open scope. safeAbs alone does not confine to the workspace.
   // repoRootOfAsync, not repoRootOf: polled on every scope switch and new
   // terminal, so its `git rev-parse` queues through the shared pool rather than
   // blocking the loop between keystrokes.
-  if (!cwd || !(await repoRootOfAsync(cwd))) return { enabled: TERMINAL_ENABLED, make: [], scripts: [] };
+  if (!cwd || !inScope(cwd) || !(await repoRootOfAsync(cwd))) return { enabled: TERMINAL_ENABLED, make: [], scripts: [] };
   const hit = cmdCache.get(cwd);
   if (hit && Date.now() - hit.at < CMD_CACHE_TTL_MS) return hit.data;
   const dirs = await commandDirsAsync(cwd); // one walk, shared by both lists, yielding between dirs

--- a/server/test/auth-token.test.ts
+++ b/server/test/auth-token.test.ts
@@ -1,0 +1,34 @@
+// The CSRF fix rides on this contract: passing loopbackOnly=false forces a
+// token to exist, and the surface's token gate then requires it. index.ts passes
+// `LOOPBACK_ONLY && !TRUST_LAN`, so enabling TRUST_LAN (which widens the origin
+// gate to trust private-IP pages) makes this false and a token mandatory — a
+// LAN-origin page then can't drive token-less writes through a loopback server.
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { resolveToken } from "../src/auth.ts";
+
+beforeEach(() => {
+  // A fresh config home per assertion so a persisted token from one doesn't
+  // decide the next, and no ambient env token.
+  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "agx-auth-"));
+  delete process.env.AGENTGLASS_TOKEN;
+});
+
+describe("resolveToken", () => {
+  test("loopback-only with no env token skips auth (token null)", () => {
+    expect(resolveToken(true).token).toBeNull();
+  });
+
+  test("not loopback-only requires a token — this is what TRUST_LAN forces", () => {
+    const auth = resolveToken(false);
+    expect(auth.token).toBeTruthy();
+    expect(auth.token!.length).toBeGreaterThan(16);
+  });
+
+  test("an explicit env token always wins, even loopback-only", () => {
+    process.env.AGENTGLASS_TOKEN = "sekret-token-value";
+    expect(resolveToken(true).token).toBe("sekret-token-value");
+  });
+});

--- a/server/test/gate-durability.test.ts
+++ b/server/test/gate-durability.test.ts
@@ -163,7 +163,11 @@ describe("restart", () => {
     const gone = db.getGate(stale)!;
     expect(gone.decision).toBe("allow"); // fail-open default
     expect(gone.resolution).toBe("restart");
-    expect(gone.reason).toContain("while the server was down");
+    // Reason stays EMPTY on a fail-open allow, exactly like the live-timeout
+    // path: a non-empty reason makes the re-attaching hook force-allow and skip
+    // Claude Code's own permission prompt. A restart must not quietly turn a
+    // pending gate into a prompt-skipping auto-allow.
+    expect(gone.reason).toBe("");
     expect(db.gateHistory(50).map((g) => g.id)).toContain(stale);
   });
 });

--- a/server/test/terminal-scope.test.ts
+++ b/server/test/terminal-scope.test.ts
@@ -1,0 +1,44 @@
+// /terminal/commands hands back a repo's Makefile targets and script names.
+// Scoped to one project, it must refuse a root outside that project — otherwise
+// ?root=/any/other/repo leaks the file contents (command names) of a repo the
+// cockpit was never opened for. safeAbs confines nothing to the workspace; only
+// inScope does.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-termscope-"));
+const SCOPED = join(dir, "scoped");
+const OTHER = join(dir, "other");
+// A real repo each: projectCommands resolves the git root and walks for a
+// Makefile, so string paths would surface nothing and the test would pass
+// vacuously.
+for (const p of [SCOPED, OTHER]) {
+  mkdirSync(p, { recursive: true });
+  spawnSync("git", ["-C", p, "init", "-q"]);
+  writeFileSync(join(p, "Makefile"), "deploy:\n\techo ship it\n");
+}
+process.env.AGENTGLASS_ROOT = SCOPED; // read at import inside config.ts
+process.env.XDG_CONFIG_HOME = dir;
+
+let terminal: typeof import("../src/terminal.ts");
+
+beforeAll(async () => {
+  terminal = await import("../src/terminal.ts");
+});
+afterAll(() => rmSync(dir, { recursive: true, force: true }));
+
+describe("projectCommands scoping", () => {
+  test("lists a Makefile target for the open project", async () => {
+    const cmds = await terminal.projectCommands(SCOPED);
+    expect(cmds.make.some((m) => m.name === "deploy")).toBe(true);
+  });
+
+  test("refuses a repo outside the open project — no command names leak", async () => {
+    const cmds = await terminal.projectCommands(OTHER);
+    expect(cmds.make).toEqual([]);
+    expect(cmds.scripts).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The three security LOW findings from the audit, as a batch:
- CSRF with TRUST_LAN: AGENTGLASS_TRUST_LAN=1 widens the origin gate to trust private-IP pages, but on a loopback bind the token was skipped, so a LAN-origin page could drive token-less destructive writes. The token decision now treats TRUST_LAN as "not loopback-only", forcing a token when the origin trust is widened.
- /terminal/commands scope bypass: projectCommands never called inScope, so ?root=/other/repo leaked that repo's Makefile targets and script names; it now confines to the workspace.
- gate fail-open on restart: restoreGates backfilled a non-empty reason on a fail-open expiry, making the re-attaching hook force-allow and skip Claude Code's prompt; it now passes timeoutOutcome's reason verbatim (empty on a fail-open allow).

## How was it tested?

`bun test` (server, 484 pass) and `bunx tsc --noEmit`. New tests: resolveToken's token-required contract; projectCommands refusing an out-of-scope repo; a restart-expired fail-open gate carrying an empty reason.