### PR TITLE
fix(backend): four LOW-severity correctness bugs from the audit

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -232,6 +232,11 @@ export function chatBypassAllowed(): boolean {
 
 export function configuredRepoDirs(): string[] {
   const fromEnv = (process.env.AGENTGLASS_REPO_DIRS || "").split(":").filter(Boolean);
-  const dirs = fromEnv.length ? fromEnv : config.repoDirs ?? [];
+  // config.repoDirs comes from a hand-editable JSON file, so it may be a non-array
+  // or hold non-string entries. Guard before mapping: an unguarded `.map(expand)`
+  // threw a TypeError that broke GET /git/repos in the default whole-machine mode
+  // — a single typo in config.json taking out the repo picker for the machine.
+  const raw = fromEnv.length ? fromEnv : config.repoDirs ?? [];
+  const dirs = Array.isArray(raw) ? raw.filter((d): d is string => typeof d === "string") : [];
   return dirs.map(expand);
 }

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -434,13 +434,13 @@ export function scopeClause(scope: string | null = workspaceRoot()): { clause: s
 
 /** Same restriction for the `sessions` table, which carries its own columns. */
 function sessionScopeClause(scope: string | null = workspaceRoot()): { clause: string; args: string[] } {
-  if (!scope) return { clause: "", args: [] };
-  const args: string[] = [];
-  const groups = scopeRoots(scope).map((r) => {
-    args.push(r, r + "/%", r, r + "/%");
-    return "project_path = ? OR project_path LIKE ? OR cwd_path = ? OR cwd_path LIKE ?";
-  });
-  return { clause: ` AND (${groups.join(" OR ")})`, args };
+  // Delegate to scopeClause rather than keep a second copy: this used its own
+  // `LIKE 'root/%'` pattern — the very thing scopeClause was rewritten to drop,
+  // because an underscore in a scope root is a single-char wildcard in LIKE and
+  // over-matches sibling projects (root_backup as well as root). The sessions
+  // table carries the same project_path/cwd_path columns, so the resolved-path
+  // IN clause applies unchanged, and correctly.
+  return scopeClause(scope);
 }
 
 /** The searchable text blob for an event — the fleet's collective memory. */

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -270,7 +270,15 @@ export function projectRootOf(anchor: string): string | null {
 // so the rev-parse goes through the pool rather than blocking between keystrokes.
 export async function currentBranch(root: string): Promise<string> {
   const b = (await gitAsync(root, ["rev-parse", "--abbrev-ref", "HEAD"])).stdout.trim();
-  return !b || b === "HEAD" ? "(detached)" : b;
+  if (b && b !== "HEAD") return b;
+  // "HEAD" from --abbrev-ref is two different states: a real detached HEAD, and
+  // an unborn branch — a freshly `git init`'d repo (or `checkout --orphan`) that
+  // has a branch name but no commit yet. symbolic-ref tells them apart: it
+  // resolves the branch name while unborn and fails only when truly detached, so
+  // a brand-new repo shows "main", not "(detached)".
+  const sym = await gitAsync(root, ["symbolic-ref", "--short", "HEAD"]);
+  const name = sym.stdout.trim();
+  return sym.code === 0 && name ? name : "(detached)";
 }
 
 function statusLabel(x: string, y: string): GitFileStatus["status"] {

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -213,8 +213,13 @@ export function normalize(body: IngestBody): NormalizedEvent {
   // Token usage: prefer explicit payload.usage, else sum the transcript.
   const chat = Array.isArray(body.chat) ? body.chat : null;
   const payloadUsage = usageFrom(pick(payload, "usage") as Record<string, unknown> | undefined);
+  // All four token kinds count as "usage present". Summing only input+output
+  // dropped a usage object carrying only cache tokens (a cache-read-only reply):
+  // its cache tokens were discarded and the event was mislabeled cumulative,
+  // then re-summed from the transcript.
   const hasPayloadUsage =
-    (payloadUsage.input_tokens ?? 0) + (payloadUsage.output_tokens ?? 0) > 0;
+    (payloadUsage.input_tokens ?? 0) + (payloadUsage.output_tokens ?? 0)
+    + (payloadUsage.cache_creation_tokens ?? 0) + (payloadUsage.cache_read_tokens ?? 0) > 0;
   const usage: TokenUsage = hasPayloadUsage ? payloadUsage : sumTranscriptTokens(chat ?? undefined);
 
   const model_name = str(body.model_name) ?? str(pick(payload, "model", "model_name"));

--- a/server/test/config-root.test.ts
+++ b/server/test/config-root.test.ts
@@ -51,4 +51,18 @@ describe("config load tolerates a corrupt config.json", () => {
     const cfg = await load();
     expect(cfg.workspaceRoot()).not.toBeNull();
   });
+
+  it("a non-array repoDirs degrades to none instead of throwing (kept /git/repos alive)", async () => {
+    delete process.env.AGENTGLASS_REPO_DIRS; // the env would shadow the file
+    const cfg = await loadWith('{"repoDirs": "not-an-array"}').load();
+    expect(() => cfg.configuredRepoDirs()).not.toThrow();
+    expect(cfg.configuredRepoDirs()).toEqual([]);
+  });
+
+  it("a repoDirs array with a non-string entry drops only the bad entry", async () => {
+    delete process.env.AGENTGLASS_REPO_DIRS;
+    const cfg = await loadWith('{"repoDirs": ["/tmp/agx-ok", 123, null]}').load();
+    expect(() => cfg.configuredRepoDirs()).not.toThrow();
+    expect(cfg.configuredRepoDirs()).toEqual(["/tmp/agx-ok"]);
+  });
 });

--- a/server/test/git-currentbranch.test.ts
+++ b/server/test/git-currentbranch.test.ts
@@ -1,0 +1,43 @@
+// currentBranch used to read "HEAD" from --abbrev-ref as detached, but a fresh
+// `git init` reports "HEAD" too — an unborn branch that has a name and no commit.
+// The panel then labelled a brand-new repo "(detached)".
+import { describe, expect, test, afterEach } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+import { currentBranch } from "../src/git.ts";
+
+let dir = "";
+const git = (...a: string[]) => spawnSync("git", ["-C", dir, ...a], { encoding: "utf8" });
+afterEach(() => dir && rmSync(dir, { recursive: true, force: true }));
+
+describe("currentBranch", () => {
+  test("an unborn branch (fresh git init) is named, not detached", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agx-branch-"));
+    git("init", "-q", "-b", "main");
+    expect(await currentBranch(dir)).toBe("main");
+  });
+
+  test("a real detached HEAD still reads as detached", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agx-branch2-"));
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "t@example.com");
+    git("config", "user.name", "T");
+    writeFileSync(join(dir, "a.txt"), "x\n");
+    git("add", "-A"); git("commit", "-qm", "seed");
+    git("checkout", "-q", git("rev-parse", "HEAD").stdout.trim()); // detach
+    expect(await currentBranch(dir)).toBe("(detached)");
+  });
+
+  test("an ordinary branch reads its name", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agx-branch3-"));
+    git("init", "-q", "-b", "main");
+    git("config", "user.email", "t@example.com");
+    git("config", "user.name", "T");
+    writeFileSync(join(dir, "a.txt"), "x\n");
+    git("add", "-A"); git("commit", "-qm", "seed");
+    git("checkout", "-q", "-b", "feature");
+    expect(await currentBranch(dir)).toBe("feature");
+  });
+});

--- a/server/test/ingest-usage.test.ts
+++ b/server/test/ingest-usage.test.ts
@@ -1,0 +1,23 @@
+// A usage object that carries only cache tokens (a cache-read-only reply) is
+// still usage. Counting only input+output tokens dropped those cache tokens and
+// mislabeled the event as cumulative, which then re-summed it from the transcript.
+import { describe, expect, test } from "bun:test";
+import { normalize } from "../src/ingest.ts";
+import type { IngestBody } from "../../shared/types.ts";
+
+const body = (over: Partial<IngestBody>): IngestBody =>
+  ({ source_app: "app", session_id: "sess", hook_event_type: "PostToolUse", ...over }) as IngestBody;
+
+describe("payload usage detection", () => {
+  test("cache-only usage is kept and not marked cumulative", () => {
+    const ev = normalize(body({ payload: { usage: { cache_read_tokens: 500, cache_creation_tokens: 20 } } }));
+    expect(ev.usage.cache_read_tokens).toBe(500);
+    expect(ev.usage.cache_creation_tokens).toBe(20);
+    expect(ev.usage_is_cumulative).toBe(false);
+  });
+
+  test("no usage at all still falls through to the transcript sum (cumulative)", () => {
+    const ev = normalize(body({ payload: { prompt: "hi" } }));
+    expect(ev.usage_is_cumulative).toBe(true);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Batch of four backend LOW correctness/robustness bugs from the audit:
- `db.ts` sessionScopeClause kept the `LIKE 'root/%'` pattern scopeClause was rewritten to drop — an underscore in a scope root over-matched sibling projects; it now delegates to scopeClause (resolved-path IN).
- `config.ts` configuredRepoDirs ran `.map(expand)` unguarded, so a non-array or non-string repoDirs in config.json threw and broke GET /git/repos in whole-machine mode; guarded now.
- `git.ts` currentBranch read "HEAD" as detached, but a fresh `git init` reports "HEAD" too — an unborn branch; symbolic-ref tells them apart.
- `ingest.ts` hasPayloadUsage counted only input+output tokens, so a cache-only usage object was dropped and mislabeled cumulative; all four token kinds count now.

## How was it tested?

`bun test` (server, 491 pass) and `bunx tsc --noEmit`. New tests: cache-only usage kept and non-cumulative; unborn/detached/named branches; a non-array and a mixed repoDirs degrading instead of throwing.