### PR TITLE
fix(backend): three more LOW-severity correctness bugs from the audit

### DIFF
--- a/server/src/fsbrowse.ts
+++ b/server/src/fsbrowse.ts
@@ -119,13 +119,19 @@ export function completePath(input: unknown): FsCompletion {
     names.push(ent.name);
   }
   names.sort((a, b) => a.localeCompare(b));
-  const truncated = names.length > MAX_ENTRIES;
+  // Cap and truncation are counted over *directories that survive the stat*, not
+  // the raw name list. Slicing to MAX_ENTRIES up front let a symlink pointing at
+  // a non-directory — dropped just below — burn a slot that a real directory
+  // further down never got to fill, silently omitting openable directories. Stat
+  // as we go and stop once one directory past the cap proves there are more.
   const entries: FsEntry[] = [];
-  for (const name of names.slice(0, MAX_ENTRIES)) {
+  let truncated = false;
+  for (const name of names) {
     const abs = dir === sep ? sep + name : dir + sep + name;
-    // A symlink to a file survived the filter above; drop it here, where we're
-    // already paying for a stat to answer the repo question.
+    // A symlink to a file survived the name filter above; drop it here, where
+    // we're already paying for a stat to answer the repo question.
     try { if (!statSync(abs).isDirectory()) continue; } catch { continue; }
+    if (entries.length >= MAX_ENTRIES) { truncated = true; break; }
     entries.push({ name, path: abs, repo: isRepo(abs) });
   }
   return { base: dir, entries, truncated };

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -2149,6 +2149,12 @@ export function removeWorktree(rootIn: string, pathIn: unknown, force: boolean):
   const g = guard(root); if (g) return g;
   const abs = safeAbs(pathIn); if (!abs) return { ok: false, error: "invalid path" };
   if (abs === root) return { ok: false, error: "can't remove the current worktree" };
+  // Must be a worktree git reports for THIS root — the same check its siblings
+  // (worktreeLeftovers, rescueLeftovers, fixWorktreeOwnership) all make. Without
+  // it, a linked worktree of a *different* repo makes `git worktree remove` fail
+  // and the restoreRegistration fallback below fabricates a phantom registration
+  // inside this repo's .git, corrupting its metadata.
+  if (!worktreeList(root).some((w) => w.path === abs)) return { ok: false, error: "not a worktree of this repository" };
 
   // Refuse rather than start something that cannot finish. Git deletes the
   // registration before the files, so "try it and see" is not free: the failure

--- a/server/src/selfupdate.ts
+++ b/server/src/selfupdate.ts
@@ -116,13 +116,16 @@ export function cmpTag(a: string, b: string): number {
  */
 const TAGS_TTL_MS = 10 * 60_000;
 const TAGS_FAIL_TTL_MS = 60_000;
-let tagCache: { at: number; url: string; tags: string[] } | null = null;
+let tagCache: { at: number; url: string; tags: string[] | null } | null = null;
 
-export async function remoteTags(originUrl: string): Promise<string[]> {
+export async function remoteTags(originUrl: string): Promise<string[] | null> {
   if (!originUrl) return [];
   const hit = tagCache;
   if (hit && hit.url === originUrl) {
-    const ttl = hit.tags.length ? TAGS_TTL_MS : TAGS_FAIL_TTL_MS;
+    // A short TTL for both a fetch failure (null) and a reachable-but-tagless
+    // remote ([]), so neither sticks: the connection or the first release could
+    // arrive any moment. A real tag list is cached for longer.
+    const ttl = hit.tags?.length ? TAGS_TTL_MS : TAGS_FAIL_TTL_MS;
     if (Date.now() - hit.at < ttl) return hit.tags;
   }
   const tags = await readRemoteTags(originUrl);
@@ -130,7 +133,7 @@ export async function remoteTags(originUrl: string): Promise<string[]> {
   return tags;
 }
 
-async function readRemoteTags(originUrl: string): Promise<string[]> {
+async function readRemoteTags(originUrl: string): Promise<string[] | null> {
   // Awaited: a network round trip on the thread that carries the terminal was
   // 469ms of the app's startup, and the timeout below allows forty-five
   // seconds of it on a bad connection.
@@ -139,7 +142,11 @@ async function readRemoteTags(originUrl: string): Promise<string[]> {
     env: { ...process.env, GIT_TERMINAL_PROMPT: "0", GIT_ASKPASS: "", SSH_ASKPASS_REQUIRE: "never" },
   });
   const [out, code] = await Promise.all([new Response(proc.stdout).text(), proc.exited]);
-  if (code !== 0) return [];
+  // null, not []: a non-zero exit is a fetch failure (offline, auth, a bad
+  // origin), which is a different thing from a reachable remote that simply has
+  // no tags yet. Collapsing both to [] made updateStatus tell an offline user to
+  // go push a tag — advice for a problem they do not have.
+  if (code !== 0) return null;
   return (out ?? "").split("\n")
     .map((l) => l.split("refs/tags/")[1]?.trim() ?? "")
     .filter((t) => TAG_RE.test(t))
@@ -156,6 +163,11 @@ export async function updateStatus(): Promise<UpdateStatus> {
   }
 
   const tags = await remoteTags(info.origin);
+  if (tags === null) {
+    // A fetch failure, not an empty remote: don't claim an update is available
+    // and don't send them to publish a tag they may already have.
+    return { ...base, available: false, blocked: "couldn't reach the remote to check for releases — check your connection and try again" };
+  }
   if (!tags.length) {
     return { ...base, available: true, blocked: "no releases published yet — tag one with `git tag v0.3.0 && git push --tags`" };
   }

--- a/server/test/fsbrowse-cap.test.ts
+++ b/server/test/fsbrowse-cap.test.ts
@@ -1,0 +1,39 @@
+// The MAX_ENTRIES cap and the "truncated" flag are counted over directories that
+// survive the stat, not the raw name list. When a symlink-to-a-file sorts ahead
+// of real directories, it must not burn a display slot a real directory never
+// gets to fill — that silently dropped openable directories off the end.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync, symlinkSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { completePath } from "../src/fsbrowse.ts";
+
+const MAX_ENTRIES = 60; // must match fsbrowse.ts
+let base = "";
+
+beforeAll(() => {
+  base = mkdtempSync(join(tmpdir(), "agx-fscap-"));
+  // Symlinks-to-files that sort first (leading "0"): under the old code they
+  // took the first slots and pushed real directories past the cap.
+  for (let i = 0; i < 5; i++) {
+    const f = join(base, `0file${i}`);
+    writeFileSync(f, "x");
+    symlinkSync(f, join(base, `0link${i}`));
+  }
+  // Exactly MAX_ENTRIES real directories, named so they all sort after the links.
+  for (let i = 0; i < MAX_ENTRIES; i++) mkdirSync(join(base, `dir${String(i).padStart(2, "0")}`));
+});
+afterAll(() => rmSync(base, { recursive: true, force: true }));
+
+describe("completePath cap", () => {
+  test("symlinks-to-files don't steal slots from real directories", () => {
+    const res = completePath(base + "/");
+    const names = res.entries.map((e) => e.name);
+    // None of the link entries are directories, so none should appear...
+    expect(names.some((n) => n.startsWith("0link"))).toBe(false);
+    // ...and every real directory fits, including the last one, which the old
+    // pre-filter cap would have dropped.
+    expect(names).toContain(`dir${String(MAX_ENTRIES - 1).padStart(2, "0")}`);
+    expect(names.filter((n) => n.startsWith("dir")).length).toBe(MAX_ENTRIES);
+  });
+});

--- a/server/test/remove-worktree-scope.test.ts
+++ b/server/test/remove-worktree-scope.test.ts
@@ -1,0 +1,51 @@
+// removeWorktree deletes a worktree's registration before its files, and on
+// failure a fallback rebuilds that registration. Handed a linked worktree of a
+// DIFFERENT repo, the removal fails and the fallback fabricates a phantom
+// registration inside the in-scope repo's .git — so the path must be verified as
+// a worktree of this repo first, exactly like its siblings do.
+import { afterAll, describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const base = mkdtempSync(join(tmpdir(), "agx-rmwt-"));
+// Restored in afterAll: process.env is shared across every test file in one
+// `bun test` run, so leaking a scope root here would silently rescope an
+// order-dependent suite that loads after this one.
+const ROOT0 = process.env.AGENTGLASS_ROOT;
+process.env.AGENTGLASS_ROOT = base; // both repos are inside the open scope
+afterAll(() => { if (ROOT0 === undefined) delete process.env.AGENTGLASS_ROOT; else process.env.AGENTGLASS_ROOT = ROOT0; });
+const A = join(base, "A");
+const B = join(base, "B");
+const Awt = join(base, "A-wt");
+const Bwt = join(base, "B-wt");
+const g = (cwd: string, ...a: string[]) => spawnSync("git", ["-C", cwd, ...a], { encoding: "utf8" });
+
+let gitwork: typeof import("../src/gitwork.ts");
+
+beforeAll(async () => {
+  for (const r of [A, B]) {
+    spawnSync("git", ["init", "-q", "-b", "main", r]);
+    g(r, "config", "user.email", "t@example.com");
+    g(r, "config", "user.name", "T");
+    writeFileSync(join(r, "f.txt"), "x\n");
+    g(r, "add", "-A"); g(r, "commit", "-qm", "seed");
+  }
+  g(A, "worktree", "add", "-q", Awt);
+  g(B, "worktree", "add", "-q", Bwt);
+  gitwork = await import("../src/gitwork.ts");
+});
+
+describe("removeWorktree membership", () => {
+  test("refuses a worktree that belongs to a different repo", () => {
+    const r = gitwork.removeWorktree(A, Bwt, false);
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("not a worktree of this repository");
+  });
+
+  test("still removes a real worktree of the repo", () => {
+    const r = gitwork.removeWorktree(A, Awt, false);
+    expect(r.ok).toBe(true);
+  });
+});

--- a/server/test/selfupdate-tags.test.ts
+++ b/server/test/selfupdate-tags.test.ts
@@ -1,0 +1,25 @@
+// A fetch failure and a tagless-but-reachable remote are different answers:
+// readRemoteTags returns null for the former, [] for the latter, so updateStatus
+// can stop telling an offline user to go publish a tag.
+//
+// Loaded through a fresh dynamic import, not a static one: selfupdate.ts reads
+// AGENTGLASS_UPDATE_SRC into a module-load const, and release-notes.test.ts
+// depends on being the module's first importer. A static import here would
+// initialise the shared module early and break that, order-dependently.
+import { describe, expect, test } from "bun:test";
+
+const load = async () => await import(`../src/selfupdate.ts?u=${Math.random()}`);
+
+describe("remoteTags", () => {
+  test("a fetch failure is null, not an empty list", async () => {
+    const { remoteTags } = await load();
+    // A local path that is not a git repo makes `git ls-remote` exit non-zero
+    // immediately — a stand-in for offline / bad origin, without a network wait.
+    expect(await remoteTags("/tmp/agx-definitely-not-a-repo-xyz")).toBeNull();
+  });
+
+  test("no origin is an empty list, not a failure", async () => {
+    const { remoteTags } = await load();
+    expect(await remoteTags("")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Three backend LOW correctness/robustness fixes from the 60-agent audit:
- `gitwork.ts` removeWorktree now requires the path be a worktree git reports for this repo (its siblings already do). A linked worktree of a different repo failed the remove and the `restoreRegistration` fallback fabricated a phantom registration inside this repo's `.git`.
- `selfupdate.ts` readRemoteTags returns `null` on a fetch failure instead of `[]`, so updateStatus reports a connectivity problem rather than telling an offline user to publish a tag.
- `fsbrowse.ts` counts the `MAX_ENTRIES` cap and `truncated` flag over post-stat directories, so a symlink to a non-directory no longer burns a slot a real directory needed (which silently omitted openable directories).

## How was it tested?

`bun test` in server/ (496 pass, 0 fail) and `bunx tsc --noEmit`. New tests: a foreign worktree refused while a real one still removes; a fetch failure as null vs an empty remote; symlinks-to-files not stealing directory slots.