### PR TITLE
perf(db): make openToolCalls index-usable — 2.5s to ~1ms, unfreezes the PTY

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -745,14 +745,28 @@ const openToolSql = (scoped: string) =>
      FROM events p
     WHERE p.hook_event_type = 'PreToolUse'
       AND p.timestamp >= ?
+      -- "Has this call been closed by a Post?" — split into two NOT EXISTS
+      -- rather than one with an OR inside. The OR mixed q.tool_use_id with
+      -- q.session_id/tool_name, and SQLite cannot use an index across it: the
+      -- subquery fell back to scanning EVERY PostToolUse for each open Pre
+      -- (306 Pres x thousands of Posts = ~2.5s on a real DB, on the thread the
+      -- terminal rides). Split, the id path uses idx on tool_use_id (the case
+      -- for essentially every modern event) and the query drops to ~1ms.
+      -- Equivalent by De Morgan: the two branches are mutually exclusive
+      -- (tool_use_id present XOR absent), and a NULL id never equals any q's id,
+      -- so the first clause is a no-op exactly when the second one applies.
       AND NOT EXISTS (
         SELECT 1 FROM events q
          WHERE q.hook_event_type IN ('PostToolUse','PostToolUseFailure')
-           AND (
-             (p.tool_use_id IS NOT NULL AND q.tool_use_id = p.tool_use_id)
-             OR (p.tool_use_id IS NULL AND q.session_id = p.session_id
-                 AND q.tool_name = p.tool_name AND q.timestamp >= p.timestamp)
-           )
+           AND q.tool_use_id = p.tool_use_id
+      )
+      AND NOT EXISTS (
+        SELECT 1 FROM events q2
+         WHERE p.tool_use_id IS NULL
+           AND q2.hook_event_type IN ('PostToolUse','PostToolUseFailure')
+           AND q2.session_id = p.session_id
+           AND q2.tool_name = p.tool_name
+           AND q2.timestamp >= p.timestamp
       )
       AND NOT EXISTS (
         SELECT 1 FROM events s

--- a/server/test/open-tool-memo.test.ts
+++ b/server/test/open-tool-memo.test.ts
@@ -37,6 +37,10 @@ const base = {
 // Pre and Post share a tool_use_id so the Post pairs (closes) the Pre.
 const pre = (session: string) => ({ ...base, session_id: session, hook_event_type: "PreToolUse", tool_use_id: session + "-t", timestamp: Date.now() });
 const post = (session: string) => ({ ...base, session_id: session, hook_event_type: "PostToolUse", tool_use_id: session + "-t", timestamp: Date.now() });
+// The legacy path: no tool_use_id, so a Post closes a Pre by session + tool +
+// a later timestamp instead. Guards the split-OR rewrite of openToolSql.
+const preNoId = (session: string, at: number) => ({ ...base, session_id: session, hook_event_type: "PreToolUse", tool_name: "Bash", tool_use_id: null, timestamp: at });
+const postNoId = (session: string, at: number) => ({ ...base, session_id: session, hook_event_type: "PostToolUse", tool_name: "Bash", tool_use_id: null, timestamp: at });
 
 beforeAll(async () => {
   db = await import("../src/db.ts");
@@ -65,6 +69,29 @@ describe("open-tool memo", () => {
     const a = db.openToolCalls();
     db.invalidateOpenTools();
     expect(db.openToolCalls()).not.toBe(a);
+  });
+});
+
+describe("open-tool pairing without a tool_use_id (legacy path)", () => {
+  test("a Post closes a Pre by session + tool + a later timestamp", () => {
+    const s = "s-legacy";
+    const t0 = Date.now();
+    db.insertEvent(preNoId(s, t0) as any);
+    db.invalidateOpenTools();
+    expect(db.openToolCalls().some((c) => c.session_id === s)).toBe(true); // open
+
+    db.insertEvent(postNoId(s, t0 + 1000) as any); // same session+tool, later → closes it
+    db.invalidateOpenTools();
+    expect(db.openToolCalls().some((c) => c.session_id === s)).toBe(false); // closed
+  });
+
+  test("a Post for a DIFFERENT tool does not close it", () => {
+    const s = "s-legacy-2";
+    const t0 = Date.now();
+    db.insertEvent(preNoId(s, t0) as any); // tool_name Bash
+    db.insertEvent({ ...postNoId(s, t0 + 1000), tool_name: "Read" } as any); // different tool
+    db.invalidateOpenTools();
+    expect(db.openToolCalls().some((c) => c.session_id === s)).toBe(true); // still open
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Fixes the terminal freezing every few seconds under real use. `openToolCalls()` ran ~2475ms on a real 23k-event DB, synchronously on the single event-loop thread the PTY and every poll ride. It is called from `pushOpenTools()` on every PreToolUse/PostToolUse ingest, so an active Claude session firing tool hooks froze the terminal for ~2.5s every few seconds.

Cause (from `EXPLAIN QUERY PLAN` on a real DB): the "has a Post closed this Pre?" subquery mixed `q.tool_use_id` with `q.session_id`/`tool_name` under a single `OR`, and SQLite cannot use an index across that OR — it scanned every PostToolUse row for each of the ~306 open Pres in the 30-min window.

Fix: split the OR into two mutually-exclusive `NOT EXISTS` (equivalent by De Morgan — `tool_use_id` present XOR absent, and a NULL id never equals any row's id). The id path now uses `idx_events_tooluse`; the query drops to ~1ms and returns an identical result set.

## How was it tested?

`bun test` in server/ (498 pass, 0 fail) and `bunx tsc --noEmit`. New tests add the legacy no-`tool_use_id` pairing path (a Post closes a Pre by session + tool + a later timestamp, and a different tool does not). Measured on a copy of the real DB: raw query 2328ms -> 1ms; the `openToolCalls()` function end to end 2475ms -> 8ms; same rows both ways. Root cause was proven live: a loop-lag probe correlated the ~2.5s freezes with this query via `/api/loopwatch`.