### PR TITLE
UX pass: PR view, terminal focus, chat resume, and an app-wide casing sweep

### DIFF
--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -1021,7 +1021,16 @@ export async function setDraft(rootIn: unknown, number: unknown, draft: unknown)
 /** Merge the base into the PR branch — the button whose absence is why half a
  *  branch list carries hand-made "Merge origin/master into …" commits. */
 export async function updateBranch(rootIn: unknown, number: unknown): Promise<PrActionResult> {
-  return runPr(rootIn, Number(number), ["pr", "update-branch", String(Number(number))]);
+  const r = await runPr(rootIn, Number(number), ["pr", "update-branch", String(Number(number))]);
+  // The merge runs on GitHub's side, so there is never a half-merged local tree
+  // to clean up — but when base and head conflict the API refuses, and gh's raw
+  // error ("failed to update branch: …") is a dead end. Turn it into an
+  // actionable one. (A future "resolve in terminal" flow can drop the user into
+  // the merge in a worktree; for now, tell them what to do.)
+  if (!r.ok && /conflict|mergeable/i.test(r.error || "")) {
+    return { ok: false, error: "can't update automatically — this branch conflicts with its base. pull the base branch and resolve the merge locally, then push." };
+  }
+  return r;
 }
 
 /** Re-run the failed jobs on the PR's head — the usual answer to a red run,

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -350,7 +350,13 @@ async function fetchList(repo: PrRepoId, filter: PrFilter): Promise<PrSummary[] 
   // a network blip holds the last good list while a genuine empty is allowed to
   // empty the panel. Collapsing both to [] is what made a merged PR linger.
   if (rows === null) return null;
-  return rows.map((r) => mapSummary(r, false));
+  // Newest-first, so the panel reads recent → old and the per-PR check probe in
+  // refreshChecks (which walks this order) fills the rows you actually watch
+  // first. `gh pr list` has no reliable `--sort`, and updatedAt is an ISO string
+  // that sorts lexically, so order it here — same idiom as branchMergeState below.
+  return rows
+    .map((r) => mapSummary(r, false))
+    .sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
 }
 
 /**

--- a/web/src/components/Alerts.tsx
+++ b/web/src/components/Alerts.tsx
@@ -102,7 +102,7 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
               <span className="relative inline-flex rounded-full h-3 w-3" style={{ background: "var(--success)" }} />
             </span>
             <div className="text-[13px]" style={{ color: "var(--text2)" }}>All systems nominal</div>
-            <div className="text-[10px] t-dim2">no agent needs you right now</div>
+            <div className="text-[10px] t-dim2">No agent needs you right now</div>
           </div>
         )}
 
@@ -124,7 +124,7 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
                 <span className="ml-auto text-[9.5px] t-dim2">{g.source_app}:{g.session_id.slice(0, 8)}</span>
               </div>
               <div className="text-[10.5px] t-dim mt-1 mb-2 break-all line-clamp-2" title={g.summary} style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden" }}>
-                {g.summary || "(no details)"}
+                {g.summary || "(No details)"}
               </div>
               <div className="flex gap-2">
                 <button
@@ -163,7 +163,7 @@ export function Alerts({ alerts, agents = [], onSelectApp, bump }: { alerts: Ale
                     {g.tool_name} {g.decision === "deny" ? "denied" : "allowed"} without you
                   </div>
                   <div className="text-[9.5px] t-dim2 truncate">
-                    {g.resolution === "restart" ? "window closed while the server was down" : "no decision before the timeout"} · {g.source_app}
+                    {g.resolution === "restart" ? "Window closed while the server was down" : "No decision before the timeout"} · {g.source_app}
                   </div>
                 </div>
                 <span className="text-[9.5px] t-dim2 shrink-0">{fmtAgo(g.decided_at ?? g.created)}</span>

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -379,8 +379,8 @@ function groupChanges(list: FileChange[], by: GroupBy, titles?: ReadonlyMap<stri
       label = titles?.get(c.session_id) ?? agentKey({ source_app: c.source_app, session_id: c.session_id });
       sub = c.source_app;
     }
-    else if (by === "agent") { key = c.source_app || "—"; label = c.source_app || "unknown"; }
-    else if (by === "tool") { key = c.tool || "—"; label = c.tool || "unknown"; }
+    else if (by === "agent") { key = c.source_app || "—"; label = c.source_app || "Unknown"; }
+    else if (by === "tool") { key = c.tool || "—"; label = c.tool || "Unknown"; }
     else { const d = dirOf(c.file_path); key = d; label = shortDir(d); }
     // The day, when the split is on, is part of the identity — so one session
     // spanning midnight becomes two sections rather than one that lies about
@@ -868,7 +868,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                     <span className={viewTitleClass} style={{ color: "var(--text)" }}>File changes</span>
                     {changes && (
                       <span className="text-[10px] t-dim2 tabular-nums truncate">
-                        {all.length} edits · <span style={{ color: "var(--success)" }}>+{totals.add}</span> <span style={{ color: "var(--error)" }}>−{totals.del}</span> · {presetTitle || "what the fleet changed"}
+                        {all.length} edits · <span style={{ color: "var(--success)" }}>+{totals.add}</span> <span style={{ color: "var(--error)" }}>−{totals.del}</span> · {presetTitle || "What the fleet changed"}
                       </span>
                     )}
                   </div>
@@ -888,7 +888,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                         title={walk ? "Re-run the AI walkthrough (overwrites the cached one)" : "AI walkthrough — one line per file + a review focus (cached per changeset)"}
                         className="text-[11px] px-2.5 py-1 rounded-lg transition-colors"
                         style={{ color: "var(--text)", background: "color-mix(in srgb, var(--info) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--info) 28%, transparent)", opacity: walkLoading ? 0.6 : 1 }}
-                      >{walkLoading ? "✨ explaining…" : walk ? "✨ re-explain" : "✨ Explain"}</button>
+                      >{walkLoading ? "✨ Explaining…" : walk ? "✨ Re-explain" : "✨ Explain"}</button>
                     )}
                     {changes && all.length > 0 && (
                       <button
@@ -948,13 +948,13 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                         <button
                           onClick={() => setByDate((v) => !v)}
                           className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors whitespace-nowrap leading-5"
-                          title={byDate ? "one section per group" : "split each group by day"}
+                          title={byDate ? "One section per group" : "Split each group by day"}
                           style={{
                             background: byDate ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
                             color: byDate ? "var(--text)" : "var(--text3)",
                             border: `1px solid color-mix(in srgb, var(--border) ${byDate ? 45 : 18}%, transparent)`,
                           }}
-                        >by date</button>
+                        >By date</button>
                         {/* Says what it is hiding, and offers it back. A
                             filter that silently drops rows makes the list lie
                             about what the session touched. */}
@@ -967,7 +967,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                             // is never worth the width it saves.
                             className="px-1.5 py-0.5 rounded text-[9.5px] transition-colors whitespace-nowrap leading-5"
                             title={showIgnored
-                              ? "hide files git ignores"
+                              ? "Hide files git ignores"
                               : `${ignoredCount} file${ignoredCount === 1 ? "" : "s"} git ignores ${ignoredCount === 1 ? "is" : "are"} hidden — build output, caches, scratch files`}
                             style={{
                               background: showIgnored ? "color-mix(in srgb, var(--primary) 18%, transparent)" : "transparent",
@@ -977,13 +977,13 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                           >{showIgnored ? `✕ ${ignoredCount} ignored` : `+ ${ignoredCount} ignored`}</button>
                         )}
                         {changes && all.length > 0 && (
-                          <span className="ml-auto text-[9.5px] t-dim2 tabular-nums" title="files reviewed">{revCount}/{visible.length}</span>
+                          <span className="ml-auto text-[9.5px] t-dim2 tabular-nums" title="Files reviewed">{revCount}/{visible.length}</span>
                         )}
                       </div>
                     </div>
                     <div className="agx-scroll flex-1 min-h-0 overflow-y-auto px-2 pb-2">
-                      {!changes && <div className="t-dim2 text-center py-10 text-[12px]">loading changes…</div>}
-                      {changes && shown.length === 0 && <div className="t-dim2 text-center py-10 text-[12px]">{q ? "no files match your filter" : "no file changes captured yet"}</div>}
+                      {!changes && <div className="t-dim2 text-center py-10 text-[12px]">Loading changes…</div>}
+                      {changes && shown.length === 0 && <div className="t-dim2 text-center py-10 text-[12px]">{q ? "No files match your filter" : "No file changes captured yet"}</div>}
                       {groups.map((g, gi) => (
                         <div key={`w:${g.key}`}>
                           {/* Only when it changes: repeating "Today" above every
@@ -1020,13 +1020,13 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                             {selected.deletions > 0 && <span style={{ color: "var(--error)" }}>−{selected.deletions}</span>}
                           </span>
                           <div className="ml-auto flex items-center gap-1.5 shrink-0">
-                            <Toggle on={reviewed.has(selected.id)} onClick={() => toggleReviewed(selected.id)} title="Mark this file reviewed (x)">{reviewed.has(selected.id) ? "reviewed ✓" : "review"}</Toggle>
-                            <Toggle on={split} onClick={() => setSplit((s) => !s)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
-                            <Toggle on={wrap} onClick={() => setWrap((w) => !w)} title="Toggle line wrap (w)">wrap</Toggle>
+                            <Toggle on={reviewed.has(selected.id)} onClick={() => toggleReviewed(selected.id)} title="Mark this file reviewed (x)">{reviewed.has(selected.id) ? "Reviewed ✓" : "Review"}</Toggle>
+                            <Toggle on={split} onClick={() => setSplit((s) => !s)} title="Split / unified">{split ? "Split" : "Unified"}</Toggle>
+                            <Toggle on={wrap} onClick={() => setWrap((w) => !w)} title="Toggle line wrap (w)">Wrap</Toggle>
                             <ThemePicker value={themePref} onChange={setThemePref} error={hiliteError} />
-                            <Toggle on={bold} onClick={() => setBold((b) => !b)} title="Bold keywords, functions & types (Neovim-style)">bold</Toggle>
-                            <Toggle onClick={() => copy("path")} title="Copy file path (c)">{copied === "path" ? "copied ✓" : "path"}</Toggle>
-                            <Toggle onClick={() => copy("diff")} title="Copy unified diff">{copied === "diff" ? "copied ✓" : "diff"}</Toggle>
+                            <Toggle on={bold} onClick={() => setBold((b) => !b)} title="Bold keywords, functions & types (Neovim-style)">Bold</Toggle>
+                            <Toggle onClick={() => copy("path")} title="Copy file path (c)">{copied === "path" ? "Copied ✓" : "Path"}</Toggle>
+                            <Toggle onClick={() => copy("diff")} title="Copy unified diff">{copied === "diff" ? "Copied ✓" : "Diff"}</Toggle>
                           </div>
                         </div>
                         <div ref={paneRef} className="flex-1 min-h-0 flex relative" style={{ background: "var(--bg)" }}>
@@ -1043,7 +1043,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                       </>
                     ) : (
                       <div className="flex-1 flex items-center justify-center t-dim2 text-[12px]">
-                        {changes ? "select a file to view its diff" : "loading changes…"}
+                        {changes ? "Select a file to view its diff" : "Loading changes…"}
                       </div>
                     )}
                   </div>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -139,12 +139,12 @@ function Inspector({ chat }: { chat: Chat }) {
         <div className="h-full rounded-full transition-all" style={{ width: `${Math.max(1, pct)}%`, background: tone }} />
       </div>
       <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 mt-0.5">
-        <Row k="in" v={fmtTokens(u.input)} />
-        <Row k="out" v={fmtTokens(u.output)} />
+        <Row k="In" v={fmtTokens(u.input)} />
+        <Row k="Out" v={fmtTokens(u.output)} />
         {/* Cache read is the cheap part and usually the biggest — worth its own
             line so a large total doesn't read as a large bill. */}
-        <Row k="cache read" v={fmtTokens(u.cacheRead)} c="var(--success)" />
-        <Row k="cache write" v={fmtTokens(u.cacheWrite)} c="var(--warning)" />
+        <Row k="Cache read" v={fmtTokens(u.cacheRead)} c="var(--success)" />
+        <Row k="Cache write" v={fmtTokens(u.cacheWrite)} c="var(--warning)" />
       </div>
       {u.costUsd > 0 && (
         <div className="flex items-baseline gap-2 pt-1 mt-0.5 border-t" style={{ borderColor: "color-mix(in srgb, var(--border) 20%, transparent)" }}>
@@ -200,7 +200,7 @@ function ChatRow({ chat, active, onPick, onClose }: { chat: Chat; active: boolea
             style={{ background: "color-mix(in srgb, var(--bg) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", color: "var(--text)" }}
           />
         ) : (
-          <div className="truncate text-[11.5px]" title="double-click to rename"
+          <div className="truncate text-[11.5px]" title="Double-click to rename"
             onDoubleClick={(e) => { e.stopPropagation(); setDraft(chat.title); setEditing(true); }}
             style={{ color: active ? "var(--text)" : "var(--text2)" }}>{chat.title}</div>
         )}
@@ -208,13 +208,13 @@ function ChatRow({ chat, active, onPick, onClose }: { chat: Chat; active: boolea
             "finished" and "stuck, needs you" are the same glance otherwise and
             they want opposite reactions from you. */}
         <div className="flex items-center gap-1.5 min-w-0">
-          <span className="truncate text-[9.5px] t-dim2">{repoName(chat.cwd) || "no repo"}</span>
+          <span className="truncate text-[9.5px] t-dim2">{repoName(chat.cwd) || "No repo"}</span>
           {chat.sending
-            ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--success)" }}>· running</span>
+            ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--success)" }}>· Running</span>
             : chat.attention === "blocked"
-            ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--warning)" }}>· needs you</span>
+            ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--warning)" }}>· Needs you</span>
             : chat.attention === "done"
-            ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--primary)" }}>· done</span>
+            ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--primary)" }}>· Done</span>
             : null}
           {/* How full this chat's context is, per row. With several open it's
               the number that decides which one you go back to first — the one
@@ -234,8 +234,8 @@ function ChatRow({ chat, active, onPick, onClose }: { chat: Chat; active: boolea
       <button
         onClick={(e) => { e.stopPropagation(); onClose(); }}
         className="opacity-0 group-focus-within:opacity-100 group-hover:opacity-100 focus-visible:opacity-100 text-[13px] leading-none px-1 t-dim2 hover:opacity-70 shrink-0"
-        title="close chat"
-        aria-label={`close chat: ${chat.title}`}
+        title="Close chat"
+        aria-label={`Close chat: ${chat.title}`}
       >✕</button>
     </div>
   );
@@ -288,11 +288,11 @@ function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: s
         </div>
       </div>
       {why === "live"
-        ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--success)" }}>● running</span>
+        ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--success)" }}>● Running</span>
         : why === "no-dir"
-        ? <span className="text-[9.5px] shrink-0 t-dim2">no dir</span>
+        ? <span className="text-[9.5px] shrink-0 t-dim2">No dir</span>
         : openChatId
-        ? <span className="text-[9.5px] shrink-0 t-dim2">open ↗</span>
+        ? <span className="text-[9.5px] shrink-0 t-dim2">Open ↗</span>
         : <span className="text-[10px] shrink-0" style={{ color: "var(--primary-hover)" }}>↩</span>}
     </button>
   );
@@ -361,18 +361,18 @@ function ResumePicker({ onPick, onClose }: { onPick: (s: SessionRollup) => void;
           boxShadow: "0 24px 60px -18px rgba(0,0,0,0.7)",
         }}
       >
-        <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="filter sessions…"
+        <input autoFocus value={q} onChange={(e) => setQ(e.target.value)} placeholder="Filter sessions…"
           className="mx-1 mt-0.5 mb-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
           style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)", color: "var(--text)" }} />
         <div role="listbox" aria-label="sessions to resume" className="agx-scroll flex-1 min-h-0 overflow-y-auto flex flex-col gap-0.5">
-          {rows === null && <div className="px-2.5 py-3 text-[11px] t-dim2">loading sessions…</div>}
-          {rows !== null && !shown.length && <div className="px-2.5 py-3 text-[11px] t-dim2">no sessions to resume</div>}
+          {rows === null && <div className="px-2.5 py-3 text-[11px] t-dim2">Loading sessions…</div>}
+          {rows !== null && !shown.length && <div className="px-2.5 py-3 text-[11px] t-dim2">No sessions to resume</div>}
           {shown.map((s) => (
             <ResumeRow key={s.session_id} s={s} openChatId={chatResuming(s.session_id)?.id} onPick={() => onPick(s)} />
           ))}
         </div>
         <div className="px-2.5 pt-1.5 pb-0.5 text-[9px] t-dim2 shrink-0">
-          resuming keeps claude's full context · running sessions can't be resumed
+          Resuming keeps claude's full context · running sessions can't be resumed
         </div>
       </motion.div>
     </>
@@ -738,15 +738,15 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                 <ViewHeader title="Chats" count={chats.length} actions={<>
                   <button onClick={() => setResumeOpen((v) => !v)} aria-expanded={resumeOpen} aria-haspopup="listbox"
                     className="text-[11px] px-2.5 py-1 rounded-lg shrink-0" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}
-                    title="continue a session that already exists — e.g. one you started in a terminal">↩ resume</button>
-                  <button onClick={add} className="text-[11px] px-2.5 py-1 rounded-lg shrink-0" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }} title="new chat">+ new</button>
+                    title="Continue a session that already exists — e.g. one you started in a terminal">↩ Resume</button>
+                  <button onClick={add} className="text-[11px] px-2.5 py-1 rounded-lg shrink-0" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }} title="New chat">+ New</button>
                 </>} />
 
                 <div className="flex-1 min-h-0 flex overflow-hidden">
                 {/* ---- sidebar: every open chat ---- */}
                 <div className="shrink-0 flex flex-col" style={{ width: sidebarW, background: "color-mix(in srgb, var(--bg) 40%, transparent)" }}>
                   {chats.length > 6 && (
-                    <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="filter chats…"
+                    <input value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Filter chats…"
                       className="mx-2.5 mt-2.5 mb-2 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
                       style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)", color: "var(--text)" }} />
                   )}
@@ -760,15 +760,15 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         one in. Only the first is about matching. */}
                     {!shown.length && (
                       <div className="px-2.5 py-3 text-[11px] t-dim2">
-                        {query.trim() ? "no chats match"
-                          : !reposKnown || !scopeKnown ? "finding your projects…"
-                          : !repos.length ? "no git repository found to run a chat in"
-                          : "no chats yet — press + new"}
+                        {query.trim() ? "No chats match"
+                          : !reposKnown || !scopeKnown ? "Finding your projects…"
+                          : !repos.length ? "No git repository found to run a chat in"
+                          : "No chats yet — press + new"}
                       </div>
                     )}
                     {noRepo && (
                       <div className="px-2.5 py-2 text-[11px]" style={{ color: "var(--warning)" }}>
-                        nowhere to run a chat: no git repository was found
+                        Nowhere to run a chat: no git repository was found
                       </div>
                     )}
                   </div>
@@ -784,7 +784,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                     {active ? (
                       <>
                         <Select value={active.cwd} onChange={(v) => { update(active.id, (c) => { c.cwd = v; }); setDefaultCwd(v); }}
-                          className={selCls} style={selStyle} options={repoOptions} placeholder="pick a repo" />
+                          className={selCls} style={selStyle} options={repoOptions} placeholder="Pick a repo" />
                         <Select value={active.model} onChange={(v) => update(active.id, (c) => { c.model = v; })}
                           className={selCls} style={selStyle} options={MODELS.map((m) => ({ value: m.id, label: m.label }))} />
                         <Select value={active.mode} onChange={(v) => update(active.id, (c) => { c.mode = v; })}
@@ -794,15 +794,15 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           <input
                             value={allowed}
                             onChange={(e) => setAllowed(e.target.value)}
-                            placeholder="allowed tools…"
+                            placeholder="Allowed tools…"
                             title={"Tools that may run without asking — space-separated.\n\nExamples: Read  Edit  Bash(git status)  Bash(gh pr view:*)\n\nWithout this, `claude -p` refuses anything that would normally prompt, because there is no terminal to prompt from."}
                             className="text-[10px] px-2 py-1 rounded-md outline-none min-w-0 flex-1 max-w-[280px]"
                             style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
                           />
                         )}
-                        {active.sessionId && <span className="text-[9.5px] t-dim2 tabular-nums" title="resuming this session">↻ {active.sessionId.slice(0, 8)}</span>}
+                        {active.sessionId && <span className="text-[9.5px] t-dim2 tabular-nums" title="Resuming this session">↻ {active.sessionId.slice(0, 8)}</span>}
                       </>
-                    ) : <span className="text-[12px] t-dim2">no chat selected</span>}
+                    ) : <span className="text-[12px] t-dim2">No chat selected</span>}
                   </div>
 
                   {/* Bottom-anchored: a short conversation sits above the input
@@ -883,7 +883,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             {!!m.images?.length && (
                               <div className="flex flex-wrap gap-1.5 mb-1.5">
                                 {m.images.map((img, j) => (
-                                  <img key={j} src={`data:${img.mediaType};base64,${img.data}`} alt="attached image"
+                                  <img key={j} src={`data:${img.mediaType};base64,${img.data}`} alt="Attached image"
                                     className="block max-h-40 max-w-full rounded-lg"
                                     style={{ border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }} />
                                 ))}
@@ -914,7 +914,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         title="Jump to the newest message and follow again"
                         className="pointer-events-auto mb-2 text-[10px] px-2.5 py-1 rounded-full font-medium shadow-lg"
                         style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 18%, var(--bg2))", border: "1px solid color-mix(in srgb, var(--success) 45%, transparent)" }}>
-                        ↓ jump to latest
+                        ↓ Jump to latest
                       </button>
                     </div>
                   )}
@@ -927,7 +927,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                       // swap reflows the textarea under the cursor mid-drag.
                       <div className="absolute inset-0 z-10 grid place-items-center rounded-lg pointer-events-none text-[11px] font-semibold"
                         style={{ background: "color-mix(in srgb, var(--primary) 14%, transparent)", border: "1px dashed color-mix(in srgb, var(--primary) 60%, transparent)", color: "var(--text)" }}>
-                        drop to attach
+                        Drop to attach
                       </div>
                     )}
                     {!!active?.attachments.length && (
@@ -937,7 +937,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}
                             title={`${a.name} · ${(a.bytes / 1024).toFixed(0)}KB`}>
                             <img src={a.url} alt={a.name} className="block h-14 w-14 object-cover" />
-                            <button onClick={() => dropAttachment(active.id, a.id)} aria-label={`remove ${a.name}`}
+                            <button onClick={() => dropAttachment(active.id, a.id)} aria-label={`Remove ${a.name}`}
                               className="absolute top-0.5 right-0.5 w-4 h-4 grid place-items-center rounded text-[10px] leading-none"
                               style={{ color: "var(--text)", background: "rgba(0,0,0,0.65)" }}>✕</button>
                           </div>
@@ -956,9 +956,9 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             {active.setupNeeded.command}
                           </code>
                           <button onClick={() => { navigator.clipboard?.writeText(active.setupNeeded!.command); }}
-                            className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>copy</button>
+                            className="text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>Copy</button>
                           <button onClick={() => update(active.id, (c) => { c.setupNeeded = undefined; c.attention = "none"; })}
-                            className="ml-auto text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text3)" }}>dismiss</button>
+                            className="ml-auto text-[10px] px-1.5 py-0.5 rounded" style={{ color: "var(--text3)" }}>Dismiss</button>
                         </div>
                       </div>
                     )}
@@ -979,10 +979,10 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           }}
                           className="shrink-0 px-2 py-1 rounded-md text-[10.5px] font-medium"
                           style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 18%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 45%, transparent)" }}>
-                          allow {active.blockedTool}
+                          Allow {active.blockedTool}
                         </button>
                         <button onClick={() => update(active.id, (c) => { c.blockedTool = undefined; })}
-                          className="shrink-0 px-1 t-dim2 hover:opacity-70" aria-label="dismiss">✕</button>
+                          className="shrink-0 px-1 t-dim2 hover:opacity-70" aria-label="Dismiss">✕</button>
                       </div>
                     )}
                     {slashMatches.length > 0 && (
@@ -1001,7 +1001,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           </div>
                         ))}
                         <div className="px-2.5 py-1 text-[9.5px] t-dim2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
-                          ↑↓ move · Tab or Enter to pick · keep typing to filter
+                          ↑↓ Move · Tab or Enter to pick · keep typing to filter
                         </div>
                       </div>
                     )}
@@ -1013,7 +1013,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         {active.queued.map((q, i) => (
                           <div key={q.id} className="flex items-baseline gap-2 px-2.5 py-1.5 rounded-lg"
                             style={{ background: "color-mix(in srgb, var(--primary) 10%, transparent)", border: "1px dashed color-mix(in srgb, var(--primary) 35%, transparent)" }}>
-                            <span className="shrink-0 text-[9.5px] t-dim2">queued {i + 1}</span>
+                            <span className="shrink-0 text-[9.5px] t-dim2">Queued {i + 1}</span>
                             <span className="flex-1 truncate text-[11.5px]" style={{ color: "var(--text3)" }}>
                               {q.text || `${q.images.length} image${q.images.length > 1 ? "s" : ""}`}
                             </span>
@@ -1023,7 +1023,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                                 is only offered where nothing is lost. */}
                             {!q.images.length && (
                               <button onClick={() => unqueue(active.id, q.id, true)} title="Put this back in the composer"
-                                className="shrink-0 text-[9.5px] t-dim2 hover:opacity-70">edit</button>
+                                className="shrink-0 text-[9.5px] t-dim2 hover:opacity-70">Edit</button>
                             )}
                             <button onClick={() => unqueue(active.id, q.id)} aria-label="Remove queued message"
                               className="shrink-0 px-1 t-dim2 hover:opacity-70">✕</button>
@@ -1049,11 +1049,11 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}>
                         <ClipIcon />
                       </button>
-                      <textarea ref={inputRef} aria-label="chat composer" value={active?.draft ?? ""} disabled={!enabled || !active} rows={2}
+                      <textarea ref={inputRef} aria-label="Chat composer" value={active?.draft ?? ""} disabled={!enabled || !active} rows={2}
                         onChange={(e) => active && update(active.id, (c) => { c.draft = e.target.value; })}
                         onKeyDown={onKey}
                         onPaste={onPaste}
-                        placeholder={!enabled ? "chat unavailable" : active?.sending ? "still replying — type anyway, Enter queues it for the next turn" : active?.sessionId ? "reply… (Enter to send, Shift+Enter newline)" : "message a new session… (Enter to send)"}
+                        placeholder={!enabled ? "Chat unavailable" : active?.sending ? "Still replying — type anyway, Enter queues it for the next turn" : active?.sessionId ? "Reply… (Enter to send, Shift+Enter newline)" : "Message a new session… (Enter to send)"}
                         className="agx-scroll flex-1 px-3 py-2 rounded-lg text-[12px] outline-none resize-none" style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }} />
                       {/* Stop stays reachable while a turn is queueing: the
                           two are different intents — "answer this next" and
@@ -1062,16 +1062,16 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           keep. */}
                       {active?.sending && (
                         <button onClick={() => stop(active.id)} title="Interrupt the turn and clear anything queued"
-                          className="shrink-0 px-3.5 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>■ stop</button>
+                          className="shrink-0 px-3.5 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>■ Stop</button>
                       )}
                       <button onClick={submit} disabled={!hasTurn || !active?.cwd || !enabled} className="shrink-0 px-4 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!hasTurn || !active?.cwd) ? 0.45 : 1 }}>
-                        {active?.sending ? "queue ↵" : "send ↵"}
+                        {active?.sending ? "Queue ↵" : "Send ↵"}
                       </button>
                     </div>
                     <div className="mt-1.5 text-[9.5px] t-dim2">
                       {hint
                         ? <span style={{ color: "var(--warning)" }}>{hint}</span>
-                        : <>runs claude in {active ? repoName(active.cwd) || "the repo" : "the repo"} · {MODES.find((x) => x.id === active?.mode)?.label} · tools appear as ⚙ chips</>}
+                        : <>Runs claude in {active ? repoName(active.cwd) || "the repo" : "the repo"} · {MODES.find((x) => x.id === active?.mode)?.label} · tools appear as ⚙ chips</>}
                       {active?.mode === "bypassPermissions" && <span style={{ color: "var(--warning)" }}> · ⚡ runs tools unattended</span>}
                     </div>
                   </div>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -838,7 +838,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           <div className={`flex ${m.role === "user" ? "justify-end" : "justify-start"}`}>
                           <div className="max-w-[86%] min-w-0 rounded-xl px-3.5 py-2.5 text-[12px] leading-relaxed break-words"
                             style={{
-                              ...CODE_FONT_STYLE, fontFamily: undefined, opacity: m.historical ? 0.72 : 1,
+                              // Resumed history reads at full strength, same as
+                              // live: the "resumed here" divider already marks the
+                              // seam, so dimming the bubbles on top of it only made
+                              // a restored conversation look degraded next to the
+                              // console it mirrors.
+                              ...CODE_FONT_STYLE, fontFamily: undefined,
                               // Stronger than the old 16%/45% wash: at that
                               // strength every bubble was the same violet as the
                               // panel behind it, and on some themes the two roles

--- a/web/src/components/CommandBar.tsx
+++ b/web/src/components/CommandBar.tsx
@@ -32,10 +32,10 @@ import { keepTermFocus } from "../lib/keepFocus.ts";
  * anything else, and costing nothing when you don't want them.
  */
 export const GIT_COMMANDS: ProjectCommand[] = [
-  { name: "status", cmd: "git status", desc: "what is changed, staged and untracked", dir: "" },
-  { name: "log", cmd: "git log --oneline -15", desc: "the last 15 commits, one line each", dir: "" },
-  { name: "diff", cmd: "git diff --stat", desc: "which files changed, and by how much", dir: "" },
-  { name: "branches", cmd: "git branch -vv", desc: "local branches with their upstreams", dir: "" },
+  { name: "status", cmd: "git status", desc: "What is changed, staged and untracked", dir: "" },
+  { name: "log", cmd: "git log --oneline -15", desc: "The last 15 commits, one line each", dir: "" },
+  { name: "diff", cmd: "git diff --stat", desc: "Which files changed, and by how much", dir: "" },
+  { name: "branches", cmd: "git branch -vv", desc: "Local branches with their upstreams", dir: "" },
 ];
 
 // --- pins --------------------------------------------------------------------
@@ -194,7 +194,7 @@ function CommandRow({ c, font, on, full, onRun, onPin }: {
         disabled={!on && full}
         className={`shrink-0 text-[11px] leading-none px-1 ${on ? "" : "opacity-0 group-hover:opacity-100"}`}
         style={{ color: on ? "var(--warning)" : "var(--text3)", opacity: !on && full ? 0.3 : undefined }}
-        title={on ? "unpin" : full ? `${MAX_PINS} pinned already — unpin one first` : `pin ${c.cmd} to the bar`}
+        title={on ? "Unpin" : full ? `${MAX_PINS} pinned already — unpin one first` : `Pin ${c.cmd} to the bar`}
       >{on ? "★" : "☆"}</button>
     </div>
   );
@@ -256,7 +256,7 @@ export function CommandBar({ root, disabled, font, onRun, onClose, dropUp }: {
           title="Ready-to-run project commands: Makefile targets & package scripts, with what each one does. Pin the ones you use."
           className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg font-medium whitespace-nowrap"
           style={{ color: n ? "var(--primary-hover)" : "var(--text2)", background: "color-mix(in srgb, var(--primary) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)", opacity: root && !IS_DEMO ? 1 : 0.5 }}>
-          ⚙ commands{n ? ` (${n})` : cmds ? " (none)" : " …"}<span className="t-dim2">▼</span>
+          ⚙ Commands{n ? ` (${n})` : cmds ? " (none)" : " …"}<span className="t-dim2">▼</span>
         </button>
         {open && (
           // keepTermFocus on the whole popover: a click on its padding, a
@@ -288,11 +288,11 @@ export function CommandBar({ root, disabled, font, onRun, onClose, dropUp }: {
                 </div>
               ))}
               {!gitMatches.length && !groups.length && (
-                <div className="px-3 py-2 t-dim2">{cmds ? `no command matches “${query.trim()}”` : "reading the project…"}</div>
+                <div className="px-3 py-2 t-dim2">{cmds ? `No command matches “${query.trim()}”` : "Reading the project…"}</div>
               )}
             </div>
             <div className="shrink-0 px-3 py-1.5 t-dim2 text-[9.5px] border-t" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
-              ☆ pins a command to the bar — {pins.length} of {MAX_PINS} used, per repo
+              ☆ Pins a command to the bar — {pins.length} of {MAX_PINS} used, per repo
             </div>
           </div>
         )}
@@ -309,13 +309,13 @@ export function CommandBar({ root, disabled, font, onRun, onClose, dropUp }: {
             <button onMouseDown={keepTermFocus} onClick={() => onRun(cmd)} disabled={disabled || !root || IS_DEMO}
               className="text-[10px] pl-2 pr-2 py-1 rounded-md whitespace-nowrap"
               style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", fontFamily: font }}
-              title={`run ${cmd}`}>{cmd}</button>
+              title={`Run ${cmd}`}>{cmd}</button>
             {/* Unpin from the chip itself: going back to the dropdown to find
                 the row you pinned is the long way round. */}
             <button onMouseDown={keepTermFocus} onClick={() => togglePin(root, cmd)}
               className="absolute -top-1 -right-1 text-[9px] leading-none rounded-full px-[3px] py-[1px] opacity-0 group-hover:opacity-100"
               style={{ background: "var(--bg3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}
-              title={`unpin ${cmd}`}>✕</button>
+              title={`Unpin ${cmd}`}>✕</button>
           </span>
         ))}
         {!pins.length && !!root && (
@@ -323,7 +323,7 @@ export function CommandBar({ root, disabled, font, onRun, onClose, dropUp }: {
           // steal the shell's cursor on the way there — see the trigger above.
           <button onMouseDown={keepTermFocus} onClick={() => setOpen(true)} className="text-[10px] px-2 py-1 rounded-md whitespace-nowrap shrink-0"
             style={{ color: "var(--text3)", border: "1px dashed color-mix(in srgb, var(--border) 30%, transparent)" }}
-            title={`Pin up to ${MAX_PINS} commands here — they stay one click away, per repo`}>☆ pin a command</button>
+            title={`Pin up to ${MAX_PINS} commands here — they stay one click away, per repo`}>☆ Pin a command</button>
         )}
       </div>
     </>

--- a/web/src/components/CommandLog.tsx
+++ b/web/src/components/CommandLog.tsx
@@ -60,7 +60,7 @@ export function CommandLog({ open, onClose }: { open: boolean; onClose: () => vo
           title={writesOnly ? "Also show the read-only queries the panel runs while polling" : "Show only commands that can change the repository"}
           className="text-[9px] px-1.5 py-0.5 rounded"
           style={{ color: writesOnly ? "var(--text)" : "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
-          {writesOnly ? "writes only" : "everything"}
+          {writesOnly ? "Writes only" : "Everything"}
         </button>
         <button onClick={onClose} className="ml-auto text-[11px] px-1.5 t-dim2 hover:opacity-70" title="Hide (@)">✕</button>
       </div>
@@ -81,7 +81,7 @@ export function CommandLog({ open, onClose }: { open: boolean; onClose: () => vo
         ))}
         {!shown.length && (
           <div className="py-6 text-center t-dim2 text-[10px]">
-            {writesOnly ? "nothing has changed the repository yet" : "no commands yet"}
+            {writesOnly ? "Nothing has changed the repository yet" : "No commands yet"}
           </div>
         )}
       </div>

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -144,7 +144,7 @@ export function CommandPalette({
                     <span className="text-[10px] t-dim2">{c.group}</span>
                   </button>
                 ))}
-                {filtered.length === 0 && <div className="px-4 py-6 text-center t-dim2 text-[12px]">no commands</div>}
+                {filtered.length === 0 && <div className="px-4 py-6 text-center t-dim2 text-[12px]">No commands</div>}
               </div>
             </motion.div>
             </div>

--- a/web/src/components/CommitModal.tsx
+++ b/web/src/components/CommitModal.tsx
@@ -52,7 +52,7 @@ function FileRow({ f, on, onToggle }: { f: GitFileStatus; on: boolean; onToggle:
       <span className="text-[11.5px] truncate" style={{ color: on ? "var(--text)" : "var(--text3)" }}>
         <span className="t-dim2">{dirName(f.path)}</span><span className="font-medium">{baseName(f.path)}</span>
       </span>
-      {!on && f.unstaged && f.staged && <span className="ml-auto text-[9px] t-dim2 shrink-0">partly staged</span>}
+      {!on && f.unstaged && f.staged && <span className="ml-auto text-[9px] t-dim2 shrink-0">Partly staged</span>}
     </button>
   );
 }
@@ -132,9 +132,9 @@ export function CommitModal({ open, onClose, paths }: { open: boolean; onClose: 
                 </div>
 
                 <div className="flex-1 min-h-0 overflow-y-auto px-5 py-3">
-                  {!repos && <div className="t-dim2 text-center py-12 text-[12px]">reading working tree…</div>}
+                  {!repos && <div className="t-dim2 text-center py-12 text-[12px]">Reading working tree…</div>}
                   {repos && repos.length === 0 && (
-                    <div className="t-dim2 text-center py-12 text-[12px]">no git repository found for these changes</div>
+                    <div className="t-dim2 text-center py-12 text-[12px]">No git repository found for these changes</div>
                   )}
 
                   {result?.ok ? (
@@ -168,10 +168,10 @@ export function CommitModal({ open, onClose, paths }: { open: boolean; onClose: 
                       <div>
                         <div className="flex items-center justify-between mb-1 px-1">
                           <span className="text-[10px] t-dim2 uppercase tracking-wide">Files in this commit</span>
-                          <button onClick={toggleAll} className="text-[10px] t-dim2 hover:opacity-80">{allOn ? "select none" : "select all"} · {selPaths.length}/{repo.files.length}</button>
+                          <button onClick={toggleAll} className="text-[10px] t-dim2 hover:opacity-80">{allOn ? "Select none" : "Select all"} · {selPaths.length}/{repo.files.length}</button>
                         </div>
                         <div className="rounded-lg p-1 space-y-0.5 max-h-[220px] overflow-y-auto" style={{ background: "color-mix(in srgb, var(--bg3) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
-                          {repo.files.length === 0 && <div className="t-dim2 text-center py-6 text-[11px]">working tree clean — nothing to commit</div>}
+                          {repo.files.length === 0 && <div className="t-dim2 text-center py-6 text-[11px]">Working tree clean — nothing to commit</div>}
                           {repo.files.map((f) => <FileRow key={f.path} f={f} on={sel.has(f.path)} onToggle={() => toggle(f.path)} />)}
                         </div>
                       </div>
@@ -221,7 +221,7 @@ export function CommitModal({ open, onClose, paths }: { open: boolean; onClose: 
                         <>
                           <button onClick={() => setConfirming(false)} className="px-3 py-1.5 rounded-lg text-[11px]" style={{ background: "color-mix(in srgb, var(--bg3) 45%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text3)" }}>Cancel</button>
                           <button onClick={doCommit} disabled={busy} className="px-3 py-1.5 rounded-lg text-[11px] font-medium" style={{ background: "var(--error)", color: "#fff", opacity: busy ? 0.6 : 1 }}>
-                            {busy ? "committing…" : `Yes, commit ${selPaths.length}`}
+                            {busy ? "Committing…" : `Yes, commit ${selPaths.length}`}
                           </button>
                         </>
                       ) : (

--- a/web/src/components/CostByModel.tsx
+++ b/web/src/components/CostByModel.tsx
@@ -15,7 +15,7 @@ export const CostByModel = memo(function CostByModel({ stats }: { stats: StatsSu
   const active = hi != null ? models[hi] : null;
 
   return (
-    <Panel eyebrow="Cost" title="Where the money goes" right={<span className="text-[10px] t-dim2">by model</span>}>
+    <Panel eyebrow="Cost" title="Where the money goes" right={<span className="text-[10px] t-dim2">By model</span>}>
       <div className="flex gap-4 h-full items-center">
         <div className="relative h-36 w-36 shrink-0">
           <ResponsiveContainer width="100%" height="100%">
@@ -51,13 +51,13 @@ export const CostByModel = memo(function CostByModel({ stats }: { stats: StatsSu
             ) : (
               <>
                 <span className="text-[17px] font-semibold tabular-nums" style={{ color: "var(--success)" }}>{fmtUsd(total)}</span>
-                <span className="text-[10px] t-dim2">total spend</span>
+                <span className="text-[10px] t-dim2">Total spend</span>
               </>
             )}
           </div>
         </div>
         <div className="flex-1 min-w-0 space-y-1.5">
-          {models.length === 0 && <div className="t-dim2 text-[11px]">no token usage yet</div>}
+          {models.length === 0 && <div className="t-dim2 text-[11px]">No token usage yet</div>}
           {models.map((m, i) => (
             <motion.div
               key={m.model_name}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -223,7 +223,7 @@ function DetailPane({ tab, env, config, top, error }: {
   if (tab !== "env" && text == null) return <div className="flex-1 grid place-items-center t-dim2 text-[12px]"><span className="agx-spin" aria-hidden="true" /></div>;
   if (tab === "env") {
     if (!env) return <div className="flex-1 grid place-items-center t-dim2 text-[12px]"><span className="agx-spin" aria-hidden="true" /></div>;
-    if (!env.length) return <div className="flex-1 grid place-items-center t-dim2 text-[12px]">this container has no environment set</div>;
+    if (!env.length) return <div className="flex-1 grid place-items-center t-dim2 text-[12px]">This container has no environment set</div>;
     return (
       <div className="agx-scroll flex-1 min-h-0 overflow-auto p-4 text-[11px] flex flex-col gap-1" style={{ color: "var(--text2)" }}>
         {env.map((line, i) => {
@@ -261,7 +261,7 @@ function DockerMissing({ reason }: { reason?: string }) {
       <div className="max-w-md flex flex-col items-center gap-2">
         <span className="text-[13px] font-semibold" style={{ color: "var(--warning)" }}>Docker isn't installed</span>
         <span className="text-[11.5px]" style={{ color: "var(--text2)" }}>
-          {reason || "the docker CLI isn't on your PATH"}. Containers, images, volumes and logs stay empty until it is.
+          {reason || "The docker CLI isn't on your PATH"}. Containers, images, volumes and logs stay empty until it is.
         </span>
         <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>
           Get it from <code>docker.com/get-started</code> (Docker Desktop), or your package manager:{" "}
@@ -354,7 +354,7 @@ export function DockerView({ active }: { active: boolean }) {
   }, []);
   const loadLogs = useCallback(async (id: string, n: number) => {
     const seq = ++logSeq.current; // drop a slow response if the container changed
-    try { const r = await api.dockerLogs(id, n); if (seq !== logSeq.current) return; setLogs(r.ok ? stripAnsi(r.text) : (r.error || "no logs")); }
+    try { const r = await api.dockerLogs(id, n); if (seq !== logSeq.current) return; setLogs(r.ok ? stripAnsi(r.text) : (r.error || "No logs")); }
     catch (e) { if (seq === logSeq.current) setLogs(String(e)); }
   }, []);
 
@@ -425,7 +425,7 @@ export function DockerView({ active }: { active: boolean }) {
     } else if (tab === "top") {
       void api.dockerTop(id).then((r) => {
         if (!live) return;
-        if (!r.ok) { setDetailErr(r.error || "not running"); setTop(null); return; }
+        if (!r.ok) { setDetailErr(r.error || "Not running"); setTop(null); return; }
         setTop(r.text); setDetailErr(null);
       });
     }
@@ -470,7 +470,7 @@ export function DockerView({ active }: { active: boolean }) {
     try {
       const fn = verb === "start" ? api.dockerStart : verb === "stop" ? api.dockerStop : verb === "restart" ? api.dockerRestart : api.dockerRm;
       const r = await fn(id);
-      flash(r.ok, r.ok ? (r.output || `${verb}ed`) : (r.error || "failed"));
+      flash(r.ok, r.ok ? (r.output || `${verb}ed`) : (r.error || "Failed"));
       await loadOverview(); await loadStats();
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); }
@@ -508,31 +508,31 @@ export function DockerView({ active }: { active: boolean }) {
                 <style>{SCROLLBAR_CSS}</style>
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
                   <span className={viewTitleClass} style={{ color: "var(--text)" }}>Docker</span>
-                  {ov?.version && <span className="text-[10px] t-dim2">engine {ov.version}</span>}
+                  {ov?.version && <span className="text-[10px] t-dim2">Engine {ov.version}</span>}
                   {/* Scoped to the open project. The fallback case is spelled out
                       rather than shown as an empty list, so an unlabelled stack
                       doesn't read as "docker is broken". */}
                   {ov?.scope && (
                     <span className="text-[9.5px] px-1.5 py-0.5 rounded shrink-0" title={ov.scope.showingAll
-                      ? `no container is labelled for ${ov.scope.project} (${ov.scope.workspace}) — showing every container on this host`
-                      : `showing containers for ${ov.scope.workspace}`}
+                      ? `No container is labelled for ${ov.scope.project} (${ov.scope.workspace}) — showing every container on this host`
+                      : `Showing containers for ${ov.scope.workspace}`}
                       style={ov.scope.showingAll
                         ? { background: "color-mix(in srgb, var(--warning) 16%, transparent)", color: "var(--warning)" }
                         : { background: "color-mix(in srgb, var(--primary) 14%, transparent)", color: "var(--text2)" }}>
-                      {ov.scope.showingAll ? `no ${ov.scope.project} containers · showing all` : ov.scope.project}
+                      {ov.scope.showingAll ? `No ${ov.scope.project} containers · showing all` : ov.scope.project}
                     </span>
                   )}
                   {/* The tabs used to live here and are now the stacked
                       column's headers — two ways to switch the same thing, one
                       of which hid three quarters of what docker was doing. */}
                   <div className="ml-auto flex items-center gap-1.5">
-                    {!writeEnabled && ov?.available && <span className="text-[9.5px] t-dim2">read-only</span>}
+                    {!writeEnabled && ov?.available && <span className="text-[9.5px] t-dim2">Read-only</span>}
                     <button onClick={() => setDense((v) => !v)} title={dense ? "Show each container's image" : "Fit more containers on screen"}
                       className="text-[10px] px-2 py-0.5 rounded-lg"
                       style={dense
                         ? { color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" }
                         : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
-                      dense
+                      Dense
                     </button>
                     <button onClick={() => { loadOverview(); loadStats(); }} title="Refresh" className="text-[13px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>⟳</button>
                   </div>
@@ -545,7 +545,7 @@ export function DockerView({ active }: { active: boolean }) {
                   cap && !cap.available ? (
                     <DockerMissing reason={cap.reason} />
                   ) : (
-                    <div className="flex-1 grid place-items-center t-dim2 text-[12px] px-6 text-center">{ov?.error || "connecting to docker…"}</div>
+                    <div className="flex-1 grid place-items-center t-dim2 text-[12px] px-6 text-center">{ov?.error || "Connecting to Docker…"}</div>
                   )
                 ) : (
                   <div className="flex-1 min-h-0 flex">
@@ -651,10 +651,10 @@ export function DockerView({ active }: { active: boolean }) {
                                 <button onClick={() => { setConsoleOpen(true); runInConsole(consoleRoot(), `docker exec -it ${selected.id.slice(0, 12)} sh -c 'command -v bash >/dev/null && exec bash || exec sh'`); }}
                                   className="text-[10px] px-2 py-0.5 rounded mr-1"
                                   style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" }}
-                                  title={`Open a shell inside ${selected.name}`}>exec</button>
+                                  title={`Open a shell inside ${selected.name}`}>Exec</button>
                               )}
                               {DETAIL_TABS.map((t) => (
-                                <button key={t} onClick={() => setTab(t)} className="text-[10px] px-2 py-0.5 rounded" style={{ background: tab === t ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: tab === t ? "var(--text)" : "var(--text3)" }}>{t}</button>
+                                <button key={t} onClick={() => setTab(t)} className="text-[10px] px-2 py-0.5 rounded" style={{ background: tab === t ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent", color: tab === t ? "var(--text)" : "var(--text3)" }}>{t[0].toUpperCase() + t.slice(1)}</button>
                               ))}
                               {tab === "logs" && (
                                 <Select value={String(tail)} onChange={(v) => setTail(Number(v))} align="right"
@@ -679,7 +679,7 @@ export function DockerView({ active }: { active: boolean }) {
                             </div>
                           )}
                         </>
-                    ) : <div className="flex-1 grid place-items-center t-dim2 text-[12px]">no containers</div>}
+                    ) : <div className="flex-1 grid place-items-center t-dim2 text-[12px]">No containers</div>}
                     </div>
                   </div>
                 )}
@@ -715,10 +715,10 @@ export function DockerView({ active }: { active: boolean }) {
                       }}
                     >
                       <span style={{ fontSize: 11 }}>{consoleOpen ? "▾" : "▸"}</span>
-                      <span>console</span>
+                      <span>Console</span>
                       <kbd className="text-[8.5px] px-1 py-[1px] rounded" style={{ border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: 0.85 }}>shell</kbd>
                     </button>
-                    <span className="ml-auto">logs auto-refresh · stats every 5s</span>
+                    <span className="ml-auto">Logs auto-refresh · stats every 5s</span>
                   </div>
                 )}
                 {toast && (

--- a/web/src/components/EventModal.tsx
+++ b/web/src/components/EventModal.tsx
@@ -46,14 +46,14 @@ export function EventModal({ event, onClose }: { event: WatchEvent | null; onClo
 
               <div className="p-5 overflow-auto">
                 <div className="grid grid-cols-2 gap-x-6 mb-4">
-                  <Row k="time" v={fmtTime(event.timestamp)} />
-                  <Row k="tool" v={event.tool_name ?? "—"} />
-                  <Row k="model" v={event.model_name ?? "—"} />
-                  <Row k="duration" v={event.duration_ms != null ? fmtMs(event.duration_ms) : "—"} />
-                  <Row k="cost" v={event.cost_usd > 0 ? fmtUsd(event.cost_usd) : "—"} />
-                  <Row k="tokens" v={event.input_tokens + event.output_tokens > 0 ? `${fmtTokens(event.input_tokens)} in · ${fmtTokens(event.output_tokens)} out` : "—"} />
-                  <Row k="session" v={event.session_id} />
-                  <Row k="error" v={event.is_error ? <span style={{ color: "var(--error)" }}>{event.error_text ?? "yes"}</span> : "no"} />
+                  <Row k="Time" v={fmtTime(event.timestamp)} />
+                  <Row k="Tool" v={event.tool_name ?? "—"} />
+                  <Row k="Model" v={event.model_name ?? "—"} />
+                  <Row k="Duration" v={event.duration_ms != null ? fmtMs(event.duration_ms) : "—"} />
+                  <Row k="Cost" v={event.cost_usd > 0 ? fmtUsd(event.cost_usd) : "—"} />
+                  <Row k="Tokens" v={event.input_tokens + event.output_tokens > 0 ? `${fmtTokens(event.input_tokens)} in · ${fmtTokens(event.output_tokens)} out` : "—"} />
+                  <Row k="Session" v={event.session_id} />
+                  <Row k="Error" v={event.is_error ? <span style={{ color: "var(--error)" }}>{event.error_text ?? "Yes"}</span> : "No"} />
                 </div>
                 <div className="text-[10px] uppercase tracking-wider t-dim2 mb-1">payload</div>
                 <pre className="text-[10.5px] leading-relaxed rounded-lg p-3 overflow-auto max-h-[38vh]"

--- a/web/src/components/Feed.tsx
+++ b/web/src/components/Feed.tsx
@@ -9,10 +9,10 @@ import { fmtTime, fmtMs, fmtUsd, agentKey, hashColor } from "../lib/format.ts";
 type Category = "all" | "tools" | "chat" | "alerts";
 
 const CATS: { key: Category; label: string }[] = [
-  { key: "all", label: "all" },
-  { key: "tools", label: "tools" },
-  { key: "chat", label: "chat" },
-  { key: "alerts", label: "alerts" },
+  { key: "all", label: "All" },
+  { key: "tools", label: "Tools" },
+  { key: "chat", label: "Chat" },
+  { key: "alerts", label: "Alerts" },
 ];
 
 const TOOL_TYPES = new Set(["PreToolUse", "PostToolUse", "PostToolUseFailure"]);
@@ -270,7 +270,7 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
             <span className="absolute inline-flex h-full w-full rounded-full opacity-70" style={{ background: "var(--success)", animation: "ping-ring 1.6s ease-out infinite" }} />
             <span className="relative inline-flex rounded-full h-2 w-2" style={{ background: "var(--success)" }} />
           </span>
-          following live
+          Following live
         </>
       ) : newCount > 0 ? (
         <AnimatePresence mode="wait">
@@ -280,7 +280,7 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
         </AnimatePresence>
       ) : (
         <>
-          <span aria-hidden style={{ letterSpacing: "-1px" }}>❚❚</span> paused
+          <span aria-hidden style={{ letterSpacing: "-1px" }}>❚❚</span> Paused
         </>
       )}
     </motion.button>
@@ -300,12 +300,12 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
       <span className="font-semibold">Filtered</span>
       {filter.app && (
         <span className="chip" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", borderColor: "color-mix(in srgb, var(--primary) 55%, transparent)" }}>
-          app: {filter.app}
+          App: {filter.app}
         </span>
       )}
       {filter.type && (
         <span className="chip" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", borderColor: "color-mix(in srgb, var(--primary) 55%, transparent)" }}>
-          event: {filter.type}
+          Event: {filter.type}
         </span>
       )}
       <span className="t-dim2 tabular-nums">· {rows.length} shown</span>
@@ -314,7 +314,7 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
         className="ml-auto flex items-center gap-1 rounded-md px-2 py-0.5 font-semibold cursor-pointer"
         style={{ color: "var(--bg2)", background: "var(--primary)" }}
       >
-        clear ✕
+        Clear ✕
       </button>
     </div>
   );
@@ -347,7 +347,7 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
             ))}
             <button
               onClick={() => setLanes((l) => !l)}
-              title="one column per session — parallel sessions get their own lane"
+              title="One column per session — parallel sessions get their own lane"
               className="chip cursor-pointer"
               style={
                 lanes
@@ -355,14 +355,14 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
                   : { color: "var(--text4)" }
               }
             >
-              ⫴ lanes
+              ⫴ Lanes
             </button>
           </div>
         </div>
         {lanes ? (
           <div className="flex-1 min-h-0 grid gap-2" style={{ gridTemplateColumns: `repeat(${Math.max(1, laneData.length)}, minmax(0, 1fr))` }}>
             {laneData.map((l) => <Lane key={l.key} aKey={l.key} rows={l.rows} onSelect={onSelect} />)}
-            {laneData.length === 0 && <div className="t-dim2 text-center py-8">no events match</div>}
+            {laneData.length === 0 && <div className="t-dim2 text-center py-8">No events match</div>}
           </div>
         ) : (
           <div ref={ref} className="flex-1 min-h-0 overflow-y-auto overflow-x-hidden pr-1"
@@ -375,7 +375,7 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
             <AnimatePresence initial={false}>
               {rows.map((row) => <EventRow key={row.key} row={row} onSelect={onSelect} />)}
             </AnimatePresence>
-            {rows.length === 0 && <div className="t-dim2 text-center py-8">no events match</div>}
+            {rows.length === 0 && <div className="t-dim2 text-center py-8">No events match</div>}
           </div>
         )}
       </div>
@@ -395,13 +395,13 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
               className="chip cursor-pointer"
               style={{ color: "var(--text3)" }}
             >
-              ⛶ expand
+              ⛶ Expand
             </button>
           </div>
         }
       >
         {full ? (
-          <div className="h-full flex items-center justify-center t-dim2 text-[11px]">feed is fullscreen — Esc to bring it back</div>
+          <div className="h-full flex items-center justify-center t-dim2 text-[11px]">Feed is fullscreen — Esc to bring it back</div>
         ) : (
           body
         )}

--- a/web/src/components/Fleet.tsx
+++ b/web/src/components/Fleet.tsx
@@ -11,10 +11,10 @@ const ago = (ts: number) => {
 };
 
 const STATUS: Record<string, { color: string; label: string }> = {
-  working: { color: "var(--success)", label: "working" },
-  waiting: { color: "var(--warning)", label: "waiting" },
-  errored: { color: "var(--error)", label: "errored" },
-  idle: { color: "var(--text4)", label: "idle" },
+  working: { color: "var(--success)", label: "Working" },
+  waiting: { color: "var(--warning)", label: "Waiting" },
+  errored: { color: "var(--error)", label: "Errored" },
+  idle: { color: "var(--text4)", label: "Idle" },
 };
 // `waiting` above `errored`: an agent stopped on a question needs a person, and
 // a person is the only thing that will move it. One that hit an error may well
@@ -53,9 +53,9 @@ function evidenceNote(a: AgentCard): string | undefined {
  * without colour.
  */
 const OUTCOME: Record<AgentOutcome, { glyph: string; color: string; title: string } | null> = {
-  settled: { glyph: "✓", color: "var(--success)", title: "finished with nothing left trailing" },
-  faulted: { glyph: "✕", color: "var(--error)", title: "ended on an error, or stopped mid-tool" },
-  unanswered: { glyph: "◷", color: "var(--warning)", title: "stopped on a question nobody answered" },
+  settled: { glyph: "✓", color: "var(--success)", title: "Finished with nothing left trailing" },
+  faulted: { glyph: "✕", color: "var(--error)", title: "Ended on an error, or stopped mid-tool" },
+  unanswered: { glyph: "◷", color: "var(--warning)", title: "Stopped on a question nobody answered" },
   // Nothing. No terminal event ever arrived, and the absence of a mark is the
   // accurate report — inventing a glyph here would be a guess wearing a badge.
   unclear: null,
@@ -209,7 +209,7 @@ export function Fleet({ agents, activeApp, onSelect }: { agents: AgentCard[]; ac
       right={
         activeApp ? (
           <span className="chip" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 20%, transparent)", borderColor: "color-mix(in srgb, var(--primary) 55%, transparent)" }}>
-            filtering: {activeApp}
+            Filtering: {activeApp}
           </span>
         ) : (
           <span className="text-[10px] t-dim2">{agents.length} live · {groups.length} projects</span>
@@ -217,7 +217,7 @@ export function Fleet({ agents, activeApp, onSelect }: { agents: AgentCard[]; ac
       }
     >
       <div className="overflow-auto h-full space-y-2.5 pr-1">
-        {agents.length === 0 && <div className="t-dim2 text-[12px] text-center py-8 shimmer rounded-lg">waiting for agents…</div>}
+        {agents.length === 0 && <div className="t-dim2 text-[12px] text-center py-8 shimmer rounded-lg">Waiting for agents…</div>}
         {groups.map(({ app, list, live, subs }) => {
           const collapsed = isCollapsed(app, live, list.length);
           const def = live === 0 && list.length > 2;

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -167,8 +167,8 @@ function PaneEmpty({ busy, what }: { busy: boolean; what: string }) {
   return (
     <div className="grid place-items-center py-10 t-dim2 text-[12px]">
       {busy
-        ? <span className="flex items-center gap-2"><span className="agx-spin" aria-hidden="true" />loading {what}…</span>
-        : <>no {what}</>}
+        ? <span className="flex items-center gap-2"><span className="agx-spin" aria-hidden="true" />Loading {what}…</span>
+        : <>No {what}</>}
     </div>
   );
 }
@@ -381,8 +381,8 @@ function BlockResolver({ blocks, error, picks, onPick, onApply, busy }: {
   busy: boolean;
 }) {
   if (error) return <div className="text-[10.5px] px-2 py-1.5 rounded" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 10%, transparent)" }}>{error}</div>;
-  if (!blocks) return <div className="text-[10.5px] t-dim2 flex items-center gap-2 px-2 py-1.5"><span className="agx-spin" aria-hidden="true" />reading the file…</div>;
-  if (!blocks.length) return <div className="text-[10.5px] t-dim2 px-2 py-1.5">no conflict markers left in this file</div>;
+  if (!blocks) return <div className="text-[10.5px] t-dim2 flex items-center gap-2 px-2 py-1.5"><span className="agx-spin" aria-hidden="true" />Reading the file…</div>;
+  if (!blocks.length) return <div className="text-[10.5px] t-dim2 px-2 py-1.5">No conflict markers left in this file</div>;
 
   const left = blocks.filter((b) => !picks[b.index]).length;
   const Side = ({ label, lines, tone }: { label: string; lines: string[]; tone: string }) => (
@@ -390,7 +390,7 @@ function BlockResolver({ blocks, error, picks, onPick, onApply, busy }: {
       <div className="text-[9px] mb-0.5 truncate" style={{ color: tone }}>{label}</div>
       <pre className="text-[10px] leading-[1.5] px-1.5 py-1 rounded overflow-x-auto agx-scroll m-0"
         style={{ background: "color-mix(in srgb, var(--bg) 60%, transparent)", color: "var(--text2)", maxHeight: 160 }}>
-        {lines.length ? lines.join("\n") : "(nothing — this side removes these lines)"}
+        {lines.length ? lines.join("\n") : "(Nothing — this side removes these lines)"}
       </pre>
     </div>
   );
@@ -413,10 +413,10 @@ function BlockResolver({ blocks, error, picks, onPick, onApply, busy }: {
             <div className="flex items-center gap-1.5">
               <span className="text-[9.5px] t-dim2 tabular-nums shrink-0">line {b.line}</span>
               <div className="flex items-center gap-1 ml-auto">
-                <Opt id="ours" label="ours" />
-                <Opt id="theirs" label="theirs" />
-                <Opt id="both" label="both" />
-                <Opt id="theirs-first" label="both \u21c5" />
+                <Opt id="ours" label="Ours" />
+                <Opt id="theirs" label="Theirs" />
+                <Opt id="both" label="Both" />
+                <Opt id="theirs-first" label="Both \u21c5" />
               </div>
             </div>
             <div className="flex gap-2">
@@ -424,19 +424,19 @@ function BlockResolver({ blocks, error, picks, onPick, onApply, busy }: {
               {/* Only when git recorded one: with the default conflict style
                   there is no ancestor, and an empty column would read as "the
                   base was empty" rather than "not recorded". */}
-              {b.base && <Side label="base" lines={b.base} tone="var(--text3)" />}
+              {b.base && <Side label="Base" lines={b.base} tone="var(--text3)" />}
               <Side label={b.theirLabel} lines={b.theirs} tone="var(--info)" />
             </div>
           </div>
         );
       })}
       <div className="flex items-center gap-2">
-        <span className="text-[9.5px] t-dim2">{left ? `${left} still to choose` : "every conflict answered"}</span>
+        <span className="text-[9.5px] t-dim2">{left ? `${left} still to choose` : "Every conflict answered"}</span>
         <button onClick={onApply} disabled={busy || left > 0}
           className="ml-auto px-2 py-0.5 rounded text-[10px] font-medium"
           style={{ color: "var(--success)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)", opacity: left ? 0.4 : 1 }}
-          title={left ? "choose a side for every conflict first" : "write these choices and stage the file"}>
-          apply and stage
+          title={left ? "Choose a side for every conflict first" : "Write these choices and stage the file"}>
+          Apply and stage
         </button>
       </div>
     </div>
@@ -539,7 +539,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     const rels = conflicts.map((p) => p.startsWith(root) ? p.slice(root.length + 1) : p);
     const c = newChat(root);
     update(c.id, (ch) => {
-      ch.title = "resolve merge conflicts";
+      ch.title = "Resolve merge conflicts";
       // Read from `tree`/`repos` rather than the `branch`/`repoRef` consts
       // declared further down: same values, no dependence on where in this
       // component the declarations happen to sit.
@@ -606,7 +606,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     const line = c.hunks[hunkIdx]?.newStart ?? c.hunks[0]?.newStart ?? 1;
     try {
       const r = await api.editorOpen(c.file_path, line);
-      if (!r.ok) return flash(false, r.error || "could not open the editor");
+      if (!r.ok) return flash(false, r.error || "Could not open the editor");
       if (r.how === "remote") {
         // It landed in a window that may be behind this one, so say so —
         // otherwise pressing `e` looks like it did nothing at all. And when it
@@ -614,8 +614,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
         // name it: the file opens in the nvim you have, which is the point, but
         // you should not have to work out which window it appeared in.
         flash(true, r.viaFamily
-          ? `sent to your nvim in ${r.viaFamily.split("/").pop()} · ${baseName(c.file_path)}:${line}`
-          : `sent to your open nvim · ${baseName(c.file_path)}:${line}`);
+          ? `Sent to your nvim in ${r.viaFamily.split("/").pop()} · ${baseName(c.file_path)}:${line}`
+          : `Sent to your open nvim · ${baseName(c.file_path)}:${line}`);
       } else if (r.command) {
         // Nothing reachable for *this* file. Saying "no nvim running" when one
         // is open two panes away sends you looking for a bug; naming the repo
@@ -624,8 +624,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
         const elsewhere = r.otherCwds?.length
           ? `nvim is open in ${r.otherCwds.map((p) => p.split("/").pop()).join(", ")}, not this repo — copied: ${r.command}`
           : r.stuck
-          ? `an nvim is running but not answering (${r.stuck} stale socket${r.stuck === 1 ? "" : "s"}) — copied: ${r.command}`
-          : `no nvim running — copied: ${r.command}`;
+          ? `An nvim is running but not answering (${r.stuck} stale socket${r.stuck === 1 ? "" : "s"}) — copied: ${r.command}`
+          : `No nvim running — copied: ${r.command}`;
         flash(true, elsewhere);
         navigator.clipboard?.writeText(r.command).catch(() => { /* no clipboard permission */ });
       }
@@ -786,16 +786,16 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const stage = async (c: GitFileChange) => { if (await act(() => api.gitStage(root, [rel(c)]))) setSelKey("s:" + c.file_path); };
   const unstage = async (c: GitFileChange) => { if (await act(() => api.gitUnstage(root, [rel(c)]))) setSelKey("u:" + c.file_path); };
   const discard = async (c: GitFileChange) => {
-    if (await ask({ title: `Discard changes to ${baseName(c.file_path)}?`, body: "This cannot be undone.", danger: true, confirmLabel: "Discard" })) act(() => api.gitDiscard(root, [rel(c)]), "discarded");
+    if (await ask({ title: `Discard changes to ${baseName(c.file_path)}?`, body: "This cannot be undone.", danger: true, confirmLabel: "Discard" })) act(() => api.gitDiscard(root, [rel(c)]), "Discarded");
   };
   const doCommit = async () => {
-    if (!title.trim()) { flash(false, "commit title required"); return; }
-    if (await act(() => api.gitCommitStaged(root, title, body), "committed")) { setTitle(""); setBody(""); api.gitGraph(root, 500, logScope).then((r) => setGraph(r.lines)).catch(() => {}); }
+    if (!title.trim()) { flash(false, "Commit title required"); return; }
+    if (await act(() => api.gitCommitStaged(root, title, body), "Committed")) { setTitle(""); setBody(""); api.gitGraph(root, 500, logScope).then((r) => setGraph(r.lines)).catch(() => {}); }
   };
   // branches
   const reloadBranches = () => api.gitBranches(root).then(setBranchData).catch(() => {});
-  const checkout = async (name: string) => { if (await act(() => api.gitCheckout(root, name), `on ${name}`)) { reloadBranches(); setView("changes"); } };
-  const createBranch = async () => { const n = newBranch.trim(); if (!n) return; if (await act(() => api.gitBranchCreate(root, n), `created ${n}`)) { setNewBranch(""); reloadBranches(); setView("changes"); } };
+  const checkout = async (name: string) => { if (await act(() => api.gitCheckout(root, name), `On ${name}`)) { reloadBranches(); setView("changes"); } };
+  const createBranch = async () => { const n = newBranch.trim(); if (!n) return; if (await act(() => api.gitBranchCreate(root, n), `Created ${n}`)) { setNewBranch(""); reloadBranches(); setView("changes"); } };
   /**
    * Delete a branch, and offer the repair when git refuses.
    *
@@ -822,21 +822,21 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const deleteBranch = async (b: GitBranch) => {
     if (busy || !(await ask({ title: `Delete branch ${b.name}?`, danger: true }))) return;
     setBusy(true);
-    setPending(`delete ${b.name}`);
+    setPending(`Delete ${b.name}`);
     try {
       let r = await api.gitBranchDelete(root, b.name, false);
       const wt = r.ok ? null : /worktree at '([^']+)'/.exec(r.error || "")?.[1];
       if (wt) {
-        if (!(await ask({ title: `${b.name} is checked out in a worktree`, body: `It lives in ${wtName(wt)}. Remove that worktree and delete the branch?`, danger: true, confirmLabel: "Remove & delete" }))) { flash(false, "kept"); return; }
+        if (!(await ask({ title: `${b.name} is checked out in a worktree`, body: `It lives in ${wtName(wt)}. Remove that worktree and delete the branch?`, danger: true, confirmLabel: "Remove & delete" }))) { flash(false, "Kept"); return; }
         let rm = await api.gitWorktreeRemove(root, wt, false);
         // git refuses to drop a worktree holding work — modified tracked files
         // or, as often, a stray untracked scratch file. Name the cost, then let
         // them take it.
         if (!rm.ok && /modified|untracked|not clean/i.test(rm.error || "")) {
-          if (!(await ask({ title: `${wtName(wt)} still has uncommitted or untracked files`, body: "Remove it anyway? That work is gone.", danger: true, confirmLabel: "Remove anyway" }))) { flash(false, rm.error || "kept"); return; }
+          if (!(await ask({ title: `${wtName(wt)} still has uncommitted or untracked files`, body: "Remove it anyway? That work is gone.", danger: true, confirmLabel: "Remove anyway" }))) { flash(false, rm.error || "Kept"); return; }
           rm = await api.gitWorktreeRemove(root, wt, true);
         }
-        if (!rm.ok) { flash(false, rm.error || "worktree remove failed"); return; }
+        if (!rm.ok) { flash(false, rm.error || "Worktree remove failed"); return; }
         reloadWorktrees();
         r = await api.gitBranchDelete(root, b.name, false);
       }
@@ -846,7 +846,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
           r = await api.gitBranchDelete(root, b.name, true);
         }
       }
-      flash(r.ok, r.ok ? `deleted ${b.name}` : r.error || "failed");
+      flash(r.ok, r.ok ? `Deleted ${b.name}` : r.error || "Failed");
       if (r.ok) reloadBranches();
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); setPending(null); }
@@ -866,7 +866,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     setBusy(true);
     try {
       const r = await api.prBranchUrl(root, b.name, trackChip(b.track).gone);
-      if (!r.ok || !r.url) { flash(false, r.error || "could not work out where that branch lives"); return; }
+      if (!r.ok || !r.url) { flash(false, r.error || "Could not work out where that branch lives"); return; }
       window.open(r.url, "_blank", "noopener,noreferrer");
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); }
@@ -934,12 +934,12 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     // first thing to appear was a dialog. A control that has been pressed has
     // to say so on the same frame.
     setBusy(true);
-    setPending("checking worktrees");
+    setPending("Checking worktrees");
     let heldByWorktree: Map<string, string>;
     // Without the map every branch looks free to delete, which is the wrong
     // half of the fork to guess at — so a failure here stops the whole thing.
     try { heldByWorktree = await heldByWorktreeNow(); }
-    catch (e) { flash(false, `couldn't list this repo's worktrees: ${String(e)}`); setBusy(false); setPending(null); return; }
+    catch (e) { flash(false, `Couldn't list this repo's worktrees: ${String(e)}`); setBusy(false); setPending(null); return; }
     const { free, held } = partitionByWorktree(goneMerged, heldByWorktree);
     setPending(null);
     setBusy(false); // the question is theirs to answer; nothing is running
@@ -949,15 +949,15 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     let done = 0;
     try {
       for (const b of free) {
-        setPending(`deleting ${b.name}`);
+        setPending(`Deleting ${b.name}`);
         const r = await api.gitBranchDelete(root, b.name, true).catch(() => ({ ok: false, error: "" }));
         if (r.ok) done++; else failed.push(`${b.name}${r.error ? ` (${r.error})` : ""}`);
       }
       if (held.length) done += await deleteHeldByWorktrees(held, heldByWorktree, failed);
       flash(failed.length === 0,
         failed.length === 0
-          ? `deleted ${done} merged branch${done === 1 ? "" : "es"}`
-          : `deleted ${done}, ${failed.length} kept: ${failed.slice(0, 2).join("; ")}${failed.length > 2 ? "…" : ""}`);
+          ? `Deleted ${done} merged branch${done === 1 ? "" : "es"}`
+          : `Deleted ${done}, ${failed.length} kept: ${failed.slice(0, 2).join("; ")}${failed.length > 2 ? "…" : ""}`);
     } finally {
       setBusy(false);
       setPending(null);
@@ -997,7 +997,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
       confirmLabel: "Hand them back",
     })) {
       for (const r of blocked) {
-        setPending(`restoring ownership of ${wtName(r.path)}`);
+        setPending(`Restoring ownership of ${wtName(r.path)}`);
         const fix = await api.gitWorktreeChown(root, r.path).catch((e) => ({ ok: false, error: String(e) }));
         if (!fix.ok) { flash(false, `${wtName(r.path)}: ${fix.error || "chown failed"}`); continue; }
         r.blocked = undefined; // re-read below now that it can succeed
@@ -1030,7 +1030,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     let rescued = 0;
     for (const [path, rels] of picked) {
       if (!rels.length) continue;
-      step(`keeping ${rels.length} file${rels.length === 1 ? "" : "s"} from ${wtName(path)}`);
+      step(`Keeping ${rels.length} file${rels.length === 1 ? "" : "s"} from ${wtName(path)}`);
       const res = await api.gitWorktreeRescue(root, path, rels).catch((e) => ({ ok: false, error: String(e), copied: [] as string[], skipped: [] as { path: string; why: string }[] }));
       // Every path asked for has to come back accounted for. Counting only
       // `skipped` trusts the server to have reported its own omissions, and a
@@ -1049,14 +1049,14 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
       if (res.copied?.length) rescued += res.copied.length;
     }
 
-    if (rescued) flash(true, `kept ${rescued} file${rescued === 1 ? "" : "s"} in the main checkout`);
+    if (rescued) flash(true, `Kept ${rescued} file${rescued === 1 ? "" : "s"} in the main checkout`);
 
     let done = 0;
     // `report.path` rather than another lookup: it is the path the server just
     // confirmed it inspected, so the thing removed is the thing priced.
     for (const { branch, report } of removable) {
       if (keptBack.has(report.path)) continue; // its rescue failed; already reported
-      step(`removing ${wtName(report.path)}`);
+      step(`Removing ${wtName(report.path)}`);
       const rm = await api.gitWorktreeRemove(root, report.path, true).catch((e) => ({ ok: false, error: String(e) }));
       if (!rm.ok) { failed.push(`${branch.name} (${rm.error || "worktree remove failed"})`); continue; }
       const r = await api.gitBranchDelete(root, branch.name, true).catch((e) => ({ ok: false, error: String(e) }));
@@ -1065,11 +1065,11 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     setRescue(null);
     return done;
   };
-  const mergeBranch = async (name: string) => { if (await ask({ title: `Merge ${name} into the current branch?`, confirmLabel: "Merge" })) act(() => api.gitMerge(root, name), `merged ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
-  const rebaseBranch = async (name: string) => { if (await ask({ title: `Rebase the current branch onto ${name}?`, confirmLabel: "Rebase" })) act(() => api.gitRebase(root, name), `rebased onto ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
+  const mergeBranch = async (name: string) => { if (await ask({ title: `Merge ${name} into the current branch?`, confirmLabel: "Merge" })) act(() => api.gitMerge(root, name), `Merged ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
+  const rebaseBranch = async (name: string) => { if (await ask({ title: `Rebase the current branch onto ${name}?`, confirmLabel: "Rebase" })) act(() => api.gitRebase(root, name), `Rebased onto ${name}`).then((ok) => { if (ok) reloadBranches(); }); };
   const renameBranch = async (name: string) => {
     const to = await askText({ title: `Rename ${name}`, input: { label: "New name", initial: name }, confirmLabel: "Rename" });
-    if (to && to !== name) act(() => api.gitBranchRename(root, name, to), `renamed → ${to}`).then((ok) => { if (ok) reloadBranches(); });
+    if (to && to !== name) act(() => api.gitBranchRename(root, name, to), `Renamed → ${to}`).then((ok) => { if (ok) reloadBranches(); });
   };
   // log
   const openCommit = async (hash: string, subject: string) => {
@@ -1085,21 +1085,21 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const addWorktree = async () => {
     const br = newWtBranch.trim(); if (!br) return;
     const path = `${root}-${br.replace(/[\/\s]+/g, "-")}`; // sibling dir named repo-branch
-    if (await act(() => api.gitWorktreeAdd(root, path, br, true), `worktree ${wtName(path)}`)) { setNewWtBranch(""); reloadWorktrees(); }
+    if (await act(() => api.gitWorktreeAdd(root, path, br, true), `Worktree ${wtName(path)}`)) { setNewWtBranch(""); reloadWorktrees(); }
   };
   // Same shape as the worktree step inside deleteBranch: a dirty worktree is a
   // question ("that work is gone — still?"), not a dead end.
   const removeWorktree = async (w: GitWorktree) => {
     if (busy || !(await ask({ title: `Remove worktree ${wtName(w.path)}?`, danger: true, confirmLabel: "Remove" }))) return;
     setBusy(true);
-    setPending(`remove ${wtName(w.path)}`);
+    setPending(`Remove ${wtName(w.path)}`);
     try {
       let r = await api.gitWorktreeRemove(root, w.path, false);
       if (!r.ok && /modified|untracked|not clean/i.test(r.error || "")) {
-        if (!(await ask({ title: `${wtName(w.path)} still has uncommitted or untracked files`, body: "Remove it anyway? That work is gone.", danger: true, confirmLabel: "Remove anyway" }))) { flash(false, r.error || "kept"); return; }
+        if (!(await ask({ title: `${wtName(w.path)} still has uncommitted or untracked files`, body: "Remove it anyway? That work is gone.", danger: true, confirmLabel: "Remove anyway" }))) { flash(false, r.error || "Kept"); return; }
         r = await api.gitWorktreeRemove(root, w.path, true);
       }
-      flash(r.ok, r.ok ? "removed worktree" : r.error || "failed");
+      flash(r.ok, r.ok ? "Removed worktree" : r.error || "Failed");
       if (r.ok) { reloadWorktrees(); reloadBranches(); }
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); setPending(null); }
@@ -1118,13 +1118,13 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const takeRemote = async (b: GitRemoteBranch, how: "local" | "checkout" | "worktree") => {
     if (how === "worktree") {
       const path = `${root}-${b.name.replace(/[\/\s]+/g, "-")}`; // sibling dir, same shape as the Worktrees tab uses
-      if (await act(() => api.gitWorktreeAdd(root, path, b.name, true, b.ref), `worktree ${wtName(path)}`, `take:${b.ref}`)) {
+      if (await act(() => api.gitWorktreeAdd(root, path, b.name, true, b.ref), `Worktree ${wtName(path)}`, `take:${b.ref}`)) {
         reloadRemoteBranches(); reloadWorktrees(); reloadBranches();
       }
       return;
     }
     const ok = await act(() => api.gitTrackRemote(root, b.ref, how === "checkout"),
-      how === "checkout" ? `on ${b.name}` : `${b.name} is local now`, `take:${b.ref}`);
+      how === "checkout" ? `On ${b.name}` : `${b.name} is local now`, `take:${b.ref}`);
     if (!ok) return;
     reloadRemoteBranches(); reloadBranches();
     // Checking out moved the working tree — the Changes view is now the thing
@@ -1140,7 +1140,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const openWorktree = (w: GitWorktree) => { setRoot(w.path); setRepoOpen(false); setSelKey(null); setView("changes"); };
   // stashes
   const reloadStashes = () => api.gitStashes(root).then((r) => setStashes(r.stashes)).catch(() => {});
-  const stashPush = async () => { if (await act(() => api.gitStashPush(root, ""), "stashed")) reloadStashes(); };
+  const stashPush = async () => { if (await act(() => api.gitStashPush(root, ""), "Stashed")) reloadStashes(); };
   const stashOp = async (op: "apply" | "pop" | "drop", index: number) => {
     if (op === "drop" && !(await ask({ title: "Drop this stash?", body: "The stashed changes are gone.", danger: true, confirmLabel: "Drop" }))) return;
     const fn = op === "apply" ? api.gitStashApply : op === "pop" ? api.gitStashPop : api.gitStashDrop;
@@ -1285,8 +1285,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     ? (i: number) => (
         <span className="inline-flex items-center gap-1">
           {selected.staged
-            ? hunkBtn("－ unstage hunk", "var(--text)", () => applyHunk("unstage", i))
-            : <>{hunkBtn("＋ stage hunk", "var(--text)", () => applyHunk("stage", i))}{hunkBtn("↺ discard", "var(--error)", () => applyHunk("discard", i))}</>}
+            ? hunkBtn("－ Unstage hunk", "var(--text)", () => applyHunk("unstage", i))
+            : <>{hunkBtn("＋ Stage hunk", "var(--text)", () => applyHunk("stage", i))}{hunkBtn("↺ Discard", "var(--error)", () => applyHunk("discard", i))}</>}
         </span>
       )
     : undefined;
@@ -1511,11 +1511,11 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                         tall and shoved the tab strip down with it. */}
                     <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[240px] shrink-0 whitespace-nowrap" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
                       title={repoRef ? `${repoRef.name}\n${repoRef.root}` : undefined}>
-                      <span className="font-medium truncate min-w-0">{repoRef?.name ?? "repo"}</span><span className="t-dim2 shrink-0">▼</span>
+                      <span className="font-medium truncate min-w-0">{repoRef?.name ?? "Repo"}</span><span className="t-dim2 shrink-0">▼</span>
                     </button>
                     {repoOpen && (
                       <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 420, overflow: "hidden" }}>
-                        <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
+                        <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                         <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
                           {/* Path included: a worktree is found by its card id
                               ("20343"), which lives in the directory name. */}

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -21,7 +21,7 @@ const WINDOWS = [
   { label: "24h", ms: 24 * 3_600_000 },
   { label: "7d", ms: 7 * 86_400_000 },
   { label: "30d", ms: 30 * 86_400_000 },
-  { label: "all", ms: 3650 * 86_400_000 },
+  { label: "All", ms: 3650 * 86_400_000 },
 ];
 
 // Shared by the header's pill-shaped controls (filters, search button).
@@ -141,14 +141,14 @@ export function Header({
             settable, let alone what it was set to. */}
         <button onClick={onOpenProject}
           className="hidden sm:flex items-center gap-1.5 px-2.5 py-1 rounded-lg text-[12px] font-medium shrink-0 transition-opacity hover:opacity-80"
-          title={workspace ? `${workspace}\nclick to switch project` : "click to open a project — the cockpit scopes itself to its folder"}
+          title={workspace ? `${workspace}\nClick to switch project` : "Click to open a project — the cockpit scopes itself to its folder"}
           style={{
             color: workspace ? "var(--primary-hover)" : "var(--text2)",
             background: `color-mix(in srgb, var(--primary) ${workspace ? 14 : 7}%, transparent)`,
             border: `1px solid color-mix(in srgb, var(--primary) ${workspace ? 40 : 20}%, transparent)`,
           }}>
           <span>⌂</span>
-          <span className="truncate" style={{ maxWidth: 200 }}>{workspace ? workspace.split("/").pop() : "every project"}</span>
+          <span className="truncate" style={{ maxWidth: 200 }}>{workspace ? workspace.split("/").pop() : "All repos/projects"}</span>
           <span className="opacity-60">▾</span>
         </button>
         <span onClick={unauth ? reauthPrompt : undefined}
@@ -195,19 +195,19 @@ export function Header({
           control that already applies, offering a list of one. It earns its
           place only in the whole-machine view. */}
       {!workspace && (
-        <Select value={filter.app} style={selStyle} options={[{ value: "", label: "all apps" }, ...apps.map((a) => ({ value: a, label: a }))]} onChange={(v) => onFilter({ ...filter, app: v })} />
+        <Select value={filter.app} style={selStyle} options={[{ value: "", label: "All apps" }, ...apps.map((a) => ({ value: a, label: a }))]} onChange={(v) => onFilter({ ...filter, app: v })} />
       )}
-      <Select value={filter.type} style={selStyle} options={[{ value: "", label: "all events" }, ...types.map((t) => ({ value: t, label: t }))]} onChange={(v) => onFilter({ ...filter, type: v })} />
+      <Select value={filter.type} style={selStyle} options={[{ value: "", label: "All events" }, ...types.map((t) => ({ value: t, label: t }))]} onChange={(v) => onFilter({ ...filter, type: v })} />
       {/* Provider is auto-detected from each session's model. With one provider
           it's shown but disabled (just so you can see it); a mixed fleet
           (Anthropic + OpenAI + …) turns it into a real filter. */}
       {providers.length === 1 && (
-        <Select value={providers[0]} style={selStyle} options={[{ value: providers[0], label: providers[0] }]} onChange={() => {}} disabled title={`only provider seen: ${providers[0]}`} />
+        <Select value={providers[0]} style={selStyle} options={[{ value: providers[0], label: providers[0] }]} onChange={() => {}} disabled title={`Only provider seen: ${providers[0]}`} />
       )}
       {providers.length > 1 && (
-        <Select value={filter.provider} style={selStyle} options={[{ value: "", label: "all providers" }, ...providers.map((p) => ({ value: p, label: p }))]} onChange={(v) => onFilter({ ...filter, provider: v })} />
+        <Select value={filter.provider} style={selStyle} options={[{ value: "", label: "All providers" }, ...providers.map((p) => ({ value: p, label: p }))]} onChange={(v) => onFilter({ ...filter, provider: v })} />
       )}
-      {hasFilter && <button onClick={onClear} className="text-[11px] px-2 py-1 rounded-lg shrink-0 whitespace-nowrap" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>clear ✕</button>}
+      {hasFilter && <button onClick={onClear} className="text-[11px] px-2 py-1 rounded-lg shrink-0 whitespace-nowrap" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>Clear ✕</button>}
       </div>{/* middle scroll zone */}
 
       <div className="shrink-0 flex items-center gap-1.5 sm:gap-2 ml-auto sm:ml-0 max-w-full overflow-x-auto agw-noscrollbar">
@@ -216,7 +216,7 @@ export function Header({
         {showUsage && <div className="hidden 2xl:block"><UsageWidget /></div>}
         {/* A keyboard-palette chip is dead weight on touch — hide it there. */}
         <button onClick={onOpenPalette} className="h-8 hidden sm:flex items-center gap-1.5 px-2.5 rounded-lg text-[11px]" style={selStyle}>
-          <span>{MOD_KEY}K</span><span className="hidden sm:inline t-dim2">search</span>
+          <span>{MOD_KEY}K</span><span className="hidden sm:inline t-dim2">Search</span>
         </button>
         {/* One button where there were five (git/diff/docker/term/chat).
             They were the app's whole purpose and yet each one opened its own
@@ -241,7 +241,7 @@ export function Header({
           }}
         >
           <WorkspaceIcon />
-          <span className="hidden sm:inline">workspace</span>
+          <span className="hidden sm:inline">Workspace</span>
           {waiting > 0 && (
             <span className="tabular-nums px-1 rounded-full text-[9.5px]"
               style={{ background: "color-mix(in srgb, var(--success) 30%, transparent)" }}>{waiting}</span>

--- a/web/src/components/HelpLegend.tsx
+++ b/web/src/components/HelpLegend.tsx
@@ -12,10 +12,10 @@ const EVENTS: [string, string][] = [
   ["Subagent activity", "#a3e635"],
 ];
 const STATUS: [string, string][] = [
-  ["working", "#34d399"],
-  ["waiting on you", "#fbbf24"],
-  ["errored", "#f87171"],
-  ["idle", "#64748b"],
+  ["Working", "#34d399"],
+  ["Waiting on you", "#fbbf24"],
+  ["Errored", "#f87171"],
+  ["Idle", "#64748b"],
 ];
 
 export function HelpLegend({ open, onClose }: { open: boolean; onClose: () => void }) {
@@ -60,31 +60,31 @@ export function HelpLegend({ open, onClose }: { open: boolean; onClose: () => vo
               <div className="mt-4 pt-3 border-t" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                 <div className="panel-eyebrow mb-2">shortcuts & tips</div>
                 <div className="grid grid-cols-2 gap-y-1 text-[11px] t-dim">
-                  <span><kbd className="chip">{MOD_KEY}K</kbd> command palette</span>
-                  <span><kbd className="chip">?</kbd> this help</span>
-                  <span><kbd className="chip">s</kbd> statistics</span>
-                  <span><kbd className="chip">k</kbd> skills explorer</span>
-                  <span><kbd className="chip">/</kbd> search all history</span>
+                  <span><kbd className="chip">{MOD_KEY}K</kbd> Command palette</span>
+                  <span><kbd className="chip">?</kbd> This help</span>
+                  <span><kbd className="chip">s</kbd> Statistics</span>
+                  <span><kbd className="chip">k</kbd> Skills explorer</span>
+                  <span><kbd className="chip">/</kbd> Search all history</span>
                   {IS_DESKTOP && (
-                    <span><kbd className="chip">{MOD_KEY}+</kbd> <kbd className="chip">{MOD_KEY}−</kbd> display size</span>
+                    <span><kbd className="chip">{MOD_KEY}+</kbd> <kbd className="chip">{MOD_KEY}−</kbd> Display size</span>
                   )}
                   <span>Click an event → full details</span>
                   <span>Click an agent → filter to it</span>
                 </div>
                 <div className="panel-eyebrow mt-3 mb-2">workspace</div>
                 <div className="grid grid-cols-2 gap-y-1 text-[11px] t-dim">
-                  <span><kbd className="chip">{MOD_KEY}\</kbd> open / close</span>
-                  <span><kbd className="chip">{MOD_KEY}1</kbd>…<kbd className="chip">{MOD_KEY}5</kbd> jump to a view</span>
-                  <span><kbd className="chip">g</kbd> git</span>
-                  <span><kbd className="chip">d</kbd> diff</span>
-                  <span><kbd className="chip">o</kbd> docker</span>
-                  <span><kbd className="chip">t</kbd> terminal</span>
-                  <span><kbd className="chip">c</kbd> chat</span>
-                  <span><kbd className="chip">{MOD_KEY}[</kbd> <kbd className="chip">{MOD_KEY}]</kbd> cycle views</span>
+                  <span><kbd className="chip">{MOD_KEY}\</kbd> Open / close</span>
+                  <span><kbd className="chip">{MOD_KEY}1</kbd>…<kbd className="chip">{MOD_KEY}5</kbd> Jump to a view</span>
+                  <span><kbd className="chip">g</kbd> Git</span>
+                  <span><kbd className="chip">d</kbd> Diff</span>
+                  <span><kbd className="chip">o</kbd> Docker</span>
+                  <span><kbd className="chip">t</kbd> Terminal</span>
+                  <span><kbd className="chip">c</kbd> Chat</span>
+                  <span><kbd className="chip">{MOD_KEY}[</kbd> <kbd className="chip">{MOD_KEY}]</kbd> Cycle views</span>
                   {/* The distinction that actually bites: bare letters are
                       swallowed by the shell and the composer, the ⌘ pair never
                       is. */}
-                  <span className="col-span-2 t-dim2">letters switch views unless you're typing; {MOD_KEY} shortcuts always work</span>
+                  <span className="col-span-2 t-dim2">Letters switch views unless you're typing; {MOD_KEY} shortcuts always work</span>
                 </div>
               </div>
             </motion.div>

--- a/web/src/components/Kpis.tsx
+++ b/web/src/components/Kpis.tsx
@@ -84,7 +84,7 @@ export function Kpis({
   const cached = t?.cache_read_tokens ?? 0;
   const health = tools > 0 ? Math.max(0, Math.round((1 - failed / Math.max(tools, 1)) * 100)) : 100;
   const spark = (stats?.timeline ?? []).slice(-24).map((b) => b.cost_usd);
-  const healthLabel = health >= 80 ? "all nominal" : health >= 50 ? "degraded" : "critical";
+  const healthLabel = health >= 80 ? "All nominal" : health >= 50 ? "Degraded" : "Critical";
   const healthColor = health >= 80 ? "var(--success)" : health >= 50 ? "var(--warning)" : "var(--error)";
 
   return (
@@ -107,7 +107,7 @@ export function Kpis({
         <div className="flex items-center gap-2.5 shrink-0">
           <HealthRing value={health} />
           <div className="text-[10px] t-dim2 leading-tight">
-            health
+            Health
             <br />
             <b className="font-semibold" style={{ color: healthColor }}>{healthLabel}</b>
           </div>
@@ -117,8 +117,8 @@ export function Kpis({
       {/* pulse — the live tempo, grouped */}
       <motion.div {...enter} transition={{ delay: 0.05, type: "spring", stiffness: 300, damping: 26 }} className="panel">
         <div className="grid grid-cols-3 h-full" style={{ background: "color-mix(in srgb, var(--primary) 9%, transparent)", gap: "1px" }}>
-          <div style={{ background: CELL_BG }}><PulseCell k="Working" v={working} u="live agents" accent="var(--success)" /></div>
-          <div style={{ background: CELL_BG }}><PulseCell k="Events / min" v={epm} u="throughput" accent="var(--info)" /></div>
+          <div style={{ background: CELL_BG }}><PulseCell k="Working" v={working} u="Live agents" accent="var(--success)" /></div>
+          <div style={{ background: CELL_BG }}><PulseCell k="Events / min" v={epm} u="Throughput" accent="var(--info)" /></div>
           <div style={{ background: CELL_BG }}><PulseCell k="Tools run" v={tools} u={`${(t?.events ?? 0).toLocaleString()} events`} /></div>
         </div>
       </motion.div>
@@ -133,7 +133,7 @@ export function Kpis({
           className="px-4 py-2 text-[10px] t-dim2 text-right tabular-nums"
           style={{ borderTop: "1px solid color-mix(in srgb, var(--primary) 10%, transparent)" }}
         >
-          uptime <b className="font-semibold" style={{ color: "var(--text3)" }}>{fmtClock(elapsed)}</b> · {agents.length} sessions tracked
+          Uptime <b className="font-semibold" style={{ color: "var(--text3)" }}>{fmtClock(elapsed)}</b> · {agents.length} sessions tracked
         </div>
       </motion.div>
     </div>

--- a/web/src/components/Latency.tsx
+++ b/web/src/components/Latency.tsx
@@ -14,7 +14,7 @@ export const Latency = memo(function Latency({ stats }: { stats: StatsSummary | 
         <p className="t-dim2 text-[10.5px] leading-snug mb-2">
           End-to-end tool duration from PreToolUse to PostToolUse, not model/API round-trip latency.
         </p>
-        {tools.length === 0 && <div className="t-dim2 text-[11px] text-center py-6">no tool calls measured yet</div>}
+        {tools.length === 0 && <div className="t-dim2 text-[11px] text-center py-6">No tool calls measured yet</div>}
         <div className="space-y-2">
           {tools.map((t, i) => (
             <motion.div key={t.tool_name} initial={{ opacity: 0, y: 6 }} animate={{ opacity: 1, y: 0 }} transition={{ delay: i * 0.03 }}>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -113,20 +113,24 @@ function Avatar({ login, size = 18 }: { login: string; size?: number }) {
   );
 }
 
-function Btn({ children, onClick, disabled, danger, primary, ok, title, small }: {
+function Btn({ children, onClick, disabled, danger, primary, ok, warn, title, small }: {
   children: React.ReactNode; onClick?: () => void; disabled?: boolean;
-  danger?: boolean; primary?: boolean; ok?: boolean; title?: string; small?: boolean;
+  danger?: boolean; primary?: boolean; ok?: boolean; warn?: boolean; title?: string; small?: boolean;
 }) {
-  const edge = danger ? "var(--error)" : ok ? "var(--success)" : primary ? "var(--primary)" : "var(--border)";
+  // `warn` is the amber "this mutates the branch" accent, matching the Source
+  // Control bar's sync/behind colour (--warning). Used for update-branch, which
+  // merges the base into this branch — a consequential action that should not
+  // read the same as its plain neighbours.
+  const edge = danger ? "var(--error)" : ok ? "var(--success)" : warn ? "var(--warning)" : primary ? "var(--primary)" : "var(--border)";
   return (
     <button onClick={onClick} disabled={disabled} title={title}
       className={`rounded disabled:opacity-40 ${small ? "text-[10px] px-2 py-0.5" : "text-[10.5px] px-2.5 py-1"}`}
       style={{
-        color: primary ? "var(--bg)" : danger ? "var(--error)" : ok ? "var(--success)" : "var(--text2)",
-        background: primary ? "var(--primary)" : "transparent",
-        border: `1px solid color-mix(in srgb, ${edge} ${primary ? 100 : 50}%, transparent)`,
+        color: primary ? "var(--bg)" : danger ? "var(--error)" : ok ? "var(--success)" : warn ? "var(--warning)" : "var(--text2)",
+        background: primary ? "var(--primary)" : warn ? "color-mix(in srgb, var(--warning) 16%, transparent)" : "transparent",
+        border: `1px solid color-mix(in srgb, ${edge} ${primary ? 100 : warn ? 55 : 50}%, transparent)`,
         cursor: disabled ? "not-allowed" : "pointer",
-        fontWeight: primary ? 500 : 400,
+        fontWeight: primary || warn ? 500 : 400,
       }}>{children}</button>
   );
 }
@@ -941,7 +945,7 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
           style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
           <Btn onClick={onMerge} disabled={busy || !canMerge} primary title={canMerge ? "squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>squash &amp; merge</Btn>
           <Btn onClick={onAutoMerge} disabled={busy} title="merge automatically once everything passes">merge when green</Btn>
-          <Btn onClick={onUpdateBranch} disabled={busy} title="merge the base branch into this one">update branch</Btn>
+          <Btn onClick={onUpdateBranch} disabled={busy} warn title="merge the base branch into this one — this updates the branch on GitHub">↻ update branch</Btn>
           {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
           <span className="ml-auto flex gap-1.5">
             <Btn onClick={onDraft} disabled={busy} small>{d.isDraft ? "mark ready" : "to draft"}</Btn>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -337,6 +337,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [root, setRoot] = useState("");
   const [repo, setRepo] = useState<PrRepoId | null>(null);
   const [filter, setFilter] = useState<Filter>("mine");
+  // A per-tab search box. Cleared when the scope changes so each tab (mine /
+  // review / all) starts fresh — "all" can be hundreds of rows, and finding one
+  // by number, title or author beats scrolling.
+  const [query, setQuery] = useState("");
   const [prs, setPrs] = useState<PrSummary[]>([]);
   const [counts, setCounts] = useState<Partial<Record<Filter, number>>>({});
   const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; checksPending?: boolean; error?: string; needsAuth?: boolean }>({ fetchedAt: 0, loading: false });
@@ -489,6 +493,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (!root || selected == null) { setDetail(null); loadedFor.current = null; return; }
     if (loadedFor.current === selected) return; // same pull request, already here
     loadedFor.current = selected;
+    // Clear the previous PR's detail so the pane shows "loading #N" instead of
+    // the last PR's data while the new one is in flight. Without this a PR→PR
+    // jump silently keeps the old content on screen and reads as a dead click.
+    // (The poll-refresh path in loadDetail deliberately keeps the current detail
+    // on a failed refresh; that path does not run this effect.)
+    setDetail(null); setDetailErr("");
     setDiff(""); setSelFile(null); setSelCommit(null); setCommitText("");
     loadDetail(selected);
   }, [root, selected, loadDetail]);
@@ -498,6 +508,18 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     const req = ++diffReq.current; // a later selection's diff must win over a slow earlier one
     api.prDiff(root, detail.number).then((r) => { if (req === diffReq.current) setDiff(r.ok ? (r.text || "") : ""); }).catch(() => {});
   }, [tab, detail, diff, root]);
+
+  // Filter the current scope's rows by the search box: PR number (with or
+  // without a leading #), title, or author login. Memoized so a 400-row "all"
+  // list does not re-scan on every keystroke or re-render.
+  const visiblePrs = useMemo(() => {
+    const q = query.trim().toLowerCase().replace(/^#/, "");
+    if (!q) return prs;
+    return prs.filter((p) =>
+      String(p.number).includes(q) ||
+      p.title.toLowerCase().includes(q) ||
+      p.author.toLowerCase().includes(q));
+  }, [prs, query]);
 
   const parsed = useMemo(() => parseUnifiedDiff(diff), [diff]);
   const byPath = useMemo(() => {
@@ -672,7 +694,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
             {FILTERS.map((f) => {
               const n = counts[f.id];
               return (
-                <button key={f.id} onClick={() => setFilter(f.id)} title={f.hint}
+                <button key={f.id} onClick={() => { setFilter(f.id); setQuery(""); }} title={f.hint}
                   className="text-[10px] px-2 py-0.5 rounded-full"
                   style={{
                     color: filter === f.id ? "var(--bg)" : "var(--text2)",
@@ -685,6 +707,19 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
               );
             })}
           </div>
+          {repo && prs.length > 0 && (
+            <div className="px-2 py-1.5 border-b shrink-0 flex items-center gap-2" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+              <input
+                value={query}
+                onChange={(e) => setQuery(e.target.value)}
+                placeholder="filter by #, title or author…"
+                className="flex-1 text-[10px] px-2 py-1 rounded bg-transparent min-w-0"
+                style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }} />
+              {query.trim() && (
+                <span className="text-[9px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{visiblePrs.length} of {prs.length}</span>
+              )}
+            </div>
+          )}
           <div className="flex-1 overflow-y-auto min-h-0 agx-scroll">
             {listState.needsAuth ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
@@ -699,7 +734,9 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                   {filter === "mine" ? "no open pull requests of yours" : filter === "review" ? "nothing waiting on your review" : "no open pull requests"}
                 </div>
               )
-            ) : prs.map((p) => (
+            ) : visiblePrs.length === 0 ? (
+              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>no pull requests match “{query.trim()}”</div>
+            ) : visiblePrs.map((p) => (
               <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
             ))}
           </div>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -35,9 +35,9 @@ type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
 
 const FILTERS: { id: Filter; label: string; hint: string }[] = [
-  { id: "mine", label: "mine", hint: "pull requests you opened" },
-  { id: "review", label: "review", hint: "waiting on your review" },
-  { id: "all", label: "all", hint: "every open pull request" },
+  { id: "mine", label: "Mine", hint: "Pull requests you opened" },
+  { id: "review", label: "Review", hint: "Waiting on your review" },
+  { id: "all", label: "All", hint: "Every open pull request" },
 ];
 
 const POLL_MS = 20_000;
@@ -261,7 +261,7 @@ function DiffPane({ file, split, wrap, onComment }: {
         if (!target) return null;
         return <button onClick={() => onComment(target)} className="text-[10px] px-1.5 rounded"
           style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" }}
-          title={`comment on line ${target}`}>+ comment</button>;
+          title={`Comment on line ${target}`}>+ Comment</button>;
       }
     : undefined;
   return split ? <SplitDiff c={file} wrap={wrap} /> : <UnifiedDiff c={file} wrap={wrap} hunkAction={action} />;
@@ -309,18 +309,18 @@ function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelec
       <div className="flex items-center gap-1.5">
         <span className="text-[10px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>#{p.number}</span>
         <span className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>{p.title}</span>
-        {p.isCurrentBranch && <Chip text="here" tint="var(--primary)" title="this checkout is on that branch" />}
+        {p.isCurrentBranch && <Chip text="here" tint="var(--primary)" title="This checkout is on that branch" />}
       </div>
       <div className="flex items-center gap-1.5 mt-0.5 text-[10px]" style={{ color: "var(--text3)" }}>
         <Dot tint={p.checksLoaded === false ? "var(--text3)" : stateTint(p)}
-          title={p.checksLoaded === false ? "check states are still loading" : `${c.success} passed · ${c.failure} failed · ${c.skipped} skipped · ${c.pending} running`} />
+          title={p.checksLoaded === false ? "Check states are still loading" : `${c.success} passed · ${c.failure} failed · ${c.skipped} skipped · ${c.pending} running`} />
         <span className="tabular-nums">
           {/* Not yet fetched is not the same as none. Saying "no checks" here
               would be a claim about the repository rather than about us. */}
-          {p.checksLoaded === false ? "checks…"
-            : c.total === 0 ? "no checks"
+          {p.checksLoaded === false ? "Checks…"
+            : c.total === 0 ? "No checks"
             : c.pending > 0 ? `${c.total - c.pending}/${c.total}`
-            : c.failure > 0 ? `${c.failure} failing` : "green"}
+            : c.failure > 0 ? `${c.failure} failing` : "Green"}
         </span>
         {p.isDraft ? <Chip text="draft" tint="var(--text3)" /> : <ReviewChip d={p.reviewDecision} />}
         <span className="ml-auto shrink-0">{ago(p.updatedAt)}</span>
@@ -460,7 +460,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       // A refresh that fails leaves what is on screen alone: the pull request
       // you are reading is better than an error where it used to be.
       else if (!force) setDetailErr(r.error || "");
-      else { setDetail(null); setDetailErr(r.error || "could not load this pull request"); }
+      else { setDetail(null); setDetailErr(r.error || "Could not load this pull request"); }
     }).catch((e) => { if (req === detailReq.current) setDetailErr(String(e)); });
   }, [root]);
 
@@ -576,7 +576,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       title: `Comment on ${path.split("/").pop()}:${line}`,
       body: "Queued with the rest of your review — nothing is sent until you submit.",
       confirmLabel: "Add to review",
-      input: { label: "Comment", placeholder: "what needs to change here…" },
+      input: { label: "Comment", placeholder: "What needs to change here…" },
     });
     if (!body?.trim() || !key) return;
     setDrafts((cur) => {
@@ -584,7 +584,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       saveMap(DRAFT_KEY, next);
       return next;
     });
-    flash(true, `queued — ${(myDrafts.length + 1)} pending comment${myDrafts.length ? "s" : ""}`);
+    flash(true, `Queued — ${(myDrafts.length + 1)} pending comment${myDrafts.length ? "s" : ""}`);
   };
 
   const dropDraft = (i: number) => {
@@ -598,7 +598,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   const submitReview = async (verb: "approve" | "request_changes" | "comment", body: string) => {
     if (!detail) return;
-    const ok = await act("review", () => api.prReviewWith(root, detail.number, verb, body, myDrafts));
+    const ok = await act("Review", () => api.prReviewWith(root, detail.number, verb, body, myDrafts));
     if (ok && key) {
       setDrafts((cur) => { const next = { ...cur, [key]: [] }; saveMap(DRAFT_KEY, next); return next; });
       setTab("conversation");
@@ -615,7 +615,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       confirmLabel: "Squash & merge", danger: true,
     });
     if (!ok) return;
-    await act("merge", () => api.prMerge(root, detail.number, "squash", { deleteBranch: true, headSha: head }));
+    await act("Merge", () => api.prMerge(root, detail.number, "squash", { deleteBranch: true, headSha: head }));
   };
 
   const doClose = async () => {
@@ -626,7 +626,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       confirmLabel: "Close pull request", danger: true,
     });
     if (!ok) return;
-    await act("close", () => api.prClose(root, detail.number));
+    await act("Close", () => api.prClose(root, detail.number));
   };
 
   const doLocalReview = async () => {
@@ -634,9 +634,9 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     setBusy(true);
     try {
       const r = await api.prLocalReview(root, detail.number);
-      if (!r.ok || !r.cwd || !r.prompt) { flash(false, r.error || "could not prepare the review"); return; }
-      if (onOpenChatWith) { onOpenChatWith(r.cwd, r.prompt); flash(true, `checked out #${detail.number} — review waiting in chat`); }
-      else flash(true, `checked out at ${r.cwd}`);
+      if (!r.ok || !r.cwd || !r.prompt) { flash(false, r.error || "Could not prepare the review"); return; }
+      if (onOpenChatWith) { onOpenChatWith(r.cwd, r.prompt); flash(true, `Checked out #${detail.number} — review waiting in chat`); }
+      else flash(true, `Checked out at ${r.cwd}`);
     } catch (e) { flash(false, String(e)); }
     finally { setBusy(false); }
   };
@@ -659,12 +659,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const canReview = !!d && !d.viewerDidAuthor;
 
   const TABS: { id: Tab; label: string; n?: number; warn?: boolean }[] = d ? [
-    { id: "overview", label: "overview" },
-    { id: "conversation", label: "conversation", n: lanes.humans.length + lanes.humanComments.length + d.threads.length + lanes.bots.length },
-    { id: "commits", label: "commits", n: d.commits.length },
-    { id: "files", label: "files", n: d.files.length },
-    { id: "checks", label: "checks", n: d.checks.total, warn: d.checks.failure > 0 },
-    ...(canReview ? [{ id: "review" as Tab, label: "review", n: myDrafts.length || undefined, warn: d.viewerRequested }] : []),
+    { id: "overview", label: "Overview" },
+    { id: "conversation", label: "Conversation", n: lanes.humans.length + lanes.humanComments.length + d.threads.length + lanes.bots.length },
+    { id: "commits", label: "Commits", n: d.commits.length },
+    { id: "files", label: "Files", n: d.files.length },
+    { id: "checks", label: "Checks", n: d.checks.total, warn: d.checks.failure > 0 },
+    ...(canReview ? [{ id: "review" as Tab, label: "Review", n: myDrafts.length || undefined, warn: d.viewerRequested }] : []),
   ] : [];
 
   return (
@@ -684,11 +684,11 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
         <div className="ml-auto flex items-center gap-2 shrink-0">
           {toast && <span className="text-[10px] max-w-[380px] truncate" style={{ color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</span>}
           <span className="text-[10px] tabular-nums" style={{ color: listState.loading || listState.checksPending ? "var(--warning)" : "var(--text3)" }}>
-            {listState.loading ? "loading pull requests…"
-              : listState.checksPending ? "loading check states…"
+            {listState.loading ? "Loading pull requests…"
+              : listState.checksPending ? "Loading check states…"
               : listState.fetchedAt ? `⟳ ${ago(new Date(listState.fetchedAt).toISOString())}` : ""}
           </span>
-          <Btn onClick={() => loadList(true)} disabled={busy} small>refresh</Btn>
+          <Btn onClick={() => loadList(true)} disabled={busy} small>Refresh</Btn>
         </div>
       </div>
 
@@ -716,7 +716,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
               <input
                 value={query}
                 onChange={(e) => setQuery(e.target.value)}
-                placeholder="filter by #, title or author…"
+                placeholder="Filter by #, title or author…"
                 className="flex-1 text-[10px] px-2 py-1 rounded bg-transparent min-w-0"
                 style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }} />
               {query.trim() && (
@@ -727,19 +727,19 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
           <div className="flex-1 overflow-y-auto min-h-0 agx-scroll">
             {listState.needsAuth ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
-                <div style={{ color: "var(--warning)" }}>{listState.error || "the GitHub CLI is not set up"}</div>
+                <div style={{ color: "var(--warning)" }}>{listState.error || "The GitHub CLI is not set up"}</div>
                 <div className="mt-2">Pull requests come from <code>gh</code>. Install it, run <code>gh auth login</code>, then refresh.</div>
               </div>
             ) : !repo ? (
-              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>{listState.error || "no GitHub remote on this repository"}</div>
+              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>{listState.error || "No GitHub remote on this repository"}</div>
             ) : prs.length === 0 ? (
               listState.loading ? <Skeletons /> : (
                 <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
-                  {filter === "mine" ? "no open pull requests of yours" : filter === "review" ? "nothing waiting on your review" : "no open pull requests"}
+                  {filter === "mine" ? "No open pull requests of yours" : filter === "review" ? "Nothing waiting on your review" : "No open pull requests"}
                 </div>
               )
             ) : visiblePrs.length === 0 ? (
-              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>no pull requests match “{query.trim()}”</div>
+              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>No pull requests match “{query.trim()}”</div>
             ) : visiblePrs.map((p) => (
               <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
             ))}
@@ -752,8 +752,8 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
           {!d ? (
             <div className="p-4 text-[11.5px]" style={{ color: "var(--text3)" }}>
               {detailErr ? detailErr
-                : selected == null ? (listState.loading ? "loading pull requests…" : "select a pull request")
-                : `loading #${selected}…`}
+                : selected == null ? (listState.loading ? "Loading pull requests…" : "Select a pull request")
+                : `Loading #${selected}…`}
             </div>
           ) : (
             <>
@@ -771,9 +771,9 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                   </button>
                 ))}
                 <div className="ml-auto flex items-center gap-1.5 px-2 shrink-0">
-                  {myDrafts.length > 0 && <Chip text={`${myDrafts.length} pending`} tint="var(--warning)" title="line comments queued but not sent" />}
+                  {myDrafts.length > 0 && <Chip text={`${myDrafts.length} pending`} tint="var(--warning)" title="Line comments queued but not sent" />}
                   {d.viewerRequested && tab !== "review" && (
-                    <Btn onClick={() => setTab("review")} primary small>add your review</Btn>
+                    <Btn onClick={() => setTab("review")} primary small>Add your review</Btn>
                   )}
                 </div>
               </div>
@@ -783,10 +783,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                   <Overview
                     d={d} busy={busy} openThreads={openThreads.length}
                     onLocalReview={doLocalReview} onMerge={doMerge} onClose={doClose}
-                    onUpdateBranch={() => act("update branch", () => api.prUpdateBranch(root, d.number))}
-                    onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))}
-                    onAutoMerge={() => act("auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
-                    onDraft={() => act(d.isDraft ? "mark ready" : "convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
+                    onUpdateBranch={() => act("Update branch", () => api.prUpdateBranch(root, d.number))}
+                    onRerun={() => act("Re-run checks", () => api.prRerun(root, d.number))}
+                    onAutoMerge={() => act("Auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
+                    onDraft={() => act(d.isDraft ? "Mark ready" : "Convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
                     onGoThreads={() => setTab("conversation")}
                   />
                 )}
@@ -794,13 +794,13 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 {tab === "conversation" && (
                   <Conversation
                     d={d} lanes={lanes} raw={rawBots} onRaw={setRawBots} busy={busy}
-                    onResolve={(t) => act(t.isResolved ? "unresolve" : "resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
+                    onResolve={(t) => act(t.isResolved ? "Unresolve" : "Resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
                     onReply={async (t) => {
                       const first = t.comments[0];
                       if (typeof first?.databaseId !== "number") return;
                       const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply" } });
                       if (!body?.trim()) return;
-                      await act("reply", () => api.prReply(root, d.number, first.databaseId as number, body));
+                      await act("Reply", () => api.prReply(root, d.number, first.databaseId as number, body));
                     }}
                   />
                 )}
@@ -819,15 +819,15 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                           <span className="shrink-0" style={{ color: "var(--text3)" }}>{selCommit === c.oid ? "▾" : "▸"}</span>
                           <span className="tabular-nums shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.short}</span>
                           <span className="truncate" style={{ color: "var(--text2)" }}>{c.message}</span>
-                          {c.isMerge && <Chip text="merge" tint="var(--text3)" title="trunk catch-up, not work to review" />}
+                          {c.isMerge && <Chip text="merge" tint="var(--text3)" title="Trunk catch-up, not work to review" />}
                           <span className="ml-auto shrink-0 flex items-center gap-1.5 text-[10px]" style={{ color: "var(--text3)" }}>
                             <Avatar login={c.author} size={14} />{c.author}
                           </span>
                         </button>
                         {selCommit === c.oid && (
                           <div className="my-2">
-                            {commitBusy ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>loading the diff…</div>
-                              : commitFiles.length === 0 ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>this commit changed nothing textual</div>
+                            {commitBusy ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>Loading the diff…</div>
+                              : commitFiles.length === 0 ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>This commit changed nothing textual</div>
                               : <FileStack files={commitFiles} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap} />}
                           </div>
                         )}
@@ -844,7 +844,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                   />
                 )}
 
-                {tab === "checks" && <Checks d={d} busy={busy} onRerun={() => act("re-run checks", () => api.prRerun(root, d.number))} />}
+                {tab === "checks" && <Checks d={d} busy={busy} onRerun={() => act("Re-run checks", () => api.prRerun(root, d.number))} />}
 
                 {tab === "review" && canReview && (
                   <ReviewTab
@@ -868,12 +868,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 // ---------------------------------------------------------------------------
 
 const MERGE_WHY: Record<string, string> = {
-  BLOCKED: "a required review or check has not passed",
-  BEHIND: "the base branch has moved — update the branch first",
-  DIRTY: "there are conflicts with the base branch",
-  UNSTABLE: "a check is failing",
-  DRAFT: "this is a draft",
-  HAS_HOOKS: "a repository hook is blocking the merge",
+  BLOCKED: "A required review or check has not passed",
+  BEHIND: "The base branch has moved — update the branch first",
+  DIRTY: "There are conflicts with the base branch",
+  UNSTABLE: "A check is failing",
+  DRAFT: "This is a draft",
+  HAS_HOOKS: "A repository hook is blocking the merge",
   UNKNOWN: "GitHub has not finished working it out",
 };
 
@@ -919,7 +919,7 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
               {canMerge ? "Ready to merge" : "Merging is blocked"}
             </span>
             <span className="block text-[11px] mt-0.5" style={{ color: "var(--text3)" }}>
-              {canMerge ? "nothing is standing in the way" : (MERGE_WHY[d.mergeState] ?? "not mergeable")}
+              {canMerge ? "Nothing is standing in the way" : (MERGE_WHY[d.mergeState] ?? "Not mergeable")}
             </span>
           </span>
         </div>
@@ -929,7 +929,7 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
             <Reason tint="var(--error)" glyph="✕"><b style={{ color: "var(--text)", fontWeight: 500 }}>Changes requested</b> by a reviewer with write access</Reason>
           )}
           {openThreads > 0 && (
-            <Reason tint="var(--warning)" glyph="◯" action={<button onClick={onGoThreads} style={{ color: "var(--primary)" }}>go to thread</button>}>
+            <Reason tint="var(--warning)" glyph="◯" action={<button onClick={onGoThreads} style={{ color: "var(--primary)" }}>Go to thread</button>}>
               {openThreads} review thread{openThreads === 1 ? "" : "s"} still open — <span style={{ color: "var(--text3)" }}>a reply is not a resolve</span>
             </Reason>
           )}
@@ -943,13 +943,13 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
 
         <div className="flex items-center gap-1.5 flex-wrap px-3 py-2.5"
           style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
-          <Btn onClick={onMerge} disabled={busy || !canMerge} primary title={canMerge ? "squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>squash &amp; merge</Btn>
-          <Btn onClick={onAutoMerge} disabled={busy} title="merge automatically once everything passes">merge when green</Btn>
-          <Btn onClick={onUpdateBranch} disabled={busy} warn title="merge the base branch into this one — this updates the branch on GitHub">↻ update branch</Btn>
-          {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>re-run failed</Btn>}
+          <Btn onClick={onMerge} disabled={busy || !canMerge} primary title={canMerge ? "Squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>Squash &amp; merge</Btn>
+          <Btn onClick={onAutoMerge} disabled={busy} title="Merge automatically once everything passes">Merge when green</Btn>
+          <Btn onClick={onUpdateBranch} disabled={busy} warn title="Merge the base branch into this one — this updates the branch on GitHub">↻ Update branch</Btn>
+          {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>Re-run failed</Btn>}
           <span className="ml-auto flex gap-1.5">
-            <Btn onClick={onDraft} disabled={busy} small>{d.isDraft ? "mark ready" : "to draft"}</Btn>
-            <Btn onClick={onClose} disabled={busy} danger small>close</Btn>
+            <Btn onClick={onDraft} disabled={busy} small>{d.isDraft ? "Mark ready" : "To draft"}</Btn>
+            <Btn onClick={onClose} disabled={busy} danger small>Close</Btn>
           </span>
         </div>
       </section>
@@ -960,9 +960,9 @@ function Overview({ d, busy, openThreads, onLocalReview, onMerge, onClose, onUpd
       </section>
 
       <div className="flex gap-1.5 flex-wrap">
-        <Btn onClick={onLocalReview} disabled={busy} primary title="check the PR out into a throwaway worktree and review it with the whole repo in context">review locally with Claude</Btn>
+        <Btn onClick={onLocalReview} disabled={busy} primary title="Check the PR out into a throwaway worktree and review it with the whole repo in context">Review locally with Claude</Btn>
         <a href={d.url} target="_blank" rel="noreferrer noopener" className="text-[10.5px] px-2.5 py-1 rounded"
-          style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>open on GitHub ↗</a>
+          style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>Open on GitHub ↗</a>
       </div>
     </div>
   );
@@ -995,8 +995,8 @@ function DiffToolbar({ path, add, del, split, wrap, onSplit, onWrap, right }: {
       {del != null && <span className="tabular-nums shrink-0" style={{ color: "var(--error)" }}>−{del}</span>}
       <span className="ml-auto flex items-center gap-1 shrink-0">
         {right}
-        <Toggle on={split} onClick={() => onSplit(!split)} title="Split / unified">{split ? "split" : "unified"}</Toggle>
-        <Toggle on={wrap} onClick={() => onWrap(!wrap)} title="Toggle line wrap">wrap</Toggle>
+        <Toggle on={split} onClick={() => onSplit(!split)} title="Split / unified">{split ? "Split" : "Unified"}</Toggle>
+        <Toggle on={wrap} onClick={() => onWrap(!wrap)} title="Toggle line wrap">Wrap</Toggle>
       </span>
     </div>
   );
@@ -1054,12 +1054,12 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
               {/* The tick means "I have read this" — a different intent from
                   "show me this", so it is a different target. */}
               <input type="checkbox" checked={done} onChange={() => onSeen(f.path)}
-                style={{ accentColor: "var(--primary)" }} title="mark reviewed" aria-label={`mark ${f.path} reviewed`} />
+                style={{ accentColor: "var(--primary)" }} title="Mark reviewed" aria-label={`Mark ${f.path} reviewed`} />
               <button onClick={() => onSel(open ? null : f.path)} className="flex-1 min-w-0 text-left flex items-center gap-2">
                 <span className="shrink-0" style={{ color: "var(--text3)" }}>{open ? "▾" : "▸"}</span>
                 <span className="truncate" style={{ color: done ? "var(--text3)" : "var(--text2)", textDecoration: done ? "line-through" : undefined }}>{f.path}</span>
                 {f.comments > 0 && <Chip text={`${f.comments} open`} tint="var(--warning)" />}
-                {nd > 0 && <Chip text={`${nd} pending`} tint="var(--primary)" title="queued in your review" />}
+                {nd > 0 && <Chip text={`${nd} pending`} tint="var(--primary)" title="Queued in your review" />}
                 <span className="ml-auto shrink-0 tabular-nums" style={{ color: "var(--success)" }}>+{f.additions}</span>
                 <span className="shrink-0 tabular-nums" style={{ color: "var(--error)" }}>−{f.deletions}</span>
               </button>
@@ -1071,11 +1071,11 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
       {sel && (
         <div className="rounded overflow-hidden flex flex-col" style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", height: 560 }}>
           <DiffToolbar path={sel} add={current?.additions} del={current?.deletions} split={split} wrap={wrap} onSplit={onSplit} onWrap={onWrap}
-            right={<span className="text-[10px] mr-1" style={{ color: "var(--text3)" }}>unified shows “+ comment”</span>} />
+            right={<span className="text-[10px] mr-1" style={{ color: "var(--text3)" }}>Unified shows “+ Comment”</span>} />
           <div className="flex-1 min-h-0 flex">
-            {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>loading the diff…</div>
+            {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>Loading the diff…</div>
               : current ? <DiffPane file={current} split={split} wrap={wrap} onComment={(line) => onAddDraft(sel, line)} />
-              : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>no textual diff — binary, renamed, or too large to show</div>}
+              : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
           </div>
         </div>
       )}
@@ -1120,7 +1120,7 @@ function Card({ who, chip, when, tone, url, children }: {
         {chip}
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
           {when && <span className="text-[10px]" style={{ color: "var(--text3)" }}>{when}</span>}
-          {url && <GhLink href={url} title="open on GitHub" />}
+          {url && <GhLink href={url} title="Open on GitHub" />}
         </span>
       </div>
       <div className="px-3 py-2.5">{children}</div>
@@ -1186,10 +1186,10 @@ function Thread({ t, onResolve, onReply, busy }: {
       <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
         style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
         <span className="truncate" style={{ color: "var(--primary)" }}>{t.path}{t.line ? `:${t.line}` : ""}</span>
-        {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="the code under this comment has changed since" />}
+        {t.isOutdated && <Chip text="outdated" tint="var(--text3)" title="The code under this comment has changed since" />}
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
           {t.isResolved ? <Chip text="resolved" tint="var(--success)" /> : <Chip text="open" tint="var(--warning)" />}
-          {t.url && <GhLink href={t.url} title="open this thread on GitHub" />}
+          {t.url && <GhLink href={t.url} title="Open this thread on GitHub" />}
         </span>
       </div>
       <ThreadSnippet hunk={t.diffHunk} line={t.originalLine ?? t.line} />
@@ -1202,7 +1202,7 @@ function Thread({ t, onResolve, onReply, busy }: {
             {c.isBot && <Chip text="automation" tint="var(--info)" />}
             <span className="ml-auto flex items-center gap-1.5" style={{ color: "var(--text3)" }}>
               {ago(c.createdAt)}
-              {c.url && <GhLink href={c.url} title="open this comment on GitHub" />}
+              {c.url && <GhLink href={c.url} title="Open this comment on GitHub" />}
             </span>
           </div>
           <Md body={c.body} />
@@ -1210,8 +1210,8 @@ function Thread({ t, onResolve, onReply, busy }: {
       ))}
       <div className="flex gap-1.5 px-3 py-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
         <Btn onClick={() => onReply(t)} disabled={busy || !canReply} small
-          title={canReply ? undefined : "this thread has no comment to reply to"}>reply</Btn>
-        <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "unresolve" : "resolve conversation"}</Btn>
+          title={canReply ? undefined : "This thread has no comment to reply to"}>Reply</Btn>
+        <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "Unresolve" : "Resolve conversation"}</Btn>
       </div>
     </div>
   );
@@ -1285,7 +1285,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, busy }: {
           {lanes.bots.map((c) => (
             <Card key={c.id} who={c.author} when={ago(c.createdAt)} url={c.url} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
               {raw ? <pre className="overflow-x-auto text-[10px] max-h-72 agx-scroll" style={{ ...CODE_FONT_STYLE, color: "var(--text3)" }}>{c.body}</pre>
-                : <span style={{ color: "var(--text2)" }}>{c.digest || "(nothing worth pulling out)"}</span>}
+                : <span style={{ color: "var(--text2)" }}>{c.digest || "(Nothing worth pulling out)"}</span>}
             </Card>
           ))}
         </>
@@ -1311,7 +1311,7 @@ const CHECK_GLYPH: Record<PrCheck["state"], string> = {
 function groupOf(k: PrCheck): string {
   if (k.workflow) return k.workflow;
   const parts = k.name.split(" / ");
-  return parts.length > 1 ? parts.slice(0, -1).join(" / ") : "checks";
+  return parts.length > 1 ? parts.slice(0, -1).join(" / ") : "Checks";
 }
 
 function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: boolean }) {
@@ -1350,8 +1350,8 @@ function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: 
           </span>
         </span>
         <span className="ml-auto shrink-0 flex items-center gap-2">
-          {c.failure > 0 && <Btn onClick={onRerun} disabled={busy} small>re-run failed</Btn>}
-          <span className="text-[10px]" style={{ color: "var(--text3)" }}>{c.allDone ? "notified once, not " + c.total : "you will be told once, at the end"}</span>
+          {c.failure > 0 && <Btn onClick={onRerun} disabled={busy} small>Re-run failed</Btn>}
+          <span className="text-[10px]" style={{ color: "var(--text3)" }}>{c.allDone ? "Notified once, not " + c.total : "You will be told once, at the end"}</span>
         </span>
       </div>
       <Bar parts={[
@@ -1384,7 +1384,7 @@ function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: 
                   {k.name.startsWith(name) ? k.name.slice(name.length).replace(/^\s*\/\s*/, "") || k.name : k.name}
                 </span>
                 <span className="ml-auto shrink-0 text-[9.5px] uppercase tracking-wide" style={{ color: CHECK_TINT[k.state] }}>{k.state}</span>
-                {k.url && <a href={k.url} target="_blank" rel="noreferrer noopener" className="shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>log ↗</a>}
+                {k.url && <a href={k.url} target="_blank" rel="noreferrer noopener" className="shrink-0 text-[10px]" style={{ color: "var(--text3)" }}>Log ↗</a>}
               </div>
             ))}
           </div>
@@ -1394,7 +1394,7 @@ function Checks({ d, onRerun, busy }: { d: PrDetail; onRerun: () => void; busy: 
       {skippedCount > 0 && (
         <button onClick={() => setShowSkipped((v) => !v)} className="text-[10px] px-2.5 py-1.5 rounded self-start"
           style={{ color: "var(--text2)", border: "1px dashed color-mix(in srgb, var(--border) 50%, transparent)" }}>
-          {showSkipped ? "hide" : "show"} {skippedCount} skipped
+          {showSkipped ? "Hide" : "Show"} {skippedCount} skipped
         </button>
       )}
     </div>
@@ -1459,14 +1459,14 @@ function ReviewTab({ d, drafts, seen, busy, onDrop, onSubmit, onGoFiles }: {
                   style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" }}>
                   <span className="shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.path.split("/").pop()}:{c.line}</span>
                   <span className="min-w-0 flex-1" style={{ color: "var(--text2)" }}>{c.body}</span>
-                  <button onClick={() => onDrop(i)} className="shrink-0 text-[10px]" style={{ color: "var(--error)" }}>drop</button>
+                  <button onClick={() => onDrop(i)} className="shrink-0 text-[10px]" style={{ color: "var(--error)" }}>Drop</button>
                 </div>
               ))}
             </div>
           ) : (
             <div className="text-[10.5px]" style={{ color: "var(--text3)" }}>
               No line comments queued. Open <button onClick={onGoFiles} style={{ color: "var(--primary)" }}>files</button> and
-              use “+ comment” on a hunk to attach one to a line.
+              use “+ Comment” on a hunk to attach one to a line.
             </div>
           )}
 
@@ -1476,7 +1476,7 @@ function ReviewTab({ d, drafts, seen, busy, onDrop, onSubmit, onGoFiles }: {
                 style={{
                   color: (m === "preview") === preview ? "var(--text)" : "var(--text3)",
                   borderBottom: `2px solid ${(m === "preview") === preview ? "var(--primary)" : "transparent"}`,
-                }}>{m}</button>
+                }}>{m === "preview" ? "Preview" : "Write"}</button>
             ))}
           </div>
 
@@ -1514,7 +1514,7 @@ function ReviewTab({ d, drafts, seen, busy, onDrop, onSubmit, onGoFiles }: {
             </span>
             <span className="ml-auto">
               <Btn onClick={() => onSubmit(verb, body)} disabled={busy || (verb !== "approve" && nothing)} primary
-                title={verb !== "approve" && nothing ? "say something, or queue a line comment" : undefined}>submit review</Btn>
+                title={verb !== "approve" && nothing ? "Say something, or queue a line comment" : undefined}>Submit review</Btn>
             </span>
           </div>
         </div>

--- a/web/src/components/ProjectPicker.tsx
+++ b/web/src/components/ProjectPicker.tsx
@@ -103,7 +103,7 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
     setError("");
     api.setWorkspace(root)
       .then((res) => {
-        if (!res.ok) { setBusy(false); setError(res.error || "could not switch project"); return; }
+        if (!res.ok) { setBusy(false); setError(res.error || "Could not switch project"); return; }
         // A failed persist or an env override only affects the *next* launch —
         // the switch itself worked — so say so without blocking the reload.
         if (res.note) console.warn(`[agentglass] ${res.note}`);
@@ -148,12 +148,12 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
 
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>⌂ Open a project</span>
-                  <span className="text-[11px] t-dim2">a project — or a folder your projects live in</span>
+                  <span className="text-[11px] t-dim2">A project — or a folder your projects live in</span>
                   <button onClick={close} className="ml-auto text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
                 </div>
 
                 <div className="px-4 pt-3 shrink-0">
-                  <input autoFocus value={query} onChange={(e) => setQuery(e.target.value)} placeholder="filter projects…"
+                  <input autoFocus value={query} onChange={(e) => setQuery(e.target.value)} placeholder="Filter projects…"
                     className="w-full px-3 py-2 rounded-lg text-[12px] outline-none"
                     style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                 </div>
@@ -165,13 +165,13 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                     style={{ background: !workspace ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
                     <span className="text-[13px]">🖥</span>
                     <span className="min-w-0 flex-1">
-                      <span className="block text-[12px] font-medium" style={{ color: "var(--text)" }}>Whole machine</span>
-                      <span className="block text-[10px] t-dim2">every project at once — no scope</span>
+                      <span className="block text-[12px] font-medium" style={{ color: "var(--text)" }}>All repos/projects</span>
+                      <span className="block text-[10px] t-dim2">Every repo/project — no scope</span>
                     </span>
-                    {!workspace && <span className="text-[9.5px] px-1.5 py-0.5 rounded-full" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 15%, transparent)" }}>current</span>}
+                    {!workspace && <span className="text-[9.5px] px-1.5 py-0.5 rounded-full" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 15%, transparent)" }}>Current</span>}
                   </button>
 
-                  {repos === null && <div className="px-3 py-3 text-[11px] t-dim2">looking for repos…</div>}
+                  {repos === null && <div className="px-3 py-3 text-[11px] t-dim2">Looking for repos…</div>}
                   {/* Two different empty states. A filter that matches nothing
                       is about the filter; an empty list with no filter is about
                       configuration, and saying "no repos found" there states a
@@ -180,10 +180,10 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                       look in"). The first reads as a bug in discovery, which is
                       how it was reported. */}
                   {repos !== null && !shown.length && (terms.length ? (
-                    <div className="px-3 py-3 text-[11px] t-dim2">no repos match that filter</div>
+                    <div className="px-3 py-3 text-[11px] t-dim2">No repos match that filter</div>
                   ) : (
                     <div className="px-3 py-3 text-[11px] t-dim2 leading-relaxed">
-                      <div style={{ color: "var(--text2)" }}>nothing to look in yet</div>
+                      <div style={{ color: "var(--text2)" }}>Nothing to look in yet</div>
                       <div className="mt-1">
                         agentglass sweeps the folders your projects already live in, and the usual ones
                         (<code>~/code</code>, <code>~/src</code>, <code>~/projects</code>…). If yours are somewhere else,
@@ -210,7 +210,7 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                         <span className="block text-[10px] t-dim2 truncate" title={r.root}>{r.root}</span>
                       </span>
                       <span className="shrink-0 text-[9.5px] t-dim2 truncate" style={{ maxWidth: 120 }}>{r.branch}</span>
-                      {r.root === workspace && <span className="shrink-0 text-[9.5px] px-1.5 py-0.5 rounded-full" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 15%, transparent)" }}>current</span>}
+                      {r.root === workspace && <span className="shrink-0 text-[9.5px] px-1.5 py-0.5 rounded-full" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 15%, transparent)" }}>Current</span>}
                     </button>
                   ))}
                 </div>
@@ -235,7 +235,7 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                           {e.repo && <span className="ml-auto shrink-0 text-[9px] px-1.5 py-0.5 rounded-full" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 15%, transparent)" }}>git</span>}
                         </div>
                       ))}
-                      {more && <div className="px-3 py-1 text-[10px] t-dim2">more matches — keep typing</div>}
+                      {more && <div className="px-3 py-1 text-[10px] t-dim2">More matches — keep typing</div>}
                     </div>
                   )}
                   <input ref={pathRef} value={path} onChange={(e) => setPath(e.target.value)} placeholder="…or type a folder: ~/code/my-project, or ~/code for everything in it"
@@ -245,12 +245,12 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
                   <button onClick={() => path.trim() && choose(path.trim())} disabled={busy || !path.trim()}
                     className="text-[11px] px-3 py-1.5 rounded-lg font-medium"
                     style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)", opacity: path.trim() ? 1 : 0.5 }}>
-                    open
+                    Open
                   </button>
                 </div>
                 {(error || busy || IS_DEMO) && (
                   <div className="px-4 pb-3 text-[10.5px] shrink-0" style={{ color: error ? "var(--error)" : "var(--text2)" }}>
-                    {IS_DEMO ? "the demo is never scoped — run agentglass locally to open a project" : error || "switching project…"}
+                    {IS_DEMO ? "The demo is never scoped — run agentglass locally to open a project" : error || "Switching project…"}
                   </div>
                 )}
               </motion.div>

--- a/web/src/components/Radar.tsx
+++ b/web/src/components/Radar.tsx
@@ -207,7 +207,7 @@ export function Radar({ agents, onSelect }: { agents: AgentCard[]; onSelect?: (a
           </div>
 
           {agents.length === 0 && (
-            <div className="absolute inset-0 flex items-center justify-center text-[11px] t-dim2">no agents tracked yet</div>
+            <div className="absolute inset-0 flex items-center justify-center text-[11px] t-dim2">No agents tracked yet</div>
           )}
         </div>
 

--- a/web/src/components/ReleaseNotesModal.tsx
+++ b/web/src/components/ReleaseNotesModal.tsx
@@ -68,7 +68,7 @@ export function ReleaseNotesModal({ open, tag, notes, title = "What's new", load
 
                 <div className="px-5 py-4 overflow-y-auto agx-scroll text-[12.5px]" style={{ color: "var(--text2)" }}>
                   {loading
-                    ? <div className="text-[11px] t-dim2">reading the notes…</div>
+                    ? <div className="text-[11px] t-dim2">Reading the notes…</div>
                     : error
                       ? <div className="text-[11px]" style={{ color: "var(--warning)" }}>{error}</div>
                       : <Markdown text={notes} />}
@@ -83,7 +83,7 @@ export function ReleaseNotesModal({ open, tag, notes, title = "What's new", load
                   <button onClick={onClose} autoFocus
                     className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
                     style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)" }}>
-                    got it
+                    Got it
                   </button>
                 </div>
               </motion.div>

--- a/web/src/components/RescueModal.tsx
+++ b/web/src/components/RescueModal.tsx
@@ -165,7 +165,7 @@ export function RescueModal({ reports, progress, onCancel, onConfirm }: {
                       <span className="text-[11.5px] truncate" style={{ color: ticked ? "var(--text)" : "var(--text3)" }}>{r.entry.path}</span>
                       {risky && (
                         <span className="text-[9px] px-1 rounded shrink-0" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 15%, transparent)" }}>
-                          overwrites the main checkout
+                          Overwrites the main checkout
                         </span>
                       )}
                       <span className="ml-auto text-[10px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{fmtBytes(r.entry.bytes)}</span>
@@ -181,7 +181,7 @@ export function RescueModal({ reports, progress, onCancel, onConfirm }: {
                   <span className="inline-block w-3 h-3 rounded-full shrink-0" style={{ border: "2px solid color-mix(in srgb, var(--primary) 35%, transparent)", borderTopColor: "var(--primary)", animation: "agx-spin 0.7s linear infinite" }} />
                   <style>{"@keyframes agx-spin{to{transform:rotate(360deg)}}"}</style>
                   <span className="text-[11.5px]" style={{ color: "var(--text2)" }}>{progress}…</span>
-                  <span className="ml-auto text-[10.5px]" style={{ color: "var(--text3)" }}>this can take a few seconds</span>
+                  <span className="ml-auto text-[10.5px]" style={{ color: "var(--text3)" }}>This can take a few seconds</span>
                 </>
               ) : (
               <>

--- a/web/src/components/SearchModal.tsx
+++ b/web/src/components/SearchModal.tsx
@@ -72,12 +72,12 @@ export function SearchModal({ open, onClose, onSelectApp }: { open: boolean; onC
                     placeholder="Search everything — prompts, commands, outputs, errors…"
                     className="flex-1 bg-transparent outline-none text-[13px]" style={{ color: "var(--text)" }}
                   />
-                  <span className="text-[10px] t-dim2 shrink-0">{loading ? "…" : hits ? `${hits.length} hits` : "your fleet's memory"}</span>
+                  <span className="text-[10px] t-dim2 shrink-0">{loading ? "…" : hits ? `${hits.length} hits` : "Your fleet's memory"}</span>
                 </div>
 
                 <div className="flex-1 min-h-0 overflow-y-auto">
                   {hits === null && <div className="t-dim2 text-center py-14 text-[12px]">Search every event ever captured — 12k+ prompts, commands and outputs.</div>}
-                  {hits && hits.length === 0 && !loading && <div className="t-dim2 text-center py-14 text-[12px]">nothing matches “{q}”</div>}
+                  {hits && hits.length === 0 && !loading && <div className="t-dim2 text-center py-14 text-[12px]">Nothing matches “{q}”</div>}
                   {hits && hits.map((h) => {
                     const f = friendly({ hook_event_type: h.hook_event_type } as any);
                     const who = agentKey({ source_app: h.source_app, session_id: h.session_id });

--- a/web/src/components/Select.tsx
+++ b/web/src/components/Select.tsx
@@ -129,7 +129,7 @@ export function Select({
                 transition={{ type: "spring", stiffness: 420, damping: 32 }}
                 ref={listRef}
                 role="listbox"
-                aria-label={title ?? "options"}
+                aria-label={title ?? "Options"}
                 className="fixed p-1.5 rounded-xl flex flex-col gap-0.5 overflow-y-auto agw-noscrollbar"
                 style={{
                   top: pos.top,

--- a/web/src/components/ServerBanner.tsx
+++ b/web/src/components/ServerBanner.tsx
@@ -63,7 +63,7 @@ export default function ServerBanner() {
       }}
     >
       <span className="font-semibold" style={{ color: foreign ? "var(--error)" : "var(--warning)" }}>
-        {foreign ? "wrong server" : "no server"}
+        {foreign ? "Wrong server" : "No server"}
       </span>
       {foreign ? (
         <span>

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -133,31 +133,31 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                         // transcript, so say why rather than offer a button
                         // that corrupts the history.
                         <span className="chip t-dim2" title="This session is still running — resume it once it stops, or watch it live below.">
-                          ● running
+                          ● Running
                         </span>
                       ) : sessionCwd(d) ? (
                         <button onClick={() => { onResume(d); onClose(); }} className="chip cursor-pointer"
                           title={`Continue this conversation in ${sessionCwd(d)} — claude keeps the full context`}
                           style={{ color: "var(--ok, #34d399)", background: "color-mix(in srgb, #34d399 15%, transparent)", borderColor: "color-mix(in srgb, #34d399 45%, transparent)" }}>
-                          ↩ resume in chat
+                          ↩ Resume in chat
                         </button>
                       ) : (
                         <span className="chip t-dim2" title="No directory recorded for this session, so there's nowhere to resume it.">
-                          ↩ resume unavailable
+                          ↩ Resume unavailable
                         </span>
                       )
                     )}
                     {d && onFilter && (
                       <button onClick={() => { onFilter(d.source_app); onClose(); }} className="chip cursor-pointer" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", borderColor: "color-mix(in srgb, var(--primary) 45%, transparent)" }}>
-                        ⧉ watch in live feed
+                        ⧉ Watch in live feed
                       </button>
                     )}
                     <button onClick={onClose} className="text-[18px] leading-none px-2 t-dim2 hover:opacity-70">✕</button>
                   </div>
                 </div>
 
-                {loading && <div className="flex-1 grid place-items-center t-dim2 text-[12px]">loading session…</div>}
-                {!loading && !d && <div className="flex-1 grid place-items-center t-dim2 text-[12px]">session not found</div>}
+                {loading && <div className="flex-1 grid place-items-center t-dim2 text-[12px]">Loading session…</div>}
+                {!loading && !d && <div className="flex-1 grid place-items-center t-dim2 text-[12px]">Session not found</div>}
 
                 {d && (
                   <div className="flex-1 min-h-0 flex flex-col">
@@ -168,7 +168,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                           conversation — the full text is in the thread below.
                           Scrolls rather than truncating, so nothing is lost. */}
                       <div className="text-[12.5px] leading-relaxed max-h-[150px] overflow-y-auto agx-scroll" style={{ color: "var(--text2)" }}>
-                        {d.summary ? <Markdown text={d.summary} /> : <span className="t-dim2 italic">no assistant summary captured for this session</span>}
+                        {d.summary ? <Markdown text={d.summary} /> : <span className="t-dim2 italic">No assistant summary captured for this session</span>}
                       </div>
                       <div className="grid grid-cols-3 sm:grid-cols-6 gap-3 mt-4">
                         <Stat k="Events" v={d.events.toLocaleString()} />
@@ -195,7 +195,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                                 </div>
                               </div>
                             ))}
-                            {d.tool_mix.length === 0 && <div className="t-dim2 text-[11px]">no tool calls</div>}
+                            {d.tool_mix.length === 0 && <div className="t-dim2 text-[11px]">No tool calls</div>}
                           </div>
                         </div>
                         <div>
@@ -220,11 +220,11 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                                 </button>
                               );
                             })}
-                            {d.subagents.length === 0 && <div className="t-dim2 text-[11px]">none</div>}
+                            {d.subagents.length === 0 && <div className="t-dim2 text-[11px]">None</div>}
                           </div>
                           {focusAgent && (
                             <button onClick={() => setFocusAgent(null)} className="mt-2 text-[10px] t-dim2 hover:opacity-70">
-                              ← showing one subagent · back to the whole session
+                              ← Showing one subagent · back to the whole session
                             </button>
                           )}
                         </div>
@@ -232,7 +232,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                           <div className="panel-eyebrow mb-2 flex items-center gap-2">
                             <span>Files changed · {d.changes.length}</span>
                             {d.changes.length > 0 && (
-                              <button onClick={() => { setDiffPath(undefined); setDiffOpen(true); }} className="ml-auto normal-case tracking-normal text-[10px] px-1.5 py-0.5 rounded transition-colors" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)" }}>view diffs →</button>
+                              <button onClick={() => { setDiffPath(undefined); setDiffOpen(true); }} className="ml-auto normal-case tracking-normal text-[10px] px-1.5 py-0.5 rounded transition-colors" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)" }}>View diffs →</button>
                             )}
                           </div>
                           <div className="space-y-1">
@@ -245,7 +245,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                                 </span>
                               </button>
                             ))}
-                            {d.changes.length === 0 && <div className="t-dim2 text-[11px]">no file changes</div>}
+                            {d.changes.length === 0 && <div className="t-dim2 text-[11px]">No file changes</div>}
                           </div>
                         </div>
                       </div>
@@ -272,7 +272,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                               className="text-[9.5px] px-1.5 py-0.5 rounded-full"
                               title="Jump to the newest turn and follow again"
                               style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 15%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 45%, transparent)" }}>
-                              ↓ resume live
+                              ↓ Resume live
                             </button>
                           )}
                           <button onClick={() => setShowTools((s) => !s)}
@@ -283,7 +283,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                               background: `color-mix(in srgb, var(--primary) ${showTools ? 15 : 6}%, transparent)`,
                               border: `1px solid color-mix(in srgb, var(--primary) ${showTools ? 40 : 18}%, transparent)`,
                             }}>
-                            ⚙ tools {toolCount > 0 && <span className="tabular-nums">{toolCount}</span>}
+                            ⚙ Tools {toolCount > 0 && <span className="tabular-nums">{toolCount}</span>}
                           </button>
                         </div>
                         {/* Watched for height changes — the eyebrow row above is
@@ -291,7 +291,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                             new turns, and tool output whose syntax highlighting
                             lands a moment after the row itself. */}
                         <div ref={convoContentRef} className="space-y-2.5">
-                          {rows.length === 0 && <div className="t-dim2 text-[11px]">no prompts or messages captured</div>}
+                          {rows.length === 0 && <div className="t-dim2 text-[11px]">No prompts or messages captured</div>}
                           {rows.map((r) => r.kind === "tool" ? (
                             <ToolRow key={r.key} e={r.e} sub={r.children} />
                           ) : (

--- a/web/src/components/Sessions.tsx
+++ b/web/src/components/Sessions.tsx
@@ -22,7 +22,7 @@ export const Sessions = memo(function Sessions({ provider = "" }: { provider?: s
   return (
     <Panel eyebrow="Timeline" title="Sessions over time" right={<span className="text-[10px] t-dim2">{sessions.length} sessions</span>}>
       <div className="overflow-auto h-full space-y-1.5 pr-1">
-        {sessions.length === 0 && <div className="t-dim2 text-[11px] text-center py-6">no sessions yet</div>}
+        {sessions.length === 0 && <div className="t-dim2 text-[11px] text-center py-6">No sessions yet</div>}
         {sessions.map((s, i) => {
           const start = ((s.started_at - min) / span) * 100;
           const end = (((s.ended_at ?? s.last_seen) - min) / span) * 100;

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -175,12 +175,12 @@ function KeyRow({ id, keyName, capturing, onCapture, error, chord }: {
               : chord.custom
                 ? { color: "var(--primary-hover)" }
                 : { color: "var(--text2)", opacity: 0.6 }}>
-            {chord.capturing ? "hold a combo…" : chordLabel(chord.key)}
+            {chord.capturing ? "Hold a combo…" : chordLabel(chord.key)}
           </button>
           <span className="w-3 shrink-0">
             {chord.custom && !chord.capturing && (
-              <button onClick={chord.onClear} title="back to its position in the rail"
-                className="text-[11px] px-0.5 t-dim2 hover:opacity-70" aria-label="reset this shortcut">✕</button>
+              <button onClick={chord.onClear} title="Back to its position in the rail"
+                className="text-[11px] px-0.5 t-dim2 hover:opacity-70" aria-label="Reset this shortcut">✕</button>
             )}
           </span>
         </span>
@@ -191,7 +191,7 @@ function KeyRow({ id, keyName, capturing, onCapture, error, chord }: {
           style={capturing
             ? { color: "var(--primary-hover)", borderColor: "color-mix(in srgb, var(--primary) 60%, transparent)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }
             : { color: "var(--text2)" }}>
-          {capturing ? "press a key…" : keyName === " " ? "space" : keyName}
+          {capturing ? "Press a key…" : keyName === " " ? "space" : keyName}
         </button>
       </span>
     </div>
@@ -227,7 +227,7 @@ function AboutPane({ open }: { open: boolean }) {
     setNotes(null);
     api.updateNotes(want.tag)
       .then((r) => { if (live) setNotes(r); })
-      .catch(() => { if (live) setNotes({ ok: false, tag: want.tag, notes: "", source: "", error: "could not reach the server" }); });
+      .catch(() => { if (live) setNotes({ ok: false, tag: want.tag, notes: "", source: "", error: "Could not reach the server" }); });
     return () => { live = false; };
   }, [want]);
 
@@ -246,13 +246,13 @@ function AboutPane({ open }: { open: boolean }) {
 
   const run = async () => {
     setBusy(true); setErr(null);
-    const r = await api.updateRun().catch(() => ({ ok: false, error: "could not reach the server" }));
+    const r = await api.updateRun().catch(() => ({ ok: false, error: "Could not reach the server" }));
     setBusy(false);
-    if (!r.ok) { setErr(r.error || "update failed to start"); return; }
+    if (!r.ok) { setErr(r.error || "Update failed to start"); return; }
     setStarted(true);
   };
 
-  if (!st) return <Section title="About"><div className="px-3 py-2 text-[11px] t-dim2">reading version…</div></Section>;
+  if (!st) return <Section title="About"><div className="px-3 py-2 text-[11px] t-dim2">Reading version…</div></Section>;
 
   const short = st.info.commit ? st.info.commit.slice(0, 7) : "unknown";
   const mine = installedNotes(st.info.baseTag, st.info.distance, st.branch);
@@ -262,7 +262,7 @@ function AboutPane({ open }: { open: boolean }) {
         <div className="flex items-baseline gap-3">
           <span className="text-[12.5px]" style={{ color: "var(--text)" }}>agentglass {st.info.version}</span>
           <span className="text-[10.5px] t-dim2 tabular-nums" title={st.info.commit}>{short}</span>
-          {st.info.builtAt && <span className="text-[10px] t-dim2">built {new Date(st.info.builtAt).toLocaleString()}</span>}
+          {st.info.builtAt && <span className="text-[10px] t-dim2">Built {new Date(st.info.builtAt).toLocaleString()}</span>}
           {/* The notes used to appear once, on the launch after an update, and
               were unreachable ever after — dismiss it, or update before it
               existed, and the only copy was on the release page. */}
@@ -270,7 +270,7 @@ function AboutPane({ open }: { open: boolean }) {
             <button onClick={() => setWant(mine)}
               className="ml-auto text-[10.5px] px-2 py-0.5 rounded-md hover:opacity-80"
               style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}>
-              release notes
+              Release notes
             </button>
           )}
         </div>
@@ -283,7 +283,7 @@ function AboutPane({ open }: { open: boolean }) {
             style={st.last.ok
               ? { color: "var(--text2)", background: "color-mix(in srgb, var(--success) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 30%, transparent)" }
               : { color: "var(--text2)", background: "color-mix(in srgb, var(--error) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 35%, transparent)" }}>
-            last update {st.last.ok ? "succeeded" : "failed"} — {new Date(st.last.at).toLocaleString()}
+            Last update {st.last.ok ? "succeeded" : "failed"} — {new Date(st.last.at).toLocaleString()}
             {!st.last.ok && st.last.tail && (
               <pre className="mt-1 text-[9.5px] whitespace-pre-wrap break-all m-0" style={{ color: "var(--text3)" }}>
                 {st.last.tail.split("~").filter(Boolean).slice(-6).join("\n")}
@@ -329,7 +329,7 @@ function AboutPane({ open }: { open: boolean }) {
               <button onClick={run} disabled={busy}
                 className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
                 style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)", opacity: busy ? 0.5 : 1 }}>
-                {busy ? "starting…" : `install ${st.branch} & restart`}
+                {busy ? "Starting…" : `Install ${st.branch} & restart`}
               </button>
               {/* Read before you install, rather than after the app has
                   restarted into it. The tag list above says which releases are
@@ -337,7 +337,7 @@ function AboutPane({ open }: { open: boolean }) {
               <button onClick={() => setWant({ tag: st.branch, title: "What's in this update" })}
                 className="text-[11.5px] px-3 py-1.5 rounded-lg hover:opacity-80"
                 style={{ color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}>
-                what's in {st.branch}
+                What's in {st.branch}
               </button>
             </div>
             <span className="text-[9.5px] t-dim2">
@@ -356,7 +356,7 @@ function AboutPane({ open }: { open: boolean }) {
         // A release with no annotation, an origin github knows nothing about,
         // a laptop on a train: all of them end here. Saying which is the whole
         // point of a button you pressed on purpose.
-        error={notes && !notes.ok ? (notes.error || "no notes for that release") : undefined}
+        error={notes && !notes.ok ? (notes.error || "No notes for that release") : undefined}
         notes={notes?.notes ?? ""}
         onClose={() => setWant(null)}
       />
@@ -581,7 +581,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         <button onClick={() => { resetBindings(); resetChords(); setKeyError(null); setCapturing(null); setCapturingChord(null); }}
                           className="text-[10.5px] px-2 py-1 rounded-lg shrink-0"
                           style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-                          reset to defaults
+                          Reset to defaults
                         </button>
                       )}
                     </div>

--- a/web/src/components/SkillsModal.tsx
+++ b/web/src/components/SkillsModal.tsx
@@ -10,11 +10,11 @@ type Usage = "all" | "used" | "never";
 type Sort = "grouped" | "used" | "recent" | "newest" | "oldest" | "az";
 
 const SORTS: { key: Sort; label: string }[] = [
-  { key: "grouped", label: "by category" },
-  { key: "used", label: "most used" },
-  { key: "recent", label: "recently used" },
-  { key: "newest", label: "newest" },
-  { key: "oldest", label: "oldest" },
+  { key: "grouped", label: "By category" },
+  { key: "used", label: "Most used" },
+  { key: "recent", label: "Recently used" },
+  { key: "newest", label: "Newest" },
+  { key: "oldest", label: "Oldest" },
   { key: "az", label: "a–z" },
 ];
 
@@ -61,15 +61,15 @@ function SkillCard({ s, isNew, isTop, expanded, onToggle }: { s: SkillInfo; isNe
           className="chip shrink-0 cursor-pointer"
           style={copied ? { color: "var(--success)", borderColor: "color-mix(in srgb, var(--success) 45%, transparent)" } : { color: "var(--text4)" }}
         >
-          {copied ? "copied ✓" : "copy"}
+          {copied ? "Copied ✓" : "Copy"}
         </button>
-        {isTop && <Badge text="top" color="var(--warning)" />}
-        {isNew && <Badge text="new" color="var(--success)" />}
+        {isTop && <Badge text="Top" color="var(--warning)" />}
+        {isNew && <Badge text="New" color="var(--success)" />}
         <span className="ml-auto flex items-center gap-2 shrink-0 text-[10px] t-dim2">
           {s.calls > 0 ? (
             <span className="tabular-nums" style={{ color: "var(--text3)" }}>{s.calls}× {s.last_used ? `· ${fmtAgo(s.last_used)}` : ""}</span>
           ) : (
-            <span>never used</span>
+            <span>Never used</span>
           )}
         </span>
       </div>
@@ -77,7 +77,7 @@ function SkillCard({ s, isNew, isTop, expanded, onToggle }: { s: SkillInfo; isNe
         <span className="chip">{s.kind}</span>
         <span className="chip">{s.category}</span>
         <span className="chip">{s.source}</span>
-        <span>added {fmtAgo(s.added)} ago</span>
+        <span>Added {fmtAgo(s.added)} ago</span>
         {s.copies > 1 && <span>· ×{s.copies} copies</span>}
         {perRun > 0 && <span className="tabular-nums" style={{ color: "var(--success)" }}>· ~{fmtUsd(perRun)}/run</span>}
       </div>
@@ -101,17 +101,17 @@ function SkillCard({ s, isNew, isTop, expanded, onToggle }: { s: SkillInfo; isNe
             : { display: "-webkit-box", WebkitLineClamp: s.when_to_use ? 1 : 2, WebkitBoxOrient: "vertical", overflow: "hidden" }
         }
       >
-        {s.description || <span className="t-dim2 italic">no description — add one to its frontmatter</span>}
+        {s.description || <span className="t-dim2 italic">No description — add one to its frontmatter</span>}
       </div>
       {expanded && (
         <div className="mt-2 pt-2 border-t flex flex-col gap-1 text-[10.5px]" style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
           <div className="flex items-center gap-2">
-            <span className="t-dim2">invoke: </span>
+            <span className="t-dim2">Invoke: </span>
             <code style={{ color: "var(--text2)" }}>{invoke}{s.argument_hint ? ` ${s.argument_hint}` : ""}</code>
           </div>
           {s.cost_usd > 0 && (
             <div className="t-dim2">
-              attributed cost: <span className="tabular-nums" style={{ color: "var(--success)" }}>{fmtUsd(s.cost_usd)}</span> total · ~{fmtUsd(perRun)}/run
+              Attributed cost: <span className="tabular-nums" style={{ color: "var(--success)" }}>{fmtUsd(s.cost_usd)}</span> total · ~{fmtUsd(perRun)}/run
             </div>
           )}
           <div className="t-dim2 truncate" title={s.path}>{s.path}</div>
@@ -246,7 +246,7 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
                 <div className="flex gap-1">
                   {(["used", "never"] as Usage[]).map((u) => (
                     <button key={u} onClick={() => setUsage((cur) => (cur === u ? "all" : u))} className="chip cursor-pointer" style={chipStyle(usage === u, "var(--warning)")}>
-                      {u === "never" ? "never used" : "used"}
+                      {u === "never" ? "Never used" : "Used"}
                     </button>
                   ))}
                 </div>
@@ -262,7 +262,7 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
               {/* category chips — the discovery rail */}
               <div className="flex items-center gap-1 px-5 pb-2 shrink-0 flex-wrap">
                 <button onClick={() => setCategory("all")} className="chip cursor-pointer" style={chipStyle(category === "all")}>
-                  all categories
+                  All categories
                 </button>
                 {categories.map(([c, n]) => (
                   <button key={c} onClick={() => setCategory((cur) => (cur === c ? "all" : c))} className="chip cursor-pointer" style={chipStyle(category === c)}>
@@ -272,8 +272,8 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
               </div>
 
               <div className="flex-1 min-h-0 overflow-y-auto px-5 pb-4">
-                {!skills && <div className="t-dim2 text-center py-10 text-[12px]">loading catalog…</div>}
-                {skills && shown.length === 0 && <div className="t-dim2 text-center py-10 text-[12px]">nothing matches</div>}
+                {!skills && <div className="t-dim2 text-center py-10 text-[12px]">Loading catalog…</div>}
+                {skills && shown.length === 0 && <div className="t-dim2 text-center py-10 text-[12px]">Nothing matches</div>}
                 {sections ? (
                   sections.map(({ category: c, items }) => (
                     <div key={c} className="mb-4">

--- a/web/src/components/StatsModal.tsx
+++ b/web/src/components/StatsModal.tsx
@@ -183,13 +183,13 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                           value: s.calls,
                           right: s.cost_usd > 0 ? `${s.calls}× · ${fmtUsd(s.cost_usd)}` : `${s.calls}×`,
                         }))}
-                        empty="no skill runs in this window"
+                        empty="No skill runs in this window"
                       />
                     </Widget>
 
                     <Widget title="skill runs over time" i={4}>
                       {skills.length === 0 ? (
-                        <div className="t-dim2 text-[11px] py-3">no skill runs in this window</div>
+                        <div className="t-dim2 text-[11px] py-3">No skill runs in this window</div>
                       ) : (
                         <div className="flex flex-col gap-1">
                           {skills.slice(0, 6).map((s) => {
@@ -234,14 +234,14 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                           value: t.calls,
                           right: `${t.calls}× · p50 ${t.p50_ms >= 1000 ? (t.p50_ms / 1000).toFixed(1) + "s" : Math.round(t.p50_ms) + "ms"}`,
                         }))}
-                        empty="no tool calls in this window"
+                        empty="No tool calls in this window"
                       />
                     </Widget>
 
                     <Widget title="event mix" i={3}>
                       <BarList
                         rows={types.map((t) => ({ label: t.hook_event_type, value: t.count, dot: typeColor(t.hook_event_type) }))}
-                        empty="no events in this window"
+                        empty="No events in this window"
                       />
                     </Widget>
                   </div>
@@ -250,7 +250,7 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                 {/* full-width — a sibling below the columns, always clears them */}
                 <Widget title="apps by spend" i={5} full>
                   {apps.length === 0 ? (
-                    <div className="t-dim2 text-[11px] py-3">no activity in this window</div>
+                    <div className="t-dim2 text-[11px] py-3">No activity in this window</div>
                   ) : (
                     <div className="flex flex-col">
                       <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,auto)] gap-x-4 text-[9px] uppercase tracking-wider t-dim2 pb-1">

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -45,12 +45,12 @@ export function consoleRoot(): string {
 /** Status dot, for anywhere that shows a shell's state. TermView builds a
  *  richer one that names the shell; this is the shared minimum. */
 const SESS_DOT: Record<SessStatus, { color: string; label: string }> = {
-  idle: { color: "var(--text2)", label: "idle" },
-  connecting: { color: "var(--warning)", label: "connecting…" },
-  live: { color: "var(--success, #98c379)", label: "live" },
-  exited: { color: "var(--text2)", label: "exited" },
-  error: { color: "var(--error)", label: "disconnected" },
-  unauthorized: { color: "var(--error)", label: "unauthorized ⚿" },
+  idle: { color: "var(--text2)", label: "Idle" },
+  connecting: { color: "var(--warning)", label: "Connecting…" },
+  live: { color: "var(--success, #98c379)", label: "Live" },
+  exited: { color: "var(--text2)", label: "Exited" },
+  error: { color: "var(--error)", label: "Disconnected" },
+  unauthorized: { color: "var(--error)", label: "Unauthorized ⚿" },
 };
 const repoName = (p: string) => p.split("/").pop() || p;
 
@@ -671,13 +671,13 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
           <button onMouseDown={keepTermFocus} onClick={() => setRepoOpen((o) => !o)} disabled={IS_DEMO}
             className="flex items-center gap-1.5 text-[10px] px-2 py-0.5 rounded-md max-w-[200px]"
             style={{ background: "color-mix(in srgb, var(--bg3) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
-            title={root || "no repo"}>
-            <span className="truncate">{root ? repoName(root) : "no repo"}</span><span className="t-dim2">▼</span>
+            title={root || "No repo"}>
+            <span className="truncate">{root ? repoName(root) : "No repo"}</span><span className="t-dim2">▼</span>
           </button>
           {repoOpen && (
             <div className="absolute left-0 rounded-lg text-[11px] shadow-2xl flex flex-col"
               style={{ zIndex: 40, bottom: "calc(100% + 4px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 360, overflow: "hidden" }}>
-              <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="filter repos…"
+              <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter repos…"
                 className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
                 style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
               <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
@@ -694,7 +694,7 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
                     {r.dirty > 0 && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--warning)" }}>●{r.dirty}</span>}
                   </button>
                 ))}
-                {!repos.length && <div className="px-3 py-2 t-dim2">reading repos…</div>}
+                {!repos.length && <div className="px-3 py-2 t-dim2">Reading repos…</div>}
               </div>
             </div>
           )}
@@ -709,8 +709,8 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
           <CommandBar root={root} disabled={!sid} font={TERM_FONT} onRun={runHere} onClose={focusConsole} dropUp />
         </div>
 
-        <span className="ml-auto text-[9px] t-dim2 shrink-0">drag to resize</span>
-        <button onClick={(e) => { e.stopPropagation(); onClose(); }} onMouseDown={(e) => e.stopPropagation()} className="text-[12px] leading-none px-1.5 t-dim2 hover:opacity-70 shrink-0" title="hide the console (the shell keeps running)">✕</button>
+        <span className="ml-auto text-[9px] t-dim2 shrink-0">Drag to resize</span>
+        <button onClick={(e) => { e.stopPropagation(); onClose(); }} onMouseDown={(e) => e.stopPropagation()} className="text-[12px] leading-none px-1.5 t-dim2 hover:opacity-70 shrink-0" title="Hide the console (the shell keeps running)">✕</button>
       </div>
       <div ref={slot} className="flex-1 min-h-0" style={{ background: "var(--bg)" }} onClick={() => sess?.term.focus()} />
     </div>
@@ -989,12 +989,12 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const disabled = cmds ? !cmds.enabled : false;
 
   const statusDot: Record<SessStatus, { color: string; label: string }> = {
-    idle: { color: "var(--text2)", label: "idle" },
-    connecting: { color: "var(--warning)", label: "connecting…" },
+    idle: { color: "var(--text2)", label: "Idle" },
+    connecting: { color: "var(--warning)", label: "Connecting…" },
     live: { color: "var(--success, #98c379)", label: sess ? `${sess.shell} · ${sess.mode === "pipe" ? "pipe" : "pty"}${sess.mode !== "pipe" && !sess.canResize ? " · fixed size" : ""}` : "live" },
-    exited: { color: "var(--text2)", label: "exited" },
-    error: { color: "var(--error)", label: "disconnected" },
-    unauthorized: { color: "var(--error)", label: "unauthorized ⚿" },
+    exited: { color: "var(--text2)", label: "Exited" },
+    error: { color: "var(--error)", label: "Disconnected" },
+    unauthorized: { color: "var(--error)", label: "Unauthorized ⚿" },
   };
 
   return (
@@ -1028,7 +1028,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   <div ref={pickersRef} className="flex items-center gap-3" onMouseDown={keepTermFocus}>
                   <div className="relative">
                     <button onClick={() => { if (repoOpen) { setRepoOpen(false); focusTerm(); } else setRepoOpen(true); }} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
-                      <span className="font-medium">{repoRef ? repoName(repoRef.root) : "pick a repo"}</span><span className="t-dim2">▼</span>
+                      <span className="font-medium">{repoRef ? repoName(repoRef.root) : "Pick a repo"}</span><span className="t-dim2">▼</span>
                     </button>
                     {repoOpen && (
                       /* Wide enough for the whole worktree name and its branch.
@@ -1038,7 +1038,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                          apart, both cut off. Source control shows them in full;
                          this now matches it. */
                       <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 460, maxWidth: "min(86vw, 760px)", maxHeight: 420, overflow: "hidden" }}>
-                        <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
+                        <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
                         <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
                           {/* The path is searchable too: with a worktree per card,
                               "20343" is how you find one — it's in the directory
@@ -1058,7 +1058,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                                     as a kind of thing. */}
                                 <span
                                   className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
-                                  title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
+                                  title={r.worktreeOf ? `Worktree of ${r.worktreeOf}` : "Main checkout"}
                                   style={r.worktreeOf
                                     ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
                                     : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
@@ -1077,7 +1077,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                                     collided with the branch beside it. */}
                                 <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.worktreeOf ? `${r.branch}\n${r.root}` : r.root}>
                                   {r.worktreeOf ? r.branch : r.name}
-                                  {live && <span title="live shell" style={{ color: "var(--success, #98c379)" }}> ●</span>}
+                                  {live && <span title="Live shell" style={{ color: "var(--success, #98c379)" }}> ●</span>}
                                 </span>
                                 {!r.worktreeOf && <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.branch}>{r.branch}</span>}
                                 {r.dirty > 0 && <span className="shrink-0 text-[9px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.dirty} changed file${r.dirty === 1 ? "" : "s"}`}>●{r.dirty}</span>}
@@ -1086,7 +1086,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                               </button>
                             );
                           })}
-                          {!repos.length && <div className="px-3 py-2 t-dim2">no repos seen yet</div>}
+                          {!repos.length && <div className="px-3 py-2 t-dim2">No repos seen yet</div>}
                         </div>
                       </div>
                     )}
@@ -1106,12 +1106,12 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   <div className="ml-auto flex items-center gap-1.5 shrink-0" onMouseDown={keepTermFocus}>
                     <span onClick={status === "unauthorized" ? reauthPrompt : undefined}
                       className={`flex items-center gap-1.5 text-[10px] t-dim2 mr-1 ${status === "unauthorized" ? "cursor-pointer" : ""}`}
-                      title={status === "unauthorized" ? "this server needs an access token — click to enter it" : "shell status"}>
+                      title={status === "unauthorized" ? "This server needs an access token — click to enter it" : "Shell status"}>
                       <span style={{ color: statusDot[status].color }}>●</span>{statusDot[status].label}
                     </span>
-                    {!tmuxActive && <button onClick={splitPane} disabled={!root || IS_DEMO || disabled || paneIds.length >= 4} title="show another shell beside this one" className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", opacity: paneIds.length >= 4 ? 0.45 : 1 }}>⊞ split</button>}
-                    <button onClick={restart} disabled={!root || IS_DEMO || disabled} title="kill this shell and start a fresh one" className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>⟲ restart</button>
-                    <button onClick={() => sess?.term.clear()} className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>clear</button>
+                    {!tmuxActive && <button onClick={splitPane} disabled={!root || IS_DEMO || disabled || paneIds.length >= 4} title="Show another shell beside this one" className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", opacity: paneIds.length >= 4 ? 0.45 : 1 }}>⊞ Split</button>}
+                    <button onClick={restart} disabled={!root || IS_DEMO || disabled} title="Kill this shell and start a fresh one" className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>⟲ Restart</button>
+                    <button onClick={() => sess?.term.clear()} className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>Clear</button>
                   </div>
                 </div>
 
@@ -1133,11 +1133,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                               : { color: "var(--text3)" }}>
                           <span className="w-1.5 h-1.5 rounded-full" style={{ background: t.status === "live" ? "var(--success, #98c379)" : t.status === "error" ? "var(--error)" : "color-mix(in srgb, var(--text4) 60%, transparent)" }} />
                           <span>{t.title}</span>
-                          <button onClick={(e) => { e.stopPropagation(); closeShell(t.id); }} className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="close shell">✕</button>
+                          <button onClick={(e) => { e.stopPropagation(); closeShell(t.id); }} className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="Close shell">✕</button>
                         </div>
                       );
                     })}
-                    <button onClick={addShell} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title="new shell in this repo">+</button>
+                    <button onClick={addShell} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title="New shell in this repo">+</button>
                   </div>
                 )}
 
@@ -1189,7 +1189,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         <div key={w.id}
                           onClick={() => { if (w.id !== activeWindow) { setPendingWindow(w.id); tmuxCmd("select", { window: w.id }); } }}
                           onDoubleClick={() => setRenaming(w.id)}
-                          title={`window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
+                          title={`Window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
                           className="group flex items-center gap-1.5 px-2 py-1 rounded-md text-[10.5px] cursor-pointer shrink-0"
                           style={w.id === activeWindow
                             ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)" }
@@ -1219,20 +1219,20 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                           ) : (
                             <span>{w.name || "shell"}</span>
                           )}
-                          {zoomed && <span className="text-[9px] font-semibold leading-none" style={{ color: "var(--text4)" }} title="a pane in this window is zoomed">⤢</span>}
-                          {bell && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--error)" }} title="bell" />}
-                          {!bell && activity && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="activity" />}
+                          {zoomed && <span className="text-[9px] font-semibold leading-none" style={{ color: "var(--text4)" }} title="A pane in this window is zoomed">⤢</span>}
+                          {bell && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--error)" }} title="Bell" />}
+                          {!bell && activity && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="Activity" />}
                           <button onClick={(e) => { e.stopPropagation(); tmuxCmd("kill", { window: w.id }); }}
-                            className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="close window (kill-window)">✕</button>
+                            className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="Close window (kill-window)">✕</button>
                         </div>
                       );
                     })}
-                    <button onClick={() => tmuxCmd("new")} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title={`new tmux window (${px} c puts it next to this one)`}>+</button>
+                    <button onClick={() => tmuxCmd("new")} className="shrink-0 px-2 py-1 rounded-md text-[10.5px]" style={{ color: "var(--text3)" }} title={`New tmux window (${px} c puts it next to this one)`}>+</button>
                     <button onClick={() => setTmuxBar((v) => !v)} className="ml-auto shrink-0 px-2 py-1 rounded-md text-[10px]" style={{ color: "var(--text3)" }}
                       title={tmuxBar
-                        ? "blank tmux's own status line for this session — it keeps the row, so its prompts and messages still have somewhere to draw"
-                        : "give tmux's own status line back"}>
-                      {tmuxBar ? "hide tmux bar" : "show tmux bar"}
+                        ? "Blank tmux's own status line for this session — it keeps the row, so its prompts and messages still have somewhere to draw"
+                        : "Give tmux's own status line back"}>
+                      {tmuxBar ? "Hide tmux bar" : "Show tmux bar"}
                     </button>
                   </div>
                 )}
@@ -1281,10 +1281,10 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   {(IS_DEMO || disabled) && (
                     <div className="absolute inset-0 flex items-center justify-center text-[12px] t-dim2" style={{ background: "color-mix(in srgb, var(--bg) 80%, transparent)" }}>
                       {IS_DEMO
-                        ? "the terminal is disabled in the demo — run agentglass locally for a real shell"
+                        ? "The terminal is disabled in the demo — run agentglass locally for a real shell"
                         : cmds?.reason === "windows"
-                        ? "the terminal is not available on Windows yet (the PTY backend needs POSIX; ConPTY support is planned)"
-                        : "terminal disabled (AGENTGLASS_TERMINAL_DISABLED=1)"}
+                        ? "The terminal is not available on Windows yet (the PTY backend needs POSIX; ConPTY support is planned)"
+                        : "Terminal disabled (AGENTGLASS_TERMINAL_DISABLED=1)"}
                     </div>
                   )}
                 </div>
@@ -1298,16 +1298,16 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   {tmuxActive ? (
                     <span className="flex items-center gap-2 flex-wrap">
                       <span className="px-1.5 rounded" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }}>tmux</span>
-                      <span>panel chrome hidden — tmux owns the panes</span>
+                      <span>Panel chrome hidden — tmux owns the panes</span>
                       <span className="t-dim2">·</span>
-                      {[["c", "window"], ['"', "split ↓"], ["%", "split →"], ["o", "next pane"], ["z", "zoom"], ["d", "detach"], ["?", "all keys"]].map(([key, what]) => (
+                      {[["c", "Window"], ['"', "Split ↓"], ["%", "Split →"], ["o", "Next pane"], ["z", "Zoom"], ["d", "Detach"], ["?", "All keys"]].map(([key, what]) => (
                         <Fragment key={key}>
                           <b style={{ color: "var(--text2)" }}>{px} {key}</b><span>{what}</span>
                         </Fragment>
                       ))}
                     </span>
                   ) : (
-                    <span>real shell — Ctrl+C, Ctrl+R, Tab-complete, vim/htop all work · sessions survive closing this panel · Shift+Esc closes it</span>
+                    <span>Real shell — Ctrl+C, Ctrl+R, Tab-complete, vim/htop all work · sessions survive closing this panel · Shift+Esc closes it</span>
                   )}
                   <span className="ml-auto">{sess ? `${sess.term.cols}×${sess.term.rows}` : ""}</span>
                 </div>

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -837,6 +837,22 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     // were dragging and cycles focus mid-keystroke.
   }, [open, paneIds, focusIdx]);
 
+  // Return the keyboard focus to the shell when the terminal view becomes
+  // visible again — e.g. after clicking the left sidebar to another view and
+  // coming back, or dismissing the app header. The mount effect above
+  // deliberately omits `active` so returning does not detach/reload the
+  // terminal, so it never refocuses on return; this does, and only that. Guard
+  // on the rising edge (hidden → visible) so an already-focused shell is not
+  // re-grabbed on every unrelated re-render.
+  const wasActive = useRef(active);
+  useEffect(() => {
+    if (active && !wasActive.current && open) {
+      const s = sessions.get(paneIds[focusIdx] ?? "");
+      if (s) requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
+    }
+    wasActive.current = active;
+  }, [active, open, paneIds, focusIdx]);
+
   const sess = sessions.get(paneIds[focusIdx] ?? "");
   // tmux is running in the shell you're looking at, so it owns the tabs and the
   // splits. Ours would be a second set of controls doing the same job worse —

--- a/web/src/components/ToolMix.tsx
+++ b/web/src/components/ToolMix.tsx
@@ -62,7 +62,7 @@ export function ToolMix({ events }: { events: WatchEvent[] }) {
               <span className="t-dim2 tabular-nums">{m.pct.toFixed(0)}%</span>
             </span>
           ))}
-          {seg.length === 0 && <span className="text-[11px] t-dim2">waiting for tool calls…</span>}
+          {seg.length === 0 && <span className="text-[11px] t-dim2">Waiting for tool calls…</span>}
         </div>
       </div>
     </Panel>

--- a/web/src/components/ToolRow.tsx
+++ b/web/src/components/ToolRow.tsx
@@ -53,7 +53,7 @@ export function ToolRow({ e, sub = [], nested = false }: {
           onClick={detail ? () => setOpen((o) => !o) : undefined}
           className={`min-w-0 flex-1 break-all ${detail ? "cursor-pointer" : ""} ${open ? "" : "truncate"}`}
           style={MONO}
-          title={detail && !open ? "click for the full command and its output" : undefined}>
+          title={detail && !open ? "Click for the full command and its output" : undefined}>
           <span style={{ color: tint }}>{e.is_error ? "✕ " : ""}{e.tool}</span>
           <span style={{ color: "var(--text4)" }}>(</span>
           <span style={{ color: "var(--text3)" }}>{firstLine}</span>

--- a/web/src/components/UsageWidget.tsx
+++ b/web/src/components/UsageWidget.tsx
@@ -111,7 +111,7 @@ export function UsageWidget() {
   // First fetch in flight — show a spinner so it's clearly loading, not missing.
   if (loading && !u) {
     return (
-      <div className="flex items-center gap-2 px-3.5 py-1.5 rounded-xl" title="loading Anthropic plan usage…"
+      <div className="flex items-center gap-2 px-3.5 py-1.5 rounded-xl" title="Loading Anthropic plan usage…"
         style={{ background: "color-mix(in srgb, var(--bg3) 30%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
         <span className="h-3 w-3 rounded-full animate-spin" style={{ border: "2px solid color-mix(in srgb, var(--primary) 25%, transparent)", borderTopColor: "var(--primary)" }} />
         <span className="text-[10px] t-dim2">Anthropic usage…</span>

--- a/web/src/components/workspace/DynamicIsland.tsx
+++ b/web/src/components/workspace/DynamicIsland.tsx
@@ -265,11 +265,11 @@ function useNotes(): { note: Note | null; behind: number; ahead: number } {
         if (first || c.attention === prev || c.attention === "none") continue;
         if (c.attention === "blocked") {
           // Blocked, not merely finished: the chat cannot continue without you.
-          push({ id: `${c.id}-b-${c.messages.length}`, kind: "blocked", color: "var(--error)", title: c.title || "chat", sub: c.blockedTool ? `needs "${c.blockedTool}"` : "waiting on you", urgent: true });
-          recordNote({ app: "chat", summary: c.title || "chat", body: c.blockedTool ? `blocked — needs "${c.blockedTool}"` : "blocked — waiting on you", urgency: 2 });
+          push({ id: `${c.id}-b-${c.messages.length}`, kind: "blocked", color: "var(--error)", title: c.title || "Chat", sub: c.blockedTool ? `Needs "${c.blockedTool}"` : "Waiting on you", urgent: true });
+          recordNote({ app: "chat", summary: c.title || "Chat", body: c.blockedTool ? `Blocked — needs "${c.blockedTool}"` : "Blocked — waiting on you", urgency: 2 });
         } else if (c.attention === "done") {
-          push({ id: `${c.id}-d-${c.messages.length}`, kind: "done", color: "var(--success)", title: c.title || "chat", sub: "turn finished" });
-          recordNote({ app: "chat", summary: c.title || "chat", body: "turn finished" });
+          push({ id: `${c.id}-d-${c.messages.length}`, kind: "done", color: "var(--success)", title: c.title || "Chat", sub: "Turn finished" });
+          recordNote({ app: "chat", summary: c.title || "Chat", body: "Turn finished" });
         }
       }
       first = false;
@@ -412,16 +412,16 @@ function HistoryRow({ n, onGone }: { n: SystemNote; onGone: () => void }) {
               onClick={() => void openNote(n.id)}
               title={n.url}
             >
-              ↗ open {hostOf(n.url)}
+              ↗ Open {hostOf(n.url)}
             </button>
           )}
         </span>
         <span className="flex items-center gap-1 shrink-0">
           {long && (
             <button className="agx-note-btn" onClick={() => setOpen((v) => !v)}
-              title={open ? "collapse" : "show the whole message"}>{open ? "▴" : "▾"}</button>
+              title={open ? "Collapse" : "Show the whole message"}>{open ? "▴" : "▾"}</button>
           )}
-          <button className="agx-note-btn" onClick={onGone} title="dismiss">✕</button>
+          <button className="agx-note-btn" onClick={onGone} title="Dismiss">✕</button>
         </span>
       </div>
     </div>
@@ -492,7 +492,7 @@ export function DynamicIsland() {
         onClick={(e) => { e.stopPropagation(); if (hist.length) setInbox((v) => !v); }}
         // Only while closed: once the panel is open the tooltip floats over
         // the list, labelling something you are already looking at.
-        title={hist.length && !inbox ? "notifications" : undefined}
+        title={hist.length && !inbox ? "Notifications" : undefined}
       >
         {/* A wipe, not a fade. The content sweeps in from one side and, when its
             few seconds are up, sweeps out the same way -- a barrido that reads
@@ -598,8 +598,8 @@ export function DynamicIsland() {
               ) : rateLimited ? (
                 <>
                   <span className="agx-sep" />
-                  <Pill cap="PLAN" title="the usage endpoint is rate-limiting us; retrying">
-                    <span className="text-[10px]" style={{ color: "color-mix(in srgb, #fff 55%, transparent)" }}>rate-limited</span>
+                  <Pill cap="PLAN" title="The usage endpoint is rate-limiting us; retrying">
+                    <span className="text-[10px]" style={{ color: "color-mix(in srgb, #fff 55%, transparent)" }}>Rate-limited</span>
                   </Pill>
                 </>
               ) : null}
@@ -633,10 +633,10 @@ export function DynamicIsland() {
                   : "Quiet mirrored notifications: keep collecting them, stop letting them interrupt"}
                 style={quiet ? { color: "var(--warning)" } : undefined}
               >
-                {quiet ? "quiet on" : "quiet"}
+                {quiet ? "Quiet on" : "Quiet"}
               </button>
-              <button className="agx-note-btn ml-auto" onClick={() => { clearNotes(); setInbox(false); }}>clear all</button>
-              <button className="agx-note-btn" onClick={() => setInbox(false)} title="close (Esc)">✕</button>
+              <button className="agx-note-btn ml-auto" onClick={() => { clearNotes(); setInbox(false); }}>Clear all</button>
+              <button className="agx-note-btn" onClick={() => setInbox(false)} title="Close (Esc)">✕</button>
             </div>
             <div className="agx-inbox-list">
               {hist.map((n) => (

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -123,7 +123,7 @@ export function ViewRail({
         <button
           onClick={onSkills}
           aria-label="Skills catalog"
-          data-tip="skills catalog · what this fleet can do"
+          data-tip="Skills catalog · what this fleet can do"
           className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
           style={{ color: "var(--text4)" }}
         >
@@ -132,7 +132,7 @@ export function ViewRail({
         <button
           onClick={onClose}
           aria-label="Close workspace"
-          data-tip="close · esc"
+          data-tip="Close · esc"
           className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
           style={{ color: "var(--text4)" }}
         >

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -53,7 +53,7 @@ export function Workspace({
    */
   const openChatWith = useCallback((cwd: string, prompt: string) => {
     const chat = newChat(cwd);
-    updateChat(chat.id, (c) => { c.draft = prompt; c.title = "pr review"; });
+    updateChat(chat.id, (c) => { c.draft = prompt; c.title = "PR review"; });
     setActiveChatId(chat.id);
     onView("chat");
   }, [onView]);

--- a/web/src/components/workspace/views.ts
+++ b/web/src/components/workspace/views.ts
@@ -15,12 +15,12 @@ export type ViewDef = {
 
 /** Order is the rail's order, and ⌘1..⌘6 index into it. */
 export const VIEWS: ViewDef[] = [
-  { id: "git", label: "git", key: "g", icon: GitIcon, hint: "stage, commit, push/pull the working tree" },
-  { id: "diff", label: "diff", key: "d", icon: DiffIcon, hint: "review & commit every diff the fleet made" },
-  { id: "pr", label: "pull requests", key: "p", icon: PrIcon, hint: "review pull requests without leaving for the browser" },
-  { id: "docker", label: "docker", key: "o", icon: DockerIcon, hint: "containers, logs, stats & actions" },
-  { id: "term", label: "term", key: "t", icon: TerminalIcon, hint: "a real shell in any repo/worktree" },
-  { id: "chat", label: "chat", key: "c", icon: ChatIcon, hint: "drive a Claude session in any repo/worktree" },
+  { id: "git", label: "Git", key: "g", icon: GitIcon, hint: "Stage, commit, push/pull the working tree" },
+  { id: "diff", label: "Diff", key: "d", icon: DiffIcon, hint: "Review & commit every diff the fleet made" },
+  { id: "pr", label: "Pull requests", key: "p", icon: PrIcon, hint: "Review pull requests without leaving for the browser" },
+  { id: "docker", label: "Docker", key: "o", icon: DockerIcon, hint: "Containers, logs, stats & actions" },
+  { id: "term", label: "Term", key: "t", icon: TerminalIcon, hint: "A real shell in any repo/worktree" },
+  { id: "chat", label: "Chat", key: "c", icon: ChatIcon, hint: "Drive a Claude session in any repo/worktree" },
 ];
 
 export const VIEW_IDS = VIEWS.map((v) => v.id);


### PR DESCRIPTION
## What

A UX pass over the workspace, from a batch of reported annoyances:

- **PR view — spinner on switch.** Selecting a different PR kept the previous one's data on screen with no loading cue, so it read as a dead click. It now clears and shows `Loading #N…` while the new detail loads.
- **PR view — newest-first.** The open-PR list was unordered; it is now sorted by `updatedAt` desc, which also makes the existing per-PR check probe fill the recent rows first.
- **PR view — per-tab search.** A search box on each scope (Mine / Review / All) matching number (`#123`), title or author, cleared when the scope changes.
- **PR view — `update branch` accent.** It merges the base into the branch, but looked identical to its neighbours. It now uses the amber "sync" accent (matching the Source Control bar) and a ↻ glyph, and turns a merge-conflict outcome into an actionable message instead of gh's raw error.
- **Terminal — refocus on return.** Coming back to the terminal from another view left it visible but unfocused; it now refocuses the shell on the hidden → visible edge, without reloading it.
- **Chat — resume reads as rich as live.** Dropped the `opacity: 0.72` wash on resumed history; the "resumed here" divider already marks the seam, and tool calls already nest/collapse.
- **Casing — sentence-case the whole UI.** Swept every human-facing label to sentence case across all views, modals, tiles and banners. Code/machine tokens (CLI strings, paths, enum values, keybindings, eyebrow labels) stay lowercase. Also renames the picker's "Whole machine" to "All repos/projects".

## How

- `PrPanel.tsx`: clear `detail` on selection change; `visiblePrs` memo + search input; `Btn` gains a `warn` (amber) variant used on update-branch.
- `prs.ts`: sort `fetchList` output desc by `updatedAt`; `updateBranch` maps the conflict error to an actionable message.
- `TerminalPanel.tsx`: focus-only effect on the `active` rising edge.
- `ChatPanel.tsx`: remove the historical-message opacity.
- Casing: label-string-only edits across ~38 component files (no logic changes). Verified with `tsc`, `vite build` and `scripts/smoke.ts` (all views mount, no console errors).

## Notes / follow-ups (separate issues)

- Project picker multi-select + user-added roots (no whole-machine scan) — data-model change, needs real-app testing.
- Opt-in bug/crash reporting with zero user data.
- `update branch` conflict: a "resolve in terminal" flow (worktree + terminal on the merge).
