### PR TITLE
fix: bump deprecated actions/* GitHub Actions to current majors across all workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest

--- a/.github/workflows/desktop-binaries.yml
+++ b/.github/workflows/desktop-binaries.yml
@@ -37,7 +37,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           # Full history + tags, so `git describe --tags` in build.mjs can name
           # the release this build descends from. A shallow checkout has no tag
@@ -116,7 +116,7 @@ jobs:
 
       - name: Keep the build even when there is no tag
         if: ${{ !startsWith(github.ref, 'refs/tags/v') }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: agentglass-${{ matrix.bunTarget }}
           path: |

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -30,7 +30,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
@@ -51,7 +51,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: bun scripts/landing-release.mjs site/index.html
-      - uses: actions/upload-pages-artifact@v3
+      - uses: actions/upload-pages-artifact@v5
         with:
           path: site
 
@@ -63,4 +63,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5

--- a/.github/workflows/pr-template-nudge.yml
+++ b/.github/workflows/pr-template-nudge.yml
@@ -17,7 +17,7 @@ jobs:
     if: github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/github-script@v7
+      - uses: actions/github-script@v9
         with:
           script: |
             const marker = '<!-- pr-template-nudge -->'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,7 +15,7 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0 # need the real tag object, not a shallow peel
       - name: Create release only if the tag has none


### PR DESCRIPTION
## What does this PR do?

Bumps each pinned official `actions/*` action to its current major so the workflows stop running on the deprecated Node 20 runtime that GitHub is currently force-overriding to Node 24. The versions match the majors the issue enumerates:

- `ci.yml`: `actions/checkout@v4` to `@v7`
- `desktop-binaries.yml`: `actions/checkout@v4` to `@v7`, `actions/upload-artifact@v4` to `@v7`
- `pages.yml`: `actions/checkout@v4` to `@v7`, `actions/upload-pages-artifact@v3` to `@v5`, `actions/deploy-pages@v4` to `@v5`
- `pr-template-nudge.yml`: `actions/github-script@v7` to `@v9`
- `release.yml`: `actions/checkout@v4` to `@v7`

These are version-string edits only. The existing usages (bare `checkout`, the single `upload-artifact` step, the standard pages upload/deploy pair, and the inline `github-script`) use no inputs the new majors renamed or removed, so no accompanying config change is needed. Third-party actions (`oven-sh/setup-bun@v2`, `browser-actions/setup-chrome@v1`) carry no Node-20 deprecation and are left untouched.

Fixes #162

## How was it tested?

Each of the five workflow files was validated to parse as YAML, and `actionlint` was run across all workflows on both this branch and `main`: the output is identical, so the bumps introduce no new findings (the one pre-existing `SC2034` shellcheck warning in `ci.yml` is unrelated and unchanged). `git diff --check` is clean and the diff is 8 changed lines, all `uses:` version tags. The workflow runs themselves are the real proof and run on GitHub's own runners: this PR triggers `ci.yml`, and `desktop-binaries.yml` can be confirmed via `workflow_dispatch` now that no tag is pending.
