### PR TITLE
fix(ingest): clamp live client timestamps to the server clock (#245)

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun";
 import type { IngestBody, WsFrame, WorkingTree } from "../../shared/types.ts";
-import { normalize, detectError } from "./ingest.ts";
+import { normalize, detectError, clampIngestTimestamp } from "./ingest.ts";
 import { db } from "./db.ts";
 import {
   insertEvent,
@@ -382,6 +382,9 @@ setInterval(pushOpenTools, OPEN_TOOL_TICK_MS).unref?.();
 /** Normalize → persist → broadcast → alert. Shared by /ingest and /v1/traces. */
 function ingestBody(body: IngestBody) {
   const n = normalize(body);
+  // Live seam only: a skewed sender's clock must not decide which time window
+  // its events land in. Backfill inserts elsewhere and keeps its real times.
+  n.timestamp = clampIngestTimestamp(n.timestamp, Date.now());
   const { event, session } = insertEvent(n);
   // The session just grew, so its cached detail is stale — drop it so a live
   // session refreshes on the next open, while static sessions keep serving from

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -193,6 +193,29 @@ function capDeep(v: object, depth: number): void {
   }
 }
 
+// A live event's client timestamp drives every windowed number (last-15m burn,
+// insights, retention pruning, tool-latency deltas), all of which compare it
+// against the server's own Date.now(). A sender whose clock is off — the named
+// failure is a host running two hours fast — would place its events outside
+// every "last N minutes" window and have them pruned on the wrong schedule,
+// silently corrupting the per-source metrics with no signal that anything is
+// wrong. A live event arrives within seconds of happening, so its timestamp
+// belongs in a small band around the server clock; anything outside that band
+// is clock skew, not a real time, so pin it to now. In-band timestamps are kept
+// exactly, because tool-latency deltas depend on them.
+//
+// This is applied only at the live ingest seam (ingestBody). Transcript backfill
+// carries genuinely historical timestamps and inserts without passing through
+// here, so those are left untouched.
+const FUTURE_SKEW_MS = 60_000; // 1 min: nothing legitimate arrives from the future
+const PAST_SKEW_MS = 5 * 60_000; // 5 min: covers real send/queue delay, catches skew beyond
+export function clampIngestTimestamp(ts: number, now: number): number {
+  if (!Number.isFinite(ts)) return now;
+  if (ts > now + FUTURE_SKEW_MS) return now;
+  if (ts < now - PAST_SKEW_MS) return now;
+  return ts;
+}
+
 export function normalize(body: IngestBody): NormalizedEvent {
   const payload = (body.payload ?? {}) as Record<string, unknown>;
   const type = String(body.hook_event_type ?? "Unknown");

--- a/server/test/ingest.test.ts
+++ b/server/test/ingest.test.ts
@@ -1,7 +1,7 @@
 // Ingest pure helpers from #10 wishlist: detectError on tool_response shapes
 // and transcript token summing (usage_is_cumulative path).
 import { describe, expect, test } from "bun:test";
-import { detectError, sumTranscriptTokens, normalize } from "../src/ingest.ts";
+import { detectError, sumTranscriptTokens, normalize, clampIngestTimestamp } from "../src/ingest.ts";
 import type { IngestBody } from "../../shared/types.ts";
 
 const MAX_FIELD = 64 * 1024; // must match ingest.ts
@@ -147,5 +147,33 @@ describe("normalize bounds every untrusted string", () => {
     expect(ev.summary).toBe("all good");
     expect(ev.payload.prompt).toBe("hi");
     expect(ev.payload.n).toBe(3);
+  });
+});
+
+describe("clampIngestTimestamp", () => {
+  const now = 1_700_000_000_000; // fixed server clock for the whole block
+
+  test("keeps an in-band timestamp exactly (tool-latency deltas rely on this)", () => {
+    expect(clampIngestTimestamp(now, now)).toBe(now);
+    expect(clampIngestTimestamp(now - 30_000, now)).toBe(now - 30_000); // 30s late: fine
+    expect(clampIngestTimestamp(now + 30_000, now)).toBe(now + 30_000); // 30s ahead: fine
+    expect(clampIngestTimestamp(now - 4 * 60_000, now)).toBe(now - 4 * 60_000); // 4m late: still in band
+  });
+
+  test("pins a future-skewed clock to now (the named 2h-fast host)", () => {
+    expect(clampIngestTimestamp(now + 2 * 3_600_000, now)).toBe(now);
+    expect(clampIngestTimestamp(now + 61_000, now)).toBe(now); // just past the 1m future bound
+  });
+
+  test("pins an absurdly-past clock to now", () => {
+    expect(clampIngestTimestamp(now - 2 * 3_600_000, now)).toBe(now); // 2h slow
+    expect(clampIngestTimestamp(0, now)).toBe(now); // epoch
+    expect(clampIngestTimestamp(now - 6 * 60_000, now)).toBe(now); // just past the 5m past bound
+  });
+
+  test("coerces non-finite input to now", () => {
+    expect(clampIngestTimestamp(NaN, now)).toBe(now);
+    expect(clampIngestTimestamp(Infinity, now)).toBe(now);
+    expect(clampIngestTimestamp(-Infinity, now)).toBe(now);
   });
 });


### PR DESCRIPTION
## What

Live event timestamps sent by a client with a skewed clock are now clamped to a small band around the server's own clock, so a single misconfigured agent host can no longer corrupt every windowed metric.

Closes #245.

## Why

`server/src/ingest.ts` trusted `body.timestamp` verbatim. That value drives, unbounded:
- retention pruning (`db.ts` `timestamp < cutoff`),
- tool-latency deltas (`db.ts` `n.timestamp - pre.timestamp`),
- every stats/insights window (`db.ts`, `insights.ts`), all of which compare it against server `Date.now()`.

A host running two hours fast posted events that never fell inside the "last 15m" window and were pruned on the wrong schedule, skewing burn/velocity/latency per-source with no signal that anything was off.

## How

- New pure helper `clampIngestTimestamp(ts, now)` in `ingest.ts`: keeps timestamps within `[now - 5m, now + 1m]` exactly, pins anything outside that band (or non-finite) to `now`. The in-band tolerance preserves real send/queue delay and the exact deltas tool-latency depends on.
- Wired in at the **live seam only** (`ingestBody`, shared by `/ingest` and `/v1/traces`). Transcript backfill inserts directly and carries genuinely historical timestamps, so it is deliberately not clamped.
- Unit tests cover in-band pass-through, future skew (the 2h-fast host), absurd past, and non-finite input.

## Validation

- `server`: `bunx tsc --noEmit` clean, `bun test` 516 pass / 0 fail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)