### PR TITLE
fix(provider): give NULL-provider sessions an Unknown bucket (#246)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -343,12 +343,24 @@ export function providerOf(model: string | null | undefined): string | null {
   return null;
 }
 
+/**
+ * The sentinel a client sends to scope to sessions whose provider never
+ * resolved (a session that only ever carried un-modelled events). It is stored
+ * as NULL, so `provider = 'unknown'` would match nothing and the rows would
+ * vanish from every provider-scoped view — the sum of the per-provider numbers
+ * then came out below the unfiltered total. Matches the web's providerOf(null),
+ * which returns this same string, so the "Unknown" filter option round-trips.
+ */
+export const UNKNOWN_PROVIDER = "unknown";
+
 /** SQL fragment + args to scope an events query to one provider (via its
- *  sessions). Empty when no provider is selected. */
+ *  sessions). Empty when no provider is selected. The Unknown bucket selects
+ *  the NULL-provider sessions so per-provider views reconcile with the total. */
 function providerScope(provider?: string | null): { clause: string; args: string[] } {
-  return provider
-    ? { clause: " AND session_id IN (SELECT session_id FROM sessions WHERE provider = ?)", args: [provider] }
-    : { clause: "", args: [] };
+  if (!provider) return { clause: "", args: [] };
+  if (provider === UNKNOWN_PROVIDER)
+    return { clause: " AND session_id IN (SELECT session_id FROM sessions WHERE provider IS NULL)", args: [] };
+  return { clause: " AND session_id IN (SELECT session_id FROM sessions WHERE provider = ?)", args: [provider] };
 }
 
 /**
@@ -889,7 +901,11 @@ export function getSessions(limit = 100, provider?: string): SessionRollup[] {
   const hit = sessionsCache.get(key);
   if (hit && Date.now() - hit.at < SESSIONS_TTL_MS) return hit.data;
   const s = sessionScopeClause();
-  const prov = provider ? { clause: " AND provider = ?", args: [provider] } : { clause: "", args: [] };
+  const prov = !provider
+    ? { clause: "", args: [] as string[] }
+    : provider === UNKNOWN_PROVIDER
+      ? { clause: " AND provider IS NULL", args: [] as string[] }
+      : { clause: " AND provider = ?", args: [provider] };
   const data = db
     .query<SessionRollup, any[]>(
       `SELECT * FROM sessions WHERE 1=1${prov.clause}${s.clause} ORDER BY last_seen DESC LIMIT ?`

--- a/server/test/provider-bucket.test.ts
+++ b/server/test/provider-bucket.test.ts
@@ -1,0 +1,85 @@
+// Provider filtering must never make sessions vanish (#246).
+//
+// `provider` is a single column on `sessions`, and a session whose model never
+// resolved is stored as NULL. Filtering with `provider = ?` matched no such
+// row, so those sessions disappeared from every provider-scoped view and the
+// sum of the per-provider numbers came out below the unfiltered total, with no
+// signal that anything was missing.
+//
+// The fix gives NULL a home: the "unknown" bucket (the same string the web's
+// providerOf(null) returns) scopes to `provider IS NULL`, so per-provider reads
+// reconcile with the total. These drive the real query layer against a throwaway
+// DB. It is scoped to a private project root so the counts are exactly this
+// test's events even though bun shares one DB across the suite, and the session
+// assertions are restricted to this test's ids as a second guard.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-provider-"));
+const PROJ = join(dir, "proj");
+mkdirSync(PROJ, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "provider.db");
+process.env.AGENTGLASS_ROOT = PROJ; // scope every read to this test's own project
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const MINE = ["pb-anthropic", "pb-openai", "pb-null-1", "pb-null-2"];
+const mineOf = (rows: { session_id: string }[]) =>
+  rows.map((s) => s.session_id).filter((id) => MINE.includes(id)).sort();
+
+const event = (session: string, model: string | null) => ({
+  source_app: "app",
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: model,
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 20, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "did a thing",
+  timestamp: Date.now(),
+  payload: { project_path: PROJ },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  db.insertEvent(event("pb-anthropic", "claude-opus-4-8") as any); // → Anthropic
+  db.insertEvent(event("pb-openai", "gpt-4o") as any); // → OpenAI
+  db.insertEvent(event("pb-null-1", null) as any); // → provider NULL (unknown)
+  db.insertEvent(event("pb-null-2", null) as any); // → provider NULL (unknown)
+});
+
+describe("provider filtering keeps NULL-provider sessions reachable", () => {
+  test("getSessions('unknown') returns exactly the NULL-provider sessions", () => {
+    expect(mineOf(db.getSessions(100, "unknown"))).toEqual(["pb-null-1", "pb-null-2"]);
+  });
+
+  test("a real provider filter still excludes the NULL sessions", () => {
+    expect(mineOf(db.getSessions(100, "Anthropic"))).toEqual(["pb-anthropic"]);
+  });
+
+  test("the per-provider session views sum to the unfiltered total (nothing lost)", () => {
+    const all = mineOf(db.getSessions(100));
+    const anthropic = mineOf(db.getSessions(100, "Anthropic"));
+    const openai = mineOf(db.getSessions(100, "OpenAI"));
+    const unknown = mineOf(db.getSessions(100, "unknown"));
+    expect(all.length).toBe(4);
+    expect(anthropic.length + openai.length + unknown.length).toBe(all.length);
+  });
+
+  test("statsSummary reconciles: per-provider event counts sum to the total", () => {
+    const events = (p?: string) => (db.statsSummary(24 * 3600 * 1000, p) as any).totals.events;
+    // Scoped to this test's project, so these are exactly its four events.
+    expect(events()).toBe(4);
+    expect(events("Anthropic") + events("OpenAI") + events("unknown")).toBe(events());
+    expect(events("unknown")).toBe(2); // the two NULL-provider sessions are no longer lost
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -239,10 +239,15 @@ export default function App() {
     providerRef.current = map;
     return map;
   }, [agentsAll]);
-  const providers = useMemo(
-    () => [...new Set([...sessionProvider.values()].filter((p) => p !== "unknown"))].sort(),
-    [sessionProvider]
-  );
+  // "unknown" (sessions whose model never resolved) is kept as a real bucket so
+  // it can be filtered to and the per-provider views reconcile with the total,
+  // but sorted to the end so it never leads the list. Header renders it as
+  // "Unknown".
+  const providers = useMemo(() => {
+    const seen = new Set(sessionProvider.values());
+    const known = [...seen].filter((p) => p !== "unknown").sort();
+    return seen.has("unknown") ? [...known, "unknown"] : known;
+  }, [sessionProvider]);
   // The Anthropic plan meters only make sense when Anthropic is what you're
   // looking at (no filter + Anthropic present, or explicitly filtered to it).
   const showUsage = (!filter.provider && providers.includes("Anthropic")) || filter.provider === "Anthropic";

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -12,6 +12,11 @@ import { Select } from "./Select.tsx";
 import { subscribe as subscribeChats, attentionCount } from "../lib/chatStore.ts";
 import { WorkspaceIcon } from "./workspace/icons.tsx";
 
+// Sessions whose model never resolved carry the "unknown" provider value; it
+// stays lowercase everywhere it is compared (server sentinel, providerOf), but
+// reads as a proper label in the dropdown.
+const providerLabel = (p: string) => (p === "unknown" ? "Unknown" : p);
+
 // The long windows matter once history isn't pruned: the transcript scan can
 // backfill months of sessions, and a 7d ceiling would hide most of the fleet.
 const WINDOWS = [
@@ -202,10 +207,10 @@ export function Header({
           it's shown but disabled (just so you can see it); a mixed fleet
           (Anthropic + OpenAI + …) turns it into a real filter. */}
       {providers.length === 1 && (
-        <Select value={providers[0]} style={selStyle} options={[{ value: providers[0], label: providers[0] }]} onChange={() => {}} disabled title={`Only provider seen: ${providers[0]}`} />
+        <Select value={providers[0]} style={selStyle} options={[{ value: providers[0], label: providerLabel(providers[0]) }]} onChange={() => {}} disabled title={`Only provider seen: ${providerLabel(providers[0])}`} />
       )}
       {providers.length > 1 && (
-        <Select value={filter.provider} style={selStyle} options={[{ value: "", label: "All providers" }, ...providers.map((p) => ({ value: p, label: p }))]} onChange={(v) => onFilter({ ...filter, provider: v })} />
+        <Select value={filter.provider} style={selStyle} options={[{ value: "", label: "All providers" }, ...providers.map((p) => ({ value: p, label: providerLabel(p) }))]} onChange={(v) => onFilter({ ...filter, provider: v })} />
       )}
       {hasFilter && <button onClick={onClear} className="text-[11px] px-2 py-1 rounded-lg shrink-0 whitespace-nowrap" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>Clear ✕</button>}
       </div>{/* middle scroll zone */}


### PR DESCRIPTION
## What does this PR do?

Provider filtering quietly lost data: a session whose model never resolved is stored with `provider = NULL`, and the filter used `provider = ?`, so those sessions matched no provider and disappeared from every provider-scoped view. The sum of the per-provider numbers came out below the unfiltered total, with no signal.

This gives NULL a home. The `"unknown"` sentinel (the exact string the web's `providerOf(null)` already returns) now scopes to `provider IS NULL` in `providerScope()` and `getSessions()`, and the web keeps `"unknown"` as a real, selectable bucket (shown as "Unknown") instead of dropping it from the filter options. Per-provider views reconcile with the total again.

Addresses #246 (the NULL-provider drop half; see scope note). Multi-provider latching is scoped out below.

## How was it tested?

- New `server/test/provider-bucket.test.ts`: inserts Anthropic, OpenAI, and two NULL-model sessions, then asserts the buckets partition the sessions and that per-provider event counts (`getSessions` and `statsSummary`) sum back to the unfiltered total. Scoped to a private project root so counts are exact under bun's shared-DB test process.
- `server`: `bunx tsc --noEmit` clean, `bun test` 520 pass / 0 fail.
- `web`: `bunx tsc --noEmit` clean, `bun test` 220 pass / 0 fail, `vite build` clean.

## Scope note / follow-up

This fixes the vanishing NULL sessions (the "totals don't add up" symptom). The other half of #246 — a session that touched two providers is latched to the first non-null one (`provider = COALESCE(...)`) — needs per-event provider attribution, which changes the single-provider session rollup model and is a larger, riskier change. I've left #246 open for that half and will file a focused follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
