### PR TITLE
fix(cost): price a cumulative delta per its own model, not the latest (#247)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -508,10 +508,11 @@ interface SessionTokenRow {
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  cost_usd: number;
   model_name: string | null;
 }
 const getSessionTokens = db.query<SessionTokenRow, [string]>(
-  `SELECT input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, model_name
+  `SELECT input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_usd, model_name
    FROM sessions WHERE session_id = ?`
 );
 
@@ -587,10 +588,20 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
     dCw = Math.max(0, dCw - prior.cache_creation_tokens);
     dCr = Math.max(0, dCr - prior.cache_read_tokens);
   }
-  const eventCost = costUsd(
-    { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
-    model
-  );
+  // The token delta above still feeds the token counters, but its COST is priced
+  // from the transcript when we have one. cost_cumulative is the whole
+  // transcript priced per message at its own model, so charging its difference
+  // against the session's recorded cost bills a mid-run model switch at the
+  // right rates — the plain delta would put the whole thing on the current
+  // event's model. The per-turn (payload usage) path is already one model, so it
+  // keeps pricing the delta directly.
+  const eventCost =
+    n.usage_is_cumulative && n.cost_cumulative != null
+      ? Math.max(0, n.cost_cumulative - (prior?.cost_usd ?? 0))
+      : costUsd(
+          { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
+          model
+        );
 
   // --- latency pairing ----------------------------------------------------
   let duration_ms: number | null = null;
@@ -625,7 +636,7 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
 
   const event = parseEventRow(rowToEvent.get(id));
   try { ftsInsert.run({ $id: id, $text: ftsText({ ...n, payload: n.payload }) }); } catch { /* fts best-effort */ }
-  const session = upsertSession(n, dIn, dOut, dCw, dCr);
+  const session = upsertSession(n, dIn, dOut, dCw, dCr, eventCost);
   // A Pre opens a call and a Post closes one, so the open-tool memo the fleet
   // draws from just went stale. Drop it here, the single write chokepoint, so
   // the next read — the push that fires right after this returns — is fresh,
@@ -669,12 +680,12 @@ function upsertSession(
   dIn: number,
   dOut: number,
   dCw: number,
-  dCr: number
+  dCr: number,
+  cost: number
 ): SessionRollup {
-  const cost = costUsd(
-    { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
-    n.model_name
-  );
+  // cost is the event's cost computed once in insertEvent (transcript-priced for
+  // the cumulative path); the session total must add exactly that, not a second,
+  // differently-computed number, or the rollup drifts from the event rows.
   const row = upsertStmt.get({
     $sid: n.session_id,
     $src: n.source_app,

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -1,6 +1,6 @@
 // Normalize a raw hook POST body into structured, storable fields.
 import type { IngestBody } from "../../shared/types.ts";
-import type { TokenUsage } from "./pricing.ts";
+import { costUsd, type TokenUsage } from "./pricing.ts";
 
 export interface NormalizedEvent {
   source_app: string;
@@ -21,6 +21,13 @@ export interface NormalizedEvent {
    * usage into a per-event delta so timeline sums stay correct.
    */
   usage_is_cumulative: boolean;
+  /**
+   * When `usage_is_cumulative`, the cost of the whole transcript priced per
+   * message at its own model. The DB charges the difference of this against what
+   * the session already recorded, so a mid-session model switch is billed at the
+   * right rates rather than the whole delta at the current model. Null otherwise.
+   */
+  cost_cumulative: number | null;
   summary: string | null;
   timestamp: number;
   payload: Record<string, unknown>;
@@ -149,6 +156,33 @@ export function sumTranscriptTokens(chat: unknown[] | undefined): TokenUsage {
   return acc;
 }
 
+/**
+ * Cost of a whole cumulative transcript, priced per message at that message's
+ * OWN model.
+ *
+ * sumTranscriptTokens() collapses every turn into one token total, and the DB
+ * used to price the delta of that total at a single model — the current event's.
+ * A session that switched models mid-run (an Opus session that hands a turn to a
+ * Haiku subagent, or any change) then had the whole delta billed at the latest
+ * model's rate, so session and total cost were wrong. Each transcript line
+ * carries its own `message.model`, so the honest total is the per-model sum;
+ * pricing the difference of these totals across events attributes each turn's
+ * tokens at the rate that actually produced them. A line with usage but no model
+ * falls back to the event's own model.
+ */
+export function sumTranscriptCost(chat: unknown[] | undefined, fallbackModel: string | null): number {
+  if (!Array.isArray(chat)) return 0;
+  let cost = 0;
+  for (const line of chat) {
+    if (!line || typeof line !== "object") continue;
+    const o = line as Record<string, unknown>;
+    const msg = (o.message ?? o) as Record<string, unknown>;
+    const usage = (msg?.usage ?? o.usage) as Record<string, unknown> | undefined;
+    if (usage) cost += costUsd(usageFrom(usage), str(msg?.model) ?? fallbackModel);
+  }
+  return cost;
+}
+
 const MAX_FIELD = 64 * 1024;
 // Deep enough for the nested shapes hooks actually send (tool_input.content,
 // tool_response.stdout, a chat turn's content blocks) without letting a
@@ -271,6 +305,9 @@ export function normalize(body: IngestBody): NormalizedEvent {
     error_text,
     usage,
     usage_is_cumulative: !hasPayloadUsage,
+    // Only the cumulative (transcript-summed) path can span models; the per-turn
+    // payload path is already one turn at one model, so it prices as before.
+    cost_cumulative: hasPayloadUsage ? null : sumTranscriptCost(chat ?? undefined, model_name),
     summary: capField(str(body.summary)),
     timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
     payload,

--- a/server/test/cumulative-cost.test.ts
+++ b/server/test/cumulative-cost.test.ts
@@ -1,0 +1,91 @@
+// Cumulative token cost must follow the model that produced each turn (#247).
+//
+// A cumulative (transcript-summed) event used to have its whole since-last-event
+// token delta priced at ONE model — the current event's. A session that switched
+// models mid-run (an Opus session that hands a turn to a Haiku subagent, and then
+// the parent's next event carries the Haiku turn's tokens) billed that delta at
+// the parent's rate. sumTranscriptCost prices each transcript message at its own
+// message.model, and the DB charges the difference of those totals, so the switch
+// is billed correctly.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sumTranscriptCost, normalize } from "../src/ingest.ts";
+import { costUsd } from "../src/pricing.ts";
+
+const OPUS = "claude-opus-4-8";
+const HAIKU = "claude-haiku-4-5";
+const opusUsage = { input_tokens: 1000, output_tokens: 200 };
+const haikuUsage = { input_tokens: 5000, output_tokens: 400 };
+const msg = (model: string, usage: Record<string, number>) => ({ message: { model, usage } });
+
+describe("sumTranscriptCost prices each turn at its own model", () => {
+  test("a two-model transcript sums the per-model costs", () => {
+    const chat = [msg(OPUS, opusUsage), msg(HAIKU, haikuUsage)];
+    const perModel = costUsd(opusUsage, OPUS) + costUsd(haikuUsage, HAIKU);
+    expect(sumTranscriptCost(chat, null)).toBeCloseTo(perModel, 10);
+  });
+
+  test("that differs from pricing the summed tokens at a single model (the old bug)", () => {
+    const chat = [msg(OPUS, opusUsage), msg(HAIKU, haikuUsage)];
+    const wrong = costUsd({ input_tokens: 6000, output_tokens: 600 }, OPUS); // whole delta at Opus
+    expect(sumTranscriptCost(chat, null)).not.toBeCloseTo(wrong, 6);
+  });
+
+  test("a line with usage but no model falls back to the event's model", () => {
+    const chat = [{ message: { usage: opusUsage } }];
+    expect(sumTranscriptCost(chat, HAIKU)).toBeCloseTo(costUsd(opusUsage, HAIKU), 10);
+  });
+
+  test("normalize fills cost_cumulative from the transcript, null when payload usage is present", () => {
+    const chat = [msg(OPUS, opusUsage), msg(HAIKU, haikuUsage)];
+    const cumulative = normalize({ session_id: "s", hook_event_type: "Stop", model_name: OPUS, chat } as any);
+    expect(cumulative.usage_is_cumulative).toBe(true);
+    expect(cumulative.cost_cumulative).toBeCloseTo(costUsd(opusUsage, OPUS) + costUsd(haikuUsage, HAIKU), 10);
+
+    const perTurn = normalize({ session_id: "s", hook_event_type: "Stop", model_name: OPUS, payload: { usage: opusUsage } } as any);
+    expect(perTurn.usage_is_cumulative).toBe(false);
+    expect(perTurn.cost_cumulative).toBeNull();
+  });
+});
+
+// --- DB path: a model switch across two cumulative events -------------------
+const dir = mkdtempSync(join(tmpdir(), "agx-cumcost-"));
+const PROJ = join(dir, "proj");
+mkdirSync(PROJ, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "cumcost.db");
+process.env.AGENTGLASS_ROOT = PROJ;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+const ing = await import("../src/ingest.ts");
+
+const body = (chat: unknown[]) => ({
+  source_app: "app",
+  session_id: "cc-session",
+  hook_event_type: "Stop",
+  model_name: OPUS, // the PARENT model on both events, even when a Haiku turn was added
+  chat,
+  payload: { project_path: PROJ },
+  timestamp: Date.now(),
+});
+
+describe("insertEvent charges a mid-run model switch at the right rates", () => {
+  beforeAll(async () => {
+    db = await import("../src/db.ts");
+    // Event 1: only the Opus turn so far.
+    db.insertEvent(ing.normalize(body([msg(OPUS, opusUsage)]) as any));
+    // Event 2: the transcript now also carries a Haiku subagent turn, but the
+    // event itself is still tagged with the parent Opus model.
+    db.insertEvent(ing.normalize(body([msg(OPUS, opusUsage), msg(HAIKU, haikuUsage)]) as any));
+  });
+
+  test("session cost is the per-model total, not the whole delta at the parent model", () => {
+    const s = db.getSessions(100).find((r) => r.session_id === "cc-session")!;
+    const right = costUsd(opusUsage, OPUS) + costUsd(haikuUsage, HAIKU);
+    const wrong = costUsd(opusUsage, OPUS) + costUsd(haikuUsage, OPUS); // Haiku tokens at Opus rate
+    expect(s.cost_usd).toBeCloseTo(right, 8);
+    expect(s.cost_usd).not.toBeCloseTo(wrong, 6);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

A cumulative (transcript-summed) event had its whole since-last-event token delta priced at a single model, the current event's. When a session switched models mid-run (an Opus session that hands a turn to a Haiku subagent, whose tokens surface on the parent's next event), that delta was billed at the parent's rate, so per-session cost, total cost, and the spend-velocity insight that reads them were wrong.

Each transcript line carries its own `message.model`. A new `sumTranscriptCost()` prices the whole transcript per message at its own model, and `insertEvent` charges the difference of that against what the session already recorded. A mid-run switch is now billed at the right rates. The per-turn (payload usage) path is already one model and prices the delta as before.

Closes #247.

While wiring this in, I found a latent split: the events row used one cost while `upsertSession` recomputed a second, differently-derived cost for the sessions rollup. They now share the single `eventCost`, so the session rollup can no longer drift from the event rows. A test caught this.

## How was it tested?

- New `server/test/cumulative-cost.test.ts`:
  - `sumTranscriptCost` sums per-model costs on a two-model transcript and differs from pricing the summed tokens at one model (the old bug), with a model fallback.
  - `normalize` fills `cost_cumulative` from the transcript, null when payload usage is present.
  - DB path: two cumulative events with a Haiku turn arriving on a parent-Opus event, asserting the session cost is the per-model total, not the whole delta at the parent's rate.
- `server`: `bunx tsc --noEmit` clean, `bun test` 525 pass / 0 fail.
- `web`: `bunx tsc --noEmit` clean (no web changes).
- Perf budget: loop p99 3ms (budget 120ms) with the added transcript walk.

## Scope note

Reporting still attributes each event's whole cost to its single `model_name` (one event, one model), so the by-model breakdown of a delta that spanned models remains approximate. The session and total figures are now correct. A true per-model split needs per-model event rows; tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)