### PR TITLE
fix(prs): only notify for PRs you have a stake in, not the whole repo (#244)

### DIFF
--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -289,6 +289,22 @@ export function noteCi(repo: PrRepoId, pr: PrSummary): void {
 export type PrFilter = "mine" | "review" | "all";
 
 /**
+ * Whether probing a filter's PRs should also raise CI notifications.
+ *
+ * The panel warms all three filters to fill the tab counts, so `all` is fetched
+ * passively the moment the panel opens — on a busy repo that is hundreds of PRs
+ * the user never authored and was not asked to review. A notification is meant
+ * to be about YOUR stake in a PR, so only the filters that encode a stake —
+ * authored (`mine`) and review-requested (`review`) — notify. Browsing `all`
+ * still renders check states; it just does not push. A PR that is both yours and
+ * in `all` still notifies exactly once, because the `mine`/`review` probe runs
+ * too and the per-PR latch dedupes across filters.
+ */
+export function ciNotifiesFor(filter: PrFilter): boolean {
+  return filter !== "all";
+}
+
+/**
  * Two field sets, because one of them costs four times the other.
  *
  * Measured on a real repo, 50 open pull requests: 1.5s without
@@ -380,7 +396,7 @@ const CHECK_PROBE_MAX = 50;
 const checkCache = new Map<string, { updatedAt: string; rollup: PrCheckRollup; all: PrCheck[] }>();
 const checkRunning = new Set<string>();
 
-function refreshChecks(repo: PrRepoId, filter: PrFilter, rows: PrSummary[]): void {
+function refreshChecks(repo: PrRepoId, filter: PrFilter, rows: PrSummary[], notify: boolean): void {
   const key = cacheKey(repo, filter);
   if (checkRunning.has(key)) return;
   checkRunning.add(key);
@@ -409,7 +425,10 @@ function refreshChecks(repo: PrRepoId, filter: PrFilter, rows: PrSummary[]): voi
         if (!cur) return;
         const next = cur.prs.map((p) => (p.number === pr.number ? { ...p, checks: rollup, checksLoaded: true } : p));
         listCache.set(key, { ...cur, prs: next, checksPending: i < Math.min(rows.length, CHECK_PROBE_MAX) });
-        noteCi(repo, { ...pr, checks: rollup });
+        // Render the check state for every filter, but only push a notification
+        // for the ones the user has a stake in — never for the passively-warmed
+        // `all` list on a busy repo.
+        if (notify) noteCi(repo, { ...pr, checks: rollup });
       }
       const cur = listCache.get(key);
       if (cur) listCache.set(key, { ...cur, checksPending: false });
@@ -462,7 +481,7 @@ function refreshList(repo: PrRepoId, filter: PrFilter): void {
         return hit && hit.updatedAt === r.updatedAt ? { ...r, checks: hit.rollup, checksLoaded: true } : r;
       });
       listCache.set(key, { at: Date.now(), prs: merged, loading: false, checksPending: merged.some((p) => !p.checksLoaded) });
-      refreshChecks(repo, filter, merged);
+      refreshChecks(repo, filter, merged, ciNotifiesFor(filter));
     } catch (e) {
       listCache.set(key, keep({ loading: false, checksPending: false, error: String(e) }));
     } finally {

--- a/server/test/prs.test.ts
+++ b/server/test/prs.test.ts
@@ -273,3 +273,15 @@ describe("CI notification latch", () => {
     expect(got).toEqual(["pytest \u00b7 vr/health"]);
   });
 });
+
+describe("CI notifications are scoped to your stake (#244)", () => {
+  // The panel warms all three filters for the tab counts, so `all` is fetched
+  // passively \u2014 hundreds of strangers' PRs on a busy repo. Only the filters that
+  // encode a stake may push a notification; `all` renders check states without
+  // notifying. Pinned so nobody flips `all` back on.
+  test("mine and review notify, all does not", () => {
+    expect(prs.ciNotifiesFor("mine")).toBe(true);
+    expect(prs.ciNotifiesFor("review")).toBe(true);
+    expect(prs.ciNotifiesFor("all")).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

On a busy repo (a real work repo has ~500 open PRs), the PR panel produced a burst of CI notifications for pull requests the user never authored and was never asked to review, drowning the ones that matter. The panel warms all three filters (`mine`, `review`, `all`) to fill the tab counts, so the `all` list is fetched passively the moment the panel opens, and `refreshChecks` then called `noteCi` for every probed PR regardless of the user's stake.

This decouples probing from notifying. `refreshChecks` takes a `notify` flag, and the caller sets it from a new pure `ciNotifiesFor(filter)` — true only for `mine` and `review`. The `all` list still renders check states (green/red/pending) when you view it; it just no longer pushes notifications.

Closes #244.

## How was it tested?

- New test pins `ciNotifiesFor`: `mine`/`review` notify, `all` does not (so nobody flips `all` back on).
- The existing `noteCi` latch tests still cover once-per-PR-per-verdict dedup, which is what makes a PR that is both yours and in `all` notify exactly once.
- `server`: `bunx tsc --noEmit` clean, `bun test` 526 pass / 0 fail.

## Notes

The per-PR latch already dedupes across filters, so a PR that is both yours and in `all` notifies exactly once, from the `mine`/`review` probe (those filters are warmed too). No `PrPanel` change is needed: warming `all` for the tab counts is fine now that it renders without notifying.

🤖 Generated with [Claude Code](https://claude.com/claude-code)