### PR TITLE
test(themesync): guarantee a theme switch never edits the user's dotfiles (#238)

### DIFF
--- a/server/test/themesync-nondestructive.test.ts
+++ b/server/test/themesync-nondestructive.test.ts
@@ -1,0 +1,98 @@
+// A theme switch must never touch the user's own dotfiles (#238).
+//
+// A user reported (r/ClaudeAI, v0.5.0) that changing the dashboard theme
+// overwrote their personal ~/.tmux.conf. Investigation found no code path,
+// current or in v0.5.0, that writes the user's tmux or nvim config: syncTheme
+// only ever writes agentglass's own ~/.config/agentglass/ files, the terminal
+// opts in with a single `source` line the user pastes themselves, and
+// snippetStatus is read-only. This test makes that guarantee permanent — a
+// future change that pointed a write at a user dotfile would fail here.
+//
+// The reload spawns (tmux source-file / nvim :luafile) never write files, so the
+// byte-for-byte assertions hold regardless; TMUX_TMPDIR and an empty
+// XDG_RUNTIME_DIR keep them from perturbing a real tmux/nvim while tests run.
+import { describe, expect, test, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ENV0 = { ...process.env };
+const home = mkdtempSync(join(tmpdir(), "agx-238-home-"));
+const config = join(home, ".config");
+const runtime = mkdtempSync(join(tmpdir(), "agx-238-run-"));
+const tmuxTmp = mkdtempSync(join(tmpdir(), "agx-238-tmux-"));
+mkdirSync(config, { recursive: true });
+
+process.env.HOME = home;
+process.env.XDG_CONFIG_HOME = config; // THEME_DIR resolves under here
+process.env.XDG_RUNTIME_DIR = runtime; // empty → liveNvimSockets() finds nothing
+process.env.TMUX_TMPDIR = tmuxTmp; // empty → tmux source-file finds no server
+delete process.env.TMUX; // do not fall through to a real session's socket
+
+// The user's own configs, with content nothing here should ever change.
+const userTmux = join(home, ".tmux.conf");
+const userTmuxBody = "set -g mouse on\nset -g prefix C-a\n# my personal config\n";
+writeFileSync(userTmux, userTmuxBody);
+const nvimDir = join(config, "nvim");
+mkdirSync(nvimDir, { recursive: true });
+const userNvim = join(nvimDir, "init.lua");
+const userNvimBody = "vim.opt.number = true\n-- my personal config\n";
+writeFileSync(userNvim, userNvimBody);
+
+let ts: typeof import("../src/themesync.ts");
+
+const palette = (bg: string, primary: string) => ({
+  "--bg": bg, "--bg2": "#161b22", "--bg3": "#21262d",
+  "--text": "#f0f6fc", "--text2": "#c9d1d9", "--text3": "#8b949e",
+  "--border": "#30363d", "--primary": primary, "--primary-hover": "#c4b5fd",
+  "--success": "#34d399", "--warning": "#fbbf24", "--error": "#f87171", "--info": "#60a5fa",
+});
+
+beforeAll(async () => {
+  ts = await import("../src/themesync.ts");
+});
+
+afterAll(() => {
+  for (const k of ["HOME", "XDG_CONFIG_HOME", "XDG_RUNTIME_DIR", "TMUX_TMPDIR", "TMUX"]) {
+    if (ENV0[k] === undefined) delete process.env[k]; else process.env[k] = ENV0[k]!;
+  }
+});
+
+describe("syncTheme never edits the user's own config", () => {
+  test("switching themes many times leaves ~/.tmux.conf and nvim config byte-for-byte unchanged", async () => {
+    for (const [bg, primary, name] of [
+      ["#0d1117", "#a78bfa", "Forest"],
+      ["#1a1333", "#c4b5fd", "Ember"],
+      ["#ffffff", "#7c3aed", "Light"],
+    ] as const) {
+      const r = await ts.syncTheme(palette(bg, primary), name);
+      expect(r.ok).toBe(true);
+      // Every path it reports writing is inside agentglass's own dir.
+      for (const p of r.wrote) expect(p.startsWith(ts.THEME_DIR)).toBe(true);
+    }
+    expect(readFileSync(userTmux, "utf8")).toBe(userTmuxBody);
+    expect(readFileSync(userNvim, "utf8")).toBe(userNvimBody);
+  });
+
+  test("it does write its own theme files, under ~/.config/agentglass only", () => {
+    const written = readdirSync(ts.THEME_DIR).sort();
+    expect(written).toContain("theme.tmux.conf");
+    expect(written).toContain("theme.lua");
+    expect(ts.TMUX_THEME.startsWith(ts.THEME_DIR)).toBe(true);
+    expect(ts.NVIM_THEME.startsWith(ts.THEME_DIR)).toBe(true);
+  });
+
+  test("snippetStatus reports opt-in state read-only, without editing anything", () => {
+    // os.homedir() ignores $HOME on POSIX, so tmuxConfPath() resolves against the
+    // real home — which is exactly why the guarantee matters: snippetStatus only
+    // ever reads. It reports booleans and paths and touches nothing.
+    const tmuxBefore = readFileSync(userTmux, "utf8");
+    const nvimBefore = readFileSync(userNvim, "utf8");
+    const s = ts.snippetStatus();
+    expect(typeof s.tmux).toBe("boolean");
+    expect(typeof s.nvim).toBe("boolean");
+    expect(typeof s.tmuxPath).toBe("string");
+    expect(readFileSync(userTmux, "utf8")).toBe(tmuxBefore);
+    expect(readFileSync(userNvim, "utf8")).toBe(nvimBefore);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

A user reported on r/ClaudeAI (v0.5.0) that changing the dashboard theme overwrote their personal `~/.tmux.conf`. I investigated where a theme change could reach the user's tmux/nvim config on disk, and found **no such code path** — in current `main` or in the exact `v0.5.0` tag they tried:

- `syncTheme()` writes only agentglass's own files, both under `~/.config/agentglass/` (`THEME_DIR`): `theme.tmux.conf` and `theme.lua`.
- The terminal opts in with a single `source` line the user pastes themselves; there is no endpoint that installs it into their config for them.
- `snippetStatus()` reads the user's config (read-only) to report opt-in state; the nvim reload sends `:luafile` which only sets highlight groups in memory. Nothing writes a user dotfile.

Rather than change behaviour that is already non-destructive, this pins the guarantee with a regression test so it can never silently regress. It lays down a real `~/.tmux.conf` and nvim config, switches themes several times, and asserts both are byte-for-byte unchanged and that every path `syncTheme` reports writing is inside `THEME_DIR`.

Addresses #238 (see the issue for the full investigation writeup).

## How was it tested?

- New `server/test/themesync-nondestructive.test.ts`: three cases covering byte-for-byte-unchanged user config, writes confined to `THEME_DIR`, and read-only `snippetStatus`. Reload spawns are isolated with `TMUX_TMPDIR` and an empty `XDG_RUNTIME_DIR`.
- `server`: `bunx tsc --noEmit` clean, `bun test` 529 pass / 0 fail.

## Note

If the reporter can share a reproduction, reopen #238 with details and this test suite is where to encode it. The guarantee it enforces is the issue's acceptance criterion: switching themes any number of times leaves the user's config byte-for-byte unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
