### PR TITLE
fix(db): fold timestamp into the scope indexes to unfreeze idle /stats (#220)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -147,13 +147,25 @@ for (const [col, path] of [["project_path", "$.project_path"], ["cwd_path", "$.c
     db.exec(`ALTER TABLE events ADD COLUMN ${col} TEXT GENERATED ALWAYS AS (json_extract(payload, '${path}')) VIRTUAL`);
   } catch { /* already present */ }
 }
-db.exec("CREATE INDEX IF NOT EXISTS idx_events_project ON events(project_path)");
-// A scoped query now tests `cwd_path` once per checkout of the project, and a
-// virtual column is recomputed by json_extract for every row it touches. Without
-// this index, the user this change is for — a dozen worktrees open — is exactly
-// the one who pays a full table scan with a JSON parse per row on /events,
-// /stats and /changes. It also bounds the backfill below.
-db.exec("CREATE INDEX IF NOT EXISTS idx_events_cwd ON events(cwd_path)");
+// Timestamp folded in on purpose. Scope never filters project_path/cwd_path
+// alone — every /stats, /events and /changes query pairs it with a `timestamp >=
+// since` window. A bare project_path index made the MULTI-INDEX OR fetch *every*
+// row that project ever produced and then filter the window row by row: on a
+// project with months of history that is the ~400ms synchronous /stats stall the
+// idle PTY rides (#220). With timestamp in the index the same OR restricts to the
+// window inside the index — measured 60ms -> 0.1ms on a 200k-row DB. The
+// composite still serves the plain `project_path = ?` lookups the single-column
+// index did (leftmost prefix), so it replaces it outright; the old single-column
+// indexes are dropped so an existing DB rebuilds to the better shape.
+db.exec("DROP INDEX IF EXISTS idx_events_project");
+db.exec("CREATE INDEX IF NOT EXISTS idx_events_project_ts ON events(project_path, timestamp)");
+// A scoped query tests `cwd_path` once per checkout of the project, and a virtual
+// column is recomputed by json_extract for every row it touches. Without this
+// index, the user this change is for — a dozen worktrees open — is exactly the
+// one who pays a full table scan with a JSON parse per row on /events, /stats and
+// /changes; and, as above, timestamp folded in keeps the scan inside the window.
+db.exec("DROP INDEX IF EXISTS idx_events_cwd");
+db.exec("CREATE INDEX IF NOT EXISTS idx_events_cwd_ts ON events(cwd_path, timestamp)");
 // `model_name` had none, so the filter dropdown's third query — SELECT DISTINCT
 // over it — was the one full scan with a temp B-tree in that endpoint. Cheap
 // index, and the covering scan it enables is what the other two already had.

--- a/server/test/stats-scope-index.test.ts
+++ b/server/test/stats-scope-index.test.ts
@@ -1,0 +1,84 @@
+// A scoped /stats query must restrict to its time window inside the index, not
+// scan a project's whole history (#220).
+//
+// Scope filters `(project_path IN (...) OR cwd_path IN (...))` and always pairs
+// it with `timestamp >= since`. With a bare project_path index the planner did a
+// MULTI-INDEX OR that fetched every row that project ever produced and then
+// filtered the window row by row — on a project with months of history that is
+// the ~400ms synchronous /stats stall the idle PTY rides. Folding timestamp into
+// the index lets the same OR bound the window inside the index. The shape is the
+// fix, so this pins the plan: the query plan must reach the rows through the
+// composite indexes with a timestamp bound.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-statsidx-"));
+const SCOPED = join(dir, "scoped");
+const OTHER = join(dir, "other");
+mkdirSync(SCOPED, { recursive: true });
+mkdirSync(OTHER, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "statsidx.db");
+process.env.AGENTGLASS_ROOT = SCOPED;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const event = (project: string, session: string, tsBack: number) => ({
+  source_app: project.split("/").pop()!,
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 20, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: Date.now() - tsBack,
+  payload: { project_path: project },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  // Three scoped events clearly inside a 1h window...
+  for (let i = 0; i < 3; i++) db.insertEvent(event(SCOPED, `s-recent-${i}`, i * 60_000) as any);
+  // ...and a long tail of scoped history clearly outside it, spread over weeks,
+  // so a 1h window is a tiny slice — the case the composite index is for.
+  for (let i = 0; i < 200; i++) db.insertEvent(event(SCOPED, `s-old-${i}`, 2 * 3_600_000 + i * 1_800_000) as any);
+  // Another project, recent — excluded by scope, not by the window.
+  for (let i = 0; i < 20; i++) db.insertEvent(event(OTHER, `o-${i}`, i * 60_000) as any);
+});
+
+describe("scoped stats queries stay inside the time window via the index", () => {
+  test("the query plan reaches rows through (project_path, timestamp), bounding the window", () => {
+    const since = Date.now() - 3_600_000; // 1h window over a wide history
+    const { clause, args } = db.scopeClause();
+    expect(clause).toContain("project_path IN"); // scope actually applied
+    const sql = `SELECT COUNT(*) AS n FROM events WHERE timestamp >= ?${clause}`;
+    const plan = db.db
+      .query<{ detail: string }, any[]>("EXPLAIN QUERY PLAN " + sql)
+      .all(since, ...args)
+      .map((r) => r.detail)
+      .join(" | ");
+    // The composite indexes carry the timestamp, so the window is bounded in the
+    // index rather than filtered per row.
+    expect(plan).toContain("idx_events_project_ts");
+    expect(plan).toContain("idx_events_cwd_ts");
+    expect(plan).toContain("timestamp>"); // the window is part of the index seek
+    // And it is not a bare full scan of the table.
+    expect(plan).not.toContain("SCAN events\n");
+  });
+
+  test("the scoped result is still correct (index change never alters the answer)", () => {
+    // Only the three recent scoped events land in a 1h window; the 200-event tail
+    // is older and the other project is out of scope.
+    const s = db.statsSummary(3_600_000) as any;
+    expect(s.totals.events).toBe(3);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

With the app idle, the PTY hitched ~250-400ms every ~4s, dominated by `GET /stats` (confirmed via `/api/loopwatch`). The dashboard polls `/stats` every 4s; its 1s memo always misses on a single 4s poll, so every poll recomputes six aggregations over `events` with the scope filter `(project_path IN (...) OR cwd_path IN (...))` and a `timestamp >= since` window.

The scope indexes were `project_path` and `cwd_path` alone. Scope is never filtered without a timestamp window, so the planner's MULTI-INDEX OR fetched every row those columns ever matched (a whole project's history) and then filtered the window row by row. On a project with months of data that is the ~400ms synchronous stall the single-threaded server, and the PTY it serves, rides.

This folds timestamp into both indexes: `(project_path, timestamp)` and `(cwd_path, timestamp)`. The same MULTI-INDEX OR now bounds the window inside the index. It is index-only, so results are unchanged; it's the issue's option 3 (profile with `EXPLAIN QUERY PLAN`, find the index).

Closes #220.

## How was it tested?

- Benchmarked on a 200k-row synthetic DB with a wide history and a 1h window: the scoped totals query went from **~60ms to ~0.1ms**, and the plan changed from `USING INDEX idx_events_project (project_path=?)` to `USING INDEX idx_events_project_ts (project_path=? AND timestamp>?)`.
- New `server/test/stats-scope-index.test.ts` pins the plan (the scoped query reaches rows through `idx_events_project_ts`/`idx_events_cwd_ts` with a `timestamp>` bound, not a per-row scan) and re-checks the scoped totals are correct.
- `server`: `bunx tsc --noEmit` clean, `bun test` 531 pass / 0 fail.
- Perf budget: loop p99 2ms (budget 120ms).

## Notes

The composite indexes still serve the plain `project_path = ?` lookups the single-column indexes did (leftmost prefix), so they replace them; the old `idx_events_project`/`idx_events_cwd` are dropped so an existing DB rebuilds to the better shape on next start. This is the surgical fix; the materialized-rollup option (a precomputed per-window/scope row) remains available later if `/stats` ever needs to be free rather than merely fast.

🤖 Generated with [Claude Code](https://claude.com/claude-code)