### PR TITLE
docs(contributing): record the silent-catch and packaged-app pitfalls (#85)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,6 +42,25 @@ python3 hooks/seed_demo.py   # populate with demo data
   rather than leaving it buried in `payload` JSON.
 - Pricing changes: edit `server/src/pricing.ts` defaults *and* mention the
   source of the numbers in the PR.
+- **Don't swallow a rejection a feature depends on.** A bare
+  `.catch(() => {})` / `catch {}` is fine for genuinely best-effort work that
+  degrades *visibly* (a failed `localStorage` write in private mode, a slow
+  poll that just retries next tick, a `URL.revokeObjectURL`). It is a bug when
+  the thing that failed is a load the feature needs: the failure becomes
+  invisible, the feature is simply absent, and the only symptom is "it doesn't
+  work and says nothing." When a catch guards a dependency, surface it — set an
+  error state the UI can show, or at least log with enough context to name what
+  failed. If a silent catch is deliberately best-effort, say so in a one-line
+  comment, so the next reader (and reviewer) can tell the two apart. This has
+  already cost multiple wrong diagnoses; see #85.
+- **The packaged desktop app is a different environment from `bun run dev`.**
+  Under Electron the UI runs with its own CSP, GPU compositing, and resource
+  paths — so a dependency that fails to load (a WASM/asset fetch the CSP blocks,
+  an engine that needs a capability the packaged app lacks) fails *only in the
+  built app* and never in dev. If you touch a load path a feature depends on,
+  don't trust `bun run dev` alone: build it (`make desktop`) and check there
+  too. A monochrome diff viewer that took three debugging rounds to trace to
+  Shiki's highlighter silently failing to initialise is exactly this shape.
 
 ## Reporting bugs / ideas
 


### PR DESCRIPTION
## What does this PR do?

#85 asks to sweep for the `.catch(() => {})`-swallows-a-dependency shape and to record it in CONTRIBUTING so the next person doesn't lose an evening to "it doesn't work and says nothing."

I did the sweep. The one historically-dangerous case — the diff viewer rendering monochrome because Shiki's highlighter silently failed to initialise — is already fixed and now surfaces its error (`web/src/lib/diffHighlight.ts` sets an error state). The remaining silent catches are legitimately best-effort: polling loads that retry on the next tick, empty-list fallbacks, offline meters that keep their last reading, and most already carry a one-line comment saying so.

So the durable fix is documentation, which is what the issue itself calls for. This adds two ground rules to CONTRIBUTING:
- **The silent-catch distinction** — surface a rejection a feature depends on; a deliberately best-effort catch gets a one-line comment so the two are tellable apart in review.
- **The packaged-app-environment trap** — a dependency the Electron CSP/GPU path blocks fails only in the built app and never in `bun run dev`, so dependency load paths should be checked with `make desktop`, not just dev.

Closes #85.

## How was it tested?

Docs only, no code change. `CONTRIBUTING.md` renders correctly; CI (typecheck/tests/build) is unaffected and still runs.

## Note

I deliberately did not convert the remaining best-effort catches to surface errors — doing so would add noise (console spam on every offline poll) and regress intentional degradation. The value here is the reviewable rule, so new dependency loads don't reintroduce the silent shape. If a specific remaining catch is found to hide a real dependency failure, that's a targeted follow-up with its own error-surfacing UX.

🤖 Generated with [Claude Code](https://claude.com/claude-code)