### PR TITLE
fix: qualify or gate the claims that are only true on Linux (#192)

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,8 @@ are:
   shared machine or a network bind safe, and it stops *other local processes*
   from opening the shell. Binding a non-loopback address **without** a token
   refuses to run unauthenticated: it mints one, prints it, and saves it
-  `0600` under your config dir.
+  `0600` under your config dir on POSIX (Linux/macOS). Windows has no POSIX
+  mode bits, so there the file falls back to your account's default ACL.
 - **Websites you visit can't touch it.** Every request is origin-checked, the
   shell and the live stream require a verified local origin, and a Host-header
   guard blocks DNS-rebinding tricks (browsers can't forge `Host`). Running it
@@ -453,8 +454,9 @@ are:
 - **⚠️ Browser-driven autonomy is opt-in.** The Chat panel's `bypassPermissions`
   mode (`claude --dangerously-skip-permissions`) is honored only when
   `AGENTGLASS_CHAT_BYPASS=1`; otherwise it's downgraded to a prompting default.
-- **Your data stays local.** Events live in a local SQLite file (owner-only
-  permissions). The only outbound call is the optional Anthropic plan-usage
+- **Your data stays local.** Events live in a local SQLite file, written
+  owner-only (`0700` dir, `0600` file) on POSIX; on Windows, which has no POSIX
+  mode bits, it falls back to your account's default ACL. The only outbound call is the optional Anthropic plan-usage
   meter (`api.anthropic.com`, using your own credentials) and anything *you*
   configure (webhook alerts).
 
@@ -558,7 +560,7 @@ inference, prompt) to an event the same way.
 |---|---|---|
 | `AGENTGLASS_PORT` | `4000` | Server HTTP/WS port. |
 | `AGENTGLASS_BIND` | `127.0.0.1` | Address the server binds to. Loopback-only by default. Exposing (`0.0.0.0`) requires `AGENTGLASS_TOKEN` **and** `AGENTGLASS_TRUST_LAN=1`, and only on a trusted network. See [Security model](#security-model--read-this-before-installing). |
-| `AGENTGLASS_TOKEN` | — | Shared secret required on every route but the telemetry intake sinks. Pass as `Authorization: Bearer <t>` or `?token=<t>`. Locks the server to you on a shared machine and makes a network bind safe. Exposing without one auto-mints + prints a token (saved `0600` in the config dir). |
+| `AGENTGLASS_TOKEN` | — | Shared secret required on every route but the telemetry intake sinks. Pass as `Authorization: Bearer <t>` or `?token=<t>`. Locks the server to you on a shared machine and makes a network bind safe. Exposing without one auto-mints + prints a token (saved `0600` in the config dir on POSIX; the default ACL on Windows). |
 | `AGENTGLASS_TRUST_LAN` | — | `1` → also trust RFC1918 (private-LAN) addresses as origins/hosts, not just loopback. Required for LAN browsers to reach an exposed instance. Off by default: a shell-granting server trusts only `localhost` unless told otherwise. |
 | `AGENTGLASS_ALLOWED_HOSTS` | — | Comma-separated extra hostnames accepted by the DNS-rebinding guard (requests must arrive under a localhost/private `Host`). Only needed behind a reverse proxy. |
 | `AGENTGLASS_DB` | `agentglass.db` | SQLite file path. |

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -77,7 +77,7 @@ function probe(): NotifyCapability {
     return { supported: false, reason: "no D-Bus session bus (headless, SSH or a container)" };
   }
   if (!Bun.which("dbus-monitor")) {
-    return { supported: false, reason: "dbus-monitor not found — install your distro's dbus package" };
+    return { supported: false, reason: "dbus-monitor not found — install the D-Bus tools for your system" };
   }
   return { supported: true };
 }

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -1306,6 +1306,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         </Fragment>
                       ))}
                     </span>
+                  ) : IS_DEMO || disabled ? (
+                    // The shell isn't running here (demo, Windows, or disabled by
+                    // env), so promising a real shell with working TUIs would be
+                    // the lie the overlay above just corrected. Say nothing.
+                    <span className="t-dim2">{cmds?.reason === "windows" ? "Terminal not available on Windows yet" : "Terminal unavailable"}</span>
                   ) : (
                     <span>Real shell — Ctrl+C, Ctrl+R, Tab-complete, vim/htop all work · sessions survive closing this panel · Shift+Esc closes it</span>
                   )}


### PR DESCRIPTION
## What does this PR do?

Three user-facing statements asserted POSIX/Linux behaviour as a fact on every platform. This makes each honest (the issue's preference order: gate, then qualify):

- **README security model** — the owner-only SQLite permissions and the `0600` auth token are POSIX mode bits, ignored on NTFS. Now stated as POSIX (Linux/macOS), with Windows falling back to the account's default ACL, instead of an unconditional guarantee a security section must not overstate.
- **Terminal footer** — the "Real shell — vim/htop all work" status line rendered even when the terminal was disabled (demo, Windows via `cmds.reason === "windows"`, or `AGENTGLASS_TERMINAL_DISABLED`). The overlay said "not available" while the footer under it promised a working shell. Now gated so it only claims a real shell when one is actually running, and names the Windows case otherwise.
- **Notification capability copy** — "install your distro's dbus package" assumed Linux; now "install the D-Bus tools for your system".

Addresses #192 (items 1, 2, 4).

## How was it tested?

- `web`: `bunx tsc --noEmit` clean, `bun test` 220 pass, `vite build` clean.
- `server`: `bunx tsc --noEmit` clean, `bun test` 531 pass / 0 fail.
- No test pinned the old strings.

## Scope note

Item 3 (`notify-send` is Linux-only) is a feature gap, not a false claim — it is env-gated behind `AGENTGLASS_NOTIFY=1` and logs a warning on failure, so it degrades honestly. Replacing it with Electron's cross-platform `Notification` API (which would also cover macOS and Windows) is a cross-process enhancement that needs per-OS verification; I've left #192 open re-scoped to just that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)