### PR TITLE
feat(terminal): allow terminalDisabled in config.json, not only the env (#190)

### DIFF
--- a/README.md
+++ b/README.md
@@ -589,7 +589,7 @@ For genuinely multi-repo work, scope to the parent folder (`~/code`) rather
 than one repo: every repo beneath it is then in scope. An unscoped (whole-machine)
 instance is unaffected.
 
-| `AGENTGLASS_TERMINAL_DISABLED` | — | `1` → disable the in-browser **Terminal** entirely (no PTY shells are spawned). |
+| `AGENTGLASS_TERMINAL_DISABLED` | — | `1` → disable the in-browser **Terminal** entirely (no PTY shells are spawned). Also settable as `"terminalDisabled": true` in `config.json`, so it is reachable from a desktop-launched app that inherits no env; the env var overrides the file when set. |
 | `AGENTGLASS_FS_BROWSE_DISABLED` | — | `1` → disable directory completion in the project picker (`/fs/complete`). Separate from the terminal switch on purpose: disabling the shell should not leave the directory tree readable. |
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
 | `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's `bypassPermissions` mode (`claude --dangerously-skip-permissions`). Off by default: the mode is downgraded to a prompting default unless you opt in. |

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -27,6 +27,12 @@ interface Config {
    *  environment: a desktop launcher passes no env, so AGENTGLASS_CHAT_BYPASS
    *  alone made the mode unreachable for the surface that wants it most. */
   chatBypass?: boolean;
+  /** Turn the terminal panel off. Stated *here* and not only in the environment
+   *  for the same reason as chatBypass: an app launched from a desktop icon
+   *  inherits no shell env, so AGENTGLASS_TERMINAL_DISABLED alone is unreachable
+   *  for a packaged install or a shell-less deployment — exactly the people who
+   *  want it off. The env var still wins when set. */
+  terminalDisabled?: boolean;
 }
 
 function load(): Config {
@@ -228,6 +234,19 @@ export function setWorkspaceRoot(rootIn: string | null): { ok: boolean; workspac
 export function chatBypassAllowed(): boolean {
   if (process.env.AGENTGLASS_CHAT_BYPASS !== undefined) return process.env.AGENTGLASS_CHAT_BYPASS === "1";
   return config.chatBypass === true;
+}
+
+/**
+ * Whether the terminal is turned off, and by which layer — so the panel can say
+ * why rather than open a socket that immediately closes. The env var overrides
+ * the file (a one-off `AGENTGLASS_TERMINAL_DISABLED=0 bun run` can force it back
+ * on), and the file makes it reachable from a desktop launcher. `null` means on.
+ */
+export function terminalDisabledSource(): "env" | "config" | null {
+  if (process.env.AGENTGLASS_TERMINAL_DISABLED !== undefined) {
+    return process.env.AGENTGLASS_TERMINAL_DISABLED === "1" ? "env" : null;
+  }
+  return config.terminalDisabled === true ? "config" : null;
 }
 
 export function configuredRepoDirs(): string[] {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -494,7 +494,7 @@ const server = Bun.serve<WsData>({
     // --- in-browser terminal: a real PTY shell over a WebSocket ---
     if (pathname === "/terminal/pty") {
       if (!trustedCaller(req)) return csrfBlocked();
-      if (!TERMINAL_ENABLED) return json({ error: "terminal is disabled (AGENTGLASS_TERMINAL_DISABLED=1)" }, 403);
+      if (!TERMINAL_ENABLED) return json({ error: "terminal is disabled" }, 403);
       const data: PtyWsData = {
         kind: "pty",
         root: url.searchParams.get("root") || "",

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -23,7 +23,7 @@ import type { ServerWebSocket } from "bun";
 import type { ProjectCommand, TerminalCommands, TerminalDisabledReason } from "../../shared/types.ts";
 import { safeAbs, repoRootOf, repoRootOfAsync } from "./git.ts";
 import { terminalActive } from "./loopwatch.ts";
-import { inScope, workspaceRoot } from "./config.ts";
+import { inScope, workspaceRoot, terminalDisabledSource } from "./config.ts";
 import { SKIP_DIRS } from "./gitwork.ts";
 
 // The PTY backend is POSIX-only: every strategy below needs a real
@@ -37,8 +37,12 @@ import { SKIP_DIRS } from "./gitwork.ts";
 // that matters, not the browser's navigator (a Windows laptop can open a
 // dashboard served by a Linux box, and that terminal works fine).
 const IS_WINDOWS = process.platform === "win32";
+// Windows first — the PTY backend needs POSIX, so no env or config toggle can
+// turn it on there. Otherwise the env/config layer decides, resolved the same
+// way chatBypass is (env overrides the file) so a desktop launcher, which
+// inherits no shell env, can still turn the shell off from config.json.
 export const TERMINAL_DISABLED_REASON: TerminalDisabledReason | null =
-  IS_WINDOWS ? "windows" : process.env.AGENTGLASS_TERMINAL_DISABLED === "1" ? "env" : null;
+  IS_WINDOWS ? "windows" : terminalDisabledSource();
 export const TERMINAL_ENABLED = TERMINAL_DISABLED_REASON === null;
 
 const HAS_SETSID = !!Bun.which("setsid");
@@ -206,6 +210,8 @@ export function ptyOpen(ws: PtyWs) {
   if (!TERMINAL_ENABLED) {
     const why = TERMINAL_DISABLED_REASON === "windows"
       ? "terminal is not available on Windows yet (no POSIX PTY backend)"
+      : TERMINAL_DISABLED_REASON === "config"
+      ? "terminal is disabled (terminalDisabled in config.json)"
       : "terminal is disabled (AGENTGLASS_TERMINAL_DISABLED=1)";
     ctl(ws, { t: "fatal", error: why }); ws.close(1008, "disabled"); return;
   }

--- a/server/test/terminal-disabled-config.test.ts
+++ b/server/test/terminal-disabled-config.test.ts
@@ -1,0 +1,56 @@
+// The terminal can be turned off from config.json, not only the environment
+// (#190). A desktop launcher inherits no shell env, so AGENTGLASS_TERMINAL_
+// DISABLED alone was unreachable for the people most likely to want the shell
+// off — a packaged install or a shell-less deployment. The env var still wins
+// when set, so an existing setup does not break.
+//
+// config.ts reads the file once at import, so each case imports a fresh copy
+// with a cache-busting query, mirroring config-root.test.ts.
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const ENV0 = process.env.AGENTGLASS_TERMINAL_DISABLED;
+const XDG0 = process.env.XDG_CONFIG_HOME;
+afterEach(() => {
+  if (ENV0 === undefined) delete process.env.AGENTGLASS_TERMINAL_DISABLED;
+  else process.env.AGENTGLASS_TERMINAL_DISABLED = ENV0;
+  if (XDG0 === undefined) delete process.env.XDG_CONFIG_HOME;
+  else process.env.XDG_CONFIG_HOME = XDG0;
+});
+
+function loadWith(json: string) {
+  const dir = mkdtempSync(join(tmpdir(), "agx-term-"));
+  mkdirSync(join(dir, "agentglass"), { recursive: true });
+  writeFileSync(join(dir, "agentglass", "config.json"), json);
+  process.env.XDG_CONFIG_HOME = dir;
+  return import(`../src/config.ts?u=${Math.random()}`);
+}
+
+describe("terminalDisabledSource", () => {
+  it("is null (terminal on) with neither env nor config set", async () => {
+    delete process.env.AGENTGLASS_TERMINAL_DISABLED;
+    const cfg = await loadWith("{}");
+    expect(cfg.terminalDisabledSource()).toBeNull();
+  });
+
+  it("reads terminalDisabled: true from config.json", async () => {
+    delete process.env.AGENTGLASS_TERMINAL_DISABLED;
+    const cfg = await loadWith('{"terminalDisabled": true}');
+    expect(cfg.terminalDisabledSource()).toBe("config");
+  });
+
+  it("the env var overrides the file when it turns it off", async () => {
+    process.env.AGENTGLASS_TERMINAL_DISABLED = "1";
+    const cfg = await loadWith("{}");
+    expect(cfg.terminalDisabledSource()).toBe("env");
+  });
+
+  it("the env var overrides the file when it turns it back on", async () => {
+    // config says off, but a one-off `AGENTGLASS_TERMINAL_DISABLED=0` forces it on.
+    process.env.AGENTGLASS_TERMINAL_DISABLED = "0";
+    const cfg = await loadWith('{"terminalDisabled": true}');
+    expect(cfg.terminalDisabledSource()).toBeNull();
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -890,7 +890,7 @@ export interface ProjectCommand {
 /** Why the terminal is off, when it is. "env" = the AGENTGLASS_TERMINAL_DISABLED
  *  kill switch; "windows" = no POSIX PTY backend on this host. Lets the panel
  *  print the server's actual answer instead of guessing from the browser. */
-export type TerminalDisabledReason = "env" | "windows";
+export type TerminalDisabledReason = "env" | "config" | "windows";
 export interface TerminalCommands {
   enabled: boolean; // false when the shell backend is unavailable
   reason?: TerminalDisabledReason; // set only when enabled is false — why it's off

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -1284,6 +1284,8 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         ? "The terminal is disabled in the demo — run agentglass locally for a real shell"
                         : cmds?.reason === "windows"
                         ? "The terminal is not available on Windows yet (the PTY backend needs POSIX; ConPTY support is planned)"
+                        : cmds?.reason === "config"
+                        ? "Terminal disabled (terminalDisabled in config.json)"
                         : "Terminal disabled (AGENTGLASS_TERMINAL_DISABLED=1)"}
                     </div>
                   )}


### PR DESCRIPTION
## What does this PR do?

`AGENTGLASS_TERMINAL_DISABLED` was module-level and env-only. An app launched from a Start Menu shortcut, a `.desktop` entry or Spotlight inherits no shell environment, so the only user who could turn the terminal off was one who was going to launch from a shell anyway — while the people most likely to want it off (a platform where the panel doesn't work, or a shell-less packaged deployment) are exactly the ones who couldn't reach it.

This resolves it the same way `chatBypass` already is: a `terminalDisabledSource()` in `config.ts` reads the file, with the env var kept as an override so existing setups don't break, and reports which layer turned it off (`"env" | "config" | "windows"`). The server decides; the client just renders the reason it is already sent via `projectCommands`, so the panel shows a clean "disabled" state instead of opening a socket that immediately closes. Messages that hard-coded the env-var name now name the actual source.

Closes #190.

## How was it tested?

- New `server/test/terminal-disabled-config.test.ts`: `terminalDisabledSource()` is null with nothing set, `"config"` from `{"terminalDisabled": true}`, `"env"` when the env var disables, and null when the env var (`=0`) overrides a config that disabled it.
- `server`: `bunx tsc --noEmit` clean, `bun test` 535 pass / 0 fail.
- `web`: `bunx tsc --noEmit` clean, `bun test` 220 pass, `vite build` clean.

## Notes

`shared/types.ts` gains a `"config"` value on `TerminalDisabledReason`, and the terminal panel overlay and the socket-refusal message name it. README documents the new `config.json` key next to the env var. This also gives #98's "or a graceful disable" a server-decided layer for the client to render, rather than the `navigator.userAgent` guess PR #140 was attempting client-side.

🤖 Generated with [Claude Code](https://claude.com/claude-code)