### PR TITLE
docs(landing): name pull requests in the social descriptions (#181)

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -4,9 +4,9 @@
 <meta charset="utf-8" />
 <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 <title>agentglass — mission control for every AI coding agent on your machine</title>
-<meta name="description" content="Open-source mission control and workspace for AI coding agents. Claude Code, Codex, Gemini CLI — every tool call, token and dollar on one radar, plus diff review, git, docker, a real terminal with native tmux tabs, and a control plane that holds risky tool calls for your approval. Desktop app for macOS, Linux and Windows." />
+<meta name="description" content="Open-source mission control and workspace for AI coding agents. Claude Code, Codex, Gemini CLI — every tool call, token and dollar on one radar, plus diff review, git, pull-request review, docker, a real terminal with native tmux tabs, and a control plane that holds risky tool calls for your approval. Desktop app for macOS, Linux and Windows." />
 <meta property="og:title" content="agentglass — every agent, one tower" />
-<meta property="og:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, hold risky tool calls for approval, then act — diff, git, docker, terminal and chat, without leaving the glass." />
+<meta property="og:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, hold risky tool calls for approval, then act — diff, git, pull requests, docker, terminal and chat, without leaving the glass." />
 <meta property="og:type" content="website" />
 <meta property="og:url" content="https://sirallap.github.io/agentglass/" />
 <meta property="og:image" content="https://sirallap.github.io/agentglass/og.png" />
@@ -15,7 +15,7 @@
 <meta property="og:image:alt" content="agentglass — a loupe whose lens is a mission-control radar, tracking your fleet of AI coding agents" />
 <meta name="twitter:card" content="summary_large_image" />
 <meta name="twitter:title" content="agentglass — every agent, one tower" />
-<meta name="twitter:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, hold risky tool calls for approval, then act — diff, git, docker, terminal and chat, without leaving the glass." />
+<meta name="twitter:description" content="Open-source mission control for AI coding agents. Watch the whole fleet live, hold risky tool calls for approval, then act — diff, git, pull requests, docker, terminal and chat, without leaving the glass." />
 <meta name="twitter:image" content="https://sirallap.github.io/agentglass/og.png" />
 <link rel="icon" type="image/svg+xml" href="data:image/svg+xml,%3Csvg%20xmlns=%22http://www.w3.org/2000/svg%22%20viewBox=%220%200%2032%2032%22%3E%3Cline%20x1=%2220.2%22%20y1=%2220.2%22%20x2=%2227%22%20y2=%2227%22%20stroke=%22%237c3aed%22%20stroke-width=%223.4%22%20stroke-linecap=%22round%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%229%22%20fill=%22%23a78bfa%22%20fill-opacity=%220.14%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%225.6%22%20fill=%22none%22%20stroke=%22%23a78bfa%22%20stroke-opacity=%220.35%22%20stroke-width=%221%22/%3E%3Cpath%20d=%22M13.5%2013.5%20L13.5%204.6%20A8.9%208.9%200%200%201%2019.7%207%20Z%22%20fill=%22%23a78bfa%22%20fill-opacity=%220.28%22/%3E%3Cline%20x1=%2213.5%22%20y1=%2213.5%22%20x2=%2219.7%22%20y2=%227%22%20stroke=%22%23c4b5fd%22%20stroke-width=%221%22/%3E%3Ccircle%20cx=%229%22%20cy=%2216.4%22%20r=%221.9%22%20fill=%22%2334d399%22/%3E%3Ccircle%20cx=%2213.5%22%20cy=%2213.5%22%20r=%229.6%22%20fill=%22none%22%20stroke=%22%237c3aed%22%20stroke-width=%222.5%22/%3E%3C/svg%3E" />
 <style>


### PR DESCRIPTION
## What does this PR do?

#181 reported the landing site describing a five-panel workspace after the PR review view (`p`) shipped in #177. Most of that has since been fixed: the hero body, the hero keycaps (`p pull requests`), the workspace showcase note ("Press g, d, p, o, t or c"), the full PR `.wpane` mock, and the showcase JS `order`/`titles` all already include pull requests.

The one thing still missing was the three social/meta descriptions — `name=description`, `og:description`, `twitter:description` — which still enumerated "diff, git, docker, terminal and chat" with no PRs. The issue calls these out specifically as "what gets pasted into Slack and X, so they matter more than the body copy." This adds pull-request review to all three.

Closes #181.

## How was it tested?

Text-only edit to `landing/index.html` (3 lines). Verified no "five-panel"/"all five" claim remains anywhere in the file, and the body/keycaps/showcase already carry the sixth panel. CI (web build) is unaffected.

## Note

The issue also mentions the screenshots in `.github/assets/` may want refreshing if any show the rail — that needs the capture pipeline (`make assets`) and a separate visual review, so I've left it out of this text fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)