### PR TITLE
fix(provider): attribute provider per event, not per session (#246)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -171,6 +171,18 @@ db.exec("CREATE INDEX IF NOT EXISTS idx_events_cwd_ts ON events(cwd_path, timest
 // index, and the covering scan it enables is what the other two already had.
 db.exec("CREATE INDEX IF NOT EXISTS idx_events_model ON events(model_name)");
 
+// Provider per EVENT, not per session. `sessions.provider` is one column set
+// first-non-null-wins, so a session that ran Opus then GPT reported all of it
+// under whichever provider was seen first. Deriving it per event (providerOf of
+// that event's model) lets a provider filter attribute each event to the model
+// that actually produced it, and lets a multi-provider session show up under
+// each provider it used. NULL when the event's model never resolved — the
+// Unknown bucket. Backfilled from model_name in backfillProvider(). Paired with
+// timestamp in the index, like the scope columns, because every provider-scoped
+// query also windows by time.
+try { db.exec("ALTER TABLE events ADD COLUMN provider TEXT"); } catch { /* already present */ }
+db.exec("CREATE INDEX IF NOT EXISTS idx_events_provider_ts ON events(provider, timestamp)");
+
 // Covering indexes for /stats — the endpoint that freezes the terminal.
 //
 // statsSummary() runs six aggregations over a time window, and every one of
@@ -365,14 +377,16 @@ export function providerOf(model: string | null | undefined): string | null {
  */
 export const UNKNOWN_PROVIDER = "unknown";
 
-/** SQL fragment + args to scope an events query to one provider (via its
- *  sessions). Empty when no provider is selected. The Unknown bucket selects
- *  the NULL-provider sessions so per-provider views reconcile with the total. */
+/** SQL fragment + args to scope an events query to one provider, on each event's
+ *  OWN provider column rather than its session's single latched one — so a
+ *  session that used two providers counts under each for exactly the events it
+ *  ran there. Empty when no provider is selected. The Unknown bucket selects the
+ *  NULL-provider events (model never resolved) so per-provider views reconcile
+ *  with the total. Every call site queries `FROM events` unaliased. */
 function providerScope(provider?: string | null): { clause: string; args: string[] } {
   if (!provider) return { clause: "", args: [] };
-  if (provider === UNKNOWN_PROVIDER)
-    return { clause: " AND session_id IN (SELECT session_id FROM sessions WHERE provider IS NULL)", args: [] };
-  return { clause: " AND session_id IN (SELECT session_id FROM sessions WHERE provider = ?)", args: [provider] };
+  if (provider === UNKNOWN_PROVIDER) return { clause: " AND provider IS NULL", args: [] };
+  return { clause: " AND provider = ?", args: [provider] };
 }
 
 /**
@@ -490,12 +504,12 @@ const ftsInsert = db.query("INSERT INTO events_fts(rowid, text) VALUES ($id, $te
 const insertStmt = db.query(`
   INSERT INTO events (
     source_app, session_id, hook_event_type, tool_name, tool_use_id,
-    agent_id, agent_type, model_name, is_error, error_text, duration_ms,
+    agent_id, agent_type, model_name, provider, is_error, error_text, duration_ms,
     input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
     cost_usd, summary, payload, timestamp
   ) VALUES (
     $source_app, $session_id, $hook_event_type, $tool_name, $tool_use_id,
-    $agent_id, $agent_type, $model_name, $is_error, $error_text, $duration_ms,
+    $agent_id, $agent_type, $model_name, $provider, $is_error, $error_text, $duration_ms,
     $input_tokens, $output_tokens, $cache_creation_tokens, $cache_read_tokens,
     $cost_usd, $summary, $payload, $timestamp
   ) RETURNING id
@@ -633,6 +647,7 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
     $agent_id: n.agent_id,
     $agent_type: n.agent_type,
     $model_name: model,
+    $provider: providerOf(model),
     $is_error: n.is_error,
     $error_text: n.error_text,
     $duration_ms: duration_ms,
@@ -924,11 +939,14 @@ export function getSessions(limit = 100, provider?: string): SessionRollup[] {
   const hit = sessionsCache.get(key);
   if (hit && Date.now() - hit.at < SESSIONS_TTL_MS) return hit.data;
   const s = sessionScopeClause();
+  // A session belongs to a provider when it ran ANY event there, not by its one
+  // latched sessions.provider — so a multi-provider session appears under each
+  // provider it used instead of only the first one seen.
   const prov = !provider
     ? { clause: "", args: [] as string[] }
     : provider === UNKNOWN_PROVIDER
-      ? { clause: " AND provider IS NULL", args: [] as string[] }
-      : { clause: " AND provider = ?", args: [provider] };
+      ? { clause: " AND session_id IN (SELECT session_id FROM events WHERE provider IS NULL)", args: [] as string[] }
+      : { clause: " AND session_id IN (SELECT session_id FROM events WHERE provider = ?)", args: [provider] };
   const data = db
     .query<SessionRollup, any[]>(
       `SELECT * FROM sessions WHERE 1=1${prov.clause}${s.clause} ORDER BY last_seen DESC LIMIT ?`

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1221,23 +1221,36 @@ backfillFts();
 // Backfill the sessions.provider column (added for the provider filter) from
 // each session's model_name — so the filter works over existing history too.
 function backfillProvider() {
-  const VER = 4;
+  const VER = 5; // 5: per-event events.provider (added alongside the multi-provider fix)
   const cur = (db.query("PRAGMA user_version").get() as { user_version: number }).user_version;
   if (cur >= VER) return;
+
+  // sessions.provider — kept for the session badge (first-seen). No-op re-run
+  // once a DB has already been tagged.
   const rows = db.query<{ session_id: string; model_name: string | null }, []>(
     "SELECT session_id, model_name FROM sessions WHERE provider IS NULL AND model_name IS NOT NULL"
   ).all();
   const upd = db.query("UPDATE sessions SET provider = $p WHERE session_id = $sid");
-  let n = 0;
+  // events.provider — one UPDATE per distinct model rather than per row: the
+  // model set is tiny, the events table is not.
+  const models = db.query<{ model_name: string | null }, []>(
+    "SELECT DISTINCT model_name FROM events WHERE provider IS NULL AND model_name IS NOT NULL"
+  ).all();
+  const updEv = db.query("UPDATE events SET provider = $p WHERE model_name = $m AND provider IS NULL");
+  let n = 0, ev = 0;
   const tx = db.transaction(() => {
     for (const r of rows) {
       const p = providerOf(r.model_name);
       if (p) { upd.run({ $p: p, $sid: r.session_id }); n++; }
     }
+    for (const m of models) {
+      const p = providerOf(m.model_name);
+      if (p) ev += updEv.run({ $p: p, $m: m.model_name }).changes;
+    }
   });
   tx();
   db.exec(`PRAGMA user_version = ${VER}`);
-  if (n) console.log(`🏷  tagged ${n} sessions with a provider`);
+  if (n || ev) console.log(`🏷  tagged ${n} sessions and ${ev} events with a provider`);
 }
 backfillProvider();
 

--- a/server/test/provider-bucket.test.ts
+++ b/server/test/provider-bucket.test.ts
@@ -26,7 +26,7 @@ process.env.XDG_CONFIG_HOME = dir;
 
 let db: typeof import("../src/db.ts");
 
-const MINE = ["pb-anthropic", "pb-openai", "pb-null-1", "pb-null-2"];
+const MINE = ["pb-anthropic", "pb-openai", "pb-null-1", "pb-null-2", "pb-multi"];
 const mineOf = (rows: { session_id: string }[]) =>
   rows.map((s) => s.session_id).filter((id) => MINE.includes(id)).sort();
 
@@ -55,6 +55,11 @@ beforeAll(async () => {
   db.insertEvent(event("pb-openai", "gpt-4o") as any); // → OpenAI
   db.insertEvent(event("pb-null-1", null) as any); // → provider NULL (unknown)
   db.insertEvent(event("pb-null-2", null) as any); // → provider NULL (unknown)
+  // One session that ran under TWO providers — the case that used to be latched
+  // to whichever was seen first. Its Opus event belongs to Anthropic, its GPT
+  // event to OpenAI.
+  db.insertEvent(event("pb-multi", "claude-opus-4-8") as any);
+  db.insertEvent(event("pb-multi", "gpt-4o") as any);
 });
 
 describe("provider filtering keeps NULL-provider sessions reachable", () => {
@@ -62,24 +67,46 @@ describe("provider filtering keeps NULL-provider sessions reachable", () => {
     expect(mineOf(db.getSessions(100, "unknown"))).toEqual(["pb-null-1", "pb-null-2"]);
   });
 
-  test("a real provider filter still excludes the NULL sessions", () => {
-    expect(mineOf(db.getSessions(100, "Anthropic"))).toEqual(["pb-anthropic"]);
-  });
-
-  test("the per-provider session views sum to the unfiltered total (nothing lost)", () => {
-    const all = mineOf(db.getSessions(100));
+  test("a real provider filter excludes the NULL sessions", () => {
     const anthropic = mineOf(db.getSessions(100, "Anthropic"));
-    const openai = mineOf(db.getSessions(100, "OpenAI"));
-    const unknown = mineOf(db.getSessions(100, "unknown"));
-    expect(all.length).toBe(4);
-    expect(anthropic.length + openai.length + unknown.length).toBe(all.length);
+    expect(anthropic).not.toContain("pb-null-1");
+    expect(anthropic).not.toContain("pb-null-2");
   });
 
-  test("statsSummary reconciles: per-provider event counts sum to the total", () => {
+  test("every session appears in at least one provider view (nothing lost)", () => {
+    const all = new Set(mineOf(db.getSessions(100)));
+    const covered = new Set([
+      ...mineOf(db.getSessions(100, "Anthropic")),
+      ...mineOf(db.getSessions(100, "OpenAI")),
+      ...mineOf(db.getSessions(100, "unknown")),
+    ]);
+    expect(all.size).toBe(5);
+    expect(covered).toEqual(all); // union of the buckets == the whole set
+  });
+
+  test("statsSummary reconciles at the EVENT level: per-provider counts sum to the total", () => {
     const events = (p?: string) => (db.statsSummary(24 * 3600 * 1000, p) as any).totals.events;
-    // Scoped to this test's project, so these are exactly its four events.
-    expect(events()).toBe(4);
+    // Five sessions, six events (pb-multi ran two). Each event is counted under
+    // exactly its own model's provider, so the buckets partition the events even
+    // though pb-multi's session shows in two of them.
+    expect(events()).toBe(6);
     expect(events("Anthropic") + events("OpenAI") + events("unknown")).toBe(events());
-    expect(events("unknown")).toBe(2); // the two NULL-provider sessions are no longer lost
+    expect(events("unknown")).toBe(2);
+  });
+});
+
+describe("a multi-provider session is attributed per event, not latched to one", () => {
+  test("the session appears under BOTH providers it used", () => {
+    expect(mineOf(db.getSessions(100, "Anthropic"))).toContain("pb-multi");
+    expect(mineOf(db.getSessions(100, "OpenAI"))).toContain("pb-multi");
+  });
+
+  test("its events split across providers by their own model, not the first-seen one", () => {
+    const events = (p: string) => (db.statsSummary(24 * 3600 * 1000, p) as any).totals.events;
+    // pb-anthropic + pb-multi's Opus event = 2 under Anthropic;
+    // pb-openai + pb-multi's GPT event = 2 under OpenAI. The GPT event is NOT
+    // billed to Anthropic just because the session was seen as Anthropic first.
+    expect(events("Anthropic")).toBe(2);
+    expect(events("OpenAI")).toBe(2);
   });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -39,6 +39,10 @@ export interface WatchEvent {
   agent_id: string | null;
   agent_type: string | null;
   model_name: string | null;
+  /** Coarse vendor for this event's model (providerOf), set at insert. NULL when
+   *  the model never resolved. Per-event so a session that switched providers is
+   *  attributed to the model that actually produced each event. */
+  provider: string | null;
   is_error: number; // 0 | 1
   error_text: string | null;
   duration_ms: number | null; // filled on PostToolUse via pre→post pairing


### PR DESCRIPTION
## What does this PR do?

The remaining half of #246. `sessions.provider` is a single column set first-non-null-wins, so a session that ran Opus then handed a turn to a GPT subagent reported all of it under whichever provider was seen first, and its cost/tokens landed entirely on that one.

This attributes provider **per event**:
- `events` gains a `provider` column, set at insert from `providerOf(the event's own model)`, and backfilled for existing rows (migration bumped to `user_version` 5, one `UPDATE` per distinct model).
- `providerScope` filters each event's own `provider` directly instead of its session's latched one.
- `getSessions` treats a session as belonging to a provider when it ran **any** event there, so a multi-provider session shows up under each provider it used.
- The per-provider stats now attribute each event to the model that produced it. The Unknown bucket (NULL provider) is unchanged.

Closes #246.

## How was it tested?

- Extended `server/test/provider-bucket.test.ts` with a `pb-multi` session that ran one Opus and one GPT event:
  - it appears under **both** Anthropic and OpenAI filters;
  - its events split by their own model (Anthropic 2, OpenAI 2), not latched to the first-seen provider;
  - event-level reconciliation still holds: per-provider event counts sum to the total (the honest invariant — a multi-provider session legitimately appears in two session buckets, so the session-level sum no longer equals the total).
- `server`: `bunx tsc --noEmit` clean, `bun test` 537 pass / 0 fail.
- `web`: `bunx tsc --noEmit` clean, `bun test` 220 pass, `vite build` clean.
- Perf budget: loop p99 2ms (added `providerOf` at insert + `idx_events_provider_ts`).

## Notes

`provider` is a real column, not a virtual generated one, because it is a regex map of `model_name` rather than a `json_extract`. It is paired with `timestamp` in `idx_events_provider_ts` since every provider-scoped query also windows by time (same reasoning as #220). `sessions.provider` is kept as the session badge's first-seen hint. `WatchEvent` gains `provider` for an honest contract; the web still derives its own per-session provider client-side, so no client behaviour changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)