### PR TITLE
docs(macos): explain the "app is damaged" Gatekeeper warning + xattr fix (#252)

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,26 @@ Installers for every release are published on
 `.AppImage` and `.deb` for Linux, `.dmg` for macOS (Apple Silicon and Intel).
 That is the way to install it.
 
+### macOS: "agentglass is damaged and can't be opened"
+
+On Apple Silicon, macOS may refuse to launch the app with a misleading
+**"agentglass.app is damaged and can't be opened"** message. The download is
+**not** actually damaged. The `.dmg` is not yet code-signed and notarized with
+an Apple Developer ID, so Gatekeeper blocks the quarantined app your browser
+downloaded and shows that wording instead of the softer "unidentified developer"
+prompt. Clear the quarantine flag with the built-in `xattr` tool, then open it
+normally:
+
+```bash
+xattr -dr com.apple.quarantine /Applications/agentglass.app
+```
+
+Right-click → Open does **not** clear this specific "damaged" variant on Apple
+Silicon; only the command above does. Signing and notarization are on the
+roadmap (they can run in CI on a macOS runner, so no Mac hardware is needed).
+For background, see Apple's [Safely open apps on your
+Mac](https://support.apple.com/en-us/102445).
+
 Building it yourself, from a clone:
 
 ```bash


### PR DESCRIPTION
## What does this PR do?

Documents the macOS **"agentglass.app is damaged and can't be opened"** warning that Apple Silicon users hit on the unsigned `v0.5.0` `.dmg`, and the one-line fix. Closes #252.

The app is **not** damaged. The `.dmg` is not yet code-signed/notarized with an Apple Developer ID, so Gatekeeper blocks the quarantined app the browser downloaded and shows that misleading wording on arm64. This adds a short subsection to the **Desktop app** section of the README with:

- the built-in `xattr -dr com.apple.quarantine /Applications/agentglass.app` workaround,
- the note that right-click → Open does **not** clear this specific variant,
- a pointer that signing + notarization is on the roadmap (doable in CI on a macOS runner, no Mac hardware needed),
- a link to Apple's official [Safely open apps on your Mac](https://support.apple.com/en-us/102445).

This is the standard, auditable fix (built-in tool, no third-party binary). Follow-up work to actually sign + notarize the release is tracked separately.

## How was it tested?

- README-only change, no code touched.
- Rendered the Markdown to confirm the new `### macOS: "agentglass is damaged and can't be opened"` subsection sits correctly under `## Desktop app` and the code block/link format as expected.
- Verified the referenced quarantine behavior against Apple Support 102445 and the Apple Developer forums (unsigned arm64 apps report as "damaged").
