### PR TITLE
feat(alerts): deliver push alerts cross-platform, not only via notify-send (#192)

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -12,10 +12,22 @@
 // web/src/lib/gateStore.ts raises every new hold onto the notch, which no
 // desktop setting can suppress. Treat everything below as best-effort reach
 // for when nobody is looking at agentglass at all.
-import type { WatchEvent } from "../../shared/types.ts";
+import type { WatchEvent, AlertNote } from "../../shared/types.ts";
 
 const WEBHOOK = process.env.AGENTGLASS_WEBHOOK;
 const DESKTOP = process.env.AGENTGLASS_NOTIFY === "1";
+
+// A connected client can raise a NATIVE OS notification, which Electron routes
+// to macOS and Windows too — the cross-platform replacement for notify-send,
+// which only exists on Linux. The server still owns the opt-in (AGENTGLASS_
+// NOTIFY) and the triggers; the client just surfaces what it is handed.
+// notify-send stays as the fallback for a headless server with no client.
+export interface AlertSink {
+  broadcast: (a: AlertNote) => void;
+  hasClients: () => boolean;
+}
+let sink: AlertSink | null = null;
+export function setAlertSink(s: AlertSink | null) { sink = s; }
 
 // Debounce identical alerts so a burst doesn't spam channels.
 const lastSent = new Map<string, number>();
@@ -29,7 +41,7 @@ function shouldSend(key: string): boolean {
   return true;
 }
 
-async function deliver(title: string, body: string) {
+async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
   if (WEBHOOK) {
     try {
       await fetch(WEBHOOK, {
@@ -42,6 +54,12 @@ async function deliver(title: string, body: string) {
     }
   }
   if (DESKTOP) {
+    // A connected client shows a native OS notification (cross-platform).
+    // notify-send is the fallback only when nothing is attached to show it.
+    if (sink?.hasClients()) {
+      sink.broadcast({ title, body, urgency });
+      return;
+    }
     try {
       Bun.spawn(["notify-send", "-a", "agentglass", "-u", "critical", "--", title, body], { stdout: "ignore" });
     } catch (e) {
@@ -76,7 +94,7 @@ export function maybeAlert(e: WatchEvent) {
   }
   if (e.hook_event_type === "Notification") {
     const msg = String((e.payload as any)?.message ?? "Agent notification");
-    if (shouldSend(`notify:${e.session_id}:${msg}`)) deliver("🔔 " + agent, msg);
+    if (shouldSend(`notify:${e.session_id}:${msg}`)) deliver("🔔 " + agent, msg, 1);
     return;
   }
   if (e.is_error) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,7 +19,7 @@ import {
   providerOf,
   gateHistory,
 } from "./db.ts";
-import { maybeAlert } from "./alerts.ts";
+import { maybeAlert, setAlertSink } from "./alerts.ts";
 import { getSkills, catalogMarkdown, catalogCsv } from "./skills.ts";
 import { getInsights } from "./insights.ts";
 import { getUsage } from "./usage.ts";
@@ -309,6 +309,9 @@ const treeCache = new Map<string, { at: number; data: WorkingTree }>();
 const WORKTREES_TTL_MS = 2_500;
 const worktreesCache = new Map<string, { at: number; body: string }>();
 setGitChangeHook(() => { treeCache.clear(); worktreesCache.clear(); broadcast({ type: "git" }); });
+// Let the alert path reach a connected client, which raises a native OS
+// notification (cross-platform) instead of the Linux-only notify-send.
+setAlertSink({ broadcast: (a) => broadcast({ type: "alert", data: a }), hasClients: () => clients.size > 0 });
 
 /**
  * Session detail, held briefly, and invalidated when the session gets an event.

--- a/server/test/alerts-sink.test.ts
+++ b/server/test/alerts-sink.test.ts
@@ -1,0 +1,53 @@
+// agentglass's own push alerts reach a connected client so it can raise a
+// NATIVE OS notification — the cross-platform replacement for notify-send, which
+// only exists on Linux (#192). The server still owns the opt-in and the
+// triggers; notify-send stays as the fallback when nothing is attached to show
+// it. These pin the routing: broadcast when a client is present, not when it
+// isn't, and the right urgency per alert kind.
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import type { AlertNote } from "../../shared/types.ts";
+
+const NOTIFY0 = process.env.AGENTGLASS_NOTIFY;
+const HOOK0 = process.env.AGENTGLASS_WEBHOOK;
+process.env.AGENTGLASS_NOTIFY = "1"; // read at import → the desktop branch is live
+delete process.env.AGENTGLASS_WEBHOOK; // no outbound fetch during the test
+afterAll(() => {
+  if (NOTIFY0 === undefined) delete process.env.AGENTGLASS_NOTIFY; else process.env.AGENTGLASS_NOTIFY = NOTIFY0;
+  if (HOOK0 === undefined) delete process.env.AGENTGLASS_WEBHOOK; else process.env.AGENTGLASS_WEBHOOK = HOOK0;
+});
+
+let alerts: typeof import("../src/alerts.ts");
+let broadcasts: AlertNote[] = [];
+let clientsPresent = true;
+
+beforeAll(async () => {
+  // Fresh instance so its module-level `DESKTOP = AGENTGLASS_NOTIFY === "1"` is
+  // read with the env set above, even if another test already imported alerts.ts
+  // (bun shares the module registry across the suite).
+  alerts = await import(`../src/alerts.ts?u=${Math.random()}`);
+  alerts.setAlertSink({ broadcast: (a) => broadcasts.push(a), hasClients: () => clientsPresent });
+});
+
+describe("desktop alert routing", () => {
+  test("with a client attached, a gate hold broadcasts a critical native alert", () => {
+    broadcasts = []; clientsPresent = true;
+    alerts.pushGate("app:sess1", "Bash", "rm -rf something-unique-1");
+    expect(broadcasts.length).toBe(1);
+    expect(broadcasts[0].title).toContain("Approval");
+    expect(broadcasts[0].urgency).toBe(2);
+    expect(broadcasts[0].body).toContain("Bash");
+  });
+
+  test("with no client attached, it does NOT broadcast (notify-send is the fallback)", () => {
+    broadcasts = []; clientsPresent = false;
+    alerts.pushGate("app:sess2", "Bash", "rm -rf something-unique-2");
+    expect(broadcasts.length).toBe(0);
+  });
+
+  test("an agent notification is normal urgency; a tool error is critical", () => {
+    broadcasts = []; clientsPresent = true;
+    alerts.maybeAlert({ hook_event_type: "Notification", session_id: "s-notif", source_app: "app", payload: { message: "heads up" } } as any);
+    alerts.maybeAlert({ hook_event_type: "PostToolUse", is_error: 1, session_id: "s-err", source_app: "app", tool_name: "Bash", error_text: "boom", payload: {} } as any);
+    expect(broadcasts.map((b) => b.urgency).sort()).toEqual([1, 2]);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -424,9 +424,21 @@ export type WsFrame =
    *  server holds the latch, so a suite of sixty-one checks sends one of these,
    *  not sixty-one. */
   | { type: "ci"; data: CiVerdict }
+  /** One of agentglass's own push alerts (a gate hold, a permission wait, a tool
+   *  error) — the same thing the server would hand to notify-send. Broadcast so a
+   *  connected client can raise a NATIVE OS notification, which Electron routes to
+   *  the OS on macOS and Windows too, not just Linux. */
+  | { type: "alert"; data: AlertNote }
   /** A UI-navigation command from POST /control, rebroadcast to every client.
    *  It changes what is *shown*, never the fleet. */
   | { type: "control"; data: ControlCmd };
+
+export interface AlertNote {
+  title: string;
+  body: string;
+  /** freedesktop urgency: 0 low, 1 normal, 2 critical. */
+  urgency: 0 | 1 | 2;
+}
 
 /** The aggregate outcome of a PR's checks, once every one of them is terminal. */
 export interface CiVerdict {

--- a/web/src/lib/sysNotify.ts
+++ b/web/src/lib/sysNotify.ts
@@ -152,6 +152,26 @@ function historyChanged() {
  * a toast holds "3755 commits to pull" for five seconds and is then gone, and
  * the number was the whole message. One inbox, whatever raised it.
  */
+/**
+ * Raise one of agentglass's OWN alerts as a native OS notification.
+ *
+ * The cross-platform half of #192: `notify-send` only exists on Linux, but the
+ * Notification API is routed to the OS by Electron on macOS and Windows too (and
+ * works in a browser tab that has been granted permission). The server owns the
+ * opt-in (AGENTGLASS_NOTIFY) and only broadcasts these while a client is
+ * attached, so this just surfaces what it is handed. Fires only when permission
+ * is already granted — which Electron does by default for the app — so it never
+ * pops a permission prompt off the back of an incoming socket frame.
+ */
+export function fireDesktopAlert(a: { title: string; body: string }) {
+  try {
+    if (typeof Notification === "undefined") return;
+    if (Notification.permission === "granted") new Notification(a.title, { body: a.body });
+  } catch {
+    /* a host without Notification support — the notch still has it */
+  }
+}
+
 export function recordNote(n: { app: string; summary: string; body: string; urgency?: 0 | 1 | 2 }) {
   const note: SystemNote = {
     id: `app-${++localSeq}`,

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -4,7 +4,7 @@ import { WS_URL, IS_DEMO, hasToken, probeAuth } from "./api.ts";
 import * as demo from "./demo.ts";
 import { gitChanged } from "./gitBus.ts";
 import { emitControl } from "./controlBus.ts";
-import { recordNote } from "./sysNotify.ts";
+import { recordNote, fireDesktopAlert } from "./sysNotify.ts";
 
 const MAX_EVENTS = 2000;
 const FLUSH_MS = 220; // coalesce bursts into ~5 renders/sec
@@ -135,6 +135,15 @@ export function useLive(): LiveData {
         // not data — hand it to App, which runs it through the same setters the
         // keyboard does.
         emitControl(frame.data);
+        return;
+      }
+      if (frame.type === "alert") {
+        // agentglass's own push alert (gate hold, permission wait, tool error),
+        // opted into on the server. Raise it as a native OS notification — the
+        // cross-platform replacement for notify-send. The notch already has the
+        // in-app copy through its own paths (gateStore et al.), so this does not
+        // also recordNote, which would double it there.
+        fireDesktopAlert(frame.data);
         return;
       }
       if (frame.type === "ci") {


### PR DESCRIPTION
## What does this PR do?

Item 3 of #192: agentglass's own push alerts (gate holds, permission waits, tool errors) shelled out to `notify-send`, which only exists on Linux — so macOS and Windows users got nothing when an agent was stopped waiting for them.

This routes them through a connected client instead. When `AGENTGLASS_NOTIFY` is set (the existing opt-in), the sidecar broadcasts an `alert` frame, and the client raises a **native OS notification** — which Electron routes to the OS on all three platforms, and which also works in a browser tab that has been granted permission. The server still owns the opt-in and the triggers; the client only surfaces what it is handed. `notify-send` stays as the fallback for a headless server with no client attached, so nothing regresses there.

Closes #192 (the last of its four items).

## How was it tested?

- New `server/test/alerts-sink.test.ts`: with a client attached a gate hold broadcasts a critical alert; with none attached it does not (notify-send fallback); agent notifications are normal urgency, tool errors critical.
- End-to-end: a real sidecar with `AGENTGLASS_NOTIFY=1` plus a connected WebSocket client — posting a `Notification` event to `/ingest` delivered `{title, body, urgency}` to the client, confirming the server→client path.
- `server`: `bunx tsc --noEmit` clean, `bun test` 540 pass / 0 fail.
- `web`: `bunx tsc --noEmit` clean, `bun test` 220 pass, `vite build` clean.

## Design notes

- **No new UI or preference.** The opt-in stays `AGENTGLASS_NOTIFY` (off by default), so there is no surprise-notification behaviour change and nothing to configure. It fires exactly when `notify-send` did, just cross-platform.
- The notch's in-app copy is unchanged (it arrives through `gateStore` et al.), so the `alert` frame deliberately does **not** also `recordNote`, which would double it there.
- The client fires only when `Notification.permission === "granted"` — which Electron grants by default for the app — so an incoming socket frame never pops a permission prompt. Electron has no permission handler that would block it.
- I verified the server→client path and the routing on Linux; the native pop itself on macOS/Windows goes through Electron's standard `Notification` and is unverified by me on those platforms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)