### PR TITLE
fix(desktop): a build on a release tag is named by the tag, not the manifest (#167)

### DIFF
--- a/electron/build.mjs
+++ b/electron/build.mjs
@@ -69,9 +69,9 @@ const readVersion = (p) => {
 const rank = (v) => (v.match(/\d+/g) ?? []).map(Number).reduce((n, part) => n * 1000 + part, 0);
 const shellVersion = readVersion(resolve(HERE, "package.json"));
 const rootVersion = readVersion(resolve(REPO, "package.json"));
-const version = (rank(rootVersion) > rank(shellVersion) ? rootVersion : shellVersion) || "0.0.0";
+const manifestVersion = (rank(rootVersion) > rank(shellVersion) ? rootVersion : shellVersion) || "0.0.0";
 if (shellVersion && rootVersion && shellVersion !== rootVersion) {
-  console.warn(`warn: package.json versions disagree (root ${rootVersion}, electron ${shellVersion}) — using ${version}`);
+  console.warn(`warn: package.json versions disagree (root ${rootVersion}, electron ${shellVersion}) — using ${manifestVersion}`);
 }
 // The remote, so the updater can clone it without ever needing this checkout.
 const origin = spawnSync("git", ["-C", REPO, "remote", "get-url", "origin"], { encoding: "utf8" }).stdout?.trim() ?? "";
@@ -83,6 +83,14 @@ const described = spawnSync("git", ["-C", REPO, "describe", "--tags", "--long", 
 const m = /^(v\d+\.\d+\.\d+)-(\d+)-g[0-9a-f]+$/.exec(described);
 const baseTag = m ? m[1] : "";
 const distance = m ? Number(m[2]) : 0;
+// Let the tag win when the build is exactly on one. A self-update compiles from
+// source on the user's machine with no CI in the path to sync the manifest, so
+// after tagging v0.4.1 an "install & restart" would otherwise stamp the previous
+// release. distance === 0 means this build IS the tagged release, whoever built
+// it; distance > 0 is an in-between build (v0.4.0+4), where the manifest is the
+// honest name. Retires the whole class of "manifest bump was half-done", making
+// CI's sync step belt-and-braces rather than the only thing holding it up.
+const version = distance === 0 && baseTag ? baseTag.replace(/^v/, "") : manifestVersion;
 writeFileSync(resolve(HERE, "staging/build-info.json"), JSON.stringify({
   version, commit, builtAt: new Date().toISOString(), source: REPO, origin, baseTag, distance,
 }, null, 2));


### PR DESCRIPTION
## What does this PR do?

`electron/build.mjs` took the version from the two `package.json` manifests, and only CI (`desktop-binaries.yml`) rewrites `electron/package.json` from the tag. A **self-update** compiles from source on the user's machine with no CI in the path, so after tagging v0.4.1 an "install & restart" produced a build that reported **0.4.0** — whatever the manifest last said — until someone remembered to bump it in the release commit.

`git describe` already yields `baseTag` and `distance` a few lines below the version read, so this lets the tag win when the build is exactly on one:
- `distance === 0` → the version is the tag, manifests ignored. A build made from a release is named by that release, whoever built it and however.
- otherwise → the manifest version, the honest answer for an in-between `v0.4.0+4` build.

That retires the class of bug rather than the instance: no release-checklist step to remember, and CI's manifest sync becomes belt-and-braces instead of the only thing holding it up.

Closes #167.

## How was it tested?

`electron/build.mjs` is a build script with no unit-test harness (CI runs server/web tests only), so I verified both branches directly with `node electron/build.mjs --provenance-only`:
- current HEAD, 47 commits past the last tag → `version: 0.5.0` (manifest);
- a temporary tag placed exactly at HEAD → `version` is the tag (distance 0, tag wins).

`node --check electron/build.mjs` passes; only `build.mjs` changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)