### PR TITLE
feat(privacy): a pure diagnostic scrubber built from an allowlist (#207)

### DIFF
--- a/server/test/scrub.test.ts
+++ b/server/test/scrub.test.ts
@@ -1,0 +1,109 @@
+// The scrubber's guarantee is the point (#207): feed it realistic dirty inputs
+// and prove none of the user's data survives. These are property-style — a
+// battery of forbidden substrings (a username, private project names, tokens,
+// home paths, a payload) that must appear NOWHERE in the emitted SafeReport —
+// not just a couple of examples.
+import { describe, expect, test } from "bun:test";
+import { scrub, redactText, type SafeReport } from "../../shared/scrub.ts";
+
+// Everything here is a thing a real agentglass error could carry and that must
+// never leave the machine.
+const FORBIDDEN = [
+  "serallap", // the OS username, leaked by every /home/<user>/ path
+  "smith", // a private project name, leaked by a repo path
+  "ghp_" + "AbCdEf0123456789AbCdEf", // a GitHub token
+  "sk-" + "abcdef0123456789abcdef", // an API key
+  "eyJ" + "hbGciOiJIUzI1NiIsInR5cCI6", // a JWT prefix
+  "write me a function that", // a prompt fragment
+  "/home/serallap", // a home path
+  "/Users/serallap", // a mac home path
+];
+
+function assertClean(report: SafeReport) {
+  const blob = JSON.stringify(report);
+  for (const bad of FORBIDDEN) expect(blob).not.toContain(bad);
+}
+
+describe("scrub — no user data survives", () => {
+  test("a stack trace full of user paths keeps only app frames, leaking no identity", () => {
+    const err = new Error("Cannot read properties of undefined (reading 'x')");
+    err.stack = [
+      "TypeError: Cannot read properties of undefined",
+      "    at derive (/home/serallap/code/agentglass/server/src/derive.ts:42:9)",
+      "    at handler (/home/serallap/code/smith/private/secret-service.ts:7:3)",
+      "    at load (/home/serallap/.claude/plugins/thing.js:1:1)",
+      "    at run (/home/serallap/code/agentglass/node_modules/react-dom/index.js:9:9)",
+      "    at web (/home/serallap/code/agentglass/web/src/App.tsx:100:5)",
+    ].join("\n");
+    const r = scrub({ error: err });
+    assertClean(r);
+    // The two app frames survive, app-relative; the user-repo, ~/.claude and
+    // node_modules frames are gone.
+    expect(r.frames.join("\n")).toContain("server/src/derive.ts");
+    expect(r.frames.join("\n")).toContain("web/src/App.tsx");
+    expect(r.frames.some((f) => f.includes("smith") || f.includes("node_modules") || f.includes(".claude"))).toBe(false);
+    expect(r.frames.length).toBe(2);
+  });
+
+  test("secrets in the message are redacted, whatever their shape", () => {
+    const err = new Error(
+      "auth failed: Bearer ghp_AbCdEf0123456789AbCdEf and key sk-abcdef0123456789abcdef and jwt eyJhbGciOiJIUzI1NiIsInR5cCI6.body.sig",
+    );
+    const r = scrub({ error: err });
+    assertClean(r);
+    expect(r.message).toContain("<redacted-secret>");
+  });
+
+  test("a token buried in a home path is caught and the path is dropped", () => {
+    const r = scrub({ error: "read /home/serallap/.claude/creds with sk-abcdef0123456789abcdef" });
+    assertClean(r);
+  });
+
+  test("extra properties the error carries (a prompt payload, a file slice) are dropped, not read", () => {
+    const err = new Error("JSON parse error") as Error & Record<string, unknown>;
+    err.prompt = "write me a function that deletes /home/serallap/code/smith";
+    err.userFile = "/home/serallap/code/smith/secret.ts";
+    err.env = { OPENAI_API_KEY: "sk-abcdef0123456789abcdef" };
+    const r = scrub({ error: err });
+    assertClean(r);
+    expect(r.message).toBe("JSON parse error"); // only the message came through
+  });
+
+  test("windows home paths are redacted too", () => {
+    const r = scrub({ error: "ENOENT: C:\\Users\\serallap\\code\\smith\\app.log not found" });
+    assertClean(r);
+  });
+});
+
+describe("scrub — the allowlist is exactly what it emits", () => {
+  test("only the allowlisted top-level keys appear", () => {
+    const r = scrub({ error: new Error("x"), category: "diff viewer", app: { version: "0.5.0", commit: "abc1234" }, runtime: { os: "linux", arch: "x64", bun: "1.3.9", electron: "33.4.11" } });
+    expect(new Set(Object.keys(r))).toEqual(new Set(["errorType", "message", "frames", "category", "app", "runtime"]));
+    expect(r.app).toEqual({ version: "0.5.0", commit: "abc1234" });
+    expect(r.runtime).toEqual({ os: "linux", arch: "x64", bun: "1.3.9", electron: "33.4.11" });
+    expect(r.category).toBe("diff viewer");
+    expect(r.errorType).toBe("Error");
+  });
+
+  test("injection characters in the safe context are stripped (it is metadata, not markup)", () => {
+    const r = scrub({ error: new Error("x"), category: "diff</script> viewer\n<b>x", app: { version: "0.5.0 && rm -rf ~" } });
+    assertClean(r);
+    expect(r.category).not.toContain("<");
+    expect(r.category).not.toContain(">");
+    expect(r.category).not.toContain("\n");
+    expect(r.app.version).not.toContain("&"); // shell metacharacters gone
+  });
+
+  test("a bare string error and a missing stack are handled", () => {
+    const r = scrub({ error: "GET /home/serallap/x failed" });
+    assertClean(r);
+    expect(r.errorType).toBe("Error");
+    expect(r.frames).toEqual([]);
+  });
+
+  test("redactText leaves app paths app-relative and drops the rest", () => {
+    expect(redactText("at /home/serallap/code/agentglass/server/src/db.ts:5")).toContain("server/src/db.ts");
+    expect(redactText("opened /home/serallap/code/smith/x.ts")).not.toContain("smith");
+    expect(redactText("read/write ratio is fine")).toBe("read/write ratio is fine"); // prose slash left alone
+  });
+});

--- a/shared/scrub.ts
+++ b/shared/scrub.ts
@@ -1,0 +1,149 @@
+// A privacy-preserving diagnostic scrubber — the core both reporting paths
+// depend on (#207, prerequisite for #208).
+//
+// Unlike most apps, an agentglass error is SATURATED with user data. A bare
+// stack trace or message routinely carries file paths (which leak the OS
+// username and the names of private projects), the content that caused the
+// error (a prompt, a file slice, a diff, command output), env values or tokens,
+// and repo/session identifiers. So "send only the error, nothing about the
+// user" is not a filter bolted on — it is the whole design.
+//
+// The design is an ALLOWLIST, not a blocklist: a report is assembled from things
+// known to be safe, and everything else is dropped by default. When in doubt,
+// drop it — a less useful report is always better than one that leaks. This
+// module is pure and dependency-free so both the server and the web can build
+// the exact same SafeReport, and so its guarantee can be proven by tests.
+
+/** The ONLY shape either reporting path is allowed to send. */
+export interface SafeReport {
+  /** The error's constructor name, e.g. "TypeError". Inert. */
+  errorType: string;
+  /** The message, redacted: paths, secrets and home dirs removed. */
+  message: string;
+  /** Stack frames from agentglass's OWN code only, app-relative. A frame that
+   *  resolves into a user repo, ~/.claude, node_modules or any path outside the
+   *  app is dropped entirely. */
+  frames: string[];
+  /** Coarse subsystem the error came from (a panel/route name), never the data
+   *  it was acting on. Omitted when absent. */
+  category?: string;
+  /** Build provenance — safe by construction. */
+  app: { version?: string; commit?: string };
+  /** Host coordinates, no identity. */
+  runtime: { os?: string; arch?: string; bun?: string; electron?: string };
+}
+
+export interface Diagnostic {
+  /** An Error, an error-like object, or a bare string. */
+  error: unknown;
+  category?: unknown;
+  app?: { version?: unknown; commit?: unknown };
+  runtime?: { os?: unknown; arch?: unknown; bun?: unknown; electron?: unknown };
+}
+
+const MAX_MSG = 500;
+const MAX_FRAMES = 20;
+const MAX_CATEGORY = 40;
+const MAX_FIELD = 40;
+
+// agentglass's own source roots. A path (in a message or a frame) is only ever
+// kept as the tail from one of these; anything else is dropped.
+const APP_MARKERS = ["/server/src/", "/web/src/", "/electron/", "/shared/", "/scripts/"];
+
+// Secrets, redacted before anything else so a token buried in a path or URL is
+// caught too. Deliberately broad — a false positive costs a bit of readability,
+// a false negative leaks a credential.
+const SECRET_PATTERNS: RegExp[] = [
+  /\bgh[posru]_[A-Za-z0-9]{20,}\b/g, // GitHub PAT / OAuth / refresh / server tokens
+  /\bsk-[A-Za-z0-9_-]{16,}\b/g, // OpenAI / Anthropic style
+  /\bxox[baprs]-[A-Za-z0-9-]{10,}\b/g, // Slack
+  /\bAKIA[0-9A-Z]{16}\b/g, // AWS access key id
+  /\beyJ[A-Za-z0-9._-]{20,}\b/g, // JWT
+  /(?:bearer|authorization|api[_-]?key|token|secret|password)\s*[:=]?\s*["']?[A-Za-z0-9._~+/-]{12,}=*/gi,
+  /\b[A-Za-z0-9+]{40,}={0,2}\b/g, // long high-entropy blob (raw base64/hex secrets); no "/" so it never eats a path
+];
+
+function stripSecrets(s: string): string {
+  let out = s;
+  for (const re of SECRET_PATTERNS) out = out.replace(re, "<redacted-secret>");
+  return out;
+}
+
+/** The app-relative tail of a path that runs through an app marker, else null. */
+function appRelative(p: string): string | null {
+  const norm = p.replace(/\\/g, "/");
+  let best: number | null = null;
+  for (const m of APP_MARKERS) {
+    const i = norm.indexOf(m);
+    if (i !== -1 && (best === null || i < best)) best = i;
+  }
+  return best === null ? null : norm.slice(best + 1); // drop the marker's leading slash
+}
+
+// Absolute paths: unix (/…/…, at least two segments) not preceded by a word
+// char, so a mid-word slash in prose ("read/write") is left alone; and windows
+// (C:\…). Each is replaced with its app-relative tail if it runs through the
+// app, otherwise dropped to <path>.
+const PATH_RE = /(?<![\w.])(?:[A-Za-z]:\\[^\s"'`):]+|\/[^\s"'`):]+(?:\/[^\s"'`):]+)+\/?)/g;
+
+function redactPaths(s: string): string {
+  return s.replace(PATH_RE, (p) => appRelative(p) ?? "<path>");
+}
+
+/** Reduce free text to something safe to send: secrets gone, paths dropped
+ *  unless they are the app's own. Exported for tests. */
+export function redactText(s: string): string {
+  if (typeof s !== "string" || !s) return "";
+  // Paths first: a path that runs through the app is reduced to its safe tail,
+  // any other absolute path (a user repo, ~/.claude, a home dir) is dropped
+  // whole — taking any token buried inside it with it. Then secrets, for tokens
+  // sitting in open text.
+  return stripSecrets(redactPaths(s));
+}
+
+function scrubFrames(stack: string): string[] {
+  const out: string[] = [];
+  for (const raw of stack.split("\n")) {
+    const line = raw.trim();
+    if (!line.startsWith("at ")) continue; // only real V8 frames
+    const path = line.match(/(?:[A-Za-z]:\\[^\s"'`):]+|\/[^\s"'`):]+)/);
+    if (!path) continue; // a native frame (no path) tells us nothing safe to keep
+    const rel = appRelative(path[0]);
+    if (!rel) continue; // node_modules, a user repo, ~/.claude — dropped
+    out.push(stripSecrets(line.replace(path[0], rel)));
+    if (out.length >= MAX_FRAMES) break;
+  }
+  return out;
+}
+
+/** A short, inert label: letters, digits, spaces and dashes only. */
+function safeField(v: unknown, max = MAX_FIELD): string | undefined {
+  if (typeof v !== "string") return undefined;
+  const s = v.replace(/[^A-Za-z0-9._+ -]/g, "").trim().slice(0, max);
+  return s || undefined;
+}
+
+export function scrub(d: Diagnostic): SafeReport {
+  const err = d?.error;
+  const errObj = (err && typeof err === "object" ? (err as { name?: unknown; message?: unknown; stack?: unknown }) : {});
+  const errorType = (String(errObj.name ?? "Error").replace(/[^A-Za-z0-9_$]/g, "").slice(0, 60)) || "Error";
+  const rawMsg = typeof err === "string" ? err : String(errObj.message ?? "");
+  const message = redactText(rawMsg).slice(0, MAX_MSG);
+  const frames = typeof errObj.stack === "string" ? scrubFrames(errObj.stack) : [];
+
+  const report: SafeReport = {
+    errorType,
+    message,
+    frames,
+    app: { version: safeField(d?.app?.version), commit: safeField(d?.app?.commit) },
+    runtime: {
+      os: safeField(d?.runtime?.os),
+      arch: safeField(d?.runtime?.arch),
+      bun: safeField(d?.runtime?.bun),
+      electron: safeField(d?.runtime?.electron),
+    },
+  };
+  const category = safeField(d?.category, MAX_CATEGORY);
+  if (category) report.category = category;
+  return report;
+}


### PR DESCRIPTION
## What does this PR do?

The linchpin both reporting paths (#208/#235) depend on. An agentglass error is saturated with user data: file paths leak the OS username and private project names, a parse/render error often carries the very prompt or file that broke it, and env values and tokens ride along in messages. So "send only the error, nothing about the user" has to be the whole design, not a filter bolted on.

`shared/scrub.ts` builds a `SafeReport` from an **allowlist** — only things known to be safe, everything else dropped by default:
- error type (constructor name) and a **redacted** message;
- stack frames from agentglass's **own** code only (`server/src`, `web/src`, `electron`, `shared`, `scripts`), app-relative; frames in a user repo, `~/.claude`, `node_modules` or any path outside the app are dropped;
- app version/commit, os/arch, bun/electron;
- a coarse caller-supplied `category`, sanitized and length-capped.

Redaction reduces absolute paths to their app-relative tail or drops them whole (taking any token inside with them); turns GitHub/OpenAI/Slack/AWS/JWT tokens and long high-entropy blobs into `<redacted-secret>`; and leaves a mid-word slash in prose alone. It's pure and dependency-free so the server and the web produce the identical report, and so the guarantee is testable.

Closes #207. `SafeReport` is exported as the only shape either reporting path should send; #208/#235 build the surfaces on top.

## How was it tested?

- `server/test/scrub.test.ts` (9 cases): property-style, with a battery of forbidden substrings — a username, private project names, GitHub/OpenAI/JWT tokens, unix and windows home paths, and a prompt payload passed as an extra error property — proven to appear **nowhere** in the emitted report; app frames survive app-relative while user/node_modules/`.claude` frames are dropped; only allowlisted keys are ever present; injection chars in metadata are stripped.
- Writing the tests surfaced two real bugs (the high-entropy pattern ate app paths; path redaction had to run before secret redaction) — both fixed.
- `server`: `bunx tsc --noEmit` clean, `bun test` 549 pass / 0 fail. `web`: `bunx tsc --noEmit` clean (shared module typechecks under both).

🤖 Generated with [Claude Code](https://claude.com/claude-code)