### PR TITLE
fix(discoverability): surface the Pull Requests view in the palette and legend

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -607,6 +607,7 @@ export default function App() {
         onSkills={() => setSkillsOpen(true)}
         onChanges={() => { setWsView("diff"); setWsOpen(true); }}
         onGit={() => { setWsView("git"); setWsOpen(true); }}
+        onPr={() => { setWsView("pr"); setWsOpen(true); }}
         onDocker={() => { setWsView("docker"); setWsOpen(true); }}
         onTerminal={() => { setWsView("term"); setWsOpen(true); }}
         onChat={() => { setWsView("chat"); setWsOpen(true); }}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -25,6 +25,7 @@ export function CommandPalette({
   onSkills,
   onChanges,
   onGit,
+  onPr,
   onDocker,
   onTerminal,
   onChat,
@@ -43,6 +44,7 @@ export function CommandPalette({
   onSkills: () => void;
   onChanges: () => void;
   onGit: () => void;
+  onPr: () => void;
   onDocker: () => void;
   onTerminal: () => void;
   onChat: () => void;
@@ -59,6 +61,7 @@ export function CommandPalette({
     list.push({ id: "skills", group: "View", label: "Browse skills — every available skill & command", run: () => onSkills() });
     list.push({ id: "changes", group: "View", label: "File changes — every diff the fleet made", run: () => onChanges() });
     list.push({ id: "git", group: "View", label: "Source control — stage, commit, push/pull the working tree", run: () => onGit() });
+    list.push({ id: "pr", group: "View", label: "Pull requests — review PRs without leaving for the browser", run: () => onPr() });
     list.push({ id: "docker", group: "View", label: "Docker — containers, logs, stats & actions", run: () => onDocker() });
     list.push({ id: "terminal", group: "View", label: "Terminal — a real shell in any repo/worktree", run: () => onTerminal() });
     list.push({ id: "chat", group: "View", label: "Chat — drive a Claude session in a repo/worktree", run: () => onChat() });
@@ -79,7 +82,7 @@ export function CommandPalette({
     list.push({ id: "csv", group: "Export", label: "Download CSV", run: () => window.open(api.exportUrl("csv")) });
     list.push({ id: "json", group: "Export", label: "Download JSON", run: () => window.open(api.exportUrl("json")) });
     return list;
-  }, [apps, types, onFilter, onWindow, onTheme, onStats, onSkills, onChanges, onGit, onDocker, onTerminal, onChat, onSearch, onClear, onZoom]);
+  }, [apps, types, onFilter, onWindow, onTheme, onStats, onSkills, onChanges, onGit, onPr, onDocker, onTerminal, onChat, onSearch, onClear, onZoom]);
 
   const filtered = useMemo(
     () => (q ? cmds.filter((c) => (c.group + " " + c.label).toLowerCase().includes(q.toLowerCase())) : cmds),

--- a/web/src/components/HelpLegend.tsx
+++ b/web/src/components/HelpLegend.tsx
@@ -74,9 +74,10 @@ export function HelpLegend({ open, onClose }: { open: boolean; onClose: () => vo
                 <div className="panel-eyebrow mt-3 mb-2">workspace</div>
                 <div className="grid grid-cols-2 gap-y-1 text-[11px] t-dim">
                   <span><kbd className="chip">{MOD_KEY}\</kbd> Open / close</span>
-                  <span><kbd className="chip">{MOD_KEY}1</kbd>…<kbd className="chip">{MOD_KEY}5</kbd> Jump to a view</span>
+                  <span><kbd className="chip">{MOD_KEY}1</kbd>…<kbd className="chip">{MOD_KEY}6</kbd> Jump to a view</span>
                   <span><kbd className="chip">g</kbd> Git</span>
                   <span><kbd className="chip">d</kbd> Diff</span>
+                  <span><kbd className="chip">p</kbd> Pull requests</span>
                   <span><kbd className="chip">o</kbd> Docker</span>
                   <span><kbd className="chip">t</kbd> Terminal</span>
                   <span><kbd className="chip">c</kbd> Chat</span>


### PR DESCRIPTION
## What does this PR do?

The sixth workspace view (pull requests, key `p`) shipped in #177, but the two places you look for a view were never updated: the command palette had no Pull-requests action, and the help legend listed five views (`g`/`d`/`o`/`t`/`c`) under `⌘1…⌘5`. So a first-class view was reachable only if you already knew its key existed.

- Command palette: adds a "Pull requests" action, wired to open the `pr` view like the others.
- Help legend: adds the `p` Pull requests row and corrects the range to `⌘1…⌘6` — which `viewForChord` already resolves (it maps `mod+N` to the Nth rail view, and the rail has six).

## How was it tested?

- `web`: `bunx tsc --noEmit` clean, `bun test` 231 pass / 0 fail, `vite build` clean.
- Confirmed `⌘6` resolves to the sixth rail view via `viewForChord`, so the legend's `⌘1…⌘6` is accurate.

## Scope note

This is the six-panel discoverability gap (#177/#181). It also improves the exact surfaces #240 asks shortcuts to live in (palette + legend). It does **not** close #240: that issue's own asks — an always-visible UI-zoom control and a first-run nudge for the server-side plugins — are UX/onboarding placement decisions I've left for a maintainer call (zoom is already surfaced on desktop, where it works, in the palette's Display group, the legend, and Settings). I'll comment on #240 with that assessment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)