### PR TITLE
fix(desktop): gate self-update off on Windows instead of shelling to bash (#189)

### DIFF
--- a/server/src/selfupdate.ts
+++ b/server/src/selfupdate.ts
@@ -153,11 +153,29 @@ async function readRemoteTags(originUrl: string): Promise<string[] | null> {
     .sort((a, b) => cmpTag(b, a));
 }
 
+/**
+ * Windows has no bash on a stock box and self-update.sh is POSIX throughout, so
+ * the updater simply cannot run there yet. Returns the honest block message on
+ * win32, null everywhere else. Gating here (rather than only refusing in
+ * startUpdate) means the About pane never offers an update button that would
+ * shell out to a bash that isn't there — the worst of the options.
+ */
+export function windowsUpdateBlock(platform: string = process.platform): string | null {
+  return platform === "win32"
+    ? "self-update is not available on Windows yet — download the latest release to update"
+    : null;
+}
+
 export async function updateStatus(): Promise<UpdateStatus> {
   const info = buildInfo();
   const base: UpdateStatus = {
     ok: true, available: false, info, branch: "", behind: 0, ahead: 0, incoming: [], last: readStamp(),
   };
+  // Before the origin check: on Windows this also replaces the misleading
+  // "reinstall from source" banner a provenance-less build would otherwise show
+  // with the real reason the button does nothing.
+  const winBlock = windowsUpdateBlock();
+  if (winBlock) return { ...base, blocked: winBlock };
   if (!info.origin) {
     return { ...base, blocked: "this build records no origin — reinstall from source once to enable updates" };
   }

--- a/server/test/selfupdate-win32.test.ts
+++ b/server/test/selfupdate-win32.test.ts
@@ -1,0 +1,30 @@
+// The self-updater shells out to bash against a POSIX-only self-update.sh, so it
+// cannot run on a stock Windows box (#189). Rather than offer an update button
+// that spawns a bash which isn't there, updateStatus() reports an honest block on
+// win32 — and startUpdate() refuses on any blocked status before it reaches the
+// spawn. This pins the platform gate that decides it.
+import { beforeAll, describe, expect, test } from "bun:test";
+
+// selfupdate.ts reads AGENTGLASS_UPDATE_SRC into a module-level const at load,
+// and release-notes.test.ts relies on being the one that first imports it, with
+// that env set. A plain top-level import here would load the shared module early
+// (without that env) and break release-notes in the suite. A cache-busted import
+// gives this file its own instance and leaves the canonical module untouched.
+let windowsUpdateBlock: (platform?: string) => string | null;
+beforeAll(async () => {
+  ({ windowsUpdateBlock } = await import(`../src/selfupdate.ts?u=${Math.random()}`));
+});
+
+describe("windowsUpdateBlock", () => {
+  test("blocks self-update on win32 with an actionable message", () => {
+    const msg = windowsUpdateBlock("win32");
+    expect(msg).toBeTruthy();
+    expect(msg).toContain("Windows");
+    expect(msg!.toLowerCase()).toContain("release"); // points at the real way to update
+  });
+
+  test("does not block on linux or macOS", () => {
+    expect(windowsUpdateBlock("linux")).toBeNull();
+    expect(windowsUpdateBlock("darwin")).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`startUpdate` spawns `bash` against `electron/self-update.sh`, which is POSIX throughout — there is no bash on a stock Windows box, so the update button did nothing but fail. Silently offering a button that shells out to a bash that isn't there is the worst of the options the issue lays out.

`updateStatus()` now returns an honest block on `win32` ("self-update is not available on Windows yet — download the latest release to update"). Because that returns before the origin check, it also replaces the misleading "this build records no origin — reinstall from source" banner a provenance-less Windows build would otherwise show. `startUpdate()` already refuses on any blocked status before it reaches the spawn, so bash is never invoked there.

## How was it tested?

- New `server/test/selfupdate-win32.test.ts`: the gate is a pure `windowsUpdateBlock(platform)` helper — blocks on `win32` with an actionable message, returns null on linux/darwin — so it is testable without a Windows box.
- `server`: `bunx tsc --noEmit` clean, `bun test` 551 pass / 0 fail (existing self-update tests unaffected on non-Windows).

## Scope note

This closes the Windows-facing half of #189 (the unrunnable updater and the misleading banner on that platform), taking the issue's accepted "gate the update surface off on win32 with an honest message" option. The other half — a build made by calling `electron-builder` directly ships with **no** `build-info.json` and should fail loudly at build time rather than produce an installer that cannot say what it is — is non-Windows build hygiene; I've left #189 open re-scoped to just that.

🤖 Generated with [Claude Code](https://claude.com/claude-code)