### PR TITLE
ci: watch the supply chain — Dependabot + CodeQL (#169)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,53 @@
+# Watch the supply chain the repo otherwise never looks at (#169).
+#
+# Grouped and weekly on purpose: the dependency surface here is tiny (a handful
+# of direct deps across the workspaces, zero in electron), so a quiet week is one
+# PR rather than six, and the signal stays high.
+#
+# The github-actions half is the point. Every workflow pins third-party actions,
+# and a moved or compromised tag in one of those runs with the repo's token — the
+# supply chain most people forget they have. The npm half is best-effort: this
+# repo uses bun.lock, and Dependabot's bun support is newer than its npm/yarn
+# support, so if it produces noise or can't update a lockfile the npm entries can
+# be narrowed or dropped without losing the higher-value Actions coverage.
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      actions:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      root:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/web"
+    schedule:
+      interval: "weekly"
+    groups:
+      web:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/server"
+    schedule:
+      interval: "weekly"
+    groups:
+      server:
+        patterns: ["*"]
+
+  - package-ecosystem: "npm"
+    directory: "/electron"
+    schedule:
+      interval: "weekly"
+    groups:
+      electron:
+        patterns: ["*"]

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,56 @@
+# Static analysis for the code itself (#169).
+#
+# This project hands out a shell, git write access and docker control over a
+# WebSocket, so the bug that matters most here — a path escaping its clamp, a
+# command built by string concatenation — is exactly what this class of tool is
+# for. Free on a public repo, no service or token.
+#
+# It reports to the Security tab and annotates PRs; it does NOT fail the build on
+# informational findings (the analyze step uploads results, it does not gate the
+# merge). Kept non-required on purpose: a new rule that blocks merges on day one
+# gets disabled by whoever it blocks first. Let it report for a few weeks first.
+#
+# Python is included for hooks/, where the PreToolUse forwarder and the PTY
+# bridge live. Both languages analyse from source (build-mode: none), so there is
+# no compile step to keep working.
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  schedule:
+    - cron: "27 4 * * 1" # weekly, to catch advisories in queries themselves
+
+permissions:
+  security-events: write
+  contents: read
+  actions: read
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: python
+            build-mode: none
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+
+      - name: Analyze
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## What does this PR do?

CI catches a leaked secret (GitGuardian) but watches nothing else about the repo's own supply chain. This adds the two free-on-a-public-repo pieces from #169:

- **`.github/dependabot.yml`** — weekly, grouped (a quiet week is one PR, not six). Covers `github-actions` in `/` (the higher-value half: a moved or compromised tag on a pinned third-party action runs with the repo's token) and `npm` in `/`, `/web`, `/server`, `/electron`. The npm half is best-effort given `bun.lock` — Dependabot's bun support is newer than npm's — and can be narrowed to Actions-only if it makes noise, without losing the Actions coverage.
- **`.github/workflows/codeql.yml`** — JavaScript/TypeScript + Python (for `hooks/`), default queries, on push to main and PRs plus a weekly run. `build-mode: none` (source analysis, no compile step). It reports to the Security tab and annotates PRs; it does **not** fail the build on informational findings, and is deliberately **not** a required check yet — a rule that blocks merges on day one gets disabled by whoever it blocks first.

Closes #169.

## How was it tested?

- Both files validated as YAML; the CodeQL workflow's matrix parses to `javascript-typescript` + `python`.
- CodeQL runs on **this PR** (it triggers on `pull_request`), so its own analyze job is the verification that it initializes and completes. Dependabot config is GitHub-native and applies once merged.

## Caveats (from the issue)

- CodeQL adds ~a couple of minutes to PR feedback — worth it, worth knowing.
- If Dependabot's npm entries produce noise or can't update `bun.lock`, drop them to Actions-only; that is the higher-value half regardless.
- Neither looks at the projects agents work in — that's the separate #168.

🤖 Generated with [Claude Code](https://claude.com/claude-code)