### PR TITLE
feat(pr): keyboard navigation in the PR files tab (j/k/n/p/x)

### DIFF
--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -30,6 +30,7 @@ import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle } from "./ChangesModal.tsx";
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
+import { stepFileIndex } from "../lib/prNav.ts";
 
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
@@ -1031,11 +1032,52 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
 }) {
   const current = sel ? byPath.get(sel) : undefined;
   const draftsFor = (p: string) => drafts.filter((x) => x.path === p).length;
+  const frameRef = useRef<HTMLDivElement>(null);
+
+  // The same keyboard model as the changes modal, so the two review surfaces
+  // don't diverge: j/k walk the file list, n/p walk the hunks of the open diff,
+  // x toggles reviewed. The diff itself is ChangesModal's UnifiedDiff/SplitDiff,
+  // so its [data-hunk] markers and [data-vscroll] container are reused verbatim.
+  const stepFile = (dir: 1 | -1) => {
+    const files = d.files;
+    if (!files.length) return;
+    const i = stepFileIndex(files.length, files.findIndex((f) => f.path === sel), dir);
+    onSel(files[i].path);
+    requestAnimationFrame(() => frameRef.current?.querySelector('[data-file="active"]')?.scrollIntoView({ block: "nearest" }));
+  };
+  const jumpHunk = (dir: 1 | -1) => {
+    const frame = frameRef.current;
+    if (!frame) return;
+    const sc = (frame.querySelector("[data-vscroll]") as HTMLElement | null) ?? frame;
+    const heads = Array.from(sc.querySelectorAll<HTMLElement>("[data-hunk]"));
+    if (!heads.length) return;
+    const scTop = sc.getBoundingClientRect().top;
+    const cur = sc.scrollTop;
+    const tops = heads.map((h) => h.getBoundingClientRect().top - scTop + cur);
+    const target = dir === 1 ? tops.find((t) => t > cur + 4) : [...tops].reverse().find((t) => t < cur - 4);
+    sc.scrollTo({ top: (target ?? (dir === 1 ? tops[tops.length - 1] : tops[0])) - 2, behavior: "smooth" });
+  };
+  const onKey = (e: React.KeyboardEvent) => {
+    // Never while a field owns the keys — the PR search box, a comment textarea,
+    // or a row's reviewed checkbox. Same guard App.tsx and ChangesModal use.
+    const inInput = /input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "");
+    if (inInput) return;
+    const k = e.key.toLowerCase();
+    if (k === "j" || e.key === "ArrowDown") { e.preventDefault(); e.stopPropagation(); stepFile(1); }
+    else if (k === "k" || e.key === "ArrowUp") { e.preventDefault(); e.stopPropagation(); stepFile(-1); }
+    else if (k === "n") { e.preventDefault(); e.stopPropagation(); jumpHunk(1); }
+    else if (k === "p") { e.preventDefault(); e.stopPropagation(); jumpHunk(-1); }
+    else if (k === "x") { e.preventDefault(); e.stopPropagation(); if (sel) onSeen(sel); }
+  };
+  // Focus the frame when the files tab mounts, so the keys work without a click
+  // first — the same first-frame focus the changes modal does.
+  useEffect(() => { requestAnimationFrame(() => frameRef.current?.focus()); }, []);
 
   return (
-    <div className="text-[11px] flex flex-col gap-2">
+    <div ref={frameRef} tabIndex={-1} onKeyDown={onKey} className="text-[11px] flex flex-col gap-2 outline-none">
       <div className="flex items-center gap-2 text-[10px]" style={{ color: "var(--text3)" }}>
         <span className="tabular-nums">{seenFiles.length}/{d.files.length} reviewed</span>
+        <span className="shrink-0 t-dim2 hidden sm:inline"><b>j/k</b> file · <b>n/p</b> hunk · <b>x</b> reviewed</span>
         <Bar parts={[{ pct: d.files.length ? (seenFiles.length / d.files.length) * 100 : 0, tint: "var(--primary)" }]} />
       </div>
 
@@ -1045,7 +1087,7 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
           const open = sel === f.path;
           const nd = draftsFor(f.path);
           return (
-            <div key={f.path} className="flex items-center gap-2 px-2 py-1"
+            <div key={f.path} data-file={open ? "active" : undefined} className="flex items-center gap-2 px-2 py-1"
               style={{
                 borderBottom: "1px solid color-mix(in srgb, var(--border) 18%, transparent)",
                 background: open ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",

--- a/web/src/lib/prNav.ts
+++ b/web/src/lib/prNav.ts
@@ -1,0 +1,11 @@
+// Pure keyboard-navigation helpers for the PR files tab. Kept out of PrPanel.tsx
+// so the wrap-around can be unit-tested without dragging the whole component
+// graph (and its browser-only imports) into a DOM-less test.
+
+/** Next file index for j/k, wrapping. From no selection (cur < 0), j lands on
+ *  the first file and k on the last. Returns -1 for an empty list. */
+export function stepFileIndex(len: number, cur: number, dir: 1 | -1): number {
+  if (len <= 0) return -1;
+  if (cur < 0) return dir === 1 ? 0 : len - 1;
+  return (cur + dir + len) % len;
+}

--- a/web/test/pr-keynav.test.ts
+++ b/web/test/pr-keynav.test.ts
@@ -1,0 +1,22 @@
+// j/k file navigation in the PR files tab wraps, and starts sensibly from no
+// selection (PR panel keyboard nav). The wrap-around is the pure part of
+// the handler; the DOM parts (hunk scroll, focus, input guard) mirror the
+// changes modal verbatim.
+import { test, expect } from "bun:test";
+import { stepFileIndex } from "../src/lib/prNav.ts";
+
+test("j/k wrap around the file list", () => {
+  expect(stepFileIndex(5, 0, 1)).toBe(1);
+  expect(stepFileIndex(5, 4, 1)).toBe(0); // past the end → first
+  expect(stepFileIndex(5, 0, -1)).toBe(4); // before the start → last
+  expect(stepFileIndex(5, 2, -1)).toBe(1);
+});
+
+test("from no selection, j lands on the first file and k on the last", () => {
+  expect(stepFileIndex(5, -1, 1)).toBe(0);
+  expect(stepFileIndex(5, -1, -1)).toBe(4);
+});
+
+test("an empty file list has no next index", () => {
+  expect(stepFileIndex(0, -1, 1)).toBe(-1);
+});


### PR DESCRIPTION
## What does this PR do?

The PR panel reuses the changes modal's diff renderer (`UnifiedDiff`/`SplitDiff`) but had **no keydown handler at all**, so its files tab couldn't be driven from the keyboard the way the changes modal can. This brings the same model to the files tab, using the exact pattern `ChangesModal` already uses so the two review surfaces don't diverge:

- **`j/k`** walk the file list (wrapping; from no selection, `j` → first, `k` → last), **`n/p`** walk the hunks of the open diff, **`x`** toggles reviewed.
- Reuses the shared renderer's `[data-hunk]` markers and `[data-vscroll]` container verbatim, plus the same first-frame focus.
- **Guarded against inputs**: never fires while the PR search box, a comment textarea, or a row's reviewed checkbox has focus, and `stopPropagation` keeps the app-level letter shortcuts (which would otherwise switch views on a bare `n/p`) from also firing.
- **No second diff renderer** introduced — `UnifiedDiff`/`SplitDiff` stay the single implementation.

This is triage Task 6.

## How was it tested?

- The wrap-around is factored into a pure `web/src/lib/prNav.ts::stepFileIndex`, unit-tested (`web/test/pr-keynav.test.ts`) without dragging the component's browser-only import graph into a DOM-less test.
- `web`: `bunx tsc --noEmit` clean, `bun test` 234 pass / 0 fail, `vite build` clean.
- `make smoke` (headless Chrome): all 6 views mount, keys switch and close, no console errors.

## Note

The DOM parts (hunk scroll, focus, input guard) mirror `ChangesModal` line-for-line, so interactive feel is inherited from the already-shipped surface; a live click-through of `j/k/n/p/x` in the panel is worth a glance but the logic and pattern are identical to the tested modal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)