### PR TITLE
fix(insights): scope insights to the project, like every other metric (#248)

### DIFF
--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -2,7 +2,7 @@
 // runaway loops, fast burn, high failure rates, overall spend velocity.
 // Computed from the full event history (better than the live buffer for loops).
 import type { Insight } from "../../shared/types.ts";
-import { db } from "./db.ts";
+import { db, scopeClause } from "./db.ts";
 
 const key = (app: string, sid: string) => `${app}:${sid.slice(0, 8)}`;
 const trim = (s: string, n = 64) => (s.length > n ? s.slice(0, n) + "…" : s);
@@ -10,21 +10,27 @@ const trim = (s: string, n = 64) => (s.length > n ? s.slice(0, n) + "…" : s);
 export function getInsights(): Insight[] {
   const now = Date.now();
   const out: Insight[] = [];
+  // Scope like every other metric: a cockpit scoped to one project must not
+  // surface another project's loop / burn / failure rate. Computed once and
+  // appended to each query below (bind order: timestamp first, then these).
+  // Empty when nothing is scoped, so a whole-machine view is unchanged; `AND 0`
+  // when the scope has no events yet, so those queries honestly return nothing.
+  const { clause: sc, args: sa } = scopeClause();
 
   // 1) Loops — the SAME command run over and over (real waste). Restricted to
   //    Bash on an identical command; iterative Edits to a file aren't a loop.
   const loops = db
-    .query<{ source_app: string; session_id: string; cmd: string; n: number; last: number }, [number]>(
+    .query<{ source_app: string; session_id: string; cmd: string; n: number; last: number }, any[]>(
       `SELECT source_app, session_id, json_extract(payload,'$.tool_input.command') AS cmd,
               COUNT(*) n, MAX(timestamp) last
        FROM events
        WHERE hook_event_type = 'PreToolUse' AND tool_name = 'Bash'
-             AND cmd IS NOT NULL AND timestamp > ?
+             AND cmd IS NOT NULL AND timestamp > ?${sc}
        GROUP BY session_id, cmd
        HAVING n >= 6
        ORDER BY n DESC LIMIT 6`
     )
-    .all(now - 30 * 60_000);
+    .all(now - 30 * 60_000, ...sa);
   for (const l of loops) {
     out.push({
       id: `loop:${l.session_id}:${l.cmd}`,
@@ -39,12 +45,12 @@ export function getInsights(): Insight[] {
 
   // 2) Fast burn — a session spending a lot in the last 15 minutes.
   const spend = db
-    .query<{ source_app: string; session_id: string; cost: number; last: number }, [number]>(
+    .query<{ source_app: string; session_id: string; cost: number; last: number }, any[]>(
       `SELECT source_app, session_id, ROUND(SUM(cost_usd),2) cost, MAX(timestamp) last
-       FROM events WHERE timestamp > ? GROUP BY session_id
+       FROM events WHERE timestamp > ?${sc} GROUP BY session_id
        HAVING cost >= 15 ORDER BY cost DESC LIMIT 4`
     )
-    .all(now - 15 * 60_000);
+    .all(now - 15 * 60_000, ...sa);
   for (const s of spend) {
     out.push({
       id: `spend:${s.session_id}`,
@@ -59,15 +65,15 @@ export function getInsights(): Insight[] {
 
   // 3) High failure rate — errors relative to tool calls in the last hour.
   const fails = db
-    .query<{ source_app: string; session_id: string; errs: number; tools: number; last: number }, [number]>(
+    .query<{ source_app: string; session_id: string; errs: number; tools: number; last: number }, any[]>(
       `SELECT source_app, session_id, SUM(is_error) errs,
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) tools,
               MAX(timestamp) last
-       FROM events WHERE timestamp > ? GROUP BY session_id
+       FROM events WHERE timestamp > ?${sc} GROUP BY session_id
        HAVING tools >= 4 AND errs * 1.0 / tools > 0.3
        ORDER BY errs DESC LIMIT 4`
     )
-    .all(now - 60 * 60_000);
+    .all(now - 60 * 60_000, ...sa);
   for (const f of fails) {
     const pct = Math.round((f.errs / f.tools) * 100);
     out.push({
@@ -83,10 +89,10 @@ export function getInsights(): Insight[] {
 
   // 4) Spend velocity — overall $/hr over the last hour (context, info-level).
   const burn = db
-    .query<{ cost: number; toks: number }, [number]>(
-      `SELECT SUM(cost_usd) cost, SUM(input_tokens + output_tokens) toks FROM events WHERE timestamp > ?`
+    .query<{ cost: number; toks: number }, any[]>(
+      `SELECT SUM(cost_usd) cost, SUM(input_tokens + output_tokens) toks FROM events WHERE timestamp > ?${sc}`
     )
-    .get(now - 60 * 60_000);
+    .get(now - 60 * 60_000, ...sa);
   if (burn && burn.cost > 1) {
     out.push({
       id: "burn:hourly",

--- a/server/test/insights-scope.test.ts
+++ b/server/test/insights-scope.test.ts
@@ -1,0 +1,93 @@
+// Insights must be scoped like every other metric. A cockpit scoped to one
+// project must not surface another project's runaway loop, fast burn, or failure
+// rate — the over-inclusion failure the repo already guards for its other event
+// queries (scope.test.ts), but which getInsights() never applied. Both
+// directions are asserted: what should appear does, and what should not still
+// does not (project isolation, the highest-risk class here).
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-insights-scope-"));
+const SCOPED = join(dir, "scoped");
+const OTHER = join(dir, "other");
+const MONO = join(dir, "mono"); // root outside the scope, but its turn ran inside it (cwd)
+for (const p of [SCOPED, OTHER, MONO]) mkdirSync(p, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "insights.db");
+process.env.AGENTGLASS_ROOT = SCOPED; // read once at db.ts/config.ts import, so set before the dynamic import
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+let insights: typeof import("../src/insights.ts");
+
+const now = Date.now();
+// One loop = >=6 identical Bash PreToolUse in a session within 30m.
+const loopEvent = (project: string, session: string, cmd: string, i: number, over: Record<string, unknown> = {}) => ({
+  source_app: project.split("/").pop()!,
+  session_id: session,
+  hook_event_type: "PreToolUse",
+  tool_name: "Bash",
+  tool_use_id: `${session}-${i}`,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "",
+  timestamp: now - i * 1000,
+  payload: { project_path: project, tool_input: { command: cmd }, ...over },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  insights = await import("../src/insights.ts");
+  const loop = (project: string, session: string, over: Record<string, unknown> = {}) => {
+    for (let i = 0; i < 8; i++) db.insertEvent(loopEvent(project, session, "npm run build", i, over) as any);
+  };
+  loop(SCOPED, "s-in"); // in scope
+  loop(OTHER, "s-out"); // out of scope — must not leak
+  loop(MONO, "s-cwd", { cwd: SCOPED + "/wt/x" }); // in scope via the cwd the turn ran in
+
+  // A second, differently-shaped query (SUM(cost)/HAVING) — a fast-burn session
+  // over $15 in 15m — to prove the scope guard covers more than the loop query.
+  const burn = (project: string, session: string) => {
+    // cost is computed from usage at insert (opus input is $5/M), so 2M input
+    // tokens ≈ $10/event; four events ≈ $40, over the $15 fast-burn threshold.
+    for (let i = 0; i < 4; i++) db.insertEvent({
+      source_app: project.split("/").pop()!, session_id: session, hook_event_type: "PostToolUse",
+      tool_name: "Bash", tool_use_id: null, agent_id: null, agent_type: null, model_name: "claude-opus-4-8",
+      is_error: 0, error_text: null,
+      usage: { input_tokens: 2_000_000, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0 },
+      usage_is_cumulative: false, summary: "", timestamp: now - i * 1000,
+      payload: { project_path: project }, chat: null,
+    } as any);
+  };
+  burn(SCOPED, "b-in");
+  burn(OTHER, "b-out");
+});
+
+const loopIds = () => insights.getInsights().filter((i) => i.kind === "loop").map((i) => i.id);
+
+describe("insights are scoped to the project", () => {
+  test("a loop in the scoped project surfaces", () => {
+    expect(loopIds().some((id) => id.startsWith("loop:s-in:"))).toBe(true);
+  });
+
+  test("a loop in ANOTHER project does not leak in", () => {
+    expect(loopIds().some((id) => id.startsWith("loop:s-out:"))).toBe(false);
+  });
+
+  test("a loop whose turn ran inside the scope (via cwd) is included", () => {
+    expect(loopIds().some((id) => id.startsWith("loop:s-cwd:"))).toBe(true);
+  });
+
+  test("a second insight kind (fast burn) is scoped too, not just loops", () => {
+    const spendIds = insights.getInsights().filter((i) => i.kind === "spend").map((i) => i.id);
+    expect(spendIds).toContain("spend:b-in"); // in-scope fast burn surfaces
+    expect(spendIds).not.toContain("spend:b-out"); // another project's does not leak
+  });
+});


### PR DESCRIPTION
`getInsights()` (/insights) filtered by timestamp alone with no scopeClause(), while every other event query is scoped — so a cockpit scoped to one project leaked another project's loops/fast-burn/failures (over-inclusion). Applied scopeClause() to all four insight queries: empty clause when unscoped (whole-machine unchanged), AND 0 when scope has no events. New test asserts both directions on two query shapes; the 'does not leak' assertion fails on pre-fix code (verified). Local: server tsc + 555 tests, web tsc + build, smoke, perfbudget p99 3ms. Part of #248.

🤖 Generated with [Claude Code](https://claude.com/claude-code)