### PR TITLE
ci: give server tests a 20s per-test timeout, not bun's 5s default

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,7 +20,13 @@ jobs:
       - name: Typecheck server
         run: cd server && bunx tsc --noEmit
       - name: Tests (server)
-        run: cd server && bun test
+        # Generous per-test timeout, not bun's 5s default: several server tests
+        # do real git/spawn/settle work that finishes in ~seconds on a dev box
+        # but brushes the 5s ceiling on the runner's constrained 2 cores, so one
+        # would occasionally time out and redden main with no logic change behind
+        # it. This only raises the ceiling — it can't hide a real regression,
+        # which fails on its assertion, not the clock.
+        run: cd server && bun test --timeout 20000
       # web/test/ was never run by CI, so the dashboard's own tests — diff
       # themes, the session-live rule, the file tree — could break on a PR and
       # nothing would say so.


### PR DESCRIPTION
Intermittent CI red on main: a test reported `(unnamed) [5427ms]` on f8086aa (a workflow-only commit → content can't be the cause). bun's default per-test timeout is 5000ms; server tests doing real git/spawn/settle work (branch-merged 5s settle, release-notes/selfupdate git clones) brush it on the runner's 2 cores and occasionally time out. Raise the server suite ceiling to 20s — only affects flaky-timeout behaviour, can't mask a real regression (that fails on its assertion, not the clock). Web tests keep the default. Verified: 551 pass/0 fail with the flag; can't reproduce locally even at --timeout 4000 (CI-load-bound).

🤖 Generated with [Claude Code](https://claude.com/claude-code)