### PR TITLE
fix(terminal): default to DOM renderer on Linux to stop the blank-white terminal

### DIFF
--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -16,6 +16,7 @@ import { ingestUpdate } from "../lib/updateStore.ts";
 import { ReleaseNotesModal } from "./ReleaseNotesModal.tsx";
 import { installedNotes, type NotesTarget } from "../lib/whatsNew.ts";
 import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESKTOP } from "../lib/desktop.ts";
+import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRenderer.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
 import type { UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
@@ -382,6 +383,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
   useEffect(() => { if (open) void isFullscreen().then(setFullscreenState); }, [open]);
 
   const [h24, setH24] = useState<boolean>(() => clock24());
+  const [renderer, setRenderer] = useState<RendererPref>(() => rendererPref());
   const [keys, setKeys] = useState(() => bindings());
   const [capturing, setCapturing] = useState<ActionId | null>(null);
   const [pane, setPane] = useState<Pane>("prefs");
@@ -527,6 +529,21 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                       value={h24 ? "24" : "12"}
                       onPick={(v) => { setClock24(v === "24"); setH24(v === "24"); }}
                       options={[{ v: "12", label: "12h" }, { v: "24", label: "24h" }]} />
+                    {/* GPU (WebGL) is faster on heavy output, but on some Linux
+                        GPU/compositor stacks it can leave the terminal blank
+                        white — so Auto uses it everywhere except Linux, where it
+                        picks Compatibility. Switch to Compatibility by hand if a
+                        shell ever goes blank; it applies to newly opened shells. */}
+                    <Choice<RendererPref>
+                      label="Terminal renderer"
+                      hint="GPU is faster; Compatibility is the safe choice if the terminal ever goes blank. Applies to newly opened shells."
+                      value={renderer}
+                      onPick={(v) => { setRenderer(v); setRendererPref(v); }}
+                      options={[
+                        { v: "auto", label: "Auto" },
+                        { v: "gpu", label: "GPU" },
+                        { v: "dom", label: "Compatibility" },
+                      ]} />
                     <Choice<SysNotifyMode>
                       label="Desktop notifications on the notch"
                       hint="Slack and the rest, mirrored onto the strip you can still see in fullscreen"

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -16,6 +16,7 @@ import type { GitRepoRef, TerminalCommands, TmuxWindow } from "../../../shared/t
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
 import { CommandBar, loadCommands } from "./CommandBar.tsx";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
+import { wantsWebgl, fallBackToDom } from "../lib/termRenderer.ts";
 
 const ROOT_KEY = "agentglass.terminalRoot";
 /** The repo the terminal view last used — what a docked console should open
@@ -75,21 +76,6 @@ function themeFromCss() {
 }
 const TERM_FONT = '"JetBrainsMono Nerd Font Mono", "JetBrainsMono Nerd Font", "JetBrains Mono", "SF Mono", ui-monospace, "Cascadia Code", "Fira Code", Menlo, Monaco, "Roboto Mono", Consolas, "Liberation Mono", monospace';
 
-// GPU renderer gate.
-//
-// The WebGL renderer is fast, but on an unstable driver/compositor the browser
-// can lose its WebGL context — sometimes repeatedly — and each loss flashes the
-// terminal white for a frame before falling back. Once we have seen a single
-// context loss on this machine, stop offering WebGL for the rest of the session
-// and remember it, so every new shell opens straight on the stable DOM renderer
-// and never flashes again. Set localStorage `agentglass.term.webgl` to "off"
-// by hand to force the DOM renderer from the start.
-const WEBGL_KEY = "agentglass.term.webgl";
-let webglBlocked = (() => { try { return localStorage.getItem(WEBGL_KEY) === "off"; } catch { return false; } })();
-function blockWebgl() {
-  webglBlocked = true;
-  try { localStorage.setItem(WEBGL_KEY, "off"); } catch { /* private mode — session flag still holds */ }
-}
 
 // --- persistent per-repo shell sessions (outlive the panel) ------------------
 type SessStatus = "idle" | "connecting" | "live" | "exited" | "error" | "unauthorized";
@@ -405,13 +391,12 @@ function createSession(root: string): Sess {
    * bug report. Neither case is worth a message: the shell keeps running and
    * the user has nothing to decide.
    */
-  if (!webglBlocked) {
+  if (wantsWebgl()) {
     try {
       const gl = new WebglAddon();
-      // A lost context flashes the terminal white before the DOM renderer takes
-      // over. Fall back for this shell AND block WebGL app-wide, so a machine
-      // whose GPU keeps dropping the context stops flashing on every new shell.
-      gl.onContextLoss(() => { blockWebgl(); try { gl.dispose(); } catch { /* already gone */ } });
+      // A lost context can leave the terminal blank-white with no repaint. Drop
+      // to the DOM renderer app-wide and remember it, so no new shell hits it.
+      gl.onContextLoss(() => { fallBackToDom(); try { gl.dispose(); } catch { /* already gone */ } });
       term.loadAddon(gl);
     } catch { /* no WebGL2 here — the DOM renderer stays */ }
   }

--- a/web/src/lib/termRenderer.ts
+++ b/web/src/lib/termRenderer.ts
@@ -1,0 +1,58 @@
+// Terminal renderer preference.
+//
+// xterm's WebGL renderer is fast, but on some Linux GPU/compositor stacks it
+// paints the terminal solid white — a lost or wedged GL context with no error
+// we can catch — and stays that way, worst of all exactly when an agent pauses
+// for input so nothing ever repaints over it. The DOM renderer is a touch
+// slower on a huge output flood but never does this. So the default is by
+// platform: WebGL where it is reliable (macOS/Windows), DOM on Linux. Either
+// way it is overridable from Settings.
+//
+// localStorage `agentglass.term.webgl`:
+//   "gpu"        force WebGL
+//   "dom"/"off"  force the DOM renderer ("off" kept for back-compat, and it is
+//                what a context loss writes to remember the fallback)
+//   "auto"/unset the platform default below
+export const RENDERER_KEY = "agentglass.term.webgl";
+export type RendererPref = "auto" | "gpu" | "dom";
+
+const isLinux = () => {
+  try { return /\bLinux\b/.test(navigator.userAgent) && !/Android/i.test(navigator.userAgent); }
+  catch { return false; }
+};
+
+/** The stored choice, normalised (legacy "off" reads as "dom"). */
+export function rendererPref(): RendererPref {
+  try {
+    const v = localStorage.getItem(RENDERER_KEY);
+    if (v === "gpu") return "gpu";
+    if (v === "dom" || v === "off") return "dom";
+    return "auto";
+  } catch { return "auto"; }
+}
+
+/** Persist a choice; "auto" clears the key so the platform default applies. */
+export function setRendererPref(p: RendererPref): void {
+  try {
+    if (p === "auto") localStorage.removeItem(RENDERER_KEY);
+    else localStorage.setItem(RENDERER_KEY, p);
+  } catch { /* private mode — nothing we can do */ }
+}
+
+// A context loss this session drops us to DOM even if localStorage can't be written.
+let sessionForceDom = false;
+
+/** Whether a newly created terminal should load the WebGL renderer. */
+export function wantsWebgl(): boolean {
+  if (sessionForceDom) return false;
+  const p = rendererPref();
+  if (p === "gpu") return true;
+  if (p === "dom") return false;
+  return !isLinux(); // auto: GPU off on Linux by default, where the white-out lives
+}
+
+/** A lost context left the terminal blank — fall back to DOM for good. */
+export function fallBackToDom(): void {
+  sessionForceDom = true;
+  try { localStorage.setItem(RENDERER_KEY, "dom"); } catch { /* session flag still holds */ }
+}

--- a/web/test/term-renderer.test.ts
+++ b/web/test/term-renderer.test.ts
@@ -1,0 +1,60 @@
+// The renderer choice: WebGL is fast but blanks the terminal white on some
+// Linux GPU/compositor stacks, so "auto" defaults to DOM on Linux and WebGL
+// elsewhere, and an explicit choice always wins. These pin that decision table
+// down by faking navigator.userAgent and localStorage.
+import { test, expect, beforeEach } from "bun:test";
+
+let store: Record<string, string> = {};
+function mockEnv(userAgent: string) {
+  Object.defineProperty(globalThis, "navigator", { value: { userAgent }, configurable: true });
+  Object.defineProperty(globalThis, "localStorage", {
+    configurable: true,
+    value: {
+      getItem: (k: string) => (k in store ? store[k] : null),
+      setItem: (k: string, v: string) => { store[k] = v; },
+      removeItem: (k: string) => { delete store[k]; },
+    },
+  });
+}
+
+import { rendererPref, setRendererPref, wantsWebgl, RENDERER_KEY } from "../src/lib/termRenderer.ts";
+
+const LINUX = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120 Electron";
+const MAC = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15) AppleWebKit/537.36 Chrome/120";
+const WIN = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120";
+
+beforeEach(() => { store = {}; });
+
+test("auto defaults to the DOM renderer on Linux (where the white-out lives)", () => {
+  mockEnv(LINUX);
+  expect(wantsWebgl()).toBe(false);
+});
+
+test("auto keeps WebGL on macOS and Windows", () => {
+  mockEnv(MAC); expect(wantsWebgl()).toBe(true);
+  mockEnv(WIN); expect(wantsWebgl()).toBe(true);
+});
+
+test("an explicit GPU choice forces WebGL, even on Linux", () => {
+  mockEnv(LINUX); setRendererPref("gpu");
+  expect(wantsWebgl()).toBe(true);
+});
+
+test("an explicit Compatibility choice forces DOM, even on macOS", () => {
+  mockEnv(MAC); setRendererPref("dom");
+  expect(wantsWebgl()).toBe(false);
+});
+
+test("the legacy \"off\" value still reads as the DOM renderer", () => {
+  mockEnv(MAC); store[RENDERER_KEY] = "off";
+  expect(rendererPref()).toBe("dom");
+  expect(wantsWebgl()).toBe(false);
+});
+
+test("choosing Auto clears the key so the platform default applies again", () => {
+  mockEnv(MAC); setRendererPref("dom");
+  expect(rendererPref()).toBe("dom");
+  setRendererPref("auto");
+  expect(rendererPref()).toBe("auto");
+  expect(wantsWebgl()).toBe(true); // back to the macOS default
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the terminal (console) going **solid blank-white and staying that way** on Linux — unreadable, and it struck worst exactly when an agent in the shell paused for input (an approval prompt), so nothing ever repainted over the blanked screen.

**Root cause (confirmed on a live setup, not guessed):** xterm's WebGL renderer leaves the terminal blank-white on some Linux GPU/compositor stacks — a lost or wedged GL context with no error we can catch. Forcing the DOM renderer (`localStorage agentglass.term.webgl=off`) made it stop; the failure does **not** reproduce under software WebGL (tried narrow and wide 240x45 in headless SwiftShader, terminal stayed dark), so it is GPU/compositor specific, not a logic bug. The earlier context-loss guard (#269) never helps here because there is no context-loss *event* to hook.

**Change:** pick the renderer by platform — WebGL where it is reliable (macOS/Windows), DOM on Linux — and make it overridable.
- New `web/src/lib/termRenderer.ts` centralises the decision (`wantsWebgl()`, `rendererPref()`, `setRendererPref()`, `fallBackToDom()`).
- `TerminalPanel` uses `wantsWebgl()` when creating a shell; a context loss still drops to DOM for good.
- New **Settings → Preferences → "Terminal renderer"** control: Auto / GPU / Compatibility (applies to newly opened shells).
- Back-compat preserved: the legacy `"off"` value and the context-loss fallback both still force DOM.

No change on macOS/Windows (still WebGL). Linux users who want GPU back can pick **GPU** in Settings.

## How was it tested?

- New decision-table unit test `web/test/term-renderer.test.ts` (6 cases): auto→DOM on Linux, auto→WebGL on macOS/Windows, explicit GPU/Compatibility overrides, legacy `"off"`→DOM, and `auto` clearing the key. All pass.
- Full web suite: **240 pass / 0 fail**.
- `bun run build` (typecheck + bundle) passes (only the pre-existing chunk-size warning).
- Live confirmation on the affected machine: forcing the DOM renderer stopped the white-out; this PR makes that the Linux default.
