### PR TITLE
fix(stats): stop the /stats timeline dropping the newest events (#248)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1121,6 +1121,13 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
   const bucketCount = 60;
   const bucketMs = Math.max(1000, Math.floor(windowMs / bucketCount));
   const start = Math.floor(since / bucketMs) * bucketMs;
+  // The buckets are aligned DOWN from `since`, so they span [start, start +
+  // 60*bucketMs), whose upper edge is <= now — the most recent up-to-one-bucket
+  // of events (an event at `now` always) fell past the last bucket and vanished
+  // from the chart while still counting in the totals. Fold anything at or past
+  // the last bucket into it, so every event in the window lands somewhere and
+  // sum(bucket events) == totals.events.
+  const lastKey = start + (bucketCount - 1) * bucketMs;
   const buckets = new Map<number, TimeBucket>();
   for (let i = 0; i < bucketCount; i++) {
     const t = start + i * bucketMs;
@@ -1133,7 +1140,7 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
     .all(...A);
   const heatmap = new Array(168).fill(0);
   for (const r of tlRows) {
-    const t = Math.floor(r.timestamp / bucketMs) * bucketMs;
+    const t = Math.min(lastKey, Math.floor(r.timestamp / bucketMs) * bucketMs);
     const b = buckets.get(t);
     if (b) {
       b.events++;

--- a/server/test/timeline-tail.test.ts
+++ b/server/test/timeline-tail.test.ts
@@ -1,0 +1,56 @@
+// Every event counted in the window must appear in exactly one timeline bucket
+// — sum(bucket events) == totals.events (#248). The 60 buckets are aligned down
+// from `since` (start = floor(since/bucketMs)*bucketMs <= since), so they end at
+// start + 60*bucketMs, which is <= now: the most recent up-to-(windowMs/60) of
+// events fell into no bucket and vanished from the chart while still counting in
+// the totals. An event at exactly `now` is always outside the aligned buckets,
+// so it is the sharp case.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-timeline-"));
+const PROJ = join(dir, "proj");
+mkdirSync(PROJ, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "timeline.db");
+process.env.AGENTGLASS_ROOT = PROJ; // scope to this test's project so counts are exact under bun's shared DB
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const now = Date.now();
+const event = (session: string, tsBack: number) => ({
+  source_app: "app",
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 20, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "",
+  timestamp: now - tsBack,
+  payload: { project_path: PROJ },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  db.insertEvent(event("s-newest", 0) as any); // at ~now — the dropped case
+  db.insertEvent(event("s-mid", 30 * 60_000) as any); // mid-window
+  db.insertEvent(event("s-old", 59 * 60_000) as any); // near the window start
+});
+
+describe("the timeline accounts for every event in the window", () => {
+  test("sum of bucket events equals totals.events (nothing falls off the newest edge)", () => {
+    const s = db.statsSummary(60 * 60_000) as any; // 1h window
+    const tlSum = s.timeline.reduce((n: number, b: any) => n + b.events, 0);
+    expect(s.totals.events).toBe(3);
+    expect(tlSum).toBe(s.totals.events); // fails on pre-fix code: the ~now event has no bucket
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The `/stats` timeline's 60 buckets are aligned down from `since` (`start = floor(since/bucketMs)*bucketMs ≤ since`), so they span `[start, start + 60*bucketMs)`, whose upper edge is `≤ now`. Any event past that edge — the most recent up-to-one-bucket of activity, and an event at exactly `now` **always** — got `buckets.get(key) === undefined` and was silently skipped: it vanished from the chart while still counting in `totals`. On a 24h window that's up to the last ~24 minutes of activity missing from the final bar, which reads as "the fleet went quiet" when it didn't.

Fix: fold anything at or past the last bucket into it (clamp the bucket key), so every event in the window lands somewhere and the invariant holds — **sum(bucket events) == totals.events**. Buckets stay aligned and the same 60; only the last one gains the newest sliver it should always have had.

Part of #248 (data-reliability audit).

## How was it tested? (change-existing-behaviour protocol)

- **Characterised first**: new `server/test/timeline-tail.test.ts` seeds an event at `now` and asserts `sum(timeline events) == totals.events`. It **fails on the pre-fix code** (timeline 2 vs totals 3) — verified before fixing. Scoped to a private project so the count is exact under bun's shared-DB test run.
- **Blast radius / diff**: only the timeline's last bucket changes (gains the folded newest events — the fix). `totals`, `by_model`/`by_app`/`by_type`, `tool_latency`, and the `heatmap` (which reads the raw timestamp, not the bucket key) are untouched. The 60-bucket shape and alignment are unchanged, so the web charts (`MissionTimeline`/`Throughput`) need no change.
- `server`: `tsc` clean, `bun test` 556 pass / 0 fail. `web`: `tsc` clean, `vite build` clean. `smoke` clean. `perfbudget` p99 1ms (one `Math.min` per row).

🤖 Generated with [Claude Code](https://claude.com/claude-code)