### PR TITLE
test(data): guard providerOf server/web parity; fix a stale totals comment (#248)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1013,10 +1013,14 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
   const pf = prov + sc;
   const A = [since, ...pa, ...sa]; // bind order: timestamp, provider (if any), project (if any)
 
-  // Totals come from the authoritative sessions table for cost/tokens,
-  // and from events for counts/errors within the window.
-  // One pass, not two: both sets of totals cover exactly the same rows, and
-  // over a wide window each separate pass is a full scan of the table.
+  // Every total here is from events within the window — cost and tokens
+  // included — because /stats is a windowed view (last 15m / 1h / …), not a
+  // lifetime one: cost_usd summed over the window's events is the spend in that
+  // window, which is what the dashboard asks for. (The sessions table holds the
+  // authoritative lifetime totals; those are what getSessions serves per row,
+  // not what a window summary wants.) One pass, not several: counts, errors,
+  // sessions, tokens and cost all cover exactly these rows, and over a wide
+  // window each separate pass would be another full scan.
   const totals = db
     .query<any, any[]>(
       `SELECT COUNT(*) AS events,

--- a/server/test/provider-parity.test.ts
+++ b/server/test/provider-parity.test.ts
@@ -1,0 +1,51 @@
+// providerOf is derived TWICE — server-side in db.ts (which decides scope
+// buckets and the sessions.provider column) and client-side in web/format.ts
+// (which decides the Fleet badge and the filter dropdown). Their comments say
+// "kept in sync", but nothing enforced it: adding a model rule to one copy and
+// forgetting the other would bucket the same model under two different providers
+// in two panels — the #246 class of inconsistency. This pins the two together.
+//
+// The only intended difference is the miss value — the server returns null (the
+// column is NULL), the web returns "unknown" (the label). #246 depends on that
+// exact correspondence (the web's "unknown" round-trips to the server's NULL
+// bucket), so it is normalised here rather than treated as a divergence.
+import { beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+process.env.AGENTGLASS_DB = join(mkdtempSync(join(tmpdir(), "agx-prov-")), "p.db");
+
+let serverProviderOf: (m: string | null | undefined) => string | null;
+let webProviderOf: (m: string | null | undefined) => string;
+
+beforeAll(async () => {
+  serverProviderOf = (await import("../src/db.ts")).providerOf;
+  webProviderOf = (await import("../../web/src/lib/format.ts")).providerOf;
+});
+
+// One real id per branch of the mapping, plus the ones that must fall through.
+const MODELS = [
+  "claude-opus-4-8", "claude-sonnet-5", "claude-3-5-haiku", "claude-fable-5", "anthropic.claude-v2",
+  "gpt-4o", "gpt-4.1", "o1-preview", "o3-mini", "o4-mini", "davinci-002", "openai/gpt-5",
+  "gemini-2.5-pro", "models/gemini-1.5-flash", "text-bison", "palm-2", "vertex_ai/gemini",
+  "deepseek-chat", "grok-2", "xai/grok", "mistral-large", "mixtral-8x7b", "codestral",
+  "llama-3.1-70b", "meta-llama/Llama-3", "command-r-plus", "cohere.command",
+  // fall-through cases — must be the miss bucket on both sides
+  "some-unknown-model", "qwen-2.5", "", "   ", "MODEL-WITH-NO-MATCH",
+];
+
+const norm = (v: string | null): string => v ?? "unknown"; // server NULL === web "unknown"
+
+describe("providerOf agrees between the server and the web copy", () => {
+  for (const m of MODELS) {
+    test(`"${m}" buckets the same on both sides`, () => {
+      expect(norm(serverProviderOf(m))).toBe(webProviderOf(m));
+    });
+  }
+
+  test("null / undefined agree (the miss bucket)", () => {
+    expect(norm(serverProviderOf(null))).toBe(webProviderOf(null));
+    expect(norm(serverProviderOf(undefined))).toBe(webProviderOf(undefined));
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Two behaviour-neutral follow-ups from the deep data audit (#248).

1. **`providerOf` parity guard.** `providerOf` is derived twice — server-side in `db.ts` (scope buckets, the `sessions.provider` column) and client-side in `web/format.ts` (the Fleet badge, the filter dropdown). Their comments say "kept in sync", but nothing enforced it: adding a model rule to one copy and forgetting the other would bucket the same model under two different providers in two panels — the #246 class of inconsistency. A new server test (`provider-parity.test.ts`) pins them together over one id per mapping branch plus the fall-through cases, normalising the one intended difference (server returns `null` for a miss, web returns `"unknown"` — #246 depends on that exact correspondence). They're currently in sync; the test keeps them that way.

2. **Stale comment fix** in `statsSummary`: it claimed cost/tokens totals come "from the authoritative sessions table", but the code sums them from `events` within the window — which is **correct** for a windowed `/stats` view (spend *in the window*, not lifetime). The comment would have led someone to "fix" it toward the sessions table and quietly break the window. Comment only, no code change.

## How was it tested?

Per protocol step 0 this is behaviour-neutral (a new guard + a comment), so tests + typecheck suffice:
- New parity test: 33 pass. `server`: `bunx tsc --noEmit` clean, `bun test` 589 pass / 0 fail.
- No web change (`format.ts` untouched); the test imports it read-only, and it's pure (no browser deps).

🤖 Generated with [Claude Code](https://claude.com/claude-code)