### PR TITLE
fix(desktop): CPU-composite the final frame on Linux to stop the white-out

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -1,9 +1,11 @@
 // agentglass Electron shell.
 //
-// Runs the EXACT web UI (web/dist) in Chromium, which GPU-composites on Linux
-// where the previous WebKitGTK-based shell fell back to software — the live
-// radar and streaming dashboard paint on the GPU instead of pinning a CPU core.
-// Same pixels as the web app.
+// Runs the EXACT web UI (web/dist) in Chromium. GPU raster and WebGL keep the
+// live radar and streaming dashboard off the CPU, where the previous
+// WebKitGTK-based shell fell back to software. On Linux the *final* frame is
+// CPU-composited (see disable-gpu-compositing below) to dodge a Wayland/GPU
+// white-out, but the accelerated painting still runs on the GPU. Same pixels
+// as the web app.
 //
 // It serves web/dist from the app's own `agentglass://` scheme and brings the
 // Bun server up with it unless one is already running.
@@ -28,6 +30,20 @@ const os = require("os");
 // GPU compositing on Wayland.
 app.commandLine.appendSwitch("ozone-platform-hint", "auto");
 app.commandLine.appendSwitch("enable-features", "UseOzonePlatform");
+
+// Software-composite the final frame on Linux.
+//
+// On some Linux GPU/compositor stacks Chromium's GPU compositor hands the
+// window stale or empty tiles — the whole UI reads as solid white until a
+// repaint (switching theme) forces the tiles to redraw. Compositing the final
+// frame on the CPU sidesteps it; GPU raster and WebGL still run, so charts and
+// the radar keep their acceleration and only the last composite is on the CPU.
+// The window being unreadable beats a hair of compositor latency. Linux only,
+// and AGENTGLASS_GPU=1 opts back into full GPU compositing for a machine whose
+// stack is fine.
+if (process.platform === "linux" && !process.env.AGENTGLASS_GPU) {
+  app.commandLine.appendSwitch("disable-gpu-compositing");
+}
 
 // One instance, one window.
 //


### PR DESCRIPTION
## What does this PR do?

Fixes the desktop app showing a **solid-white window** on Linux — the whole UI blank-white, readable only after forcing a repaint (e.g. switching theme in the picker).

**Root cause (confirmed live, not guessed):** on some Linux GPU/compositor stacks (here: Wayland) Chromium's **GPU compositor** hands the window stale or empty tiles, so the composited frame is white even though the page renders correctly (a CDP screenshot of the renderer showed the correct themed UI while the on-screen window was white). Launching with `--disable-gpu-compositing` fixed it on the affected machine.

This is **not** the terminal WebGL white-out (`#280`) — that was xterm only; this is the window compositor blanking the entire UI. Different layer, different fix.

**Change:** on **Linux only**, append `--disable-gpu-compositing` so the *final* frame is composited on the CPU. GPU raster and WebGL still run, so charts and the live radar keep their acceleration; only the last composite moves to the CPU. `AGENTGLASS_GPU=1` opts back into full GPU compositing for machines whose stack is fine. macOS/Windows are untouched.

## How was it tested?

- Reproduced and fixed live on the affected Wayland machine: with default GPU compositing the window was solid white (content correct under CDP); relaunching with `--disable-gpu-compositing` rendered the dashboard correctly, and the lighter `--disable-gpu-compositing` was confirmed sufficient (no need for full `--disable-gpu`).
- `node --check electron/main.js` passes; the switch is appended at module top level, before `app` is ready (required for command-line switches) and behind a `process.platform === "linux"` guard with an `AGENTGLASS_GPU` escape hatch.
- No renderer/web changes, so the web build and test suite are unaffected.
