### PR TITLE
feat(desktop): ship the Claude Code hooks and wire them from Settings (#187)

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -26,7 +26,8 @@
     "files": ["main.js", "preload.js", "icons/**"],
     "extraResources": [
       { "from": "../web/dist", "to": "web" },
-      { "from": "staging", "to": "." }
+      { "from": "staging", "to": "." },
+      { "from": "../hooks", "to": "hooks", "filter": ["**/*", "!__pycache__", "!__pycache__/**", "!*.pyc"] }
     ],
     "publish": [
       { "provider": "github", "owner": "SirAllap", "repo": "agentglass" }

--- a/server/src/hooksetup.ts
+++ b/server/src/hooksetup.ts
@@ -1,0 +1,221 @@
+// Install the agentglass event forwarder into Claude Code's settings from
+// inside the app, so someone who installed the binary (README's advised path
+// since #186) can turn on live streaming and PreToolUse gating without cloning
+// the repo to run a Python script (#187).
+//
+// This is a faithful TypeScript port of hooks/install_hooks.py's merge, kept
+// deliberately in lockstep with it: same nine events, same marker, same
+// idempotent "strip our old entries, re-append" so a moved install re-points
+// cleanly and nobody else's hooks are touched, same backup-before-write. The
+// port exists so the *install* step (writing settings.json) needs no Python —
+// the forwarder it wires still runs under python3, which is a separate runtime
+// concern the UI names.
+import { copyFileSync, existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import type { HookSetupStatus, HookSetupResult } from "../../shared/types.ts";
+
+// event -> [matcher | null, attach transcript for token/cost]. Mirrors
+// install_hooks.py:EVENTS exactly; drift here would let a PR read one way in the
+// packaged installer and another from `bun run setup`.
+const EVENTS: ReadonlyArray<readonly [string, string | null, boolean]> = [
+  ["SessionStart", null, false],
+  ["UserPromptSubmit", null, false],
+  ["PreToolUse", "*", false],
+  ["PostToolUse", "*", false],
+  ["Notification", null, false],
+  ["SubagentStop", null, true],
+  ["Stop", null, true],
+  ["PreCompact", null, false],
+  ["SessionEnd", null, true],
+];
+
+// The substring that identifies a hook command as ours. Same as the Python
+// installer's MARKER, so the two agree on what to strip and what "installed"
+// means — the app can uninstall hooks `bun run setup` wrote and vice versa.
+const MARKER = "send_event.py";
+
+export type { HookSetupStatus, HookSetupResult };
+
+// Resolve the home dir the way Python's expanduser and Claude Code itself do:
+// $HOME (or %USERPROFILE% on Windows) wins over the passwd entry. os.homedir()
+// alone reads getpwuid and ignores $HOME, so under a custom HOME the sidecar
+// would write settings.json where Claude Code will never read it.
+function home(): string {
+  const env = process.platform === "win32" ? process.env.USERPROFILE : process.env.HOME;
+  return env && env.length ? env : homedir();
+}
+
+function settingsPath(): string {
+  return join(home(), ".claude", "settings.json");
+}
+
+/**
+ * The shipped `hooks/` directory, or null if this build does not carry it.
+ *
+ * Packaged: beside the sidecar binary (extraResources drops `hooks/` into the
+ * resources root, next to `agentglass-server`), found via
+ * `dirname(process.execPath)` — the same way selfupdate.ts finds build-info.json
+ * and self-update.sh. Dev/checkout: the repo's own hooks/, relative to this
+ * source file, with cwd as a last resort. Presence is proven by send_event.py,
+ * the one file the install actually references.
+ */
+export function hooksDir(): string | null {
+  const candidates = [
+    join(dirname(process.execPath), "hooks"),
+    resolve(import.meta.dir, "../../hooks"),
+    resolve(process.cwd(), "hooks"),
+  ];
+  for (const d of candidates) {
+    if (existsSync(join(d, "send_event.py"))) return d;
+  }
+  return null;
+}
+
+// Interpreter written into the hook command. Mirrors install_hooks.py's
+// _hook_python: python3 everywhere but Windows, where python3 is usually absent
+// and `py`/`python` is what exists. sys.executable is deliberately not used —
+// a venv deleted later would break every hook.
+function hookPython(): string {
+  if (process.platform !== "win32") return "python3";
+  for (const cand of ["py", "python"]) {
+    if (onPath(cand)) return cand;
+  }
+  return "py";
+}
+
+function onPath(cmd: string): boolean {
+  const dirs = (process.env.PATH ?? "").split(process.platform === "win32" ? ";" : ":");
+  const exts = process.platform === "win32" ? [".exe", ".cmd", ".bat", ""] : [""];
+  for (const d of dirs) {
+    if (!d) continue;
+    for (const ext of exts) {
+      if (existsSync(join(d, cmd + ext))) return true;
+    }
+  }
+  return false;
+}
+
+function isOurs(entry: unknown): boolean {
+  const hooks = (entry as { hooks?: unknown })?.hooks;
+  return Array.isArray(hooks) && hooks.some((h) => typeof (h as { command?: unknown })?.command === "string" && (h as { command: string }).command.includes(MARKER));
+}
+
+function asArray(v: unknown): any[] {
+  return Array.isArray(v) ? v : [];
+}
+
+// Append our forwarder to each event after stripping any prior agentglass entry
+// (so a moved install re-points cleanly). Every other hook is preserved.
+function doInstall(cfg: any, sendEvent: string, python: string): void {
+  const hooks = (cfg.hooks ??= {});
+  for (const [event, matcher, addChat] of EVENTS) {
+    const arr = asArray(hooks[event]).filter((e) => !isOurs(e));
+    // Quote the script path unconditionally: a clone under a spaced path breaks
+    // the hook command on every platform, not only Windows.
+    let cmd = `${python} "${sendEvent}" --event-type ${event}`;
+    if (addChat) cmd += " --add-chat";
+    const entry: any = { hooks: [{ type: "command", command: cmd }] };
+    if (matcher !== null) entry.matcher = matcher;
+    arr.push(entry);
+    hooks[event] = arr;
+  }
+}
+
+// Drop only our entries; leave everyone else's hooks untouched, and remove a
+// now-empty event / an empty hooks object so uninstall is a clean reversal.
+function doUninstall(cfg: any): void {
+  const hooks = cfg.hooks;
+  if (!hooks || typeof hooks !== "object") return;
+  for (const event of Object.keys(hooks)) {
+    const kept = asArray(hooks[event]).filter((e) => !isOurs(e));
+    if (kept.length) hooks[event] = kept;
+    else delete hooks[event];
+  }
+  if (cfg.hooks && Object.keys(cfg.hooks).length === 0) delete cfg.hooks;
+}
+
+// Sorted-key stringify for change detection, matching the Python installer's
+// json.dumps(sort_keys=True): a rewrite happens only on a real change, never
+// because two runs serialised the same object in a different key order. Array
+// order is preserved (our entries are always appended last, so re-running is a
+// no-op).
+function stable(v: any): string {
+  return JSON.stringify(v, (_k, val) => {
+    if (val && typeof val === "object" && !Array.isArray(val)) {
+      return Object.fromEntries(Object.keys(val).sort().map((k) => [k, val[k]]));
+    }
+    return val;
+  });
+}
+
+function stamp(): string {
+  const d = new Date();
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${d.getFullYear()}${p(d.getMonth() + 1)}${p(d.getDate())}-${p(d.getHours())}${p(d.getMinutes())}${p(d.getSeconds())}`;
+}
+
+function readCfg(path: string): { cfg: any } | { error: string } {
+  if (!existsSync(path)) return { cfg: {} };
+  let raw: string;
+  try {
+    raw = readFileSync(path, "utf8").trim();
+  } catch (e: any) {
+    return { error: `could not read ${path}: ${String(e?.message ?? e)}` };
+  }
+  if (!raw) return { cfg: {} };
+  try {
+    return { cfg: JSON.parse(raw) };
+  } catch {
+    // Same stance as the Python installer: never touch a settings.json we
+    // cannot parse. Overwriting it would eat hooks we do not understand.
+    return { error: `${path} is not valid JSON; leaving it untouched. Fix it and try again.` };
+  }
+}
+
+export function hookStatus(): HookSetupStatus {
+  const path = settingsPath();
+  const r = readCfg(path);
+  let installed = false;
+  if ("cfg" in r) {
+    const hooks = (r.cfg?.hooks ?? {}) as Record<string, unknown>;
+    installed = Object.values(hooks).some((arr) => asArray(arr).some(isOurs));
+  }
+  return { installed, bundled: hooksDir() !== null, settingsPath: path, python: hookPython() };
+}
+
+export function applyHooks(action: "install" | "uninstall"): HookSetupResult {
+  const path = settingsPath();
+  const dir = hooksDir();
+  if (action === "install" && !dir) {
+    return { ok: false, installed: false, changed: false, settingsPath: path, error: "the hook scripts are not bundled with this build" };
+  }
+
+  const r = readCfg(path);
+  if ("error" in r) return { ok: false, installed: false, changed: false, settingsPath: path, error: r.error };
+  const cfg = r.cfg;
+
+  const before = stable(cfg);
+  if (action === "install") doInstall(cfg, join(dir!, "send_event.py"), hookPython());
+  else doUninstall(cfg);
+  const changed = stable(cfg) !== before;
+
+  const installed = action === "install";
+  if (!changed) return { ok: true, installed, changed: false, settingsPath: path };
+
+  let backup: string | undefined;
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    if (existsSync(path)) {
+      backup = `${path}.bak.agentglass.${stamp()}`;
+      copyFileSync(path, backup);
+    }
+    writeFileSync(path, JSON.stringify(cfg, null, 2) + "\n");
+  } catch (e: any) {
+    return { ok: false, installed: false, changed: false, settingsPath: path, error: String(e?.message ?? e) };
+  }
+  return { ok: true, installed, changed: true, backup, settingsPath: path };
+}
+
+// Exported for the test that pins parity with the Python installer's merge.
+export const _internal = { doInstall, doUninstall, isOurs, stable, EVENTS, MARKER };

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -60,6 +60,7 @@ import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERM
 import { chatStream, CHAT_ENABLED, CHAT_BYPASS_ALLOWED } from "./chat.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, inScope, CONFIG_PATH } from "./config.ts";
+import { hookStatus, applyHooks } from "./hooksetup.ts";
 import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { updateStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
@@ -627,6 +628,16 @@ const server = Bun.serve<WsData>({
       if (res.ok) await resyncScope();
       return json(res, res.ok ? 200 : 400);
     }
+    // Claude Code hook wiring (#187): a packaged install can turn on live
+    // streaming + gating from Settings instead of cloning the repo to run a
+    // Python script. GET reports state; POST writes ~/.claude/settings.json with
+    // the same idempotent, backup-first merge the CLI installer uses.
+    if (pathname === "/hooks/status") return json(hookStatus());
+    if ((pathname === "/hooks/install" || pathname === "/hooks/uninstall") && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      return json(applyHooks(pathname === "/hooks/install" ? "install" : "uninstall"));
+    }
+
     if (pathname === "/insights") return json({ insights: getInsights() });
     if (pathname === "/usage") return json(await getUsage()); // Anthropic plan-limit windows (only meaningful for Claude)
 

--- a/server/test/hooksetup.test.ts
+++ b/server/test/hooksetup.test.ts
@@ -1,0 +1,219 @@
+// The server-side hook installer (#187). It writes ~/.claude/settings.json so a
+// packaged install can turn on streaming + gating from a button, and it is a
+// port of hooks/install_hooks.py — so the property that matters most is that the
+// two AGREE: either can undo the other, and neither disturbs a third party's
+// hooks. Every case here is one a real settings.json can be in.
+import { describe, expect, test, beforeEach } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, readdirSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+import { applyHooks, hookStatus, hooksDir, _internal } from "../src/hooksetup.ts";
+
+const { doInstall, doUninstall, isOurs, EVENTS, MARKER } = _internal;
+
+// Each test gets its own HOME so applyHooks/hookStatus (which resolve
+// ~/.claude via os.homedir()) touch a throwaway tree, never the real one.
+// hooksetup reads homedir() at call time, not import time, so setting it here
+// is enough — no module cache to fight.
+let HOME = "";
+function settingsFile() { return join(HOME, ".claude", "settings.json"); }
+function writeSettings(obj: unknown) {
+  mkdirSync(join(HOME, ".claude"), { recursive: true });
+  writeFileSync(settingsFile(), JSON.stringify(obj, null, 2));
+}
+function readSettings(): any {
+  return JSON.parse(readFileSync(settingsFile(), "utf8"));
+}
+
+beforeEach(() => {
+  HOME = mkdtempSync(join(tmpdir(), "agx-hooks-"));
+  process.env.HOME = HOME;
+  delete process.env.USERPROFILE; // homedir() prefers this on some platforms
+});
+
+describe("merge logic (pure, no disk)", () => {
+  test("install wires all nine events, with the right matchers and --add-chat", () => {
+    const cfg: any = {};
+    doInstall(cfg, "/x/hooks/send_event.py", "python3");
+    // exactly the nine events, no more
+    expect(Object.keys(cfg.hooks).sort()).toEqual([...EVENTS.map((e) => e[0])].sort());
+    // PreToolUse/PostToolUse carry the "*" matcher; the rest carry none
+    expect(cfg.hooks.PreToolUse[0].matcher).toBe("*");
+    expect(cfg.hooks.SessionStart[0].matcher).toBeUndefined();
+    // --add-chat only on the three transcript-bearing events
+    const cmd = (ev: string) => cfg.hooks[ev][0].hooks[0].command;
+    expect(cmd("Stop")).toContain("--add-chat");
+    expect(cmd("SubagentStop")).toContain("--add-chat");
+    expect(cmd("SessionEnd")).toContain("--add-chat");
+    expect(cmd("SessionStart")).not.toContain("--add-chat");
+    // the script path is quoted (spaced paths break the command otherwise)
+    expect(cmd("Stop")).toContain('"/x/hooks/send_event.py"');
+  });
+
+  test("a third party's hooks in the same events are preserved", () => {
+    const guard = { matcher: "Bash", hooks: [{ type: "command", command: "my-guard.sh" }] };
+    const cfg: any = { hooks: { PreToolUse: [guard], Stop: [{ hooks: [{ type: "command", command: "someone-else" }] }] } };
+    doInstall(cfg, "/x/hooks/send_event.py", "python3");
+    // theirs is still there, and ours was appended after it
+    expect(cfg.hooks.PreToolUse[0]).toEqual(guard);
+    expect(isOurs(cfg.hooks.PreToolUse[1])).toBe(true);
+    expect(cfg.hooks.PreToolUse).toHaveLength(2);
+  });
+
+  test("re-installing re-points our entry in place instead of duplicating it", () => {
+    const cfg: any = {};
+    doInstall(cfg, "/old/hooks/send_event.py", "python3");
+    doInstall(cfg, "/new/hooks/send_event.py", "python3");
+    const ours = cfg.hooks.Stop.filter(isOurs);
+    expect(ours).toHaveLength(1); // not two
+    expect(ours[0].hooks[0].command).toContain("/new/hooks/send_event.py");
+    expect(ours[0].hooks[0].command).not.toContain("/old/");
+  });
+
+  test("uninstall removes only ours, keeps foreign, and prunes empty containers", () => {
+    const guard = { matcher: "Bash", hooks: [{ type: "command", command: "my-guard.sh" }] };
+    const cfg: any = { otherTopLevel: 1, hooks: {} };
+    cfg.hooks.PreToolUse = [guard];
+    doInstall(cfg, "/x/hooks/send_event.py", "python3");
+    doUninstall(cfg);
+    // foreign guard survives; the events that were ONLY ours are gone
+    expect(cfg.hooks.PreToolUse).toEqual([guard]);
+    expect(cfg.hooks.Stop).toBeUndefined();
+    // unrelated top-level keys are never touched
+    expect(cfg.otherTopLevel).toBe(1);
+  });
+
+  test("uninstall drops the whole hooks object when nothing else is left in it", () => {
+    const cfg: any = { theme: "dark" };
+    doInstall(cfg, "/x/hooks/send_event.py", "python3");
+    doUninstall(cfg);
+    expect("hooks" in cfg).toBe(false);
+    expect(cfg.theme).toBe("dark");
+  });
+
+  test("install then uninstall is a clean round-trip back to the original", () => {
+    const original = { hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "guard.sh" }] }] }, permissions: { allow: ["Read"] } };
+    const cfg: any = JSON.parse(JSON.stringify(original));
+    doInstall(cfg, "/x/hooks/send_event.py", "python3");
+    doUninstall(cfg);
+    expect(cfg).toEqual(original);
+  });
+
+  test("isOurs recognises our command by the send_event.py marker, and only that", () => {
+    expect(MARKER).toBe("send_event.py");
+    expect(isOurs({ hooks: [{ command: 'python3 "/a/b/send_event.py" --event-type Stop' }] })).toBe(true);
+    expect(isOurs({ hooks: [{ command: "someone_elses_thing.py" }] })).toBe(false);
+    expect(isOurs({})).toBe(false);
+    expect(isOurs({ hooks: "not-an-array" as any })).toBe(false);
+  });
+});
+
+describe("applyHooks / hookStatus (on disk)", () => {
+  test("install writes the file, reports installed, and status agrees", () => {
+    const r = applyHooks("install");
+    expect(r.ok).toBe(true);
+    expect(r.installed).toBe(true);
+    expect(r.changed).toBe(true);
+    expect(existsSync(settingsFile())).toBe(true);
+    expect(hookStatus().installed).toBe(true);
+  });
+
+  test("no settings file yet: install creates ~/.claude and writes trailing newline, no backup", () => {
+    expect(existsSync(settingsFile())).toBe(false);
+    const r = applyHooks("install");
+    expect(r.backup).toBeUndefined(); // nothing to back up
+    expect(readFileSync(settingsFile(), "utf8").endsWith("}\n")).toBe(true);
+  });
+
+  test("installing twice is idempotent: the second call changes nothing and writes no backup", () => {
+    applyHooks("install");
+    const backupsAfterFirst = readdirSync(join(HOME, ".claude")).filter((f) => f.includes(".bak.agentglass."));
+    const r2 = applyHooks("install");
+    expect(r2.ok).toBe(true);
+    expect(r2.changed).toBe(false);
+    expect(r2.installed).toBe(true);
+    const backupsAfterSecond = readdirSync(join(HOME, ".claude")).filter((f) => f.includes(".bak.agentglass."));
+    expect(backupsAfterSecond).toEqual(backupsAfterFirst); // no new backup for a no-op
+  });
+
+  test("a real change backs up the prior file first", () => {
+    writeSettings({ permissions: { allow: ["Read"] } });
+    const r = applyHooks("install");
+    expect(r.changed).toBe(true);
+    expect(r.backup).toBeDefined();
+    expect(existsSync(r.backup!)).toBe(true);
+    // the backup is the pre-change content, verbatim
+    expect(JSON.parse(readFileSync(r.backup!, "utf8"))).toEqual({ permissions: { allow: ["Read"] } });
+    // and the real file kept the foreign key
+    expect(readSettings().permissions.allow).toEqual(["Read"]);
+  });
+
+  test("uninstall on a file that never had our hooks is a no-op, not an error", () => {
+    writeSettings({ hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "guard.sh" }] }] } });
+    const r = applyHooks("uninstall");
+    expect(r.ok).toBe(true);
+    expect(r.changed).toBe(false);
+    expect(r.installed).toBe(false);
+    // foreign guard untouched
+    expect(readSettings().hooks.PreToolUse[0].hooks[0].command).toBe("guard.sh");
+  });
+
+  test("malformed settings.json is left untouched and reported, never overwritten", () => {
+    mkdirSync(join(HOME, ".claude"), { recursive: true });
+    writeFileSync(settingsFile(), "{ this is not json ");
+    const r = applyHooks("install");
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain("not valid JSON");
+    // the file is exactly as it was — no write, no backup
+    expect(readFileSync(settingsFile(), "utf8")).toBe("{ this is not json ");
+    expect(readdirSync(join(HOME, ".claude")).filter((f) => f.includes(".bak"))).toHaveLength(0);
+  });
+
+  test("empty file is treated as empty config, not a parse error", () => {
+    mkdirSync(join(HOME, ".claude"), { recursive: true });
+    writeFileSync(settingsFile(), "   \n");
+    const r = applyHooks("install");
+    expect(r.ok).toBe(true);
+    expect(r.installed).toBe(true);
+  });
+
+  test("status: bundled is true in a checkout (hooks/ resolves)", () => {
+    // This test runs from the repo, so the dev hooks dir must resolve.
+    expect(hooksDir()).not.toBeNull();
+    expect(hookStatus().bundled).toBe(true);
+  });
+});
+
+// The strongest check: run the real Python installer against the same input and
+// demand a byte-identical settings.json. If the two ever drift, this fails.
+// Skipped only where python3 is genuinely absent (never on CI).
+describe("golden parity with install_hooks.py", () => {
+  const py = spawnSync("python3", ["--version"]);
+  const havePython = py.status === 0;
+  const repoHooks = hooksDir();
+
+  test.if(havePython && !!repoHooks)("TS applyHooks writes what the Python installer writes", () => {
+    const seed = { permissions: { allow: ["Read"] }, hooks: { PreToolUse: [{ matcher: "Bash", hooks: [{ type: "command", command: "guard.sh" }] }] } };
+
+    // TS side: install into this test's HOME.
+    writeSettings(seed);
+    applyHooks("install");
+    const tsOut = readSettings();
+
+    // Python side: a separate project tree, installed via --project so it writes
+    // <proj>/.claude/settings.json using the same repo hooks dir.
+    const proj = mkdtempSync(join(tmpdir(), "agx-pyproj-"));
+    mkdirSync(join(proj, ".claude"), { recursive: true });
+    writeFileSync(join(proj, ".claude", "settings.json"), JSON.stringify(seed, null, 2));
+    const run = spawnSync("python3", [join(repoHooks!, "install_hooks.py"), "--project", proj], { encoding: "utf8" });
+    expect(run.status).toBe(0);
+    const pyOut = JSON.parse(readFileSync(join(proj, ".claude", "settings.json"), "utf8"));
+    rmSync(proj, { recursive: true, force: true });
+
+    // Same structure, same commands, same everything. (Both resolve send_event.py
+    // to the same absolute repo path, so even the command strings match.)
+    expect(tsOut).toEqual(pyOut);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1160,3 +1160,29 @@ export interface PrListResponse {
 }
 
 export interface PrActionResult { ok: boolean; error?: string; detail?: string }
+
+/** State of the Claude Code hook wiring (#187), read from ~/.claude/settings.json. */
+export interface HookSetupStatus {
+  /** Our forwarder is present in settings.json right now. */
+  installed: boolean;
+  /** The hook scripts are shipped with this build (a source checkout, or a
+   *  packaged install that carries hooks/). False = install is unavailable. */
+  bundled: boolean;
+  /** Where the change is written, shown so the user knows what they are editing. */
+  settingsPath: string;
+  /** The interpreter the wired command uses (python3, or py on Windows). The
+   *  hooks run under it; the install itself does not. */
+  python: string;
+}
+
+export interface HookSetupResult {
+  ok: boolean;
+  /** The wiring state after this call. */
+  installed: boolean;
+  /** Whether settings.json actually changed (false = it was already so). */
+  changed: boolean;
+  /** The backup written before the change, when there was one. */
+  backup?: string;
+  settingsPath: string;
+  error?: string;
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -19,7 +19,7 @@ import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESK
 import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRenderer.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
-import type { UpdateStatus, ReleaseNotes } from "../../../shared/types.ts";
+import type { UpdateStatus, ReleaseNotes, HookSetupStatus } from "../../../shared/types.ts";
 import { sysNotifyMode, setSysNotifyMode, notifyCapability, notifyQuiet, setNotifyQuiet, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
 import { clock24, setClock24 } from "../lib/clockPref.ts";
 import { bindings, rebind, resetBindings, subscribeBindings, isCustomised, LABELS, DEFAULTS, type ActionId,
@@ -120,12 +120,13 @@ function Row({ label, hint, kbd, href, download, onClick }: { label: string; hin
     : <button onClick={onClick} className={cls}>{body}</button>;
 }
 
-type Pane = "prefs" | "keys" | "open" | "export" | "about";
+type Pane = "prefs" | "keys" | "open" | "export" | "hooks" | "about";
 const TABS: { id: Pane; label: string }[] = [
   { id: "prefs", label: "Preferences" },
   { id: "keys", label: "Shortcuts" },
   { id: "open", label: "Open" },
   { id: "export", label: "Export" },
+  { id: "hooks", label: "Hooks" },
   { id: "about", label: "About" },
 ];
 
@@ -361,6 +362,99 @@ function AboutPane({ open }: { open: boolean }) {
         notes={notes?.notes ?? ""}
         onClose={() => setWant(null)}
       />
+    </Section>
+  );
+}
+
+/**
+ * Turn Claude Code's event forwarder on or off from inside the app (#187).
+ *
+ * Someone who installed the binary (the README's advised path) can now enable
+ * live streaming and PreToolUse gating without cloning the repo to run a Python
+ * script. The write is server-side, idempotent, and backs up settings.json
+ * first, so this is a safe thing to offer from a button. Two things it has to
+ * say plainly: the hooks load at Claude Code startup, so a running session
+ * won't pick them up, and the forwarder itself runs under python3, which the
+ * install does not check for.
+ */
+function HooksPane({ open }: { open: boolean }) {
+  const [st, setSt] = useState<HookSetupStatus | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  const [note, setNote] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    let live = true;
+    api.hooksStatus()
+      .then((r) => { if (live) setSt(r); })
+      .catch(() => { if (live) setSt(null); });
+    return () => { live = false; };
+  }, [open]);
+
+  const act = async (kind: "install" | "uninstall") => {
+    setBusy(true); setErr(null); setNote(null);
+    const r = await (kind === "install" ? api.hooksInstall() : api.hooksUninstall())
+      .catch(() => ({ ok: false, installed: false, changed: false, settingsPath: "", error: "Could not reach the server" }));
+    setBusy(false);
+    if (!r.ok) { setErr(r.error || "Could not update the hooks"); return; }
+    setSt((s) => (s ? { ...s, installed: r.installed } : s));
+    setNote(
+      !r.changed
+        ? (r.installed ? "Already enabled — nothing to change." : "Already off — nothing to change.")
+        : r.installed
+          ? "Enabled. Start a new Claude Code session for it to take effect."
+          : "Disabled. Existing sessions keep the old hooks until they restart.",
+    );
+  };
+
+  if (!st) return <Section title="Claude Code hooks"><div className="px-3 py-2 text-[11px] t-dim2">Reading hook state…</div></Section>;
+
+  return (
+    <Section title="Claude Code hooks">
+      <div className="px-3 py-2 flex flex-col gap-2.5">
+        <div className="text-[11.5px]" style={{ color: "var(--text2)" }}>
+          Wire agentglass into Claude Code so every session streams here live, and gate approvals (<span className="tabular-nums">PreToolUse</span>) reach the app. Edits <span className="t-mono text-[10.5px]" style={{ color: "var(--text)" }}>{st.settingsPath}</span>, backing it up first, and leaves your other hooks untouched.
+        </div>
+
+        {!st.bundled ? (
+          <div className="text-[11px] px-2.5 py-2 rounded-lg" style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)" }}>
+            This build does not carry the hook scripts, so there is nothing to wire. Install from a Release, or run <span className="t-mono">bun run setup</span> in a checkout.
+          </div>
+        ) : (
+          <>
+            <div className="text-[11px]" style={{ color: st.installed ? "var(--success)" : "var(--text2)" }}>
+              {st.installed ? "Enabled — this Claude Code is streaming to agentglass." : "Not wired yet."}
+            </div>
+            {err && <div className="text-[10.5px]" style={{ color: "var(--error)" }}>{err}</div>}
+            {note && <div className="text-[10.5px]" style={{ color: "var(--text2)" }}>{note}</div>}
+            <div className="flex items-center gap-2">
+              {!st.installed ? (
+                <button onClick={() => act("install")} disabled={busy}
+                  className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
+                  style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 40%, transparent)", opacity: busy ? 0.5 : 1 }}>
+                  {busy ? "Enabling…" : "Enable hooks"}
+                </button>
+              ) : (
+                <button onClick={() => act("uninstall")} disabled={busy}
+                  className="text-[11.5px] px-3 py-1.5 rounded-lg hover:opacity-80"
+                  style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 34%, transparent)", opacity: busy ? 0.5 : 1 }}>
+                  {busy ? "Disabling…" : "Disable hooks"}
+                </button>
+              )}
+            </div>
+            {/* The forwarder is a python script; the install writes the command
+                but cannot make an interpreter appear. Said up front rather than
+                left to a session that streams nothing and no error anywhere. */}
+            <div className="text-[10.5px] px-2.5 py-1.5 rounded-lg" style={{ color: "var(--text2)", background: "color-mix(in srgb, var(--warning) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)" }}>
+              The hooks run under <span style={{ color: "var(--warning)" }}>{st.python}</span> — it has to be on your PATH for events to arrive. Takes effect on the next Claude Code session; hooks load at startup.
+            </div>
+            <span className="text-[9.5px] t-dim2">
+              Reversible any time from here, or with <span className="t-mono">python3 hooks/install_hooks.py --uninstall</span> in a checkout. Global (<span className="t-mono">~/.claude</span>), so it covers every project.
+            </span>
+          </>
+        )}
+      </div>
     </Section>
   );
 }
@@ -628,6 +722,8 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                       href={api.skillsExportUrl()} download="agentglass-skills.md" />
                   </Section>
                   )}
+
+                  {pane === "hooks" && <HooksPane open={open} />}
 
                   {pane === "about" && <AboutPane open={open} />}
                   </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -337,6 +337,11 @@ const realApi = {
   updateNotes: (tag?: string) => get<ReleaseNotes>(`/update/notes${tag ? `?tag=${encodeURIComponent(tag)}` : ""}`),
   updateRun: () => post<{ ok: boolean; error?: string }>("/update/run", {}),
   updateLog: () => get<{ ok: boolean; text: string }>("/update/log"),
+  // Claude Code hook wiring (#187): read state, and turn it on/off by writing
+  // ~/.claude/settings.json server-side (idempotent, backed up first).
+  hooksStatus: () => get<HookSetupStatus>("/hooks/status"),
+  hooksInstall: () => post<HookSetupResult>("/hooks/install", {}),
+  hooksUninstall: () => post<HookSetupResult>("/hooks/uninstall", {}),
   dockerInspect: (id: string) => get<{ ok: boolean; env: string[]; config: string; error?: string }>(`/docker/inspect?id=${encodeURIComponent(id)}`),
   dockerTop: (id: string) => get<{ ok: boolean; text: string; error?: string }>(`/docker/top?id=${encodeURIComponent(id)}`),
   // --- pull requests (gh-backed) ---
@@ -517,6 +522,9 @@ const demoApi: typeof realApi = {
   updateNotes: (_tag?: string) => D({ ok: false, tag: "", notes: "", source: "", error: "not available in the demo" } as ReleaseNotes),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),
   updateRun: () => D({ ok: false, error: "not available in the demo" }),
+  hooksStatus: () => D({ installed: false, bundled: false, settingsPath: "~/.claude/settings.json", python: "python3" } as HookSetupStatus),
+  hooksInstall: () => D({ ok: false, installed: false, changed: false, settingsPath: "~/.claude/settings.json", error: "not available in the demo" } as HookSetupResult),
+  hooksUninstall: () => D({ ok: false, installed: false, changed: false, settingsPath: "~/.claude/settings.json", error: "not available in the demo" } as HookSetupResult),
   updateLog: () => D({ ok: true, text: "" }),
   dockerInspect: (_id: string) => D({ ok: false, env: [] as string[], config: "", error: "not available in the demo" }),
   dockerTop: (_id: string) => D({ ok: false, text: "", error: "not available in the demo" }),


### PR DESCRIPTION
## What

A Release install fills the cockpit (the transcript scanner reads `~/.claude/projects`), but the next step people want, live streaming and `PreToolUse` gating, needs the hooks, and there was **no way to get them from inside the app**. The packaged app shipped `web/dist` + the sidecar, not `hooks/`, so the documented next step for someone who deliberately avoided the terminal was to clone the repo and run a Python script.

Closes #187.

## How

- **Ship `hooks/`** via a new `extraResources` entry in `electron/package.json`, filtered to drop `__pycache__`/`*.pyc`. It lands beside the sidecar binary in the resources root, so the server resolves it via `dirname(process.execPath)`, exactly how `selfupdate.ts` finds `build-info.json` and `self-update.sh`. No `electron/main.js` change needed.
- **`server/src/hooksetup.ts`** — a faithful TypeScript port of `hooks/install_hooks.py`'s `~/.claude/settings.json` merge: same nine events, same `send_event.py` marker, idempotent strip-then-append (a moved install re-points cleanly, other hooks untouched), backup-before-write. The port keeps the *install* off Python so the button works regardless of the host interpreter; the forwarder it wires still runs under `python3`, which the UI names as a requirement.
- **Routes**: `GET /hooks/status`, `POST /hooks/install`, `POST /hooks/uninstall` (CSRF-guarded like the other config writers).
- **Settings → Hooks tab**: enable/disable, shows the settings path, says the change takes effect on the *next* Claude Code session and that the hooks need `python3` on PATH. Stays **opt-in**.
- Also corrected home-dir resolution to prefer `$HOME`/`%USERPROFILE%` over the passwd entry, matching Python's `expanduser` and Claude Code itself, so a custom-`HOME` session writes `settings.json` where Claude Code will actually read it (`os.homedir()` alone ignores `$HOME`).

## Verification

- **New `hooksetup` suite (16 tests)**: merge invariants (matchers, `--add-chat`), foreign-hook isolation in **both** directions (install adds only ours, uninstall removes only ours), idempotency (second install = no-op, no new backup), malformed JSON left untouched, empty file, backup-on-change, and a **golden parity** test that runs the real `install_hooks.py` and asserts byte-identical output.
- **`--dir` pack** confirms `resources/hooks/` ships `send_event.py` and friends with no bytecode.
- Full server suite (613 pass), web `tsc` + `vite build`, `smoke`, `perfbudget` (loop p99 1ms) all green.

## QA

- [ ] Install from a Release, open Settings → Hooks, click Enable. New Claude Code session streams into the app.
- [ ] Disable puts `settings.json` back; a `.bak.agentglass.*` backup is written on the change.
- [ ] Existing non-agentglass hooks in `settings.json` survive both operations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)