### PR TITLE
feat(prs): GitHub-style facet filters + query bar for the PR list

### DIFF
--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -317,7 +317,7 @@ export function ciNotifiesFor(filter: PrFilter): boolean {
  * whose checks have not landed says so rather than claiming "no checks", which
  * is a different and wrong answer.
  */
-const LIST_FIELDS_FAST = "number,title,author,state,isDraft,headRefName,baseRefName,url,updatedAt,reviewDecision,additions,deletions,changedFiles,labels";
+const LIST_FIELDS_FAST = "number,title,author,state,isDraft,headRefName,baseRefName,url,updatedAt,reviewDecision,additions,deletions,changedFiles,labels,assignees,milestone";
 
 type Entry = { at: number; prs: PrSummary[]; loading: boolean; checksPending: boolean; error?: string };
 const listCache = new Map<string, Entry>();
@@ -329,7 +329,9 @@ const LIST_TTL_MS = 90_000;
 // same keys, still searchable.
 const cacheKey = (repo: PrRepoId, filter: PrFilter) => `${repo.key}\u0000${filter}`;
 
-function mapSummary(p: any, withChecks: boolean): PrSummary {
+// Exported for the test that pins the gh-JSON field extraction (assignees,
+// milestone) — the shapes gh returns are an assumption worth guarding.
+export function mapSummary(p: any, withChecks: boolean): PrSummary {
   const { rollup } = rollupChecks(withChecks ? p.statusCheckRollup : []);
   return {
     number: p.number,
@@ -346,6 +348,8 @@ function mapSummary(p: any, withChecks: boolean): PrSummary {
     deletions: p.deletions ?? 0,
     changedFiles: p.changedFiles ?? 0,
     labels: (p.labels || []).map((l: any) => ({ name: l.name, color: l.color })),
+    assignees: (p.assignees || []).map((a: any) => a.login).filter(Boolean),
+    milestone: p.milestone?.title || null,
     checks: rollup,
     // Absent is not zero: a row without this must say "checks loading", never
     // "no checks", which is a claim about the repository rather than about us.
@@ -717,6 +721,7 @@ const DETAIL_QUERY = `query($owner:String!,$name:String!,$number:Int!){
     mergeable mergeStateStatus reviewDecision viewerDidAuthor
     author{login}
     labels(first:20){nodes{name color}}
+    milestone{title}
     assignees(first:10){nodes{login}}
     reviewRequests(first:10){nodes{requestedReviewer{... on User{login} ... on Team{name}}}}
     reviews(first:50){nodes{author{login} state body submittedAt url}}
@@ -868,6 +873,7 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     deletions: p.deletions ?? 0,
     changedFiles: p.changedFiles ?? 0,
     labels: (p.labels?.nodes || []).map((l: any) => ({ name: l.name, color: l.color })),
+    milestone: p.milestone?.title || null,
     checks: rollup,
     checksAll: all,
     body: p.body || "",

--- a/server/test/prs.test.ts
+++ b/server/test/prs.test.ts
@@ -184,6 +184,25 @@ describe("rollup from aggregate counts (#249)", () => {
   });
 });
 
+describe("list row mapping (#assignee/milestone facets)", () => {
+  test("assignee logins and milestone title are pulled off the gh JSON shape", () => {
+    const row = prs.mapSummary({
+      number: 7, title: "t", author: { login: "octo" }, state: "OPEN",
+      assignees: [{ login: "a" }, { login: "b" }],
+      milestone: { title: "v1.0" },
+      labels: [{ name: "bug", color: "red" }],
+    }, false);
+    expect(row.assignees).toEqual(["a", "b"]);
+    expect(row.milestone).toBe("v1.0");
+  });
+
+  test("no assignees and no milestone map to [] and null, not undefined", () => {
+    const row = prs.mapSummary({ number: 8, title: "t", author: { login: "octo" }, state: "OPEN" }, false);
+    expect(row.assignees).toEqual([]);
+    expect(row.milestone).toBeNull();
+  });
+});
+
 describe("bot digest", () => {
   /** The real one is 46,551 characters. Three numbers is what gets read. */
   test("pulls the figures out of a coverage table", () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1037,6 +1037,10 @@ export interface PrSummary {
   deletions: number;
   changedFiles: number;
   labels: PrLabel[];
+  /** Assignee logins, for the Assignee facet. Empty when nobody is assigned. */
+  assignees: string[];
+  /** Milestone title, or null when the PR is on no milestone. */
+  milestone: string | null;
   checks: PrCheckRollup;
   /** This checkout is on the PR's head branch — "you are here". */
   isCurrentBranch?: boolean;

--- a/web/src/components/FacetMenu.tsx
+++ b/web/src/components/FacetMenu.tsx
@@ -1,0 +1,206 @@
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import { Portal } from "./Portal.tsx";
+
+/**
+ * A multi-select facet dropdown, GitHub-style: a pill that opens a checkbox list
+ * with a live count beside every option.
+ *
+ * It is the sibling of Select.tsx and shares its machinery on purpose — the same
+ * Portal (so the open list is not clipped by the narrow PR sidebar, nor
+ * width-bound by it), the same spring, the same capture-phase key handling so
+ * the app's single-letter shortcuts never fire while you are picking. The
+ * differences from Select: options toggle instead of pick-and-close (unless
+ * `mode="radio"`, used for Sort), each row shows a count, a real search box
+ * appears once the list is long, and there is a "Clear" footer.
+ */
+export interface FacetMenuOption { value: string; label: string; count: number }
+
+export function FacetMenu({
+  label, options, selected, onToggle, onClear, mode = "multi", align = "left", note, disabled, pillActive,
+}: {
+  label: string;
+  options: FacetMenuOption[];
+  selected: string[];
+  onToggle: (value: string) => void;
+  onClear: () => void;
+  mode?: "multi" | "radio";
+  align?: "left" | "right";
+  /** A line shown under the list, e.g. "checks still loading". */
+  note?: string;
+  disabled?: boolean;
+  /** Override the pill's "active" styling. Defaults to selected.length > 0;
+   *  Sort passes false when on the default so it does not read as a filter. */
+  pillActive?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+  const [q, setQ] = useState("");
+  const [cursor, setCursor] = useState(0);
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const listRef = useRef<HTMLDivElement>(null);
+  const searchRef = useRef<HTMLInputElement>(null);
+  const [pos, setPos] = useState({ top: 0, left: 0, right: 0, minWidth: 0 });
+
+  const filtered = useMemo(() => {
+    const s = q.trim().toLowerCase();
+    return s ? options.filter((o) => o.label.toLowerCase().includes(s) || o.value.toLowerCase().includes(s)) : options;
+  }, [q, options]);
+  const showSearch = options.length > 12;
+
+  useLayoutEffect(() => {
+    if (open && btnRef.current) {
+      const r = btnRef.current.getBoundingClientRect();
+      setPos({ top: r.bottom + 6, left: r.left, right: window.innerWidth - r.right, minWidth: r.width });
+    }
+  }, [open]);
+
+  useEffect(() => {
+    if (open) { setCursor(0); setQ(""); }
+  }, [open]);
+
+  // Keep the highlighted row in view. Focus stays in the search box (or the
+  // list) so type-to-filter works the moment the menu opens.
+  useEffect(() => {
+    if (!open) return;
+    const el = listRef.current?.children[cursor] as HTMLElement | undefined;
+    el?.scrollIntoView({ block: "nearest" });
+    if (showSearch) searchRef.current?.focus();
+  }, [open, cursor, showSearch]);
+
+  const close = () => { setOpen(false); btnRef.current?.focus(); };
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => {
+      // Capture phase + stopPropagation: the PR list binds j/k and the app binds
+      // single letters — neither should fire while this menu is open.
+      if (e.key === "Escape") { e.stopPropagation(); close(); return; }
+      if (e.key === "ArrowDown" || e.key === "ArrowUp" || e.key === "Home" || e.key === "End") {
+        e.preventDefault(); e.stopPropagation();
+        setCursor((c) => {
+          if (e.key === "Home") return 0;
+          if (e.key === "End") return filtered.length - 1;
+          const d = e.key === "ArrowDown" ? 1 : -1;
+          return filtered.length ? (c + d + filtered.length) % filtered.length : 0;
+        });
+        return;
+      }
+      if (e.key === "Enter" || (e.key === " " && !showSearch)) {
+        e.preventDefault(); e.stopPropagation();
+        const o = filtered[cursor];
+        if (o) { onToggle(o.value); if (mode === "radio") close(); }
+        return;
+      }
+      // Let the search box receive normal typing; just keep it from reaching the app.
+      if (e.key.length === 1 && !e.metaKey && !e.ctrlKey && !e.altKey) e.stopPropagation();
+    };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, cursor, filtered, showSearch, mode]);
+
+  const n = selected.length;
+  const active = pillActive ?? n > 0;
+  const badge = mode === "radio" ? (options.find((o) => o.value === selected[0])?.label ?? selected[0]) : String(n);
+  const pill = "text-[10px] px-2 py-0.5 rounded-full shrink-0 flex items-center gap-1 whitespace-nowrap";
+
+  return (
+    <>
+      <button
+        ref={btnRef}
+        disabled={disabled}
+        onClick={() => !disabled && (open ? close() : setOpen(true))}
+        role="combobox"
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        aria-label={label}
+        className={pill}
+        style={{
+          color: active ? "var(--bg)" : "var(--text2)",
+          background: active ? "var(--primary)" : "transparent",
+          border: `1px solid ${active || open ? "var(--primary)" : "color-mix(in srgb, var(--border) 45%, transparent)"}`,
+          opacity: disabled ? 0.5 : 1,
+        }}
+      >
+        {label}
+        {active && <span className="tabular-nums" style={{ opacity: 0.85 }}>{badge}</span>}
+        <span className="text-[7px] opacity-70">▼</span>
+      </button>
+      <Portal>
+        <AnimatePresence>
+          {open && (
+            <>
+              <div className="fixed inset-0" style={{ zIndex: 9998 }} onClick={close} />
+              <motion.div
+                initial={{ opacity: 0, y: -8, scale: 0.96 }} animate={{ opacity: 1, y: 0, scale: 1 }} exit={{ opacity: 0, y: -8, scale: 0.96 }}
+                transition={{ type: "spring", stiffness: 420, damping: 32 }}
+                role="listbox"
+                aria-label={label}
+                className="fixed p-1.5 rounded-xl flex flex-col overflow-hidden"
+                style={{
+                  top: pos.top,
+                  ...(align === "right" ? { right: pos.right } : { left: pos.left }),
+                  minWidth: Math.max(pos.minWidth, 180),
+                  maxWidth: 300,
+                  maxHeight: "min(60vh, 420px)",
+                  zIndex: 9999,
+                  background: "color-mix(in srgb, var(--bg2) 97%, black)",
+                  border: "1px solid color-mix(in srgb, var(--border) 70%, transparent)",
+                  boxShadow: "0 24px 60px -18px rgba(0,0,0,0.7)",
+                  backdropFilter: "blur(18px)",
+                }}
+              >
+                {showSearch && (
+                  <input
+                    ref={searchRef}
+                    value={q}
+                    onChange={(e) => { setQ(e.target.value); setCursor(0); }}
+                    placeholder={`Filter ${label.toLowerCase()}…`}
+                    className="text-[11px] px-2 py-1 mb-1 rounded-lg bg-transparent"
+                    style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }}
+                  />
+                )}
+                <div ref={listRef} className="flex flex-col gap-0.5 overflow-y-auto agw-noscrollbar">
+                  {filtered.length === 0 ? (
+                    <div className="px-2.5 py-2 text-[10.5px]" style={{ color: "var(--text3)" }}>No matches</div>
+                  ) : filtered.map((o, i) => {
+                    const on = selected.includes(o.value);
+                    return (
+                      <button key={o.value} onClick={() => { onToggle(o.value); if (mode === "radio") close(); }}
+                        role="option"
+                        aria-selected={on}
+                        tabIndex={-1}
+                        onMouseEnter={() => setCursor(i)}
+                        className="px-2 py-1.5 rounded-lg text-[11.5px] text-left flex items-center gap-2"
+                        style={i === cursor ? { background: "color-mix(in srgb, var(--primary) 22%, transparent)" } : undefined}>
+                        <span aria-hidden className="shrink-0 grid place-items-center text-[9px]"
+                          style={{
+                            width: 14, height: 14,
+                            borderRadius: mode === "radio" ? 999 : 4,
+                            border: `1px solid ${on ? "var(--primary)" : "color-mix(in srgb, var(--border) 70%, transparent)"}`,
+                            background: on ? "var(--primary)" : "transparent",
+                            color: "var(--bg)",
+                          }}>
+                          {on ? (mode === "radio" ? "●" : "✓") : ""}
+                        </span>
+                        <span className="flex-1 truncate" style={{ color: on ? "var(--text)" : "var(--text2)" }}>{o.label}</span>
+                        <span className="text-[9.5px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{o.count}</span>
+                      </button>
+                    );
+                  })}
+                </div>
+                {note && <div className="px-2.5 pt-1.5 text-[9.5px]" style={{ color: "var(--warning)" }}>{note}</div>}
+                {mode === "multi" && n > 0 && (
+                  <button onClick={() => { onClear(); }}
+                    className="mt-1 px-2.5 py-1 rounded-lg text-[10.5px] text-left hover:bg-white/5"
+                    style={{ color: "var(--text3)", borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+                    Clear {label.toLowerCase()}
+                  </button>
+                )}
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+      </Portal>
+    </>
+  );
+}

--- a/web/src/components/PrFilterBar.tsx
+++ b/web/src/components/PrFilterBar.tsx
@@ -1,0 +1,115 @@
+import { FacetMenu } from "./FacetMenu.tsx";
+import {
+  serializeQuery, toggleFacet, clearFacet, setSort, DEFAULT_SORT, SORT_OPTIONS,
+  type FilterState, type FacetView, type SortTok,
+} from "../lib/prFilter.ts";
+
+/**
+ * The PR list's filter bar (#pulldash-style): a query input, a wrapping row of
+ * GitHub-style facet pills, a Sort pill, and a row of removable chips for what
+ * is active.
+ *
+ * Every control edits ONE thing — the query string — through parse/serialize, so
+ * the bar and the dropdowns are always the same filter. This component holds no
+ * state; it turns clicks into new query strings and hands them up via `onQuery`.
+ */
+export function PrFilterBar({
+  query, filters, facets, onQuery, checksPending, shown, total,
+}: {
+  query: string;
+  filters: FilterState;
+  facets: FacetView[];
+  onQuery: (q: string) => void;
+  /** Second-pass check states still loading — the Checks menu says so. */
+  checksPending?: boolean;
+  shown: number;
+  total: number;
+}) {
+  const emit = (next: FilterState) => onQuery(serializeQuery(next));
+
+  // Chips mirror every active token, each with its own removal. Free text is one
+  // chip (removing it strips only the words, keeping the facets).
+  const chips: { key: string; label: string; onRemove: () => void }[] = [];
+  for (const f of facets) {
+    for (const v of f.selected) {
+      const opt = f.options.find((o) => o.value === v);
+      chips.push({
+        key: `${f.key}:${v}`,
+        label: `${f.label}: ${opt?.label ?? v}`,
+        onRemove: () => emit(toggleFacet(filters, f.key, v)),
+      });
+    }
+  }
+  if (filters.text.trim()) {
+    chips.push({ key: "text", label: `"${filters.text.trim()}"`, onRemove: () => emit({ ...filters, text: "" }) });
+  }
+
+  const border = "1px solid color-mix(in srgb, var(--border) 45%, transparent)";
+
+  return (
+    <div className="px-2 py-1.5 border-b shrink-0 flex flex-col gap-1.5" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+      {/* Query input — the source of truth every pill also writes to. */}
+      <div className="flex items-center gap-1.5">
+        <input
+          data-pr-filter-input
+          value={query}
+          onChange={(e) => onQuery(e.target.value)}
+          placeholder="Filter, e.g. author:me label:bug is:draft"
+          spellCheck={false}
+          className="flex-1 text-[10px] px-2 py-1 rounded bg-transparent min-w-0"
+          style={{ color: "var(--text2)", border, outline: "none" }} />
+        {query.trim() && (
+          <button onClick={() => onQuery("")} title="Clear all filters" aria-label="Clear all filters"
+            className="text-[11px] px-1.5 py-0.5 rounded shrink-0 hover:bg-white/5" style={{ color: "var(--text3)", border }}>
+            ×
+          </button>
+        )}
+      </div>
+
+      {/* Facet pills — wrap in the narrow sidebar; each menu floats via a Portal. */}
+      <div className="flex flex-wrap items-center gap-1">
+        {facets.map((f) => (
+          <FacetMenu
+            key={f.key}
+            label={f.label}
+            options={f.options}
+            selected={f.selected}
+            onToggle={(v) => emit(toggleFacet(filters, f.key, v))}
+            onClear={() => emit(clearFacet(filters, f.key))}
+            note={f.key === "checks" && checksPending ? "Checks are still loading; unfinished rows are kept." : undefined}
+          />
+        ))}
+        <div className="ml-auto">
+          <FacetMenu
+            label="Sort"
+            mode="radio"
+            align="right"
+            pillActive={filters.sort !== DEFAULT_SORT}
+            options={SORT_OPTIONS.map((o) => ({ value: o.value, label: o.label, count: 0 }))}
+            selected={[filters.sort]}
+            onToggle={(v) => emit(setSort(filters, v as SortTok))}
+            onClear={() => emit(setSort(filters, DEFAULT_SORT))}
+          />
+        </div>
+      </div>
+
+      {/* Active-filter chips + count. Only when something is narrowing the list. */}
+      {chips.length > 0 && (
+        <div className="flex flex-wrap items-center gap-1">
+          {chips.map((c) => (
+            <button key={c.key} onClick={c.onRemove}
+              className="text-[9.5px] pl-2 pr-1 py-0.5 rounded-full flex items-center gap-1 hover:opacity-80"
+              style={{ color: "var(--text2)", background: "color-mix(in srgb, var(--primary) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 28%, transparent)" }}>
+              <span className="truncate max-w-[140px]">{c.label}</span>
+              <span aria-hidden style={{ color: "var(--text3)" }}>×</span>
+            </button>
+          ))}
+          <button onClick={() => onQuery("")} className="text-[9.5px] px-1.5 py-0.5 rounded-full hover:bg-white/5" style={{ color: "var(--text3)" }}>
+            Clear all
+          </button>
+          <span className="ml-auto text-[9px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{shown} of {total}</span>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -31,6 +31,8 @@ import { useDialogs } from "./ConfirmDialog.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle } from "./ChangesModal.tsx";
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 import { stepFileIndex } from "../lib/prNav.ts";
+import { PrFilterBar } from "./PrFilterBar.tsx";
+import { parseQuery, applyFilters, buildFacets, activeCount } from "../lib/prFilter.ts";
 
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
@@ -342,9 +344,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [root, setRoot] = useState("");
   const [repo, setRepo] = useState<PrRepoId | null>(null);
   const [filter, setFilter] = useState<Filter>("mine");
-  // A per-tab search box. Cleared when the scope changes so each tab (mine /
-  // review / all) starts fresh — "all" can be hundreds of rows, and finding one
-  // by number, title or author beats scrolling.
+  // The filter query for the current scope tab — the single source of truth for
+  // both the search box and every facet dropdown (parsed in lib/prFilter.ts).
+  // Cleared when the scope changes so each tab (mine / review / all) starts
+  // fresh; "all" can be hundreds of rows and a facet beats scrolling.
   const [query, setQuery] = useState("");
   const [prs, setPrs] = useState<PrSummary[]>([]);
   const [counts, setCounts] = useState<Partial<Record<Filter, number>>>({});
@@ -517,14 +520,53 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   // Filter the current scope's rows by the search box: PR number (with or
   // without a leading #), title, or author login. Memoized so a 400-row "all"
   // list does not re-scan on every keystroke or re-render.
-  const visiblePrs = useMemo(() => {
-    const q = query.trim().toLowerCase().replace(/^#/, "");
-    if (!q) return prs;
-    return prs.filter((p) =>
-      String(p.number).includes(q) ||
-      p.title.toLowerCase().includes(q) ||
-      p.author.toLowerCase().includes(q));
-  }, [prs, query]);
+  // The query string is the single source of truth; the facet dropdowns are
+  // editors of it (see lib/prFilter.ts). `filters` is a pure derivation, never
+  // stored, so the bar and the menus can never disagree.
+  const filters = useMemo(() => parseQuery(query), [query]);
+  const visiblePrs = useMemo(() => applyFilters(prs, filters), [prs, filters]);
+  const facets = useMemo(() => buildFacets(prs, filters), [prs, filters]);
+
+  // If the selected row is filtered out, move the selection to the first row
+  // still visible rather than leaving a phantom highlight on a hidden PR — the
+  // same reconciliation loadList does when the list itself changes. Only when a
+  // selection existed; never auto-selects out of the empty initial state.
+  useEffect(() => {
+    if (selected != null && !visiblePrs.some((p) => p.number === selected)) {
+      setSelected(visiblePrs[0]?.number ?? null);
+    }
+  }, [visiblePrs, selected]);
+
+  // Keyboard nav over the list, keyboard-first like the files tab (which relies
+  // on the same thing: App.tsx ignores bare letters while the workspace is open,
+  // so j/k/n/p are free here). Selection is derived, not a second state.
+  const listRef = useRef<HTMLDivElement>(null);
+  const stepSel = (d: number) => {
+    if (!visiblePrs.length) return;
+    const i = visiblePrs.findIndex((p) => p.number === selected);
+    const ni = i < 0 ? (d > 0 ? 0 : visiblePrs.length - 1) : (i + d + visiblePrs.length) % visiblePrs.length;
+    setSelected(visiblePrs[ni].number);
+    setTab("overview");
+  };
+  const onListKey = (e: React.KeyboardEvent) => {
+    const inInput = /input|textarea/i.test((e.target as HTMLElement)?.tagName ?? "");
+    if (e.key === "/" && !inInput) {
+      e.preventDefault();
+      (document.querySelector("[data-pr-filter-input]") as HTMLInputElement | null)?.focus();
+      return;
+    }
+    if (inInput) { if (e.key === "Escape") (e.target as HTMLElement).blur(); return; }
+    const k = e.key.toLowerCase();
+    if (k === "j" || e.key === "ArrowDown") { e.preventDefault(); e.stopPropagation(); stepSel(1); }
+    else if (k === "k" || e.key === "ArrowUp") { e.preventDefault(); e.stopPropagation(); stepSel(-1); }
+    else if (e.key === "Escape" && query) { e.preventDefault(); setQuery(""); }
+  };
+  // Make the list keyboard-ready the moment the panel opens, but never steal
+  // focus from a field the user is already in (only claim it off <body>).
+  useEffect(() => {
+    if (!active) return;
+    requestAnimationFrame(() => { if (document.activeElement === document.body) listRef.current?.focus(); });
+  }, [active]);
 
   const parsed = useMemo(() => parseUnifiedDiff(diff), [diff]);
   const byPath = useMemo(() => {
@@ -713,19 +755,17 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
             })}
           </div>
           {repo && prs.length > 0 && (
-            <div className="px-2 py-1.5 border-b shrink-0 flex items-center gap-2" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
-              <input
-                value={query}
-                onChange={(e) => setQuery(e.target.value)}
-                placeholder="Filter by #, title or author…"
-                className="flex-1 text-[10px] px-2 py-1 rounded bg-transparent min-w-0"
-                style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", outline: "none" }} />
-              {query.trim() && (
-                <span className="text-[9px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{visiblePrs.length} of {prs.length}</span>
-              )}
-            </div>
+            <PrFilterBar
+              query={query}
+              filters={filters}
+              facets={facets}
+              onQuery={setQuery}
+              checksPending={listState.checksPending}
+              shown={visiblePrs.length}
+              total={prs.length}
+            />
           )}
-          <div className="flex-1 overflow-y-auto min-h-0 agx-scroll">
+          <div ref={listRef} tabIndex={-1} onKeyDown={onListKey} className="flex-1 overflow-y-auto min-h-0 agx-scroll outline-none">
             {listState.needsAuth ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
                 <div style={{ color: "var(--warning)" }}>{listState.error || "The GitHub CLI is not set up"}</div>
@@ -740,7 +780,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 </div>
               )
             ) : visiblePrs.length === 0 ? (
-              <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>No pull requests match “{query.trim()}”</div>
+              <div className="p-3 text-[11px] flex flex-col items-start gap-1.5" style={{ color: "var(--text3)" }}>
+                <span>No pull requests match {activeCount(filters) === 1 ? "this filter" : "these filters"}.</span>
+                <button onClick={() => setQuery("")} className="text-[10.5px] px-2 py-0.5 rounded hover:bg-white/5" style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)" }}>Clear filters</button>
+              </div>
             ) : visiblePrs.map((p) => (
               <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
             ))}

--- a/web/src/lib/prFilter.ts
+++ b/web/src/lib/prFilter.ts
@@ -1,0 +1,306 @@
+// The PR list's filter model (#pulldash-style facets).
+//
+// One rule holds the whole thing together: the query STRING is the single
+// source of truth. `FilterState` is a pure `parseQuery(query)` derivation, never
+// stored; the facet dropdowns are editors of the string (toggle -> parse ->
+// mutate -> serialize -> setQuery). Two independent states that must "never
+// disagree" is the bug this design refuses to have — there is only one state,
+// so the bar and the menus cannot drift.
+//
+// Grammar: `key:value` tokens plus bare free-text words, space separated, keys
+// case-insensitive, double-quotes for values with spaces (`label:"needs work"`).
+// parseQuery is TOTAL: unknown keys, partial tokens, and unclosed quotes all
+// degrade gracefully (to free text or to no-constraint), never throw, never
+// silently empty the list.
+//
+// Semantics: OR within a facet, AND across facets. Two authors selected shows
+// PRs by either; adding a label then intersects. This is a deliberate
+// divergence from github.com's raw search (where repeated `label:` is AND) —
+// a multi-select checkbox facet has to be OR, or ticking a second box can only
+// ever shrink the result to zero, which reads as broken.
+import type { PrSummary } from "../../../shared/types.ts";
+
+export type ReviewTok = "approved" | "changes-requested" | "required" | "none";
+export type ChecksTok = "green" | "red" | "pending";
+export type IsTok = "draft" | "ready";
+export type SortTok = "recently-updated" | "newest" | "oldest" | "most-changed" | "title" | "checks";
+
+export const REVIEW_TOKS: ReviewTok[] = ["approved", "changes-requested", "required", "none"];
+export const CHECKS_TOKS: ChecksTok[] = ["green", "red", "pending"];
+export const IS_TOKS: IsTok[] = ["draft", "ready"];
+export const SORT_TOKS: SortTok[] = ["recently-updated", "newest", "oldest", "most-changed", "title", "checks"];
+export const DEFAULT_SORT: SortTok = "recently-updated";
+
+export const SORT_OPTIONS: { value: SortTok; label: string }[] = [
+  { value: "recently-updated", label: "Recently updated" },
+  { value: "newest", label: "Newest" },
+  { value: "oldest", label: "Oldest" },
+  { value: "most-changed", label: "Most changed" },
+  { value: "title", label: "Title" },
+  { value: "checks", label: "Checks status" },
+];
+
+export interface FilterState {
+  authors: string[];
+  assignees: string[];
+  labels: string[];
+  milestones: string[];
+  reviews: ReviewTok[];
+  checks: ChecksTok[];
+  is: IsTok[];
+  base: string[];
+  text: string; // free words, matched as today: number / title / author substring
+  sort: SortTok;
+}
+
+// The array-valued facets, in display order. `queryKey` is the token key in the
+// string; `field` reads the token(s) a PR matches for this facet — returning
+// `null` means "unknown, fail open" (only checks, and only before its second
+// fetch pass has landed). `label` names the facet in the UI.
+type ArrayKey = "authors" | "assignees" | "labels" | "milestones" | "reviews" | "checks" | "is" | "base";
+
+export interface FacetDef {
+  key: ArrayKey;
+  queryKey: string;
+  label: string;
+  /** Fixed option set (enum facets); free-form facets derive options from the rows. */
+  fixed?: string[];
+  field: (p: PrSummary) => string[] | null;
+}
+
+export function reviewTokenOf(d: PrSummary["reviewDecision"]): ReviewTok {
+  return d === "APPROVED" ? "approved"
+    : d === "CHANGES_REQUESTED" ? "changes-requested"
+    : d === "REVIEW_REQUIRED" ? "required"
+    : "none";
+}
+
+function checksTokenOf(p: PrSummary): string[] | null {
+  if (p.checksLoaded === false) return null; // second pass not in yet — fail open
+  const r = p.checks;
+  if (!r || r.total === 0) return []; // known: no checks. Matches no checks-token.
+  if (r.verdict === "green") return ["green"];
+  if (r.verdict === "red") return ["red"];
+  return ["pending"]; // has checks, not yet a verdict
+}
+
+export const FACETS: FacetDef[] = [
+  { key: "authors", queryKey: "author", label: "Author", field: (p) => (p.author ? [p.author] : []) },
+  { key: "labels", queryKey: "label", label: "Label", field: (p) => p.labels.map((l) => l.name) },
+  { key: "reviews", queryKey: "review", label: "Reviews", fixed: REVIEW_TOKS, field: (p) => [reviewTokenOf(p.reviewDecision)] },
+  { key: "checks", queryKey: "checks", label: "Checks", fixed: CHECKS_TOKS, field: checksTokenOf },
+  { key: "is", queryKey: "is", label: "Draft", fixed: IS_TOKS, field: (p) => [p.isDraft ? "draft" : "ready"] },
+  { key: "base", queryKey: "base", label: "Base", field: (p) => (p.baseRefName ? [p.baseRefName] : []) },
+  { key: "assignees", queryKey: "assignee", label: "Assignee", field: (p) => p.assignees },
+  { key: "milestones", queryKey: "milestone", label: "Milestone", field: (p) => (p.milestone ? [p.milestone] : []) },
+];
+
+const FACET_BY_QKEY = new Map(FACETS.map((f) => [f.queryKey, f]));
+const KNOWN_KEYS = new Set([...FACET_BY_QKEY.keys(), "sort"]);
+
+function empty(): FilterState {
+  return { authors: [], assignees: [], labels: [], milestones: [], reviews: [], checks: [], is: [], base: [], text: "", sort: DEFAULT_SORT };
+}
+
+// Split into tokens, keeping `key:"a b"` whole (a space inside quotes is not a
+// separator) and letting an unclosed quote run to the end of the input.
+function splitTokens(input: string): string[] {
+  const toks: string[] = [];
+  let i = 0;
+  const n = input.length;
+  while (i < n) {
+    while (i < n && /\s/.test(input[i])) i++;
+    if (i >= n) break;
+    let tok = "";
+    let inQuote = false;
+    while (i < n && (inQuote || !/\s/.test(input[i]))) {
+      const c = input[i];
+      if (c === '"') inQuote = !inQuote;
+      tok += c;
+      i++;
+    }
+    toks.push(tok);
+  }
+  return toks;
+}
+
+function stripQuotes(v: string): string {
+  if (v.startsWith('"')) return v.slice(1, v.endsWith('"') && v.length > 1 ? -1 : undefined);
+  return v;
+}
+
+function pushUnique<T>(arr: T[], v: T): void {
+  if (!arr.includes(v)) arr.push(v);
+}
+
+export function parseQuery(input: string): FilterState {
+  const s = empty();
+  const free: string[] = [];
+  for (const tok of splitTokens(input || "")) {
+    const ci = tok.indexOf(":");
+    const key = ci > 0 ? tok.slice(0, ci).toLowerCase() : "";
+    if (ci > 0 && KNOWN_KEYS.has(key)) {
+      const value = stripQuotes(tok.slice(ci + 1)).trim();
+      if (!value) continue; // partial token while typing — no constraint yet
+      if (key === "sort") {
+        if ((SORT_TOKS as string[]).includes(value)) s.sort = value as SortTok;
+        continue;
+      }
+      const facet = FACET_BY_QKEY.get(key)!;
+      // Enum facets validate their value; an out-of-range value is ignored
+      // rather than pushed to free text (where it would substring-match nothing
+      // and empty the list).
+      if (facet.fixed && !facet.fixed.includes(value.toLowerCase())) continue;
+      pushUnique(s[facet.key] as string[], facet.fixed ? value.toLowerCase() : value);
+    } else {
+      free.push(tok);
+    }
+  }
+  s.text = free.join(" ");
+  return s;
+}
+
+function quote(v: string): string {
+  return /[\s:"]/.test(v) ? `"${v.replace(/"/g, "")}"` : v;
+}
+
+// Canonical form: facets in FACETS order, each value deduped and quoted as
+// needed, then free text, then a non-default sort last. parseQuery(serialize(s))
+// round-trips to the normalized s.
+export function serializeQuery(s: FilterState): string {
+  const parts: string[] = [];
+  for (const f of FACETS) {
+    for (const v of s[f.key] as string[]) parts.push(`${f.queryKey}:${quote(v)}`);
+  }
+  const text = s.text.trim();
+  if (text) parts.push(text);
+  if (s.sort !== DEFAULT_SORT) parts.push(`sort:${s.sort}`);
+  return parts.join(" ");
+}
+
+/** Toggle a value in an array facet, returning a new state (for the menus). */
+export function toggleFacet(s: FilterState, key: ArrayKey, value: string): FilterState {
+  const cur = s[key] as string[];
+  const next = cur.includes(value) ? cur.filter((v) => v !== value) : [...cur, value];
+  return { ...s, [key]: next };
+}
+
+export function clearFacet(s: FilterState, key: ArrayKey): FilterState {
+  return { ...s, [key]: [] };
+}
+
+export function setSort(s: FilterState, sort: SortTok): FilterState {
+  return { ...s, sort };
+}
+
+/** How many facets (plus free text) are actively narrowing the list. */
+export function activeCount(s: FilterState): number {
+  let n = FACETS.reduce((acc, f) => acc + ((s[f.key] as string[]).length ? 1 : 0), 0);
+  if (s.text.trim()) n += 1;
+  return n;
+}
+
+function textMatch(p: PrSummary, text: string): boolean {
+  const q = text.trim().toLowerCase();
+  if (!q) return true;
+  return String(p.number).includes(q) || p.title.toLowerCase().includes(q) || p.author.toLowerCase().includes(q);
+}
+
+// AND across facets, OR within a facet. A facet with nothing selected is a
+// no-op. A `null` field (checks still loading) fails open.
+function matches(p: PrSummary, f: FilterState): boolean {
+  for (const facet of FACETS) {
+    const sel = f[facet.key] as string[];
+    if (sel.length === 0) continue;
+    const vals = facet.field(p);
+    if (vals === null) continue; // unknown -> fail open
+    if (!sel.some((s) => vals.includes(s))) return false;
+  }
+  return textMatch(p, f.text);
+}
+
+const SORTERS: Record<SortTok, (a: PrSummary, b: PrSummary) => number> = {
+  "recently-updated": (a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)),
+  newest: (a, b) => b.number - a.number,
+  oldest: (a, b) => a.number - b.number,
+  "most-changed": (a, b) => (b.additions + b.deletions) - (a.additions + a.deletions),
+  title: (a, b) => a.title.localeCompare(b.title),
+  // Surface what needs attention first: red, then pending, then green, then no-checks.
+  checks: (a, b) => checksRank(a) - checksRank(b) || String(b.updatedAt).localeCompare(String(a.updatedAt)),
+};
+
+function checksRank(p: PrSummary): number {
+  const v = checksTokenOf(p);
+  if (v === null || v.length === 0) return 3;
+  return v[0] === "red" ? 0 : v[0] === "pending" ? 1 : 2;
+}
+
+/** The filtered + sorted rows the list renders. */
+export function applyFilters(prs: PrSummary[], f: FilterState): PrSummary[] {
+  return prs.filter((p) => matches(p, f)).sort(SORTERS[f.sort] ?? SORTERS[DEFAULT_SORT]);
+}
+
+export interface FacetOption { value: string; label: string; count: number }
+export interface FacetView {
+  key: ArrayKey;
+  queryKey: string;
+  label: string;
+  options: FacetOption[];
+  selected: string[];
+}
+
+const REVIEW_LABEL: Record<string, string> = {
+  approved: "Approved", "changes-requested": "Changes requested", required: "Review required", none: "No review",
+};
+const CHECKS_LABEL: Record<string, string> = { green: "Passing", red: "Failing", pending: "Pending" };
+const IS_LABEL: Record<string, string> = { draft: "Draft", ready: "Ready" };
+
+function optionLabel(key: ArrayKey, value: string): string {
+  if (key === "reviews") return REVIEW_LABEL[value] ?? value;
+  if (key === "checks") return CHECKS_LABEL[value] ?? value;
+  if (key === "is") return IS_LABEL[value] ?? value;
+  return value;
+}
+
+// Per-facet options with GitHub-style live counts: an option's count is the
+// number of rows that pass every OTHER facet and carry that option — so a
+// facet's own ticks never shrink its sibling counts. Rows whose field is
+// unknown (checks still loading) are left out of the tally.
+export function buildFacets(prs: PrSummary[], f: FilterState): FacetView[] {
+  return FACETS.map((facet) => {
+    const others: FilterState = { ...f, [facet.key]: [] };
+    const pool = prs.filter((p) => matches(p, others));
+
+    const counts = new Map<string, number>();
+    const order: string[] = [];
+    const note = (v: string) => {
+      if (!counts.has(v)) order.push(v);
+      counts.set(v, (counts.get(v) ?? 0) + 1);
+    };
+    for (const p of pool) {
+      const vals = facet.field(p);
+      if (vals === null) continue; // don't count rows we can't classify yet
+      for (const v of vals) note(v);
+    }
+
+    // Fixed-enum facets show every option (even zero) in a stable order;
+    // free-form facets show the values that exist, most-common first.
+    let values: string[];
+    if (facet.fixed) {
+      values = facet.fixed.slice();
+    } else {
+      values = order.sort((a, b) => (counts.get(b)! - counts.get(a)!) || a.localeCompare(b));
+    }
+    // Keep a selected value visible even if it currently matches nothing, so its
+    // checkbox stays tickable (the escape hatch out of an empty filter).
+    for (const v of f[facet.key] as string[]) if (!values.includes(v)) values.push(v);
+
+    return {
+      key: facet.key,
+      queryKey: facet.queryKey,
+      label: facet.label,
+      selected: f[facet.key] as string[],
+      options: values.map((v) => ({ value: v, label: optionLabel(facet.key, v), count: counts.get(v) ?? 0 })),
+    };
+  });
+}

--- a/web/test/prFilter.test.ts
+++ b/web/test/prFilter.test.ts
@@ -1,0 +1,260 @@
+// The PR filter model, pinned. The invariants that matter: parseQuery never
+// throws and never empties the list on garbage input; the string is the single
+// source of truth, so parse<->serialize round-trips; facets are OR within /
+// AND across; per-option counts ignore the facet's own selection; and checks
+// that haven't loaded fail open instead of hiding rows.
+import { describe, expect, test } from "bun:test";
+import type { PrSummary } from "../../shared/types.ts";
+import {
+  parseQuery, serializeQuery, applyFilters, buildFacets, toggleFacet, activeCount, DEFAULT_SORT,
+} from "../src/lib/prFilter.ts";
+
+let seq = 100;
+function pr(over: Partial<PrSummary> = {}): PrSummary {
+  seq += 1;
+  return {
+    number: over.number ?? seq,
+    title: "a pull request",
+    author: "octocat",
+    state: "OPEN",
+    isDraft: false,
+    headRefName: "feature",
+    baseRefName: "main",
+    url: "",
+    updatedAt: "2026-07-20T00:00:00Z",
+    reviewDecision: null,
+    additions: 0,
+    deletions: 0,
+    changedFiles: 0,
+    labels: [],
+    assignees: [],
+    milestone: null,
+    checks: { total: 0, success: 0, failure: 0, skipped: 0, pending: 0, allDone: false, verdict: null, failing: [] },
+    checksLoaded: true,
+    ...over,
+  };
+}
+
+describe("parseQuery is total", () => {
+  test("empty / whitespace parses to a neutral state", () => {
+    for (const s of ["", "   ", "\n\t"]) {
+      const f = parseQuery(s);
+      expect(f.text).toBe("");
+      expect(activeCount(f)).toBe(0);
+      expect(f.sort).toBe(DEFAULT_SORT);
+    }
+  });
+
+  test("unknown keys, unclosed quotes and lone colons never throw", () => {
+    for (const junk of ['foo:bar', 'label:"unclosed', ':::', 'author:', '-', 'a:b:c', '"']) {
+      expect(() => parseQuery(junk)).not.toThrow();
+      expect(() => applyFilters([pr()], parseQuery(junk))).not.toThrow();
+    }
+  });
+
+  test("a no-constraint token (empty value, bare key) does NOT empty the list", () => {
+    const rows = [pr(), pr(), pr()];
+    for (const q of ["author:", "label:", "sort:", "sort:bogus", "review:", "   "]) {
+      expect(applyFilters(rows, parseQuery(q))).toHaveLength(3);
+    }
+  });
+
+  test("free text that matches nothing empties the list — that is search working, not a bug", () => {
+    expect(applyFilters([pr({ title: "hello" })], parseQuery("zzz-nope"))).toHaveLength(0);
+  });
+
+  test("unknown key is kept as free text, not dropped", () => {
+    expect(parseQuery("foo:bar").text).toBe("foo:bar");
+  });
+
+  test("a partial token (empty value) adds no constraint", () => {
+    const f = parseQuery("author:");
+    expect(f.authors).toEqual([]);
+    expect(activeCount(f)).toBe(0);
+  });
+});
+
+describe("grammar", () => {
+  test("quoted values with spaces survive", () => {
+    expect(parseQuery('label:"needs review"').labels).toEqual(["needs review"]);
+  });
+
+  test("keys are case-insensitive; enum values normalise to lowercase", () => {
+    const f = parseQuery("Author:Octo REVIEW:Approved");
+    expect(f.authors).toEqual(["Octo"]); // free-form value keeps case
+    expect(f.reviews).toEqual(["approved"]);
+  });
+
+  test("an out-of-range enum value is ignored, not turned into list-emptying free text", () => {
+    const f = parseQuery("review:banana");
+    expect(f.reviews).toEqual([]);
+    expect(f.text).toBe(""); // NOT "review:banana"
+  });
+
+  test("duplicate values dedupe", () => {
+    expect(parseQuery("label:bug label:bug").labels).toEqual(["bug"]);
+  });
+
+  test("free text and tokens mix in any order", () => {
+    const f = parseQuery("fix author:octo urgent");
+    expect(f.authors).toEqual(["octo"]);
+    expect(f.text).toBe("fix urgent");
+  });
+});
+
+describe("parse <-> serialize round-trip", () => {
+  const cases = [
+    "",
+    "author:octo",
+    'label:"needs review" label:bug review:approved',
+    "is:draft base:main author:a author:b",
+    "checks:red sort:most-changed",
+    "fix the thing author:octo",
+  ];
+  for (const c of cases) {
+    test(`normalized(${JSON.stringify(c)}) is a fixed point`, () => {
+      const once = parseQuery(c);
+      const round = parseQuery(serializeQuery(once));
+      expect(round).toEqual(once);
+    });
+  }
+
+  test("serialize drops the default sort and keeps a non-default one", () => {
+    expect(serializeQuery(parseQuery("sort:recently-updated"))).not.toContain("sort:");
+    expect(serializeQuery(parseQuery("sort:oldest"))).toContain("sort:oldest");
+  });
+
+  test("serialize quotes only values that need it", () => {
+    expect(serializeQuery(parseQuery("label:bug"))).toBe("label:bug");
+    expect(serializeQuery(parseQuery('label:"two words"'))).toBe('label:"two words"');
+  });
+});
+
+describe("filtering: OR within a facet, AND across facets", () => {
+  const rows = [
+    pr({ number: 1, author: "alice", labels: [{ name: "bug" }] }),
+    pr({ number: 2, author: "bob", labels: [{ name: "bug" }] }),
+    pr({ number: 3, author: "carol", labels: [{ name: "docs" }] }),
+  ];
+
+  test("two authors is a union (OR within the facet)", () => {
+    const out = applyFilters(rows, parseQuery("author:alice author:bob"));
+    expect(out.map((p) => p.number).sort()).toEqual([1, 2]);
+  });
+
+  test("author AND label intersect (AND across facets)", () => {
+    const out = applyFilters(rows, parseQuery("author:alice label:bug"));
+    expect(out.map((p) => p.number)).toEqual([1]);
+    expect(applyFilters(rows, parseQuery("author:carol label:bug"))).toHaveLength(0);
+  });
+
+  test("is:draft / is:ready split on the draft flag", () => {
+    const mixed = [pr({ number: 4, isDraft: true }), pr({ number: 5, isDraft: false })];
+    expect(applyFilters(mixed, parseQuery("is:draft")).map((p) => p.number)).toEqual([4]);
+    expect(applyFilters(mixed, parseQuery("is:ready")).map((p) => p.number)).toEqual([5]);
+  });
+
+  test("review:none matches a null review decision", () => {
+    const rs = [pr({ number: 6, reviewDecision: null }), pr({ number: 7, reviewDecision: "APPROVED" })];
+    expect(applyFilters(rs, parseQuery("review:none")).map((p) => p.number)).toEqual([6]);
+    expect(applyFilters(rs, parseQuery("review:approved")).map((p) => p.number)).toEqual([7]);
+  });
+});
+
+describe("checks facet", () => {
+  const green = pr({ number: 1, checks: { total: 3, success: 3, failure: 0, skipped: 0, pending: 0, allDone: true, verdict: "green", failing: [] } });
+  const red = pr({ number: 2, checks: { total: 3, success: 2, failure: 1, skipped: 0, pending: 0, allDone: true, verdict: "red", failing: [] } });
+  const pending = pr({ number: 3, checks: { total: 3, success: 1, failure: 0, skipped: 0, pending: 2, allDone: false, verdict: null, failing: [] } });
+
+  test("green / red / pending select the right rows", () => {
+    const rows = [green, red, pending];
+    expect(applyFilters(rows, parseQuery("checks:green")).map((p) => p.number)).toEqual([1]);
+    expect(applyFilters(rows, parseQuery("checks:red")).map((p) => p.number)).toEqual([2]);
+    expect(applyFilters(rows, parseQuery("checks:pending")).map((p) => p.number)).toEqual([3]);
+  });
+
+  test("a row whose checks have not loaded fails OPEN — a checks filter keeps it", () => {
+    const loading = pr({ number: 9, checksLoaded: false });
+    const out = applyFilters([green, loading], parseQuery("checks:green"));
+    expect(out.map((p) => p.number).sort()).toEqual([1, 9]); // 9 not hidden despite unknown checks
+  });
+});
+
+describe("sort orders", () => {
+  const rows = [
+    pr({ number: 1, title: "zebra", updatedAt: "2026-01-01T00:00:00Z", additions: 1, deletions: 0 }),
+    pr({ number: 3, title: "apple", updatedAt: "2026-03-01T00:00:00Z", additions: 50, deletions: 50 }),
+    pr({ number: 2, title: "mango", updatedAt: "2026-02-01T00:00:00Z", additions: 5, deletions: 5 }),
+  ];
+  const nums = (q: string) => applyFilters(rows, parseQuery(q)).map((p) => p.number);
+
+  test("recently-updated (default), newest, oldest", () => {
+    expect(nums("")).toEqual([3, 2, 1]); // by updatedAt desc
+    expect(nums("sort:newest")).toEqual([3, 2, 1]);
+    expect(nums("sort:oldest")).toEqual([1, 2, 3]);
+  });
+  test("most-changed and title", () => {
+    expect(nums("sort:most-changed")).toEqual([3, 2, 1]);
+    expect(nums("sort:title")).toEqual([3, 2, 1]); // apple, mango, zebra
+  });
+  test("checks sort surfaces red first, then pending, then green", () => {
+    const cr = [
+      pr({ number: 10, checks: { total: 1, success: 1, failure: 0, skipped: 0, pending: 0, allDone: true, verdict: "green", failing: [] } }),
+      pr({ number: 11, checks: { total: 1, success: 0, failure: 1, skipped: 0, pending: 0, allDone: true, verdict: "red", failing: [] } }),
+      pr({ number: 12, checks: { total: 1, success: 0, failure: 0, skipped: 0, pending: 1, allDone: false, verdict: null, failing: [] } }),
+    ];
+    expect(applyFilters(cr, parseQuery("sort:checks")).map((p) => p.number)).toEqual([11, 12, 10]);
+  });
+});
+
+describe("buildFacets counts", () => {
+  const rows = [
+    pr({ number: 1, author: "alice", labels: [{ name: "bug" }] }),
+    pr({ number: 2, author: "alice", labels: [{ name: "docs" }] }),
+    pr({ number: 3, author: "bob", labels: [{ name: "bug" }] }),
+  ];
+
+  test("option counts reflect the current rows", () => {
+    const facets = buildFacets(rows, parseQuery(""));
+    const authors = facets.find((f) => f.key === "authors")!;
+    expect(authors.options.find((o) => o.value === "alice")!.count).toBe(2);
+    expect(authors.options.find((o) => o.value === "bob")!.count).toBe(1);
+  });
+
+  test("a facet's own selection does NOT shrink its sibling counts (GitHub-style)", () => {
+    // With author:alice selected, the Author facet still counts bob's PR, so
+    // the user can widen the selection. But the Label facet reflects alice only.
+    const facets = buildFacets(rows, parseQuery("author:alice"));
+    const authors = facets.find((f) => f.key === "authors")!;
+    expect(authors.options.find((o) => o.value === "bob")!.count).toBe(1); // unshrunk
+    const labels = facets.find((f) => f.key === "labels")!;
+    expect(labels.options.find((o) => o.value === "bug")!.count).toBe(1); // alice's bug only
+    expect(labels.options.find((o) => o.value === "docs")!.count).toBe(1);
+  });
+
+  test("a selected value with no matching rows stays visible so it can be unticked", () => {
+    const facets = buildFacets(rows, parseQuery("author:ghost"));
+    const authors = facets.find((f) => f.key === "authors")!;
+    expect(authors.options.find((o) => o.value === "ghost")).toBeTruthy();
+    expect(authors.options.find((o) => o.value === "ghost")!.count).toBe(0);
+  });
+
+  test("rows with unloaded checks are excluded from the checks counts", () => {
+    const rs = [
+      pr({ number: 4, checks: { total: 1, success: 1, failure: 0, skipped: 0, pending: 0, allDone: true, verdict: "green", failing: [] } }),
+      pr({ number: 5, checksLoaded: false }),
+    ];
+    const checks = buildFacets(rs, parseQuery("")).find((f) => f.key === "checks")!;
+    expect(checks.options.find((o) => o.value === "green")!.count).toBe(1); // row 5 not counted
+  });
+});
+
+describe("toggleFacet round-trips through the string", () => {
+  test("toggling adds then removes a value", () => {
+    let f = parseQuery("");
+    f = toggleFacet(f, "labels", "bug");
+    expect(serializeQuery(f)).toBe("label:bug");
+    f = toggleFacet(parseQuery(serializeQuery(f)), "labels", "bug");
+    expect(serializeQuery(f)).toBe("");
+  });
+});


### PR DESCRIPTION
## What

The PR panel had three scope tabs (Mine / Review / All) and a substring search. This makes it a proper, pulldash-inspired filter surface: **Author, Label, Reviews, Checks/CI, Draft, Base, Assignee, Milestone** facet dropdowns (multi-select, live per-option counts), a **Sort** control, a **query bar**, **active-filter chips** with clear-all, and **keyboard nav**.

Inspired by [coder/pulldash](https://github.com/coder/pulldash): keyboard-first, fast, multi-criteria.

## How

- **The query string is the single source of truth.** `FilterState` is a pure `parseQuery(query)` derivation, never stored; the dropdowns are *editors of the string* (`toggle -> parse -> mutate -> serialize -> setQuery`). The bar and the menus are two views of one state, so they cannot drift. Sort lives in the string too (`sort:...`); switching scope tabs clears everything via the existing `setQuery("")`.
- **Grammar** `key:value | freeword`, quotes for spaces (`label:"needs review"`), case-insensitive, and **total**: unknown keys / partial tokens / unclosed quotes degrade to free text, never throw, never surprise-empty the list.
- **Semantics**: OR within a facet, AND across facets. A multi-select checkbox has to be OR, or ticking a second box could only ever shrink the result to zero. Counts are GitHub-style (an option's count ignores its own facet's selection, so you can always widen).
- **Server**: `gh pr list --json` gains `assignees` + `milestone` (cheap fields), mapped in `mapSummary`; `PrSummary` gains the two fields. No GraphQL / rate-limit change. Projects facet deferred (needs `projectItems`).
- **Layout** fits the narrow sidebar: facet pills wrap, and each menu floats through the `Portal` so it is not width-bound by the column. New `FacetMenu` reuses `Select.tsx`'s Portal + spring + positioning + capture-phase keys.
- **Keyboard**: `j`/`k` move the selection, `/` focuses the query, `esc` clears. Reuses the workspace-open guard that already frees bare letters in this panel (same as the files tab).
- **Checks fail open** while the second fetch pass is still loading, so the list does not collapse then re-expand.

## New files

- `web/src/lib/prFilter.ts` (pure): `parseQuery`, `serializeQuery`, `applyFilters`, `buildFacets`, sort comparators.
- `web/src/components/FacetMenu.tsx`: multi-select (+ radio for Sort) dropdown with counts.
- `web/src/components/PrFilterBar.tsx`: query input + wrapping facet pills + Sort + chips.

## Verification

- **`web/test/prFilter.test.ts` (33 tests)**: parse totality (garbage never throws), parse↔serialize round-trip + normalization, quoting, OR-within / AND-across, live counts (sibling counts unaffected by own selection), every sort order, checks fail-open.
- `server/test/prs.test.ts`: pins the `assignees`/`milestone` mapping (present + empty/null cases).
- Full suites green: **web 273**, **server 615**; web `tsc` + `vite build`, `smoke`, `perfbudget` all pass.

## QA

- [ ] Open the PR panel, open each facet, confirm multi-select + counts.
- [ ] Toggle a facet, confirm the query bar text updates; type `label:bug` and confirm the pill/chip reflect it (both directions).
- [ ] `j`/`k` move selection, `/` focuses search, `esc` clears; chips remove individually, Clear all resets.
- [ ] Sort orders behave; narrow-sidebar wrapping holds.

## Follow-ups (separate issues)

Projects facet (GraphQL `projectItems`), group-by sections, saved named filters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)