### PR TITLE
fix(alerts): stop the test suite raising real desktop notifications

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -29,6 +29,25 @@ export interface AlertSink {
 let sink: AlertSink | null = null;
 export function setAlertSink(s: AlertSink | null) { sink = s; }
 
+// Both outbound channels leave the machine, so neither may fire from a test
+// run. The gate test used to reach the real `notify-send`: `bun test` popped
+// "✋ Approval needed — app:sess2 wants to run Bash: rm -rf something-unique-2"
+// onto the desktop of whoever ran the suite, indistinguishable from a live
+// agent asking to delete something. A webhook set in the environment would
+// have been posted to Slack the same way. `bun test` sets NODE_ENV=test.
+const IS_TEST = process.env.NODE_ENV === "test";
+
+/**
+ * The notify-send half of delivery, as a seam.
+ *
+ * Tests install one of these and assert on what the fallback WOULD have shown,
+ * which is both safe and a stronger check than the absence of a broadcast.
+ * Left unset in the app: `null` means the built-in `notify-send` below.
+ */
+export type DesktopNotifier = (a: AlertNote) => void;
+let notifier: DesktopNotifier | null = null;
+export function setDesktopNotifier(n: DesktopNotifier | null) { notifier = n; }
+
 // Debounce identical alerts so a burst doesn't spam channels.
 const lastSent = new Map<string, number>();
 const DEBOUNCE_MS = 30_000;
@@ -42,7 +61,7 @@ function shouldSend(key: string): boolean {
 }
 
 async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
-  if (WEBHOOK) {
+  if (WEBHOOK && !IS_TEST) {
     try {
       await fetch(WEBHOOK, {
         method: "POST",
@@ -60,6 +79,11 @@ async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
       sink.broadcast({ title, body, urgency });
       return;
     }
+    if (notifier) { notifier({ title, body, urgency }); return; }
+    // No seam installed and this is a test run: say nothing. A suite must never
+    // put an approval prompt on somebody's desktop for a hold that never
+    // happened, and a test that wants to check this path installs a notifier.
+    if (IS_TEST) return;
     try {
       Bun.spawn(["notify-send", "-a", "agentglass", "-u", "critical", "--", title, body], { stdout: "ignore" });
     } catch (e) {

--- a/server/test/alerts-sink.test.ts
+++ b/server/test/alerts-sink.test.ts
@@ -18,6 +18,7 @@ afterAll(() => {
 
 let alerts: typeof import("../src/alerts.ts");
 let broadcasts: AlertNote[] = [];
+let fallbacks: AlertNote[] = [];
 let clientsPresent = true;
 
 beforeAll(async () => {
@@ -26,26 +27,39 @@ beforeAll(async () => {
   // (bun shares the module registry across the suite).
   alerts = await import(`../src/alerts.ts?u=${Math.random()}`);
   alerts.setAlertSink({ broadcast: (a) => broadcasts.push(a), hasClients: () => clientsPresent });
+  // Captures the notify-send fallback instead of running it. Without this the
+  // no-client test spawned a REAL desktop notification, so anyone running the
+  // suite got "✋ Approval needed — wants to run Bash: rm -rf …" from a hold
+  // that did not exist. alerts.ts also refuses to spawn under NODE_ENV=test;
+  // this seam is what lets the path still be asserted.
+  alerts.setDesktopNotifier((a) => fallbacks.push(a));
 });
 
 describe("desktop alert routing", () => {
+  // Fixture summaries are deliberately inert. They end up in the text of a
+  // real "Approval needed" alert the moment anything stops stubbing delivery,
+  // and `rm -rf <path>` in that position is alarming enough to be acted on.
   test("with a client attached, a gate hold broadcasts a critical native alert", () => {
-    broadcasts = []; clientsPresent = true;
-    alerts.pushGate("app:sess1", "Bash", "rm -rf something-unique-1");
+    broadcasts = []; fallbacks = []; clientsPresent = true;
+    alerts.pushGate("app:sess1", "Bash", "ls fixture-one");
     expect(broadcasts.length).toBe(1);
     expect(broadcasts[0].title).toContain("Approval");
     expect(broadcasts[0].urgency).toBe(2);
     expect(broadcasts[0].body).toContain("Bash");
+    expect(fallbacks.length).toBe(0); // the client showed it; no notify-send
   });
 
-  test("with no client attached, it does NOT broadcast (notify-send is the fallback)", () => {
-    broadcasts = []; clientsPresent = false;
-    alerts.pushGate("app:sess2", "Bash", "rm -rf something-unique-2");
+  test("with no client attached, it does NOT broadcast — notify-send gets it instead", () => {
+    broadcasts = []; fallbacks = []; clientsPresent = false;
+    alerts.pushGate("app:sess2", "Bash", "ls fixture-two");
     expect(broadcasts.length).toBe(0);
+    expect(fallbacks.length).toBe(1);
+    expect(fallbacks[0].title).toContain("Approval");
+    expect(fallbacks[0].body).toContain("ls fixture-two");
   });
 
   test("an agent notification is normal urgency; a tool error is critical", () => {
-    broadcasts = []; clientsPresent = true;
+    broadcasts = []; fallbacks = []; clientsPresent = true;
     alerts.maybeAlert({ hook_event_type: "Notification", session_id: "s-notif", source_app: "app", payload: { message: "heads up" } } as any);
     alerts.maybeAlert({ hook_event_type: "PostToolUse", is_error: 1, session_id: "s-err", source_app: "app", tool_name: "Bash", error_text: "boom", payload: {} } as any);
     expect(broadcasts.map((b) => b.urgency).sort()).toEqual([1, 2]);


### PR DESCRIPTION
## What does this PR do?

Running `bun test` fired a **real** desktop notification. `alerts-sink.test.ts` exercises the no-client path of the gate alert, and that path falls through to `notify-send`, so every suite run put this on the desktop of whoever ran it:

> ✋ **Approval needed** — app:sess2 wants to run Bash: `rm -rf something-unique-2` — approve or deny in agentglass.

Indistinguishable from a live agent asking to delete something, and it names a destructive command nobody authorised. A contributor's first `bun test` should not do that.

Delivery now has a seam on the notify-send half, matching the one the broadcast half already had:

- `setDesktopNotifier()` alongside `setAlertSink()`. The test installs one, so the fallback is **captured and asserted** instead of run — a stronger check than the old "does NOT broadcast".
- Belt as well as braces: `deliver()` refuses to spawn `notify-send` or POST `AGENTGLASS_WEBHOOK` when `NODE_ENV === "test"` (bun sets it), so a future test importing `alerts.ts` with `AGENTGLASS_NOTIFY=1` cannot leak to a desktop or a Slack channel either.
- Fixture summaries are inert (`ls fixture-two`) rather than `rm -rf …`, since they end up verbatim in alert text the moment anything stops stubbing delivery.

No behaviour change in the app: with no notifier installed and outside a test run, the `notify-send` fallback is exactly as before.

## How was it tested?

- **Proved the leak and the fix** with a fake `notify-send` first on `PATH`: before the change, one real notification per run (`FIRED: … rm -rf something-unique-2`); after, zero.
- `bun test` in `server/` — 613 pass, 0 fail.
- `bunx tsc --noEmit` in `server/` — clean.