### PR TITLE
fix(models): track the Claude 5 family, and the 1M context window

### DIFF
--- a/hooks/seed_demo.py
+++ b/hooks/seed_demo.py
@@ -29,7 +29,7 @@ def _agentglass_local_only(url):
         sys.exit(0)
 
 APPS = ["api-refactor", "docs-agent", "test-writer", "migration"]
-MODELS = ["claude-opus-4-8", "claude-sonnet-5", "claude-haiku-4-5"]
+MODELS = ["claude-opus-5", "claude-sonnet-5", "claude-haiku-4-5"]
 TOOLS = ["Bash", "Read", "Edit", "Grep", "Write", "WebFetch", "Task"]
 _seed = random.Random(7)
 

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -212,7 +212,9 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   // An image on its own is a complete thought ("what's wrong with this?"), so a
   // turn only needs text when it carries nothing else.
   if (!message.trim() && !imgs.length) return err("invalid message");
-  const m = typeof model === "string" && MODEL_RE.test(model) ? model : "claude-opus-4-8";
+  // Keep in step with DEFAULT_MODEL in web/src/lib/chatStore.ts — this is the
+  // same default, reached when a caller sends no model or a malformed one.
+  const m = typeof model === "string" && MODEL_RE.test(model) ? model : "claude-opus-5";
   let pm = typeof mode === "string" && MODES.has(mode) ? mode : "default";
   if (pm === "bypassPermissions" && !BYPASS_ALLOWED) pm = "default"; // opt-in only
   const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -36,8 +36,9 @@ import { SidebarGrip } from "./SidebarGrip.tsx";
 // list is its own job. The 1M entry is here because it is what this fix buys:
 // the suffix now survives the server, so the window is actually selectable.
 const MODELS = [
-  { id: "claude-opus-4-8", label: "Opus 4.8" },
-  { id: "claude-opus-4-8[1m]", label: "Opus 4.8 · 1M" },
+  { id: "claude-fable-5", label: "Fable 5" },
+  { id: "claude-opus-5", label: "Opus 5" },
+  { id: "claude-opus-5[1m]", label: "Opus 5 · 1M" },
   { id: "claude-sonnet-5", label: "Sonnet 5" },
   { id: "claude-haiku-4-5", label: "Haiku 4.5" },
 ];

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -148,7 +148,7 @@ const chats = new Map<string, Chat>();
 const subs = new Set<() => void>();
 let seq = 0;
 
-export const DEFAULT_MODEL = "claude-opus-4-8";
+export const DEFAULT_MODEL = "claude-opus-5";
 export const DEFAULT_MODE = "default";
 
 // A cached snapshot, rebuilt only when something actually changes.

--- a/web/src/lib/contextWindow.ts
+++ b/web/src/lib/contextWindow.ts
@@ -25,12 +25,31 @@ function suffixWindow(m: string): number | null {
   return hit[2] === "m" ? n * 1_000_000 : n * 1_000;
 }
 
+/**
+ * Claude ids whose default window is 1M: the 5 family (Fable, Mythos, Opus,
+ * Sonnet) and Opus/Sonnet 4.6 onward. Everything else Claude — Haiku, Opus 4.5
+ * and older, Sonnet 4.5 and older, the 3.x line — is 200k.
+ *
+ * Written as the *wide* list rather than the narrow one so an id nobody has
+ * taught this file about falls to 200k. That is the recoverable direction of
+ * error: under-reading a window draws the bar too full, which `ctxLimitOf`
+ * then corrects the moment an observation exceeds it. Over-reading has no such
+ * backstop — it would quietly draw a session that is genuinely about to
+ * compact as having plenty of room, which is the failure this file exists to
+ * prevent.
+ *
+ * `-4-[678]` rather than a general `4-\d` because the cut is mid-generation:
+ * Opus 4.5 is 200k and Opus 4.6 is 1M.
+ */
+const CLAUDE_1M = /fable|mythos|opus-5|sonnet-5|opus-4-[678]|sonnet-4-6/;
+
 /** Ceiling by model family. Only consulted when the id doesn't say outright. */
 function familyWindow(m: string): number {
   if (m.includes("gemini")) return 1_000_000;
   if (m.includes("gpt-5")) return 400_000;
   if (m.includes("gpt") || /\bo[134]\b/.test(m)) return 128_000;
-  return 200_000;  // every current Claude model, absent a suffix
+  if (CLAUDE_1M.test(m)) return 1_000_000;
+  return 200_000;  // Haiku, and Claude 4.5 and older
 }
 
 /**

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -23,14 +23,14 @@ const uid = () => Array.from({ length: 8 }, () => "0123456789abcdef"[rint(0, 15)
 
 // A deliberately mixed fleet so the demo shows off multi-provider support:
 // Anthropic + OpenAI + Google, all auto-detected from the model name.
-const MODELS = ["claude-opus-4-8", "claude-sonnet-5", "gpt-5", "gpt-5-mini", "gemini-3-flash"];
+const MODELS = ["claude-fable-5", "claude-opus-5", "claude-sonnet-5", "gpt-5", "gpt-5-mini", "gemini-3-flash"];
 interface Sess { app: string; sid: string; model: string }
 // Fictional app suite for a made-up online store.
 const SESSIONS: Sess[] = [
-  { app: "shop-web", sid: "7a3f21c9-demo", model: "claude-opus-4-8" },
+  { app: "shop-web", sid: "7a3f21c9-demo", model: "claude-opus-5" },
   { app: "shop-web", sid: "e2b8d640-demo", model: "gpt-5" },
   { app: "shop-api", sid: "3c9a1f52-demo", model: "claude-sonnet-5" },
-  { app: "agentglass", sid: "b7e40a18-demo", model: "claude-opus-4-8" },
+  { app: "agentglass", sid: "b7e40a18-demo", model: "claude-opus-5" },
   { app: "payments-svc", sid: "5f6d2e93-demo", model: "gemini-3-flash" },
   { app: "inventory-svc", sid: "8a1c7b04-demo", model: "gpt-5-mini" },
   { app: "sandbox", sid: "d4e903a7-demo", model: "gpt-5" },

--- a/web/test/context-window.test.ts
+++ b/web/test/context-window.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+
+import { ctxLimitOf } from "../src/lib/contextWindow.ts";
+
+/**
+ * The context ceiling per model, and the one property that makes it safe.
+ *
+ * This is the number the Radar's "about to compact" ring and the chat context
+ * meter are drawn against, so getting it wrong doesn't error — it silently
+ * mis-draws. The bug that motivated these tests: every Claude model was
+ * assumed to be 200k, which was true a generation ago and is now wrong for
+ * everything except Haiku. A 1M-window Opus 5 session read as about to compact
+ * at a fifth of its real capacity.
+ */
+
+const M = 1_000_000;
+const K = 1_000;
+
+describe("ctxLimitOf — the 1M Claude models", () => {
+  it("reads the 5 family as 1M", () => {
+    for (const id of ["claude-opus-5", "claude-sonnet-5", "claude-fable-5", "claude-mythos-5"]) {
+      expect(ctxLimitOf(id)).toBe(M);
+    }
+  });
+
+  it("reads Opus/Sonnet 4.6 onward as 1M", () => {
+    for (const id of ["claude-opus-4-6", "claude-opus-4-7", "claude-opus-4-8", "claude-sonnet-4-6"]) {
+      expect(ctxLimitOf(id)).toBe(M);
+    }
+  });
+});
+
+describe("ctxLimitOf — the 200k Claude models", () => {
+  it("keeps Haiku at 200k", () => {
+    expect(ctxLimitOf("claude-haiku-4-5")).toBe(200 * K);
+  });
+
+  /** The cut is mid-generation, which is why the pattern can't be a loose `4-\d`. */
+  it("keeps Opus 4.5 and Sonnet 4.5 at 200k — 4.6 is where the window widens", () => {
+    expect(ctxLimitOf("claude-opus-4-5")).toBe(200 * K);
+    expect(ctxLimitOf("claude-sonnet-4-5")).toBe(200 * K);
+  });
+
+  it("keeps the older lines at 200k", () => {
+    expect(ctxLimitOf("claude-opus-4-1")).toBe(200 * K);
+    expect(ctxLimitOf("claude-3-5-sonnet-20241022")).toBe(200 * K);
+  });
+});
+
+describe("ctxLimitOf — an id this file has never seen", () => {
+  /**
+   * Under-reading is recoverable (the observation rule below promotes it);
+   * over-reading is not. An unknown id must therefore land on 200k, not 1M.
+   */
+  it("falls to the conservative 200k rather than guessing wide", () => {
+    expect(ctxLimitOf("claude-something-7")).toBe(200 * K);
+    expect(ctxLimitOf("")).toBe(200 * K);
+    expect(ctxLimitOf(null)).toBe(200 * K);
+    expect(ctxLimitOf(undefined)).toBe(200 * K);
+  });
+
+  it("is promoted by an observation that exceeds it", () => {
+    // The self-healing rule: the measurement is harder evidence than the name.
+    expect(ctxLimitOf("claude-something-7", 250_000)).toBe(400 * K);
+    expect(ctxLimitOf("claude-something-7", 900_000)).toBe(M);
+  });
+});
+
+describe("ctxLimitOf — the explicit suffix wins", () => {
+  it("believes the id over the family default", () => {
+    expect(ctxLimitOf("claude-opus-5[200k]")).toBe(200 * K);
+    expect(ctxLimitOf("claude-haiku-4-5[1m]")).toBe(M);
+  });
+});
+
+describe("ctxLimitOf — other providers are untouched", () => {
+  it("keeps the non-Claude ceilings", () => {
+    expect(ctxLimitOf("gemini-3-flash")).toBe(M);
+    expect(ctxLimitOf("gpt-5")).toBe(400 * K);
+    expect(ctxLimitOf("gpt-4o")).toBe(128 * K);
+  });
+});


### PR DESCRIPTION
The model picker, the chat default and both demo seeders still named Claude Opus 4.8. That model is **current, not retired**, so nothing was broken — but the list had fallen a generation behind what the CLI actually runs. Adds Fable 5, moves the default to Opus 5, keeps the 1M variant entry alongside it.

## The part that was actually wrong

`contextWindow.ts` → `familyWindow()` returned `200_000` for every Claude id, with a comment asserting that was *"every current Claude model, absent a suffix"*. That held a generation ago. Today only Haiku is 200k — the 5 family and Opus/Sonnet 4.6 onward all ship 1M.

This is the number the Radar's compaction ring (`derive.ts` → `a.ctxLimit`) and the chat context meter are drawn against, so the effect wasn't an error but a **mis-draw**: an Opus 5 session read as *about to compact* at roughly a fifth of its real capacity. The file's own promote-on-observation rule blunted it — but only after a prompt passed 200k, and only to the next rung up (400k), so the reading stayed wrong, just less wrong.

Moving the default to Opus 5 is what would have made this bite by default, which is why it belongs in this PR rather than a separate one.

Worth noting the irony: the file's header comment describes this exact class of silent wrongness as the reason it was written.

## Two deliberate choices in the fix

**The 1M set is the wide list, not the narrow one.** An id nobody has taught the file about falls to 200k. That's the recoverable direction — under-reading is corrected by the observation rule; over-reading has no backstop and would quietly draw a session that really is about to compact as having plenty of room.

**`-4-[678]`, not a general `4-\d`.** The cut lands mid-generation: Opus 4.5 is 200k, Opus 4.6 is 1M. `web/test/context-window.test.ts` pins that boundary explicitly, along with unknown-id fallback, observation promotion, and suffix-wins.

## Also

- `server/src/chat.ts` dropped to Opus 4.8 when a request carried no model or a malformed one, while `DEFAULT_MODEL` had moved on. Only reachable on a bad request, but the two shouldn't disagree about what "default" means. Coupled by comment, matching the existing convention in `control.ts` ("Kept in step with shared/types.ts by hand") — happy to promote it to a shared constant instead if you'd rather it were enforced.
- `hooks/seed_demo.py` was still seeding Opus 4.8 while `web/src/lib/demo.ts` had been updated — same job, half done.

**Pricing needed no change.** `PRICE_TABLE` matches on family substring (`opus`/`sonnet`/`haiku`/`fable`), so Opus 5 and Fable 5 already resolve correctly, and the `fable` row was already there. Test fixtures using `claude-opus-4-8` as opaque strings are left alone — swapping them is diff noise with no behaviour change.

## Testing

- 9 new tests in `web/test/context-window.test.ts`.
- Full suite green: **897 pass, 0 fail** (888 on `main` + 9). `web` typecheck clean, `seed_demo.py` compiles.

## Ordering

Independent of #288 — different concern, and the two touch different hunks of `ChatPanel.tsx`, so they should merge in either order without conflict. If #288 lands first this may want a trivial rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)