### PR TITLE
fix(demo): measure demo context against the same ceiling the radar draws

### DIFF
--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -35,11 +35,18 @@ const BYPASS_ALLOWED = CHAT_BYPASS_ALLOWED;
 /** How long a turn may produce nothing at all before we assume the CLI is stuck
  *  on something it can't ask us for. Only ever armed before the first byte. */
 const STARTUP_TIMEOUT_MS = Number(process.env.AGENTGLASS_CHAT_STARTUP_TIMEOUT_MS ?? 20_000);
-// A model id, with the optional window suffix Claude Code uses to ask for a
-// non-default context size: `claude-opus-4-8[1m]`. The suffix has to be allowed
-// through rather than sanitised away — without it the request silently fell
-// back to the 200k default, so a chat asking for the 1M window got a fifth of
-// it and the UI still measured against whatever the name implied.
+// A model id, with the optional window suffix Claude Code uses to ask for the
+// 1M context window: `claude-opus-4-8[1m]`. The suffix has to be allowed
+// through rather than sanitised away, because stripping it silently downgraded
+// the window a chat had asked for and the UI still measured against whatever
+// the name implied.
+//
+// It buys less than it once did, and only in specific places. On the
+// first-party API the Claude 5 family and Opus 4.7+ run at 1M unconditionally,
+// so the suffix is a no-op there. It still decides the window behind an LLM
+// gateway, on Bedrock / Vertex / Foundry, and for Opus 4.6 — which is why it
+// survives here rather than being dropped now that `contextWindow.ts` knows
+// the families outright.
 const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}(\[[a-z0-9]{1,8}\])?$/;
 const SESSION_RE = /^[A-Za-z0-9][A-Za-z0-9-]{7,64}$/;
 

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -37,6 +37,7 @@ export const PRICE_TABLE: ModelPrice[] = [
   { match: ["sonnet"], label: "Sonnet", input: 3, output: 15, cache_write: 3.75, cache_read: 0.3 },
   { match: ["haiku"], label: "Haiku", input: 1, output: 5, cache_write: 1.25, cache_read: 0.1 },
   { match: ["fable"], label: "Fable", input: 10, output: 50, cache_write: 12.5, cache_read: 1.0 },
+  { match: ["mythos"], label: "Mythos", input: 10, output: 50, cache_write: 12.5, cache_read: 1.0 },
 
   // --- OpenAI (approx; verify at openai.com/pricing) ---
   { match: ["gpt-4o-mini", "4o-mini"], label: "GPT-4o mini", input: 0.15, output: 0.6, cache_write: 0, cache_read: 0.075 },

--- a/server/src/walkthrough.ts
+++ b/server/src/walkthrough.ts
@@ -14,7 +14,7 @@ import type { WalkthroughResult, WalkthroughInputFile } from "../../shared/types
 
 // Haiku by default: the task is a one-liner per file, so a small fast model is
 // plenty and keeps latency + token cost low. Override with the env var to trade
-// speed for depth (e.g. claude-opus-4-8). Results are cached client-side, so the
+// speed for depth (e.g. claude-opus-5). Results are cached client-side, so the
 // model only runs on genuinely new changesets.
 const MODEL = process.env.AGENTGLASS_WALKTHROUGH_MODEL || "claude-haiku-4-5";
 const MAX_FILES = 40;

--- a/server/test/pricing.test.ts
+++ b/server/test/pricing.test.ts
@@ -11,6 +11,16 @@ describe("priceFor", () => {
     expect(priceFor("claude-3-5-haiku-latest")?.label).toBe("Haiku");
   });
 
+  test("the premium Claude tiers are priced apart from Opus", () => {
+    // Both are $10/$50 rather than Opus's $5/$25, and neither name contains
+    // "opus"/"sonnet"/"haiku", so a missing row would silently fall through to
+    // DEFAULT_PRICE and under-report the cost by ~3x rather than fail.
+    expect(priceFor("claude-fable-5")?.label).toBe("Fable");
+    expect(priceFor("claude-mythos-5")?.label).toBe("Mythos");
+    expect(priceFor("claude-mythos-5")?.input).toBe(10);
+    expect(priceFor("claude-mythos-5")?.output).toBe(50);
+  });
+
   test("more specific OpenAI fragments win over generic ones", () => {
     expect(priceFor("gpt-4o-mini")?.label).toBe("GPT-4o mini");
     expect(priceFor("chatgpt-4o-latest")?.label).toBe("GPT-4o");

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -33,8 +33,15 @@ import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 
 // Still hand-maintained, and still drifts every release — the runtime-sourced
-// list is its own job. The 1M entry is here because it is what this fix buys:
-// the suffix now survives the server, so the window is actually selectable.
+// list is its own job.
+//
+// The `· 1M` entry no longer changes what this app measures: `ctxLimitOf`
+// knows Opus 5 is a 1M model, so the plain id and the suffixed one resolve to
+// the same ceiling. It stays because the suffix is not ours to interpret — it
+// is what `claude` reads to pick a window behind an LLM gateway or on Bedrock
+// / Vertex / Foundry, where the plain id really does mean 200k. Locally the
+// two entries are the same choice; for someone pointed at a provider they are
+// not, and only they can tell which.
 const MODELS = [
   { id: "claude-fable-5", label: "Fable 5" },
   { id: "claude-opus-5", label: "Opus 5" },

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -13,6 +13,7 @@ import type {
   GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult,
 } from "../../../shared/types.ts";
 import { providerOf } from "./format.ts";
+import { ctxLimitOf } from "./contextWindow.ts";
 
 export const IS_DEMO = import.meta.env.VITE_DEMO === "1";
 
@@ -112,7 +113,14 @@ function nextEvent(): WatchEvent {
     // Each turn re-sends the growing conversation (mostly as cache reads), so
     // per-session context creeps up between turns and drops on "compaction" —
     // that drift toward the radar's edge and snap back is the point of it.
-    const limit = s.model.includes("gemini") ? 1_000_000 : s.model.includes("gpt-5") ? 400_000 : s.model.includes("gpt") ? 128_000 : 200_000;
+    //
+    // The ceiling has to be the one the radar measures against, not a second
+    // copy of it: this file used to carry its own model→window cascade, and
+    // when `contextWindow.ts` learned that the Claude 5 family is 1M this one
+    // stayed at 200k. The demo then generated up to 184k against a 1M ring, so
+    // every Claude blip sat in the inner third and never drifted anywhere —
+    // the one behaviour the demo exists to show.
+    const limit = ctxLimitOf(s.model);
     let ctx = demoCtx.get(s.sid) ?? rint(8_000, limit * 0.5);
     ctx += rint(3_000, 14_000);
     if (ctx > limit * 0.92) ctx = rint(limit * 0.2, limit * 0.35); // compacted


### PR DESCRIPTION
## What does this PR do?

Follow-up to #289, which taught `contextWindow.ts` that the Claude 5 family runs at 1M.

`demo.ts` carried its own copy of the model→window cascade, so it did not learn the same thing. The demo grew fabricated context to at most `200_000 * 0.92` = 184k while `derive.ts` measured it against 1,000,000 — every Claude blip parked at 18% of the radar ring and never moved. The drift toward the edge and the snap back on compaction, which the comment three lines above calls "the point of it", stopped happening in the demo build. It now calls `ctxLimitOf` rather than duplicating it.

Also correcting what #289 made stale elsewhere:

- **`server/src/chat.ts`** still said a bare model id "silently fell back to the 200k default". That was the old regime, where 1M sat behind the `context-1m-2025-08-07` beta header. On the first-party API the Claude 5 family and Opus 4.7+ run at 1M unconditionally, so the suffix is a no-op there — it still decides the window behind an LLM gateway, on Bedrock / Vertex / Foundry, and for Opus 4.6, which is why it stays allowed through `MODEL_RE` rather than being dropped.
- **`web/src/components/ChatPanel.tsx`** said the `· 1M` picker entry exists because the window is "actually selectable". Both ids now resolve to the same ceiling, so it no longer changes anything this app measures. The entry stays for the provider cases above; the comment now says so.
- **`server/src/pricing.ts`** had no `mythos` row, so a Mythos session fell through to `DEFAULT_PRICE` at $3/$15 instead of $10/$50 — while `contextWindow.ts` and its test claimed to track the model. Added, with a test covering both premium tiers.
- **`server/src/walkthrough.ts`** still suggested `claude-opus-4-8` as the depth override.

## How was it tested?

- `bunx tsc --noEmit` — clean in both `server/` and `web/`
- `bun test` — 616 pass in `server/` (one new), 282 in `web/`
- `bunx vite build` and `bun run build:demo` — both green
- `bun scripts/perfbudget.ts` — p99 4ms against a 120ms budget
- Probed the fix directly: the demo's Claude sessions now peak at 92% of the ring (920k against 1M) rather than 18%, matching what gpt-5 and Haiku already did at their own ceilings.

`bun scripts/smoke.ts` fails in this container, but it fails identically on a clean `main` — the headless Chromium here never mounts the workspace views. Not related to this change.