### PR TITLE
pr panel: fix the prose column, the comment order, and the missing feedback

### DIFF
--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -33,6 +33,7 @@ import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedF
 import { stepFileIndex } from "../lib/prNav.ts";
 import { PrFilterBar } from "./PrFilterBar.tsx";
 import { parseQuery, applyFilters, buildFacets, activeCount } from "../lib/prFilter.ts";
+import { getHighlighter, shikiTheme } from "../lib/highlight.ts";
 
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
@@ -127,7 +128,7 @@ function Btn({ children, onClick, disabled, danger, primary, ok, warn, title, sm
   const edge = danger ? "var(--error)" : ok ? "var(--success)" : warn ? "var(--warning)" : primary ? "var(--primary)" : "var(--border)";
   return (
     <button onClick={onClick} disabled={disabled} title={title}
-      className={`rounded disabled:opacity-40 ${small ? "text-[10px] px-2 py-0.5" : "text-[10.5px] px-2.5 py-1"}`}
+      className={`agx-btn rounded disabled:opacity-40 ${small ? "text-[10px] px-2 py-0.5" : "text-[10.5px] px-2.5 py-1"}`}
       style={{
         color: primary ? "var(--bg)" : danger ? "var(--error)" : ok ? "var(--success)" : warn ? "var(--warning)" : "var(--text2)",
         background: primary ? "var(--primary)" : warn ? "color-mix(in srgb, var(--warning) 16%, transparent)" : "transparent",
@@ -150,7 +151,21 @@ function Btn({ children, onClick, disabled, danger, primary, ok, warn, title, sm
  * inline styles cannot reach. `.agx-md` scopes every one of them.
  */
 export const MD_CSS = `
-.agx-md{max-width:78ch;margin:0 auto;line-height:1.7;font-size:12.5px;color:var(--text2)}
+/* Feedback, so a press is legible before the work behind it finishes.
+   :active answers within one frame; :focus-visible keeps the keyboard
+   visible; [data-busy] dims the label and blocks a second press without
+   resizing the button, so the row does not jump under the cursor. */
+.agx-btn{transition:background .13s,border-color .13s,color .13s,transform .07s}
+.agx-btn:active:not(:disabled){transform:translateY(1px) scale(.99)}
+.agx-btn:focus-visible{outline:2px solid var(--primary);outline-offset:2px}
+.agx-btn[data-busy]{pointer-events:none;opacity:.6}
+/* margin:0, not "0 auto". The measure is still capped for reading, but a
+   centred column inside a card sets the body 380px away from the author name
+   above it, which reads as a layout fault rather than as typography. */
+.agx-hl pre{margin:0;padding:10px 12px;border-radius:8px;overflow-x:auto;background:color-mix(in srgb,#000 42%,transparent) !important;border:1px solid color-mix(in srgb,var(--border) 30%,transparent)}
+.agx-hl code{font-size:11.5px;line-height:1.65}
+.agx-md .agx-hl{margin:0 0 .85em}
+.agx-md{max-width:78ch;margin:0;line-height:1.7;font-size:12.5px;color:var(--text2)}
 .agx-md>*:first-child{margin-top:0}
 .agx-md>*:last-child{margin-bottom:0}
 .agx-md p{margin:0 0 .85em}
@@ -193,7 +208,7 @@ function Block({ b }: { b: MdBlock }) {
   }
   if (b.kind === "para") return <p dangerouslySetInnerHTML={{ __html: b.html }} />;
   if (b.kind === "rule") return <hr />;
-  if (b.kind === "code") return <pre><code>{b.text}</code></pre>;
+  if (b.kind === "code") return <CodeBlock text={b.text} lang={b.lang} />;
   if (b.kind === "quote") return <blockquote dangerouslySetInnerHTML={{ __html: b.html }} />;
   if (b.kind === "image") {
     return (
@@ -225,6 +240,35 @@ function Block({ b }: { b: MdBlock }) {
       ))}
     </List>
   );
+}
+
+/**
+ * A fenced code block, tokenised by the same shiki highlighter the diff
+ * surfaces already use. The parser has carried `lang` since it was written;
+ * the renderer dropped it and printed plain text, so a code reference from a
+ * person or a bot arrived as prose. Falls back to plain text while the
+ * highlighter loads and whenever the language is unknown — a block that
+ * renders unstyled is fine, one that renders late or blank is not.
+ */
+function CodeBlock({ text, lang }: { text: string; lang?: string }) {
+  const [html, setHtml] = useState<string | null>(null);
+  useEffect(() => {
+    let live = true;
+    const id = (lang || "").toLowerCase();
+    if (!id) return;
+    (async () => {
+      try {
+        const hl = await getHighlighter();
+        await hl.loadLanguage(id as never).catch(() => {});
+        if (!hl.getLoadedLanguages().includes(id)) return;
+        const out = hl.codeToHtml(text, { lang: id as never, theme: shikiTheme() });
+        if (live) setHtml(out);
+      } catch { /* unstyled is a fine outcome */ }
+    })();
+    return () => { live = false; };
+  }, [text, lang]);
+  if (html) return <div className="agx-hl" dangerouslySetInnerHTML={{ __html: html }} />;
+  return <pre><code>{text}</code></pre>;
 }
 
 export function Md({ body, className }: { body: string; className?: string }) {
@@ -686,11 +730,16 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   const lanes = useMemo(() => {
     if (!detail) return { humans: [] as PrReview[], botReviews: [] as PrReview[], humanComments: [] as PrComment[], bots: [] as PrComment[] };
+    // Oldest first, the way a conversation is read — GitHub's order, and the
+    // one the replies were written in. The API hands these back newest-first,
+    // so a thread arrived answered before it was asked.
+    const byTime = <T,>(xs: T[], at: (x: T) => string) =>
+      [...xs].sort((p, q) => at(p).localeCompare(at(q)));
     return {
-      humans: detail.reviews.filter((r) => !r.isBot && (r.body.trim() || r.state !== "COMMENTED")),
-      botReviews: detail.reviews.filter((r) => r.isBot && r.body.trim()),
-      humanComments: detail.comments.filter((c) => !c.isBot),
-      bots: detail.comments.filter((c) => c.isBot),
+      humans: byTime(detail.reviews.filter((r) => !r.isBot && (r.body.trim() || r.state !== "COMMENTED")), (r) => r.submittedAt),
+      botReviews: byTime(detail.reviews.filter((r) => r.isBot && r.body.trim()), (r) => r.submittedAt),
+      humanComments: byTime(detail.comments.filter((c) => !c.isBot), (c) => c.createdAt),
+      bots: byTime(detail.comments.filter((c) => c.isBot), (c) => c.createdAt),
     };
   }, [detail]);
 


### PR DESCRIPTION
## What does this PR do?

Four changes to the pull request panel, each one measured on the running panel before it was made. This is the first slice of a larger redesign — see **Deliberately not in this PR** below.

### The comment body was set in a centred column

`.agx-md` carried `max-width:78ch; margin:0 auto`. Inside a comment card that centres the body: the author's name sits flush left and the prose starts 380px away from it, which reads as a layout fault rather than as typography.

Measured on the running panel: the paragraph began at **x=765** inside a container that began at **x=383** — a computed `margin-left` of **370px**.

Now `margin:0`. The measure is still capped for reading; it just starts where everything else in the card starts, the way GitHub sets a comment.

### A conversation read backwards

Reviews and comments were rendered in the order the API returns them, which is newest-first — so a thread arrived answered before it was asked. Sorted oldest first: the order they were written in, and the order GitHub shows.

### Fenced code arrived as prose

`prBody.ts` has parsed a fence's language since it was written. The renderer dropped it and printed a plain `<pre><code>`, so a code reference from a person or a bot lost its highlighting — while the diff surfaces two panels away were already tokenising with shiki.

`CodeBlock` asks that same shared highlighter, falling back to plain text while it loads and whenever the language is unknown. A block that renders unstyled is fine; one that renders late or blank is not.

### A press was not legible until the work finished

Buttons had hover and nothing else — no pressed state, no keyboard ring, no way to tell a click had landed. `.agx-btn` adds `:active` inside one frame, a `:focus-visible` ring that is never suppressed, and a `[data-busy]` state that dims the label **without resizing the button**, so a row does not jump under the cursor mid-press.

## How was it tested?

- `bun test` — **616 pass, 0 fail**.
- `bunx tsc --noEmit` clean in `web/` and `server/`.
- A headless pass over the **built demo bundle**, driven to the panel: no JS errors, `margin-left` now `0px`, the conversation reads forwards, `.agx-btn` present and the pressed rule in the stylesheet.

Two of my first assertions were wrong and are worth naming: one counted a static-asset 404 as a JS error, the other compared the prose to the card's *border* box rather than its content box, so a correct 12px padding read as a failure. Both checks were tightened before this was called green.

## Deliberately not in this PR

These came out of the same design pass and are each large enough to deserve their own review rather than riding along:

- **The filter bar.** Nine controls compete for one job — a query box, eight facet menus, a sort pill and a chip row, all on screen before the panel knows the question. The proposal is three layers: saved views (`Needs my review`, `Mine`, `Failing`, `Ready`), one search field with completion that offers `author:` then the authors with counts, and a single `+ Filter` menu holding the facets.
- **The 50-row wall.** `gh pr list --limit 50` (`server/src/prs.ts:361`) has no pagination, so the other 163 open PRs are unreachable. A bigger number is the wrong fix — 213 rows in one call is a slow first paint for a question most people answer in the first five rows. The proposal is a sentinel that pages ahead of the scroll, skeleton rows that hold the space, and a count that says what is actually loaded.
- **A single chronological timeline** for the conversation, with the events GitHub shows (force-push, review requested, ready for review) and appliable suggested changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_