### PR TITLE
feat(prs): Open / Closed / All filter — see merged and closed PRs, not only open

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -975,6 +975,7 @@ const server = Bun.serve<WsData>({
       return json(await listPrs(
         url.searchParams.get("root") || "",
         url.searchParams.get("filter") || "mine",
+        url.searchParams.get("state") || "open",
         url.searchParams.get("force") === "1",
       ));
     }

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -287,6 +287,11 @@ export function noteCi(repo: PrRepoId, pr: PrSummary): void {
 // ---------------------------------------------------------------------------
 
 export type PrFilter = "mine" | "review" | "all";
+// The open/closed axis, orthogonal to the mine/review/all scope. `closed`
+// includes merged, exactly as gh's `--state closed` and GitHub's own "Closed"
+// tab do; `all` is everything. Drives the fetch (a closed PR is never fetched
+// under `open`), so it is part of the cache key, not a client-side facet.
+export type PrState = "open" | "closed" | "all";
 
 /**
  * Whether probing a filter's PRs should also raise CI notifications.
@@ -327,7 +332,7 @@ const LIST_TTL_MS = 90_000;
 // `\u0000` written as an escape, never as the byte: a raw NUL makes the whole
 // file read as binary to grep, which then skips it in silence. Same separator,
 // same keys, still searchable.
-const cacheKey = (repo: PrRepoId, filter: PrFilter) => `${repo.key}\u0000${filter}`;
+const cacheKey = (repo: PrRepoId, filter: PrFilter, state: PrState) => `${repo.key}\u0000${filter}\u0000${state}`;
 
 // Exported for the test that pins the gh-JSON field extraction (assignees,
 // milestone) — the shapes gh returns are an assumption worth guarding.
@@ -357,8 +362,11 @@ export function mapSummary(p: any, withChecks: boolean): PrSummary {
   };
 }
 
-async function fetchList(repo: PrRepoId, filter: PrFilter): Promise<PrSummary[] | null> {
-  const args = ["pr", "list", "-R", repo.nameWithOwner, "--state", "open", "--limit", "50", "--json", LIST_FIELDS_FAST];
+async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState): Promise<PrSummary[] | null> {
+  // `closed` returns merged + closed (gh's own semantics, matching GitHub's
+  // "Closed" tab); each row still carries its own OPEN/CLOSED/MERGED state, so
+  // the list can tell them apart.
+  const args = ["pr", "list", "-R", repo.nameWithOwner, "--state", state, "--limit", "50", "--json", LIST_FIELDS_FAST];
   // `gh pr list --search` rather than `gh search prs`: the latter is a global
   // search that would need its own repo filter anyway, and it rate-limits
   // separately from the REST path everything else here uses.
@@ -489,8 +497,8 @@ async function fetchCheckRollups(repo: PrRepoId, numbers: number[]): Promise<Map
   return out;
 }
 
-function refreshChecks(repo: PrRepoId, filter: PrFilter, rows: PrSummary[], notify: boolean): void {
-  const key = cacheKey(repo, filter);
+function refreshChecks(repo: PrRepoId, filter: PrFilter, state: PrState, rows: PrSummary[], notify: boolean): void {
+  const key = cacheKey(repo, filter, state);
   if (checkRunning.has(key)) return;
   checkRunning.add(key);
 
@@ -534,8 +542,8 @@ function refreshChecks(repo: PrRepoId, filter: PrFilter, rows: PrSummary[], noti
 }
 
 /** Refresh behind the response. Never awaited by a request handler. */
-function refreshList(repo: PrRepoId, filter: PrFilter): void {
-  const key = cacheKey(repo, filter);
+function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState): void {
+  const key = cacheKey(repo, filter, state);
   if (inflight.has(key)) return;
   inflight.add(key);
   const prev = listCache.get(key);
@@ -555,7 +563,7 @@ function refreshList(repo: PrRepoId, filter: PrFilter): void {
       // One cheap query for the rows themselves — titles, authors, review
       // decisions. Enough to choose a pull request, and it is what the panel
       // is blocked on.
-      const rows = await fetchList(repo, filter);
+      const rows = await fetchList(repo, filter, state);
       if (rows === null) {
         // gh itself failed (a network blip, a rate-limit) — far more likely than
         // a repository that lost every pull request, so keep whatever we had. But
@@ -573,7 +581,9 @@ function refreshList(repo: PrRepoId, filter: PrFilter): void {
         return hit && hit.updatedAt === r.updatedAt ? { ...r, checks: hit.rollup, checksLoaded: true } : r;
       });
       listCache.set(key, { at: Date.now(), prs: merged, loading: false, checksPending: merged.some((p) => !p.checksLoaded) });
-      refreshChecks(repo, filter, merged, ciNotifiesFor(filter));
+      // Only open PRs raise CI notifications — a merged or closed PR's checks
+      // are history, not something to alert on.
+      refreshChecks(repo, filter, state, merged, state === "open" && ciNotifiesFor(filter));
     } catch (e) {
       listCache.set(key, keep({ loading: false, checksPending: false, error: String(e) }));
     } finally {
@@ -587,8 +597,9 @@ function refreshList(repo: PrRepoId, filter: PrFilter): void {
  * old — so the poll never waits on the network, and the age is shown rather
  * than hidden behind a spinner that lies.
  */
-export async function listPrs(rootIn: unknown, filterIn: unknown, force = false): Promise<PrListResponse> {
+export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unknown, force = false): Promise<PrListResponse> {
   const filter: PrFilter = filterIn === "review" || filterIn === "all" ? filterIn : "mine";
+  const state: PrState = stateIn === "closed" || stateIn === "all" ? stateIn : "open";
   const repo = await repoIdFor(rootIn);
   if (!repo) {
     const cap = await ghCapability();
@@ -598,10 +609,10 @@ export async function listPrs(rootIn: unknown, filterIn: unknown, force = false)
       error: !cap.available || !cap.authed ? cap.reason : "no GitHub remote on this repository",
     };
   }
-  const key = cacheKey(repo, filter);
+  const key = cacheKey(repo, filter, state);
   const hit = listCache.get(key);
   const age = hit ? Date.now() - hit.at : Infinity;
-  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter);
+  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter, state);
   const cur = listCache.get(key);
 
   // "you are here" — the checkout's branch, matched against the PR heads. This

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -38,6 +38,14 @@ import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
+// The open/closed axis, orthogonal to the scope views. "closed" holds merged +
+// closed, exactly like GitHub's own Closed tab; "all" is everything.
+type StateSel = "open" | "closed" | "all";
+const STATES: { id: StateSel; label: string }[] = [
+  { id: "open", label: "Open" },
+  { id: "closed", label: "Closed" },
+  { id: "all", label: "All" },
+];
 
 /**
  * Saved views: a scope and a query, together, under one name.
@@ -394,6 +402,8 @@ function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelec
         boxShadow: active ? "inset 2px 0 0 var(--primary)" : undefined,
       }}>
       <div className="flex items-center gap-1.5">
+        {p.state === "MERGED" ? <Chip text="merged" tint="var(--primary)" title="Merged" />
+          : p.state === "CLOSED" ? <Chip text="closed" tint="var(--error)" title="Closed without merging" /> : null}
         <span className="text-[10px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>#{p.number}</span>
         <span className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>{p.title}</span>
         {p.isCurrentBranch && <Chip text="here" tint="var(--primary)" title="This checkout is on that branch" />}
@@ -432,6 +442,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
    *  the first load falls through to your own pull requests once, so opening it
    *  never lands on an empty pane. */
   const [filter, setFilter] = useState<Filter>("review");
+  const [stateSel, setStateSel] = useState<StateSel>("open");
   const fellBack = useRef(false);
   // The filter query for the current scope tab — the single source of truth for
   // both the search box and every facet dropdown (parsed in lib/prFilter.ts).
@@ -485,7 +496,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (!root) return;
     const req = ++listReq.current;
     const want = filter;
-    api.prList(root, filter, force).then((r) => {
+    api.prList(root, filter, stateSel, force).then((r) => {
       if (req !== listReq.current) return; // a newer request already won
       setRepo(r.repo);
       setPrs(r.prs);
@@ -494,7 +505,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       setSelected((cur) => (cur && r.prs.some((p) => p.number === cur) ? cur : r.prs[0]?.number ?? null));
       // Nothing waiting on you: show your own instead of an empty pane. Once
       // only, so choosing "Needs my review" yourself is never overruled.
-      if (want === "review" && r.prs.length === 0 && !r.loading && !r.error && !fellBack.current) {
+      if (want === "review" && stateSel === "open" && r.prs.length === 0 && !r.loading && !r.error && !fellBack.current) {
         fellBack.current = true;
         setFilter("mine");
       }
@@ -502,7 +513,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       if (req !== listReq.current) return;
       setListState({ fetchedAt: 0, loading: false, error: String(e) });
     });
-  }, [root, filter]);
+  }, [root, filter, stateSel]);
 
   /**
    * Switching filter empties the pane before anything is fetched.
@@ -513,7 +524,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
    */
   const lastScope = useRef<string>("");
   useEffect(() => {
-    const scope = `${root}\u0000${filter}`;
+    const scope = `${root}\u0000${filter}\u0000${stateSel}`;
     if (lastScope.current === scope) return; // re-render, not a switch
     const first = lastScope.current === "";
     lastScope.current = scope;
@@ -524,7 +535,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     setDetail(null);
     setDetailErr("");
     setListState((st) => ({ ...st, loading: true, fetchedAt: 0 }));
-  }, [filter, root]);
+  }, [filter, root, stateSel]);
 
   // Polling pauses while the view is hidden — no point spending requests on a
   // pane nobody is looking at — and resumes on return. Resuming refreshes; it
@@ -543,12 +554,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (!active || !root) return;
     const others = (["mine", "review", "all"] as Filter[]).filter((f) => f !== filter);
     const timers = others.map((f, i) => setTimeout(() => {
-      api.prList(root, f, false)
+      api.prList(root, f, stateSel, false)
         .then((r) => setCounts((c) => ({ ...c, [f]: r.prs.length })))
         .catch(() => {});
     }, 1200 + i * 2500));
     return () => timers.forEach(clearTimeout);
-  }, [active, root, filter]);
+  }, [active, root, filter, stateSel]);
 
   const loadDetail = useCallback((n: number, force = false) => {
     const req = ++detailReq.current;
@@ -955,6 +966,20 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
               <span className="text-[10px] px-2 py-0.5 rounded-full shrink-0 self-center"
                 style={{ color: "var(--text3)", border: "1px dashed color-mix(in srgb, var(--border) 45%, transparent)" }}>Custom</span>
             )}
+            {/* Open / Closed / All — the state axis. "Closed" holds merged +
+                closed, like GitHub's own Closed tab. */}
+            <div className="ml-auto flex rounded-full overflow-hidden shrink-0 self-center" style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+              {STATES.map((s) => (
+                <button key={s.id} onClick={() => setStateSel(s.id)} title={`Show ${s.label.toLowerCase()} pull requests`}
+                  className="agx-btn text-[10px] px-2 py-0.5"
+                  style={{
+                    color: stateSel === s.id ? "var(--bg)" : "var(--text3)",
+                    background: stateSel === s.id ? "var(--primary)" : "transparent",
+                  }}>
+                  {s.label}
+                </button>
+              ))}
+            </div>
           </div>
           {repo && prs.length > 0 && (
             <PrFilterBar

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -346,8 +346,8 @@ const realApi = {
   dockerTop: (id: string) => get<{ ok: boolean; text: string; error?: string }>(`/docker/top?id=${encodeURIComponent(id)}`),
   // --- pull requests (gh-backed) ---
   prCapability: (force = false) => get<{ available: boolean; authed: boolean; login?: string; reason?: string }>(`/prs/capability${force ? "?force=1" : ""}`),
-  prList: (root: string, filter: "mine" | "review" | "all", force = false) =>
-    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}${force ? "&force=1" : ""}`),
+  prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false) =>
+    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}`),
   prDetail: (root: string, number: number, force = false) =>
     get<{ ok: boolean; detail?: PrDetail; error?: string }>(`/prs/detail?root=${encodeURIComponent(root)}&number=${number}${force ? "&force=1" : ""}`),
   prDiff: (root: string, number: number) =>
@@ -547,7 +547,7 @@ const demoApi: typeof realApi = {
   // The panel used to answer available:false here, so the feature the landing
   // page calls out as new was dead in the demo that page links to.
   prCapability: (_force?: boolean) => D(demo.prCapability()),
-  prList: (root: string, filter: "mine" | "review" | "all", _force?: boolean) => D<PrListResponse>(demo.prList(root, filter)),
+  prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean) => D<PrListResponse>(demo.prList(root, filter)),
   prDetail: (_root: string, number: number, _force?: boolean) => D(demo.prDetail(number)),
   prDiff: (_root: string, number: number) => D(demo.prDiff(number)),
   prAssetUrl: (raw: string) => raw,


### PR DESCRIPTION
## What does this PR do?

The PR panel only ever fetched `--state open`, so the 200+ **merged and closed** pull requests were invisible — you had to leave agentglass to see them. This adds a GitHub-style **Open · Closed · All** control.

- A **state axis** (open / closed / all) threaded end to end: `fetchList` passes it to `gh pr list --state`, and it is part of the list cache key so each state is its own entry. **"Closed" holds merged + closed**, exactly like `gh` and GitHub's own Closed tab; each row still carries its own `OPEN`/`CLOSED`/`MERGED` state.
- An **Open · Closed · All** segmented control at the end of the views row. Switching refetches (a closed PR was never fetched under `open`) and warms the scope counts under the same state so they never disagree with the list.
- Rows in Closed/All views carry a **`merged`** (purple) or **`closed`** (red) badge.
- CI notifications stay **open-only** — a merged PR's checks are history, not an alert.
- The "empty review falls back to mine" nudge is gated to the open state so it never hijacks a Closed view.

## How was it tested?

- Server + web `tsc`, full suites (**server 618**, **web 294**), `vite build`.
- **Live** against this repo: Closed returned **46 merged + 4 closed** in the first 50.

Note: the list caps at the 50 most recent per state (same limit Open already had). Pagination to walk all 200+ is a small follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)