### PR TITLE
fix: recognize Windows-style paths in scope, completion and env splitting (fixes #188)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -8,7 +8,7 @@
 
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { homedir } from "node:os";
-import { join, resolve, dirname } from "node:path";
+import { join, resolve, dirname, sep, delimiter } from "node:path";
 import { worktreeFamily } from "./worktree.ts";
 
 export const CONFIG_PATH = join(
@@ -131,14 +131,26 @@ export function workspaceRoot(): string | null {
  * beside `~/code/orbit`), which no prefix test can ever match; that is the whole
  * reason this consults git rather than the path alone.
  */
+/** child === parent, or child sits inside parent — compared with the OS's own
+ *  separator (injectable so this can be exercised against both `/` and `\`
+ *  from a single-OS test run). `resolve()` returns backslash-joined paths on
+ *  Windows, so a hardcoded `parent + "/"` prefix test matches the scope root
+ *  itself but never anything inside it there; every path in the project
+ *  reads as out-of-scope. */
+export function isWithin(child: string, parent: string, s: string = sep): boolean {
+  if (child === parent) return true;
+  const prefix = parent.endsWith(s) ? parent : parent + s;
+  return child.startsWith(prefix);
+}
+
 export function inScope(path: string | null | undefined, scope = workspaceRoot()): boolean {
   if (!scope) return true; // whole-machine: nothing to enforce
   if (!path) return false;
   const p = resolve(expand(path));
   // The plain prefix test first: it answers every non-worktree case without a
   // subprocess, including the container-folder scope where the family is moot.
-  if (p === scope || p.startsWith(scope + "/")) return true;
-  return worktreeFamily(scope).some((r) => p === r || p.startsWith(r + "/"));
+  if (isWithin(p, scope)) return true;
+  return worktreeFamily(scope).some((r) => isWithin(p, r));
 }
 
 /** The directories a scoped instance is about: the project plus its linked
@@ -250,7 +262,7 @@ export function terminalDisabledSource(): "env" | "config" | null {
 }
 
 export function configuredRepoDirs(): string[] {
-  const fromEnv = (process.env.AGENTGLASS_REPO_DIRS || "").split(":").filter(Boolean);
+  const fromEnv = (process.env.AGENTGLASS_REPO_DIRS || "").split(delimiter).filter(Boolean);
   // config.repoDirs comes from a hand-editable JSON file, so it may be a non-array
   // or hold non-string entries. Guard before mapping: an unguarded `.map(expand)`
   // threw a TypeError that broke GET /git/repos in the default whole-machine mode

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -16,7 +16,7 @@ import type {
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
 import { costUsd, modelLabel } from "./pricing.ts";
-import { workspaceRoot, scopeRoots } from "./config.ts";
+import { workspaceRoot, scopeRoots, isWithin } from "./config.ts";
 
 /**
  * Where the database lives.
@@ -457,7 +457,12 @@ export function scopeClause(scope: string | null = workspaceRoot()): { clause: s
   // dashboard for a day spent working in ~/code/orbit-WEB-1042, which is where
   // the work actually happens.
   const roots = scopeRoots(scope);
-  const inScope = recordedPaths().filter((p) => roots.some((r) => p === r || p.startsWith(r + "/")));
+  // isWithin rather than a hardcoded `r + "/"`: these are resolve()-derived
+  // host paths, so on Windows they are backslash-joined and the literal slash
+  // matched a checkout root itself but nothing inside it — the same bug fixed
+  // in config.ts one layer up (#188), which would have left a scoped cockpit
+  // there showing an empty dashboard for every project it was opened on.
+  const inScope = recordedPaths().filter((p) => roots.some((r) => isWithin(p, r)));
   // Nothing recorded for this project yet. `AND 0` is the honest answer and the
   // fast one; an empty IN list is a syntax error.
   if (!inScope.length) return { clause: " AND 0", args: [] };

--- a/server/src/fsbrowse.ts
+++ b/server/src/fsbrowse.ts
@@ -66,6 +66,18 @@ function expandHome(p: string): string {
  * the desktop app happened to be launched from — completions that shift
  * depending on how you started the process are worse than none.
  */
+// `resolve()`/`dirname()`/`basename()` below are OS-native, so on a real
+// Windows install they already understand `C:\Users\x` correctly; the bug is
+// entirely in these two guards rejecting it before that code ever runs.
+const DRIVE_LETTER_ROOT = /^[a-zA-Z]:[\\/]/;
+
+/** Absolute by POSIX convention (`/...`) or by Windows drive-letter
+ *  convention (`C:\...` / `C:/...`). Pure string check, no OS dependency, so
+ *  it behaves the same regardless of which platform runs it. */
+export function isAbsoluteLike(p: string): boolean {
+  return p.startsWith("/") || DRIVE_LETTER_ROOT.test(p);
+}
+
 export function splitPrefix(input: unknown): { dir: string; partial: string } | null {
   if (typeof input !== "string") return null;
   // A NUL truncates the path at the syscall boundary, so `/safe\0/../../etc`
@@ -74,13 +86,13 @@ export function splitPrefix(input: unknown): { dir: string; partial: string } | 
   if (input.includes("\0")) return null;
   const raw = input.trim();
   if (!raw) return null;
-  if (!raw.startsWith("/") && !raw.startsWith("~")) return null;
+  if (!isAbsoluteLike(raw) && !raw.startsWith("~")) return null;
   const expanded = expandHome(raw);
-  if (!expanded.startsWith("/")) return null; // `~foo` — another user's home, not ours to guess
+  if (!isAbsoluteLike(expanded)) return null; // `~foo` — another user's home, not ours to guess
   // Ask the *raw* input about the trailing separator: join() drops it while
   // expanding `~/`, which would turn "list my home" into "filter /home by my
   // username". Bare `~` counts as committed for the same reason.
-  const committed = raw.endsWith("/") || raw === "~";
+  const committed = raw.endsWith("/") || raw.endsWith("\\") || raw === "~";
   // resolve() collapses `.`, `..` and doubled separators, so what we list is
   // always the real target rather than a path that merely spells it.
   if (committed) return { dir: resolve(expanded), partial: "" };

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -4,7 +4,7 @@
 // (never a shell string); paths are validated to stay inside the repo root; and
 // every mutating op is gated by AGENTGLASS_GIT_WRITE_DISABLED=1.
 
-import { resolve, basename, relative, dirname, sep, join } from "node:path";
+import { resolve, basename, relative, dirname, sep, delimiter, join } from "node:path";
 import { statSync, readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync } from "node:fs";
 import { git, gitAsync, safeAbs, repoRootOfAsync, currentBranch } from "./git.ts";
 import { configuredRepoDirs, workspaceRoot, inScope } from "./config.ts";
@@ -312,7 +312,8 @@ function reposUnder(baseDir: string, depth = REPO_SCAN_DEPTH): string[] {
 /** Repos agentglass offers in the panel: the server's own repo, every project
  *  the transcript scan found, any repo seen in recent telemetry, and
  *  env-configured extras (AGENTGLASS_REPOS=path1:path2,
- *  AGENTGLASS_REPO_DIRS=dir1:dir2). No blind directory sweep — see discoverRepos.
+ *  AGENTGLASS_REPO_DIRS=dir1:dir2 — path.delimiter-separated, so `;` on
+ *  Windows). No blind directory sweep — see discoverRepos.
  *
  *  `knownRoots` are already-resolved project roots, so they're added directly.
  *  They matter because the panel would otherwise only reach repos that sit next
@@ -554,7 +555,7 @@ export async function discoverRepos(paths: string[], knownRoots: string[] = [], 
   for (const p of paths) { const a = safeAbs(p); if (a) dirs.add(dirname(a)); }
   const resolved = await Promise.all([
     repoRootOfAsync(process.cwd()),
-    ...(process.env.AGENTGLASS_REPOS || "").split(":").filter(Boolean).map((p) => repoRootOfAsync(p)),
+    ...(process.env.AGENTGLASS_REPOS || "").split(delimiter).filter(Boolean).map((p) => repoRootOfAsync(p)),
     ...[...dirs].map((d) => repoRootOfAsync(d)),
   ]);
   for (const r of resolved) if (r) roots.add(r);

--- a/server/test/windows-paths.test.ts
+++ b/server/test/windows-paths.test.ts
@@ -1,0 +1,86 @@
+// Windows portability: four places assumed POSIX path syntax (issue #188).
+// A prior audit against a Windows install found the app functionally broken
+// there — env vars split on the wrong delimiter, the scope check refused
+// every path inside an open project, and path completion never recognised a
+// drive letter. These are pure string checks, so `sep`/drive-letter behaviour
+// is exercised directly rather than requiring an actual Windows machine.
+import { describe, expect, test } from "bun:test";
+import { delimiter } from "node:path";
+import { isWithin, configuredRepoDirs } from "../src/config.ts";
+import { isAbsoluteLike } from "../src/fsbrowse.ts";
+
+describe("isWithin (inScope's prefix test)", () => {
+  test("POSIX: a path under the parent is inside it", () => {
+    expect(isWithin("/home/x/proj/src", "/home/x/proj", "/")).toBe(true);
+  });
+
+  test("POSIX: a sibling sharing the name prefix is not inside it", () => {
+    expect(isWithin("/home/x/proj-backup", "/home/x/proj", "/")).toBe(false);
+  });
+
+  test("Windows: a path under the parent is inside it (this was the bug)", () => {
+    // Before the fix, the prefix test hardcoded "/" - on a real Windows
+    // install, resolve() returns backslashes, so this comparison always
+    // failed and every file in an open project read as out-of-scope.
+    expect(isWithin("C:\\Users\\x\\proj\\src", "C:\\Users\\x\\proj", "\\")).toBe(true);
+  });
+
+  test("Windows: the scope root itself is inside it", () => {
+    expect(isWithin("C:\\Users\\x\\proj", "C:\\Users\\x\\proj", "\\")).toBe(true);
+  });
+
+  test("Windows: a sibling sharing the name prefix is not inside it", () => {
+    expect(isWithin("C:\\Users\\x\\proj-backup", "C:\\Users\\x\\proj", "\\")).toBe(false);
+  });
+
+  test("Windows: an unrelated path is not inside it", () => {
+    expect(isWithin("C:\\Users\\x\\other", "C:\\Users\\x\\proj", "\\")).toBe(false);
+  });
+});
+
+describe("isAbsoluteLike (path-completion's absolute-path guard)", () => {
+  test("POSIX absolute paths are recognised", () => {
+    expect(isAbsoluteLike("/home/x/code")).toBe(true);
+  });
+
+  test("Windows drive-letter paths are recognised (this was the bug)", () => {
+    // Before the fix, only a leading "/" passed, so typing a Windows path
+    // like this into the picker's completion box matched nothing at all.
+    expect(isAbsoluteLike("C:\\Users\\x\\code")).toBe(true);
+    expect(isAbsoluteLike("D:/code")).toBe(true);
+    expect(isAbsoluteLike("z:\\code")).toBe(true); // lowercase drive letter
+  });
+
+  test("a relative path is not absolute-like", () => {
+    expect(isAbsoluteLike("code/current_project")).toBe(false);
+    expect(isAbsoluteLike("relative:with-a-colon")).toBe(false);
+  });
+
+  test("a bare tilde is not itself absolute-like (handled separately for ~ expansion)", () => {
+    expect(isAbsoluteLike("~")).toBe(false);
+  });
+});
+
+describe("configuredRepoDirs (AGENTGLASS_REPO_DIRS delimiter)", () => {
+  test("splits on the platform path delimiter, not a hardcoded colon", async () => {
+    // On POSIX, path.delimiter is ":" - the same character the old, broken
+    // code hardcoded, so this alone doesn't distinguish them. What it does
+    // confirm is that configuredRepoDirs() actually calls into path.delimiter
+    // (imported and asserted below) rather than a literal ":" that would
+    // silently diverge from it on Windows, where path.delimiter is ";".
+    expect(delimiter).toBe(process.platform === "win32" ? ";" : ":");
+
+    const prev = process.env.AGENTGLASS_REPO_DIRS;
+    process.env.AGENTGLASS_REPO_DIRS = ["/tmp/a", "/tmp/b"].join(delimiter);
+    try {
+      // Re-imported per test file in this suite via a cache-busting query so
+      // each run reads the env var fresh; configuredRepoDirs re-reads env on
+      // every call (no module-level caching), so a plain import is enough.
+      const dirs = configuredRepoDirs();
+      expect(dirs).toEqual(["/tmp/a", "/tmp/b"]);
+    } finally {
+      if (prev === undefined) delete process.env.AGENTGLASS_REPO_DIRS;
+      else process.env.AGENTGLASS_REPO_DIRS = prev;
+    }
+  });
+});

--- a/server/test/windows-paths.test.ts
+++ b/server/test/windows-paths.test.ts
@@ -61,6 +61,24 @@ describe("isAbsoluteLike (path-completion's absolute-path guard)", () => {
   });
 });
 
+describe("recorded paths vs scope roots (db.ts scopeClause)", () => {
+  // scopeClause filters the paths the events table actually holds against the
+  // project's checkouts, and used its own hardcoded `r + "/"`. It now shares
+  // isWithin. The DB-level test for this lives in scope.test.ts and cannot
+  // cover Windows: it builds real directories on disk, and a POSIX box has no
+  // `C:\`. So the predicate that call site applies is asserted here instead.
+  const roots = ["C:\\Users\\x\\proj", "C:\\Users\\x\\proj-WEB-1042"];
+  const recordedIn = (p: string) => roots.some((r) => isWithin(p, r, "\\"));
+
+  test("Windows: a path inside a linked worktree is in scope", () => {
+    expect(recordedIn("C:\\Users\\x\\proj-WEB-1042\\server")).toBe(true);
+  });
+
+  test("Windows: a sibling that merely shares the prefix is not", () => {
+    expect(recordedIn("C:\\Users\\x\\proj-backup\\server")).toBe(false);
+  });
+});
+
 describe("configuredRepoDirs (AGENTGLASS_REPO_DIRS delimiter)", () => {
   test("splits on the platform path delimiter, not a hardcoded colon", async () => {
     // On POSIX, path.delimiter is ":" - the same character the old, broken

--- a/web/src/components/ProjectPicker.tsx
+++ b/web/src/components/ProjectPicker.tsx
@@ -18,6 +18,12 @@ import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 export const PICKER_ANSWERED_KEY = "agentglass.projectChosen";
 const markAnswered = () => { try { localStorage.setItem(PICKER_ANSWERED_KEY, "1"); } catch { /* ignore */ } };
 
+// Mirrors isAbsoluteLike() in server/src/fsbrowse.ts: POSIX absolute (`/...`)
+// or a Windows drive-letter root (`C:\...` / `C:/...`). Kept local rather than
+// a shared import since this is the client bundle, not the server process.
+const DRIVE_LETTER_ROOT = /^[a-zA-Z]:[\\/]/;
+const isAbsoluteLike = (p: string) => p.startsWith("/") || DRIVE_LETTER_ROOT.test(p);
+
 export function ProjectPicker({ open, workspace, onClose }: { open: boolean; workspace: string | null; onClose: () => void }) {
   const [repos, setRepos] = useState<GitRepoRef[] | null>(null);
   const [query, setQuery] = useState("");
@@ -49,7 +55,7 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
     const p = path.trim();
     // Only absolute / `~`-rooted input has a meaningful parent to list, which is
     // the same rule the server applies before it will answer at all.
-    if (!open || (!p.startsWith("/") && !p.startsWith("~"))) { setSugg([]); setMore(false); return; }
+    if (!open || (!isAbsoluteLike(p) && !p.startsWith("~"))) { setSugg([]); setMore(false); return; }
     let live = true;
     const t = setTimeout(() => {
       api.fsComplete(p)


### PR DESCRIPTION
## What does this PR do?

Fixes #188: Windows path handling was POSIX-only in four places, which left a scoped install there showing an empty dashboard for every project it was opened on.

**The work here is @SpiliosDimakopoulos's.** It was originally #243, reviewed and green, and closed only because the fork was deleted. His commit is preserved as-is with him as the author; this PR adds the one call site his review flagged.

His commit:
- `isWithin(child, parent, sep)` in `config.ts`, with the separator injectable so Windows behaviour is exercised from a POSIX CI run rather than needing a Windows box. `inScope` routes through it.
- `path.delimiter` instead of a hardcoded `":"` for `AGENTGLASS_REPO_DIRS` (`config.ts`) and `AGENTGLASS_REPOS` (`gitwork.ts`), so `;` works on Windows.
- `isAbsoluteLike()` in `fsbrowse.ts` plus a mirrored guard in `ProjectPicker.tsx`, so a drive-letter root (`C:\...`, `D:/...`) is accepted by path completion, and a trailing `\` counts as committed.
- `server/test/windows-paths.test.ts` pinning both branches of each.

Added on top:
- `db.ts` `scopeClause()` kept its own hardcoded `r + "/"` over recorded paths. Same bug, one layer up from `config.ts`, so it now shares `isWithin`. POSIX behaviour is unchanged and `scope.test.ts` still guards it, including the sibling-prefix case; the Windows half is asserted in `windows-paths.test.ts`, since the DB suite builds real directories and a POSIX box has no `C:\`.
- `docker.ts` deliberately keeps its hardcoded slash: those are container working directories, always Linux paths.

Point 4 of the issue (`TOO_BROAD`) is moot, that code was removed in a refactor after the issue was filed.

## How was it tested?

- `bun test`: 925 pass, 0 fail (13 of them new, covering `isWithin`, `isAbsoluteLike`, the delimiter split and the `scopeClause` predicate).
- `bunx tsc --noEmit` in `server/` and `web/`: clean.
- `bunx vite build` in `web/`: clean.
- Cherry-picked onto current main with no conflicts, then the full suite re-run there. No Windows machine was available, which is exactly why the separator is a parameter.

---

<sub>CI runs typecheck, tests and the production build for you. If you changed the server↔web contract update `shared/types.ts`; if behavior or config changed, update the docs. See [CONTRIBUTING.md](../CONTRIBUTING.md).</sub>
