### PR TITLE
feat(landing): put the real dashboard behind the glass, and make the designator resolve

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -36,10 +36,48 @@
   a{color:inherit; text-decoration:none;}
   ::selection{background:var(--primary); color:var(--bg);}
 
-  .hud{position:relative; height:100svh; min-height:680px; overflow:hidden; cursor:crosshair;}
-  .hud canvas{position:absolute; inset:0; width:100%; height:100%; display:block;}
+  .hud{position:relative; height:100svh; min-height:680px; overflow:hidden; cursor:crosshair;
+       background:#030407;}
+  .hud canvas{position:absolute; inset:0; width:100%; height:100%; display:block; z-index:2;}
   .hud.nogl canvas{display:none;}
   .chrome{position:absolute; inset:0; z-index:4; pointer-events:none; display:flex; flex-direction:column;}
+
+  /* ══════════════════════════════════════════════════════════════════
+     BEYOND THE GLASS.
+
+     A head-up display is transparent: the symbology is drawn on the
+     combiner, and what you are looking at is behind it. Behind this one
+     is the product — the live demo build, in an iframe, running the same
+     fabricated fleet the symbology flies. The glass does not magnify a
+     picture of a dashboard. It is a hole in the dark, and the dashboard
+     is what was always there.
+
+     Clipped to the lens, dimmed the way a tinted combiner dims the world,
+     and inert: no pointer, no tab stop, no scroll. Loaded late and only
+     where it is affordable — see the guard in the script.
+     ══════════════════════════════════════════════════════════════════ */
+  .beyond{position:absolute; inset:0; z-index:1; overflow:hidden; pointer-events:none;
+    opacity:0; transition:opacity .8s ease;}
+  .beyond.lit{opacity:1;}
+  .beyond iframe{position:absolute; inset:0; width:100%; height:100%; border:0; display:block;
+    /* The world seen through a tinted combiner. Level comes down so the
+       symbology stays the brightest thing on the glass, and chroma comes down
+       with it for a subtler reason: the app under here is wearing the same
+       phosphor the HUD is drawn in, and purple-on-purple was one texture.
+       Draining the world's colour puts the two layers back on separate
+       planes — which is what a combiner does to the view through it. */
+    filter:brightness(.54) saturate(.32) contrast(1.06);}
+
+  /* The combiner treatment — scanlines, phosphor haze, vignette — over
+     everything the glass carries, symbology and world alike. It used to be
+     the last few lines of the fragment shader, which could only reach the
+     canvas; the iframe behind it would have sat outside the effect and read
+     as a browser window sitting in a hole. */
+  .combiner{position:absolute; inset:0; z-index:3; pointer-events:none;
+    background:
+      repeating-linear-gradient(180deg, rgba(0,0,0,.30) 0 1px, rgba(0,0,0,0) 1px 3px),
+      radial-gradient(120% 100% at 50% 50%, rgba(0,0,0,0) 42%, rgba(0,0,0,.55) 100%);}
+  .hud.nogl .combiner{display:none;}
 
   /* line-height:1 — the default leading on the anonymous text box next to the
      19px mark made the lockup 28px tall against 10px links, so the wordmark
@@ -852,7 +890,9 @@
 
 <div class="stagewrap">
 <section class="hud" id="hud" aria-label="A head-up display. Move the target designator to lock a session and resolve its data.">
+  <div class="beyond" id="beyond" aria-hidden="true"></div>
   <canvas id="gl"></canvas>
+  <div class="combiner" aria-hidden="true"></div>
 
   <div class="chrome">
     <div class="rail">
@@ -895,10 +935,10 @@
       <div class="ccard">
         <div class="top">
           <span class="q">Approve Bash?</span>
-          <span class="sid" id="cSid">AG-5F6D</span>
+          <span class="sid" id="cSid">shop-api:3c9a1f52</span>
         </div>
-        <div class="cmd">kubectl delete deploy api --namespace production</div>
-        <div class="meta"><span id="cRepo">acme/infra</span> · opus 5 · unattended <span id="cAge">6m 12s</span></div>
+        <div class="cmd">kubectl delete deploy api --namespace prod</div>
+        <div class="meta"><span id="cModel">Sonnet</span> · unattended <span id="cAge">6m 12s</span></div>
         <div class="crow">
           <button class="allow" id="btnAllow">✓ Approve</button>
           <button class="deny"  id="btnDeny">✕ Deny</button>
@@ -1223,7 +1263,9 @@ sudo apt install ./agentglass_*.deb</code>
 (function(){
   "use strict";
   const hud=document.getElementById("hud"), cv=document.getElementById("gl");
-  const gl=cv.getContext("webgl2",{antialias:false,alpha:false,powerPreference:"high-performance"});
+  // alpha:true, and every frame leaves with alpha 0 — the canvas is a sheet of
+  // light laid over the page, so what sits behind the lens shows through it.
+  const gl=cv.getContext("webgl2",{antialias:false,alpha:true,powerPreference:"high-performance"});
   const reduce=matchMedia("(prefers-reduced-motion: reduce)").matches;
 
   /* ══════════════════════════════════════════════════════════════════
@@ -1281,42 +1323,86 @@ sudo apt install ./agentglass_*.deb</code>
   // HUD symbology is drawn in light, so alpha is the only blend that matters.
   function ink(col,alpha){ const c=parse(col); return "rgba("+c[0]+","+c[1]+","+c[2]+","+alpha+")"; }
 
-  /* ── the fleet ── */
-  const REPOS=["acme/shop-api","acme/shop-web","acme/infra","acme/billing","acme/mobile","acme/docs","acme/edge","acme/ops"];
+  /* ══════════════════════════════════════════════════════════════════
+     THE FLEET.
+
+     These eight contacts are the eight sessions the demo build flies —
+     same apps, same session ids, same models as `web/src/lib/demo.ts`.
+     That is not decoration. The glass opens onto the demo's own dashboard,
+     so the symbology drawn over it has to name the sessions that dashboard
+     names, or the two would be arguing in front of the visitor.
+
+     Everything here is invented, and invented in one place: the demo is a
+     fictional online store, and nothing in it is a real repo or company.
+     ══════════════════════════════════════════════════════════════════ */
+  const SESSIONS=[
+    {app:"shop-web",      sid:"7a3f21c9", model:"Opus"},
+    {app:"shop-web",      sid:"e2b8d640", model:"GPT-5"},
+    {app:"shop-api",      sid:"3c9a1f52", model:"Sonnet"},
+    {app:"agentglass",    sid:"b7e40a18", model:"Opus"},
+    {app:"payments-svc",  sid:"5f6d2e93", model:"Gemini Flash"},
+    {app:"inventory-svc", sid:"8a1c7b04", model:"GPT-5 mini"},
+    {app:"sandbox",       sid:"d4e903a7", model:"GPT-5"},
+    {app:"sandbox",       sid:"20f5c86b", model:"Sonnet"},
+  ];
   const TOOLS=["Write","Edit","Bash","Grep","Read","Glob","Task","WebFetch"];
-  const FILES=["src/routes/checkout.ts","src/components/Cart.tsx","src/services/pricing.ts",
-               "test/checkout.test.ts","src/lib/useLive.ts","docker-compose.yml","db/migrations/014.sql"];
+  // one of the four commands the demo's own gate holds, so the card in the
+  // corner and the Alerts panel under the glass are telling one story
+  const HELD_CMD="kubectl delete deploy api --namespace prod";
+  // the tails of the demo's own PATHS, so a resolved contact names a file the
+  // Live events panel under the glass is naming too
+  const FILES=["src/services/pricing.ts","src/components/Cart.tsx","src/routes/checkout.ts",
+               "models/product.py","handlers/webhook.go"];
   const rnd=(a,b)=>a+Math.random()*(b-a), pick=a=>a[(Math.random()*a.length)|0];
-  const fleet=[];
-  for(let i=0;i<8;i++) fleet.push({
-    id:"AG-"+(0x1000+((Math.random()*0xEFFF)|0)).toString(16).toUpperCase().slice(0,4),
-    repo:REPOS[i], ctx:rnd(0.10,0.66), rate:rnd(0.00019,0.00085),
+  const tok=n=>n>=1e6?(n/1e6).toFixed(2)+"M tok":n>=1000?(n/1000).toFixed(1)+"k tok":(n|0)+" tok";
+  const fleet=SESSIONS.map(s=>({
+    id:s.app+":"+s.sid, app:s.app, model:s.model,
+    // what the app's own timeline calls it when it is short of room
+    short:s.app+":"+s.sid.slice(0,5),
+    ctx:rnd(0.10,0.66), rate:rnd(0.00019,0.00085),
     cost:rnd(0.4,22), burn:rnd(0.0035,0.019), tool:pick(TOOLS), file:pick(FILES),
-    ms:rnd(30,380)|0, next:rnd(0.9,3.6), age:rnd(60,900), state:"run",
+    tools:rnd(3,180)|0, ms:rnd(30,380)|0, next:rnd(0.9,3.6), age:rnd(60,900), state:"run",
     brg:rnd(0,Math.PI*2), drift:rnd(-0.05,0.05)
-  });
-  const actor=fleet[2]; actor.repo="acme/infra"; actor.ctx=0.91; actor.rate=0.0004;
+  }));
+  // the one the master caution will be about: far enough along the context
+  // ladder to be the contact your eye goes to first
+  const actor=fleet[2]; actor.ctx=0.91; actor.rate=0.0004;
   // The closing instrument reads this same fleet: the eight contacts you met
   // at the top are the eight you leave with, further along than you found them.
   window.__fleet = fleet;
   window.__since = () => ({calls:callsSince, cost:costSince});
 
+  // What the fleet has cost. It starts at the figure the demo's own KPI strip
+  // shows, and once the app behind the glass is up it IS that figure.
+  let spend=359.85;
   let started=performance.now(), callsSince=0, costSince=0, ctxSince=0;
   const log=[]; const two=n=>String(n).padStart(2,"0");
   let clock=Math.floor(Date.now()/1000)-120;
   function stamp(){ clock+=1+((Math.random()*3)|0); const d=new Date(clock*1000);
     return two(d.getHours())+":"+two(d.getMinutes())+":"+two(d.getSeconds()); }
-  function push(s){ log.unshift({t:stamp(),tool:s.tool,file:s.repo.split("/")[1]+"/"+s.file,ms:s.ms,sid:s.id});
+  function push(s){ log.unshift({t:stamp(),tool:s.tool,file:s.app+"/"+s.file,ms:s.ms,sid:s.id});
     if(log.length>140) log.pop(); }
   for(let i=0;i<60;i++) push(fleet[i%fleet.length]);
   function tick(dt){
     for(const s of fleet){
+      if(s.state==="done") continue;
+      // Context and spend belong to the app behind the glass from the moment it
+      // is up. Running our own alongside its would put two answers to the same
+      // question on one screen, and the wrong one would be ours.
+      if(bridged){
+        if(s.ctxTarget!=null) s.ctx+=(s.ctxTarget-s.ctx)*Math.min(1,dt*2.5);
+      } else if(s.state==="run"){
+        s.ctx+=s.rate*dt; if(s.ctx>=1) s.ctx=rnd(0.16,0.34);
+        s.cost+=s.burn*dt; costSince+=s.burn*dt; spend+=s.burn*dt; ctxSince+=s.rate*dt*1000;
+        s.tools++;
+      }
+      s.age+=dt; s.brg+=s.drift*dt;
+      // The record keeps running either way: the rain outside the lens is the
+      // raw hook stream, and it is ours to draw whether or not the app is up.
       if(s.state!=="run") continue;
-      s.age+=dt; s.ctx+=s.rate*dt; if(s.ctx>=1) s.ctx=rnd(0.16,0.34);
-      s.cost+=s.burn*dt; costSince+=s.burn*dt; ctxSince+=s.rate*dt*1000;
-      s.brg+=s.drift*dt; s.next-=dt;
+      s.next-=dt;
       if(s.next<=0){ s.next=rnd(0.9,3.6); s.tool=pick(TOOLS); s.file=pick(FILES); s.ms=rnd(30,380)|0;
-        callsSince++; push(s); }
+        if(!bridged) callsSince++; push(s); }
     }
   }
 
@@ -1329,6 +1415,19 @@ sudo apt install ./agentglass_*.deb</code>
      block. Both share the same geometry function, so a contact never
      moves between the two layers — the glass only ever adds knowledge,
      which is the entire claim the product makes.
+
+     This is the whole point of the hero, and for a while it was dead: the
+     resolved half was never drawn. Layer B had been replaced by a second,
+     separate picture — a hand-drawn imitation of the dashboard on its own
+     grid — so the lens showed a crop of a mock that had nothing to do with
+     the contact you had aimed at, and every contact stayed UNK wherever you
+     put the glass. The imitation is gone. Under the lens now: the real
+     product (see `.beyond`), with the contacts over it resolved.
+
+     Both layers are drawn as LIGHT — transparent canvases, composited by
+     adding. Nothing the HUD draws can darken what is behind it, which is
+     how a combiner works and, more practically, is what lets the dashboard
+     show through the gaps in the symbology.
      ══════════════════════════════════════════════════════════════════ */
   let W=0,H=0,DPR=1,R=0,lockOn=null;
   const A=document.createElement("canvas"), a=A.getContext("2d");
@@ -1370,13 +1469,14 @@ sudo apt install ./agentglass_*.deb</code>
   function drawScene(c,C,res,t){
     C.width=W; C.height=H; c.setTransform(DPR,0,0,DPR,0,0);
     const w=W/DPR,h=H/DPR;
-    c.fillStyle="#030407"; c.fillRect(0,0,w,h);
+    c.clearRect(0,0,w,h);                       // light on clear glass, never a fill
     const P=V("--primary"), WARN=V("--warning"), ERR=V("--error"), OK=V("--success");
 
-    // The record itself, running underneath everything. Barely there without
-    // the glass; readable through it. A HUD is transparent — you are always
-    // looking at something beyond the symbology.
-    (function(){
+    // The record itself, running underneath everything: the raw hook stream,
+    // which is all a terminal ever gives you. Skipped on the resolved layer
+    // once the demo is actually behind the glass — the dashboard down there
+    // IS this record, read. Drawing our own over it would be arguing with it.
+    if(!(res && beyond.live)) (function(){
       const fs=10, lh=fs*1.62, cols=Math.max(1,Math.round(w/380));
       c.font=fs+'px ui-monospace,"SF Mono",Menlo,monospace';
       const n=Math.ceil(h/lh)+2, off=(t*20)%lh, step=Math.floor(t*20/lh);
@@ -1449,11 +1549,58 @@ sudo apt install ./agentglass_*.deb</code>
     c.moveTo(g0.cx,g0.cy-12); c.lineTo(g0.cx,g0.cy-4);
     c.moveTo(g0.cx,g0.cy+4); c.lineTo(g0.cx,g0.cy+12); c.stroke();
 
-    // ── the contacts
+    /* ── the contacts
+       On the resolved layer a contact only opens up if the glass is actually
+       over it. Resolving all eight at once was the honest reading of "res=1",
+       and it was unreadable: at low context the fleet sits close in around the
+       boresight, and six data blocks landed on top of each other and on the
+       app behind them. A designator resolves what it is pointed at — so the
+       nearest three to the lens centre resolve, fading in over the last 44px,
+       and the rest stay UNK on both sides of the glass. */
+    const lx=lens.x/DPR, ly=lens.y/DPR, lr=R/DPR, tight=lr<130;
+    const gain=new Array(fleet.length).fill(0), slot=new Array(fleet.length).fill(null);
+    if(res){
+      // Wide enough for the longest line the block can draw, and no wider: the
+      // lens is 460px across, and a block that measures a third of that is one
+      // a contact near the rim can still hang inside the glass. A phone's lens
+      // is 188px across, where the full block cannot fit at all — so there it
+      // resolves to the two facts that carry the argument, and not the rest.
+      const BW=tight?116:162, BH=tight?36:60;
+      const near=fleet.map((s,i)=>({i, p:contactPos(s,i,w,h,t)}))
+        .map(o=>(o.d=Math.hypot(o.p.x-lx,o.p.y-ly), o))
+        .sort((m,n)=>m.d-n.d).slice(0,3);
+      const boxes=[];
+      for(const it of near){
+        const g=Math.max(0,Math.min(1,(lr*0.80-it.d)/44));
+        if(g<=0) continue;
+        gain[it.i]=g;
+        // The block hangs toward the middle of the lens, never toward the middle
+        // of the screen: a contact resolved at the left rim used to write its
+        // data off the left rim, where the glass is not, and a careful aim was
+        // rewarded with four clipped characters.
+        const right = it.p.x<=lx;
+        const x0 = right ? it.p.x+28 : it.p.x-28-BW;
+        // Two contacts a few pixels apart would otherwise stack their blocks in
+        // the same place. Try above, then below, then further out — the nearest
+        // contact is placed first, so the one you aimed at keeps the best spot.
+        const up = it.p.y>ly;
+        let by=null;
+        for(const cd of tight ? [up?-20:12, up?12:-20] : [up?-30:14, up?14:-30, -102, 86]){
+          const y=it.p.y+cd;
+          if(!boxes.some(b=> x0<b.x1 && x0+BW>b.x0 && y-14<b.y1 && y+BH>b.y0)){ by=y; break; }
+        }
+        // Nowhere clear to hang it. Two blocks written across each other are
+        // worth less than one block and a contact that stays honestly unknown,
+        // so this one keeps its UNK and waits for you to aim at it.
+        if(by===null){ gain[it.i]=0; continue; }
+        boxes.push({x0, x1:x0+BW, y0:by-14, y1:by+BH});
+        slot[it.i]={by, right};
+      }
+    }
     fleet.forEach((s,i)=>{
-      const p=contactPos(s,i,w,h,t), f=Math.min(1,s.ctx);
+      const p=contactPos(s,i,w,h,t), f=Math.min(1,s.ctx), g=gain[i];
       const hot=s.state==="held"||f>=0.86;
-      const col=hot?ERR:f>=0.7?WARN:OK;
+      const col=hot?ERR:(s.state==="wait"||f>=0.7)?WARN:OK;
       const sz=hot?15:12;
       // a contact is a bracket, never a filled dot — HUD symbology is drawn in light
       c.strokeStyle=ink(col,hot?1:.9); c.lineWidth=hot?1.8:1.4;
@@ -1470,37 +1617,67 @@ sudo apt install ./agentglass_*.deb</code>
 
       if(lock.on && lock.i===i) drawLock(c,p.x,p.y,sz,col);
 
-      if(res < 0.5){
-        // unaided: bearing only. You know it is there. Nothing else.
-        c.fillStyle=ink(col,.75); c.textAlign="center";
+      if(g < 0.999){
+        // Unaided, or aimed elsewhere: bearing only. You know it is there,
+        // and that is the whole of what you know.
+        c.fillStyle=ink(col,.75*(1-g)); c.textAlign="center";
         c.font='9px ui-monospace,Menlo,monospace';
         c.fillText("UNK",p.x,p.y+3); c.textAlign="left";
         c.font='10px ui-monospace,Menlo,monospace';
-        return;
+        if(g <= 0.001) return;
       }
 
-      // through the glass: the contact resolves into a full data block,
-      // hung off a leader line the way a HUD tags a designated target.
-      const right = p.x < w*0.5;
-      const dx = right ? 1 : -1;
-      const bx = p.x + dx*(sz+16), by = p.y - 26;
-      c.strokeStyle=ink(col,.45);
-      c.beginPath(); c.moveTo(p.x+dx*sz,p.y); c.lineTo(bx-dx*6,by+28); c.lineTo(bx,by+28); c.stroke();
+      // Through the glass the contact resolves, hung off a leader line the way
+      // a HUD tags a designated target. The fields are the ones the app's own
+      // session card carries — key, model, what it is doing, tools, spend,
+      // context against the model's window — because the card itself is on the
+      // other side of this glass and the two have to agree.
+      const right = slot[i].right, by = slot[i].by;
+      const dx = right ? 1 : -1, up = by < p.y;
+      const bx = p.x + dx*(sz+16);
+      c.strokeStyle=ink(col,.45*g);
+      c.beginPath(); c.moveTo(p.x+dx*sz,p.y); c.lineTo(bx-dx*6,by+(up?30:0)); c.lineTo(bx,by+(up?30:0)); c.stroke();
       c.textAlign = right ? "left" : "right";
       const ax = right ? bx+4 : bx-4;
-      c.fillStyle=ink(V("--text"),.95); c.font='600 11px ui-monospace,Menlo,monospace';
-      c.fillText(s.id,ax,by+4);
-      c.font='9.5px ui-monospace,Menlo,monospace';
-      c.fillStyle=ink(P,.8);  c.fillText(s.repo.toUpperCase(),ax,by+16);
-      c.fillStyle=ink(col,.9);
-      c.fillText(hot?"HELD · KUBECTL DELETE":Math.round(f*100)+"% CTX · "+s.tool.toUpperCase(),ax,by+28);
-      c.fillStyle=ink(V("--text3"),.75);
-      c.fillText("$"+s.cost.toFixed(2)+" · "+s.ms+"MS",ax,by+40);
+      // status light, on the leader side of the key — the rail the card carries
+      c.fillStyle=ink(col,.95*g);
+      c.beginPath(); c.arc(right?ax-6:ax+6, by, 2.6, 0, Math.PI*2); c.fill();
+      // the identifier, lower case: it is what you paste into a resume command,
+      // and it is spelled exactly like this on the card below the glass
+      const cut=(x,n)=>x.length>n?x.slice(0,n-1)+"…":x;
+      c.fillStyle=ink(V("--text"),.97*g);
+      c.font='600 '+(tight?10:11.5)+'px ui-monospace,Menlo,monospace';
+      c.fillText(tight?s.short:s.id,ax,by+4);
+      c.font=(tight?9:9.5)+'px ui-monospace,Menlo,monospace';
+      if(tight){
+        // key, spend, context bar. On 188px of glass a fourth line is a smudge.
+        c.fillStyle=ink(hot&&s.state==="held"?ERR:V("--text2"),.9*g);
+        c.fillText(hot&&s.state==="held"?"HELD FOR APPROVAL":"$"+s.cost.toFixed(2),ax,by+16);
+      } else if(hot && s.state==="held"){
+        c.fillStyle=ink(ERR,.95*g); c.fillText("HELD · "+cut(HELD_CMD,20),ax,by+18);
+      } else {
+        c.fillStyle=ink(P,.9*g);
+        c.fillText(cut(s.model+" · "+(s.action || ("running "+s.tool)),26),ax,by+18);
+      }
+      if(!tight){
+        c.fillStyle=ink(V("--text2"),.85*g);
+        // Tokens once the app behind the glass is reporting them, milliseconds
+        // while we are flying our own simulation. Never both: a real spend beside
+        // an invented latency is a lie wearing three true numbers as cover.
+        c.fillText(s.tools+" tools · "+(bridged ? tok(s.tokens) : s.ms+"ms")+" · $"+s.cost.toFixed(2),ax,by+31);
+      }
+      // context against the window, the same law the range rings measure by
+      const bw=tight?76:88, byy=by+(tight?24:40);
+      const bxx=right?bx+4:bx-4-bw;
+      c.fillStyle=ink(P,.16*g); c.fillRect(bxx,byy,bw,3.5);
+      c.fillStyle=ink(col,.9*g); c.fillRect(bxx,byy,bw*f,3.5);
+      c.font=(tight?8.5:9)+'px ui-monospace,Menlo,monospace'; c.fillStyle=ink(col,.85*g);
+      c.letterSpacing="0.1em";
+      c.fillText(tight ? Math.round(f*100)+"% CONTEXT"
+               : f>=0.86 ? Math.round(f*100)+"% · COMPACTION IMMINENT"
+                         : Math.round(f*100)+"% OF 1M CONTEXT", ax, byy+13);
+      c.letterSpacing="0em";
       c.textAlign="left";
-      // a context bar under the block
-      const bw=76, byy=by+46;
-      c.strokeStyle=ink(P,.3); c.strokeRect(right?bx+4:bx-4-bw,byy,bw,3);
-      c.fillStyle=ink(col,.8); c.fillRect(right?bx+4:bx-4-bw,byy,bw*f,3);
     });
 
     // ── corner blocks
@@ -1521,14 +1698,14 @@ sudo apt install ./agentglass_*.deb</code>
       // to stand apart; at 390 they collided in the middle and both clipped.
       block(18,h-150,"left",[
         ["FLEET · 8 CONTACTS · "+clock,0,10,P,.85],
-        ["$"+(359.85+costSince).toFixed(2)+"  +$"+costSince.toFixed(2)+" SINCE YOU CAME",0,13,V("--text"),.95],
+        ["$"+spend.toFixed(2)+"  +$"+costSince.toFixed(2)+" SINCE YOU CAME",0,13,V("--text"),.95],
         ["779.2K TOKENS · P50 73MS",0,null,V("--text3"),.7],
         [held?"⚠ "+held+" HELD FOR APPROVAL":"NO HOLDS · THEY HAVE NOT STOPPED",0,null,held?ERR:OK,.9]
       ]);
     } else {
       block(30,h-118,"left",[
         ["FLEET · 8 CONTACTS",0,10,P,.85],
-        ["SPEND  $"+(359.85+costSince).toFixed(2),0,13,V("--text"),.95],
+        ["SPEND  $"+spend.toFixed(2),0,13,V("--text"),.95],
         ["TOKENS 779.2K · P50 73MS",0,null,V("--text3"),.7],
         [held?"⚠ "+held+" HELD FOR APPROVAL":"NO HOLDS",0,null,held?ERR:OK,.9]
       ]);
@@ -1554,248 +1731,114 @@ sudo apt install ./agentglass_*.deb</code>
     // the long form does not fit a phone, and a clipped instruction is worse
     // than a short one
     c.fillText(res<0.5 ? (nar?"THE GLASS IS THE INSTRUMENT":"THE GLASS IS THE INSTRUMENT — MOVE IT OVER A CONTACT")
+             : beyond.live ? (nar?"RESOLVED · THE APP ITSELF, BEHIND THE GLASS":"EVERY CONTACT RESOLVED — AND THAT IS THE APP ITSELF BEHIND THE GLASS")
                        : (nar?"EVERY CONTACT RESOLVED · SAME SECOND":"EVERY CONTACT RESOLVED · SAME MACHINE · SAME SECOND"),
                sx, sy+size*0.98+24);
     c.letterSpacing="0em";
   }
 
-  const drawUnaided = t => drawScene(a,A,0,t);
+  const drawUnaided  = t => drawScene(a,A,0,t);
+  const drawResolved = t => drawScene(b,B,1,t);
 
   /* ══════════════════════════════════════════════════════════════════
-     UNDER THE GLASS — the cockpit itself.
+     WHAT THE GLASS OPENS ONTO.
 
-     Not symbology standing in for the app: these are the dashboard's own
-     panels, with the eyebrows and titles it actually ships (Live radar,
-     Live events, What needs you, Every agent session, Tool wall-clock
-     duration, Where the money goes, Activity over time). Drawn in stroke
-     and phosphor so it belongs to the HUD, and with the radar pinned to
-     the same boresight the symbology uses — so the glass reads as tearing
-     the HUD open onto the real thing, not cutting to a different picture.
+     The demo build — the real UI, running the fabricated fleet, the same
+     thing /demo/ serves — parked behind the hero and clipped to the lens.
+     It is the product's own dashboard, not a drawing of one, and it is the
+     honest answer to the only question the hero asks: what does the glass
+     show you that the dark does not.
+
+     Held back until it is cheap: it costs a second document and an app
+     bundle, so it waits for the page to be idle, and it never loads on a
+     phone, on a metered connection, or for a visitor who asked for less
+     motion. When it is absent nothing breaks — the resolved layer still
+     names every contact, which is the part that carries the argument.
      ══════════════════════════════════════════════════════════════════ */
-  function pnl(c,x,y,w,hh,eyebrow,title,right){
-    const P=V("--primary"), cut=11;
-    c.beginPath();
-    c.moveTo(x+cut,y); c.lineTo(x+w,y); c.lineTo(x+w,y+hh-cut);
-    c.lineTo(x+w-cut,y+hh); c.lineTo(x,y+hh); c.lineTo(x,y+cut); c.closePath();
-    const g=c.createLinearGradient(0,y,0,y+hh*0.5);
-    g.addColorStop(0,ink(P,.055)); g.addColorStop(1,"rgba(0,0,0,0)");
-    c.fillStyle="#02040A"; c.fill(); c.fillStyle=g; c.fill();
-    c.strokeStyle=ink(P,.30); c.lineWidth=1; c.stroke();
-    if(eyebrow){
-      c.font='600 8.5px ui-monospace,Menlo,monospace'; c.fillStyle=ink(P,.9);
-      c.letterSpacing="0.22em"; c.fillText(eyebrow.toUpperCase(),x+13,y+18); c.letterSpacing="0em";
-    }
-    if(title){
-      c.font='600 13px ui-sans-serif,system-ui,-apple-system,sans-serif';
-      c.fillStyle=ink(V("--text"),.95); c.fillText(title,x+13,y+36);
-    }
-    if(right){
-      c.font='9px ui-monospace,Menlo,monospace'; c.fillStyle=ink(V("--text4"),.85);
-      c.textAlign="right"; c.fillText(right,x+w-13,y+18); c.textAlign="left";
-    }
-    return y+48;
-  }
-
-  function drawResolved(t){
-    B.width=W; B.height=H; b.setTransform(DPR,0,0,DPR,0,0);
-    const w=W/DPR, hh=H/DPR;
-    const P=V("--primary"), OK=V("--success"), WARN=V("--warning"), ERR=V("--error"), TX=V("--text");
-    b.fillStyle="#010309"; b.fillRect(0,0,w,hh);
-    const au=b.createRadialGradient(w*0.72,-hh*0.1,0,w*0.72,-hh*0.1,Math.max(w,hh)*0.65);
-    au.addColorStop(0,ink(P,.10)); au.addColorStop(1,"rgba(0,0,0,0)");
-    b.fillStyle=au; b.fillRect(0,0,w,hh);
-    b.lineWidth=1; b.textBaseline="alphabetic";
-
-    const pad=12, gap=10;
-    const colL=Math.min(w*0.34,470), colR=Math.min(w*0.30,400);
-    const colM=w-pad*2-colL-colR-gap*2;
-    const xL=pad, xM=xL+colL+gap, xR=xM+colM+gap;
-
-    /* ── KPI strip: the app's own hero row ── */
-    const kh=62;
-    (function(){
-      const cells=[
-        ["Spend · this window","$"+(359.85+costSince).toFixed(2),OK,"779,200 tokens · 402k cached"],
-        ["Working",String(fleet.filter(s=>s.state==="run").length),OK,"live agents"],
-        ["Tools run","2,955",TX,"18,402 events"],
-        ["Failed","3",ERR,""],
-        ["Waiting",String(fleet.filter(s=>s.state==="held").length),WARN,""]
-      ];
-      const ws=[1.85,1,1,.7,.7], tot=ws.reduce((a,c)=>a+c,0);
-      let x=pad;
-      cells.forEach((cl,i)=>{
-        const cw=(w-pad*2-gap*(cells.length-1))*ws[i]/tot;
-        pnl(b,x,pad,cw,kh,null,null,null);
-        b.font='600 8.5px ui-monospace,Menlo,monospace'; b.fillStyle=ink(P,.85);
-        b.letterSpacing="0.2em"; b.fillText(cl[0].toUpperCase(),x+12,pad+18); b.letterSpacing="0em";
-        b.font='600 26px ui-monospace,Menlo,monospace'; b.fillStyle=ink(cl[2],.98);
-        b.fillText(cl[1],x+12,pad+46);
-        if(cl[3]){ b.font='9px ui-monospace,Menlo,monospace'; b.fillStyle=ink(V("--text4"),.8);
-          b.fillText(cl[3],x+12,pad+58); }
-        if(i===0){ // the sparkline + health ring the hero cell carries
-          const sw=64, sx=x+cw-sw-58, sy=pad+42;
-          b.strokeStyle=ink(OK,.75); b.beginPath();
-          for(let k=0;k<24;k++){
-            const v=0.5+0.42*Math.sin(k*0.7+t*0.25)*Math.cos(k*0.31);
-            const px2=sx+sw*k/23, py=sy-v*22;
-            k?b.lineTo(px2,py):b.moveTo(px2,py);
-          }
-          b.stroke();
-          const rx=x+cw-30, ry=pad+kh/2, rr2=15;
-          b.strokeStyle=ink(P,.25); b.beginPath(); b.arc(rx,ry,rr2,0,Math.PI*2); b.stroke();
-          b.strokeStyle=ink(OK,.95); b.lineWidth=2.5;
-          b.beginPath(); b.arc(rx,ry,rr2,-Math.PI/2,-Math.PI/2+Math.PI*2*0.97); b.stroke(); b.lineWidth=1;
-          b.font='600 9px ui-monospace,Menlo,monospace'; b.fillStyle=ink(OK,.95);
-          b.textAlign="center"; b.fillText("97",rx,ry+3); b.textAlign="left";
-        }
-        x+=cw+gap;
-      });
-    })();
-
-    const yTop=pad+kh+gap, hBody=hh-yTop-pad;
-
-    /* ── Radar · Live radar — pinned to the HUD's own boresight ── */
-    const radH=Math.min(hBody*0.62,360);
-    let cy0=pnl(b,xL,yTop,colL,radH,"Radar","Live radar","context = distance");
-    (function(){
-      const g0=contactPos(fleet[0],0,w,hh,t);
-      const rcx=g0.cx, rcy=Math.min(yTop+radH-24, Math.max(cy0+70, g0.cy));
-      const rad=Math.min(colL*0.40,(radH-70)*0.46);
-      b.strokeStyle=ink(P,.20);
-      for(let i=1;i<=4;i++){ b.beginPath(); b.arc(rcx,rcy,rad*i/4,0,Math.PI*2); b.stroke(); }
-      b.strokeStyle=ink(ERR,.5); b.setLineDash([3,4]);
-      b.beginPath(); b.arc(rcx,rcy,rad*0.92,0,Math.PI*2); b.stroke(); b.setLineDash([]);
-      b.font='8.5px ui-monospace,Menlo,monospace'; b.fillStyle=ink(ERR,.8);
-      b.fillText("COMPACTION",rcx-rad*0.92,rcy-rad*0.92-5);
-      if(b.createConicGradient){
-        const cg=b.createConicGradient(t*0.6,rcx,rcy);
-        cg.addColorStop(0,ink(P,.30)); cg.addColorStop(0.08,"rgba(0,0,0,0)"); cg.addColorStop(1,"rgba(0,0,0,0)");
-        b.fillStyle=cg; b.beginPath(); b.arc(rcx,rcy,rad,0,Math.PI*2); b.fill();
-      }
-      fleet.forEach((s,i)=>{
-        const f=Math.min(1,s.ctx), ang=s.brg+i*(Math.PI*2/fleet.length)+t*0.05;
-        const x=rcx+Math.cos(ang)*rad*f, y=rcy+Math.sin(ang)*rad*f;
-        const hot=s.state==="held"||f>=0.86, col=hot?ERR:f>=0.7?WARN:OK;
-        b.fillStyle=ink(col,.18); b.beginPath(); b.arc(x,y,hot?11:8,0,Math.PI*2); b.fill();
-        b.fillStyle=ink(col,.98); b.beginPath(); b.arc(x,y,hot?4:2.8,0,Math.PI*2); b.fill();
-        b.font='8.5px ui-monospace,Menlo,monospace'; b.fillStyle=ink(hot?col:V("--text3"),.9);
-        b.fillText(s.id,x+8,y+3);
-      });
-    })();
-
-    /* ── Alerts · What needs you ── */
-    const alY=yTop+radH+gap, alH=hBody-radH-gap;
-    let ay=pnl(b,xL,alY,colL,alH,"Alerts","What needs you",null);
-    (function(){
-      const held=fleet.filter(s=>s.state==="held");
-      if(held.length){
-        b.font='600 12px ui-monospace,Menlo,monospace'; b.fillStyle=ink(ERR,.98);
-        b.fillText("● "+held.length+" TOOL CALL HELD",xL+13,ay+6);
-        b.font='10px ui-monospace,Menlo,monospace'; b.fillStyle=ink(V("--text3"),.85);
-        b.fillText(held[0].id+" · kubectl delete deploy api",xL+13,ay+22);
-      } else {
-        b.font='600 12px ui-monospace,Menlo,monospace'; b.fillStyle=ink(OK,.9);
-        b.fillText("● ALL NOMINAL",xL+13,ay+6);
-      }
-      b.font='10px ui-monospace,Menlo,monospace'; b.fillStyle=ink(WARN,.9);
-      b.fillText("▲ AG-33F9 at 92% context — compaction imminent",xL+13,ay+40);
-      b.fillStyle=ink(V("--text4"),.8);
-      b.fillText("▲ 3 tool errors in the last 5 min · shop-web",xL+13,ay+56);
-    })();
-
-    /* ── Mission timeline · Activity over time ── */
-    const tlH=Math.min(hBody*0.34,168);
-    let my=pnl(b,xM,yTop,colM,tlH,"Mission timeline","Activity over time",null);
-    (function(){
-      const n=38, bw=(colM-26)/n, base=yTop+tlH-16;
-      for(let i=0;i<n;i++){
-        const v=0.25+0.6*Math.abs(Math.sin(i*0.42+t*0.2))*Math.abs(Math.cos(i*0.19));
-        const hgt=(base-my-6)*v;
-        b.fillStyle=ink(P,.28+0.4*v);
-        b.fillRect(xM+13+i*bw, base-hgt, Math.max(1.5,bw-2), hgt);
-      }
-      b.strokeStyle=ink(P,.16); b.beginPath(); b.moveTo(xM+13,base); b.lineTo(xM+colM-13,base); b.stroke();
-    })();
-
-    /* ── Performance · Tool wall-clock duration ── */
-    const ltY=yTop+tlH+gap, ltH=Math.min(hBody*0.34,168);
-    let ly=pnl(b,xM,ltY,colM,ltH,"Performance","Tool wall-clock duration","p50 · p95");
-    (function(){
-      const rows=[["Bash",73,261],["Write",41,118],["Edit",38,96],["Grep",22,64],["Task",380,1240]];
-      const max=1240;
-      rows.forEach((r,i)=>{
-        const y=ly+8+i*20;
-        b.font='10px ui-monospace,Menlo,monospace'; b.fillStyle=ink(V("--text2"),.9);
-        b.fillText(r[0],xM+13,y+4);
-        const bx=xM+68, bw=colM-68-70;
-        b.fillStyle=ink(P,.22); b.fillRect(bx,y-4,bw*(r[2]/max),7);
-        b.fillStyle=ink(P,.85); b.fillRect(bx,y-4,bw*(r[1]/max),7);
-        b.font='9.5px ui-monospace,Menlo,monospace'; b.fillStyle=ink(V("--text4"),.85);
-        b.textAlign="right"; b.fillText(r[1]+" / "+r[2]+"ms",xM+colM-13,y+4); b.textAlign="left";
-      });
-    })();
-
-    /* ── Cost · Where the money goes ── */
-    const cmY=ltY+ltH+gap, cmH=hh-cmY-pad;
-    if(cmH>60){
-      let cy2=pnl(b,xM,cmY,colM,cmH,"Cost","Where the money goes","By model");
-      const models=[["opus 5",.58,P],["sonnet 5",.27,OK],["haiku 4.5",.11,WARN],["gpt-5",.04,V("--info")]];
-      let cx2=xM+13; const bw=colM-26;
-      models.forEach(m=>{ b.fillStyle=ink(m[2],.8); b.fillRect(cx2,cy2+2,bw*m[1],12); cx2+=bw*m[1]; });
-      models.forEach((m,i)=>{
-        const y=cy2+34+i*15;
-        if(y>cmY+cmH-8) return;
-        b.fillStyle=ink(m[2],.85); b.fillRect(xM+13,y-7,7,7);
-        b.font='10px ui-monospace,Menlo,monospace'; b.fillStyle=ink(V("--text3"),.9);
-        b.fillText(m[0],xM+26,y);
-        b.textAlign="right"; b.fillStyle=ink(V("--text2"),.9);
-        b.fillText("$"+((359.85+costSince)*m[1]).toFixed(2),xM+colM-13,y); b.textAlign="left";
-      });
-    }
-
-    /* ── Live · Live events ── */
-    const feH=Math.min(hBody*0.56,330);
-    let fy=pnl(b,xR,yTop,colR,feH,"Live","Live events",null);
-    (function(){
-      const fs=10.5, lh=fs*1.72, n=Math.floor((feH-52)/lh);
-      b.font=fs+'px ui-monospace,Menlo,monospace';
-      const off=(t*20)%lh, step=Math.floor(t*20/lh);
-      for(let i=0;i<n;i++){
-        const r=log[(i+step)%log.length]; if(!r) continue;
-        const y=fy+10+i*lh;
-        b.fillStyle=ink(V("--text4"),.75); b.fillText(r.t,xR+13,y);
-        b.fillStyle=ink(TX,.92); b.fillText(r.tool,xR+58,y);
-        b.fillStyle=ink(V("--text3"),.6);
-        const f=r.file.length>22?r.file.slice(-22):r.file;
-        b.fillText(f,xR+108,y);
-        b.textAlign="right"; b.fillStyle=ink(OK,.8);
-        b.fillText(r.ms+"ms",xR+colR-13,y); b.textAlign="left";
-      }
-    })();
-
-    /* ── Sessions · Every agent session ── */
-    const seY=yTop+feH+gap, seH=hh-seY-pad;
-    let sy=pnl(b,xR,seY,colR,seH,"Sessions","Every agent session",null);
-    if(lock.on){
-      const lp=contactPos(actor,lock.i,w,hh,t);
-      drawLock(b,lp.x,lp.y,15,ERR);
-    }
-    fleet.slice(0,Math.max(0,Math.floor((seH-56)/26))).forEach((s,i)=>{
-      const f=Math.min(1,s.ctx), hot=s.state==="held"||f>=0.86;
-      const col=hot?ERR:f>=0.7?WARN:OK, y=sy+10+i*26;
-      b.font='10.5px ui-monospace,Menlo,monospace';
-      b.fillStyle=ink(TX,.92); b.fillText(s.id,xR+13,y);
-      b.fillStyle=ink(V("--text4"),.8); b.fillText(s.repo.split("/")[1],xR+70,y);
-      b.textAlign="right"; b.fillStyle=ink(V("--text2"),.9);
-      b.fillText("$"+s.cost.toFixed(2),xR+colR-13,y); b.textAlign="left";
-      const bx=xR+13, bw=colR-26;
-      b.fillStyle=ink(P,.14); b.fillRect(bx,y+6,bw,3);
-      b.fillStyle=ink(col,.9); b.fillRect(bx,y+6,bw*f,3);
+  const beyond={el:document.getElementById("beyond"), frame:null, live:false};
+  function openBeyond(){
+    if(beyond.frame || !beyond.el || !ok) return;
+    if(innerWidth<980 || innerHeight<620) return;      // the glass is too small to read it
+    if(reduce) return;
+    const conn=navigator.connection;
+    if(conn && (conn.saveData || /2g/.test(conn.effectiveType||""))) return;
+    const f=document.createElement("iframe");
+    f.src="./demo/";
+    f.title="agentglass, running";                     // aria-hidden on the wrapper; this is for tooling
+    f.setAttribute("tabindex","-1");
+    f.setAttribute("scrolling","no");
+    // Nothing behind the glass is reachable: not by pointer, not by tab, not by
+    // a screen reader. It is scenery, and a visitor who tabs from the rail to
+    // the download button must not fall into a whole second application on the
+    // way — `inert` is what carries that through to the framed document.
+    f.setAttribute("inert","");
+    f.addEventListener("load",()=>{
+      // A landing page served without its /demo/ next door gets a 404 document
+      // here, and a 404 under the lens is worse than the honest dark.
+      try{ if(!f.contentWindow.document.getElementById("root")) return void drop(); }catch(e){ return void drop(); }
+      beyond.live=true; beyond.el.classList.add("lit");
     });
+    beyond.el.appendChild(f);
+    beyond.frame=f;
+    function drop(){ f.remove(); beyond.frame=null; beyond.live=false; }
+  }
+  // The lens is a hole in the dark. Nothing behind it is visible anywhere else,
+  // so the clip is the only thing standing between a visitor and a whole second
+  // app rendered flat on the page.
+  function clipBeyond(){
+    if(!beyond.frame) return;
+    const x=lens.x/DPR, y=lens.y/DPR, r=R/DPR;
+    beyond.el.style.clipPath="circle("+r.toFixed(1)+"px at "+x.toFixed(1)+"px "+y.toFixed(1)+"px)";
+  }
+
+  /* ── the fleet, as the app behind the glass reports it ──
+     The demo publishes what it knows (web/src/lib/demoBridge.ts) and this reads
+     it straight out of the frame — same origin, no messaging. From then on the
+     contacts are not a simulation of the app's fleet, they ARE it: the block
+     you resolve over a card is quoting that card.
+
+     Read at 4Hz, eased into place, and entirely optional: an older /demo/ build
+     publishes nothing, and the hero keeps flying its own eight. */
+  let bridged=false, bridgeAt=0, spend0=null, calls0=0;
+  function readBeyond(now){
+    if(!beyond.live || now-bridgeAt<250) return;
+    bridgeAt=now;
+    let d=null;
+    try{ d=beyond.frame.contentWindow.__agxFleet; }catch(e){}
+    if(!d || d.v!==1 || !d.sessions) return;
+    const by=new Map(d.sessions.map(x=>[x.key.replace(/-demo$/,""),x]));
+    let hit=0, calls=0;
+    for(const s of fleet){
+      const x=by.get(s.id); if(!x) continue;
+      hit++;
+      // Context is the radar's whole geometry, so it moves at the speed the
+      // glass can follow rather than snapping between polls.
+      if(x.ctx>0) s.ctxTarget=x.ctx;
+      s.cost=x.cost; s.tools=x.tools; s.model=x.model; s.tokens=x.tokens;
+      calls+=x.tools;
+      // the card's own sentence — "running Read · 220ms", "Agent is waiting for
+      // your input" — rather than a tool name guessed back out of it
+      s.action=x.action||"";
+      if(s.state!=="held") s.state = x.status==="waiting" ? "wait" : "run";
+    }
+    if(!hit) return;
+    bridged=true;
+    // What it has cost since you arrived, and how many calls it took — both
+    // measured from the first reading, which is the moment you got here.
+    if(spend0===null){ spend0=d.spend; calls0=calls; }
+    spend=d.spend; costSince=Math.max(0,d.spend-spend0); callsSince=Math.max(0,calls-calls0);
   }
 
 
-  /* ══ the glass: a curved combiner, not a magnifier ══ */
+  /* ══════════════════════════════════════════════════════════════════
+     THE GLASS — a curved combiner, not a magnifier.
+
+     Both layers arrive as premultiplied light on clear film, and the frame
+     leaves with alpha 0, so the compositor ADDS it to the page: the HUD can
+     brighten what is behind it and can never darken it. That is what lets
+     the demo behind the lens read through the gaps in the symbology instead
+     of being painted over by a black canvas.
+     ══════════════════════════════════════════════════════════════════ */
   const VS='#version 300 es\nin vec2 p; out vec2 uv;\nvoid main(){ uv=p*0.5+0.5; gl_Position=vec4(p,0.,1.); }';
   const FS=[
   '#version 300 es','precision highp float;',
@@ -1803,6 +1846,9 @@ sudo apt install ./agentglass_*.deb</code>
   'uniform sampler2D uA; uniform sampler2D uB;',
   'uniform vec2 uRes; uniform vec2 uLens; uniform float uR; uniform float uT;',
   'uniform vec3 uPh;',
+  // Each channel is bent by a slightly different amount — the dispersion a
+  // thick curved combiner puts on everything it carries. Textures are uploaded
+  // premultiplied, so every sample is already light and needs no alpha of its own.
   'vec3 disperse(vec2 c, vec2 dir, float bend, float zoom){',
   '  vec2 base = uLens/uRes;',
   '  vec2 rel  = c - base;',
@@ -1838,14 +1884,12 @@ sudo apt install ./agentglass_*.deb</code>
   '    col = mix(col, uPh*1.15, edge*0.55);',
   '    col = mix(texture(uA,uv).rgb, col, 1.0 - smoothstep(0.995,1.0,r));',
   '  }',
-  // ── combiner treatment over the whole frame: scanlines, bloom-ish lift,
-  //    and a vignette, so the page reads as projected light on curved glass.
-  '  float scan = 0.955 + 0.045*sin(uv.y*uRes.y*1.6 + uT*1.4);',
-  '  col *= scan;',
-  '  float vig = 1.0 - 0.55*pow(length((uv-0.5)*vec2(1.16,1.0)), 2.4);',
-  '  col *= vig;',
+  // The scanlines and the vignette used to live here, where they could only
+  // reach the canvas. They are CSS now (.combiner), one layer above, so the
+  // world behind the glass is under the same treatment as the symbology.
   '  col += uPh * 0.018;',                                          // ambient phosphor haze
-  '  frag = vec4(col, 1.0);',
+  // alpha 0: everything this shader draws is added to the page, never over it
+  '  frag = vec4(col, 0.0);',
   '}'].join('\n');
 
   let prog=null,uRes,uLens,uR,uT,uPh,texA,texB;
@@ -1864,6 +1908,11 @@ sudo apt install ./agentglass_*.deb</code>
     const l=gl.getAttribLocation(prog,"p");
     gl.enableVertexAttribArray(l); gl.vertexAttribPointer(l,2,gl.FLOAT,false,0,0);
     gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL,true);
+    // Upload premultiplied, so a texel is already the light it contributes and
+    // the shader never has to un-premultiply a canvas that was premultiplied to
+    // begin with — the rain is drawn at alpha .055, where that round trip costs
+    // visible banding.
+    gl.pixelStorei(gl.UNPACK_PREMULTIPLY_ALPHA_WEBGL,true);
     const tex=u=>{const x=gl.createTexture(); gl.activeTexture(gl.TEXTURE0+u); gl.bindTexture(gl.TEXTURE_2D,x);
       gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_S,gl.CLAMP_TO_EDGE);
       gl.texParameteri(gl.TEXTURE_2D,gl.TEXTURE_WRAP_T,gl.CLAMP_TO_EDGE);
@@ -1928,7 +1977,7 @@ sudo apt install ./agentglass_*.deb</code>
   function raise(){
     asked=true; askAt=performance.now(); actor.state="held";
     document.getElementById("cSid").textContent=actor.id;
-    document.getElementById("cRepo").textContent=actor.repo;
+    document.getElementById("cModel").textContent=actor.model;
     document.getElementById("cAge").textContent=((actor.age/60)|0)+"m "+two((actor.age%60)|0)+"s";
     setMode("CAUTION · DECISION REQUIRED");
     cEl.classList.add("on"); document.getElementById("btnDeny").focus();
@@ -1959,10 +2008,11 @@ sudo apt install ./agentglass_*.deb</code>
   document.getElementById("btnAllow").addEventListener("click",()=>settle("allow"));
   cEl.addEventListener("keydown",e=>{ if(e.key==="Escape") settle("deny"); });
 
-  let prev=performance.now();
+  let prev=performance.now(), beyondOn=true;
   function frame(now){
     const dt=Math.min(0.1,(now-prev)/1000); prev=now;
     const t=(now-started)/1000;
+    readBeyond(now);
     tick(dt);
     if(!asked && document.visibilityState==="visible" && (t>14 || leaving)) raise();
     if(asked && !decided){
@@ -1971,6 +2021,13 @@ sudo apt install ./agentglass_*.deb</code>
       document.getElementById("cdN").textContent=Math.ceil(left);
       document.getElementById("ringFg").setAttribute("stroke-dashoffset",String(CIRC*(1-left/CD)));
       if(left<=0) settle("timeout");
+    }
+    // Scrolled past: the render loop stands down below, and the app behind the
+    // glass stops being composited with it. It keeps running — coming back to a
+    // frozen dashboard would read as a crash — it is just not drawn.
+    if(beyond.frame){
+      const on=window.__hudVisible!==false;
+      if(on!==beyondOn){ beyondOn=on; beyond.el.style.visibility=on?"":"hidden"; }
     }
     if(ok && window.__hudVisible !== false){
       if(!introDone && !reduce){
@@ -2016,8 +2073,13 @@ sudo apt install ./agentglass_*.deb</code>
             lens.tx=g.cx*DPR+Math.cos(t*0.22)*orbit;
             lens.ty=g.cy*DPR+Math.sin(t*0.22)*orbit*0.62;
           } else {
-            const m=Math.min(W,H)*0.5-R*0.4;
-            lens.tx=W*0.5+Math.cos(t*0.19)*m*1.05; lens.ty=H*0.5+Math.sin(t*0.27)*m*0.55;
+            // Orbit the boresight, the way the phone already did. The old figure
+            // swung 1.05 of the half-screen and spent a third of its time parked
+            // on the headline — which was survivable when there was nothing under
+            // the glass but rain, and is not now that the app is under there.
+            const g=contactPos(fleet[0],0,W/DPR,H/DPR,t);
+            lens.tx=g.cx*DPR+Math.cos(t*0.19)*g.rad*0.58*DPR;
+            lens.ty=g.cy*DPR+Math.sin(t*0.27)*g.rad*0.42*DPR;
           }
         }
         // A fixed per-frame weight makes the glass heavier the faster your
@@ -2026,6 +2088,7 @@ sudo apt install ./agentglass_*.deb</code>
         const k = reduce ? 1 : 1-Math.pow(1-0.085, Math.min(4, dt*60));
         lens.x+=(lens.tx-lens.x)*k; lens.y+=(lens.ty-lens.y)*k;
       }
+      clipBeyond();
       drawUnaided(t); drawResolved(t);
       gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D,texA);
       gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,gl.RGBA,gl.UNSIGNED_BYTE,A);
@@ -2045,6 +2108,15 @@ sudo apt install ./agentglass_*.deb</code>
   setMode(modeTxt);
   addEventListener("resize",()=>{ resize(); setMode(modeTxt); });
   requestAnimationFrame(frame);
+
+  // The app behind the glass comes up once the page has nothing better to do.
+  // The intro slew is 7 seconds long and the visitor is reading a headline for
+  // the first two of them, which is exactly the room a second document needs.
+  (function(){
+    const go=()=>openBeyond();
+    if(document.readyState==="complete") setTimeout(go,350);
+    else addEventListener("load",()=>setTimeout(go,350),{once:true});
+  })();
 })();
 </script>
 <script>
@@ -2283,7 +2355,7 @@ sudo apt install ./agentglass_*.deb</code>
         const c=cells[i]; if(!c) return;
         const f=Math.min(1,s.ctx), hot=s.state==="held"||f>=0.86;
         c.id.textContent=s.id;
-        c.repo.textContent=s.repo.split("/")[1];
+        c.repo.textContent=s.model;
         c.cost.textContent="$"+s.cost.toFixed(2);
         c.bar.style.width=(f*100).toFixed(1)+"%";
         c.bar.style.background= hot?ERR : f>=0.7?WARN : OK;

--- a/landing/index.html
+++ b/landing/index.html
@@ -60,13 +60,13 @@
     opacity:0; transition:opacity .8s ease;}
   .beyond.lit{opacity:1;}
   .beyond iframe{position:absolute; inset:0; width:100%; height:100%; border:0; display:block;
-    /* The world seen through a tinted combiner. Level comes down so the
-       symbology stays the brightest thing on the glass, and chroma comes down
-       with it for a subtler reason: the app under here is wearing the same
-       phosphor the HUD is drawn in, and purple-on-purple was one texture.
-       Draining the world's colour puts the two layers back on separate
-       planes — which is what a combiner does to the view through it. */
-    filter:brightness(.54) saturate(.32) contrast(1.06);}
+    /* The world through a tinted combiner: a touch under full, and no more.
+       It was down at half brightness and a third of its colour, because the
+       symbology was pure additive light and anything lit behind it won. Now
+       the symbology carries its own coverage and its own plates, so the app
+       can be shown as the app — which is the entire point of putting it
+       there. */
+    filter:brightness(.86) saturate(.98) contrast(1.02);}
 
   /* The combiner treatment — scanlines, phosphor haze, vignette — over
      everything the glass carries, symbology and world alike. It used to be
@@ -102,6 +102,25 @@
      equal specificity and the cue kept showing on phones */
   @media (max-width:700px){ .hud.glass .cue{display:none;} }
   .acts{display:flex; gap:8px; pointer-events:auto; flex-wrap:wrap;}
+  /* What a button resolves into when the designator is on it. Same surface as
+     the data blocks the contacts resolve into — cut corner, phosphor edge, dark
+     enough to be read over whatever the glass is showing at the time. */
+  .rev{
+    /* Right-aligned, always: .acts is pinned to the right end of the hero's
+       foot, and a callout anchored to a button's left edge ran off the
+       viewport and lost its last four words. */
+    position:absolute; right:0; bottom:calc(100% + 10px); white-space:nowrap;
+    font-size:9.5px; letter-spacing:.14em; text-transform:uppercase; line-height:1;
+    color:var(--primary); padding:7px 10px;
+    border:1px solid color-mix(in srgb,var(--primary) 42%,transparent);
+    background:color-mix(in srgb,#02040a 88%,transparent);
+    clip-path:polygon(6px 0,100% 0,100% calc(100% - 6px),calc(100% - 6px) 100%,0 100%,0 6px);
+    opacity:0; transform:translateY(5px); pointer-events:none;
+    transition:opacity .2s ease, transform .2s ease;
+  }
+  .act{position:relative; display:inline-flex;}
+  .act.lit .rev{opacity:1; transform:none;}
+  @media (max-width:820px){ .rev{display:none;} }
   .btn{
     font-family:var(--mono); font-size:11.5px; letter-spacing:.09em; text-transform:uppercase;
     padding:10px 18px; color:var(--primary); background:transparent; position:relative;
@@ -112,12 +131,14 @@
   .btn:hover,.btn:focus-visible{background:color-mix(in srgb,var(--primary) 14%,transparent); border-color:var(--primary); outline:none; text-shadow:0 0 10px var(--primary);}
   .btn.pri{background:color-mix(in srgb,var(--primary) 20%,transparent); border-color:var(--primary); font-weight:700;}
 
+  /* The phosphor picker, on the console rather than on the glass — it used to
+     be pinned to the hero's top-left, which is exactly where the app behind the
+     lens keeps its own theme control. */
   .themer{
-    /* clear of the bearing tape at y=64 — at 1440 the swatch row reached it */
-    position:absolute; left:30px; top:92px; z-index:5; pointer-events:auto;
-    display:flex; align-items:center; gap:6px; padding:7px 10px;
-    border:1px solid color-mix(in srgb,var(--primary) 30%,transparent);
-    background:color-mix(in srgb,#000 55%,transparent); backdrop-filter:blur(6px);
+    display:inline-flex; align-items:center; gap:7px; flex-wrap:wrap;
+    margin:0 0 18px; padding:8px 11px;
+    border:1px solid color-mix(in srgb,var(--primary) 26%,transparent);
+    background:color-mix(in srgb,#000 45%,transparent);
     clip-path:polygon(6px 0,100% 0,100% calc(100% - 6px),calc(100% - 6px) 100%,0 100%,0 6px);
   }
   .themer .cap{font-size:9px; letter-spacing:.2em; text-transform:uppercase; color:var(--text4);}
@@ -125,7 +146,6 @@
   .themer button{width:13px; height:13px; border:1px solid rgba(255,255,255,.2); cursor:pointer; padding:0; transition:transform .14s;}
   .themer button:hover,.themer button:focus-visible{transform:scale(1.3); outline:none; border-color:#fff;}
   .themer button[aria-pressed="true"]{box-shadow:0 0 0 1px #000,0 0 0 2.5px currentColor;}
-  @media (max-width:960px){ .themer{display:none;} }
   @media (max-width:820px){ .rail a:not(.gh){display:none;} }
 
   /* ══════════════════════════════════════════════════════════════════
@@ -910,16 +930,24 @@
 
     <div class="foot">
       <div class="cue">Move the designator — <b>lock any contact</b></div>
+      <!-- Under the glass a contact stops being UNK. So does a button: the
+           designator crossing one resolves what taking it actually costs you.
+           Absolutely positioned, so nothing on the page moves when it opens. -->
       <div class="acts">
-        <a class="btn pri" target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass/releases/latest">Download <span data-agx="version">the app</span></a>
-        <a class="btn" href="./demo/">Live demo</a>
+        <!-- The callout is a sibling of the button, not a child of it: .btn is
+             cut-cornered with clip-path, and clip-path clips its descendants —
+             the first version of this drew the callout perfectly, inside a
+             shape 18px too small to show any of it. -->
+        <span class="act" data-glass>
+          <a class="btn pri" target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass/releases/latest">Download <span data-agx="version">the app</span></a>
+          <span class="rev">macOS · Linux · Windows · MIT · nothing phones home</span>
+        </span>
+        <span class="act" data-glass>
+          <a class="btn" href="./demo/">Live demo</a>
+          <span class="rev">No install · it is already running behind this glass</span>
+        </span>
       </div>
     </div>
-  </div>
-
-  <div class="themer" id="themer" aria-label="Theme">
-    <span class="cap">PHOSPHOR</span>
-    <span class="nm" id="thName">Midnight Purple</span>
   </div>
 
   <div class="glare" aria-hidden="true"></div>
@@ -1232,6 +1260,15 @@ sudo apt install ./agentglass_*.deb</code>
     <a class="btn" data-dl="win" target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass/releases/latest">Windows</a>
     <a class="btn" target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass">Star on GitHub</a>
   </div>
+  <!-- The phosphor picker. It sat in the top-left corner of the hero until the
+       glass started opening onto the app, whose own theme control is up there
+       too: two theme pickers stacked, one of them refracted. Down here it is
+       out of the instrument, and it still repaints the page, the hero and the
+       app behind the glass in one go. -->
+  <div class="themer" id="themer" aria-label="Phosphor">
+    <span class="cap">Phosphor</span>
+    <span class="nm" id="thName">Midnight Purple</span>
+  </div>
   <p class="meta">Open source · MIT · Bun + SQLite · React + Vite · Electron · 22 phosphors · macOS, Linux, Windows</p>
 </section>
 
@@ -1449,6 +1486,28 @@ sudo apt install ./agentglass_*.deb</code>
     return {x:cx+Math.cos(ang)*rad*Math.min(1,s.ctx), y:cy+Math.sin(ang)*rad*Math.min(1,s.ctx)*sq, cx:cx, cy:cy, rad:rad, sq:sq};
   }
 
+  /* The plate a resolved block is written on.
+     The app behind the glass is lit, and lit is what it should be — but a
+     phosphor sentence over a phosphor panel is two things at once and neither
+     of them readable. So the block gets a surface: cut-cornered the way every
+     panel in the app is, dark enough to own its own pixels, with the phosphor
+     edge that says it belongs to the glass rather than to what is under it. */
+  function plate(c,x,y,w,hh,col,al){
+    const cut=8;
+    c.beginPath();
+    c.moveTo(x+cut,y); c.lineTo(x+w,y); c.lineTo(x+w,y+hh-cut);
+    c.lineTo(x+w-cut,y+hh); c.lineTo(x,y+hh); c.lineTo(x,y+cut); c.closePath();
+    c.fillStyle="rgba(2,4,10,"+(0.88*al).toFixed(3)+")"; c.fill();
+    c.strokeStyle=ink(col,.45*al); c.lineWidth=1; c.stroke();
+  }
+  /* Symbology that has to survive a lit background under it. A dark halo is
+     what a HUD does not have and a canvas badly needs: at 9px over a panel,
+     phosphor on phosphor loses every time. */
+  function halo(c,on){
+    c.shadowColor = on ? "rgba(0,0,0,0.92)" : "transparent";
+    c.shadowBlur  = on ? 5 : 0;
+  }
+
   /* Designator lock. The brackets fly in from wide and settle — how a HUD
      says "this one". Drawn on both layers so it survives the glass arriving. */
   function drawLock(c,x,y,sz,col){
@@ -1597,7 +1656,7 @@ sudo apt install ./agentglass_*.deb</code>
         // so this one keeps its UNK and waits for you to aim at it.
         if(by===null){ gain[it.i]=0; continue; }
         boxes.push({x0, x1:x0+BW, y0:by-14, y1:by+BH});
-        slot[it.i]={by, right};
+        slot[it.i]={by, right, w:BW, h:BH};
       }
     }
     fleet.forEach((s,i)=>{
@@ -1622,11 +1681,16 @@ sudo apt install ./agentglass_*.deb</code>
 
       if(g < 0.999){
         // Unaided, or aimed elsewhere: bearing only. You know it is there,
-        // and that is the whole of what you know.
-        c.fillStyle=ink(col,.75*(1-g)); c.textAlign="center";
-        c.font='9px ui-monospace,Menlo,monospace';
-        c.fillText("UNK",p.x,p.y+3); c.textAlign="left";
+        // and that is the whole of what you know. Set heavy and haloed — it
+        // was 9px of thin phosphor, and over the rain it read as lint.
+        halo(c,true);
+        c.fillStyle=ink(col,.96*(1-g)); c.textAlign="center";
+        c.font='700 10px ui-monospace,Menlo,monospace';
+        c.letterSpacing="0.06em";
+        c.fillText("UNK",p.x,p.y+3.5);
+        c.letterSpacing="0em"; c.textAlign="left";
         c.font='10px ui-monospace,Menlo,monospace';
+        halo(c,false);
         if(g <= 0.001) return;
       }
 
@@ -1638,6 +1702,11 @@ sudo apt install ./agentglass_*.deb</code>
       const right = slot[i].right, by = slot[i].by;
       const dx = right ? 1 : -1, up = by < p.y;
       const bx = p.x + dx*(sz+16);
+      {
+        const pw=slot[i].w, ph=slot[i].h;
+        plate(c, right?bx-6:bx+6-pw, by-15, pw, ph, col, g);
+      }
+      halo(c,true);
       c.strokeStyle=ink(col,.45*g);
       c.beginPath(); c.moveTo(p.x+dx*sz,p.y); c.lineTo(bx-dx*6,by+(up?30:0)); c.lineTo(bx,by+(up?30:0)); c.stroke();
       c.textAlign = right ? "left" : "right";
@@ -1667,7 +1736,8 @@ sudo apt install ./agentglass_*.deb</code>
         // Tokens once the app behind the glass is reporting them, milliseconds
         // while we are flying our own simulation. Never both: a real spend beside
         // an invented latency is a lie wearing three true numbers as cover.
-        c.fillText(s.tools+" tools · "+(bridged ? tok(s.tokens) : s.ms+"ms")+" · $"+s.cost.toFixed(2),ax,by+31);
+          const mid = bridged ? (s.tokens>0 ? tok(s.tokens)+" · " : "") : s.ms+"ms · ";
+        c.fillText(s.tools+" tools · "+mid+"$"+s.cost.toFixed(2),ax,by+31);
       }
       // context against the window, the same law the range rings measure by
       const bw=tight?76:88, byy=by+(tight?24:40);
@@ -1681,6 +1751,7 @@ sudo apt install ./agentglass_*.deb</code>
                          : Math.round(f*100)+"% OF 1M CONTEXT", ax, byy+13);
       c.letterSpacing="0em";
       c.textAlign="left";
+      halo(c,false);
     });
 
     // ── corner blocks
@@ -1706,17 +1777,27 @@ sudo apt install ./agentglass_*.deb</code>
         [held?"⚠ "+held+" HELD FOR APPROVAL":"NO HOLDS · THEY HAVE NOT STOPPED",0,null,held?ERR:OK,.9]
       ]);
     } else {
-      block(30,h-118,"left",[
+      // A fourth line on each block, on the resolved side only: the readouts
+      // are as unaided as the contacts are until the glass is over them.
+      // Counted, never asserted: the fleet is bridged from the app behind the
+      // glass, and a hand-typed "3 providers" would be a claim about data we
+      // are holding in our hand.
+      const apps=new Set(fleet.map(x=>x.app)).size;
+      const models=new Set(fleet.map(x=>x.model)).size;
+      const provs=new Set(fleet.map(x=>/gpt/i.test(x.model)?"openai":/gemini/i.test(x.model)?"google":"anthropic")).size;
+      block(30,h-133,"left",[
         ["FLEET · 8 CONTACTS",0,10,P,.85],
         ["SPEND  $"+spend.toFixed(2),0,13,V("--text"),.95],
         ["TOKENS 779.2K · P50 73MS",0,null,V("--text3"),.7],
-        [held?"⚠ "+held+" HELD FOR APPROVAL":"NO HOLDS",0,null,held?ERR:OK,.9]
+        [held?"⚠ "+held+" HELD FOR APPROVAL":"NO HOLDS",0,null,held?ERR:OK,.9],
+        ...(res?[[apps+" PROJECTS · "+models+" MODELS · "+provs+" PROVIDERS",0,null,OK,.8]]:[])
       ]);
-      block(w-30,h-118,"right",[
+      block(w-30,h-133,"right",[
         ["MISSION CLOCK",0,10,P,.85],
         [clock+" ON GLASS",0,13,V("--text"),.95],
         ["THEY HAVE NOT STOPPED",0,null,V("--text3"),.7],
-        ["+$"+costSince.toFixed(2)+" SINCE YOU ARRIVED",0,null,WARN,.9]
+        ["+$"+costSince.toFixed(2)+" SINCE YOU ARRIVED",0,null,WARN,.9],
+        ...(res?[[callsSince+" TOOL CALLS WHILE YOU READ THIS",0,null,OK,.8]]:[])
       ]);
     }
 
@@ -1726,17 +1807,37 @@ sudo apt install ./agentglass_*.deb</code>
     c.font='800 '+size+'px ui-sans-serif,system-ui,-apple-system,sans-serif';
     const sx=nar?18:30, sy=nar?h*0.275:h*0.30;
     c.fillStyle=ink(V("--text"),.96); c.fillText("EIGHT ARE FLYING.",sx,sy);
-    c.fillStyle=ink(P,.96); c.fillText("YOU CAN SEE ONE.",sx,sy+size*0.98);
+    /* The claim is the demonstration.
+       Both layers write "YOU CAN SEE " identically, so nothing doubles or
+       shivers as the glass crosses the line — and then the last word, and only
+       the last word, is different on the far side of the glass. Sweep the
+       designator along the sentence and the sentence changes its mind: ONE
+       becomes ALL EIGHT, in the colour the fleet reads when it is resolved.
+       There is no copy on this page that argues the product better than a
+       visitor doing that once by accident. */
+    const lead="YOU CAN SEE ", ly2=sy+size*0.98;
+    c.fillStyle=ink(P,.96); c.fillText(lead,sx,ly2);
+    const lw=c.measureText(lead).width;
+    c.fillStyle=ink(res>=0.5?OK:P,.96);
+    c.fillText(res>=0.5?"ALL EIGHT.":"ONE.",sx+lw,ly2);
     c.letterSpacing="0em";
     c.font=(nar?'10px ':'10.5px ')+'ui-monospace,Menlo,monospace';
     c.fillStyle=ink(V("--text3"),.72);
     c.letterSpacing=nar?"0.05em":"0.09em";
     // the long form does not fit a phone, and a clipped instruction is worse
     // than a short one
-    c.fillText(res<0.5 ? (nar?"THE GLASS IS THE INSTRUMENT":"THE GLASS IS THE INSTRUMENT — MOVE IT OVER A CONTACT")
-             : beyond.live ? (nar?"RESOLVED · THE APP ITSELF, BEHIND THE GLASS":"EVERY CONTACT RESOLVED — AND THAT IS THE APP ITSELF BEHIND THE GLASS")
-                       : (nar?"EVERY CONTACT RESOLVED · SAME SECOND":"EVERY CONTACT RESOLVED · SAME MACHINE · SAME SECOND"),
-               sx, sy+size*0.98+24);
+    // Shared opening, swapped tail — for the same reason as the line above it.
+    // Two entirely different sentences fighting over the same 700px read as a
+    // rendering fault, which is what the old pair did.
+    const cue0=nar?"THE GLASS IS THE INSTRUMENT":"THE GLASS IS THE INSTRUMENT — ";
+    c.fillText(cue0, sx, sy+size*0.98+24);
+    if(!nar){
+      const cw=c.measureText(cue0).width;
+      c.fillStyle=ink(res<0.5?V("--text3"):OK,res<0.5?.72:.9);
+      c.fillText(res<0.5 ? "MOVE IT OVER A CONTACT"
+               : beyond.live ? "AND THAT IS THE APP ITSELF UNDER IT"
+                             : "EVERY CONTACT UNDER IT IS RESOLVED", sx+cw, sy+size*0.98+24);
+    }
     c.letterSpacing="0em";
   }
 
@@ -1782,12 +1883,47 @@ sudo apt install ./agentglass_*.deb</code>
       beyond.live=true; beyond.el.classList.add("lit");
       // The claim below the fold changes when the app is genuinely up there.
       const sub=document.getElementById("reelSub");
-      if(sub) sub.innerHTML='The symbology up there is drawn. What resolved under the glass is not — that was the app itself, live in the page, flying the eight sessions the designator named. This is the rest of it, recorded on a real machine.';
+      if(sub) sub.innerHTML='The symbology up there is drawn. What resolved under the glass is not: that was the app itself, live in the page, flying the eight sessions the designator named. This is the rest of it, recorded on a real machine.';
     });
     beyond.el.appendChild(f);
     beyond.frame=f;
     function drop(){ f.remove(); beyond.frame=null; beyond.live=false; }
   }
+  /* ── what the glass does to the chrome ──
+     The rail and the buttons are HTML, a layer above the canvas, so the lens
+     cannot bend them. It can still be over them, and a designator that resolves
+     every contact it crosses and then slides across a button as if the button
+     were scenery is a designator that stops meaning anything. So the elements
+     that have something worth saying are asked directly. */
+  const glassy=[...document.querySelectorAll("[data-glass]")];
+  let glassBox=[];
+  function measureGlassy(){
+    const r=hud.getBoundingClientRect();
+    glassBox=glassy.map(el=>{
+      const b=el.getBoundingClientRect();
+      return {el, x0:b.left-r.left, y0:b.top-r.top, x1:b.right-r.left, y1:b.bottom-r.top, on:false};
+    });
+  }
+  function litGlassy(){
+    if(!glassBox.length) return;
+    const x=lens.x/DPR, y=lens.y/DPR, rr=R/DPR*0.92;
+    // One designator, one target. Both buttons fall inside a 460px lens at
+    // once and lit both, which put two callouts on top of each other — and a
+    // designator that resolves everything it can reach is not aiming at all.
+    let best=null, bd=1e9;
+    for(const g of glassBox){
+      // nearest point of the box to the lens centre, which is the honest test
+      // for "is the glass over this" for something that is not a point
+      const nx=Math.max(g.x0,Math.min(x,g.x1)), ny=Math.max(g.y0,Math.min(y,g.y1));
+      const d=Math.hypot(x-nx,y-ny);
+      if(d<=rr && d<bd){ bd=d; best=g; }
+    }
+    for(const g of glassBox){
+      const on=g===best;
+      if(on!==g.on){ g.on=on; g.el.classList.toggle("lit",on); }
+    }
+  }
+
   // The lens is a hole in the dark. Nothing behind it is visible anywhere else,
   // so the clip is the only thing standing between a visitor and a whole second
   // app rendered flat on the page.
@@ -1839,11 +1975,16 @@ sudo apt install ./agentglass_*.deb</code>
   /* ══════════════════════════════════════════════════════════════════
      THE GLASS — a curved combiner, not a magnifier.
 
-     Both layers arrive as premultiplied light on clear film, and the frame
-     leaves with alpha 0, so the compositor ADDS it to the page: the HUD can
-     brighten what is behind it and can never darken it. That is what lets
-     the demo behind the lens read through the gaps in the symbology instead
-     of being painted over by a black canvas.
+     Both layers arrive as premultiplied ink on clear film. The frame leaves
+     carrying that ink's own coverage as alpha, plus the glass's light — the
+     fresnel, the rim, the glare — added on top with no coverage of its own.
+     So the light only ever brightens what is behind the glass, while the
+     symbology can sit ON the world rather than glowing through it.
+
+     That distinction is the whole reason the app behind the lens can be shown
+     at something close to its real brightness. Pure addition meant every lit
+     pixel of the dashboard fought every lit pixel of the HUD, and the way to
+     make the HUD win was to turn the dashboard down until it was a rumour.
      ══════════════════════════════════════════════════════════════════ */
   const VS='#version 300 es\nin vec2 p; out vec2 uv;\nvoid main(){ uv=p*0.5+0.5; gl_Position=vec4(p,0.,1.); }';
   const FS=[
@@ -1853,16 +1994,23 @@ sudo apt install ./agentglass_*.deb</code>
   'uniform vec2 uRes; uniform vec2 uLens; uniform float uR; uniform float uT;',
   'uniform vec3 uPh;',
   // Each channel is bent by a slightly different amount — the dispersion a
-  // thick curved combiner puts on everything it carries. Textures are uploaded
-  // premultiplied, so every sample is already light and needs no alpha of its own.
-  'vec3 disperse(vec2 c, vec2 dir, float bend, float zoom){',
+  // thick curved combiner puts on everything it carries. Coverage comes from
+  // the middle tap: at a bend of about a pixel, three alphas would be the same
+  // alpha anyway.
+  // Magnification is small on purpose: most of what the two layers carry is
+  // identical (the headline, the rings, the ladder), and at 1.07 the glass drew
+  // a second, offset copy of every one of them — a lens that ghosts its own
+  // furniture rather than one that magnifies.
+  'vec4 disperse(vec2 c, vec2 dir, float bend, float zoom){',
   '  vec2 base = uLens/uRes;',
   '  vec2 rel  = c - base;',
   '  vec2 off  = dir*bend/uRes;',
-  '  return vec3(',
+  '  vec4 g = texture(uB, base + rel/(zoom*1.0000) - off*1.000);',
+  '  return vec4(',
   '    texture(uB, base + rel/(zoom*0.9945) - off*1.012).r,',
-  '    texture(uB, base + rel/(zoom*1.0000) - off*1.000).g,',
-  '    texture(uB, base + rel/(zoom*1.0055) - off*0.988).b);',
+  '    g.g,',
+  '    texture(uB, base + rel/(zoom*1.0055) - off*0.988).b,',
+  '    g.a);',
   '}',
   'void main(){',
   // Declared separately: initialising d from px in the same statement leaves it
@@ -1871,31 +2019,38 @@ sudo apt install ./agentglass_*.deb</code>
   '  vec2 px = uv*uRes;',
   '  vec2 d  = px - uLens;',
   '  float r = length(d)/uR;',
-  '  vec3 col;',
+  '  vec4 ink;',
+  '  vec3 lit = vec3(0.0);',
   '  if(r >= 1.0){',
-  '    col = texture(uA, uv).rgb;',
+  '    ink = texture(uA, uv);',
   // edge0 < edge1 always: a reversed smoothstep is undefined and returns NaN.
-  '    col *= 1.0 - (1.0 - smoothstep(1.0, 1.34, r)) * 0.30;',
+  // Scaling colour and coverage together keeps the symbology's hue and just
+  // lets more of the page through — dimming rgb alone would grey it out.
+  '    ink *= 1.0 - (1.0 - smoothstep(1.0, 1.34, r)) * 0.30;',
   '  } else {',
   '    float h = sqrt(max(0.0, 1.0 - r*r));',
   '    vec2 dir = (r > 0.0001) ? d/(r*uR) : vec2(0.0);',
   '    float k = 1.0 - h;',
-  '    col = disperse(uv, dir, k*k*uR*0.16, 1.0 + 0.07*h) * 1.06;',
-  '    col += uPh * pow(1.0-h, 3.0) * 0.20;',                       // fresnel, in phosphor
+  '    ink = disperse(uv, dir, k*k*uR*0.16, 1.0 + 0.022*h);',
+  '    ink.rgb *= 1.06;',                                           // symbology runs hot on glass
+  '    lit += uPh * pow(1.0-h, 3.0) * 0.13;',                       // fresnel, in phosphor
   '    float caustic = smoothstep(0.90,0.975,r) * (1.0 - smoothstep(0.975,1.0,r));',
-  '    col += uPh * caustic * 0.42;',                               // the combiner rim glows
+  '    lit += uPh * caustic * 0.34;',                               // the combiner rim glows
   '    vec2 L = normalize(vec2(-0.55, 0.62 + 0.05*sin(uT*0.5)));',
-  '    col += vec3(1.0) * (1.0 - smoothstep(0.0, 0.34, length(d/uR - L*0.5))) * 0.07;',
+  '    lit += vec3(1.0) * (1.0 - smoothstep(0.0, 0.34, length(d/uR - L*0.5))) * 0.045;',
   '    float edge = smoothstep(0.982,1.0,r);',
-  '    col = mix(col, uPh*1.15, edge*0.55);',
-  '    col = mix(texture(uA,uv).rgb, col, 1.0 - smoothstep(0.995,1.0,r));',
+  '    lit += uPh * edge * 0.42;',
+  // the last half-pixel of the rim, where the two layers change places
+  '    ink = mix(texture(uA,uv), ink, 1.0 - smoothstep(0.995,1.0,r));',
   '  }',
+  // Every figure above came down when the world behind the glass came up:
+  // the same phosphor that read as glass over black reads as fog over a lit
+  // dashboard.
   // The scanlines and the vignette used to live here, where they could only
   // reach the canvas. They are CSS now (.combiner), one layer above, so the
   // world behind the glass is under the same treatment as the symbology.
-  '  col += uPh * 0.018;',                                          // ambient phosphor haze
-  // alpha 0: everything this shader draws is added to the page, never over it
-  '  frag = vec4(col, 0.0);',
+  '  lit += uPh * 0.012;',                                          // ambient phosphor haze
+  '  frag = vec4(ink.rgb + lit, ink.a);',
   '}'].join('\n');
 
   let prog=null,uRes,uLens,uR,uT,uPh,texA,texB;
@@ -2094,7 +2249,7 @@ sudo apt install ./agentglass_*.deb</code>
         const k = reduce ? 1 : 1-Math.pow(1-0.085, Math.min(4, dt*60));
         lens.x+=(lens.tx-lens.x)*k; lens.y+=(lens.ty-lens.y)*k;
       }
-      clipBeyond();
+      clipBeyond(); litGlassy();
       drawUnaided(t); drawResolved(t);
       gl.activeTexture(gl.TEXTURE0); gl.bindTexture(gl.TEXTURE_2D,texA);
       gl.texImage2D(gl.TEXTURE_2D,0,gl.RGBA,gl.RGBA,gl.UNSIGNED_BYTE,A);
@@ -2110,9 +2265,9 @@ sudo apt install ./agentglass_*.deb</code>
     }
     requestAnimationFrame(frame);
   }
-  resize(); lens.x=lens.tx=W*0.5; lens.y=lens.ty=H*0.5;
+  resize(); measureGlassy(); lens.x=lens.tx=W*0.5; lens.y=lens.ty=H*0.5;
   setMode(modeTxt);
-  addEventListener("resize",()=>{ resize(); setMode(modeTxt); });
+  addEventListener("resize",()=>{ resize(); measureGlassy(); setMode(modeTxt); });
   requestAnimationFrame(frame);
 
   // The app behind the glass comes up once the page has nothing better to do.

--- a/landing/index.html
+++ b/landing/index.html
@@ -986,7 +986,10 @@
   <div class="reel-head">
     <span class="eyebrow">Recorded, not drawn</span>
     <h2>This is it, <em>actually running.</em></h2>
-    <p class="reel-sub">Everything above this line is a simulation of the product. This is the product.</p>
+    <!-- True as it stands, for the visitor who never got the frame — a phone, a
+         metered connection, a request for less motion. The hero rewrites it the
+         moment the app really is behind the glass. -->
+    <p class="reel-sub" id="reelSub">Everything above this line is a simulation of the product. This is the product.</p>
   </div>
 
   <figure class="reel">
@@ -1777,6 +1780,9 @@ sudo apt install ./agentglass_*.deb</code>
       // here, and a 404 under the lens is worse than the honest dark.
       try{ if(!f.contentWindow.document.getElementById("root")) return void drop(); }catch(e){ return void drop(); }
       beyond.live=true; beyond.el.classList.add("lit");
+      // The claim below the fold changes when the app is genuinely up there.
+      const sub=document.getElementById("reelSub");
+      if(sub) sub.innerHTML='The symbology up there is drawn. What resolved under the glass is not — that was the app itself, live in the page, flying the eight sessions the designator named. This is the rest of it, recorded on a real machine.';
     });
     beyond.el.appendChild(f);
     beyond.frame=f;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -3,6 +3,7 @@ import type { WatchEvent, SessionRollup } from "../../shared/types.ts";
 import { useLive } from "./lib/useLive.ts";
 import { useStats } from "./lib/useStats.ts";
 import { deriveAgents, deriveAlerts, buildTitles } from "./lib/derive.ts";
+import { publishFleet } from "./lib/demoBridge.ts";
 import { providerOf } from "./lib/format.ts";
 import { api, IS_DEMO } from "./lib/api.ts";
 import { initialTheme, applyTheme, THEMES } from "./lib/themes.ts";
@@ -268,6 +269,14 @@ export default function App() {
   );
   const alerts = useMemo(() => deriveAlerts(agents), [agents]);
   useAlertSound(alerts.length, sound);
+
+  // Demo builds only: hand the fleet to whoever is showing this build inside a
+  // frame. Today that is the landing page's head-up display, which draws the
+  // same eight sessions over the top of this dashboard and has to agree with it
+  // to the cent. A no-op in every other build — see lib/demoBridge.ts.
+  useEffect(() => {
+    publishFleet(agentsAll, stats?.totals.cost_usd ?? 0);
+  }, [agentsAll, stats]);
 
   const clearFilters = useCallback(() => setFilter({ app: "", type: "", provider: "" }), []);
 

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -13,7 +13,7 @@ import type {
   GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult,
   PrRepoId, PrSummary, PrDetail, PrThread, PrCheck, PrCheckRollup, PrCheckState, PrListResponse,
 } from "../../../shared/types.ts";
-import { providerOf } from "./format.ts";
+import { modelLabelOf, providerOf } from "./format.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
 
 export const IS_DEMO = import.meta.env.VITE_DEMO === "1";
@@ -57,6 +57,28 @@ const PATHS = [
   "/home/dev/code/payments-svc/handlers/webhook.go",
 ];
 const SKILL_NAMES = ["pr-summary", "code-review", "test-scaffold", "dep-upgrade", "changelog-gen"];
+
+// What the live stream has spent since this page opened.
+//
+// The totals below are a fixed portrait of one window, and the stream that
+// runs on top of them used to be free: the fleet visibly worked, tool calls
+// piled up, the session cards' own costs climbed — and "Spend · this window"
+// sat at exactly $359.85 for as long as you cared to watch. Spend is the first
+// number anyone checks against the clock, and a frozen one is the demo saying
+// out loud that none of this is connected to anything.
+//
+// Kept by model as well as in total, so the KPI and the donut that breaks it
+// down never disagree.
+const streamed = { events: 0, tools: 0, cost: 0, byModel: new Map<string, number>() };
+function account(e: WatchEvent) {
+  streamed.events++;
+  if (e.tool_name && e.hook_event_type === "PostToolUse") streamed.tools++;
+  if (e.cost_usd) {
+    streamed.cost += e.cost_usd;
+    const m = modelLabelOf(e.model_name);
+    streamed.byModel.set(m, (streamed.byModel.get(m) ?? 0) + e.cost_usd);
+  }
+}
 
 let idc = 1000;
 const demoCtx = new Map<string, number>(); // session → simulated context size
@@ -150,7 +172,7 @@ let streamTimer: ReturnType<typeof setInterval> | null = null;
 export function startStream(push: (e: WatchEvent) => void): () => void {
   listeners.push(push);
   if (!streamTimer) {
-    const tick = () => listeners.forEach((l) => l(nextEvent()));
+    const tick = () => { const e = nextEvent(); account(e); listeners.forEach((l) => l(e)); };
     streamTimer = setInterval(tick, 900);
   }
   return () => {
@@ -216,7 +238,7 @@ export function stats(windowMs: number, provider?: string): StatsSummary {
     return { t, events: rint(0, Math.round(40 * busy)), errors: Math.random() < 0.1 ? rint(1, 3) : 0, cost_usd: Number(rnd(0, 12 * busy).toFixed(3)), tokens: rint(0, Math.round(60000 * busy)) };
   });
   const summary: StatsSummary = {
-    totals: { events: si(12840), sessions: si(41), tool_calls: si(6210), errors: Math.round(34 * f), cost_usd: sc(4498.08), input_tokens: Math.round(9_100_000 * f), output_tokens: Math.round(640_000 * f), cache_creation_tokens: Math.round(1_200_000 * f), cache_read_tokens: Math.round(78_000_000 * f) },
+    totals: { events: si(12840) + streamed.events, sessions: si(41), tool_calls: si(6210) + streamed.tools, errors: Math.round(34 * f), cost_usd: Number((sc(4498.08) + streamed.cost).toFixed(2)), input_tokens: Math.round(9_100_000 * f), output_tokens: Math.round(640_000 * f), cache_creation_tokens: Math.round(1_200_000 * f), cache_read_tokens: Math.round(78_000_000 * f) },
     by_model: [
       { model_name: "Opus", input_tokens: Math.round(4_100_000 * f), output_tokens: Math.round(300_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(2350.0), sessions: si(14) },
       { model_name: "GPT-5", input_tokens: Math.round(3_200_000 * f), output_tokens: Math.round(240_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(1180.3), sessions: si(11) },
@@ -238,6 +260,10 @@ export function stats(windowMs: number, provider?: string): StatsSummary {
     heatmap,
     window_ms: windowMs,
   };
+  for (const m of summary.by_model) {
+    const extra = streamed.byModel.get(m.model_name);
+    if (extra) m.cost_usd = Number((m.cost_usd + extra).toFixed(2));
+  }
   return provider ? scopeStats(summary, provider) : summary;
 }
 

--- a/web/src/lib/demoBridge.ts
+++ b/web/src/lib/demoBridge.ts
@@ -1,0 +1,58 @@
+// The landing page's head-up display flies the same eight sessions this build
+// shows, and on the landing page the demo is literally behind the glass — an
+// iframe under the lens. Two pictures of one fleet, a few hundred pixels apart,
+// so they had better carry the same numbers: symbology reading $17.76 over a
+// card reading $4.30 is the kind of detail that costs a visitor their trust in
+// everything else on the page.
+//
+// So the demo publishes what it knows on `window`, and the landing reads it
+// through the (same-origin) frame. Demo builds only: there is nothing here to
+// leak, but a real fleet is nobody's business but its owner's, and a global is
+// exactly the wrong place for it.
+//
+// The landing tolerates the absence of this entirely — an older /demo/ build,
+// a slow frame, a browser that blocked it — and falls back to flying its own
+// simulation. Nothing here may become load-bearing.
+import { IS_DEMO } from "./demo.ts";
+import type { AgentCard } from "./derive.ts";
+import { modelLabelOf } from "./format.ts";
+
+export interface BeyondSession {
+  /** `source_app:session_id`, the same key the fleet cards are titled with. */
+  key: string;
+  app: string;
+  model: string;
+  status: string;
+  /** What it is doing right now, as the card says it. */
+  action: string;
+  tools: number;
+  cost: number;
+  tokens: number;
+  /** Context used against this model's window, 0..1 — the radar's own law. */
+  ctx: number;
+}
+export interface BeyondFleet {
+  v: 1;
+  spend: number;
+  sessions: BeyondSession[];
+}
+
+export function publishFleet(agents: AgentCard[], spend: number) {
+  if (!IS_DEMO) return;
+  const payload: BeyondFleet = {
+    v: 1,
+    spend,
+    sessions: agents.map((a) => ({
+      key: a.key,
+      app: a.source_app,
+      model: modelLabelOf(a.model_name),
+      status: a.status,
+      action: a.lastAction,
+      tools: a.tools,
+      cost: a.cost,
+      tokens: a.tokens,
+      ctx: a.ctxLimit > 0 ? Math.min(1, a.ctxTokens / a.ctxLimit) : 0,
+    })),
+  };
+  (window as unknown as { __agxFleet?: BeyondFleet }).__agxFleet = payload;
+}

--- a/web/src/lib/themes.ts
+++ b/web/src/lib/themes.ts
@@ -82,3 +82,23 @@ function syncTheme(t: Theme) {
 export function initialTheme(): string {
   try { return localStorage.getItem("agentglass-theme") || DEFAULT_THEME; } catch { return DEFAULT_THEME; }
 }
+
+/**
+ * Follow the theme when another document of ours changes it.
+ *
+ * `storage` only fires in the OTHER documents on this origin, which is exactly
+ * the case worth handling: a second tab, and the landing page, which picks a
+ * phosphor for the demo it is showing behind the glass and writes it to the
+ * same key this app reads. Without this the frame kept whatever palette it
+ * booted in and the page had two colour schemes on screen at once.
+ *
+ * Never syncs outward: this document did not make the choice, so it has no
+ * business telling tmux and nvim about it.
+ */
+export function watchThemeStorage() {
+  addEventListener("storage", (e) => {
+    if (e.key !== "agentglass-theme" || !e.newValue) return;
+    if (document.documentElement.getAttribute("data-theme") === e.newValue) return;
+    applyTheme(e.newValue);
+  });
+}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -1,11 +1,12 @@
 import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
-import { applyTheme, initialTheme } from "./lib/themes.ts";
+import { applyTheme, initialTheme, watchThemeStorage } from "./lib/themes.ts";
 import { restoreScale } from "./lib/uiScale.ts";
 import "./index.css";
 
 applyTheme(initialTheme());
+watchThemeStorage();
 // The webview always launches at 100%, so the saved zoom has to be re-asked for
 // on every start. Fire-and-forget: it resolves a tick later and the window
 // reflows into it, which is far less jarring than blocking the first paint.


### PR DESCRIPTION
## What does this PR do?

The hero asks one question — what does the glass show you that the dark does not — and until now it answered with nothing. Two faults: the resolved half of the scene was dead code (`drawScene` was only ever called with `res=0`, so every contact read UNK wherever you put the designator), and what the lens actually showed was a second, separate picture — a hand-drawn imitation of the dashboard on its own grid, cropped by the lens, unrelated to the contact you had aimed at.

The lens is now a hole in the dark, and behind it is the product: the demo build in an iframe, clipped to the glass. Symbology composites over it as ink with its own coverage plus the glass's light on top, so the HUD sits on the world rather than glowing through it — which is what lets the app be shown at near its real brightness and colour instead of being held down to a rumour.

- **Contacts resolve, where you aim.** The three nearest the lens centre open into the fields the app's own session card carries; the rest stay UNK. Blocks are placed so they never cross each other, and a contact that cannot be placed clear keeps its UNK rather than write over its neighbour.
- **The two pictures agree.** The eight contacts are the eight sessions in `web/src/lib/demo.ts`, by app, session id and model. New `web/src/lib/demoBridge.ts` publishes the fleet on `window` (demo builds only) and the hero flies those numbers, so a block reading $10.40 sits over a card reading $10.40. Where the app cannot tell us something we no longer invent it: the metrics row shows tokens when the bridge is up and milliseconds only while the page is flying its own simulation.
- **The headline is the demonstration.** Both layers write "YOU CAN SEE " identically and differ on the last word, so sweeping the designator along the sentence changes its mind: ONE becomes ALL EIGHT.
- **Buttons and readouts resolve too.** The two calls to action say what taking them costs you; the corner blocks gain a line each on the resolved side, counted from the bridged fleet.
- **The phosphor picker moved off the glass** to the closing section, next to the line that already talks about phosphors. It was pinned exactly where the app behind the lens keeps its own theme control.
- **`fix(demo)`, separate commit:** the demo's spend was frozen at $359.85 while its fleet visibly worked, because `stats()` returns a fixed portrait of a window and the live stream on top of it was free. The stream now keeps what it spends, by model as well as in total so the KPI and the donut cannot disagree. The landing's closing argument ("$X further along than you found them") needed that number to move, and the demo needed it on its own terms.
- **`watchThemeStorage()`** in `web/src/lib/themes.ts`: picking a phosphor on the landing repaints the framed app instantly, and two windows of the app now stay in step.

Held back where it would cost more than it gives: no frame under 980px, on reduced motion, or on a metered connection, and the page falls back to the resolved symbology alone. The frame is `inert`, has no pointer events and no tab stop, is dropped if `/demo/` is not there, and stops being composited once the hero scrolls away.

## How was it tested?

- `bun test` — 925 pass, 0 fail. `bunx tsc --noEmit -p web/tsconfig.json` clean. `bun run build:demo` clean.
- Reviewed locally against the deployed layout (landing at `/agentglass/`, demo at `/agentglass/demo/`, absolute asset base) in Chromium, at 1770×1000, 1440×900 and 430×900: intro slew, contact resolve and de-resolve, the headline swap, both button callouts, the approval card, the closing instrument, and the phosphor picker repainting page and frame together.
- Frame rate measured the same way on both branches (headless, software GL): 19fps on `main`, 21fps here, so the frame is not a regression.
- Bridge verified live: `window.__agxFleet` read out of the frame, and spend sampled climbing 359.85 → 364.72 → 368.88 over 25s.
