### PR TITLE
feat(prs): GitHub parity for the pull request panel — timeline, reactions, sidebar, pages, and a list that is not cold

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,6 +52,7 @@ import {
 } from "./docker.ts";
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
+  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts,
   setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
   rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi, commitDiff as prCommitDiff, submitReviewWith,
 } from "./prs.ts";
@@ -977,7 +978,11 @@ const server = Bun.serve<WsData>({
         url.searchParams.get("filter") || "mine",
         url.searchParams.get("state") || "open",
         url.searchParams.get("force") === "1",
+        url.searchParams.get("after") || undefined,
       ));
+    }
+    if (pathname === "/prs/counts") {
+      return json(await viewCounts(url.searchParams.get("root") || "", url.searchParams.get("state") || "open"));
     }
     if (pathname === "/prs/detail") {
       return json(await prDetail(
@@ -1015,14 +1020,19 @@ const server = Bun.serve<WsData>({
         case "/prs/comment": res = await addComment(root, n, b.body); break;
         case "/prs/reply": res = await replyToThread(root, n, b.commentId, b.body); break;
         case "/prs/thread-resolved": res = await setThreadResolved(root, b.threadId, b.resolved); break;
-        case "/prs/react": res = await react(root, b.commentId, b.content); break;
+        case "/prs/react": res = await react(root, b.nodeId ?? b.commentId, b.content, b.on); break;
+        case "/prs/comment-edit": res = await editComment(root, b.nodeId, b.body, b.kind); break;
+        case "/prs/comment-delete": res = await deleteComment(root, b.nodeId, b.kind); break;
+        case "/prs/file-viewed": res = await setFileViewed(root, b.prNodeId, b.path, b.viewed); break;
+        case "/prs/assignees": res = await setAssignees(root, n, b.add, b.remove); break;
+        case "/prs/milestone": res = await setMilestone(root, n, b.title); break;
         case "/prs/edit": res = await editPr(root, n, { title: b.title, body: b.body, base: b.base }); break;
         case "/prs/labels": res = await setLabels(root, n, b.add, b.remove); break;
         case "/prs/reviewers": res = await setReviewers(root, n, b.add, b.remove); break;
         case "/prs/draft": res = await setDraft(root, n, b.draft); break;
         case "/prs/update-branch": res = await updateBranch(root, n); break;
         case "/prs/rerun": res = await rerunFailedChecks(root, n); break;
-        case "/prs/merge": res = await mergePr(root, n, b.method, { deleteBranch: b.deleteBranch, auto: b.auto, headSha: b.headSha }); break;
+        case "/prs/merge": res = await mergePr(root, n, b.method, { deleteBranch: b.deleteBranch, auto: b.auto, headSha: b.headSha, subject: b.subject, body: b.body, disableAuto: b.disableAuto }); break;
         case "/prs/close": res = await closePr(root, n, b.reopen === true); break;
         case "/prs/local-review": res = await prepareLocalReview(root, n); break;
         case "/prs/local-review-discard": res = await discardLocalReview(root, n); break;

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -14,11 +14,15 @@
 // 3. Writes are public. A stray `gh pr merge` is not a UI bug, it is a deploy,
 //    so every mutation goes through `writeGuard` and the irreversible ones are
 //    named separately from the rest.
+import { existsSync, mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { dirname, join } from "node:path";
 import { gitAsync, safeAbs, repoRootOf } from "./git.ts";
 import { inScope } from "./config.ts";
 import type {
   PrRepoId, PrSummary, PrDetail, PrListResponse, PrActionResult, PrCheck, PrCheckRollup,
   PrCheckState, PrThread, PrReview, PrComment, PrCommit, PrFile, PrChecklistItem, PrMergeState, CiVerdict,
+  PrAuthored, PrReaction, PrEvent,
 } from "../../shared/types.ts";
 
 /** Same escape hatch the git writes use, so one variable disables both. */
@@ -92,6 +96,21 @@ const CAP_TTL_MS = 60_000;
  * errors: "install gh" and "run gh auth login" are things the user can act on,
  * and a red toast saying "failed" is not.
  */
+/**
+ * The last known answer, without waiting for a fresh one.
+ *
+ * `gh auth status` is a 344ms subprocess (measured), and it sat in front of
+ * every list refresh — so a poll that had nothing else to do still paid it, on
+ * the one thread the PTY shares. Auth does not change between two polls; a
+ * minute-old answer is the right answer, and a stale one only ever means the
+ * *next* refresh reports "not logged in" instead of this one. Returns null the
+ * very first time, when there is genuinely nothing to go on.
+ */
+export function ghCapabilityCached(): GhCapability | null {
+  if (capCache && Date.now() - capCache.at < CAP_TTL_MS * 10) return capCache.cap;
+  return null;
+}
+
 export async function ghCapability(force = false): Promise<GhCapability> {
   if (!force && capCache && Date.now() - capCache.at < CAP_TTL_MS) return capCache.cap;
   let cap: GhCapability;
@@ -324,15 +343,64 @@ export function ciNotifiesFor(filter: PrFilter): boolean {
  */
 const LIST_FIELDS_FAST = "number,title,author,state,isDraft,headRefName,baseRefName,url,updatedAt,reviewDecision,additions,deletions,changedFiles,labels,assignees,milestone";
 
-type Entry = { at: number; prs: PrSummary[]; loading: boolean; checksPending: boolean; error?: string };
+type Entry = { at: number; prs: PrSummary[]; loading: boolean; checksPending: boolean; error?: string; total?: number; hasNext?: boolean; cursor?: string | null };
 const listCache = new Map<string, Entry>();
 const inflight = new Set<string>();
+
+/**
+ * The list cache, kept across restarts.
+ *
+ * Measured: a no-op call to api.github.com costs ~280ms before it does anything,
+ * and the list query 650-1000ms — while github.com's own page, rendered next to
+ * its database and served from their edge, answers in ~115ms. That gap is not
+ * something a better query closes; it is the internet. So the answer is to stop
+ * starting from nothing: the last known list is written to disk, read back at
+ * boot, and shown at once while a refresh runs behind it. Stale rows you can
+ * read beat a spinner you cannot, and the age is on screen either way.
+ *
+ * Rows only. Nothing here is secret (it is a public pull request list you can
+ * already read), but it is scoped to the user's own cache directory all the
+ * same, and a corrupt or unreadable file is simply ignored.
+ */
+const CACHE_FILE = join(homedir(), ".cache", "agentglass", "pr-list.json");
+const CACHE_MAX_ENTRIES = 24;
+let cacheWriteTimer: ReturnType<typeof setTimeout> | null = null;
+
+function loadDiskCache(): void {
+  try {
+    if (!existsSync(CACHE_FILE)) return;
+    const raw = JSON.parse(readFileSync(CACHE_FILE, "utf8")) as Record<string, Entry>;
+    for (const [k, e] of Object.entries(raw)) {
+      if (!e || !Array.isArray(e.prs)) continue;
+      // Never restored as "fresh": `at` is what it was, so the age shown is
+      // honest and the first read triggers a refresh.
+      listCache.set(k, { ...e, loading: false, checksPending: false });
+    }
+  } catch { /* unreadable or from an older shape — start empty */ }
+}
+
+function saveDiskCache(): void {
+  if (cacheWriteTimer) clearTimeout(cacheWriteTimer);
+  // Debounced: a burst of refreshes writes once.
+  cacheWriteTimer = setTimeout(() => {
+    try {
+      const entries = [...listCache.entries()]
+        .filter(([, e]) => e.prs.length > 0 && !e.error)
+        .sort((a, b) => b[1].at - a[1].at)
+        .slice(0, CACHE_MAX_ENTRIES);
+      mkdirSync(dirname(CACHE_FILE), { recursive: true });
+      writeFileSync(CACHE_FILE, JSON.stringify(Object.fromEntries(entries)));
+    } catch { /* a cache that cannot be written is not an error worth raising */ }
+  }, 1_000);
+}
+
+loadDiskCache();
 const LIST_TTL_MS = 90_000;
 
 // `\u0000` written as an escape, never as the byte: a raw NUL makes the whole
 // file read as binary to grep, which then skips it in silence. Same separator,
 // same keys, still searchable.
-const cacheKey = (repo: PrRepoId, filter: PrFilter, state: PrState) => `${repo.key}\u0000${filter}\u0000${state}`;
+const cacheKey = (repo: PrRepoId, filter: PrFilter, state: PrState, after?: string) => `${repo.key}\u0000${filter}\u0000${state}\u0000${after ?? ""}`;
 
 // Exported for the test that pins the gh-JSON field extraction (assignees,
 // milestone) — the shapes gh returns are an assumption worth guarding.
@@ -362,29 +430,106 @@ export function mapSummary(p: any, withChecks: boolean): PrSummary {
   };
 }
 
-async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState): Promise<PrSummary[] | null> {
-  // `closed` returns merged + closed (gh's own semantics, matching GitHub's
-  // "Closed" tab); each row still carries its own OPEN/CLOSED/MERGED state, so
-  // the list can tell them apart.
-  const args = ["pr", "list", "-R", repo.nameWithOwner, "--state", state, "--limit", "50", "--json", LIST_FIELDS_FAST];
-  // `gh pr list --search` rather than `gh search prs`: the latter is a global
-  // search that would need its own repo filter anyway, and it rate-limits
-  // separately from the REST path everything else here uses.
-  if (filter === "review") args.push("--search", "review-requested:@me");
-  if (filter === "mine") args.push("--author", "@me");
-  const rows = await ghJson<any[]>(args);
-  // null (gh failed / unparsable) and [] (gh answered, no matching PRs) are
-  // different facts and the caller has to tell them apart: keep null distinct so
-  // a network blip holds the last good list while a genuine empty is allowed to
-  // empty the panel. Collapsing both to [] is what made a merged PR linger.
-  if (rows === null) return null;
-  // Newest-first, so the panel reads recent → old and the per-PR check probe in
-  // refreshChecks (which walks this order) fills the rows you actually watch
-  // first. `gh pr list` has no reliable `--sort`, and updatedAt is an ISO string
-  // that sorts lexically, so order it here — same idiom as branchMergeState below.
-  return rows
-    .map((r) => mapSummary(r, false))
-    .sort((a, b) => String(b.updatedAt).localeCompare(String(a.updatedAt)));
+/** One page of the list, and everything the rows need, in a single request. */
+const LIST_PAGE = 25;
+
+const SEARCH_ROWS = `query($q:String!,$first:Int!,$after:String){
+  search(query:$q, type:ISSUE, first:$first, after:$after){
+    issueCount
+    pageInfo{hasNextPage endCursor}
+    nodes{ ... on PullRequest {
+      number title url state isDraft createdAt updatedAt
+      additions deletions changedFiles baseRefName headRefName reviewDecision
+      author{login}
+      labels(first:10){nodes{name color}}
+      assignees(first:5){nodes{login}}
+      milestone{title}
+    } }
+  }
+}`;
+
+/**
+ * The same page, but only its check rollups.
+ *
+ * Measured against this repo: the row fields cost ~730ms and `statusCheckRollup`
+ * adds ~410ms on top when they travel together. Asked for separately the two
+ * run at the same time, so the whole thing costs what the slower one costs
+ * (~810ms) instead of their sum — and, more to the point, the rows can be put
+ * on screen the moment they land rather than waiting for the checks.
+ */
+const SEARCH_CHECKS = `query($q:String!,$first:Int!,$after:String){
+  search(query:$q, type:ISSUE, first:$first, after:$after){
+    nodes{ ... on PullRequest {
+      number
+      commits(last:1){nodes{commit{statusCheckRollup{
+        state
+        contexts(first:0){checkRunCountsByState{state count} statusContextCountsByState{state count}}
+      }}}}
+    } }
+  }
+}`;
+
+/** The search expression for a scope + state, in GitHub's own qualifier grammar. */
+function searchExpr(repo: PrRepoId, filter: PrFilter, state: PrState): string {
+  const parts = [`repo:${repo.nameWithOwner}`, "is:pr"];
+  // `is:closed` covers merged as well, which is what GitHub's own Closed tab
+  // means and what this panel promises.
+  if (state === "open") parts.push("is:open");
+  else if (state === "closed") parts.push("is:closed");
+  if (filter === "mine") parts.push("author:@me");
+  else if (filter === "review") parts.push("review-requested:@me");
+  parts.push("sort:updated-desc");
+  return parts.join(" ");
+}
+
+/**
+ * A page of pull requests WITH their check states, in one GraphQL request.
+ *
+ * This used to be two round trips — `gh pr list` for the rows, then a second
+ * batched query for the check rollups — which is why every row said "Checks…"
+ * for a beat, and why the whole list waited on a REST call that returns
+ * everything or nothing. `search` takes a cursor, so it also gives the panel
+ * something it never had: a second page. `contexts(first: 0)` keeps the
+ * rollup to its cheap aggregate counts (see fetchCheckRollups).
+ */
+type ListPage = { rows: PrSummary[]; total: number; hasNext: boolean; cursor: string | null };
+async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: string, onRows?: (p: ListPage) => void): Promise<ListPage | null> {
+  const vars = { q: searchExpr(repo, filter, state), first: LIST_PAGE, ...(after ? { after } : {}) };
+  // Both at once — GitHub really does run them concurrently (measured: the pair
+  // costs what the slower one costs, not their sum). The rows are handed over
+  // the moment they land rather than waiting on the checks, so the list appears
+  // as soon as there is a list to show.
+  const rowsP = ghGraphql<any>(SEARCH_ROWS, vars);
+  const checksP = ghGraphql<any>(SEARCH_CHECKS, vars);
+  const rowsRes = await rowsP;
+  const search = rowsRes?.data?.search;
+  // null (gh failed / unparsable) and an empty page are different facts: keep
+  // null distinct so a network blip holds the last good list while a genuine
+  // empty is allowed to empty the panel.
+  if (!search) return null;
+  const bare: PrSummary[] = (search.nodes || [])
+    .filter((n: any) => n && typeof n.number === "number")
+    .map((n: any) => mapSummary({ ...n, labels: n.labels?.nodes ?? [], assignees: n.assignees?.nodes ?? [] }, false));
+  const meta = {
+    total: Number(search.issueCount ?? bare.length),
+    hasNext: !!search.pageInfo?.hasNextPage,
+    cursor: search.pageInfo?.endCursor ?? null,
+  };
+  onRows?.({ rows: bare, ...meta });
+
+  const checksRes = await checksP;
+  const rollups = new Map<number, PrCheckRollup>();
+  for (const n of checksRes?.data?.search?.nodes ?? []) {
+    if (!n?.number) continue;
+    const roll = n.commits?.nodes?.[0]?.commit?.statusCheckRollup;
+    const ctx = roll?.contexts;
+    rollups.set(n.number, rollupFromCounts(ctx?.checkRunCountsByState, ctx?.statusContextCountsByState, roll?.state));
+  }
+  const rows: PrSummary[] = bare.map((r) => {
+    const rollup = rollups.get(r.number);
+    return rollup ? { ...r, checks: rollup, checksLoaded: true } : r;
+  });
+  return { rows, ...meta };
 }
 
 /**
@@ -542,8 +687,8 @@ function refreshChecks(repo: PrRepoId, filter: PrFilter, state: PrState, rows: P
 }
 
 /** Refresh behind the response. Never awaited by a request handler. */
-function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState): void {
-  const key = cacheKey(repo, filter, state);
+function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: string): void {
+  const key = cacheKey(repo, filter, state, after);
   if (inflight.has(key)) return;
   inflight.add(key);
   const prev = listCache.get(key);
@@ -554,17 +699,25 @@ function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState): void {
 
   void (async () => {
     try {
-      const cap = await ghCapability();
+      // Do not pay `gh auth status` (344ms) before every refresh. Trust the
+      // last answer if there is one, and only block on a fresh check the very
+      // first time — after that, a failed fetch is what tells us auth broke.
+      const cap = ghCapabilityCached() ?? await ghCapability();
       if (!cap.available || !cap.authed) {
         listCache.set(key, keep({ at: Date.now(), loading: false, checksPending: false, error: cap.reason }));
         return;
       }
 
-      // One cheap query for the rows themselves — titles, authors, review
-      // decisions. Enough to choose a pull request, and it is what the panel
-      // is blocked on.
-      const rows = await fetchList(repo, filter, state);
-      if (rows === null) {
+      // Rows and their check rollups, in one request.
+      // Put the rows on screen the moment they arrive; the checks land a beat
+      // later and only fill in the dots.
+      const page = await fetchList(repo, filter, state, after, (early) => {
+        listCache.set(key, {
+          at: Date.now(), prs: early.rows, loading: false, checksPending: true,
+          total: early.total, hasNext: early.hasNext, cursor: early.cursor,
+        });
+      });
+      if (page === null) {
         // gh itself failed (a network blip, a rate-limit) — far more likely than
         // a repository that lost every pull request, so keep whatever we had. But
         // DO advance `at`: leaving it stale re-runs gh on every single poll and
@@ -574,16 +727,18 @@ function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState): void {
         listCache.set(key, keep({ at: Date.now(), loading: false, checksPending: false }));
         return;
       }
-      // Carry over any check states already known, so switching back to a tab
-      // does not blank the states it had.
-      const merged = rows.map((r) => {
-        const hit = checkCache.get(`${repo.key}\u0000${r.number}`);
-        return hit && hit.updatedAt === r.updatedAt ? { ...r, checks: hit.rollup, checksLoaded: true } : r;
+      // The rollups arrived with the rows, so there is no second pass to wait
+      // on and nothing to carry over. Feed the per-PR cache anyway: the detail
+      // view and the notification latch both read it.
+      for (const r of page.rows) checkCache.set(`${repo.key}\u0000${r.number}`, { updatedAt: r.updatedAt, rollup: r.checks });
+      listCache.set(key, {
+        at: Date.now(), prs: page.rows, loading: false, checksPending: false,
+        total: page.total, hasNext: page.hasNext, cursor: page.cursor,
       });
-      listCache.set(key, { at: Date.now(), prs: merged, loading: false, checksPending: merged.some((p) => !p.checksLoaded) });
+      saveDiskCache();
       // Only open PRs raise CI notifications — a merged or closed PR's checks
       // are history, not something to alert on.
-      refreshChecks(repo, filter, state, merged, state === "open" && ciNotifiesFor(filter));
+      if (state === "open" && ciNotifiesFor(filter)) for (const r of page.rows) noteCi(repo, r);
     } catch (e) {
       listCache.set(key, keep({ loading: false, checksPending: false, error: String(e) }));
     } finally {
@@ -593,13 +748,84 @@ function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState): void {
 }
 
 /**
+ * Exact counts for every saved view, in one request.
+ *
+ * The panel used to get these by fetching the OTHER scopes' lists in the
+ * background — two extra full list queries, each costing what the visible one
+ * costs, purely to put a number on a pill. `issueCount` with `first: 0` returns
+ * the count and no rows, so all five arrive together for ~700ms and nothing is
+ * fetched twice. They are also the TRUE totals: a count taken from the page on
+ * screen stopped being the answer the moment the list got pages.
+ */
+const VIEW_COUNT_QUERY = `query($a:String!,$b:String!,$c:String!,$d:String!,$e:String!){
+  review:search(query:$a,type:ISSUE,first:0){issueCount}
+  mine:search(query:$b,type:ISSUE,first:0){issueCount}
+  failing:search(query:$c,type:ISSUE,first:0){issueCount}
+  ready:search(query:$d,type:ISSUE,first:0){issueCount}
+  all:search(query:$e,type:ISSUE,first:0){issueCount}
+}`;
+
+export type PrViewCounts = { review: number; mine: number; failing: number; ready: number; all: number };
+const countCache = new Map<string, { at: number; counts: PrViewCounts }>();
+const COUNT_TTL_MS = 60_000;
+
+export async function viewCounts(rootIn: unknown, stateIn: unknown): Promise<{ ok: boolean; counts?: PrViewCounts; error?: string }> {
+  const state: PrState = stateIn === "closed" || stateIn === "all" ? stateIn : "open";
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const key = `${repo.key}|${state}`;
+  const hit = countCache.get(key);
+  if (hit && Date.now() - hit.at < COUNT_TTL_MS) return { ok: true, counts: hit.counts };
+  const base = `repo:${repo.nameWithOwner} is:pr${state === "open" ? " is:open" : state === "closed" ? " is:closed" : ""}`;
+  const res = await ghGraphql<any>(VIEW_COUNT_QUERY, {
+    a: `${base} review-requested:@me`,
+    b: `${base} author:@me`,
+    c: `${base} status:failure`,
+    d: `${base} review:approved status:success`,
+    e: base,
+  });
+  const d = res?.data;
+  if (!d) return { ok: false, error: "could not read the counts" };
+  const counts: PrViewCounts = {
+    review: Number(d.review?.issueCount ?? 0),
+    mine: Number(d.mine?.issueCount ?? 0),
+    failing: Number(d.failing?.issueCount ?? 0),
+    ready: Number(d.ready?.issueCount ?? 0),
+    all: Number(d.all?.issueCount ?? 0),
+  };
+  countCache.set(key, { at: Date.now(), counts });
+  return { ok: true, counts };
+}
+
+/**
+ * The checkout's current branch, cached briefly.
+ *
+ * `git rev-parse` ran on every single list read — a process spawn on the 20s
+ * poll, for a value that only changes when somebody checks out. Five seconds is
+ * short enough that switching branches still lights up "you are here" almost at
+ * once, and long enough that the poll costs nothing.
+ */
+const headCache = new Map<string, { at: number; head: string }>();
+const HEAD_TTL_MS = 5_000;
+async function headBranch(root: string): Promise<string> {
+  const hit = headCache.get(root);
+  if (hit && Date.now() - hit.at < HEAD_TTL_MS) return hit.head;
+  const r = await gitAsync(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
+  const head = r.code === 0 ? r.stdout.trim() : "";
+  headCache.set(root, { at: Date.now(), head });
+  return head;
+}
+
+/**
  * The panel's read. Answers from cache and triggers a refresh if the copy is
  * old — so the poll never waits on the network, and the age is shown rather
  * than hidden behind a spinner that lies.
  */
-export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unknown, force = false): Promise<PrListResponse> {
+export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unknown, force = false, afterIn?: unknown): Promise<PrListResponse> {
   const filter: PrFilter = filterIn === "review" || filterIn === "all" ? filterIn : "mine";
   const state: PrState = stateIn === "closed" || stateIn === "all" ? stateIn : "open";
+  // A cursor is opaque base64 from GitHub; anything else is not ours to send on.
+  const after = typeof afterIn === "string" && /^[A-Za-z0-9+/=_-]{1,200}$/.test(afterIn) ? afterIn : undefined;
   const repo = await repoIdFor(rootIn);
   if (!repo) {
     const cap = await ghCapability();
@@ -609,25 +835,30 @@ export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unkno
       error: !cap.available || !cap.authed ? cap.reason : "no GitHub remote on this repository",
     };
   }
-  const key = cacheKey(repo, filter, state);
+  const key = cacheKey(repo, filter, state, after);
   const hit = listCache.get(key);
   const age = hit ? Date.now() - hit.at : Infinity;
-  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter, state);
+  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter, state, after);
   const cur = listCache.get(key);
 
   // "you are here" — the checkout's branch, matched against the PR heads. This
   // is the branch/PR link, and it falls out of the dedupe rather than costing
   // a call of its own.
-  let head = "";
   const abs = safeAbs(rootIn);
   const root = abs ? repoRootOf(abs) : null;
-  if (root) {
-    const r = await gitAsync(root, ["rev-parse", "--abbrev-ref", "HEAD"]);
-    if (r.code === 0) head = r.stdout.trim();
-  }
+  const head = root ? await headBranch(root) : "";
   const prs = (cur?.prs ?? []).map((p) => (p.headRefName && p.headRefName === head ? { ...p, isCurrentBranch: true } : p));
 
-  const cap = await ghCapability();
+  // Never block the read on it. With rows already in hand (from the disk cache
+  // at boot, or a previous refresh) waiting 344ms on `gh auth status` only
+  // delays showing them; if auth really is broken the refresh behind this
+  // response says so, and the next poll reports it. Only a first read with
+  // nothing to show waits.
+  let cap = ghCapabilityCached();
+  if (!cap) {
+    if (cur?.prs.length) void ghCapability();
+    else cap = await ghCapability();
+  }
   return {
     ok: true,
     repo,
@@ -637,7 +868,16 @@ export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unkno
     loading: !!cur?.loading,
     checksPending: !!cur?.checksPending,
     error: cur?.error,
-    needsAuth: !cap.available || !cap.authed,
+    // Unknown yet (the check runs behind an already-cached list) is not the
+    // same as "not logged in" — claiming the latter would put a "run gh auth
+    // login" banner over rows that are plainly on screen.
+    needsAuth: cap ? !cap.available || !cap.authed : false,
+    // What the panel needs to offer a second page: how many there are in total,
+    // whether another page exists, and the cursor that fetches it.
+    total: cur?.total,
+    hasNext: !!cur?.hasNext,
+    cursor: cur?.cursor ?? null,
+    pageSize: LIST_PAGE,
   };
 }
 
@@ -724,32 +964,178 @@ export function parseChecklist(body: string): PrChecklistItem[] {
 // detail
 // ---------------------------------------------------------------------------
 
+// Everything the detail view renders, in one request.
+//
+// `reactionGroups`, `lastEditedAt`, `authorAssociation` and `viewerDidAuthor`
+// ride along on every authored thing — they are what turn a wall of text into
+// a conversation you can read and answer (who has standing, what was edited,
+// what people already said with an emoji rather than another paragraph).
+//
+// Note `comments(last:…)`: GraphQL's `first:` is oldest-first, so a PR with
+// more comments than the page size lost its NEWEST ones — the opposite of what
+// anyone wants from a conversation. `last:` keeps the recent end.
 const DETAIL_QUERY = `query($owner:String!,$name:String!,$number:Int!){
   repository(owner:$owner,name:$name){ pullRequest(number:$number){
-    number title url state isDraft createdAt updatedAt
-    additions deletions changedFiles
+    id number title url state isDraft createdAt updatedAt closedAt mergedAt
+    additions deletions changedFiles totalCommentsCount
     baseRefName headRefName body
-    mergeable mergeStateStatus reviewDecision viewerDidAuthor
+    mergeable mergeStateStatus reviewDecision viewerDidAuthor viewerCanUpdate
     author{login}
-    labels(first:20){nodes{name color}}
+    mergedBy{login}
+    reactionGroups{content viewerHasReacted users{totalCount}}
+    labels(first:50){nodes{name color}}
     milestone{title}
-    assignees(first:10){nodes{login}}
-    reviewRequests(first:10){nodes{requestedReviewer{... on User{login} ... on Team{name}}}}
-    reviews(first:50){nodes{author{login} state body submittedAt url}}
-    comments(first:50){nodes{databaseId author{login} body createdAt url}}
-    commits(first:100){nodes{commit{oid messageHeadline parents{totalCount} author{user{login} name}}}}
-    files(first:100){nodes{path additions deletions changeType}}
-    reviewThreads(first:50){nodes{
-      id isResolved isOutdated path line
-      comments(first:20){nodes{id databaseId author{login} body createdAt url diffHunk originalLine}}
+    closingIssuesReferences(first:10){nodes{number title url state}}
+    participants(first:30){nodes{login}}
+    autoMergeRequest{enabledBy{login} mergeMethod}
+    assignees(first:20){nodes{login}}
+    reviewRequests(first:20){nodes{requestedReviewer{... on User{login} ... on Team{name}}}}
+    reviews(last:60){nodes{
+      id author{login} state body submittedAt url lastEditedAt authorAssociation viewerDidAuthor
+      reactionGroups{content viewerHasReacted users{totalCount}}
     }}
-    timelineItems(last:30, itemTypes:[HEAD_REF_FORCE_PUSHED_EVENT]){nodes{... on HeadRefForcePushedEvent{createdAt}}}
+    comments(last:80){nodes{
+      id databaseId author{login} body createdAt url lastEditedAt authorAssociation viewerDidAuthor
+      reactionGroups{content viewerHasReacted users{totalCount}}
+    }}
+    commits(last:100){nodes{commit{
+      oid message committedDate parents{totalCount}
+      author{user{login} name}
+      authors(first:8){nodes{user{login} name}}
+      signature{isValid state}
+      statusCheckRollup{state}
+    }}}
+    files(first:100){nodes{path additions deletions changeType viewerViewedState}}
+    reviewThreads(first:80){nodes{
+      id isResolved isOutdated path line startLine
+      comments(first:50){nodes{
+        id databaseId author{login} body createdAt url diffHunk originalLine
+        lastEditedAt authorAssociation viewerDidAuthor
+        reactionGroups{content viewerHasReacted users{totalCount}}
+      }}
+    }}
+    timelineItems(last:80, itemTypes:[
+      HEAD_REF_FORCE_PUSHED_EVENT, RENAMED_TITLE_EVENT, LABELED_EVENT, UNLABELED_EVENT,
+      ASSIGNED_EVENT, UNASSIGNED_EVENT, REVIEW_REQUESTED_EVENT, REVIEW_REQUEST_REMOVED_EVENT,
+      READY_FOR_REVIEW_EVENT, CONVERT_TO_DRAFT_EVENT, MERGED_EVENT, CLOSED_EVENT, REOPENED_EVENT,
+      CROSS_REFERENCED_EVENT, MILESTONED_EVENT, DEMILESTONED_EVENT, HEAD_REF_DELETED_EVENT,
+      AUTO_MERGE_ENABLED_EVENT, AUTO_MERGE_DISABLED_EVENT
+    ]){nodes{
+      __typename
+      ... on HeadRefForcePushedEvent{createdAt actor{login} beforeCommit{oid} afterCommit{oid}}
+      ... on RenamedTitleEvent{createdAt actor{login} previousTitle currentTitle}
+      ... on LabeledEvent{createdAt actor{login} label{name color}}
+      ... on UnlabeledEvent{createdAt actor{login} label{name color}}
+      ... on AssignedEvent{createdAt actor{login} assignee{... on User{login}}}
+      ... on UnassignedEvent{createdAt actor{login} assignee{... on User{login}}}
+      ... on ReviewRequestedEvent{createdAt actor{login} requestedReviewer{... on User{login} ... on Team{name}}}
+      ... on ReviewRequestRemovedEvent{createdAt actor{login} requestedReviewer{... on User{login} ... on Team{name}}}
+      ... on ReadyForReviewEvent{createdAt actor{login}}
+      ... on ConvertToDraftEvent{createdAt actor{login}}
+      ... on MergedEvent{createdAt actor{login} mergeRefName commit{oid} url}
+      ... on ClosedEvent{createdAt actor{login} url}
+      ... on ReopenedEvent{createdAt actor{login}}
+      ... on CrossReferencedEvent{createdAt actor{login} source{
+        ... on PullRequest{number title url} ... on Issue{number title url}
+      }}
+      ... on MilestonedEvent{createdAt actor{login} milestoneTitle}
+      ... on DemilestonedEvent{createdAt actor{login} milestoneTitle}
+      ... on HeadRefDeletedEvent{createdAt actor{login} headRefName}
+      ... on AutoMergeEnabledEvent{createdAt actor{login}}
+      ... on AutoMergeDisabledEvent{createdAt actor{login} reason}
+    }}
     statusCheckRollup:commits(last:1){nodes{commit{statusCheckRollup{contexts(first:100){nodes{
       __typename
       ... on CheckRun{name status conclusion detailsUrl checkSuite{workflowRun{workflow{name}}}}
       ... on StatusContext{context state targetUrl}
     }}}}}}
   } } }`;
+
+/** The reaction tallies, "edited", standing and ownership that ride on
+ *  everything a person wrote. Shared by comments, reviews and thread replies so
+ *  the three can never drift apart. */
+function authoredOf(n: any): Partial<PrAuthored> {
+  const reactions: PrReaction[] = (n?.reactionGroups || [])
+    .map((g: any) => ({
+      content: String(g?.content || ""),
+      count: Number(g?.users?.totalCount ?? 0),
+      viewerHasReacted: !!g?.viewerHasReacted,
+    }))
+    // Only what somebody actually pressed: GitHub returns all eight groups with
+    // zeroes, and rendering eight empty buttons on every comment is noise.
+    .filter((r: PrReaction) => r.count > 0 || r.viewerHasReacted);
+  return {
+    reactions,
+    editedAt: n?.lastEditedAt ?? null,
+    association: n?.authorAssociation ?? undefined,
+    viewerDidAuthor: !!n?.viewerDidAuthor,
+  };
+}
+
+const ACTOR = (n: any) => n?.actor?.login || "";
+const REVIEWER = (n: any) => n?.requestedReviewer?.login || n?.requestedReviewer?.name || "";
+
+/**
+ * The conversation's non-comment events, in the shape the panel renders.
+ *
+ * GitHub interleaves these with comments, and without them a conversation reads
+ * as if nothing happened between remarks — the force-push that invalidated a
+ * review, the rename, the label, the merge itself all vanish. Unknown types are
+ * dropped rather than guessed at.
+ */
+function mapTimeline(nodes: any[]): PrEvent[] {
+  const out: PrEvent[] = [];
+  for (const n of nodes || []) {
+    const at = n?.createdAt || "";
+    const actor = ACTOR(n);
+    const base = { at, actor };
+    switch (n?.__typename) {
+      case "HeadRefForcePushedEvent":
+        out.push({ ...base, kind: "force-push", detail: `${(n.beforeCommit?.oid || "").slice(0, 7)} → ${(n.afterCommit?.oid || "").slice(0, 7)}` });
+        break;
+      case "RenamedTitleEvent":
+        out.push({ ...base, kind: "renamed", detail: n.currentTitle || "" });
+        break;
+      case "LabeledEvent":
+        out.push({ ...base, kind: "labeled", detail: n.label?.name || "", tint: n.label?.color || null });
+        break;
+      case "UnlabeledEvent":
+        out.push({ ...base, kind: "unlabeled", detail: n.label?.name || "", tint: n.label?.color || null });
+        break;
+      case "AssignedEvent":
+        out.push({ ...base, kind: "assigned", detail: n.assignee?.login || "" });
+        break;
+      case "UnassignedEvent":
+        out.push({ ...base, kind: "unassigned", detail: n.assignee?.login || "" });
+        break;
+      case "ReviewRequestedEvent":
+        out.push({ ...base, kind: "review-requested", detail: REVIEWER(n) });
+        break;
+      case "ReviewRequestRemovedEvent":
+        out.push({ ...base, kind: "review-request-removed", detail: REVIEWER(n) });
+        break;
+      case "ReadyForReviewEvent": out.push({ ...base, kind: "ready-for-review" }); break;
+      case "ConvertToDraftEvent": out.push({ ...base, kind: "convert-to-draft" }); break;
+      case "MergedEvent":
+        out.push({ ...base, kind: "merged", detail: n.mergeRefName || "", url: n.url || undefined });
+        break;
+      case "ClosedEvent": out.push({ ...base, kind: "closed", url: n.url || undefined }); break;
+      case "ReopenedEvent": out.push({ ...base, kind: "reopened" }); break;
+      case "CrossReferencedEvent": {
+        const s = n.source || {};
+        if (s.number) out.push({ ...base, kind: "cross-referenced", detail: `#${s.number} ${s.title || ""}`.trim(), url: s.url || undefined });
+        break;
+      }
+      case "MilestonedEvent": out.push({ ...base, kind: "milestoned", detail: n.milestoneTitle || "" }); break;
+      case "DemilestonedEvent": out.push({ ...base, kind: "demilestoned", detail: n.milestoneTitle || "" }); break;
+      case "HeadRefDeletedEvent": out.push({ ...base, kind: "head-ref-deleted", detail: n.headRefName || "" }); break;
+      case "AutoMergeEnabledEvent": out.push({ ...base, kind: "auto-merge-enabled" }); break;
+      case "AutoMergeDisabledEvent": out.push({ ...base, kind: "auto-merge-disabled", detail: n.reason || "" }); break;
+      default: break; // a type we do not render yet; dropping beats guessing
+    }
+  }
+  return out.filter((e) => e.at).sort((a, b) => a.at.localeCompare(b.at));
+}
 
 const detailCache = new Map<string, { at: number; detail: PrDetail }>();
 const DETAIL_TTL_MS = 45_000;
@@ -798,6 +1184,8 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     body: r.body || "",
     submittedAt: r.submittedAt || "",
     url: r.url || "",
+    nodeId: r.id || "",
+    ...authoredOf(r),
   }));
 
   const comments: PrComment[] = (p.comments?.nodes || []).map((c: any) => {
@@ -805,12 +1193,14 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     const bot = isBotLogin(author);
     return {
       id: c.databaseId,
+      nodeId: c.id || "",
       author,
       isBot: bot,
       body: c.body || "",
       createdAt: c.createdAt || "",
       url: c.url || "",
       digest: bot ? digestBotComment(c.body || "") : null,
+      ...authoredOf(c),
     };
   });
 
@@ -836,16 +1226,36 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
       body: c.body || "",
       createdAt: c.createdAt || "",
       url: c.url || "",
+      ...authoredOf(c),
     })),
   }));
 
   const commits: PrCommit[] = (p.commits?.nodes || []).map((n: any) => {
     const c = n.commit || {};
+    // Everyone credited, in order, deduped. A commit written with an agent
+    // carries a Co-authored-by trailer, and GitHub says "X and claude
+    // committed" — naming only the first author hides half of who wrote it.
+    const authors: string[] = [];
+    for (const a of c.authors?.nodes || []) {
+      const who = a?.user?.login || a?.name || "";
+      if (who && !authors.includes(who)) authors.push(who);
+    }
     return {
+      // Split the FULL message ourselves. `messageHeadline` is GitHub's own
+      // truncation — it cuts the subject at ~70 characters with an ellipsis and
+      // puts the remainder at the front of `messageBody`, so using the pair
+      // renders a chopped subject and an orphan fragment underneath it.
       oid: c.oid || "",
       short: (c.oid || "").slice(0, 8),
-      message: c.messageHeadline || "",
+      message: String(c.message || "").split("\n")[0] ?? "",
+      body: String(c.message || "").split("\n").slice(1).join("\n").trim(),
       author: c.author?.user?.login || c.author?.name || "",
+      authors,
+      committedAt: c.committedDate || "",
+      // A signature GitHub could verify. The badge is the whole point: it says
+      // this commit is from who it claims to be from.
+      verified: !!c.signature?.isValid,
+      checks: c.statusCheckRollup?.state ?? null,
       // A trunk catch-up merge is not work to review. Naming it lets the UI
       // dim it instead of making you read it.
       isMerge: (c.parents?.totalCount ?? 1) > 1,
@@ -859,13 +1269,21 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     path: f.path,
     additions: f.additions ?? 0,
     deletions: f.deletions ?? 0,
-    status: f.changeType || "",
+    // Lowercased on purpose: GraphQL says `MODIFIED`, and the panel's "only
+    // chip it when it is not a plain modification" test compares against
+    // "modified" — so every single file was wearing a MODIFIED badge.
+    status: String(f.changeType || "").toLowerCase(),
     comments: openByPath.get(f.path) ?? 0,
+    // GitHub's own per-reviewer tick, so "viewed" survives leaving the panel
+    // and agrees with what github.com shows.
+    viewed: f.viewerViewedState === "VIEWED",
   }));
+
+  const timeline = mapTimeline(p.timelineItems?.nodes || []);
 
   // A force-push after a submitted review makes that review stale — the
   // approval you are looking at was for code that no longer exists.
-  const pushes: string[] = (p.timelineItems?.nodes || []).map((n: any) => n?.createdAt).filter(Boolean);
+  const pushes: string[] = timeline.filter((e) => e.kind === "force-push").map((e) => e.at);
   const lastReviewAt = reviews.length ? reviews[reviews.length - 1]!.submittedAt : "";
   const forcePushedSinceReview = !!lastReviewAt && pushes.some((at) => at > lastReviewAt);
 
@@ -901,6 +1319,40 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     viewerDidAuthor: !!p.viewerDidAuthor,
     viewerRequested: (p.reviewRequests?.nodes || [])
       .some((n: any) => (n.requestedReviewer?.login || "") === viewerLogin && !!viewerLogin),
+    timeline,
+    participants: (p.participants?.nodes || []).map((n: any) => n?.login).filter(Boolean),
+    bodyReactions: authoredOf(p).reactions ?? [],
+    nodeId: p.id || "",
+    // Deliberately not fetched: `projectsV2` needs the `read:project` scope,
+    // which a normal `gh auth login` token does not carry — asking for it makes
+    // the WHOLE query fail with INSUFFICIENT_SCOPES and the panel shows nothing.
+    // A projects column is not worth costing everyone their pull requests.
+    projects: [],
+    linkedIssues: (p.closingIssuesReferences?.nodes || [])
+      .filter((n: any) => n?.number)
+      .map((n: any) => ({ number: n.number, title: n.title || "", url: n.url || "", state: n.state || "" })),
+    autoMerge: p.autoMergeRequest
+      ? { enabledBy: p.autoMergeRequest.enabledBy?.login || "", method: p.autoMergeRequest.mergeMethod || "" }
+      : null,
+    mergedBy: p.mergedBy?.login || null,
+    mergedAt: p.mergedAt || null,
+    closedAt: p.closedAt || null,
+    createdAt: p.createdAt || "",
+    viewerCanUpdate: !!p.viewerCanUpdate,
+    // Say what a page size cut off, rather than letting it disappear. The file
+    // list disagreeing with the header count is how nobody noticed for months.
+    // Only claim truncation when a page came back FULL — that is the one
+    // unambiguous signal there is more. Subtracting counts that measure
+    // different things (totalCommentsCount includes review bodies) invents a
+    // "1 more comment" that does not exist, and a lying badge is worse than
+    // none. `files` is the exception: `changedFiles` is an exact total.
+    truncated: {
+      files: Math.max(0, (p.changedFiles ?? 0) - files.length) || undefined,
+      commits: (p.commits?.nodes || []).length >= 100 ? 100 : undefined,
+      comments: comments.length >= 80 ? 80 : undefined,
+      threads: (p.reviewThreads?.nodes || []).length >= 80 ? 80 : undefined,
+      checks: rawChecks.length >= 100 ? 100 : undefined,
+    },
   };
 
   detailCache.set(key, { at: Date.now(), detail });
@@ -950,6 +1402,38 @@ export function assetAllowed(raw: string): URL | null {
 let tokenCache: { at: number; token: string } | null = null;
 
 /** The token `gh` already holds. Never sent anywhere but the allowlisted host. */
+/**
+ * A GraphQL call over HTTP, with no `gh` process in the way.
+ *
+ * `gh api graphql` is a Go binary that re-resolves auth on every invocation:
+ * measured against this repo it costs 570-710ms where the same query over
+ * `fetch` costs 520-540ms, and every one of those spawns lands on the single
+ * thread the PTY rides. The token is already cached for five minutes, so the
+ * subprocess buys nothing. It stays as the fallback for the case the token
+ * cannot be read (an unusual `gh` setup, a keyring that will not answer).
+ */
+async function ghGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T | null> {
+  const token = await ghToken();
+  if (!token) return ghJson<T>(["api", "graphql", "-f", `query=${query}`,
+    ...Object.entries(variables).flatMap(([k, v]) => ["-F", `${k}=${String(v)}`])]);
+  try {
+    const res = await fetch("https://api.github.com/graphql", {
+      method: "POST",
+      headers: {
+        authorization: `bearer ${token}`,
+        "content-type": "application/json",
+        "user-agent": "agentglass",
+      },
+      body: JSON.stringify({ query, variables }),
+      signal: AbortSignal.timeout(GH_TIMEOUT_MS),
+    });
+    if (!res.ok) return null;
+    return (await res.json()) as T;
+  } catch {
+    return null;
+  }
+}
+
 async function ghToken(): Promise<string> {
   if (tokenCache && Date.now() - tokenCache.at < 5 * 60_000) return tokenCache.token;
   const r = await gh(["auth", "token"]);
@@ -1088,19 +1572,107 @@ export async function setThreadResolved(rootIn: unknown, threadId: unknown, reso
   return { ok: true };
 }
 
-/** 👍 on a review comment — how most teams acknowledge without adding noise. */
-export async function react(rootIn: unknown, commentId: unknown, content: unknown): Promise<PrActionResult> {
+/** The eight GitHub allows. There is no ninth, and no custom emoji. */
+const REACTIONS = ["THUMBS_UP", "THUMBS_DOWN", "LAUGH", "HOORAY", "CONFUSED", "HEART", "ROCKET", "EYES"];
+
+/**
+ * React to anything: the pull request body, a conversation comment, a review, or
+ * a line comment.
+ *
+ * GraphQL's `addReaction`/`removeReaction` take a node id and do not care which
+ * kind of thing it is — which is the whole reason to use them. The REST route
+ * this used to call was `/pulls/comments/{id}/reactions`, the *review comment*
+ * endpoint, so reacting to an ordinary conversation comment answered 404: the
+ * one case anybody actually hits. Toggling off needs a mutation of its own,
+ * which REST could not express here either.
+ */
+export async function react(rootIn: unknown, nodeId: unknown, content: unknown, on: unknown = true): Promise<PrActionResult> {
   const g = writeGuard(rootIn); if (g) return g;
-  const cid = Number(commentId);
-  const allowed = ["+1", "-1", "laugh", "confused", "heart", "hooray", "rocket", "eyes"];
-  const c = String(content || "+1");
-  if (!Number.isInteger(cid)) return { ok: false, error: "invalid comment" };
-  if (!allowed.includes(c)) return { ok: false, error: "invalid reaction" };
+  const id = String(nodeId || "");
+  const c = String(content || "THUMBS_UP").toUpperCase();
+  if (!id) return { ok: false, error: "invalid comment" };
+  if (!REACTIONS.includes(c)) return { ok: false, error: "invalid reaction" };
+  const add = on !== false && on !== "false";
+  const mutation = add
+    ? `mutation($id:ID!,$c:ReactionContent!){addReaction(input:{subjectId:$id,content:$c}){clientMutationId}}`
+    : `mutation($id:ID!,$c:ReactionContent!){removeReaction(input:{subjectId:$id,content:$c}){clientMutationId}}`;
+  const r = await gh(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${id}`, "-F", `c=${c}`]);
+  // Drop the cached detail either way: a reaction that does not show up until
+  // the 45s TTL expires reads as a button that did nothing.
   const repo = await repoIdFor(rootIn);
-  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
-  const r = await gh(["api", "--method", "POST", `repos/${repo.nameWithOwner}/pulls/comments/${cid}/reactions`, "-f", `content=${c}`]);
+  if (repo) invalidate(repo);
   if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "reaction failed" };
   return { ok: true };
+}
+
+/** Edit your own comment. The PR body goes through `editPr`, not here. */
+export async function editComment(rootIn: unknown, nodeId: unknown, body: unknown, kind: unknown = "issue"): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const id = String(nodeId || "");
+  const text = String(body ?? "");
+  if (!id) return { ok: false, error: "invalid comment" };
+  if (!text.trim()) return { ok: false, error: "a comment cannot be empty" };
+  const review = kind === "review";
+  const mutation = review
+    ? `mutation($id:ID!,$b:String!){updatePullRequestReviewComment(input:{pullRequestReviewCommentId:$id,body:$b}){clientMutationId}}`
+    : `mutation($id:ID!,$b:String!){updateIssueComment(input:{id:$id,body:$b}){clientMutationId}}`;
+  const r = await gh(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${id}`, "-F", `b=${text}`]);
+  const repo = await repoIdFor(rootIn);
+  if (repo) invalidate(repo);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "could not edit the comment" };
+  return { ok: true };
+}
+
+/** Delete your own comment. */
+export async function deleteComment(rootIn: unknown, nodeId: unknown, kind: unknown = "issue"): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const id = String(nodeId || "");
+  if (!id) return { ok: false, error: "invalid comment" };
+  const review = kind === "review";
+  const mutation = review
+    ? `mutation($id:ID!){deletePullRequestReviewComment(input:{id:$id}){clientMutationId}}`
+    : `mutation($id:ID!){deleteIssueComment(input:{id:$id}){clientMutationId}}`;
+  const r = await gh(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${id}`]);
+  const repo = await repoIdFor(rootIn);
+  if (repo) invalidate(repo);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "could not delete the comment" };
+  return { ok: true };
+}
+
+/**
+ * GitHub's own per-reviewer "viewed" tick.
+ *
+ * The panel has always kept this in localStorage, which means it disagreed with
+ * github.com and was lost on another machine. GitHub also un-ticks a file by
+ * itself when it changes after you marked it, which local state cannot do.
+ */
+export async function setFileViewed(rootIn: unknown, prNodeId: unknown, path: unknown, viewed: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const id = String(prNodeId || "");
+  const p = String(path || "");
+  if (!id || !p) return { ok: false, error: "invalid file" };
+  const mutation = viewed !== false && viewed !== "false"
+    ? `mutation($id:ID!,$p:String!){markFileAsViewed(input:{pullRequestId:$id,path:$p}){clientMutationId}}`
+    : `mutation($id:ID!,$p:String!){unmarkFileAsViewed(input:{pullRequestId:$id,path:$p}){clientMutationId}}`;
+  const r = await gh(["api", "graphql", "-f", `query=${mutation}`, "-F", `id=${id}`, "-F", `p=${p}`]);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "could not mark the file" };
+  return { ok: true };
+}
+
+/** Assignees and milestone: the two sidebar fields that were read-only. */
+export async function setAssignees(rootIn: unknown, number: unknown, add: unknown[], remove: unknown[]): Promise<PrActionResult> {
+  const args = ["pr", "edit", String(Number(number))];
+  for (const a of (add || [])) if (String(a).trim()) args.push("--add-assignee", String(a).trim());
+  for (const a of (remove || [])) if (String(a).trim()) args.push("--remove-assignee", String(a).trim());
+  if (args.length === 3) return { ok: false, error: "nothing to change" };
+  return runPr(rootIn, Number(number), args);
+}
+
+export async function setMilestone(rootIn: unknown, number: unknown, title: unknown): Promise<PrActionResult> {
+  const t = String(title ?? "").trim();
+  // gh spells "no milestone" as an empty --milestone, so clearing is expressible.
+  const args = ["pr", "edit", String(Number(number)), t ? "--milestone" : "--remove-milestone", ...(t ? [t] : [])];
+  return runPr(rootIn, Number(number), args);
 }
 
 export async function editPr(rootIn: unknown, number: unknown, patch: { title?: unknown; body?: unknown; base?: unknown }): Promise<PrActionResult> {
@@ -1192,13 +1764,26 @@ export async function rerunFailedChecks(rootIn: unknown, number: unknown): Promi
  * would merge a commit you never saw. The caller passes the head it showed you,
  * and GitHub refuses if that is no longer the tip.
  */
-export async function mergePr(rootIn: unknown, number: unknown, method: unknown, opts: { deleteBranch?: unknown; auto?: unknown; headSha?: unknown }): Promise<PrActionResult> {
+export async function mergePr(rootIn: unknown, number: unknown, method: unknown, opts: { deleteBranch?: unknown; auto?: unknown; headSha?: unknown; subject?: unknown; body?: unknown; disableAuto?: unknown }): Promise<PrActionResult> {
+  // Cancelling an armed auto-merge is its own verb, not a merge with a flag —
+  // and it was missing entirely, so a "merge when green" could be armed and
+  // never called off from here.
+  if (opts.disableAuto === true || opts.disableAuto === "true") {
+    return runPr(rootIn, Number(number), ["pr", "merge", String(Number(number)), "--disable-auto"]);
+  }
   const flag = method === "merge" ? "--merge" : method === "rebase" ? "--rebase" : method === "squash" ? "--squash" : null;
   if (!flag) return { ok: false, error: "choose squash, merge or rebase" };
   const args = ["pr", "merge", String(Number(number)), flag];
   if (opts.auto === true || opts.auto === "true") args.push("--auto");
   if (opts.deleteBranch === true || opts.deleteBranch === "true") args.push("--delete-branch");
   if (typeof opts.headSha === "string" && /^[0-9a-f]{7,40}$/i.test(opts.headSha)) args.push("--match-head-commit", opts.headSha);
+  // The commit this writes onto the base branch is permanent and public; being
+  // able to fix its subject before it lands is the whole point of the dialog.
+  // Rebase writes no commit of its own, so gh rejects a message there.
+  if (flag !== "--rebase") {
+    if (typeof opts.subject === "string" && opts.subject.trim()) args.push("--subject", opts.subject.trim());
+    if (typeof opts.body === "string" && opts.body.trim()) args.push("--body", opts.body);
+  }
   return runPr(rootIn, Number(number), args);
 }
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1059,7 +1059,34 @@ export interface PrSummary {
 export type PrMergeState =
   | "CLEAN" | "BLOCKED" | "BEHIND" | "DIRTY" | "UNSTABLE" | "DRAFT" | "HAS_HOOKS" | "UNKNOWN";
 
-export interface PrThreadComment {
+/** One emoji tally on a comment, straight from GraphQL's `reactionGroups`.
+ *  `viewerHasReacted` is what lets the button render as already-pressed. */
+export interface PrReaction {
+  /** GitHub's own name: THUMBS_UP, HEART, ROCKET, EYES, LAUGH, HOORAY, CONFUSED, THUMBS_DOWN. */
+  content: string;
+  count: number;
+  viewerHasReacted: boolean;
+}
+
+/** How GitHub labels the person who wrote a comment: OWNER, MEMBER,
+ *  COLLABORATOR, CONTRIBUTOR, FIRST_TIME_CONTRIBUTOR, NONE. Shown as the little
+ *  badge beside the name — it is how a reader weighs a review at a glance. */
+export type PrAuthorAssociation =
+  | "OWNER" | "MEMBER" | "COLLABORATOR" | "CONTRIBUTOR"
+  | "FIRST_TIME_CONTRIBUTOR" | "FIRST_TIMER" | "MANNEQUIN" | "NONE";
+
+/** What everything a person wrote carries: who, when, whether they edited it,
+ *  what standing they have, and how people reacted. */
+export interface PrAuthored {
+  reactions?: PrReaction[];
+  /** Non-null when the comment was edited after posting — GitHub shows "edited". */
+  editedAt?: string | null;
+  association?: PrAuthorAssociation;
+  /** You wrote it, so you may edit or delete it. */
+  viewerDidAuthor?: boolean;
+}
+
+export interface PrThreadComment extends PrAuthored {
   id: string;
   /** The numeric id the REST reply endpoint wants; the `id` above is a GraphQL
    *  node id and the two are not interchangeable. */
@@ -1089,16 +1116,18 @@ export interface PrThread {
   comments: PrThreadComment[];
 }
 
-export interface PrReview {
+export interface PrReview extends PrAuthored {
   author: string;
   isBot: boolean;
   state: "APPROVED" | "CHANGES_REQUESTED" | "COMMENTED" | "DISMISSED" | "PENDING";
   body: string;
   submittedAt: string;
   url?: string;
+  /** GraphQL node id, for reacting to the review body. */
+  nodeId?: string;
 }
 
-export interface PrComment {
+export interface PrComment extends PrAuthored {
   id: number;
   author: string;
   isBot: boolean;
@@ -1108,9 +1137,31 @@ export interface PrComment {
   /** Bot noise reduced to its point — a 46KB coverage table is three numbers
    *  and 1,847 rows nobody reads. Null when nothing could be extracted. */
   digest?: string | null;
+  /** GraphQL node id — what the reaction and edit mutations take. */
+  nodeId?: string;
 }
 
-export interface PrCommit { oid: string; short: string; message: string; author: string; isMerge: boolean }
+export interface PrCommit {
+  oid: string;
+  short: string;
+  /** The subject line. */
+  message: string;
+  /** Everything after the subject — the paragraphs, the Co-authored-by
+   *  trailers, the "why". Empty for a one-line commit. */
+  body?: string;
+  author: string;
+  isMerge: boolean;
+  /** Everyone credited, not just the first: a commit written with an agent
+   *  carries a Co-authored-by trailer, and "X and claude committed" is the
+   *  honest line. Includes the author; empty falls back to `author`. */
+  authors?: string[];
+  /** When it landed, so commits can be grouped by day like GitHub does. */
+  committedAt?: string;
+  /** A valid signature earns the Verified badge. */
+  verified?: boolean;
+  /** This commit's own check rollup: SUCCESS / FAILURE / PENDING / null. */
+  checks?: "SUCCESS" | "FAILURE" | "ERROR" | "PENDING" | "EXPECTED" | null;
+}
 
 export interface PrFile {
   path: string;
@@ -1119,6 +1170,31 @@ export interface PrFile {
   status: string;
   /** Unresolved threads anchored to this file. */
   comments: number;
+  /** GitHub's own per-reviewer "viewed" tick, so marking a file read survives
+   *  leaving the panel and matches what github.com shows. */
+  viewed?: boolean;
+  /** Where it came from, when the change is a rename. */
+  previousPath?: string | null;
+}
+
+/** One entry in the conversation timeline that is not a comment: a push, a
+ *  rename, a label, a merge. GitHub renders these inline between comments, and
+ *  without them the conversation reads as if nothing happened between remarks. */
+export interface PrEvent {
+  kind:
+    | "force-push" | "commit" | "renamed" | "labeled" | "unlabeled"
+    | "assigned" | "unassigned" | "review-requested" | "review-request-removed"
+    | "ready-for-review" | "convert-to-draft" | "merged" | "closed" | "reopened"
+    | "cross-referenced" | "milestoned" | "demilestoned" | "head-ref-deleted"
+    | "auto-merge-enabled" | "auto-merge-disabled";
+  at: string;
+  actor: string;
+  /** One line of detail, already shaped for reading: the new title, the label
+   *  name, the sha pair of a force-push, the PR that referenced this one. */
+  detail?: string;
+  /** Colour for the label chip on labeled/unlabeled. */
+  tint?: string | null;
+  url?: string;
 }
 
 export interface PrChecklistItem { checked: boolean; text: string }
@@ -1147,6 +1223,29 @@ export interface PrDetail extends PrSummary {
   viewerDidAuthor: boolean;
   /** Somebody asked you for a review. This is what the review tab is for. */
   viewerRequested: boolean;
+  /** Everything that happened which is not a comment: pushes, renames, labels,
+   *  the merge itself. Ascending, so it interleaves with comments by time. */
+  timeline: PrEvent[];
+  /** Everyone who has touched the conversation — the sidebar's avatar row. */
+  participants: string[];
+  /** Reactions on the pull request body itself. */
+  bodyReactions: PrReaction[];
+  /** Emoji on the body needs the PR's own node id. */
+  nodeId?: string;
+  projects: string[];
+  /** Issues this pull request closes when it merges. */
+  linkedIssues: { number: number; title: string; url: string; state: string }[];
+  /** Armed auto-merge, so the UI can offer to cancel it rather than only arm it. */
+  autoMerge?: { enabledBy: string; method: string } | null;
+  mergedBy?: string | null;
+  mergedAt?: string | null;
+  closedAt?: string | null;
+  createdAt?: string;
+  /** You may edit the title/body. */
+  viewerCanUpdate?: boolean;
+  /** What the page could not show because a list hit its page size. Silence
+   *  here used to be a lie: a hundred-and-first file simply vanished. */
+  truncated?: { files?: number; commits?: number; comments?: number; threads?: number; checks?: number };
 }
 
 export interface PrListResponse {
@@ -1164,6 +1263,13 @@ export interface PrListResponse {
   error?: string;
   /** `gh` missing or not logged in — a first-class state, not an error toast. */
   needsAuth?: boolean;
+  /** How many pull requests match, across every page. */
+  total?: number;
+  /** Another page exists after this one. */
+  hasNext?: boolean;
+  /** Opaque cursor that fetches the page after this one. */
+  cursor?: string | null;
+  pageSize?: number;
 }
 
 export interface PrActionResult { ok: boolean; error?: string; detail?: string }

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -23,12 +23,15 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type {
   PrSummary, PrDetail, PrRepoId, PrThread, PrComment, PrReview, PrCheck, GitRepoRef, FileChange,
+  PrReaction, PrAuthorAssociation, PrEvent, PrCommit, PrFile,
 } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle } from "./ChangesModal.tsx";
+import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
+import { Select } from "./Select.tsx";
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 import { stepFileIndex } from "../lib/prNav.ts";
 import { PrFilterBar } from "./PrFilterBar.tsx";
@@ -359,7 +362,18 @@ function DiffPane({ file, split, wrap, onComment }: {
           title={`Comment on line ${target}`}>+ Comment</button>;
       }
     : undefined;
-  return split ? <SplitDiff c={file} wrap={wrap} /> : <UnifiedDiff c={file} wrap={wrap} hunkAction={action} />;
+  // Syntax highlighting, which this pane never had: `Code` reads the theme out
+  // of `HiliteCtx`, and with no Provider above it every PR diff rendered as
+  // plain monochrome text while the very same viewer in the changes modal came
+  // out coloured. A very long diff drops the theme (not the parse) so a
+  // thousand-line file does not spend its time colouring.
+  const { hilite } = useDiffHighlight(file.file_path);
+  const heavy = file.hunks.reduce((n, h) => n + h.lines.length, 0) > 3000;
+  return (
+    <HiliteCtx.Provider value={heavy ? { ...hilite, theme: null } : hilite}>
+      {split ? <SplitDiff c={file} wrap={wrap} /> : <UnifiedDiff c={file} wrap={wrap} hunkAction={action} />}
+    </HiliteCtx.Provider>
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -402,8 +416,8 @@ function PrRow({ p, active, onSelect }: { p: PrSummary; active: boolean; onSelec
         boxShadow: active ? "inset 2px 0 0 var(--primary)" : undefined,
       }}>
       <div className="flex items-center gap-1.5">
-        {p.state === "MERGED" ? <Chip text="merged" tint="var(--primary)" title="Merged" />
-          : p.state === "CLOSED" ? <Chip text="closed" tint="var(--error)" title="Closed without merging" /> : null}
+        {p.state === "MERGED" ? <Chip text="⏣ merged" tint="var(--primary)" title="Merged" />
+          : p.state === "CLOSED" ? <Chip text="⊘ closed" tint="var(--text3)" title="Closed without merging" /> : null}
         <span className="text-[10px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>#{p.number}</span>
         <span className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>{p.title}</span>
         {p.isCurrentBranch && <Chip text="here" tint="var(--primary)" title="This checkout is on that branch" />}
@@ -443,6 +457,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
    *  never lands on an empty pane. */
   const [filter, setFilter] = useState<Filter>("review");
   const [stateSel, setStateSel] = useState<StateSel>("open");
+  /** Cursors we have walked through. `[]` is page 1; each Next pushes the
+   *  cursor that fetched the page we are about to show, so Previous is a pop.
+   *  GitHub's cursors are opaque and only move forward, so a stack is the only
+   *  way back. */
+  const [pages, setPages] = useState<string[]>([]);
+  const cursor = pages[pages.length - 1];
   const fellBack = useRef(false);
   // The filter query for the current scope tab — the single source of truth for
   // both the search box and every facet dropdown (parsed in lib/prFilter.ts).
@@ -450,8 +470,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   // fresh; "all" can be hundreds of rows and a facet beats scrolling.
   const [query, setQuery] = useState("");
   const [prs, setPrs] = useState<PrSummary[]>([]);
-  const [counts, setCounts] = useState<Partial<Record<Filter, number>>>({});
-  const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; checksPending?: boolean; error?: string; needsAuth?: boolean }>({ fetchedAt: 0, loading: false });
+  const [listState, setListState] = useState<{ fetchedAt: number; loading: boolean; checksPending?: boolean; error?: string; needsAuth?: boolean; total?: number; hasNext?: boolean; cursor?: string | null; pageSize?: number }>({ fetchedAt: 0, loading: false });
   const [selected, setSelected] = useState<number | null>(null);
   const [detail, setDetail] = useState<PrDetail | null>(null);
   const [detailErr, setDetailErr] = useState("");
@@ -464,6 +483,14 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   const [diff, setDiff] = useState("");
   const [selFile, setSelFile] = useState<string | null>(null);
   const [selCommit, setSelCommit] = useState<string | null>(null);
+  // Which commits have their full message open. Separate from `selCommit`, so
+  // reading the message costs nothing and does not fetch a diff.
+  const [openMsgs, setOpenMsgs] = useState<Set<string>>(new Set());
+  const toggleMsg = (oid: string) => setOpenMsgs((cur) => {
+    const next = new Set(cur);
+    if (next.has(oid)) next.delete(oid); else next.add(oid);
+    return next;
+  });
   const [commitText, setCommitText] = useState("");
   const [commitBusy, setCommitBusy] = useState(false);
   const [split, setSplit] = useState(true);
@@ -496,12 +523,11 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (!root) return;
     const req = ++listReq.current;
     const want = filter;
-    api.prList(root, filter, stateSel, force).then((r) => {
+    api.prList(root, filter, stateSel, force, cursor).then((r) => {
       if (req !== listReq.current) return; // a newer request already won
       setRepo(r.repo);
       setPrs(r.prs);
-      setCounts((c) => ({ ...c, [want]: r.prs.length }));
-      setListState({ fetchedAt: r.fetchedAt, loading: r.loading, checksPending: r.checksPending, error: r.error, needsAuth: r.needsAuth });
+      setListState({ fetchedAt: r.fetchedAt, loading: r.loading, checksPending: r.checksPending, error: r.error, needsAuth: r.needsAuth, total: r.total, hasNext: r.hasNext, cursor: r.cursor ?? null, pageSize: r.pageSize });
       setSelected((cur) => (cur && r.prs.some((p) => p.number === cur) ? cur : r.prs[0]?.number ?? null));
       // Nothing waiting on you: show your own instead of an empty pane. Once
       // only, so choosing "Needs my review" yourself is never overruled.
@@ -513,7 +539,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       if (req !== listReq.current) return;
       setListState({ fetchedAt: 0, loading: false, error: String(e) });
     });
-  }, [root, filter, stateSel]);
+  }, [root, filter, stateSel, cursor]);
 
   /**
    * Switching filter empties the pane before anything is fetched.
@@ -530,17 +556,63 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     lastScope.current = scope;
     if (first) return; // nothing on screen yet to clear
     listReq.current++;
-    setPrs([]);
+    // Back to page one: a cursor belongs to the search it came from, and
+    // carrying it into a different scope asks GitHub to continue a list that no
+    // longer exists. The counts go too — they are per-state, and leaving them
+    // up is how every pill read 0 after switching to Closed.
+    setPages([]);
+    setViewCounts({});
+    // The rows STAY on screen while the new ones are fetched.
+    //
+    // Blanking them meant every switch showed a skeleton for as long as GitHub
+    // took — about a second and a half, and the round trip is the floor, not
+    // something a faster query removes. Keeping the previous list up (dimmed,
+    // and labelled as loading) is what GitHub does, and it turns that second and
+    // a half from a wait into a redraw. `listReq` still guards the answer, so a
+    // slow reply for the scope you left can never land on the one you are in.
     setSelected(null);
     setDetail(null);
     setDetailErr("");
-    setListState((st) => ({ ...st, loading: true, fetchedAt: 0 }));
+    setListState((st) => ({ ...st, loading: true }));
   }, [filter, root, stateSel]);
 
   // Polling pauses while the view is hidden — no point spending requests on a
   // pane nobody is looking at — and resumes on return. Resuming refreshes; it
   // does not reset.
 
+  /**
+   * Warm the states you are not looking at.
+   *
+   * Each state is its own cache entry on the server, so the first visit to
+   * Closed or All paid the whole fetch — about a second and a half of GitHub —
+   * while the user watched. Touching them once in the background makes the
+   * switch instant. Staggered, because the point is to spend idle time, not to
+   * queue three searches behind the one being waited on.
+   */
+  useEffect(() => {
+    if (!active || !root || listState.loading) return;
+    const others = (["open", "closed", "all"] as StateSel[]).filter((st) => st !== stateSel);
+    const timers = others.map((st, i) => setTimeout(() => {
+      void api.prList(root, filter, st, false).catch(() => {});
+      void api.prCounts(root, st).catch(() => {});
+    }, 1500 + i * 2000));
+    return () => timers.forEach(clearTimeout);
+  }, [active, root, filter, stateSel, listState.loading]);
+
+  /**
+   * Fetch the next page before it is asked for.
+   *
+   * Each page is its own entry in the server's cache, so touching it once means
+   * Next answers from memory instead of waiting on GitHub. Deliberately after a
+   * beat, and never while the current page is still loading: the point is to
+   * spend the idle time, not to compete for it.
+   */
+  useEffect(() => {
+    if (!active || !root || !listState.hasNext || !listState.cursor || listState.loading) return;
+    const next = listState.cursor;
+    const t = setTimeout(() => { void api.prList(root, filter, stateSel, false, next).catch(() => {}); }, 900);
+    return () => clearTimeout(t);
+  }, [active, root, filter, stateSel, listState.hasNext, listState.cursor, listState.loading]);
 
   /**
    * Warm the filters you are not looking at.
@@ -552,14 +624,16 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
    */
   useEffect(() => {
     if (!active || !root) return;
-    const others = (["mine", "review", "all"] as Filter[]).filter((f) => f !== filter);
-    const timers = others.map((f, i) => setTimeout(() => {
-      api.prList(root, f, stateSel, false)
-        .then((r) => setCounts((c) => ({ ...c, [f]: r.prs.length })))
-        .catch(() => {});
-    }, 1200 + i * 2500));
-    return () => timers.forEach(clearTimeout);
-  }, [active, root, filter, stateSel]);
+    let live = true;
+    // One request for all five numbers, and they are the TRUE totals for the
+    // current state — not a tally of the page on screen, which stopped being
+    // the answer the moment the list got pages, and not a stale figure carried
+    // over from a different state.
+    api.prCounts(root, stateSel)
+      .then((r) => { if (live && r.ok && r.counts) setViewCounts(r.counts as unknown as Record<string, number>); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, [active, root, stateSel, listState.fetchedAt]);
 
   const loadDetail = useCallback((n: number, force = false) => {
     const req = ++detailReq.current;
@@ -650,9 +724,14 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   }, [prs, filter, listState.loading]);
 
   const viewCount = useCallback((v: (typeof VIEWS)[number]): number | null => {
-    if (v.scope === filter && !listState.loading) return applyFilters(prs, parseQuery(v.query)).length;
-    return viewCounts[v.id] ?? (v.query ? null : counts[v.scope] ?? null);
-  }, [filter, prs, counts, viewCounts, listState.loading]);
+    // The server's exact total wins. Counting the rows on screen was right when
+    // the list was everything; with pages it answers "how many on this page",
+    // which is a different question wearing the same badge.
+    const exact = viewCounts[v.id];
+    if (typeof exact === "number") return exact;
+    if (v.scope === filter && !listState.loading && !listState.hasNext) return applyFilters(prs, parseQuery(v.query)).length;
+    return null;
+  }, [filter, prs, viewCounts, listState.loading, listState.hasNext]);
 
   const activeView = VIEWS.find((v) => v.scope === filter && v.query === query.trim());
 
@@ -729,18 +808,38 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   }, [busy, flash, loadList, selected, loadDetail]);
 
   const key = repo && detail ? `${repo.key}#${detail.number}` : "";
-  const seenFiles = key ? (seen[key] ?? []) : [];
+  // What GitHub already knows you have read, unioned with this browser's copy.
+  // GitHub's is the authority — it also un-ticks a file that changed after you
+  // marked it — but the local set still counts so a tick shows before the
+  // round trip lands.
+  const seenFiles = useMemo(() => {
+    const local = key ? (seen[key] ?? []) : [];
+    const remote = (detail?.files ?? []).filter((f) => f.viewed).map((f) => f.path);
+    return [...new Set([...remote, ...local])];
+  }, [key, seen, detail]);
   const myDrafts = key ? (drafts[key] ?? []) : [];
 
+  /**
+   * Mark a file read, here and on GitHub.
+   *
+   * This used to be local only, so the tick disagreed with github.com, was lost
+   * on another machine, and never un-ticked itself when the file changed under
+   * you — all three of which GitHub's own state gets right. The local copy is
+   * still written first so the switch answers instantly; the network call is
+   * the one that makes it true anywhere else.
+   */
   const toggleSeen = (path: string) => {
     if (!key) return;
+    let nowViewed = false;
     setSeen((cur) => {
       const list = new Set(cur[key] ?? []);
-      if (list.has(path)) list.delete(path); else list.add(path);
+      if (list.has(path)) list.delete(path); else { list.add(path); nowViewed = true; }
       const next = { ...cur, [key]: [...list] };
       saveMap(SEEN_KEY, next);
       return next;
     });
+    const id = detail?.nodeId;
+    if (id) void api.prFileViewed(root, id, path, nowViewed).catch(() => { /* local tick still stands */ });
   };
 
   const addDraft = async (path: string, line: number) => {
@@ -777,28 +876,53 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     }
   };
 
-  const doMerge = async () => {
+  const doMerge = async (method: MergeMethod = "squash") => {
     if (!detail) return;
     const head = detail.commits[detail.commits.length - 1]?.oid;
-    const ok = await ask({
-      title: `Merge #${detail.number} into ${detail.baseRefName}?`,
-      body: `${detail.title}\n\nSquash and merge, then delete the branch. This is public and cannot be undone from here.` +
-        (head ? `\n\nPinned to ${head.slice(0, 8)} — if anyone pushes before this lands, GitHub refuses rather than merging a commit you have not seen.` : ""),
-      confirmLabel: "Squash & merge", danger: true,
-    });
-    if (!ok) return;
-    await act("Merge", () => api.prMerge(root, detail.number, "squash", { deleteBranch: true, headSha: head }));
+    const how = method === "squash" ? "Squash and merge" : method === "merge" ? "Create a merge commit" : "Rebase and merge";
+    // The subject is offered for editing because it is what lands on the base
+    // branch for ever. Rebase writes no commit of its own, so there is nothing
+    // to name there and gh rejects the flag.
+    let subject: string | undefined;
+    if (method !== "rebase") {
+      const t = await askText({
+        title: `${how} #${detail.number} into ${detail.baseRefName}`,
+        confirmLabel: how,
+        input: { label: "Commit subject — this is permanent", initial: `${detail.title} (#${detail.number})` },
+      });
+      if (t == null) return;
+      subject = t.trim() || undefined;
+    } else {
+      const ok = await ask({
+        title: `Rebase and merge #${detail.number} into ${detail.baseRefName}?`,
+        body: `${detail.title}\n\nEvery commit is replayed onto ${detail.baseRefName} with new SHAs, and no merge commit is written.`,
+        confirmLabel: "Rebase & merge", danger: true,
+      });
+      if (!ok) return;
+    }
+    await act("Merge", () => api.prMerge(root, detail.number, method, { deleteBranch: true, headSha: head, subject }));
   };
 
+  /**
+   * Close, or reopen a closed one.
+   *
+   * The menu has offered "Reopen pull request" all along and then called close
+   * with `reopen` left false, so reopening was unreachable from the UI while the
+   * server supported it the whole time. The dialog was wrong in the same way,
+   * asking "Close #N?" over a pull request that was already closed.
+   */
   const doClose = async () => {
     if (!detail) return;
+    const reopen = detail.state === "CLOSED";
     const ok = await ask({
-      title: `Close #${detail.number}?`,
-      body: `${detail.title}\n\nClosed without merging. You can reopen it afterwards.`,
-      confirmLabel: "Close pull request", danger: true,
+      title: reopen ? `Reopen #${detail.number}?` : `Close #${detail.number}?`,
+      body: reopen
+        ? `${detail.title}\n\nIt goes back to open, with its comments and reviews intact.`
+        : `${detail.title}\n\nClosed without merging. You can reopen it afterwards.`,
+      confirmLabel: reopen ? "Reopen pull request" : "Close pull request", danger: !reopen,
     });
     if (!ok) return;
-    await act("Close", () => api.prClose(root, detail.number));
+    await act(reopen ? "Reopen" : "Close", () => api.prClose(root, detail.number, reopen));
   };
 
   const doLocalReview = async () => {
@@ -842,6 +966,44 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     await act("Labels", () => api.prLabels(root, detail.number, add, remove));
   };
 
+  const doReply = async (t: PrThread) => {
+    if (!detail) return;
+    const first = t.comments[0];
+    if (typeof first?.databaseId !== "number") return;
+    const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply" } });
+    if (!body?.trim()) return;
+    await act("Reply", () => api.prReply(root, detail.number, first.databaseId as number, body));
+  };
+  /** Toggle an emoji. The node id is the GraphQL one, so the same call serves
+   *  the body, a comment, a review and a line comment. */
+  const doReact = async (nodeId: string, content: string, on: boolean) => {
+    if (!nodeId) return;
+    await act(on ? "Reaction" : "Reaction removed", () => api.prReactTo(root, nodeId, content, on));
+  };
+  const doAssignees = async () => {
+    if (!detail) return;
+    const cur = detail.assignees;
+    const next = await askText({
+      title: `Assignees on #${detail.number}`, confirmLabel: "Save",
+      input: { label: "Comma-separated logins — @me works, remove one by deleting it", initial: cur.join(", ") },
+    });
+    if (next == null) return;
+    const want = next.split(",").map((s) => s.trim().replace(/^@(?!me$)/, "")).filter(Boolean);
+    const add = want.filter((l) => !cur.includes(l));
+    const remove = cur.filter((l) => !want.includes(l));
+    if (add.length === 0 && remove.length === 0) return;
+    await act("Assignees", () => api.prAssignees(root, detail.number, add, remove));
+  };
+  const doMilestone = async () => {
+    if (!detail) return;
+    const next = await askText({
+      title: `Milestone on #${detail.number}`, confirmLabel: "Save",
+      input: { label: "Milestone title — leave empty to clear", initial: detail.milestone ?? "" },
+    });
+    if (next == null) return;
+    if ((next.trim() || null) === (detail.milestone ?? null)) return;
+    await act("Milestone", () => api.prMilestone(root, detail.number, next.trim()));
+  };
   const doReviewers = async () => {
     if (!detail) return;
     const cur = detail.reviewers;
@@ -906,7 +1068,9 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
   // You cannot review your own pull request — GitHub does not offer it either,
   // and a review control on every row buries the ones actually waiting on you.
-  const canReview = !!d && !d.viewerDidAuthor;
+  // You cannot review your own work, and you cannot review something that has
+  // already merged or been closed — GitHub takes the review form away too.
+  const canReview = !!d && !d.viewerDidAuthor && d.state === "OPEN";
 
   const TABS: { id: Tab; label: string; n?: number; warn?: boolean }[] = d ? [
     { id: "overview", label: "Overview" },
@@ -1003,7 +1167,12 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
             ) : prs.length === 0 ? (
               listState.loading ? <Skeletons /> : (
                 <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
-                  {filter === "mine" ? "No open pull requests of yours" : filter === "review" ? "Nothing waiting on your review" : "No open pull requests"}
+                  {(() => {
+                    const what = stateSel === "open" ? "open " : stateSel === "closed" ? "closed " : "";
+                    return filter === "mine" ? `No ${what}pull requests of yours`
+                      : filter === "review" ? "Nothing waiting on your review"
+                      : `No ${what}pull requests`;
+                  })()}
                 </div>
               )
             ) : visiblePrs.length === 0 ? (
@@ -1011,10 +1180,37 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 <span>No pull requests match {activeCount(filters) === 1 ? "this filter" : "these filters"}.</span>
                 <button onClick={() => setQuery("")} className="text-[10.5px] px-2 py-0.5 rounded hover:bg-white/5" style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 30%, transparent)" }}>Clear filters</button>
               </div>
-            ) : visiblePrs.map((p) => (
-              <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
-            ))}
+            ) : (
+              // Dimmed, not blanked, while the next scope loads: you can still
+              // read what is there, and it is obvious it is being replaced.
+              <div style={{ opacity: listState.loading ? 0.45 : 1, transition: "opacity .15s" }}>
+                {visiblePrs.map((p) => (
+                  <PrRow key={p.number} p={p} active={p.number === selected} onSelect={() => { setSelected(p.number); setTab("overview"); }} />
+                ))}
+              </div>
+            )}
           </div>
+          {/* Pages, because a repository has more pull requests than one screen
+              of them and the panel used to stop at the first fifty with no way
+              to say so. Cursors only move forward, so Previous walks a stack. */}
+          {repo && (listState.hasNext || pages.length > 0) && (
+            <div className="flex items-center gap-2 px-2 py-1.5 border-t shrink-0 text-[10px]"
+              style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)", color: "var(--text3)" }}>
+              <button onClick={() => setPages((p) => p.slice(0, -1))} disabled={pages.length === 0 || listState.loading}
+                className="agx-btn px-2 py-0.5 rounded disabled:opacity-35"
+                style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text2)" }}>‹ Previous</button>
+              <span className="tabular-nums">
+                Page {pages.length + 1}
+                {listState.total != null && listState.pageSize
+                  ? ` of ${Math.max(1, Math.ceil(listState.total / listState.pageSize))} · ${listState.total} total`
+                  : ""}
+              </span>
+              <button onClick={() => { if (listState.cursor) setPages((p) => [...p, listState.cursor!]); }}
+                disabled={!listState.hasNext || !listState.cursor || listState.loading}
+                className="agx-btn ml-auto px-2 py-0.5 rounded disabled:opacity-35"
+                style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text2)" }}>Next ›</button>
+            </div>
+          )}
         </div>
 
         <SidebarGrip />
@@ -1055,63 +1251,115 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                 </div>
               </div>
 
+              {/* Prose on the left at a fixed reading width, metadata on the
+                  right — the arrangement GitHub uses, and the reason the body
+                  no longer hugs the left edge with the whole right half of the
+                  panel empty. Files/Checks/Commits keep the full width: a diff
+                  and a check list want every pixel. */}
               <div className="flex-1 overflow-y-auto min-h-0 agx-scroll p-3">
-                {tab === "overview" && (
-                  <Overview
-                    d={d} busy={busy} openThreads={openThreads.length}
-                    conversationCount={d.comments.length + d.reviews.length + d.threads.length}
-                    onEditBody={doEditBody}
-                    onLocalReview={doLocalReview} onMerge={doMerge} onClose={doClose}
-                    onUpdateBranch={() => act("Update branch", () => api.prUpdateBranch(root, d.number))}
-                    onRerun={() => act("Re-run checks", () => api.prRerun(root, d.number))}
-                    onAutoMerge={() => act("Auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
-                    onDraft={() => act(d.isDraft ? "Mark ready" : "Convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
-                    onGoThreads={() => setTab("conversation")}
-                  />
-                )}
-
-                {tab === "conversation" && (
-                  <Conversation
-                    d={d} lanes={lanes} raw={rawBots} onRaw={setRawBots} busy={busy} onComment={doComment}
-                    onResolve={(t) => act(t.isResolved ? "Unresolve" : "Resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
-                    onReply={async (t) => {
-                      const first = t.comments[0];
-                      if (typeof first?.databaseId !== "number") return;
-                      const body = await askText({ title: `Reply on ${t.path}${t.line ? `:${t.line}` : ""}`, confirmLabel: "Reply", input: { label: "Reply" } });
-                      if (!body?.trim()) return;
-                      await act("Reply", () => api.prReply(root, d.number, first.databaseId as number, body));
-                    }}
-                  />
-                )}
+                {(tab === "overview" || tab === "conversation") ? (
+                  <div className="flex gap-4 items-start mx-auto" style={{ maxWidth: 1180 }}>
+                    <div className="min-w-0 flex-1">
+                      {tab === "overview" ? (
+                        <Overview
+                          d={d} busy={busy} openThreads={openThreads.length}
+                          conversationCount={d.comments.length + d.reviews.length + d.threads.length}
+                          onEditBody={doEditBody}
+                          onLocalReview={doLocalReview} onMerge={doMerge} onClose={doClose}
+                          onUpdateBranch={() => act("Update branch", () => api.prUpdateBranch(root, d.number))}
+                          onRerun={() => act("Re-run checks", () => api.prRerun(root, d.number))}
+                          onAutoMerge={() => act("Auto-merge", () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }))}
+                          onCancelAutoMerge={() => act("Auto-merge cancelled", () => api.prMerge(root, d.number, "squash", { disableAuto: true }))}
+                          onDraft={() => act(d.isDraft ? "Mark ready" : "Convert to draft", () => api.prDraft(root, d.number, !d.isDraft))}
+                          onGoThreads={() => setTab("conversation")}
+                        />
+                      ) : (
+                        <Conversation
+                          d={d} lanes={lanes} raw={rawBots} onRaw={setRawBots} busy={busy} onComment={doComment}
+                          onResolve={(t) => act(t.isResolved ? "Unresolve" : "Resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
+                          onReply={doReply}
+                          onReact={doReact}
+                        />
+                      )}
+                    </div>
+                    <PrSidebar d={d} onLabels={doLabels} onReviewers={doReviewers} onAssignees={doAssignees} onMilestone={doMilestone} />
+                  </div>
+                ) : null}
 
                 {tab === "commits" && (
-                  <div className="text-[11px]">
-                    {d.commits.map((c) => (
-                      <div key={c.oid}>
-                        <button onClick={() => openCommit(selCommit === c.oid ? "" : c.oid)}
-                          className="w-full text-left flex items-center gap-2 py-1.5 border-b"
-                          style={{
-                            borderColor: "color-mix(in srgb, var(--border) 18%, transparent)",
-                            opacity: c.isMerge ? 0.55 : 1,
-                            background: selCommit === c.oid ? "color-mix(in srgb, var(--primary) 10%, transparent)" : "transparent",
-                          }}>
-                          <span className="shrink-0" style={{ color: "var(--text3)" }}>{selCommit === c.oid ? "▾" : "▸"}</span>
-                          <span className="tabular-nums shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.short}</span>
-                          <span className="truncate" style={{ color: "var(--text2)" }}>{c.message}</span>
-                          {c.isMerge && <Chip text="merge" tint="var(--text3)" title="Trunk catch-up, not work to review" />}
-                          <span className="ml-auto shrink-0 flex items-center gap-1.5 text-[10px]" style={{ color: "var(--text3)" }}>
-                            <Avatar login={c.author} size={14} />{c.author}
-                          </span>
-                        </button>
-                        {selCommit === c.oid && (
-                          <div className="my-2">
-                            {commitBusy ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>Loading the diff…</div>
-                              : commitFiles.length === 0 ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>This commit changed nothing textual</div>
-                              : <FileStack files={commitFiles} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap} />}
-                          </div>
-                        )}
+                  <div className="text-[11px] flex flex-col gap-2">
+                    {groupCommitsByDay(d.commits).map(([day, list]) => (
+                      <div key={day}>
+                        {/* Grouped by the day they landed, as GitHub does — a
+                            long branch reads as a history rather than a list. */}
+                        <div className="text-[10px] uppercase tracking-wider mb-1 pl-1" style={{ color: "var(--text3)" }}>{day}</div>
+                        <div className="rounded-lg overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 24%, transparent)" }}>
+                          {list.map((c, i) => (
+                            <div key={c.oid} style={i ? { borderTop: "1px solid color-mix(in srgb, var(--border) 16%, transparent)" } : undefined}>
+                              <button onClick={() => openCommit(selCommit === c.oid ? "" : c.oid)}
+                                className="agx-btn w-full text-left flex items-center gap-2 px-2.5 py-2"
+                                style={{
+                                  opacity: c.isMerge ? 0.6 : 1,
+                                  background: selCommit === c.oid ? "color-mix(in srgb, var(--primary) 10%, transparent)" : "transparent",
+                                }}>
+                                <span className="shrink-0 text-[9px]" style={{ color: "var(--text3)" }}>{selCommit === c.oid ? "▾" : "▸"}</span>
+                                <span className="min-w-0 flex-1">
+                                  {/* Subject only, in full. The rest of the
+                                      message is behind the `…` button, exactly
+                                      as GitHub does it: a long body should not
+                                      push every other commit off the screen. */}
+                                  <span className="block" style={{ color: "var(--text)" }}>
+                                    {c.message}
+                                    {c.body?.trim() && (
+                                      <button
+                                        onClick={(ev) => { ev.stopPropagation(); toggleMsg(c.oid); }}
+                                        title={openMsgs.has(c.oid) ? "Hide the full message" : "Show the full commit message"}
+                                        aria-expanded={openMsgs.has(c.oid)}
+                                        className="agx-btn ml-1.5 align-middle text-[10px] px-1.5 rounded leading-none"
+                                        style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)" }}>…</button>
+                                    )}
+                                  </span>
+                                  {c.body?.trim() && openMsgs.has(c.oid) && (
+                                    <span className="block mt-1.5 px-2 py-1.5 rounded text-[10.5px] whitespace-pre-wrap"
+                                      style={{ ...CODE_FONT_STYLE, color: "var(--text2)", background: "color-mix(in srgb, var(--border) 14%, transparent)" }}>{c.body.trim()}</span>
+                                  )}
+                                  <span className="flex items-center gap-1.5 mt-0.5 text-[10px]" style={{ color: "var(--text3)" }}>
+                                    {/* Everyone credited. A commit written with an
+                                        agent says so here, exactly like GitHub. */}
+                                    {(c.authors?.length ? c.authors : [c.author]).slice(0, 3).map((a) => (
+                                      <Avatar key={a} login={a} size={14} />
+                                    ))}
+                                    <span className="truncate">{commitAuthorLine(c)}</span>
+                                    {c.committedAt && <span>· {ago(c.committedAt)}</span>}
+                                  </span>
+                                </span>
+                                {c.isMerge && <Chip text="merge" tint="var(--text3)" title="Trunk catch-up, not work to review" />}
+                                {c.verified && <Chip text="verified" tint="var(--success)" title="Signature verified by GitHub" />}
+                                {c.checks && (
+                                  <span className="shrink-0 text-[11px]" title={`Checks on this commit: ${c.checks.toLowerCase()}`}
+                                    style={{ color: c.checks === "SUCCESS" ? "var(--success)" : c.checks === "FAILURE" || c.checks === "ERROR" ? "var(--error)" : "var(--warning)" }}>
+                                    {c.checks === "SUCCESS" ? "✓" : c.checks === "FAILURE" || c.checks === "ERROR" ? "✕" : "•"}
+                                  </span>
+                                )}
+                                <span className="tabular-nums shrink-0 px-1.5 py-0.5 rounded" style={{ ...CODE_FONT_STYLE, fontSize: "10px", color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 12%, transparent)" }}>{c.short}</span>
+                              </button>
+                              {selCommit === c.oid && (
+                                <div className="my-2">
+                                  {commitBusy ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>Loading the diff…</div>
+                                    : commitFiles.length === 0 ? <div className="text-[10.5px] p-2" style={{ color: "var(--text3)" }}>This commit changed nothing textual</div>
+                                    : <FileStack files={commitFiles} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap} />}
+                                </div>
+                              )}
+                            </div>
+                          ))}
+                        </div>
                       </div>
                     ))}
+                    {d.truncated?.commits && (
+                      <div className="text-[10px] px-1" style={{ color: "var(--warning)" }}>
+                        Showing the most recent {d.truncated.commits} commits — GitHub caps a page at that.
+                      </div>
+                    )}
                   </div>
                 )}
 
@@ -1120,6 +1368,8 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                     d={d} byPath={byPath} loaded={!!diff} seenFiles={seenFiles} onSeen={toggleSeen}
                     sel={selFile} onSel={setSelFile} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap}
                     drafts={myDrafts} onAddDraft={addDraft}
+                    busy={busy} onReply={doReply}
+                    onResolve={(t) => act(t.isResolved ? "Unresolve" : "Resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
                   />
                 )}
 
@@ -1152,6 +1402,13 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 // overview
 // ---------------------------------------------------------------------------
 
+export type MergeMethod = "squash" | "merge" | "rebase";
+const MERGE_LABEL: Record<MergeMethod, string> = {
+  squash: "Squash & merge",
+  merge: "Merge commit",
+  rebase: "Rebase & merge",
+};
+
 const MERGE_WHY: Record<string, string> = {
   BLOCKED: "A required review or check has not passed",
   BEHIND: "The base branch has moved — update the branch first",
@@ -1162,13 +1419,14 @@ const MERGE_WHY: Record<string, string> = {
   UNKNOWN: "GitHub has not finished working it out",
 };
 
-function Overview({ d, busy, openThreads, conversationCount, onLocalReview, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onDraft, onGoThreads, onEditBody }: {
+function Overview({ d, busy, openThreads, conversationCount, onLocalReview, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onCancelAutoMerge, onDraft, onGoThreads, onEditBody }: {
   d: PrDetail; busy: boolean; openThreads: number; conversationCount: number;
-  onLocalReview: () => void; onMerge: () => void; onClose: () => void; onUpdateBranch: () => void;
-  onRerun: () => void; onAutoMerge: () => void; onDraft: () => void; onGoThreads: () => void;
+  onLocalReview: () => void; onMerge: (method: MergeMethod) => void; onClose: () => void; onUpdateBranch: () => void;
+  onRerun: () => void; onAutoMerge: () => void; onCancelAutoMerge: () => void; onDraft: () => void; onGoThreads: () => void;
   onEditBody: (body: string) => Promise<boolean>;
 }) {
   const c = d.checks;
+  const [mergeMethod, setMergeMethod] = useState<MergeMethod>("squash");
   const canMerge = d.mergeState === "CLEAN";
 
   return (
@@ -1179,7 +1437,37 @@ function Overview({ d, busy, openThreads, conversationCount, onLocalReview, onMe
         </div>
       )}
 
-      {/* merge, and why not */}
+      {/* Merged and closed pull requests are history: there is nothing to merge,
+          no branch to update, and no draft to go back to. Offering those buttons
+          was not just clutter, it was a lie — "Merging is blocked, GitHub has
+          not finished working it out" on a pull request that merged an hour ago.
+          What is left is what GitHub leaves: what happened, and reopen. */}
+      {d.state !== "OPEN" ? (
+        <section className="rounded-lg overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+          <div className="flex gap-2.5 items-start p-3">
+            <span className="shrink-0 rounded-full flex items-center justify-center text-[13px]"
+              style={{ width: 26, height: 26, background: d.state === "MERGED" ? "var(--primary)" : "color-mix(in srgb, var(--text3) 60%, transparent)", color: "var(--bg)" }}>
+              {d.state === "MERGED" ? "⏣" : "⊘"}
+            </span>
+            <span className="min-w-0">
+              <span className="block text-[13px] font-semibold leading-tight" style={{ color: "var(--text)" }}>
+                {d.state === "MERGED" ? "Merged" : "Closed without merging"}
+              </span>
+              <span className="block text-[11px] mt-0.5" style={{ color: "var(--text3)" }}>
+                {d.state === "MERGED"
+                  ? `${d.mergedBy ? `${d.mergedBy} merged ` : "Merged "}into ${d.baseRefName}${d.mergedAt ? ` ${ago(d.mergedAt)}` : ""}`
+                  : `This branch was never merged into ${d.baseRefName}${d.closedAt ? ` · closed ${ago(d.closedAt)}` : ""}`}
+              </span>
+            </span>
+          </div>
+          <div className="flex items-center gap-1.5 flex-wrap px-3 py-2.5"
+            style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
+            {d.state === "CLOSED" && <Btn onClick={onClose} disabled={busy} title="Put it back to open, with its comments and reviews intact">↺ Reopen</Btn>}
+            <a href={externalUrl(d.url)} target="_blank" rel="noreferrer noopener" className="text-[10.5px] px-2.5 py-1 rounded"
+              style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>Open on GitHub ↗</a>
+          </div>
+        </section>
+      ) : (
       <section className="rounded-lg overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 38%, transparent)" }}>
         <div className="flex gap-2.5 items-start p-3">
           <span className="shrink-0 rounded-full flex items-center justify-center text-[13px]"
@@ -1215,8 +1503,35 @@ function Overview({ d, busy, openThreads, conversationCount, onLocalReview, onMe
 
         <div className="flex items-center gap-1.5 flex-wrap px-3 py-2.5"
           style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
-          <Btn onClick={onMerge} disabled={busy || !canMerge} primary title={canMerge ? "Squash, merge and delete the branch" : MERGE_WHY[d.mergeState]}>Squash &amp; merge</Btn>
-          <Btn onClick={onAutoMerge} disabled={busy} title="Merge automatically once everything passes">Merge when green</Btn>
+          {/* All three methods GitHub offers, not just squash. Which one a repo
+              wants is a real decision — a release branch is merged, a tidy
+              feature is squashed — and hard-coding squash made the other two
+              unreachable even though the server supported them all along. */}
+          <span className="flex items-center rounded overflow-hidden shrink-0" style={{ border: "1px solid var(--primary)" }}>
+            <button onClick={() => onMerge(mergeMethod)} disabled={busy || !canMerge}
+              title={canMerge ? `${MERGE_LABEL[mergeMethod]} and delete the branch` : MERGE_WHY[d.mergeState]}
+              className="agx-btn text-[10.5px] px-2.5 py-1 disabled:opacity-40"
+              style={{ background: "var(--primary)", color: "var(--bg)", fontWeight: 500 }}>
+              {MERGE_LABEL[mergeMethod]}
+            </button>
+            <Select
+              value={mergeMethod}
+              onChange={(v: string) => setMergeMethod(v as MergeMethod)}
+              options={[
+                { value: "squash", label: "Squash and merge", hint: "one commit" },
+                { value: "merge", label: "Create a merge commit", hint: "keeps every commit" },
+                { value: "rebase", label: "Rebase and merge", hint: "no merge commit" },
+              ]}
+              title="Merge method"
+              align="right"
+              className="text-[10.5px] px-1.5 py-1 outline-none"
+              style={{ background: "var(--primary)", color: "var(--bg)", borderLeft: "1px solid color-mix(in srgb, var(--bg) 35%, transparent)" }}
+              placeholder=""
+            />
+          </span>
+          {d.autoMerge
+            ? <Btn onClick={onCancelAutoMerge} disabled={busy} warn title={`Armed by ${d.autoMerge.enabledBy}`}>Cancel auto-merge</Btn>
+            : <Btn onClick={onAutoMerge} disabled={busy} title="Merge automatically once everything passes">Merge when green</Btn>}
           <Btn onClick={onUpdateBranch} disabled={busy} warn title="Merge the base branch into this one — this updates the branch on GitHub">↻ Update branch</Btn>
           {c.failure > 0 && <Btn onClick={onRerun} disabled={busy}>Re-run failed</Btn>}
           <span className="ml-auto flex gap-1.5">
@@ -1225,6 +1540,7 @@ function Overview({ d, busy, openThreads, conversationCount, onLocalReview, onMe
           </span>
         </div>
       </section>
+      )}
 
       <Description d={d} busy={busy} onSave={onEditBody} />
 
@@ -1390,20 +1706,124 @@ function Field({ label, children }: { label: string; children: React.ReactNode }
  * moment you opened Files you no longer knew whose pull request you were
  * reading or what branch it targeted.
  */
+/**
+ * The right-hand column, as GitHub has it.
+ *
+ * Two things at once. It carries the metadata that had nowhere to live —
+ * reviewers, assignees, labels, milestone, the issues this closes, who is
+ * taking part — and it occupies the space to the right of the prose, which is
+ * the reason the reading column can be a fixed, comfortable width instead of
+ * stretching to the window and leaving half the panel empty.
+ */
+function SidebarSection({ title, onEdit, children }: { title: string; onEdit?: () => void; children: React.ReactNode }) {
+  return (
+    <div className="py-2.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
+      <div className="flex items-center gap-2 mb-1.5">
+        <span className="text-[9.5px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>{title}</span>
+        {onEdit && (
+          <button onClick={onEdit} title={`Edit ${title.toLowerCase()}`} aria-label={`Edit ${title.toLowerCase()}`}
+            className="agx-btn ml-auto text-[10px] px-1 rounded hover:bg-white/5" style={{ color: "var(--text3)" }}>✎</button>
+        )}
+      </div>
+      {children}
+    </div>
+  );
+}
+
+function SidebarPeople({ logins, empty }: { logins: string[]; empty: string }) {
+  if (!logins.length) return <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>{empty}</span>;
+  return (
+    <div className="flex flex-col gap-1">
+      {logins.map((l) => (
+        <span key={l} className="flex items-center gap-1.5 text-[11px]" style={{ color: "var(--text2)" }}>
+          <Avatar login={l} size={16} />{l}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function PrSidebar({ d, onLabels, onReviewers, onAssignees, onMilestone }: {
+  d: PrDetail;
+  onLabels: () => void; onReviewers: () => void; onAssignees: () => void; onMilestone: () => void;
+}) {
+  return (
+    <aside className="shrink-0 w-[210px] pl-4 hidden lg:block" style={{ borderLeft: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
+      <SidebarSection title="Reviewers" onEdit={onReviewers}>
+        <SidebarPeople logins={d.reviewers} empty="No reviewers" />
+      </SidebarSection>
+      <SidebarSection title="Assignees" onEdit={onAssignees}>
+        <SidebarPeople logins={d.assignees} empty="No one assigned" />
+      </SidebarSection>
+      <SidebarSection title="Labels" onEdit={onLabels}>
+        {d.labels.length
+          ? <div className="flex flex-wrap gap-1">{d.labels.map((l) => <Chip key={l.name} text={l.name} tint={l.color ? `#${l.color}` : "var(--primary)"} />)}</div>
+          : <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>None yet</span>}
+      </SidebarSection>
+      <SidebarSection title="Milestone" onEdit={onMilestone}>
+        <span className="text-[11px]" style={{ color: d.milestone ? "var(--text2)" : "var(--text3)" }}>{d.milestone || "No milestone"}</span>
+      </SidebarSection>
+      {d.linkedIssues.length > 0 && (
+        <SidebarSection title="Development">
+          <div className="flex flex-col gap-1">
+            <span className="text-[10px]" style={{ color: "var(--text3)" }}>Merging this closes:</span>
+            {d.linkedIssues.map((i) => (
+              <a key={i.number} href={externalUrl(i.url)} target="_blank" rel="noreferrer noopener"
+                className="text-[11px] truncate" style={{ color: "var(--primary)" }} title={i.title}>#{i.number} {i.title}</a>
+            ))}
+          </div>
+        </SidebarSection>
+      )}
+      {d.participants.length > 0 && (
+        <SidebarSection title={`${d.participants.length} participant${d.participants.length === 1 ? "" : "s"}`}>
+          <div className="flex flex-wrap gap-1">
+            {d.participants.map((p) => <span key={p} title={p}><Avatar login={p} size={20} /></span>)}
+          </div>
+        </SidebarSection>
+      )}
+      {d.autoMerge && (
+        <SidebarSection title="Auto-merge">
+          <span className="text-[10.5px]" style={{ color: "var(--warning)" }}>
+            Armed by {d.autoMerge.enabledBy} ({d.autoMerge.method.toLowerCase()})
+          </span>
+        </SidebarSection>
+      )}
+    </aside>
+  );
+}
+
+/**
+ * How a pull request's own state looks: colour, word and glyph.
+ *
+ * Merged is purple, closed is grey, draft is grey, open is green — GitHub's
+ * palette, because everyone already reads it. A closed pull request wearing the
+ * green of a passing build (which is what tinting by check verdict did) says
+ * exactly the wrong thing.
+ */
+function prStateBadge(d: { state: PrSummary["state"]; isDraft: boolean }): { tint: string; state: string; glyph: string } {
+  if (d.state === "MERGED") return { tint: "var(--primary)", state: "Merged", glyph: "⏣" };
+  if (d.state === "CLOSED") return { tint: "var(--text3)", state: "Closed", glyph: "⊘" };
+  if (d.isDraft) return { tint: "var(--text3)", state: "Draft", glyph: "◌" };
+  return { tint: "var(--success)", state: "Open", glyph: "◉" };
+}
+
 function Masthead({ d, busy, onEditTitle, onDraft, onClose, onLocalReview, onLabels, onReviewers, onCopyLink }: {
   d: PrDetail; busy: boolean;
   onEditTitle: () => void; onDraft: () => void; onClose: () => void; onLocalReview: () => void;
   onLabels: () => void; onReviewers: () => void; onCopyLink: () => void;
 }) {
-  const tint = stateTint(d);
-  const state = d.state === "MERGED" ? "Merged" : d.state === "CLOSED" ? "Closed" : d.isDraft ? "Draft" : "Open";
+  // The PR's own state, which is not the same thing as its check verdict —
+  // colouring a merged pull request by whether CI went green says nothing about
+  // it being merged. GitHub's palette: open green, merged purple, closed grey,
+  // draft grey; each with its own glyph so the state reads without the word.
+  const { tint, state, glyph } = prStateBadge(d);
   return (
     <div className="px-3 pt-2.5 pb-2 shrink-0" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
       <div className="flex items-start gap-2">
         <div className="min-w-0 flex-1">
-          <span className="text-[9.5px] px-1.5 py-0.5 rounded-full align-middle"
+          <span className="text-[9.5px] px-1.5 py-0.5 rounded-full align-middle inline-flex items-center gap-1"
             style={{ color: tint, border: `1px solid color-mix(in srgb, ${tint} 45%, transparent)`, background: `color-mix(in srgb, ${tint} 12%, transparent)` }}>
-            ● {state}
+            <span aria-hidden>{glyph}</span>{state}
           </span>
           <span className="text-[14px] leading-snug ml-2" style={{ color: "var(--text)" }}>
             <span className="tabular-nums mr-1.5" style={{ color: "var(--text3)" }}>#{d.number}</span>{d.title}
@@ -1413,15 +1833,24 @@ function Masthead({ d, busy, onEditTitle, onDraft, onClose, onLocalReview, onLab
           {(close) => (
             <>
               <MenuItem onClick={() => { close(); onEditTitle(); }}>✎ Edit title</MenuItem>
-              <MenuItem onClick={() => { close(); onReviewers(); }}>◍ Request a review</MenuItem>
+              {/* Requesting a review or flipping the draft flag are things you do
+                  to a pull request that is still going. On a merged one GitHub
+                  does not offer them either. */}
+              {d.state === "OPEN" && <>
+                <MenuItem onClick={() => { close(); onReviewers(); }}>◍ Request a review</MenuItem>
+                <MenuItem onClick={() => { close(); onDraft(); }}>◌ {d.isDraft ? "Mark ready for review" : "Convert to draft"}</MenuItem>
+              </>}
               <MenuItem onClick={() => { close(); onLabels(); }}>⌗ Edit labels</MenuItem>
-              <MenuItem onClick={() => { close(); onDraft(); }}>◌ {d.isDraft ? "Mark ready for review" : "Convert to draft"}</MenuItem>
               <MenuSep />
               <MenuItem onClick={() => { close(); onCopyLink(); }}>🔗 Copy link</MenuItem>
               <MenuItem onClick={() => { close(); openExternal(d.url); }}>↗ Open on GitHub</MenuItem>
               <MenuItem onClick={() => { close(); onLocalReview(); }}>✦ Review locally with Claude</MenuItem>
-              <MenuSep />
-              <MenuItem onClick={() => { close(); onClose(); }} danger>✕ {d.state === "CLOSED" ? "Reopen" : "Close"} pull request</MenuItem>
+              {d.state !== "MERGED" && <>
+                <MenuSep />
+                <MenuItem onClick={() => { close(); onClose(); }} danger={d.state !== "CLOSED"}>
+                  {d.state === "CLOSED" ? "↺ Reopen pull request" : "✕ Close pull request"}
+                </MenuItem>
+              </>}
             </>
           )}
         </Menu>
@@ -1547,15 +1976,121 @@ function LazyMount({ minHeight, children }: { minHeight: number; children: React
  *  not something anybody reads, and it should not be what the tab opens on. */
 const BIG_FILE_LINES = 600;
 
-function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wrap, onSplit, onWrap, drafts, onAddDraft }: {
+/** A directory node in the changed-files tree. */
+type TreeNode = { name: string; path: string; dirs: Map<string, TreeNode>; files: PrFile[] };
+
+/** Group changed paths into directories, then collapse the runs of single-child
+ *  directories the way GitHub does (`web/src/lib` on one row, not three). */
+function buildFileTree(files: PrFile[]): TreeNode {
+  const root: TreeNode = { name: "", path: "", dirs: new Map(), files: [] };
+  for (const f of files) {
+    const parts = f.path.split("/");
+    let node = root;
+    for (const dir of parts.slice(0, -1)) {
+      let next = node.dirs.get(dir);
+      if (!next) { next = { name: dir, path: node.path ? `${node.path}/${dir}` : dir, dirs: new Map(), files: [] }; node.dirs.set(dir, next); }
+      node = next;
+    }
+    node.files.push(f);
+  }
+  const squash = (n: TreeNode): TreeNode => {
+    let cur = n;
+    while (cur.files.length === 0 && cur.dirs.size === 1) {
+      const only = [...cur.dirs.values()][0]!;
+      cur = { ...only, name: `${cur.name}/${only.name}`.replace(/^\//, "") };
+    }
+    return { ...cur, dirs: new Map([...cur.dirs].map(([k, v]) => [k, squash(v)])) };
+  };
+  return { ...root, dirs: new Map([...root.dirs].map(([k, v]) => [k, squash(v)])) };
+}
+
+function FileTree({ node, sel, onPick, seen, drafts, depth = 0 }: {
+  node: TreeNode; sel: string | null; onPick: (p: string) => void;
+  seen: (p: string) => boolean; drafts: (p: string) => number; depth?: number;
+}) {
+  return (
+    <>
+      {[...node.dirs.values()].map((dir) => (
+        <div key={dir.path}>
+          <div className="truncate text-[10px] px-1 py-0.5" style={{ paddingLeft: 6 + depth * 10, color: "var(--text3)" }} title={dir.path}>
+            {dir.name}
+          </div>
+          <FileTree node={dir} sel={sel} onPick={onPick} seen={seen} drafts={drafts} depth={depth + 1} />
+        </div>
+      ))}
+      {node.files.map((f) => {
+        const base = f.path.split("/").pop() ?? f.path;
+        const on = sel === f.path;
+        const n = drafts(f.path);
+        return (
+          <button key={f.path} onClick={() => onPick(f.path)} title={f.path}
+            className="agx-btn w-full text-left flex items-center gap-1 py-0.5 rounded truncate hover:bg-white/5"
+            style={{
+              paddingLeft: 6 + depth * 10, paddingRight: 4,
+              background: on ? "color-mix(in srgb, var(--primary) 16%, transparent)" : undefined,
+              color: seen(f.path) ? "var(--text3)" : "var(--text2)",
+            }}>
+            <span className="truncate text-[10.5px]">{base}</span>
+            {n > 0 && <span className="ml-auto text-[9px] shrink-0" style={{ color: "var(--warning)" }}>{n}</span>}
+            {f.comments > 0 && <span className="ml-auto text-[9px] shrink-0" style={{ color: "var(--primary)" }}>{f.comments}</span>}
+            {seen(f.path) && <span className="ml-auto text-[9px] shrink-0" style={{ color: "var(--success)" }}>✓</span>}
+          </button>
+        );
+      })}
+    </>
+  );
+}
+
+function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wrap, onSplit, onWrap, drafts, onAddDraft, onResolve, onReply, busy }: {
   d: PrDetail; byPath: Map<string, FileChange>; loaded: boolean;
   seenFiles: string[]; onSeen: (p: string) => void;
   sel: string | null; onSel: (p: string | null) => void;
   split: boolean; wrap: boolean; onSplit: (v: boolean) => void; onWrap: (v: boolean) => void;
   drafts: DraftComment[]; onAddDraft: (path: string, line: number) => void;
+  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
 }) {
   const draftsFor = (p: string) => drafts.filter((x) => x.path === p).length;
+  /** Unresolved first: a resolved thread is history, an open one is a question. */
+  const threadsFor = (p: string) => d.threads.filter((t) => t.path === p)
+    .sort((a, b) => Number(a.isResolved) - Number(b.isResolved));
   const frameRef = useRef<HTMLDivElement>(null);
+  /**
+   * How tall the sticky toolbar is, right now.
+   *
+   * Anything scrolled to — a file picked in the tree, the next hunk, the next
+   * file under j/k — otherwise lands underneath it: `scrollIntoView` aligns to
+   * the top of the scroll box and knows nothing about a bar floating over that
+   * top. Measured rather than guessed, because the bar wraps to two rows on a
+   * narrow panel, and fed to `scroll-margin-top`, which is the property
+   * `scrollIntoView` actually honours.
+   */
+  const barRef = useRef<HTMLDivElement>(null);
+  const [barH, setBarH] = useState(76);
+  useEffect(() => {
+    const el = barRef.current;
+    if (!el) return;
+    const measure = () => setBarH(el.offsetHeight + 10);
+    measure();
+    const ro = new ResizeObserver(measure);
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+  /**
+   * Scroll a file (or any element) to just under the sticky bar.
+   *
+   * `scrollIntoView` aligns to the top of the scrollport, and the bar floats
+   * over that top, so the thing you asked for lands behind it. `scroll-margin`
+   * is the documented cure and did not take here, so this does the arithmetic
+   * itself against the real scroll container: where the element sits inside it,
+   * minus the bar's measured height.
+   */
+  const scrollUnderBar = (el: Element | null | undefined) => {
+    if (!el) return;
+    const sc = el.closest<HTMLElement>(".agx-scroll");
+    if (!sc) { el.scrollIntoView({ block: "start" }); return; }
+    const top = el.getBoundingClientRect().top - sc.getBoundingClientRect().top + sc.scrollTop;
+    sc.scrollTo({ top: Math.max(0, top - (barRef.current?.offsetHeight ?? 76) - 8), behavior: "smooth" });
+  };
   const [q, setQ] = useState("");
   // Folded, not opened: every file is open by default and this records the ones
   // you have put away. Seeded with the files too big to be a sensible default.
@@ -1586,19 +2121,29 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
     if (!files.length) return;
     const i = stepFileIndex(files.length, files.findIndex((f) => f.path === sel), dir);
     onSel(files[i].path);
-    requestAnimationFrame(() => frameRef.current?.querySelector('[data-file="active"]')?.scrollIntoView({ block: "nearest" }));
+    requestAnimationFrame(() => scrollUnderBar(frameRef.current?.querySelector('[data-file="active"]')));
   };
   const jumpHunk = (dir: 1 | -1) => {
     const frame = frameRef.current;
     if (!frame) return;
-    const sc = (frame.querySelector("[data-vscroll]") as HTMLElement | null) ?? frame;
+    // The page's scroller, the same one scrollUnderBar uses. It used to look for
+    // `[data-vscroll]`, the per-file inner scroller — which no longer exists now
+    // that files scroll with the page, so every jump was measured against the
+    // wrong box.
+    const sc = frame.closest<HTMLElement>(".agx-scroll") ?? frame;
     const heads = Array.from(sc.querySelectorAll<HTMLElement>("[data-hunk]"));
     if (!heads.length) return;
     const scTop = sc.getBoundingClientRect().top;
     const cur = sc.scrollTop;
     const tops = heads.map((h) => h.getBoundingClientRect().top - scTop + cur);
-    const target = dir === 1 ? tops.find((t) => t > cur + 4) : [...tops].reverse().find((t) => t < cur - 4);
-    sc.scrollTo({ top: (target ?? (dir === 1 ? tops[tops.length - 1] : tops[0])) - 2, behavior: "smooth" });
+    // Compare against the first line the reader can actually see, not the raw
+    // scrollTop: the sticky bar covers `barH` of it, so a hunk sitting under
+    // the bar counts as already passed and "next" would skip the one you are
+    // looking for. The same offset comes back off the destination, which is
+    // why this cannot use scroll-margin like the others do.
+    const eye = cur + barH;
+    const target = dir === 1 ? tops.find((t) => t > eye + 4) : [...tops].reverse().find((t) => t < eye - 4);
+    sc.scrollTo({ top: Math.max(0, (target ?? (dir === 1 ? tops[tops.length - 1] : tops[0])) - barH - 2), behavior: "smooth" });
   };
   const onKey = (e: React.KeyboardEvent) => {
     // Never while a field owns the keys — the PR search box, a comment textarea,
@@ -1621,8 +2166,9 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
     <div ref={frameRef} tabIndex={-1} onKeyDown={onKey} className="text-[11px] flex flex-col gap-2 outline-none">
       {/* One bar, and it stays put: filter, view mode, progress. Everything that
           used to be repeated on each file's own toolbar lives here once. */}
-      <div className="flex items-center gap-2 flex-wrap sticky top-0 z-20 py-1.5 px-1 -mx-1 rounded"
+      <div ref={barRef} className="flex flex-col gap-1 sticky top-0 z-30 py-1.5 px-1 -mx-1 rounded"
         style={{ background: "var(--bg)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
+      <div className="flex items-center gap-2 flex-wrap">
         <span className="flex items-center gap-1.5 px-2 py-1 rounded shrink-0"
           style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
           <span style={{ color: "var(--text3)" }}>⌕</span>
@@ -1643,15 +2189,38 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
           <Bar parts={[{ pct: d.files.length ? (seenFiles.length / d.files.length) * 100 : 0, tint: seenFiles.length === d.files.length ? "var(--success)" : "var(--primary)" }]} />
         </span>
       </div>
-
       <div className="text-[10px] px-1" style={{ color: "var(--text3)" }}>
         <b>j/k</b> file · <b>n/p</b> hunk · <b>x</b> viewed · <b>↵</b> fold
         {q && <span> · showing {shownFiles.length} of {d.files.length}</span>}
       </div>
+      </div>
 
+      {/* Tree on the left, diffs on the right — the arrangement GitHub uses, and
+          the only way to keep your bearings in a change that touches thirty
+          files. The tree is the navigator; the stack is still the reading. */}
+      <div className="flex gap-3 items-start">
+        {shownFiles.length > 4 && (
+          <aside className="shrink-0 w-[190px] sticky top-[68px] z-10 max-h-[calc(100vh-160px)] overflow-y-auto agx-scroll hidden md:block pr-1"
+            style={{ borderRight: "1px solid color-mix(in srgb, var(--border) 20%, transparent)" }}>
+            <FileTree
+              node={buildFileTree(shownFiles)} sel={sel}
+              onPick={(path) => { onSel(path); setFolded((cur) => { const n = new Set(cur); n.delete(path); return n; }); requestAnimationFrame(() => scrollUnderBar(frameRef.current?.querySelector(`[data-path="${CSS.escape(path)}"]`))); }}
+              seen={(path) => seenFiles.includes(path)}
+              drafts={draftsFor}
+            />
+          </aside>
+        )}
+        <div className="min-w-0 flex-1 flex flex-col gap-2">
       {shownFiles.length === 0 && (
         <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No file matches “{q}”.</div>
       )}
+      {/* A file list that quietly disagreed with the header count is how nobody
+          noticed the hundred-and-first file was missing. Say it. */}
+      {d.truncated?.files ? (
+        <div className="text-[10px] px-1 py-1" style={{ color: "var(--warning)" }}>
+          {d.truncated.files} more file{d.truncated.files === 1 ? "" : "s"} changed than GitHub will return on one page — open it on GitHub to see the rest.
+        </div>
+      ) : null}
 
       {shownFiles.map((f) => {
         const done = seenFiles.includes(f.path);
@@ -1660,7 +2229,7 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
         const nd = draftsFor(f.path);
         const change = byPath.get(f.path);
         return (
-          <div key={f.path} data-file={focused ? "active" : undefined} className="rounded overflow-hidden"
+          <div key={f.path} data-file={focused ? "active" : undefined} data-path={f.path} className="rounded overflow-hidden"
             style={{
               border: `1px solid color-mix(in srgb, ${focused ? "var(--primary) 45%" : "var(--border) 30%"}, transparent)`,
               opacity: done && !open ? 0.72 : 1,
@@ -1687,16 +2256,33 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
             </div>
             {open && (
               <LazyMount minHeight={Math.min(320, 40 + (f.additions + f.deletions) * 18)}>
-                <div className="flex" style={{ maxHeight: 560, overflow: "auto" }}>
+                {/* No inner scroller: a scroll box inside the page scroll is
+                    how a click in the tree lands on a file you then cannot
+                    scroll, and it is not what GitHub does. Long files are
+                    folded by default instead, which is the honest cap. */}
+                <div className="flex" style={{ overflowX: "auto" }}>
                   {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>Loading the diff…</div>
                     : change ? <DiffPane file={change} split={split} wrap={wrap} onComment={(line) => onAddDraft(f.path, line)} />
                     : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
                 </div>
               </LazyMount>
             )}
+            {/* The conversation about THIS file, under it. The count in the
+                header said threads existed but you had to leave for the
+                conversation tab to read them, which is the wrong way round
+                while you are looking at the code they are about. */}
+            {open && threadsFor(f.path).length > 0 && (
+              <div className="px-2.5 py-2 flex flex-col gap-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 6%, transparent)" }}>
+                {threadsFor(f.path).map((t) => (
+                  <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} busy={busy} />
+                ))}
+              </div>
+            )}
           </div>
         );
       })}
+        </div>
+      </div>
     </div>
   );
 }
@@ -1729,8 +2315,88 @@ function Lane({ label, extra }: { label: string; extra?: string }) {
   );
 }
 
-function Card({ who, chip, when, tone, url, children }: {
-  who: string; chip?: React.ReactNode; when?: string; tone?: "chg" | "appr" | "bot"; url?: string; children: React.ReactNode;
+/** The eight GitHub allows, with the glyph each one renders as. */
+const REACTION_EMOJI: { content: string; glyph: string; title: string }[] = [
+  { content: "THUMBS_UP", glyph: "👍", title: "Like" },
+  { content: "THUMBS_DOWN", glyph: "👎", title: "Dislike" },
+  { content: "LAUGH", glyph: "😄", title: "Laugh" },
+  { content: "HOORAY", glyph: "🎉", title: "Hooray" },
+  { content: "CONFUSED", glyph: "😕", title: "Confused" },
+  { content: "HEART", glyph: "❤️", title: "Heart" },
+  { content: "ROCKET", glyph: "🚀", title: "Rocket" },
+  { content: "EYES", glyph: "👀", title: "Eyes" },
+];
+
+/**
+ * Emoji on a comment, as GitHub has them: the ones already pressed are shown
+ * with their tally, and a `+` opens the rest. Acknowledging with a reaction is
+ * how a thread stays short — the alternative is another comment saying "agreed".
+ */
+function Reactions({ nodeId, reactions, onReact }: {
+  nodeId?: string; reactions?: PrReaction[]; onReact?: (nodeId: string, content: string, on: boolean) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const has = reactions ?? [];
+  if (!onReact || !nodeId) {
+    if (!has.length) return null;
+    return (
+      <div className="flex gap-1 flex-wrap mt-2">
+        {has.map((r) => <span key={r.content} className="text-[10px] px-1.5 py-0.5 rounded-full" style={{ border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text2)" }}>{REACTION_EMOJI.find((e) => e.content === r.content)?.glyph ?? "•"} {r.count}</span>)}
+      </div>
+    );
+  }
+  return (
+    <div className="flex gap-1 flex-wrap items-center mt-2">
+      {has.map((r) => {
+        const e = REACTION_EMOJI.find((x) => x.content === r.content);
+        return (
+          <button key={r.content} onClick={() => onReact(nodeId, r.content, !r.viewerHasReacted)}
+            title={r.viewerHasReacted ? "Remove your reaction" : e?.title}
+            className="agx-btn text-[10px] px-1.5 py-0.5 rounded-full tabular-nums"
+            style={{
+              border: `1px solid ${r.viewerHasReacted ? "var(--primary)" : "color-mix(in srgb, var(--border) 45%, transparent)"}`,
+              background: r.viewerHasReacted ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent",
+              color: r.viewerHasReacted ? "var(--primary-hover)" : "var(--text2)",
+            }}>
+            {e?.glyph ?? "•"} {r.count}
+          </button>
+        );
+      })}
+      <div className="relative">
+        <button onClick={() => setOpen((v) => !v)} title="Add a reaction" aria-label="Add a reaction"
+          className="agx-btn text-[10px] px-1.5 py-0.5 rounded-full"
+          style={{ border: "1px dashed color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}>☺ +</button>
+        {open && (
+          <div className="absolute z-20 mt-1 flex gap-0.5 p-1 rounded-lg"
+            style={{ background: "color-mix(in srgb, var(--bg2) 97%, black)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 12px 30px -14px rgba(0,0,0,.7)" }}>
+            {REACTION_EMOJI.map((e) => {
+              const mine = has.find((r) => r.content === e.content)?.viewerHasReacted ?? false;
+              return (
+                <button key={e.content} title={e.title}
+                  onClick={() => { onReact(nodeId, e.content, !mine); setOpen(false); }}
+                  className="agx-btn text-[13px] px-1 rounded hover:bg-white/10">{e.glyph}</button>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** OWNER / MEMBER / CONTRIBUTOR — how much weight a remark carries, at a glance. */
+function AssocChip({ a }: { a?: PrAuthorAssociation }) {
+  if (!a || a === "NONE" || a === "MANNEQUIN") return null;
+  const label = a === "FIRST_TIME_CONTRIBUTOR" || a === "FIRST_TIMER" ? "first-time" : a.toLowerCase();
+  const tint = a === "OWNER" || a === "MEMBER" ? "var(--primary)" : "var(--text3)";
+  return <Chip text={label} tint={tint} title={`GitHub says this author is ${label}`} />;
+}
+
+function Card({ who, chip, when, tone, url, edited, assoc, nodeId, reactions, onReact, children }: {
+  who: string; chip?: React.ReactNode; when?: string; tone?: "chg" | "appr" | "bot"; url?: string;
+  edited?: string | null; assoc?: PrAuthorAssociation;
+  nodeId?: string; reactions?: PrReaction[]; onReact?: (nodeId: string, content: string, on: boolean) => void;
+  children: React.ReactNode;
 }) {
   const edge = tone === "chg" ? "var(--error)" : tone === "appr" ? "var(--success)" : tone === "bot" ? "var(--info)" : "var(--border)";
   return (
@@ -1740,13 +2406,20 @@ function Card({ who, chip, when, tone, url, children }: {
         style={{ background: `color-mix(in srgb, ${edge} ${tone ? 10 : 14}%, transparent)`, borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
         <Avatar login={who} size={17} />
         <b style={{ color: "var(--text)", fontWeight: 500 }}>{who}</b>
+        <AssocChip a={assoc} />
         {chip}
         <span className="ml-auto flex items-center gap-1.5 shrink-0">
           {when && <span className="text-[10px]" style={{ color: "var(--text3)" }}>{when}</span>}
+          {/* GitHub says "edited" here, and it matters: the words you are
+              reading may not be the words that were replied to. */}
+          {edited && <span className="text-[10px]" title={`Edited ${ago(edited)}`} style={{ color: "var(--text3)" }}>· edited</span>}
           {url && <GhLink href={url} title="Open on GitHub" />}
         </span>
       </div>
-      <div className="px-3 py-2.5">{children}</div>
+      <div className="px-3 py-2.5">
+        {children}
+        <Reactions nodeId={nodeId} reactions={reactions} onReact={onReact} />
+      </div>
     </div>
   );
 }
@@ -1853,12 +2526,86 @@ function Thread({ t, onResolve, onReply, busy }: {
  * the threads submitted with it, because that grouping IS the meaning: a
  * "requested changes" is a verdict and the threads under it are the reasons.
  */
-function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, busy }: {
+/** "X and claude committed", or "X, Y and 2 others" — how GitHub credits a
+ *  commit that carries Co-authored-by trailers. */
+function commitAuthorLine(c: PrCommit): string {
+  const who = c.authors?.length ? c.authors : (c.author ? [c.author] : []);
+  if (who.length === 0) return "unknown";
+  if (who.length === 1) return `${who[0]} committed`;
+  if (who.length === 2) return `${who[0]} and ${who[1]} committed`;
+  return `${who[0]}, ${who[1]} and ${who.length - 2} other${who.length - 2 === 1 ? "" : "s"} committed`;
+}
+
+/** Commits under the day they landed, newest day last (the branch's own order). */
+function groupCommitsByDay(commits: PrCommit[]): [string, PrCommit[]][] {
+  const out: [string, PrCommit[]][] = [];
+  for (const c of commits) {
+    const day = c.committedAt
+      ? new Date(c.committedAt).toLocaleDateString(undefined, { month: "short", day: "numeric", year: "numeric" })
+      : "Undated";
+    const last = out[out.length - 1];
+    if (last && last[0] === day) last[1].push(c);
+    else out.push([day, [c]]);
+  }
+  return out;
+}
+
+const EVENT_GLYPH: Record<string, string> = {
+  "force-push": "↻", renamed: "✎", labeled: "🏷", unlabeled: "🏷",
+  assigned: "👤", unassigned: "👤", "review-requested": "👁", "review-request-removed": "👁",
+  "ready-for-review": "◉", "convert-to-draft": "◌", merged: "⏣", closed: "✕", reopened: "↺",
+  "cross-referenced": "🔗", milestoned: "◈", demilestoned: "◈", "head-ref-deleted": "⌫",
+  "auto-merge-enabled": "⏱", "auto-merge-disabled": "⏱",
+};
+const EVENT_TINT: Record<string, string> = {
+  "force-push": "var(--warning)", merged: "var(--primary)", closed: "var(--error)",
+  reopened: "var(--success)", "ready-for-review": "var(--success)",
+};
+
+/** One non-comment event, written the way GitHub words it. */
+function TimelineEvent({ e }: { e: PrEvent }) {
+  const who = <b style={{ color: "var(--text2)" }}>{e.actor || "somebody"}</b>;
+  const mono = (t: string) => <code style={{ ...CODE_FONT_STYLE, color: "var(--text2)" }}>{t}</code>;
+  const said = (() => {
+    switch (e.kind) {
+      case "force-push": return <>{who} force-pushed {e.detail ? mono(e.detail) : null}</>;
+      case "renamed": return <>{who} changed the title to “{e.detail}”</>;
+      case "labeled": return <>{who} added the <Chip text={e.detail || ""} tint={e.tint ? `#${e.tint}` : "var(--primary)"} /> label</>;
+      case "unlabeled": return <>{who} removed the <Chip text={e.detail || ""} tint="var(--text3)" /> label</>;
+      case "assigned": return <>{who} assigned <b style={{ color: "var(--text2)" }}>{e.detail}</b></>;
+      case "unassigned": return <>{who} unassigned <b style={{ color: "var(--text2)" }}>{e.detail}</b></>;
+      case "review-requested": return <>{who} requested a review from <b style={{ color: "var(--text2)" }}>{e.detail}</b></>;
+      case "review-request-removed": return <>{who} withdrew the review request for {e.detail}</>;
+      case "ready-for-review": return <>{who} marked this ready for review</>;
+      case "convert-to-draft": return <>{who} converted this to a draft</>;
+      case "merged": return <>{who} merged this into {mono(e.detail || "")}</>;
+      case "closed": return <>{who} closed this</>;
+      case "reopened": return <>{who} reopened this</>;
+      case "cross-referenced": return <>{who} mentioned this in {e.detail}</>;
+      case "milestoned": return <>{who} added this to the {e.detail} milestone</>;
+      case "demilestoned": return <>{who} removed this from the {e.detail} milestone</>;
+      case "head-ref-deleted": return <>{who} deleted the {mono(e.detail || "")} branch</>;
+      case "auto-merge-enabled": return <>{who} armed auto-merge</>;
+      case "auto-merge-disabled": return <>{who} cancelled auto-merge{e.detail ? ` (${e.detail})` : ""}</>;
+      default: return <>{who} did something</>;
+    }
+  })();
+  const inner = <span>{said} <span style={{ color: "var(--text3)" }}>· {ago(e.at)}</span></span>;
+  return (
+    <div className="agx-tiny">
+      {e.url ? <a href={externalUrl(e.url)} target="_blank" rel="noreferrer noopener" style={{ color: "inherit" }}>{inner}</a> : inner}
+    </div>
+  );
+}
+
+function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onReact, busy }: {
   d: PrDetail;
   lanes: { humans: PrReview[]; botReviews: PrReview[]; humanComments: PrComment[]; bots: PrComment[] };
   raw: boolean; onRaw: (v: boolean) => void;
   onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void;
-  onComment: (body: string) => Promise<boolean>; busy: boolean;
+  onComment: (body: string) => Promise<boolean>;
+  onReact: (nodeId: string, content: string, on: boolean) => void;
+  busy: boolean;
 }) {
   const [newest, setNewest] = useState(false);
   const kb = Math.round(lanes.bots.reduce((n, c) => n + c.body.length, 0) / 1024);
@@ -1878,6 +2625,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, bus
       body: (
         <>
           <Card who={r.author} when={ago(r.submittedAt)} url={r.url} tone={tone}
+            edited={r.editedAt} assoc={r.association} nodeId={r.nodeId} reactions={r.reactions} onReact={onReact}
             chip={r.state === "CHANGES_REQUESTED" ? <Chip text="requested changes" tint="var(--error)" />
               : r.state === "APPROVED" ? <Chip text="approved" tint="var(--success)" /> : undefined}>
             {r.body ? <Md body={r.body} />
@@ -1895,7 +2643,8 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, bus
   for (const c of lanes.humanComments) {
     entries.push({
       at: c.createdAt, key: `c${c.id}`, node: <span style={{ color: "var(--text3)" }}>💬</span>,
-      body: <Card who={c.author} when={ago(c.createdAt)} url={c.url}><Md body={c.body} /></Card>,
+      body: <Card who={c.author} when={ago(c.createdAt)} url={c.url}
+        edited={c.editedAt} assoc={c.association} nodeId={c.nodeId} reactions={c.reactions} onReact={onReact}><Md body={c.body} /></Card>,
     });
   }
   for (const t of orphanThreads) {
@@ -1909,6 +2658,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, bus
     entries.push({
       at: r.submittedAt, key: `br${i}`, node: <span style={{ color: "var(--info)" }}>⌬</span>,
       body: <Card who={r.author} when={ago(r.submittedAt)} url={r.url} tone="bot"
+        nodeId={r.nodeId} reactions={r.reactions} onReact={onReact}
         chip={<Chip text="automation" tint="var(--info)" />}><Md body={r.body} /></Card>,
     });
   }
@@ -1916,12 +2666,24 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, bus
     entries.push({
       at: c.createdAt, key: `b${c.id}`, node: <span style={{ color: "var(--info)" }}>⌬</span>,
       body: (
-        <Card who={c.author} when={ago(c.createdAt)} url={c.url} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}>
+        <Card who={c.author} when={ago(c.createdAt)} url={c.url} tone="bot" chip={<Chip text="automation" tint="var(--info)" />}
+          nodeId={c.nodeId} reactions={c.reactions} onReact={onReact}>
           {raw
             ? <pre className="overflow-x-auto text-[10px] max-h-72 agx-scroll" style={{ ...CODE_FONT_STYLE, color: "var(--text3)" }}>{c.body}</pre>
             : <span style={{ color: "var(--text2)" }}>{c.digest || "(Nothing worth pulling out)"}</span>}
         </Card>
       ),
+    });
+  }
+
+  // The events between the remarks: pushes, renames, labels, the merge itself.
+  // Without them the conversation reads as if nothing happened between comments
+  // — the force-push that invalidated a review simply is not there.
+  for (const [i, e] of d.timeline.entries()) {
+    entries.push({
+      at: e.at, key: `e${i}`,
+      node: <span style={{ color: EVENT_TINT[e.kind] ?? "var(--text3)" }}>{EVENT_GLYPH[e.kind] ?? "•"}</span>,
+      body: <TimelineEvent e={e} />,
     });
   }
 
@@ -1937,10 +2699,13 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, bus
       <span><b>{d.author}</b> opened this pull request from <code style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{d.headRefName}</code> into <code style={{ ...CODE_FONT_STYLE, color: "var(--text2)" }}>{d.baseRefName}</code></span>
     </div>
   );
+  /* The real force-push events now come from the timeline with their own
+     timestamps, so this is only the *warning* that the newest one invalidated a
+     review — a judgement the raw event cannot make. */
   const forced = d.forcePushedSinceReview ? (
     <div key="forced" className="agx-tiny">
       <span className="agx-node" style={{ color: "var(--warning)" }}>↻</span>
-      <span><b>{d.author}</b> force-pushed after the last review — <span style={{ color: "var(--warning)" }}>that review was for code that is no longer here</span></span>
+      <span style={{ color: "var(--warning)" }}>The last review was for code that is no longer here — it was force-pushed over</span>
     </div>
   ) : null;
 
@@ -1959,7 +2724,10 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, bus
   return (
     <div className="text-[11px]">
       <div className="flex items-center gap-2 mb-3 text-[10px]" style={{ color: "var(--text3)" }}>
-        <span>One timeline — reviews, comments and threads in the order they happened</span>
+        <span>One timeline — reviews, comments, threads and events in the order they happened</span>
+        {d.truncated?.comments ? (
+          <span style={{ color: "var(--warning)" }}>· showing the most recent {d.truncated.comments}</span>
+        ) : null}
         <span className="flex-1" />
         {lanes.bots.length > 0 && (
           <Btn small onClick={() => onRaw(!raw)}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -346,8 +346,27 @@ const realApi = {
   dockerTop: (id: string) => get<{ ok: boolean; text: string; error?: string }>(`/docker/top?id=${encodeURIComponent(id)}`),
   // --- pull requests (gh-backed) ---
   prCapability: (force = false) => get<{ available: boolean; authed: boolean; login?: string; reason?: string }>(`/prs/capability${force ? "?force=1" : ""}`),
-  prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false) =>
-    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}`),
+  /** Emoji on anything: the body, a comment, a review, a line comment. `nodeId`
+   *  is the GraphQL id, and `on:false` takes the reaction back off. */
+  prReactTo: (root: string, nodeId: string, content: string, on: boolean) =>
+    post<PrActionResult>("/prs/react", { root, nodeId, content, on }),
+  prEditComment: (root: string, nodeId: string, body: string, kind: "issue" | "review" = "issue") =>
+    post<PrActionResult>("/prs/comment-edit", { root, nodeId, body, kind }),
+  prDeleteComment: (root: string, nodeId: string, kind: "issue" | "review" = "issue") =>
+    post<PrActionResult>("/prs/comment-delete", { root, nodeId, kind }),
+  /** GitHub's own viewed tick, so it survives leaving the panel. */
+  prFileViewed: (root: string, prNodeId: string, path: string, viewed: boolean) =>
+    post<PrActionResult>("/prs/file-viewed", { root, prNodeId, path, viewed }),
+  prAssignees: (root: string, number: number, add: string[], remove: string[]) =>
+    post<PrActionResult>("/prs/assignees", { root, number, add, remove }),
+  prMilestone: (root: string, number: number, title: string) =>
+    post<PrActionResult>("/prs/milestone", { root, number, title }),
+  prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false, after?: string) =>
+    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}${after ? `&after=${encodeURIComponent(after)}` : ""}`),
+  /** Exact totals for every saved view, in one request. */
+  prCounts: (root: string, state: "open" | "closed" | "all") =>
+    get<{ ok: boolean; counts?: { review: number; mine: number; failing: number; ready: number; all: number }; error?: string }>(
+      `/prs/counts?root=${encodeURIComponent(root)}&state=${state}`),
   prDetail: (root: string, number: number, force = false) =>
     get<{ ok: boolean; detail?: PrDetail; error?: string }>(`/prs/detail?root=${encodeURIComponent(root)}&number=${number}${force ? "&force=1" : ""}`),
   prDiff: (root: string, number: number) =>
@@ -376,7 +395,7 @@ const realApi = {
   prDraft: (root: string, number: number, draft: boolean) => post<PrActionResult>("/prs/draft", { root, number, draft }),
   prUpdateBranch: (root: string, number: number) => post<PrActionResult>("/prs/update-branch", { root, number }),
   prRerun: (root: string, number: number) => post<PrActionResult>("/prs/rerun", { root, number }),
-  prMerge: (root: string, number: number, method: "squash" | "merge" | "rebase", opts: { deleteBranch?: boolean; auto?: boolean; headSha?: string }) =>
+  prMerge: (root: string, number: number, method: "squash" | "merge" | "rebase", opts: { deleteBranch?: boolean; auto?: boolean; headSha?: string; subject?: string; body?: string; disableAuto?: boolean }) =>
     post<PrActionResult>("/prs/merge", { root, number, method, ...opts }),
   prClose: (root: string, number: number, reopen = false) => post<PrActionResult>("/prs/close", { root, number, reopen }),
   prLocalReview: (root: string, number: number) =>
@@ -547,7 +566,8 @@ const demoApi: typeof realApi = {
   // The panel used to answer available:false here, so the feature the landing
   // page calls out as new was dead in the demo that page links to.
   prCapability: (_force?: boolean) => D(demo.prCapability()),
-  prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean) => D<PrListResponse>(demo.prList(root, filter)),
+  prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean, _after?: string) => D<PrListResponse>(demo.prList(root, filter)),
+  prCounts: (_r: string, _s: "open" | "closed" | "all") => D({ ok: false, error: "not available in the demo" } as { ok: boolean; counts?: { review: number; mine: number; failing: number; ready: number; all: number }; error?: string }),
   prDetail: (_root: string, number: number, _force?: boolean) => D(demo.prDetail(number)),
   prDiff: (_root: string, number: number) => D(demo.prDiff(number)),
   prAssetUrl: (raw: string) => raw,
@@ -557,13 +577,19 @@ const demoApi: typeof realApi = {
   prReply: (_r: string, _n: number, _c: number, _b: string) => D(demoPrAction()),
   prSetThreadResolved: (_r: string, _t: string, _v: boolean) => D(demoPrAction()),
   prReact: (_r: string, _c: number, _content?: string) => D(demoPrAction()),
+  prReactTo: (_r: string, _id: string, _c: string, _on: boolean) => D(demoPrAction()),
+  prEditComment: (_r: string, _id: string, _b: string, _k?: "issue" | "review") => D(demoPrAction()),
+  prDeleteComment: (_r: string, _id: string, _k?: "issue" | "review") => D(demoPrAction()),
+  prFileViewed: (_r: string, _p: string, _path: string, _v: boolean) => D(demoPrAction()),
+  prAssignees: (_r: string, _n: number, _a: string[], _rm: string[]) => D(demoPrAction()),
+  prMilestone: (_r: string, _n: number, _t: string) => D(demoPrAction()),
   prEdit: (_r: string, _n: number, _p: { title?: string; body?: string; base?: string }) => D(demoPrAction()),
   prLabels: (_r: string, _n: number, _a: string[], _rm: string[]) => D(demoPrAction()),
   prReviewers: (_r: string, _n: number, _a: string[], _rm: string[]) => D(demoPrAction()),
   prDraft: (_r: string, _n: number, _d: boolean) => D(demoPrAction()),
   prUpdateBranch: (_r: string, _n: number) => D(demoPrAction()),
   prRerun: (_r: string, _n: number) => D(demoPrAction()),
-  prMerge: (_r: string, _n: number, _m: "squash" | "merge" | "rebase", _o: { deleteBranch?: boolean; auto?: boolean; headSha?: string }) => D(demoPrAction()),
+  prMerge: (_r: string, _n: number, _m: "squash" | "merge" | "rebase", _o: { deleteBranch?: boolean; auto?: boolean; headSha?: string; subject?: string; body?: string; disableAuto?: boolean }) => D(demoPrAction()),
   prClose: (_r: string, _n: number, _reopen?: boolean) => D(demoPrAction()),
   prLocalReview: (_r: string, _n: number) => D({ ok: false, error: "not available in the demo" }),
   prLocalReviewDiscard: (_r: string, _n: number) => D(demoPrAction()),

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -741,6 +741,11 @@ const PR_482_THREADS: PrThread[] = [
 
 const PR_482_DETAIL: PrDetail = {
   ...PR_SUMMARIES[0],
+  timeline: [],
+  participants: [],
+  bodyReactions: [],
+  projects: [],
+  linkedIssues: [],
   body: [
     "Prices were rounded per line item, so a cart of 3 × €4.995 charged €15.00 while the",
     "invoice said €14.99. Rounding moves to the cart boundary.",
@@ -870,6 +875,7 @@ function prDetailOf(n: number): PrDetail | null {
   return {
     ...s,
     body: "", mergeable: "UNKNOWN", mergeState: "UNKNOWN", checklist: [],
+    timeline: [], participants: [], bodyReactions: [], projects: [], linkedIssues: [],
     reviewers: [], assignees: s.assignees, reviews: [], comments: [], threads: [],
     commits: [{ oid: "d4f7b03c5e42a6fb", short: "d4f7b03", message: s.title, author: s.author, isMerge: false }],
     files: [], checksAll: [],


### PR DESCRIPTION
## What does this PR do?

Brings the pull request panel up to GitHub's own feature set, and stops it starting cold.

**Data** — one query, verified live against #288/#243: reactions, `lastEditedAt`, `authorAssociation` and `viewerDidAuthor` on everything authored; commit **co-authors**, signature (Verified), per-commit checks and the full message; per-file `viewerViewedState`; participants, linked issues, auto-merge, mergedBy/At. **Nineteen timeline event types** rendered inline (force-push, rename, labels, assign, review requested, merged, closed, cross-reference, milestone…).

**New actions**: react (all four comment kinds), edit/delete your own comment, GitHub's own file-viewed tick, assignees, milestone, reopen, **merge-commit and rebase** merges with an editable subject, cancel auto-merge, exact per-view counts.

**UI**: a right-hand sidebar (reviewers, assignees, labels, milestone, development, participants) so the prose gets a fixed reading column; a **file tree** in Files with review threads inline under each file; commits grouped by day; **pages** (25 per page, "Page 1 of 9 · 209 total").

**Speed** — measured, not guessed. A no-op call to `api.github.com` costs **280ms** and the list query **650-1000ms**, while github.com's own page answers in **115ms**: the round trip is the floor, so the fix is to not start from nothing. The list cache is now written to disk and read back at boot — a brand-new server answers its first request in **17ms with 25 rows**, where it used to return nothing and show a skeleton for ~1.5s. `gh auth status` (344ms) and `git rev-parse` are off the poll path, the GraphQL calls no longer spawn `gh`, rows and check rollups are two queries GitHub runs concurrently, and switching scope dims the list instead of blanking it.

**Bugs found along the way**: `comments(first:50)` dropped the *newest* comments; every file wore a `MODIFIED` badge (GraphQL says `MODIFIED`, the test compared `"modified"`); PR diffs rendered with no syntax highlighting (missing `HiliteCtx.Provider`); **Reopen was unreachable** (the menu called close); merged and closed PRs offered Squash & merge / Update branch / To draft under the words "Merging is blocked"; the state badge was tinted by CI verdict, so a closed PR read green.

## How was it tested?

- `bunx tsc --noEmit` in `server/` and `web/`; `bun test` (**server 631**, **web 294**); `bunx vite build`; `bun scripts/smoke.ts`.
- Every GraphQL change run against the live API before shipping — which is how two query-killers were caught: `projectsV2` needs the `read:project` scope and fails the *whole* query with `INSUFFICIENT_SCOPES`, and `files(first:300)` / `commits(last:150)` exceed GitHub's hard limit of 100.
- The panel driven by hand in the desktop app against this repository: every tab on open, merged and closed pull requests; reactions on and off; the file tree and viewed ticks; paging through 209 closed PRs; and the cold-start path (fresh server, first request) timed.

---

<sub>CI runs typecheck, tests and the production build for you. If you changed the server↔web contract update `shared/types.ts`; if behavior or config changed, update the docs. See [CONTRIBUTING.md](../CONTRIBUTING.md).</sub>
