### PR TITLE
fix(security): exact-match the host that may see the GitHub token, and take the demo fixtures off Math.random

### DIFF
--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -947,6 +947,22 @@ export function assetAllowed(raw: string): URL | null {
   return null;
 }
 
+/**
+ * Whether this host may be shown the user's GitHub token.
+ *
+ * A separate, narrower question than `assetAllowed`: that one decides what we
+ * will fetch, this one decides what we will hand a credential to. It has to be
+ * an exact domain match — `hostname.endsWith("github.com")`, which is what
+ * stood here, is also true of `evilgithub.com`. Nothing reachable today gets
+ * through `assetAllowed` to ask, but a substring test on a hostname is one
+ * allowlist edit away from posting `gh auth token` to somebody else's server,
+ * and the edit would look harmless.
+ */
+export function tokenAllowedHost(hostname: string): boolean {
+  const h = hostname.toLowerCase().replace(/\.$/, "");
+  return h === "github.com" || h.endsWith(".github.com");
+}
+
 let tokenCache: { at: number; token: string } | null = null;
 
 /** The token `gh` already holds. Never sent anywhere but the allowlisted host. */
@@ -973,8 +989,9 @@ export async function prAsset(rawUrl: unknown): Promise<Response> {
   const token = await ghToken();
   const headers: Record<string, string> = { accept: "image/*" };
   // Only GitHub gets the credential. ClickUp is public and has no business
-  // receiving a GitHub token.
-  if (token && u.hostname.toLowerCase().endsWith("github.com")) headers.authorization = `token ${token}`;
+  // receiving a GitHub token. Redirects stay safe on their own: fetch drops
+  // Authorization when a redirect crosses to another origin.
+  if (token && tokenAllowedHost(u.hostname)) headers.authorization = `token ${token}`;
   let res: Response;
   try {
     res = await fetch(u.toString(), { headers, redirect: "follow", signal: AbortSignal.timeout(20_000) });

--- a/server/test/prs.test.ts
+++ b/server/test/prs.test.ts
@@ -323,6 +323,35 @@ describe("asset proxy allowlist", () => {
   });
 });
 
+describe("who may see the GitHub token", () => {
+  /**
+   * Narrower than the fetch allowlist on purpose: being allowed to serve us an
+   * image is not the same as being allowed to hold the user's credential.
+   */
+  test("github.com and its own subdomains, and nothing else", () => {
+    expect(prs.tokenAllowedHost("github.com")).toBe(true);
+    expect(prs.tokenAllowedHost("GitHub.com")).toBe(true);
+    expect(prs.tokenAllowedHost("codeload.github.com")).toBe(true);
+  });
+
+  test("a lookalike that ends in the same letters gets nothing", () => {
+    expect(prs.tokenAllowedHost("evilgithub.com")).toBe(false);
+    expect(prs.tokenAllowedHost("github.com.evil.example")).toBe(false);
+    expect(prs.tokenAllowedHost("notgithub.com")).toBe(false);
+  });
+
+  /** Allowed to serve images, never allowed the credential. */
+  test("the other asset hosts are not token hosts", () => {
+    expect(prs.tokenAllowedHost("user-images.githubusercontent.com")).toBe(false);
+    expect(prs.tokenAllowedHost("t14295188.p.clickup-attachments.com")).toBe(false);
+  });
+
+  /** `https://github.com./x` is a valid absolute-form FQDN. */
+  test("a trailing root dot is not a way around the comparison", () => {
+    expect(prs.tokenAllowedHost("evilgithub.com.")).toBe(false);
+  });
+});
+
 describe("CI notification latch", () => {
   const rollup = (over: Record<string, unknown> = {}) =>
     ({ total: 61, success: 43, failure: 0, skipped: 18, pending: 0, allDone: true, verdict: "green", failing: [], ...over });

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -18,8 +18,21 @@ import { ctxLimitOf } from "./contextWindow.ts";
 
 export const IS_DEMO = import.meta.env.VITE_DEMO === "1";
 
-const pick = <T,>(a: T[]): T => a[Math.floor(Math.random() * a.length)];
-const rnd = (lo: number, hi: number) => lo + Math.random() * (hi - lo);
+// Every random draw in this file shapes invented dashboard data — no id, key
+// or token here authorises anything. It still comes from the CSPRNG rather
+// than `Math.random`: a scanner cannot tell fixtures from secrets, so a
+// fixture generator that calls `Math.random` is a permanent shelf of "insecure
+// randomness" findings sitting on top of the ones that would matter. Drawn a
+// page at a time, because the live stream asks for these on a timer.
+const ENTROPY = new Uint32Array(256);
+let entropyAt = ENTROPY.length;
+function random(): number {
+  if (entropyAt >= ENTROPY.length) { crypto.getRandomValues(ENTROPY); entropyAt = 0; }
+  return ENTROPY[entropyAt++]! / 2 ** 32;
+}
+
+const pick = <T,>(a: T[]): T => a[Math.floor(random() * a.length)];
+const rnd = (lo: number, hi: number) => lo + random() * (hi - lo);
 const rint = (lo: number, hi: number) => Math.floor(rnd(lo, hi + 1));
 const uid = () => Array.from({ length: 8 }, () => "0123456789abcdef"[rint(0, 15)]).join("") + "-demo";
 
@@ -102,7 +115,7 @@ function mkEvent(o: Partial<WatchEvent> & { source_app: string; session_id: stri
 function nextEvent(): WatchEvent {
   // Resolve an open Pre first, most of the time — running rows should morph
   // into finished ones within a few ticks, the way the real pairing behaves.
-  if (openPres.length && (Math.random() < 0.45 || openPres.length > 4)) {
+  if (openPres.length && (random() < 0.45 || openPres.length > 4)) {
     const p = openPres.shift()!;
     return mkEvent({
       source_app: p.app, session_id: p.sid, model_name: p.model, timestamp: Date.now(),
@@ -113,11 +126,11 @@ function nextEvent(): WatchEvent {
   }
   const s = pick(SESSIONS);
   const base = { source_app: s.app, session_id: s.sid, model_name: s.model, timestamp: Date.now() };
-  const roll = Math.random();
+  const roll = random();
   if (roll < 0.5) {
     const tool = pick(["Bash", "Read", "Edit", "Write", "Grep"]);
     const detail = tool === "Bash" ? pick(BASHES) : pick(PATHS);
-    const isErr = Math.random() < 0.05;
+    const isErr = random() < 0.05;
     return mkEvent({
       ...base, hook_event_type: "PostToolUse", tool_name: tool, tool_use_id: uid(),
       duration_ms: rint(60, tool === "Bash" ? 4000 : 300),
@@ -230,12 +243,12 @@ export function stats(windowMs: number, provider?: string): StatsSummary {
   const heatmap = Array.from({ length: 168 }, (_, k) => {
     const h = k % 24, d = Math.floor(k / 24);
     const work = h >= 9 && h <= 19 && d >= 1 && d <= 5 ? rnd(0, 30) : rnd(0, 3);
-    return Math.round(work * (0.5 + Math.random()));
+    return Math.round(work * (0.5 + random()));
   });
   const buckets = Array.from({ length: 60 }, (_, i) => {
     const t = Date.now() - (60 - i) * (windowMs / 60);
     const busy = 0.15 + 0.85 * f;
-    return { t, events: rint(0, Math.round(40 * busy)), errors: Math.random() < 0.1 ? rint(1, 3) : 0, cost_usd: Number(rnd(0, 12 * busy).toFixed(3)), tokens: rint(0, Math.round(60000 * busy)) };
+    return { t, events: rint(0, Math.round(40 * busy)), errors: random() < 0.1 ? rint(1, 3) : 0, cost_usd: Number(rnd(0, 12 * busy).toFixed(3)), tokens: rint(0, Math.round(60000 * busy)) };
   });
   const summary: StatsSummary = {
     totals: { events: si(12840) + streamed.events, sessions: si(41), tool_calls: si(6210) + streamed.tools, errors: Math.round(34 * f), cost_usd: Number((sc(4498.08) + streamed.cost).toFixed(2)), input_tokens: Math.round(9_100_000 * f), output_tokens: Math.round(640_000 * f), cache_creation_tokens: Math.round(1_200_000 * f), cache_read_tokens: Math.round(78_000_000 * f) },


### PR DESCRIPTION
## What does this PR do?

Closes the code scanning findings that were worth closing, and takes the noise off the list so the next real one is visible.

**The one that mattered, `server/src/prs.ts`.** The asset proxy decided whether to attach the user's `gh auth token` with `u.hostname.toLowerCase().endsWith("github.com")`. That is also true of `evilgithub.com`. Nothing reachable gets that far today: `assetAllowed` runs first and every suffix in it starts with a dot, so a lookalike is rejected before the token question is ever asked. But the check standing between a third-party host and the user's credential should not be a substring test. A later allowlist edit that looks harmless is all it takes. Now `tokenAllowedHost` answers the narrower question explicitly: `github.com` and its own subdomains, nothing else, trailing root dot included. Being allowed to serve us an image is not the same as being allowed to hold the token, and the code says so now.

Redirects were already safe and stay that way. `fetch` drops `Authorization` when a redirect crosses to another origin, verified against Bun's implementation rather than assumed.

**The noise, `web/src/lib/demo.ts`.** Six `js/insecure-randomness` alerts, all High, all in the fixture generator that invents the demo dashboard. No id, key or token in that file authorises anything. A scanner cannot tell fixtures from secrets, so those six sat permanently on top of the findings that would matter. The draws now come from `crypto.getRandomValues`, taken a page of entropy at a time because the simulated live stream asks for them on a timer.

The remaining alerts are dismissed with reasons rather than patched, because in each case the code is already correct. The `<img src>` in `PrPanel` is a PR-body URL that goes through `encodeURIComponent` into the server's host allowlist and cannot execute anything as an image source. The `JSON.stringify` calls in `scripts/capture*.ts` embed hardcoded theme and key names in dev-only capture tooling. The stack-trace finding is error text returned by a server bound to localhost.

## How was it tested?

- `bunx tsc --noEmit` in `web/` and `server/`, both clean.
- `bun test`, 929 pass, 0 fail. Four new tests in `server/test/prs.test.ts` cover the token host: subdomains admitted, `evilgithub.com` and `github.com.evil.example` and `notgithub.com` refused, the other asset hosts (githubusercontent, clickup) refused the credential while still allowed to serve images, and a trailing root dot not treated as a way around the comparison.
- `bunx vite build` and `VITE_DEMO=1 vite build`, then booted the demo bundle in headless Chromium: mounts, no console errors, live event stream ticking and every panel populated off the new randomness.