### PR TITLE
perf(session): make a long session scroll like a terminal again

### DIFF
--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -63,32 +63,6 @@ const keepIfSame = <T,>(set: (v: T) => void) => {
 };
 
 export default function App() {
-  const { events, conn, lastEvent, openTools } = useLive();
-  // The live socket is the app's only real-time source, and until now the chat
-  // panel was the one view that never saw it — a resumed session sat frozen on
-  // whatever had been true when you opened it while the agent kept working.
-  // This is the whole subscription: the store decides which chat, if any, each
-  // event belongs to, and ignores everything else.
-  //
-  // Only the events past the high-water mark. `events` is a rolling buffer of
-  // two thousand and every socket flush replaces the array, so handing the
-  // whole thing to the store each time meant re-walking all of it — and the
-  // store's own "seen" guard doesn't help, because it only records events that
-  // matched an open chat. With no chat open, which is most of the time, nothing
-  // was ever marked and every flush paid for all two thousand. That work lands
-  // on the same thread that draws the terminal, which is where it showed up:
-  // sluggish output and dropped keystrokes.
-  const appliedThrough = useRef(0);
-  useEffect(() => {
-    let high = appliedThrough.current;
-    for (const e of events) {
-      if (e.id <= appliedThrough.current) continue;
-      applyLiveEvent(e);
-      if (e.id > high) high = e.id;
-    }
-    appliedThrough.current = high;
-  }, [events]);
-
   const [windowMs, setWindowMs] = useState(3_600_000);
   const [filter, setFilter] = useState({ app: "", type: "", provider: "" });
   const [theme, setTheme] = useState(initialTheme());
@@ -150,9 +124,52 @@ export default function App() {
   // it already does for a backgrounded tab. It is a play-state flip rather than
   // an unmount, so closing the workspace resumes them instantly and switching
   // between the two stays immediate.
+  //
+  // A full-screen modal covers it just as completely, and that case was missed:
+  // reading a session meant scrolling a few hundred rows on the same CPU that
+  // was still sweeping a radar and pulsing a ring per live agent behind the
+  // dim. Same treatment, same attribute.
+  const covered = wsOpen || anyPanelOpen;
   useEffect(() => {
-    document.documentElement.dataset.ws = wsOpen ? "1" : "0";
-  }, [wsOpen]);
+    document.documentElement.dataset.ws = covered ? "1" : "0";
+  }, [covered]);
+
+  // Same argument, one level deeper: freezing the animations still left the
+  // dashboard re-rendering five times a second — a two-thousand-event feed, two
+  // charts and a fleet grid — behind whatever is on top of it. Holding the
+  // socket's buffer instead gives the panel you are actually reading the main
+  // thread to itself, and uncovering flushes it in one go.
+  //
+  // NOT while the workspace is open, even though it covers the dashboard just
+  // as thoroughly: the chat panel inside it is a live view fed by these very
+  // events, and holding them would freeze a streaming answer mid-word. A modal
+  // over the workspace (the skills catalog opens there) is left alone for the
+  // same reason.
+  const { events, conn, lastEvent, openTools } = useLive(anyPanelOpen && !wsOpen);
+  // The live socket is the app's only real-time source, and until now the chat
+  // panel was the one view that never saw it — a resumed session sat frozen on
+  // whatever had been true when you opened it while the agent kept working.
+  // This is the whole subscription: the store decides which chat, if any, each
+  // event belongs to, and ignores everything else.
+  //
+  // Only the events past the high-water mark. `events` is a rolling buffer of
+  // two thousand and every socket flush replaces the array, so handing the
+  // whole thing to the store each time meant re-walking all of it — and the
+  // store's own "seen" guard doesn't help, because it only records events that
+  // matched an open chat. With no chat open, which is most of the time, nothing
+  // was ever marked and every flush paid for all two thousand. That work lands
+  // on the same thread that draws the terminal, which is where it showed up:
+  // sluggish output and dropped keystrokes.
+  const appliedThrough = useRef(0);
+  useEffect(() => {
+    let high = appliedThrough.current;
+    for (const e of events) {
+      if (e.id <= appliedThrough.current) continue;
+      applyLiveEvent(e);
+      if (e.id > high) high = e.id;
+    }
+    appliedThrough.current = high;
+  }, [events]);
 
   // Which folder is this cockpit about? Ask once on first open when nothing is
   // scoped yet — picking a project up front is what gives the terminal, git

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -1062,7 +1062,7 @@ export function ChangesModal({ open, onClose, ...rest }: Omit<DiffViewProps, "ac
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
               <motion.div
                 initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -109,7 +109,7 @@ export function CommandPalette({
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             {/* Centering wrapper: Motion owns the modal's `transform` (scale/y
                 animation), which clobbers a Tailwind -translate-x-1/2 — so a
                 flex wrapper does the centering instead. */}

--- a/web/src/components/CommitModal.tsx
+++ b/web/src/components/CommitModal.tsx
@@ -115,7 +115,7 @@ export function CommitModal({ open, onClose, paths }: { open: boolean; onClose: 
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10002, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10002 }} onClick={onClose} />
             <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10003 }}>
               <motion.div
                 initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}

--- a/web/src/components/ConfirmDialog.tsx
+++ b/web/src/components/ConfirmDialog.tsx
@@ -72,7 +72,7 @@ export function ConfirmDialog({ pending }: { pending: Pending | null }) {
       {pending && (
         <Portal>
           <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-            className="fixed inset-0" style={{ zIndex: 10004, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+            className="fixed inset-0 agx-scrim" style={{ zIndex: 10004 }}
             onClick={() => pending.resolve(isPrompt ? null : false)} />
           <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10005 }}>
             <motion.div

--- a/web/src/components/EventModal.tsx
+++ b/web/src/components/EventModal.tsx
@@ -21,7 +21,7 @@ export function EventModal({ event, onClose }: { event: WatchEvent | null; onClo
           <>
             <motion.div
               initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.6)", backdropFilter: "blur(3px)" }}
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }}
               onClick={onClose}
             />
             {/* Flex wrapper centers the card — Motion owns `transform` for its

--- a/web/src/components/Feed.tsx
+++ b/web/src/components/Feed.tsx
@@ -412,7 +412,7 @@ function FeedInner({ events, filter, sessionProvider, onSelect, onClearFilter }:
           {full && (
             <>
               <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-                className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.6)", backdropFilter: "blur(3px)" }} onClick={() => setFull(false)} />
+                className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={() => setFull(false)} />
               {/* Flex wrapper centers the card — Motion owns `transform` for its
                   scale/y animation, so Tailwind translate centering can't be used. */}
               <div className="fixed inset-0 flex items-center justify-center pointer-events-none" style={{ zIndex: 10001 }}>

--- a/web/src/components/HelpLegend.tsx
+++ b/web/src/components/HelpLegend.tsx
@@ -25,7 +25,7 @@ export function HelpLegend({ open, onClose }: { open: boolean; onClose: () => vo
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.5)", backdropFilter: "blur(2px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             {/* Flex wrapper centers the card — Motion owns `transform` for its
                 scale/y animation, so Tailwind translate centering can't be used. */}
             <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10001 }}>

--- a/web/src/components/ProjectPicker.tsx
+++ b/web/src/components/ProjectPicker.tsx
@@ -143,7 +143,7 @@ export function ProjectPicker({ open, workspace, onClose }: { open: boolean; wor
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={close} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={close} />
             <div className="fixed inset-0 flex items-center justify-center p-3 pointer-events-none" style={{ zIndex: 10001 }}>
               <motion.div
                 initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}

--- a/web/src/components/ReleaseNotesModal.tsx
+++ b/web/src/components/ReleaseNotesModal.tsx
@@ -50,7 +50,7 @@ export function ReleaseNotesModal({ open, tag, notes, title = "What's new", load
           <>
             <motion.div
               initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10010, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }}
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10010 }}
               onClick={onClose} />
             <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none" style={{ zIndex: 10011 }}>
               <motion.div

--- a/web/src/components/RescueModal.tsx
+++ b/web/src/components/RescueModal.tsx
@@ -119,7 +119,7 @@ export function RescueModal({ reports, progress, onCancel, onConfirm }: {
     <Portal>
       <AnimatePresence>
         <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-          className="fixed inset-0" style={{ zIndex: 10002, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onCancel} />
+          className="fixed inset-0 agx-scrim" style={{ zIndex: 10002 }} onClick={onCancel} />
         <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10003 }}>
           <motion.div
             initial={{ opacity: 0, scale: 0.98, y: 6 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.98 }}

--- a/web/src/components/SearchModal.tsx
+++ b/web/src/components/SearchModal.tsx
@@ -57,7 +57,7 @@ export function SearchModal({ open, onClose, onSelectApp }: { open: boolean; onC
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             <div className="fixed inset-0 flex justify-center items-start pt-[9vh] px-4 pointer-events-none" style={{ zIndex: 10001 }}>
               <motion.div
                 initial={{ opacity: 0, scale: 0.97, y: -10 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.98, y: -6 }}

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { memo, useEffect, useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { SessionDetail, TimelineEntry } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
@@ -8,7 +8,7 @@ import { usePoll } from "../lib/usePoll.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { fmtUsd, fmtTokens, fmtAgo, fmtTime, modelLabelOf, modelColor, sessionTitle } from "../lib/format.ts";
 import { ToolRow } from "./ToolRow.tsx";
-import { buildRows, type Row } from "../lib/toolTree.ts";
+import { buildRows, entryKey, type Row } from "../lib/toolTree.ts";
 import { sessionIsLive } from "../lib/derive.ts";
 import { sessionWorktree, sessionCwd } from "../lib/worktree.ts";
 import { useStuckBottom } from "../lib/useStuckBottom.ts";
@@ -25,7 +25,31 @@ function Stat({ k, v, color }: { k: string; v: string; color?: string }) {
   );
 }
 
-export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume }: { sessionId: string | null; sourceApp?: string; onClose: () => void; onFilter?: (app: string) => void; onResume?: (s: SessionDetail) => void }) {
+// Mixed against a solid base rather than `transparent`: over the panel's own
+// violet the old wash left both roles nearly the same colour, and some themes
+// flattened them completely. The left border carries the distinction even where
+// the fills don't.
+//
+// Hoisted out of the render, and memoised on three primitives: these were object
+// literals rebuilt for every message on every poll, which is a fresh style
+// recalculation for a bubble whose colours have never once changed.
+const USER_BUBBLE = { background: "color-mix(in srgb, var(--primary) 26%, var(--bg2))", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--primary) 55%, transparent)", borderLeft: "3px solid var(--primary)" };
+const AGENT_BUBBLE = { background: "color-mix(in srgb, var(--bg3) 85%, var(--bg))", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", borderLeft: "3px solid color-mix(in srgb, var(--info) 70%, transparent)" };
+
+const Bubble = memo(function Bubble({ role, ts, text }: { role: string; ts: number; text: string }) {
+  const user = role === "user";
+  return (
+    <div className={`flex ${user ? "justify-end" : "justify-start"}`}>
+      <div className="max-w-[85%] min-w-0 rounded-xl px-3 py-2 text-[11.5px] leading-relaxed break-words"
+        style={user ? USER_BUBBLE : AGENT_BUBBLE}>
+        <div className="text-[9px] uppercase tracking-wider mb-1" style={{ color: user ? "var(--primary-hover)" : "var(--info)" }}>{role} · {fmtTime(ts)}</div>
+        <Markdown text={text} />
+      </div>
+    </div>
+  );
+});
+
+export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume }:{ sessionId: string | null; sourceApp?: string; onClose: () => void; onFilter?: (app: string) => void; onResume?: (s: SessionDetail) => void }) {
   const [d, setD] = useState<SessionDetail | null>(null);
   const [loading, setLoading] = useState(false);
   const [diffOpen, setDiffOpen] = useState(false);
@@ -44,6 +68,12 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
   // the file list all keep moving while the modal sits open. Refreshed in place
   // — no `loading` flag, no clearing `d` — so a running session updates under
   // you instead of flickering through an empty state every few seconds.
+  //
+  // A finished session polls slowly rather than not at all: its roll-up can
+  // still gain a cost correction or a late file change, but nothing about it is
+  // moving, and this response carries the whole conversation — a few hundred
+  // kilobytes to fetch and parse on the main thread, every tick, next to the
+  // scrolling the user is trying to do.
   usePoll(!!sessionId, () => {
     if (!sessionId) return;
     api.session(sessionId).then((s) => {
@@ -51,7 +81,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
       // genuinely changed session from an idle poll and skip the re-render.
       setD((prev) => (prev && s && prev.last_seen === s.last_seen && prev.events === s.events ? prev : s));
     }).catch(() => { /* keep showing what we have */ });
-  }, 3000);
+  }, d && !sessionIsLive(d) ? 20_000 : 3000);
 
   const open = !!sessionId;
   // The name if it has one, the uuid otherwise. `id` stays available for the
@@ -69,21 +99,31 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
 
   // Oldest-first, so it reads as a story rather than in reverse. Falls back to
   // the plain conversation for a server that predates the timeline field.
-  const entries: TimelineEntry[] = d?.timeline?.length
-    ? d.timeline
-    : (d?.conversation ?? []).map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text }));
-  const toolCount = entries.reduce((n, e) => n + (e.kind === "tool" ? 1 : 0), 0);
-  // Subagents report the parent's session id, so a fleet of them lands on this
-  // one timeline. Focusing one is the only way to read what it actually did
-  // without its work being shuffled together with three siblings'.
-  const ordered = [...entries].reverse().filter((e) => showTools || e.kind !== "tool");
-  // Focusing one is a request to read ITS thread alone, so it stays flat —
-  // nesting it under a spawn row it is the only occupant of would only indent
-  // it. Unfocused, the fleet's work folds back under the calls that started it.
-  const rows: Row[] = focusAgent
-    ? ordered.filter((e) => e.agent_id === focusAgent).map((e, i): Row =>
-        e.kind === "tool" ? { kind: "tool", e, children: [], key: `f${i}` } : { kind: "message", e, key: `f${i}` })
-    : buildRows(ordered);
+  //
+  // Memoised as one unit, because none of it is cheap and all of it is redone
+  // on every re-render of this panel — and while a session is live the panel
+  // re-renders every three seconds, plus once per scroll-away and scroll-back.
+  const { rows, toolCount } = useMemo(() => {
+    const entries: TimelineEntry[] = d?.timeline?.length
+      ? d.timeline
+      : (d?.conversation ?? []).map((c) => ({ kind: "message" as const, ts: c.ts, role: c.role, text: c.text }));
+    const tools = entries.reduce((n, e) => n + (e.kind === "tool" ? 1 : 0), 0);
+    // Subagents report the parent's session id, so a fleet of them lands on this
+    // one timeline. Focusing one is the only way to read what it actually did
+    // without its work being shuffled together with three siblings'.
+    const ordered = [...entries].reverse().filter((e) => showTools || e.kind !== "tool");
+    // Focusing one is a request to read ITS thread alone, so it stays flat —
+    // nesting it under a spawn row it is the only occupant of would only indent
+    // it. Unfocused, the fleet's work folds back under the calls that started it.
+    const seen = new Map<string, number>();
+    const built: Row[] = focusAgent
+      ? ordered.filter((e) => e.agent_id === focusAgent).map((e): Row =>
+          e.kind === "tool"
+            ? { kind: "tool", e, children: [], key: entryKey(e, seen) }
+            : { kind: "message", e, key: entryKey(e, seen) })
+      : buildRows(ordered);
+    return { rows: built, toolCount: tools };
+  }, [d, showTools, focusAgent]);
 
   // Follow the newest turn, the way a terminal does — but only while you are
   // already at the bottom. Scrolling up to read something is an explicit "leave
@@ -101,7 +141,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10001 }}>
               <motion.div
                 initial={{ opacity: 0, scale: 0.95, y: 14 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.96, y: 8 }}
@@ -292,27 +332,14 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                             lands a moment after the row itself. */}
                         <div ref={convoContentRef} className="space-y-2.5">
                           {rows.length === 0 && <div className="t-dim2 text-[11px]">No prompts or messages captured</div>}
-                          {rows.map((r) => r.kind === "tool" ? (
-                            <ToolRow key={r.key} e={r.e} sub={r.children} />
-                          ) : (
-                            <div key={r.key} className={`flex ${r.e.role === "user" ? "justify-end" : "justify-start"}`}>
-                              <div
-                                className="max-w-[85%] min-w-0 rounded-xl px-3 py-2 text-[11.5px] leading-relaxed break-words"
-                                // Mixed against a solid base rather than
-                                // `transparent`: over the panel's own violet the
-                                // old wash left both roles nearly the same
-                                // colour, and some themes flattened them
-                                // completely. The left border carries the
-                                // distinction even where the fills don't.
-                                style={
-                                  r.e.role === "user"
-                                    ? { background: "color-mix(in srgb, var(--primary) 26%, var(--bg2))", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--primary) 55%, transparent)", borderLeft: "3px solid var(--primary)" }
-                                    : { background: "color-mix(in srgb, var(--bg3) 85%, var(--bg))", color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", borderLeft: "3px solid color-mix(in srgb, var(--info) 70%, transparent)" }
-                                }
-                              >
-                                <div className="text-[9px] uppercase tracking-wider mb-1" style={{ color: r.e.role === "user" ? "var(--primary-hover)" : "var(--info)" }}>{r.e.role} · {fmtTime(r.e.ts)}</div>
-                                <Markdown text={r.e.text ?? ""} />
-                              </div>
+                          {/* `agx-row` is what keeps a long session scrolling
+                              smoothly: the rows you are not looking at cost no
+                              layout and no paint. */}
+                          {rows.map((r) => (
+                            <div key={r.key} className={r.kind === "tool" ? "agx-row" : "agx-row agx-row-tall"}>
+                              {r.kind === "tool"
+                                ? <ToolRow e={r.e} sub={r.children} />
+                                : <Bubble role={r.e.role ?? "assistant"} ts={r.e.ts} text={r.e.text ?? ""} />}
                             </div>
                           ))}
                         </div>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -552,7 +552,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             <div className="fixed inset-0 flex items-center justify-center p-4 pointer-events-none" style={{ zIndex: 10001 }}>
               <motion.div
                 initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}

--- a/web/src/components/SkillsModal.tsx
+++ b/web/src/components/SkillsModal.tsx
@@ -200,7 +200,7 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
         {open && (
           <>
             <motion.div initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-              className="fixed inset-0" style={{ zIndex: 10000, background: "rgba(0,0,0,0.55)", backdropFilter: "blur(3px)" }} onClick={onClose} />
+              className="fixed inset-0 agx-scrim" style={{ zIndex: 10000 }} onClick={onClose} />
             {/* Flex wrapper centers the card — Motion owns `transform` for its
                 scale/y animation, so Tailwind translate centering can't be used. */}
             <div className="fixed inset-0 flex items-center justify-center p-6 pointer-events-none" style={{ zIndex: 10001 }}>

--- a/web/src/components/ToolRow.tsx
+++ b/web/src/components/ToolRow.tsx
@@ -10,7 +10,7 @@
 // event, so a session's exploration buried the conversation it was supposed to
 // sit alongside. All of that detail is still here; it is what you open a row
 // FOR, not what you read a hundred rows of.
-import { useState } from "react";
+import { memo, useState } from "react";
 import type { TimelineEntry } from "../../../shared/types.ts";
 import { fmtTime } from "../lib/format.ts";
 
@@ -22,14 +22,20 @@ const HEAD = 3;
 const MONO = { fontFamily: "var(--font-mono, ui-monospace, monospace)" };
 const RULE = "1px solid color-mix(in srgb, var(--border) 40%, transparent)";
 
-export function ToolRow({ e, sub = [], nested = false }: {
+/** Memoised: a session timeline is hundreds of these, and the panel around them
+ *  re-renders every few seconds while the session is live. The entry objects
+ *  come straight from the fetched payload, so an unchanged row gets identical
+ *  props and does no work at all. */
+interface ToolRowProps {
   e: TimelineEntry;
   /** A spawned subagent's entries, nested under the call that started it. */
   sub?: TimelineEntry[];
   /** Already inside a group: drop the timestamp gutter, as the CLI does, and
    *  indent against the parent instead. */
   nested?: boolean;
-}) {
+}
+
+export const ToolRow = memo(function ToolRow({ e, sub = [], nested = false }: ToolRowProps) {
   const [open, setOpen] = useState(false);
   const [all, setAll] = useState(false);
   const target = e.target ?? "";
@@ -103,4 +109,24 @@ export function ToolRow({ e, sub = [], nested = false }: {
       )}
     </div>
   );
+}, same);
+
+/** Compared by content, not by identity: every poll parses a fresh payload, so
+ *  the entry for a tool run that finished an hour ago is a brand-new object with
+ *  exactly the same fields in it. Reference equality would call all of those
+ *  changed and re-render the entire timeline for one new row at the bottom. */
+function same(a: ToolRowProps, b: ToolRowProps): boolean {
+  return a.nested === b.nested && sameEntry(a.e, b.e) && sameList(a.sub, b.sub);
+}
+
+function sameEntry(a: TimelineEntry, b: TimelineEntry): boolean {
+  return a.ts === b.ts && a.tool === b.tool && a.target === b.target && a.text === b.text
+    && a.is_error === b.is_error && a.duration_ms === b.duration_ms && a.note === b.note
+    && a.output === b.output && a.output_clipped === b.output_clipped && a.tool_use_id === b.tool_use_id;
+}
+
+function sameList(a: TimelineEntry[] = [], b: TimelineEntry[] = []): boolean {
+  if (a === b) return true;
+  if (a.length !== b.length) return false;
+  return a.every((e, i) => sameEntry(e, b[i]));
 }

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -221,9 +221,9 @@
   .rdr-sweep, .shimmer { animation: none !important; }
   [style*="ping-ring"] { animation: none !important; }
 }
-/* `data-ws` joins `data-idle` here: the workspace covers the dashboard, so its
-   ambient loops are animating something nobody can see. That is not a rounding
-   error. The desktop webview composites in software (no GPU process, measured),
+/* `data-ws` joins `data-idle` here: the workspace — or any full-screen modal —
+   covers the dashboard, so its ambient loops are animating something nobody can
+   see. That is not a rounding error. The desktop webview composites in software (no GPU process, measured),
    so every frame of these loops is a full repaint charged to the CPU: the UI
    process and the web process together sit at ~172% while the server, doing the
    actual work, uses 8%. Disabling the loops outright took the same page from
@@ -296,6 +296,41 @@
 }
 @media (prefers-reduced-motion: reduce) {
   .agw-tip::after { transition: opacity 0.12s ease 0.25s; transform: none; }
+}
+
+/* The dim behind a modal.
+ *
+ * No backdrop-filter, for the same reason the panels dropped theirs: the
+ * desktop app composites in software, so a full-viewport blur is re-rastered on
+ * the CPU whenever anything under it moves — and what is under it is a live
+ * dashboard with a radar sweep, a ping per running agent and an event feed. The
+ * blur was charged per frame of all of that, while the modal on top was trying
+ * to scroll. At 3px over a dark wash almost nobody could see it anyway; the
+ * extra opacity does the same job of pushing the app back, for free.
+ *
+ * Modals with their own ground (a frosted panel, a lighter dim) set `background`
+ * inline over this and keep it. */
+.agx-scrim {
+  background: rgba(0, 0, 0, 0.66);
+}
+
+/* One row of a long, scrolling list — a session's conversation, a diff.
+ *
+ * `content-visibility: auto` lets the browser skip layout and paint for the
+ * rows that are off screen, which on a session with hundreds of tool runs is
+ * nearly all of them. `contain-intrinsic-size: auto` keeps the last real height
+ * of each row, so the scrollbar stops jumping once a row has been seen once and
+ * scrolling back over it lands where you left it. */
+.agx-row {
+  content-visibility: auto;
+  contain-intrinsic-size: auto 22px;
+}
+/* A message bubble rather than a one-line tool run. The guess only stands in
+   until a row has been on screen once, but a guess an order of magnitude out
+   makes the scrollbar leap around on the way through — so the two shapes in
+   this list guess separately. */
+.agx-row-tall {
+  contain-intrinsic-size: auto 110px;
 }
 
 /* The workspace dynamic island.

--- a/web/src/lib/markdown.tsx
+++ b/web/src/lib/markdown.tsx
@@ -14,7 +14,7 @@
 // dangerouslySetInnerHTML anywhere in here. Message text is untrusted (it can
 // contain anything a model or a tool emitted), so it must never be able to
 // become markup.
-import type { ReactNode } from "react";
+import { memo, type ReactNode } from "react";
 
 const CODE_BG = "color-mix(in srgb, var(--bg3) 55%, transparent)";
 
@@ -53,8 +53,14 @@ function inline(text: string, keyBase: string): ReactNode[] {
 }
 
 /** Render a markdown string as React nodes. Block level: fenced code, ATX
- *  headings, bullet and numbered lists, blockquotes, paragraphs. */
-export function Markdown({ text }: { text: string }) {
+ *  headings, bullet and numbered lists, blockquotes, paragraphs.
+ *
+ *  Memoised on the text. A session view holds a few hundred kilobytes of
+ *  messages and re-renders every few seconds while the session is live; parsing
+ *  all of it again to produce identical output is the single most expensive
+ *  thing that panel can do, and its one prop is a string, so the check is free.
+ */
+export const Markdown = memo(function Markdown({ text }: { text: string }) {
   const lines = text.split("\n");
   const blocks: ReactNode[] = [];
   let i = 0;
@@ -204,4 +210,4 @@ export function Markdown({ text }: { text: string }) {
   flushPara(para);
 
   return <>{blocks}</>;
-}
+});

--- a/web/src/lib/toolTree.ts
+++ b/web/src/lib/toolTree.ts
@@ -30,12 +30,37 @@ export type Row =
  * running when we attached) still gets a row of its own rather than being
  * scattered through the main thread.
  */
+/**
+ * A key that names the *entry*, not its position in the list.
+ *
+ * The position is not stable and using it was expensive: the server returns a
+ * window of the newest runs, so every new tool call pushes the oldest one out
+ * and shifts every index by one. Index keys made React treat that as "every row
+ * changed", so a live session tore down and rebuilt its whole conversation —
+ * hundreds of rows, each re-parsing its markdown — on every three-second poll.
+ * It also silently collapsed any row the user had opened to read.
+ *
+ * `tool_use_id` identifies a run outright. Without one, the timestamp plus what
+ * the row is does the same job; the counter only breaks ties between entries
+ * that are genuinely indistinguishable, and a tie stays a tie across polls
+ * because the entries arrive in the same order every time.
+ */
+export function entryKey(e: TimelineEntry, seen: Map<string, number>): string {
+  const base = e.kind === "tool"
+    ? `t:${e.tool_use_id || `${e.ts}:${e.tool ?? ""}:${e.target ?? ""}`}`
+    : `m:${e.ts}:${e.role ?? ""}`;
+  const n = seen.get(base) ?? 0;
+  seen.set(base, n + 1);
+  return n ? `${base}#${n}` : base;
+}
+
 export function buildRows(entries: TimelineEntry[]): Row[] {
   const rows: Row[] = [];
   const byAgent = new Map<string, Row & { kind: "tool" }>();
   const unclaimed: (Row & { kind: "tool" })[] = [];
+  const seen = new Map<string, number>();
 
-  entries.forEach((e, i) => {
+  entries.forEach((e) => {
     const agent = e.agent_id || "";
     if (agent) {
       let host = byAgent.get(agent);
@@ -58,12 +83,12 @@ export function buildRows(entries: TimelineEntry[]): Row[] {
       return;
     }
     if (e.kind === "tool") {
-      const row: Row & { kind: "tool" } = { kind: "tool", e, children: [], key: `t${i}` };
+      const row: Row & { kind: "tool" } = { kind: "tool", e, children: [], key: entryKey(e, seen) };
       rows.push(row);
       if (SPAWN_TOOLS.has(e.tool ?? "")) unclaimed.push(row);
       return;
     }
-    rows.push({ kind: "message", e, key: `m${i}` });
+    rows.push({ kind: "message", e, key: entryKey(e, seen) });
   });
 
   return rows;

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -29,7 +29,7 @@ export interface LiveData {
  * flushed on a timer (not per-message) so a busy fleet causes a few renders a
  * second instead of dozens. Rendering pauses entirely while the tab is hidden.
  */
-export function useLive(): LiveData {
+export function useLive(paused = false): LiveData {
   const [events, setEvents] = useState<WatchEvent[]>([]);
   const [conn, setConn] = useState<ConnState>("connecting");
   const [lastEvent, setLastEvent] = useState<WatchEvent | null>(null);
@@ -48,18 +48,30 @@ export function useLive(): LiveData {
   const pending = useRef<WatchEvent[]>([]);
   const seen = useRef(new Set<number>());
   const flushScheduled = useRef(false);
+  // What is currently on screen. Read by the trim below, which used to close
+  // over the first render's empty array and so rebuilt the dedupe set without
+  // the ids it was meant to remember.
+  const shown = useRef(events);
+  shown.current = events;
+  // "Something is covering the dashboard." Rendering behind it is work nobody
+  // can see, and on the desktop app it is work charged to the same CPU that is
+  // trying to scroll whatever opened on top. Held in a ref so the flush reads it
+  // without the callback being rebuilt on each toggle.
+  const pausedRef = useRef(paused);
+  pausedRef.current = paused;
 
   const flush = useCallback(() => {
     flushScheduled.current = false;
-    // Don't touch React state while hidden — just keep the buffer bounded.
-    if (typeof document !== "undefined" && document.hidden) {
+    // Don't touch React state while hidden or covered — just keep the buffer
+    // bounded. Nothing is lost: uncovering flushes at once.
+    if (pausedRef.current || (typeof document !== "undefined" && document.hidden)) {
       if (pending.current.length > MAX_EVENTS) {
         pending.current = pending.current.slice(-MAX_EVENTS);
         // Rebuild the dedup set too, or it grows one id per event for the whole
         // time the tab is backgrounded. Keep the ids already displayed (events)
         // as well as those buffered, so a re-delivery of a shown event is still
         // caught after the trim.
-        seen.current = new Set([...events.map((e) => e.id), ...pending.current.map((e) => e.id)]);
+        seen.current = new Set([...shown.current.map((e) => e.id), ...pending.current.map((e) => e.id)]);
       }
       return;
     }
@@ -210,6 +222,12 @@ export function useLive(): LiveData {
   // on top — this is a monitoring surface people leave on-screen and watch, and
   // freezing the sweep under a still-visible, still-focused window would read as
   // a hung app rather than a saving.
+  // Catch up the moment the dashboard is uncovered — one render for everything
+  // that arrived while it was hidden, instead of five a second into the dark.
+  useEffect(() => {
+    if (!paused) flush();
+  }, [paused, flush]);
+
   useEffect(() => {
     const sync = () => {
       const looking = !document.hidden && document.hasFocus();

--- a/web/test/tool-tree.test.ts
+++ b/web/test/tool-tree.test.ts
@@ -82,3 +82,28 @@ test("a non-spawning tool never adopts a subagent", () => {
   expect(rows[0].kind === "tool" && rows[0].children).toHaveLength(0);
   expect(rows[1].kind === "tool" && rows[1].e.tool).toBe("subagent");
 });
+
+test("a row keeps its key when the server's window slides", () => {
+  // The session response carries the newest N runs, so every new tool call
+  // pushes the oldest one out and moves everything else along by one. Keys used
+  // to be that position, which told React the whole conversation had changed:
+  // a live session tore down and rebuilt hundreds of rows every poll, losing
+  // any row the reader had opened. The rows themselves are what must be named.
+  const a = tool("Read", "a.ts", { tool_use_id: "u1" });
+  const b = tool("Bash", "ls", { tool_use_id: "u2" });
+  const c = tool("Edit", "b.ts", { tool_use_id: "u3" });
+  const d = tool("Bash", "git status", { tool_use_id: "u4" });
+
+  const before = buildRows([a, b, c]);
+  const after = buildRows([b, c, d]); // `a` aged out, `d` arrived
+  expect(before.slice(1).map((r) => r.key)).toEqual(after.slice(0, 2).map((r) => r.key));
+});
+
+test("indistinguishable rows still get distinct keys", () => {
+  // Same timestamp, same tool, same target, and no tool_use_id to tell them
+  // apart. They still need one key each, and the same key on each rebuild.
+  const twin = (): TimelineEntry => ({ kind: "tool", ts: 500, tool: "Bash", target: "ls" });
+  const keys = buildRows([twin(), twin(), twin()]).map((r) => r.key);
+  expect(new Set(keys).size).toBe(3);
+  expect(buildRows([twin(), twin(), twin()]).map((r) => r.key)).toEqual(keys);
+});


### PR DESCRIPTION
## What does this PR do?

Makes the session view scroll smoothly again on a large session. A run with 4,619 events and 1,463 tool calls scrolled in visible steps and no longer opened cleanly. Five separate causes, each paid on every frame or every poll:

- **Row keys were list positions.** The server returns a window of the newest runs, so every new tool call pushes the oldest out and shifts every index — which told React the whole conversation had changed. A live session tore down and rebuilt several hundred rows, re-parsing a few hundred kilobytes of markdown, every three seconds, and silently collapsed any row that had been opened to read. Rows are named by `tool_use_id` now.
- **Nothing was memoised.** The row tree, the tool count and every message's markdown were rebuilt on each render, including the renders that scrolling itself causes. The tree is one `useMemo`; `Markdown`, `ToolRow` and the message bubble are memoised (`ToolRow` by content, since each poll parses a fresh payload and identical rows are never the same object twice).
- **Off-screen rows were still laid out and painted.** `content-visibility` skips both for the rows nobody is looking at, with separate size hints for a one-line tool run and a message bubble.
- **The dashboard kept working behind the dim.** The radar swept, a ring pulsed per live agent and the event feed re-rendered five times a second under an overlay nobody could see through, on the same CPU the modal was scrolling with. The existing `data-ws` animation freeze now covers modals too, and the socket holds its buffer while one is open, flushing in a single render on close. Not while the workspace is open: the chat panel in there is fed by those same events.
- **Every full-screen scrim carried `backdrop-filter: blur(3px)`.** The desktop app composites in software, so that is a full-viewport blur re-rastered whenever anything underneath moves — and what was underneath was all of the above. One `.agx-scrim` class and a slightly deeper dim look the same at 3px and cost nothing. The stats overlay keeps its deliberate frost, which now sits over a still image.

Also: a finished session polls every 20s instead of every 3s. Its conversation is not moving, and that response is the largest one the app fetches.

## How was it tested?

- `bunx tsc --noEmit` in `web/` and `server/`, `bunx vite build`, `bun test` (296 pass, 2 new ones pinning key stability across a sliding window), `bun scripts/perfbudget.ts`.
- Installed the desktop build from this branch with `electron/install-local.sh` and exercised the session view on the session that prompted this: scrolling the conversation, opening tool rows and leaving them open across several polls, opening and closing the modal, and the file-diff modal on top of it.
