### PR TITLE
feat(chat): fold a turn's tool calls, and stop its sentences running together

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -15,6 +15,7 @@ import type { GitRepoRef, SessionRollup } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
+import { ToolFeed } from "./ToolFeed.tsx";
 import { buildRows } from "../lib/toolTree.ts";
 import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
@@ -80,17 +81,18 @@ const selStyle = { background: "color-mix(in srgb, var(--bg3) 50%, transparent)"
  * nothing to say. Collapsed by default and deliberately quiet — this is the
  * working-out, not the answer, and it is usually several times longer.
  *
- * Auto-opens only while it's the only thing happening: watching it stream is the
- * difference between "thinking" and "frozen". It folds itself the moment real
- * output starts.
+ * Closed until asked, streaming or not. It used to open itself while it was the
+ * only thing happening, on the grounds that watching it stream is the difference
+ * between "thinking" and "frozen" — but that put the working-out on screen by
+ * default, which is exactly what nobody asked to read. Liveness is the tool
+ * feed's running call and the composer's caret; this stays folded.
  */
 function Thinking({ text, streaming }: { text: string; streaming: boolean }) {
-  const [openedByHand, setOpenedByHand] = useState<boolean | null>(null);
-  const open = openedByHand ?? streaming;
+  const [open, setOpen] = useState(false);
   const lines = text.trim().split("\n");
   return (
     <div className="mb-1.5 rounded-md overflow-hidden" style={{ background: "color-mix(in srgb, var(--bg3) 30%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
-      <button onClick={() => setOpenedByHand(!open)}
+      <button onClick={() => setOpen(!open)} aria-expanded={open}
         className="w-full flex items-center gap-1.5 px-2 py-1 text-left hover:opacity-80">
         <span className="text-[8px] t-dim2 transition-transform" style={{ transform: open ? "none" : "rotate(-90deg)" }}>▼</span>
         <span className="text-[9px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>thinking</span>
@@ -903,21 +905,22 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                               <span className="t-dim2 normal-case tracking-normal">{fmtTime(m.ts)}</span>
                             </div>
                             {m.thinking && <Thinking text={m.thinking} streaming={!!m.streaming && !m.text} />}
-                            {m.tools.length > 0 && (
-                              <div className="flex flex-col gap-0.5 mb-1.5 pb-1.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
-                                {/* Folded the same way the session timeline
-                                    folds it: a subagent's work nests under the
-                                    call that spawned it rather than being
-                                    interleaved with the main thread's. */}
-                                {buildRows(m.tools.map((t) => ({
-                                  kind: "tool" as const, ts: t.ts, tool: t.name, target: t.target,
-                                  is_error: t.error, output: t.output, note: t.note,
-                                  agent_id: t.agentId, agent_type: t.agentType, tool_use_id: t.id,
-                                }))).map((r) => r.kind === "tool" && (
-                                  <ToolRow key={r.key} e={r.e} sub={r.children} />
-                                ))}
-                              </div>
-                            )}
+                            {/* Behind a fold, not in front of the answer. The
+                                summary line carries the running call and any
+                                failure; the feed itself is one click away. */}
+                            <ToolFeed tools={m.tools} streaming={!!m.streaming}>
+                              {/* Folded the same way the session timeline
+                                  folds it: a subagent's work nests under the
+                                  call that spawned it rather than being
+                                  interleaved with the main thread's. */}
+                              {buildRows(m.tools.map((t) => ({
+                                kind: "tool" as const, ts: t.ts, tool: t.name, target: t.target,
+                                is_error: t.error, output: t.output, note: t.note,
+                                agent_id: t.agentId, agent_type: t.agentType, tool_use_id: t.id,
+                              }))).map((r) => r.kind === "tool" && (
+                                <ToolRow key={r.key} e={r.e} sub={r.children} />
+                              ))}
+                            </ToolFeed>
                             {!!m.images?.length && (
                               <div className="flex flex-wrap gap-1.5 mb-1.5">
                                 {m.images.map((img, j) => (
@@ -1109,7 +1112,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                     <div className="mt-1.5 text-[9.5px] t-dim2">
                       {hint
                         ? <span style={{ color: "var(--warning)" }}>{hint}</span>
-                        : <>Runs claude in {active ? repoName(active.cwd) || "the repo" : "the repo"} · {MODES.find((x) => x.id === active?.mode)?.label} · tools appear as ⚙ chips</>}
+                        : <>Runs claude in {active ? repoName(active.cwd) || "the repo" : "the repo"} · {MODES.find((x) => x.id === active?.mode)?.label} · tool calls fold away, click to open</>}
                       {active?.mode === "bypassPermissions" && <span style={{ color: "var(--warning)" }}> · ⚡ runs tools unattended</span>}
                     </div>
                   </div>

--- a/web/src/components/ToolFeed.tsx
+++ b/web/src/components/ToolFeed.tsx
@@ -1,0 +1,69 @@
+// A turn's tool calls, folded behind one line.
+//
+// The rows themselves were already right — `Tool(what it acted on)`, detail on
+// click, subagents nested. What was wrong was how many of them a reader is shown
+// without asking. A turn that greps twenty files printed twenty rows above the
+// sentence it was working towards, so the answer arrived below its own
+// machinery and the conversation scrolled away under it.
+//
+// So: one summary line, and the feed behind it. The information the fold must
+// not lose is (a) that something is happening right now, and (b) that something
+// failed — a folded failure is worse than no fold at all. Both are on the
+// summary line; everything else is what you open it FOR.
+import { useState } from "react";
+import type { ChatTool } from "../lib/chatStore.ts";
+import { toolFeedSummary, toolLabel } from "../lib/toolFeed.ts";
+
+const MONO = { fontFamily: "var(--font-mono, ui-monospace, monospace)" };
+
+/**
+ * The fold. `children` is the real feed, rendered by the caller so this stays
+ * ignorant of how a row is built.
+ *
+ * Starts closed even while streaming. Watching the tools scroll past is the
+ * thing being fixed, and the running call on the summary line answers "is it
+ * alive" without reprinting the whole run to do it.
+ */
+export function ToolFeed({ tools, streaming, children }: {
+  tools: ChatTool[];
+  /** The turn is still going, so the last row is the one running now. */
+  streaming: boolean;
+  children: React.ReactNode;
+}) {
+  const [open, setOpen] = useState(false);
+  const { n, failed, latest } = toolFeedSummary(tools);
+  if (!n) return null;
+
+  const running = streaming && !!latest;
+  const tint = failed ? "var(--error)" : "var(--info)";
+
+  return (
+    <div className="mb-1.5 pb-1.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+      <button
+        onClick={() => setOpen((o) => !o)}
+        aria-expanded={open}
+        className="w-full flex items-center gap-1.5 text-left hover:opacity-80 px-1 py-0.5"
+        title={open ? "Fold the tool calls away" : "Show what this turn ran"}>
+        <span className="text-[8px] t-dim2 transition-transform shrink-0" style={{ transform: open ? "none" : "rotate(-90deg)" }}>▼</span>
+        <span className="text-[9px] uppercase tracking-wider shrink-0" style={{ color: tint }}>
+          {n} tool call{n === 1 ? "" : "s"}
+        </span>
+        {/* Only while it runs: which call is in flight. This is the whole reason
+            the fold can default to closed. */}
+        {running && !open && (
+          <span className="text-[10px] min-w-0 flex-1 truncate" style={{ ...MONO, color: "var(--text4)" }}>
+            {toolLabel(latest)}
+          </span>
+        )}
+        {running && <span className="text-[9px] shrink-0" style={{ color: "var(--info)" }}>·</span>}
+        {/* A failure never folds silently. */}
+        {failed > 0 && (
+          <span className="text-[9px] tabular-nums ml-auto shrink-0" style={{ color: "var(--error)" }}>
+            ✕ {failed} failed
+          </span>
+        )}
+      </button>
+      {open && <div className="flex flex-col gap-0.5 mt-1">{children}</div>}
+    </div>
+  );
+}

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -45,6 +45,26 @@ export function toolTarget(name: string, inp: Record<string, unknown>): string |
     : strv(inp.file_path) ?? strv(inp.path) ?? strv(inp.url) ?? strv(inp.query) ?? strv(inp.pattern) ?? strv(inp.description) ?? strv(inp.command);
 }
 
+/**
+ * Add a text block to what the assistant has said so far.
+ *
+ * A turn is one bubble, but the model reaches it in several frames: it says a
+ * sentence, runs a tool, says the next one. Each of those is its own complete
+ * text block, and appending them raw ran them together mid-word — "…in your
+ * screenshot.Picking it up again" — because the block that ended a thought had
+ * no reason to carry a trailing newline. Nothing was lost, but a turn's worth of
+ * separate remarks arrived as one paragraph nobody can skim.
+ *
+ * So blocks are joined the way they were meant: a blank line between them,
+ * unless the previous one already ended in a break of its own (a list, a code
+ * fence, a heading), where adding another would open a gap in the markdown.
+ */
+export function joinBlock(prev: string, next: string): string {
+  if (!prev) return next;
+  if (!next) return prev;
+  return /\n\s*$/.test(prev) ? prev + next : `${prev}\n\n${next}`;
+}
+
 export type ChatMsg = {
   role: "user" | "assistant";
   text: string;
@@ -571,10 +591,10 @@ export async function send(id: string, text: string, isActive: () => boolean, al
         const last = c.messages[c.messages.length - 1];
         if (!last || last.role !== "assistant") return;
         for (const b of blocks) {
-          if (b.type === "text" && typeof b.text === "string") last.text += b.text;
+          if (b.type === "text" && typeof b.text === "string") last.text = joinBlock(last.text, b.text);
           // Reasoning, kept apart from the answer. Streams in chunks like text.
           else if (b.type === "thinking" && typeof b.thinking === "string") {
-            last.thinking = (last.thinking ?? "") + b.thinking;
+            last.thinking = joinBlock(last.thinking ?? "", b.thinking);
           }
           else if (b.type === "tool_use" && typeof b.name === "string") {
             // The result comes back later keyed only by id, so remember which

--- a/web/src/lib/toolFeed.ts
+++ b/web/src/lib/toolFeed.ts
@@ -1,0 +1,32 @@
+// What a folded turn of tool calls says about itself.
+//
+// Kept apart from the component for the same reason `toolTree` is: this is the
+// part with rules — what the fold is allowed to hide and what it must not — and
+// rules are worth testing without a DOM to render them into.
+import type { ChatTool } from "./chatStore.ts";
+
+export interface ToolFeedSummary {
+  /** How many calls the turn made. */
+  n: number;
+  /** How many of them came back an error. A folded failure is worse than no
+   *  fold at all, so this always reaches the summary line. */
+  failed: number;
+  /** The call to show while the turn is still running: the most recent one. */
+  latest: ChatTool | null;
+}
+
+export function toolFeedSummary(tools: ChatTool[]): ToolFeedSummary {
+  return {
+    n: tools.length,
+    failed: tools.reduce((k, t) => k + (t.error ? 1 : 0), 0),
+    latest: tools.length ? tools[tools.length - 1] : null,
+  };
+}
+
+/** One line describing a call, written the way the expanded row writes it:
+ *  `Tool(what it acted on)`. A command can be a whole script, and only its
+ *  first line identifies the run. */
+export function toolLabel(t: ChatTool): string {
+  const target = (t.target ?? "").split("\n")[0];
+  return target ? `${t.name}(${target})` : t.name;
+}

--- a/web/test/chat-text.test.ts
+++ b/web/test/chat-text.test.ts
@@ -1,0 +1,73 @@
+import { test, expect, beforeAll } from "bun:test";
+
+// A turn is one bubble, but the model reaches it in several frames: a sentence,
+// a tool call, the next sentence. Those arrived concatenated raw, so a turn's
+// separate remarks ran together mid-word and the bubble became one paragraph
+// nobody can skim. These pin the join — and the case where adding a break of
+// our own would damage the markdown instead of helping it.
+
+let store: typeof import("../src/lib/chatStore.ts");
+let api: typeof import("../src/lib/api.ts")["api"];
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  api = (await import("../src/lib/api.ts")).api;
+  store = await import("../src/lib/chatStore.ts");
+});
+
+const active = () => true;
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+/** Replay a turn as the CLI actually frames it: one message per block. */
+function replay(...blocks: Array<Record<string, unknown>>) {
+  api.chatStream = (async (_p: unknown, onEvent: (o: Record<string, unknown>) => void) => {
+    for (const b of blocks) onEvent({ type: "assistant", message: { content: [b] } });
+  }) as typeof api.chatStream;
+}
+
+test("two sentences from two frames do not run together", async () => {
+  replay(
+    { type: "text", text: "The list is duplicated in your screenshot." },
+    { type: "tool_use", id: "t1", name: "Bash", input: { command: "rg dup" } },
+    { type: "text", text: "Picking it up with the new finding." },
+  );
+  const c = store.newChat("/tmp/repo");
+  await store.send(c.id, "go", active);
+  await tick();
+  const [m] = store.getChat(c.id)!.messages.filter((x) => x.role === "assistant");
+  expect(m.text).toBe("The list is duplicated in your screenshot.\n\nPicking it up with the new finding.");
+  store.closeChat(c.id);
+});
+
+test("a block that already ends in a break keeps its own spacing", async () => {
+  // A list or a code fence closes with a newline. A blank line bolted on top of
+  // it opens a gap the author did not write.
+  replay(
+    { type: "text", text: "Two things:\n- the fold\n- the join\n" },
+    { type: "text", text: "Both shipped." },
+  );
+  const c = store.newChat("/tmp/repo");
+  await store.send(c.id, "go", active);
+  await tick();
+  const [m] = store.getChat(c.id)!.messages.filter((x) => x.role === "assistant");
+  expect(m.text).toBe("Two things:\n- the fold\n- the join\nBoth shipped.");
+  store.closeChat(c.id);
+});
+
+test("reasoning is joined the same way the answer is", async () => {
+  replay(
+    { type: "thinking", thinking: "First I check the store." },
+    { type: "thinking", thinking: "Then the panel." },
+  );
+  const c = store.newChat("/tmp/repo");
+  await store.send(c.id, "go", active);
+  await tick();
+  const [m] = store.getChat(c.id)!.messages.filter((x) => x.role === "assistant");
+  expect(m.thinking).toBe("First I check the store.\n\nThen the panel.");
+  store.closeChat(c.id);
+});
+
+test("the join is a no-op on the first block and on an empty one", () => {
+  expect(store.joinBlock("", "hello")).toBe("hello");
+  expect(store.joinBlock("hello", "")).toBe("hello");
+});

--- a/web/test/tool-feed.test.ts
+++ b/web/test/tool-feed.test.ts
@@ -1,0 +1,42 @@
+// What the folded tool feed is allowed to hide, and what it never hides.
+import { expect, test } from "bun:test";
+import { toolFeedSummary, toolLabel } from "../src/lib/toolFeed.ts";
+import type { ChatTool } from "../src/lib/chatStore.ts";
+
+const tool = (over: Partial<ChatTool> = {}): ChatTool => ({
+  id: "t1", name: "Bash", target: "rg foo", output: null, error: false, ts: 1, ...over,
+});
+
+test("counts the calls it is folding", () => {
+  const s = toolFeedSummary([tool(), tool({ id: "t2" }), tool({ id: "t3" })]);
+  expect(s.n).toBe(3);
+  expect(s.failed).toBe(0);
+});
+
+test("a failure is never folded silently", () => {
+  const s = toolFeedSummary([tool(), tool({ id: "t2", error: true }), tool({ id: "t3", error: true })]);
+  expect(s.failed).toBe(2);
+});
+
+test("the running call is the most recent one", () => {
+  const s = toolFeedSummary([tool({ id: "a", target: "first" }), tool({ id: "b", target: "last" })]);
+  expect(s.latest?.id).toBe("b");
+});
+
+test("an empty turn has nothing to say", () => {
+  const s = toolFeedSummary([]);
+  expect(s.n).toBe(0);
+  expect(s.latest).toBeNull();
+});
+
+test("the label reads like the row: Tool(what it acted on)", () => {
+  expect(toolLabel(tool({ name: "Read", target: "/tmp/a.ts" }))).toBe("Read(/tmp/a.ts)");
+});
+
+test("a multi-line command is identified by its first line", () => {
+  expect(toolLabel(tool({ target: "cd /tmp\nmake test" }))).toBe("Bash(cd /tmp)");
+});
+
+test("a tool with no target is just its name", () => {
+  expect(toolLabel(tool({ name: "TodoWrite", target: null }))).toBe("TodoWrite");
+});


### PR DESCRIPTION
## What does this PR do?

Chat turns were unreadable. A turn that grepped twenty files printed twenty rows above the sentence it was working towards, so the answer arrived underneath its own machinery and the conversation scrolled away under it. Two changes:

**The tool feed folds.** One summary line, `28 tool calls`, and the feed behind it. The fold is only allowed to hide what nobody needs: the call in flight stays on the summary while the turn is live, which is what makes "is it working" a glance rather than a scroll, and a failed call surfaces as `✕ N failed` in the error tint so nothing breaks quietly behind a fold. Thinking loses its auto-open for the same reason: it used to unfold itself whenever it was the only thing happening, on the grounds that watching it stream is the difference between thinking and frozen, but that put the working-out on screen by default, which is the thing being fixed. Liveness is now the feed's running call and the streaming caret.

**A turn's remarks stay separate paragraphs.** A turn is one bubble but arrives in several frames: a sentence, a tool call, the next sentence. Each text block is complete, and appending them raw ran them together mid-word (`...in your screenshot.Picking it up again`) because a block that ends a thought has no reason to carry a trailing newline. Nothing was lost; a turn's worth of separate remarks just arrived as one paragraph nobody can skim. Blocks now join with a blank line, except where the previous one already ended in a break of its own (a list, a fence, a heading), since a gap bolted onto those is markdown the author did not write. This got worse the moment the feed folded away: the tool rows used to sit between the sentences and do the separating by accident.

The summary rules live in `web/src/lib/toolFeed.ts` and the join in `joinBlock()` rather than in the components, so what the fold may hide and how blocks meet are testable without a DOM, the way `toolTree` already is.

## How was it tested?

- `bunx tsc --noEmit -p web/tsconfig.json` clean.
- `bun test`: 936 pass, 0 fail. New: `web/test/tool-feed.test.ts` (7) covers the summary count, the failure count reaching the line, and the label a running call shows; `web/test/chat-text.test.ts` (4) drives `send()` with a real multi-frame turn and pins both the join and the case where a trailing break must be left alone.
- Exercised in the packaged desktop app, built from this branch with `electron/install-local.sh`: folded a live turn open and shut mid-run, confirmed the running call tracks on the summary line, and re-read a turn whose sentences used to concatenate.
