### PR TITLE
fix(themes): stop the test suite repainting the developer's tmux white

### DIFF
--- a/server/src/themesync.ts
+++ b/server/src/themesync.ts
@@ -17,14 +17,48 @@
 // it would put our update cycle in a fight with their local edits forever.
 
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
-import { homedir } from "node:os";
+import { homedir, tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { liveNvimSockets } from "./editor.ts";
 
-const CONFIG_HOME = process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
-export const THEME_DIR = join(CONFIG_HOME, "agentglass");
-export const NVIM_THEME = join(THEME_DIR, "theme.lua");
-export const TMUX_THEME = join(THEME_DIR, "theme.tmux.conf");
+/*
+ * Resolved per call, not once at import.
+ *
+ * These used to be module constants, which meant the first `import` of this
+ * file froze the paths for the whole process. A test that points HOME and
+ * XDG_CONFIG_HOME at a scratch directory and only then imports this module got
+ * the cached copy, still aimed at the real one, and wrote a white "Light"
+ * palette into the user's own theme file. Every tmux server that sourced it
+ * afterwards painted its panes `#ffffff`, which is what a terminal turning
+ * white on its own actually was.
+ */
+const configHome = () => process.env.XDG_CONFIG_HOME || join(homedir(), ".config");
+export const themeDir = () => join(configHome(), "agentglass");
+export const nvimThemePath = () => join(themeDir(), "theme.lua");
+export const tmuxThemePath = () => join(themeDir(), "theme.tmux.conf");
+
+/*
+ * A second lock on the same door.
+ *
+ * Lazy paths fix the cache, but only for a test that remembers to redirect
+ * HOME. This makes forgetting harmless: under `bun test`, which sets
+ * NODE_ENV=test, these files may only be written inside the scratch directory,
+ * and no palette may be pushed into a live tmux or nvim at all.
+ *
+ * The rule is "inside `os.tmpdir()`" rather than "outside the user's home"
+ * because `$HOME` is the very thing an isolated test moves, and Bun's
+ * `homedir()` and `userInfo()` both follow it. Anchoring on the scratch
+ * directory instead cannot be defeated by import order or by which variable a
+ * test remembered to set. Same shape as the notification guard in alerts.ts,
+ * and for the same reason: a test suite may not redecorate the machine it runs
+ * on.
+ */
+const IS_TEST = process.env.NODE_ENV === "test";
+function blockedInTest(target: string): boolean {
+  if (!IS_TEST) return false;
+  const scratch = tmpdir();
+  return !(target === scratch || target.startsWith(scratch + "/"));
+}
 
 /** The subset of the palette worth exporting. Everything here exists in every
  *  theme; anything theme-specific would break the ones that lack it. */
@@ -438,8 +472,14 @@ export async function syncTheme(vars: Record<string, unknown>, themeName: string
   const v = normalizeVars(vars);
   const wrote: string[] = [];
   const reloaded: string[] = [];
+  const dir = themeDir();
+  const NVIM_THEME = nvimThemePath();
+  const TMUX_THEME = tmuxThemePath();
+  if (blockedInTest(dir)) {
+    return { ok: false, wrote, reloaded, error: `refusing to write ${dir} from a test: point XDG_CONFIG_HOME at a directory under os.tmpdir()` };
+  }
   try {
-    mkdirSync(THEME_DIR, { recursive: true });
+    mkdirSync(dir, { recursive: true });
     writeFileSync(NVIM_THEME, nvimTheme(v, themeName));
     wrote.push(NVIM_THEME);
     writeFileSync(TMUX_THEME, tmuxTheme(v, themeName));
@@ -450,7 +490,13 @@ export async function syncTheme(vars: Record<string, unknown>, themeName: string
 
   // tmux: cheap and safe — sourcing a file it already sources is a no-op if
   // nothing changed, and there is no session to disturb if it isn't running.
-  try {
+  //
+  // Never from a test, and the guard has to live here rather than in the test's
+  // environment: `Bun.spawn` hands the child the environment the process
+  // started with, so a test that sets TMUX_TMPDIR and deletes TMUX at runtime
+  // changes nothing about the tmux it spawns. That is how a "Light" fixture
+  // reached a developer's own session and painted every pane white.
+  if (!IS_TEST) try {
     const p = Bun.spawn(["tmux", "source-file", TMUX_THEME], { stdout: "ignore", stderr: "ignore" });
     const t = setTimeout(() => { try { p.kill(); } catch { /* gone */ } }, 2000);
     if ((await p.exited) === 0) reloaded.push("tmux");
@@ -466,7 +512,7 @@ export async function syncTheme(vars: Record<string, unknown>, themeName: string
    * now. `luafile` because the generated file is a module that applies itself
    * and registers its own ColorScheme autocmd.
    */
-  try {
+  if (!IS_TEST) try {
     const socks = await liveNvimSockets();
     const keys = `<C-\\><C-N>:luafile ${NVIM_THEME}<CR>`;
     const done = await Promise.all(socks.map(async (sock) => {
@@ -507,7 +553,7 @@ export const SNIPPETS = {
  * reads it and it is the path every tmux answer on the internet names.
  */
 export function tmuxConfPath(): string {
-  const xdg = join(CONFIG_HOME, "tmux", "tmux.conf");
+  const xdg = join(configHome(), "tmux", "tmux.conf");
   const dot = join(homedir(), ".tmux.conf");
   if (existsSync(xdg)) return xdg;
   return existsSync(dot) ? dot : xdg;
@@ -529,7 +575,9 @@ export function tmuxConfPath(): string {
  * the file is not there yet.
  */
 export function applyThemeTo(socket: string[]): boolean {
-  if (!existsSync(TMUX_THEME)) return false;
+  const TMUX_THEME = tmuxThemePath();
+  // A test may open a terminal; it may not repaint the machine's tmux.
+  if (IS_TEST || !existsSync(TMUX_THEME)) return false;
   try {
     const p = Bun.spawnSync(["tmux", ...socket, "source-file", "-q", TMUX_THEME], {
       stdout: "ignore", stderr: "ignore", timeout: 2000,
@@ -540,7 +588,7 @@ export function applyThemeTo(socket: string[]): boolean {
 
 /** Has the user already opted in? Read-only — this never edits their files. */
 export function snippetStatus(): { nvim: boolean; tmux: boolean; nvimPath: string; tmuxPath: string } {
-  const nvimPath = join(CONFIG_HOME, "nvim", "lua", "plugins", "theme.lua");
+  const nvimPath = join(configHome(), "nvim", "lua", "plugins", "theme.lua");
   const tmuxPath = tmuxConfPath();
   const has = (p: string, needle: string) => {
     try { return existsSync(p) && readFileSync(p, "utf8").includes(needle); } catch { return false; }

--- a/server/test/themesync-nondestructive.test.ts
+++ b/server/test/themesync-nondestructive.test.ts
@@ -12,7 +12,7 @@
 // byte-for-byte assertions hold regardless; TMUX_TMPDIR and an empty
 // XDG_RUNTIME_DIR keep them from perturbing a real tmux/nvim while tests run.
 import { describe, expect, test, beforeAll, afterAll } from "bun:test";
-import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync } from "node:fs";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, readdirSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -67,19 +67,63 @@ describe("syncTheme never edits the user's own config", () => {
     ] as const) {
       const r = await ts.syncTheme(palette(bg, primary), name);
       expect(r.ok).toBe(true);
+      // Nothing running is repainted from a test. Env isolation cannot deliver
+      // this on its own: Bun.spawn gives the child the environment the process
+      // started with, so TMUX_TMPDIR set at runtime never reaches tmux.
+      expect(r.reloaded).toEqual([]);
       // Every path it reports writing is inside agentglass's own dir.
-      for (const p of r.wrote) expect(p.startsWith(ts.THEME_DIR)).toBe(true);
+      for (const p of r.wrote) expect(p.startsWith(ts.themeDir())).toBe(true);
+      // And inside the scratch home this file set up, never the real one.
+      for (const p of r.wrote) expect(p.startsWith(home)).toBe(true);
     }
     expect(readFileSync(userTmux, "utf8")).toBe(userTmuxBody);
     expect(readFileSync(userNvim, "utf8")).toBe(userNvimBody);
   });
 
   test("it does write its own theme files, under ~/.config/agentglass only", () => {
-    const written = readdirSync(ts.THEME_DIR).sort();
+    const written = readdirSync(ts.themeDir()).sort();
     expect(written).toContain("theme.tmux.conf");
     expect(written).toContain("theme.lua");
-    expect(ts.TMUX_THEME.startsWith(ts.THEME_DIR)).toBe(true);
-    expect(ts.NVIM_THEME.startsWith(ts.THEME_DIR)).toBe(true);
+    expect(ts.tmuxThemePath().startsWith(ts.themeDir())).toBe(true);
+    expect(ts.nvimThemePath().startsWith(ts.themeDir())).toBe(true);
+  });
+
+  /**
+   * The leak this file was supposed to prevent, and did not.
+   *
+   * The paths used to be module constants, so the first import in the process
+   * froze them. `security.test.ts` and `terminal-commands.test.ts` sort ahead of
+   * this file and pull `themesync.ts` in through `terminal.ts`, which meant the
+   * env redirected above arrived too late and the "Light" palette below was
+   * written straight into the developer's own `~/.config/agentglass/`. Every
+   * tmux server that sourced it afterwards painted its panes `#ffffff`. That is
+   * what "the terminal went white on its own" was.
+   *
+   * Two things stop it now, and both are worth holding: the paths resolve per
+   * call, and a write outside the scratch directory is refused outright while
+   * NODE_ENV=test.
+   */
+  test("a test that forgot to redirect its home cannot write the real one", async () => {
+    const saved = process.env.XDG_CONFIG_HOME;
+    // Deliberately outside os.tmpdir(): this stands in for a real home. Reading
+    // the actual one is not an option here, since by this point in a full suite
+    // another file may already have moved HOME somewhere harmless.
+    const notScratch = "/home/agx-not-a-scratch-dir";
+    process.env.XDG_CONFIG_HOME = join(notScratch, ".config");
+    try {
+      expect(ts.themeDir().startsWith(notScratch)).toBe(true); // resolved live, not at import
+      const r = await ts.syncTheme(palette("#ffffff", "#7c3aed"), "Light");
+      expect(r.ok).toBe(false);
+      expect(r.wrote).toEqual([]);
+      expect(r.error).toContain("refusing to write");
+      expect(existsSync(notScratch)).toBe(false); // and it created nothing on the way
+    } finally {
+      process.env.XDG_CONFIG_HOME = saved;
+    }
+  });
+
+  test("no live tmux is repainted from a test, whatever the file says", () => {
+    expect(ts.applyThemeTo([])).toBe(false);
   });
 
   test("snippetStatus reports opt-in state read-only, without editing anything", () => {


### PR DESCRIPTION
## What does this PR do?

`bun test` was rewriting the developer's own `~/.config/agentglass/theme.tmux.conf` to the "Light" palette and sourcing it into their live tmux server. That sets `window-style "bg=#ffffff"`, so every pane goes white and stays white until something re-sources a dark palette. It reads exactly like the terminal blanking on its own, which is what the white-out hunt has been chasing across #269, #280 and #283. It was never the GPU, the xterm WebGL context or the compositor.

Reproduced before touching anything: back up the file, run `bun test server/test/`, and it comes back as `# Theme: Light` with `set -g window-style "bg=#ffffff"`.

Two independent failures had to line up.

**Paths were resolved once, at import.** `server/test/themesync-nondestructive.test.ts` points `HOME` and `XDG_CONFIG_HOME` at a scratch directory and only then imports `themesync.ts`, which is the right idea. But `security.test.ts` and `terminal-commands.test.ts` sort earlier in the run and already pulled that module in through `terminal.ts`, so the redirect arrived long after `THEME_DIR` was frozen on the real home. `themeDir()`, `nvimThemePath()` and `tmuxThemePath()` now resolve per call.

**The reload spawns escaped the test environment entirely.** `Bun.spawn` hands the child the environment the process started with, so setting `TMUX_TMPDIR` and deleting `TMUX` at runtime changes nothing about the `tmux` that gets spawned: it goes straight to the default socket. Probed rather than assumed (`process.env.TMUX_TMPDIR="/tmp/x"` then spawning `sh -c 'echo $TMUX_TMPDIR'` prints empty). So the guard has to live in the code being tested: under `NODE_ENV=test` the tmux and nvim pushes do not run, and `applyThemeTo` returns false.

**Belt and braces.** A write whose target resolves outside `os.tmpdir()` is refused while `NODE_ENV=test`. Anchoring on the scratch directory rather than on "not the user's home" is deliberate: `$HOME` is the very thing an isolated test moves, and Bun's `homedir()` and `userInfo()` both follow it, so a home-based rule can be defeated by import order. A future test that forgets to redirect anything now gets an error instead of a repainted machine.

Same class as the notification guard in `alerts.ts` (#287), and the same rule: a test suite may not redecorate the machine it runs on.

## How was it tested?

- Reproduced first, with the live file backed up and restored afterwards.
- `bunx tsc --noEmit` in `server/`, clean.
- `bun test`, 931 pass, 0 fail (three new assertions: nothing is reloaded from a test, a non-scratch target is refused and creates nothing, `applyThemeTo` is inert under test).
- Ran the full suite with `inotifywait -r` on `~/.config`, `~/.local/share`, `~/.tmux.conf` and `~/.bashrc`, and with the live tmux server's `window-style` read before and after: zero writes, `bg=#0f0a1a` unchanged. Before the fix the same check showed the file rewritten and the server repainted white.