### PR TITLE
feat(prs): review tools — line and range comments, CI logs, suggestions, mentions, and the markdown a PR is actually written in

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,7 +52,7 @@ import {
 } from "./docker.ts";
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
-  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts,
+  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts, jobLog, checkJobs, rerunJobs, addLineComment, mentionables,
   setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
   rerunFailedChecks, mergePr, closePr, prepareLocalReview, discardLocalReview, branchUrl, subscribeCi, commitDiff as prCommitDiff, submitReviewWith,
 } from "./prs.ts";
@@ -981,6 +981,15 @@ const server = Bun.serve<WsData>({
         url.searchParams.get("after") || undefined,
       ));
     }
+    if (pathname === "/prs/mentions") {
+      return json(await mentionables(url.searchParams.get("root") || ""));
+    }
+    if (pathname === "/prs/job-log") {
+      return json(await jobLog(url.searchParams.get("root") || "", url.searchParams.get("job") || ""));
+    }
+    if (pathname === "/prs/check-jobs") {
+      return json(await checkJobs(url.searchParams.get("root") || "", url.searchParams.get("number") || ""));
+    }
     if (pathname === "/prs/counts") {
       return json(await viewCounts(url.searchParams.get("root") || "", url.searchParams.get("state") || "open"));
     }
@@ -1032,6 +1041,8 @@ const server = Bun.serve<WsData>({
         case "/prs/draft": res = await setDraft(root, n, b.draft); break;
         case "/prs/update-branch": res = await updateBranch(root, n); break;
         case "/prs/rerun": res = await rerunFailedChecks(root, n); break;
+        case "/prs/rerun-jobs": res = await rerunJobs(root, b.what, b.id); break;
+        case "/prs/line-comment": res = await addLineComment(root, n, b); break;
         case "/prs/merge": res = await mergePr(root, n, b.method, { deleteBranch: b.deleteBranch, auto: b.auto, headSha: b.headSha, subject: b.subject, body: b.body, disableAuto: b.disableAuto }); break;
         case "/prs/close": res = await closePr(root, n, b.reopen === true); break;
         case "/prs/local-review": res = await prepareLocalReview(root, n); break;

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -22,7 +22,7 @@ import { inScope } from "./config.ts";
 import type {
   PrRepoId, PrSummary, PrDetail, PrListResponse, PrActionResult, PrCheck, PrCheckRollup,
   PrCheckState, PrThread, PrReview, PrComment, PrCommit, PrFile, PrChecklistItem, PrMergeState, CiVerdict,
-  PrAuthored, PrReaction, PrEvent,
+  PrAuthored, PrReaction, PrEvent, PrCheckJob,
 } from "../../shared/types.ts";
 
 /** Same escape hatch the git writes use, so one variable disables both. */
@@ -795,6 +795,37 @@ export async function viewCounts(rootIn: unknown, stateIn: unknown): Promise<{ o
   };
   countCache.set(key, { at: Date.now(), counts });
   return { ok: true, counts };
+}
+
+/**
+ * What `@` and `#` can complete to.
+ *
+ * Typing a mention or an issue reference by hand means leaving the panel to go
+ * look the name up, which is the thing this is trying to avoid. Both lists are
+ * small, change slowly, and are cached for a few minutes — the point is that
+ * the dropdown is instant, not that it is live to the second.
+ */
+export type PrMentions = { users: string[]; issues: { number: number; title: string }[] };
+const mentionCache = new Map<string, { at: number; data: PrMentions }>();
+const MENTION_TTL_MS = 5 * 60_000;
+
+export async function mentionables(rootIn: unknown): Promise<{ ok: boolean; data?: PrMentions; error?: string }> {
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const hit = mentionCache.get(repo.key);
+  if (hit && Date.now() - hit.at < MENTION_TTL_MS) return { ok: true, data: hit.data };
+  const [collab, issues] = await Promise.all([
+    ghJson<any[]>(["api", `repos/${repo.nameWithOwner}/collaborators?per_page=100`]),
+    ghJson<any[]>(["api", `repos/${repo.nameWithOwner}/issues?state=all&per_page=50&sort=updated`]),
+  ]);
+  const data: PrMentions = {
+    users: (collab ?? []).map((c: any) => String(c?.login ?? "")).filter(Boolean),
+    issues: (issues ?? [])
+      .filter((i: any) => typeof i?.number === "number")
+      .map((i: any) => ({ number: i.number, title: String(i.title ?? "") })),
+  };
+  mentionCache.set(repo.key, { at: Date.now(), data });
+  return { ok: true, data };
 }
 
 /**
@@ -1748,6 +1779,90 @@ export async function updateBranch(rootIn: unknown, number: unknown): Promise<Pr
 
 /** Re-run the failed jobs on the PR's head — the usual answer to a red run,
  *  and today the usual reason to leave the app. */
+/**
+ * The log of one CI job, in the app.
+ *
+ * The panel used to say "the log itself lives on GitHub — this panel does not
+ * download run logs", which meant every red check sent you to a browser. It is
+ * one REST call. Capped, because a chatty job runs to megabytes and this is a
+ * panel, not a log store: the TAIL is kept, since the failure is at the end.
+ */
+const LOG_MAX_BYTES = 400_000;
+const logCache = new Map<string, { at: number; text: string }>();
+const LOG_TTL_MS = 5 * 60_000;
+
+export async function jobLog(rootIn: unknown, jobIdIn: unknown): Promise<{ ok: boolean; text?: string; truncated?: boolean; error?: string }> {
+  const jobId = String(jobIdIn ?? "");
+  if (!/^\d+$/.test(jobId)) return { ok: false, error: "invalid job" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const key = `${repo.key}#${jobId}`;
+  const hit = logCache.get(key);
+  if (hit && Date.now() - hit.at < LOG_TTL_MS) return { ok: true, text: hit.text };
+  const r = await gh(["api", `repos/${repo.nameWithOwner}/actions/jobs/${jobId}/logs`]);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "could not read the log" };
+  const full = r.stdout;
+  const truncated = full.length > LOG_MAX_BYTES;
+  const text = truncated ? full.slice(full.length - LOG_MAX_BYTES) : full;
+  logCache.set(key, { at: Date.now(), text });
+  return { ok: true, text, truncated };
+}
+
+/**
+ * The jobs behind this pull request's checks, so a check can be opened.
+ *
+ * A check run's `detailsUrl` carries the run id; the jobs under it are what
+ * actually have logs and what a single re-run targets.
+ */
+export async function checkJobs(rootIn: unknown, number: unknown): Promise<{ ok: boolean; jobs?: PrCheckJob[]; error?: string }> {
+  const n = Number(number);
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, error: "invalid pull request number" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const det = await prDetail(rootIn, n);
+  if (!det.ok || !det.detail) return { ok: false, error: det.error };
+  const runIds = new Set<string>();
+  for (const c of det.detail.checksAll) {
+    const m = /\/actions\/runs\/(\d+)/.exec(c.url || "");
+    if (m) runIds.add(m[1]!);
+  }
+  const jobs: PrCheckJob[] = [];
+  for (const id of [...runIds].slice(0, 6)) {
+    const r = await ghJson<any>(["api", `repos/${repo.nameWithOwner}/actions/runs/${id}/jobs`, "--paginate"]);
+    for (const j of r?.jobs ?? []) {
+      jobs.push({
+        id: String(j.id),
+        runId: id,
+        name: String(j.name ?? ""),
+        status: String(j.status ?? ""),
+        conclusion: j.conclusion ?? null,
+        startedAt: j.started_at ?? null,
+        completedAt: j.completed_at ?? null,
+        url: j.html_url ?? "",
+      });
+    }
+  }
+  return { ok: true, jobs };
+}
+
+/** Re-run everything, only what failed, or one job. */
+export async function rerunJobs(rootIn: unknown, what: unknown, id: unknown): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const target = String(id ?? "");
+  if (!/^\d+$/.test(target)) return { ok: false, error: "invalid run or job" };
+  const args = what === "job"
+    ? ["api", "--method", "POST", `repos/${repo.nameWithOwner}/actions/jobs/${target}/rerun`]
+    : what === "all"
+      ? ["api", "--method", "POST", `repos/${repo.nameWithOwner}/actions/runs/${target}/rerun`]
+      : ["api", "--method", "POST", `repos/${repo.nameWithOwner}/actions/runs/${target}/rerun-failed-jobs`];
+  const r = await gh(args);
+  if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "could not start the re-run" };
+  invalidate(repo);
+  return { ok: true, detail: what === "job" ? "Re-running that job" : what === "all" ? "Re-running every job" : "Re-running the failed jobs" };
+}
+
 export async function rerunFailedChecks(rootIn: unknown, number: unknown): Promise<PrActionResult> {
   const g = writeGuard(rootIn); if (g) return g;
   const n = Number(number);
@@ -1981,6 +2096,46 @@ export async function commitDiff(rootIn: unknown, shaIn: unknown): Promise<{ ok:
  * `position` (an offset within the diff), which is fragile the moment the
  * branch moves; the line number survives a rebase.
  */
+/**
+ * One line comment, on its own, without opening a review.
+ *
+ * GitHub offers both — "Add single comment" and "Start a review" — and only the
+ * second existed here, so a one-line remark meant queueing a draft, going to the
+ * review tab and submitting a verdict you did not want to give.
+ */
+export async function addLineComment(rootIn: unknown, numberIn: unknown, c: {
+  path?: unknown; line?: unknown; startLine?: unknown; side?: unknown; body?: unknown;
+}): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const n = Number(numberIn);
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, error: "invalid pull request number" };
+  const path = typeof c.path === "string" ? c.path : "";
+  const line = Number(c.line);
+  const text = typeof c.body === "string" ? c.body.trim() : "";
+  if (!path || !Number.isInteger(line) || line <= 0) return { ok: false, error: "invalid line" };
+  if (!text) return { ok: false, error: "a comment cannot be empty" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const side = c.side === "LEFT" ? "LEFT" : "RIGHT";
+  const start = Number(c.startLine);
+  const payload: Record<string, unknown> = { path, line, side, body: text };
+  if (Number.isInteger(start) && start > 0 && start < line) { payload.start_line = start; payload.start_side = side; }
+  // The single-comment endpoint needs the commit it applies to.
+  const head = await ghJson<any>(["api", `repos/${repo.nameWithOwner}/pulls/${n}`]);
+  const sha = head?.head?.sha;
+  if (!sha) return { ok: false, error: "could not read the head commit" };
+  payload.commit_id = sha;
+  const r = await gh(
+    ["api", "--method", "POST", `repos/${repo.nameWithOwner}/pulls/${n}/comments`, "--input", "-"],
+    undefined, JSON.stringify(payload),
+  );
+  invalidate(repo, n);
+  if (r.code !== 0) {
+    return { ok: false, error: (r.stderr || r.stdout).trim().split("\n").find((l) => l.trim()) || "the comment was not accepted" };
+  }
+  return { ok: true, detail: `commented on ${path}:${payload.start_line ? `${payload.start_line}-${line}` : line}` };
+}
+
 export async function submitReviewWith(
   rootIn: unknown, numberIn: unknown, verb: unknown, body: unknown, commentsIn: unknown,
 ): Promise<PrActionResult> {
@@ -1990,13 +2145,27 @@ export async function submitReviewWith(
   const event = verb === "approve" ? "APPROVE" : verb === "request_changes" ? "REQUEST_CHANGES" : verb === "comment" ? "COMMENT" : null;
   if (!event) return { ok: false, error: "choose approve, request changes, or comment" };
 
-  const comments: { path: string; line: number; side: string; body: string }[] = [];
+  // A comment can cover a RANGE, which is how you say "this whole block is the
+  // problem" instead of pinning it on one arbitrary line. GitHub takes
+  // `start_line`/`start_side` alongside `line`/`side`; sending only `line` (all
+  // this could do before) collapsed every multi-line remark to its last line.
+  type OutComment = { path: string; line: number; side: string; body: string; start_line?: number; start_side?: string };
+  const comments: OutComment[] = [];
   for (const c of Array.isArray(commentsIn) ? commentsIn : []) {
     const path = typeof c?.path === "string" ? c.path : "";
     const line = Number(c?.line);
     const text = typeof c?.body === "string" ? c.body.trim() : "";
     if (!path || !Number.isInteger(line) || line <= 0 || !text) continue;
-    comments.push({ path, line, side: c?.side === "LEFT" ? "LEFT" : "RIGHT", body: text });
+    const side = c?.side === "LEFT" ? "LEFT" : "RIGHT";
+    const out: OutComment = { path, line, side, body: text };
+    const start = Number(c?.startLine);
+    // GitHub rejects a start that is not strictly before the end, and a range
+    // that spans both sides of the diff.
+    if (Number.isInteger(start) && start > 0 && start < line) {
+      out.start_line = start;
+      out.start_side = c?.startSide === "LEFT" ? "LEFT" : side;
+    }
+    comments.push(out);
   }
 
   const text = String(body ?? "").trim();

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1197,6 +1197,19 @@ export interface PrEvent {
   url?: string;
 }
 
+/** One CI job behind a check — what actually has a log, and what a single
+ *  re-run targets. */
+export interface PrCheckJob {
+  id: string;
+  runId: string;
+  name: string;
+  status: string;
+  conclusion: string | null;
+  startedAt: string | null;
+  completedAt: string | null;
+  url: string;
+}
+
 export interface PrChecklistItem { checked: boolean; text: string }
 
 export interface PrDetail extends PrSummary {

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -24,6 +24,10 @@ export const CODE_FONT_STYLE = { fontFamily: DIFF_FONT, fontFeatureSettings: '"c
 // imperatively on mousedown, before the browser extends the selection.
 export const SPLIT_SEL_CSS = '.agx-split[data-sel="l"] [data-side="r"]{user-select:none;-webkit-user-select:none}.agx-split[data-sel="r"] [data-side="l"]{user-select:none;-webkit-user-select:none}';
 // Themed, slim scrollbars for the modal's scrollers (primary-tinted thumb).
+/** The gutter "+" only appears on the line you are pointing at, so the diff
+ *  reads as a diff until you want to say something about it. */
+export const LINEBTN_CSS = '.agx-gutter{position:relative}.agx-linebtn{position:absolute;left:-2px;top:50%;transform:translateY(-50%);width:15px;height:15px;line-height:13px;text-align:center;border-radius:4px;background:var(--primary);color:var(--bg);font-size:12px;opacity:0;transition:opacity .1s;cursor:pointer;z-index:2}.agx-gutter:hover .agx-linebtn,.agx-linebtn:focus-visible{opacity:1}';
+
 export const SCROLLBAR_CSS = '.agx-scroll{scrollbar-width:thin;scrollbar-color:color-mix(in srgb,var(--primary) 45%,transparent) transparent}.agx-scroll::-webkit-scrollbar{width:11px;height:11px}.agx-scroll::-webkit-scrollbar-track{background:transparent}.agx-scroll::-webkit-scrollbar-thumb{background:color-mix(in srgb,var(--primary) 38%,transparent);border-radius:999px;border:3px solid transparent;background-clip:padding-box}.agx-scroll::-webkit-scrollbar-thumb:hover{background:color-mix(in srgb,var(--primary) 62%,transparent);background-clip:padding-box}.agx-scroll::-webkit-scrollbar-corner{background:transparent}';
 const cellBg = (k?: string) => (k === "del" ? "color-mix(in srgb, var(--error) 13%, transparent)" : k === "add" ? "color-mix(in srgb, var(--success) 13%, transparent)" : "transparent");
 const cellFg = (k?: string) => (k === "del" ? "var(--error)" : k === "add" ? "var(--success)" : "var(--text3)");
@@ -155,7 +159,38 @@ export function unifiedRows(h: DiffHunk): URow[] {
   return rows;
 }
 
-export function UnifiedDiff({ c, wrap, hunkAction }: { c: FileChange; wrap: boolean; hunkAction?: (hunkIndex: number) => React.ReactNode }) {
+/** Where a comment lands: a line, on a side of the diff, optionally a range. */
+export type DiffSide = "LEFT" | "RIGHT";
+export type LinePick = { line: number; side: DiffSide; shift: boolean };
+export type LineSel = { start: number; end: number; side: DiffSide } | null;
+
+/** Is this line inside the pending selection? */
+function inSel(sel: LineSel, n: number | null | undefined, side: DiffSide): boolean {
+  if (!sel || n == null || sel.side !== side) return false;
+  return n >= Math.min(sel.start, sel.end) && n <= Math.max(sel.start, sel.end);
+}
+
+/**
+ * The "+" that starts a comment, in the line-number gutter.
+ *
+ * Per line, not per hunk: a remark belongs to the line it is about, and
+ * anchoring every comment to "the last added line of the hunk" put them
+ * somewhere nobody chose. Shift-click extends from the last pick, which is how
+ * GitHub does a multi-line comment.
+ */
+function LineBtn({ n, side, onPick }: { n: number | null | undefined; side: DiffSide; onPick?: (p: LinePick) => void }) {
+  if (!onPick || n == null) return null;
+  return (
+    <button
+      onClick={(e) => onPick({ line: n, side, shift: e.shiftKey })}
+      title={`Comment on line ${n} — shift-click to cover a range`}
+      aria-label={`Comment on line ${n}`}
+      className="agx-linebtn"
+    >+</button>
+  );
+}
+
+export function UnifiedDiff({ c, wrap, hunkAction, onPick, sel }: { c: FileChange; wrap: boolean; hunkAction?: (hunkIndex: number) => React.ReactNode; onPick?: (p: LinePick) => void; sel?: LineSel }) {
   const wrapCls = wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre";
   const hunks = useMemo(() => c.hunks.map((h) => ({ h, rows: unifiedRows(h) })), [c]);
   return (
@@ -172,8 +207,11 @@ export function UnifiedDiff({ c, wrap, hunkAction }: { c: FileChange; wrap: bool
             {rows.map((r, ri) => (
               <div key={ri} className="contents">
                 <div className="text-right pr-1.5 tabular-nums select-none sticky z-[1]" style={{ left: 0, background: numBg(r.kind) }}><span className="opacity-40">{r.oldN ?? ""}</span></div>
-                <div className="text-right pr-1.5 tabular-nums select-none sticky z-[1]" style={{ left: "4ch", background: numBg(r.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}><span className="opacity-40">{r.newN ?? ""}</span></div>
-                <div className={`${wrapCls} px-1.5`} style={{ background: cellBg(r.kind), color: cellFg(r.kind) }}>
+                <div className="text-right pr-1.5 tabular-nums select-none sticky z-[1] agx-gutter" style={{ left: "4ch", background: numBg(r.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
+                  <LineBtn n={r.newN ?? r.oldN} side={r.newN != null ? "RIGHT" : "LEFT"} onPick={onPick} />
+                  <span className="opacity-40">{r.newN ?? ""}</span>
+                </div>
+                <div className={`${wrapCls} px-1.5`} style={{ background: inSel(sel ?? null, r.newN, "RIGHT") || inSel(sel ?? null, r.oldN, "LEFT") ? "color-mix(in srgb, var(--primary) 20%, transparent)" : cellBg(r.kind), color: cellFg(r.kind) }}>
                   <span className="select-none opacity-60">{r.kind === "add" ? "+" : r.kind === "del" ? "−" : " "} </span><Code text={r.text} segs={r.segs} kind={r.kind} />
                 </div>
               </div>
@@ -217,7 +255,7 @@ export function splitRows(h: DiffHunk): { l: Cell | null; r: Cell | null }[] {
 // long line on one side scrolls independently, with its scrollbar pinned to the
 // bottom of the pane). Vertical scroll is kept in sync between the two so rows
 // stay aligned; only the right side shows the vertical scrollbar.
-export function SplitDiff({ c, wrap }: { c: FileChange; wrap: boolean }) {
+export function SplitDiff({ c, wrap, onPick, sel }: { c: FileChange; wrap: boolean; onPick?: (p: LinePick) => void; sel?: LineSel }) {
   const hunks = useMemo(() => c.hunks.map((h) => ({ h, rows: splitRows(h) })), [c]);
   const wrapCls = wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre";
   const leftRef = useRef<HTMLDivElement>(null);
@@ -248,8 +286,11 @@ export function SplitDiff({ c, wrap }: { c: FileChange; wrap: boolean }) {
           const cell = which === "l" ? row.l : row.r;
           return (
             <div key={ri} className="flex" style={{ minWidth: "100%", background: cell ? cellBg(cell.kind) : HATCH }}>
-              <div data-side={which} className="text-right pr-1.5 tabular-nums select-none shrink-0 sticky left-0 z-[1]" style={{ width: "3.6ch", background: numBg(cell?.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}><span className="opacity-40">{cell?.num ?? ""}</span></div>
-              <div className={`${wrapCls} px-1.5`} style={{ color: cellFg(cell?.kind) }}>{cell ? <Code text={cell.text} segs={cell.segs} kind={cell.kind} /> : ""}</div>
+              <div data-side={which} className="text-right pr-1.5 tabular-nums select-none shrink-0 sticky left-0 z-[1] agx-gutter" style={{ width: "3.6ch", background: numBg(cell?.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
+                <LineBtn n={cell?.num} side={which === "l" ? "LEFT" : "RIGHT"} onPick={onPick} />
+                <span className="opacity-40">{cell?.num ?? ""}</span>
+              </div>
+              <div className={`${wrapCls} px-1.5`} style={{ color: cellFg(cell?.kind), background: inSel(sel ?? null, cell?.num, which === "l" ? "LEFT" : "RIGHT") ? "color-mix(in srgb, var(--primary) 20%, transparent)" : undefined }}>{cell ? <Code text={cell.text} segs={cell.segs} kind={cell.kind} /> : ""}</div>
             </div>
           );
         })}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -19,17 +19,17 @@
 //
 // 4. Nothing waits on the network. `gh` costs a second or more per call and the
 //    server has one thread; every read is a cached answer with its age shown.
-import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { createContext, useCallback, useContext, useEffect, useMemo, useRef, useState } from "react";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type {
   PrSummary, PrDetail, PrRepoId, PrThread, PrComment, PrReview, PrCheck, GitRepoRef, FileChange,
-  PrReaction, PrAuthorAssociation, PrEvent, PrCommit, PrFile,
+  PrReaction, PrAuthorAssociation, PrEvent, PrCommit, PrFile, PrCheckJob,
 } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
-import { SCROLLBAR_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle } from "./ChangesModal.tsx";
+import { SCROLLBAR_CSS, LINEBTN_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle, type LinePick, type LineSel } from "./ChangesModal.tsx";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
 import { Select } from "./Select.tsx";
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
@@ -73,7 +73,16 @@ const SEEN_KEY = "agentglass.pr.seen";
 const DRAFT_KEY = "agentglass.pr.drafts";
 
 /** A line comment written but not yet sent — GitHub's "pending review". */
-export interface DraftComment { path: string; line: number; body: string }
+export interface DraftComment {
+  path: string;
+  /** The last line of the comment — GitHub's `line`. */
+  line: number;
+  /** The first, when the comment covers a range. Absent for a single line. */
+  startLine?: number;
+  /** Which side of the diff: RIGHT is the new file, LEFT the old. */
+  side?: "LEFT" | "RIGHT";
+  body: string;
+}
 
 const loadMap = <T,>(k: string): Record<string, T> => {
   try { return JSON.parse(localStorage.getItem(k) || "{}"); } catch { return {}; }
@@ -244,6 +253,14 @@ export const MD_CSS = `
 .agx-md th{text-align:left;padding:.4em .8em;background:color-mix(in srgb,var(--border) 22%,transparent);color:var(--text);font-weight:600;border:1px solid color-mix(in srgb,var(--border) 40%,transparent);white-space:nowrap}
 .agx-md td{padding:.4em .8em;border:1px solid color-mix(in srgb,var(--border) 30%,transparent);vertical-align:top}
 .agx-md tbody tr:nth-child(even) td{background:color-mix(in srgb,var(--border) 10%,transparent)}
+.agx-md .agx-details{margin:0 0 .9em;border:1px solid color-mix(in srgb,var(--border) 40%,transparent);border-radius:6px;padding:.5em .8em;background:color-mix(in srgb,var(--border) 8%,transparent)}
+.agx-md .agx-details>summary{cursor:pointer;color:var(--text);font-weight:600;list-style:revert}
+.agx-md .agx-details>div{margin-top:.7em}
+.agx-md .agx-suggestion{margin:0 0 .9em;border:1px solid color-mix(in srgb,var(--success) 45%,transparent);border-radius:6px;overflow:hidden}
+.agx-md .agx-suggestion-head{font-size:.8em;letter-spacing:.05em;text-transform:uppercase;padding:.35em .8em;color:var(--success);background:color-mix(in srgb,var(--success) 12%,transparent)}
+.agx-md .agx-suggestion pre{margin:0;border:0;border-radius:0;background:color-mix(in srgb,var(--success) 6%,transparent)}
+.agx-md .agx-alert{margin:0 0 .9em;padding:.6em .9em;border-left:3px solid;border-radius:0 6px 6px 0;display:flex;flex-direction:column;gap:.3em}
+.agx-md .agx-alert>b{font-size:.82em;letter-spacing:.06em}
 .agx-md hr{border:0;border-top:1px solid color-mix(in srgb,var(--border) 40%,transparent);margin:1.2em 0}
 .agx-md figure{margin:0 0 .9em}
 .agx-md figure img{max-width:100%;border-radius:6px;border:1px solid color-mix(in srgb,var(--border) 40%,transparent);display:block}
@@ -276,6 +293,39 @@ function Block({ b }: { b: MdBlock }) {
           <thead><tr>{b.head.map((h, i) => <th key={i} dangerouslySetInnerHTML={{ __html: h }} />)}</tr></thead>
           <tbody>{b.rows.map((r, i) => <tr key={i}>{r.map((c, j) => <td key={j} dangerouslySetInnerHTML={{ __html: c }} />)}</tr>)}</tbody>
         </table>
+      </div>
+    );
+  }
+  if (b.kind === "details") {
+    // A real disclosure. Bots fold their output into <details>, and until now
+    // the tags came through escaped — the "collapsed" part of a collapsed
+    // comment was the one thing that did not work.
+    return (
+      <details className="agx-details">
+        <summary>{b.summary}</summary>
+        <div>{b.blocks.map((inner, i) => <Block key={i} b={inner} />)}</div>
+      </details>
+    );
+  }
+  if (b.kind === "alert") {
+    const tint = b.level === "caution" || b.level === "warning" ? "var(--warning)"
+      : b.level === "important" ? "var(--primary)"
+      : b.level === "tip" ? "var(--success)" : "var(--info)";
+    return (
+      <div className="agx-alert" style={{ borderColor: tint, background: `color-mix(in srgb, ${tint} 8%, transparent)` }}>
+        <b style={{ color: tint }}>{b.level.toUpperCase()}</b>
+        <span dangerouslySetInnerHTML={{ __html: b.html }} />
+      </div>
+    );
+  }
+  if (b.kind === "suggestion") {
+    // Shown as what it is: the replacement being proposed. Rendering it as an
+    // ordinary code block (which is what happened before) hid the fact that
+    // there was a change on offer at all.
+    return (
+      <div className="agx-suggestion">
+        <div className="agx-suggestion-head">Suggested change</div>
+        <pre><code>{b.text}</code></pre>
       </div>
     );
   }
@@ -322,8 +372,28 @@ function CodeBlock({ text, lang }: { text: string; lang?: string }) {
   return <pre><code>{text}</code></pre>;
 }
 
+/** Who `@` completes to and which issues `#` does, for the composer. A context
+ *  for the same reason as RepoCtx: the composer is rendered from several places
+ *  and none of them should have to carry this. */
+export type Mentionables = { users: string[]; issues: { number: number; title: string }[] };
+export const MentionCtx = createContext<Mentionables | null>(null);
+
+/** The emoji names the composer offers. Same table the renderer uses. */
+const EMOJI_NAMES: Record<string, string> = {
+  tada: "🎉", rocket: "🚀", sparkles: "✨", bug: "🐛", fire: "🔥", warning: "⚠️",
+  white_check_mark: "✅", x: "❌", "+1": "👍", "-1": "👎", eyes: "👀", heart: "❤️",
+  pray: "🙏", clap: "👏", wrench: "🔧", memo: "📝", lock: "🔒", zap: "⚡",
+  boom: "💥", art: "🎨", recycle: "♻️", bulb: "💡", mag: "🔍", robot: "🤖",
+};
+
+/** The `owner/name` these bodies belong to, so `#123` and bare SHAs can link
+ *  somewhere real. A context because `Md` is rendered from a dozen places and
+ *  threading a prop through all of them to reach the same value is noise. */
+export const RepoCtx = createContext<string | undefined>(undefined);
+
 export function Md({ body, className }: { body: string; className?: string }) {
-  const blocks = useMemo(() => parseBody(body), [body]);
+  const repo = useContext(RepoCtx);
+  const blocks = useMemo(() => parseBody(body, repo), [body, repo]);
   if (!body?.trim()) return null;
   return <div className={`agx-md ${className ?? ""}`}>{blocks.map((b, i) => <Block key={i} b={b} />)}</div>;
 }
@@ -341,27 +411,10 @@ function toFileChange(f: ParsedFile, i: number): FileChange {
   };
 }
 
-function DiffPane({ file, split, wrap, onComment }: {
+function DiffPane({ file, split, wrap, onPick, sel }: {
   file: FileChange; split: boolean; wrap: boolean;
-  onComment?: (line: number) => void;
+  onPick?: (p: LinePick) => void; sel?: LineSel;
 }) {
-  // `hunkAction` is the seam the viewer already offers. A comment anchors to
-  // the last added line of its hunk — the line you are almost always talking
-  // about — falling back to the hunk's last line when it only removes.
-  const action = onComment
-    ? (hi: number) => {
-        const h = file.hunks[hi];
-        if (!h) return null;
-        const nums = newLineNumbers(h);
-        let target = 0;
-        h.lines.forEach((l, i) => { if (l.startsWith("+") && nums[i]) target = nums[i]!; });
-        if (!target) for (let i = nums.length - 1; i >= 0; i--) if (nums[i]) { target = nums[i]!; break; }
-        if (!target) return null;
-        return <button onClick={() => onComment(target)} className="text-[10px] px-1.5 rounded"
-          style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" }}
-          title={`Comment on line ${target}`}>+ Comment</button>;
-      }
-    : undefined;
   // Syntax highlighting, which this pane never had: `Code` reads the theme out
   // of `HiliteCtx`, and with no Provider above it every PR diff rendered as
   // plain monochrome text while the very same viewer in the changes modal came
@@ -371,7 +424,9 @@ function DiffPane({ file, split, wrap, onComment }: {
   const heavy = file.hunks.reduce((n, h) => n + h.lines.length, 0) > 3000;
   return (
     <HiliteCtx.Provider value={heavy ? { ...hilite, theme: null } : hilite}>
-      {split ? <SplitDiff c={file} wrap={wrap} /> : <UnifiedDiff c={file} wrap={wrap} hunkAction={action} />}
+      {split
+        ? <SplitDiff c={file} wrap={wrap} onPick={onPick} sel={sel} />
+        : <UnifiedDiff c={file} wrap={wrap} onPick={onPick} sel={sel} />}
     </HiliteCtx.Provider>
   );
 }
@@ -486,6 +541,20 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   // Which commits have their full message open. Separate from `selCommit`, so
   // reading the message costs nothing and does not fetch a diff.
   const [openMsgs, setOpenMsgs] = useState<Set<string>>(new Set());
+  // The CI jobs behind this pull request's checks. Fetched only when the checks
+  // tab is opened — it costs a couple of REST calls and most visits never look.
+  const [jobs, setJobs] = useState<PrCheckJob[]>([]);
+  // Fetched once per repo, cached server-side for five minutes: the composer
+  // wants an instant dropdown, not a live directory.
+  const [mentions, setMentions] = useState<Mentionables | null>(null);
+  useEffect(() => {
+    if (!active || !root) return;
+    let live = true;
+    api.prMentions(root)
+      .then((r) => { if (live && r.ok && r.data) setMentions(r.data); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, [active, root]);
   const toggleMsg = (oid: string) => setOpenMsgs((cur) => {
     const next = new Set(cur);
     if (next.has(oid)) next.delete(oid); else next.add(oid);
@@ -745,6 +814,16 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     }
   }, [visiblePrs, selected]);
 
+  useEffect(() => {
+    if (tab !== "checks" || !detail || !root) return;
+    let live = true;
+    setJobs([]);
+    api.prCheckJobs(root, detail.number)
+      .then((r) => { if (live && r.ok && r.jobs) setJobs(r.jobs); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, [tab, detail?.number, root]);
+
   // Keyboard nav over the list, keyboard-first like the files tab (which relies
   // on the same thing: App.tsx ignores bare letters while the workspace is open,
   // so j/k/n/p are free here). Selection is derived, not a second state.
@@ -842,16 +921,17 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (id) void api.prFileViewed(root, id, path, nowViewed).catch(() => { /* local tick still stands */ });
   };
 
-  const addDraft = async (path: string, line: number) => {
+  const addDraft = async (path: string, line: number, startLine?: number, side?: "LEFT" | "RIGHT") => {
+    const where = startLine && startLine !== line ? `${startLine}-${line}` : String(line);
     const body = await askText({
-      title: `Comment on ${path.split("/").pop()}:${line}`,
+      title: `Comment on ${path.split("/").pop()}:${where}`,
       body: "Queued with the rest of your review — nothing is sent until you submit.",
       confirmLabel: "Add to review",
       input: { label: "Comment", placeholder: "What needs to change here…" },
     });
     if (!body?.trim() || !key) return;
     setDrafts((cur) => {
-      const next = { ...cur, [key]: [...(cur[key] ?? []), { path, line, body: body.trim() }] };
+      const next = { ...cur, [key]: [...(cur[key] ?? []), { path, line, ...(startLine && startLine !== line ? { startLine } : {}), ...(side ? { side } : {}), body: body.trim() }] };
       saveMap(DRAFT_KEY, next);
       return next;
     });
@@ -1082,8 +1162,10 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   ] : [];
 
   return (
+    <RepoCtx.Provider value={repo?.nameWithOwner}>
+    <MentionCtx.Provider value={mentions}>
     <div className="flex flex-col h-full min-h-0">
-      <style>{SCROLLBAR_CSS}{MD_CSS}</style>
+      <style>{SCROLLBAR_CSS}{LINEBTN_CSS}{MD_CSS}</style>
 
       <div className={viewHeaderClass} style={viewHeaderStyle}>
         <span className={viewTitleClass} style={{ color: "var(--text)" }}>Pull Requests</span>
@@ -1375,8 +1457,9 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
                 {tab === "checks" && (
                   <Checks
-                    d={d} busy={busy}
+                    d={d} root={root} jobs={jobs} busy={busy}
                     onRerun={() => act("Re-run checks", () => api.prRerun(root, d.number))}
+                    onRerunJobs={(what, id) => act("Re-run", () => api.prRerunJobs(root, what, id))}
                     onAsk={onOpenChatWith ? (k) => askClaudeAboutCheck(k) : undefined}
                   />
                 )}
@@ -1395,6 +1478,8 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       </div>
       {dialog}
     </div>
+    </MentionCtx.Provider>
+    </RepoCtx.Provider>
   );
 }
 
@@ -2046,10 +2131,34 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
   seenFiles: string[]; onSeen: (p: string) => void;
   sel: string | null; onSel: (p: string | null) => void;
   split: boolean; wrap: boolean; onSplit: (v: boolean) => void; onWrap: (v: boolean) => void;
-  drafts: DraftComment[]; onAddDraft: (path: string, line: number) => void;
+  drafts: DraftComment[]; onAddDraft: (path: string, line: number, startLine?: number, side?: "LEFT" | "RIGHT") => void;
   onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
 }) {
   const draftsFor = (p: string) => drafts.filter((x) => x.path === p).length;
+  /**
+   * The line, or range of lines, a comment is being written about.
+   *
+   * A plain click starts at that line; shift-click extends from it, which is
+   * GitHub's gesture for "this whole block". Kept here rather than in the diff
+   * component so the highlight survives a re-render of the file and so only one
+   * file can be mid-selection at a time.
+   */
+  const [selRange, setSelRange] = useState<{ path: string; sel: LineSel } | null>(null);
+  const pickLine = (path: string, pk: LinePick) => {
+    const cur = selRange?.path === path ? selRange.sel : null;
+    if (pk.shift && cur && cur.side === pk.side) {
+      const sel = { start: cur.start, end: pk.line, side: pk.side };
+      setSelRange({ path, sel });
+      onAddDraft(path, Math.max(sel.start, sel.end), Math.min(sel.start, sel.end), pk.side);
+      setSelRange(null);
+      return;
+    }
+    // A single line: offer it straight away, and remember it so a following
+    // shift-click can stretch the range instead of starting over.
+    setSelRange({ path, sel: { start: pk.line, end: pk.line, side: pk.side } });
+    onAddDraft(path, pk.line, undefined, pk.side);
+    setSelRange(null);
+  };
   /** Unresolved first: a resolved thread is history, an open one is a question. */
   const threadsFor = (p: string) => d.threads.filter((t) => t.path === p)
     .sort((a, b) => Number(a.isResolved) - Number(b.isResolved));
@@ -2262,7 +2371,7 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
                     folded by default instead, which is the honest cap. */}
                 <div className="flex" style={{ overflowX: "auto" }}>
                   {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>Loading the diff…</div>
-                    : change ? <DiffPane file={change} split={split} wrap={wrap} onComment={(line) => onAddDraft(f.path, line)} />
+                    : change ? <DiffPane file={change} split={split} wrap={wrap} onPick={(pk) => pickLine(f.path, pk)} sel={selRange?.path === f.path ? selRange.sel : null} />
                     : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
                 </div>
               </LazyMount>
@@ -2764,6 +2873,63 @@ function Composer({ onSend, busy, placeholder, sendLabel }: {
   const [text, setText] = useState("");
   const [preview, setPreview] = useState(false);
   const [sending, setSending] = useState(false);
+  const taRef = useRef<HTMLTextAreaElement>(null);
+
+  /**
+   * `@`, `#` and `:` complete.
+   *
+   * Typing a collaborator's login or an issue number from memory means leaving
+   * the panel to look it up, which is exactly the trip this is meant to save.
+   * The trigger is the token immediately before the caret; Enter or Tab takes
+   * the highlighted match, Escape drops the menu without touching the text.
+   */
+  const mentions = useContext(MentionCtx);
+  const [ac, setAc] = useState<{ kind: "@" | "#" | ":"; q: string; at: number } | null>(null);
+  const [acIdx, setAcIdx] = useState(0);
+
+  type AcItem = { insert: string; label: string; hint?: string };
+  const matches = useMemo<AcItem[]>(() => {
+    if (!ac) return [];
+    const q = ac.q.toLowerCase();
+    if (ac.kind === "@") {
+      return (mentions?.users ?? [])
+        .filter((u) => u.toLowerCase().includes(q))
+        .slice(0, 8).map((u) => ({ insert: `@${u} `, label: u }));
+    }
+    if (ac.kind === "#") {
+      return (mentions?.issues ?? [])
+        .filter((i) => String(i.number).startsWith(q) || i.title.toLowerCase().includes(q))
+        .slice(0, 8).map((i) => ({ insert: `#${i.number} `, label: `#${i.number}`, hint: i.title.slice(0, 44) }));
+    }
+    return Object.keys(EMOJI_NAMES).filter((n) => n.startsWith(q)).slice(0, 8)
+      .map((n) => ({ insert: `:${n}: `, label: `${EMOJI_NAMES[n]}  :${n}:` }));
+  }, [ac, mentions]);
+
+  const onType = (v: string, caret: number) => {
+    setText(v);
+    // Only the token the caret is sitting in, and only at a word boundary —
+    // an email address must not open a mention menu.
+    const before = v.slice(0, caret);
+    const m = /(^|[\s(])([@#:])([\w.-]*)$/.exec(before);
+    if (!m) { setAc(null); return; }
+    setAc({ kind: m[2] as "@", q: m[3] ?? "", at: caret - (m[3]?.length ?? 0) - 1 });
+    setAcIdx(0);
+  };
+
+  const take = (i: number) => {
+    const pick = matches[i];
+    if (!ac || !pick) return;
+    const next = text.slice(0, ac.at) + pick.insert + text.slice(ac.at + 1 + ac.q.length);
+    setText(next);
+    setAc(null);
+    requestAnimationFrame(() => {
+      const el = taRef.current;
+      if (!el) return;
+      const pos = ac.at + pick.insert.length;
+      el.focus();
+      el.setSelectionRange(pos, pos);
+    });
+  };
 
   const send = async () => {
     if (!text.trim() || sending) return;
@@ -2782,16 +2948,42 @@ function Composer({ onSend, busy, placeholder, sendLabel }: {
       {preview ? (
         <div className="p-3 min-h-[80px]">{text.trim() ? <Md body={text} /> : <span className="text-[11px]" style={{ color: "var(--text3)" }}>Nothing to preview.</span>}</div>
       ) : (
-        <textarea
-          value={text} onChange={(e) => setText(e.target.value)} rows={4} placeholder={placeholder}
-          onKeyDown={(e) => { if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); void send(); } }}
-          className="w-full p-3 text-[11.5px] outline-none resize-y bg-transparent agx-scroll"
-          style={{ color: "var(--text)", lineHeight: 1.6 }}
-        />
+        <div className="relative">
+          <textarea
+            ref={taRef}
+            value={text}
+            onChange={(e) => onType(e.target.value, e.target.selectionStart ?? e.target.value.length)}
+            rows={4} placeholder={placeholder}
+            onKeyDown={(e) => {
+              if (ac && matches.length) {
+                if (e.key === "ArrowDown") { e.preventDefault(); setAcIdx((i) => (i + 1) % matches.length); return; }
+                if (e.key === "ArrowUp") { e.preventDefault(); setAcIdx((i) => (i - 1 + matches.length) % matches.length); return; }
+                if (e.key === "Enter" || e.key === "Tab") { e.preventDefault(); take(acIdx); return; }
+                if (e.key === "Escape") { e.preventDefault(); setAc(null); return; }
+              }
+              if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); void send(); }
+            }}
+            className="w-full p-3 text-[11.5px] outline-none resize-y bg-transparent agx-scroll"
+            style={{ color: "var(--text)", lineHeight: 1.6 }}
+          />
+          {ac && matches.length > 0 && (
+            <div className="absolute left-3 bottom-2 z-20 rounded-lg overflow-hidden"
+              style={{ background: "color-mix(in srgb, var(--bg2) 97%, black)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 14px 34px -16px rgba(0,0,0,.75)" }}>
+              {matches.map((m, i) => (
+                <button key={m.label} onMouseEnter={() => setAcIdx(i)} onClick={() => take(i)}
+                  className="agx-btn w-full text-left flex items-center gap-2 px-2.5 py-1 text-[11px]"
+                  style={{ background: i === acIdx ? "color-mix(in srgb, var(--primary) 22%, transparent)" : "transparent", color: "var(--text2)" }}>
+                  <span>{m.label}</span>
+                  {m.hint && <span className="truncate text-[10px]" style={{ color: "var(--text3)" }}>{m.hint}</span>}
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
       )}
       <div className="flex items-center gap-2 px-2.5 py-2"
         style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
-        <span className="text-[10px]" style={{ color: "var(--text3)" }}>Markdown · ⌘↵ to send</span>
+        <span className="text-[10px]" style={{ color: "var(--text3)" }}>Markdown · <b>@</b> people · <b>#</b> issues · <b>:</b> emoji · ⌘↵ to send</span>
         <span className="ml-auto">
           <Btn onClick={send} disabled={sending || busy || !text.trim()} primary small
             title={!text.trim() ? "Write something first" : undefined}>
@@ -2823,7 +3015,99 @@ function groupOf(k: PrCheck): string {
   return parts.length > 1 ? parts.slice(0, -1).join(" / ") : "Checks";
 }
 
-function Checks({ d, onRerun, onAsk, busy }: { d: PrDetail; onRerun: () => void; onAsk?: (check: PrCheck) => void; busy: boolean }) {
+/**
+ * One job's log, folded by its own step markers.
+ *
+ * GitHub Actions writes `##[group]` / `##[endgroup]` around each step and
+ * stamps every line with an ISO timestamp. Folding on the first and stripping
+ * the second is the difference between a wall of two thousand lines and a list
+ * of steps you can open — and the failing step opens itself, because that is
+ * the one you came for.
+ */
+function JobLog({ root, name, jobs }: { root: string; name: string; jobs: PrCheckJob[] }) {
+  // Match the check to its job by name; GitHub names them the same thing.
+  const job = useMemo(() => jobs.find((j) => j.name === name) ?? jobs.find((j) => name.includes(j.name)), [jobs, name]);
+  const [text, setText] = useState<string | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  const [open, setOpen] = useState(false);
+  const [openSteps, setOpenSteps] = useState<Set<number>>(new Set());
+
+  useEffect(() => {
+    if (!open || !job || text !== null) return;
+    let live = true;
+    api.prJobLog(root, job.id)
+      .then((r) => { if (!live) return; if (r.ok) setText(r.text ?? ""); else setErr(r.error || "Could not read the log"); })
+      .catch(() => { if (live) setErr("Could not reach the server"); });
+    return () => { live = false; };
+  }, [open, job, root, text]);
+
+  const steps = useMemo(() => {
+    if (!text) return [];
+    const out: { title: string; lines: string[]; failed: boolean }[] = [];
+    let cur: { title: string; lines: string[]; failed: boolean } | null = null;
+    for (const raw of text.split("\n")) {
+      // Strip the timestamp GitHub prefixes to every single line.
+      const line = raw.replace(/^\uFEFF?\d{4}-\d\d-\d\dT[\d:.]+Z\s?/, "");
+      const g = line.match(/^##\[group\](.*)$/);
+      if (g) { if (cur) out.push(cur); cur = { title: g[1] || "step", lines: [], failed: false }; continue; }
+      if (/^##\[endgroup\]/.test(line)) { if (cur) { out.push(cur); cur = null; } continue; }
+      const target = cur ?? (out[out.length - 1] && !cur ? null : null);
+      if (/^##\[error\]/.test(line) && cur) cur.failed = true;
+      if (cur) cur.lines.push(line);
+      else if (line.trim()) {
+        if (!out.length || out[out.length - 1]!.title !== "output") out.push({ title: "output", lines: [], failed: false });
+        out[out.length - 1]!.lines.push(line);
+        if (/^##\[error\]/.test(line)) out[out.length - 1]!.failed = true;
+      }
+      void target;
+    }
+    if (cur) out.push(cur);
+    return out;
+  }, [text]);
+
+  // The failing step opens itself.
+  useEffect(() => {
+    const bad = steps.findIndex((st) => st.failed);
+    if (bad >= 0) setOpenSteps((cur) => (cur.has(bad) ? cur : new Set([...cur, bad])));
+  }, [steps]);
+
+  if (!job) return null;
+  return (
+    <div className="px-2.5 pb-2">
+      <button onClick={() => setOpen((v) => !v)} className="agx-btn text-[10px] px-2 py-0.5 rounded"
+        style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>
+        {open ? "▾ Hide log" : "▸ Show log"}
+      </button>
+      {open && (
+        <div className="mt-1.5 rounded overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+          {err ? <div className="p-2 text-[10.5px]" style={{ color: "var(--error)" }}>{err}</div>
+            : text === null ? <div className="p-2 text-[10.5px]" style={{ color: "var(--text3)" }}>Reading the log…</div>
+            : steps.length === 0 ? <div className="p-2 text-[10.5px]" style={{ color: "var(--text3)" }}>The log is empty.</div>
+            : steps.map((st, i) => {
+              const on = openSteps.has(i);
+              return (
+                <div key={i} style={i ? { borderTop: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" } : undefined}>
+                  <button onClick={() => setOpenSteps((c) => { const n = new Set(c); if (n.has(i)) n.delete(i); else n.add(i); return n; })}
+                    className="agx-btn w-full text-left flex items-center gap-2 px-2 py-1 text-[10.5px]"
+                    style={{ background: st.failed ? "color-mix(in srgb, var(--error) 10%, transparent)" : "transparent" }}>
+                    <span className="text-[9px]" style={{ color: "var(--text3)" }}>{on ? "▾" : "▸"}</span>
+                    <span className="truncate" style={{ color: st.failed ? "var(--error)" : "var(--text2)" }}>{st.title}</span>
+                    <span className="ml-auto tabular-nums text-[9.5px]" style={{ color: "var(--text3)" }}>{st.lines.length}</span>
+                  </button>
+                  {on && (
+                    <pre className="overflow-x-auto text-[10px] max-h-80 agx-scroll px-2 py-1"
+                      style={{ ...CODE_FONT_STYLE, color: "var(--text3)", background: "var(--bg)" }}>{st.lines.join("\n")}</pre>
+                  )}
+                </div>
+              );
+            })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function Checks({ d, root, jobs, onRerun, onRerunJobs, onAsk, busy }: { d: PrDetail; root: string; jobs: PrCheckJob[]; onRerun: () => void; onRerunJobs?: (what: "all" | "failed" | "job", id: string) => void; onAsk?: (check: PrCheck) => void; busy: boolean }) {
   const c = d.checks;
   const [openGroups, setOpenGroups] = useState<Record<string, boolean>>({});
   const [showSkipped, setShowSkipped] = useState(false);
@@ -2911,9 +3195,25 @@ function Checks({ d, onRerun, onAsk, busy }: { d: PrDetail; onRerun: () => void;
                           style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>Open run ↗</a>
                       )}
                       <Btn onClick={onRerun} disabled={busy} small title="Re-run every failing check on this pull request">↻ Re-run failed</Btn>
-                      <span className="text-[10px]" style={{ color: "var(--text3)" }}>The log itself lives on GitHub — this panel does not download run logs.</span>
+                      {/* GitHub offers all three, and "the whole run failed
+                          again for one flaky job" is exactly when you want the
+                          single-job one. */}
+                      {(() => {
+                        const job = jobs.find((j) => j.name === k.name) ?? jobs.find((j) => k.name.includes(j.name));
+                        if (!job || !onRerunJobs) return null;
+                        return (
+                          <>
+                            <Btn onClick={() => onRerunJobs("job", job.id)} disabled={busy} small title={`Re-run only ${job.name}`}>↻ This job</Btn>
+                            <Btn onClick={() => onRerunJobs("all", job.runId)} disabled={busy} small title="Re-run every job in this run, passing ones included">↻ All jobs</Btn>
+                          </>
+                        );
+                      })()}
                     </div>
                   )}
+                  {/* The log, here. It used to say "the log lives on GitHub" and
+                      send you to a browser for the one thing you opened the
+                      check to read. */}
+                  {expanded && <JobLog root={root} name={k.name} jobs={jobs} />}
                 </div>
               );
             })}
@@ -2987,7 +3287,7 @@ function ReviewTab({ d, drafts, seen, busy, onDrop, onSubmit, onGoFiles }: {
               {drafts.map((c, i) => (
                 <div key={i} className="flex items-start gap-2 px-2.5 py-1.5 text-[11px]"
                   style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 18%, transparent)" }}>
-                  <span className="shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.path.split("/").pop()}:{c.line}</span>
+                  <span className="shrink-0" style={{ ...CODE_FONT_STYLE, color: "var(--primary)" }}>{c.path.split("/").pop()}:{c.startLine && c.startLine !== c.line ? `${c.startLine}-${c.line}` : c.line}</span>
                   <span className="min-w-0 flex-1" style={{ color: "var(--text2)" }}>{c.body}</span>
                   <button onClick={() => onDrop(i)} className="shrink-0 text-[10px]" style={{ color: "var(--error)" }}>Drop</button>
                 </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob } from "../../../shared/types.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -363,6 +363,23 @@ const realApi = {
     post<PrActionResult>("/prs/milestone", { root, number, title }),
   prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false, after?: string) =>
     get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}${after ? `&after=${encodeURIComponent(after)}` : ""}`),
+  /** Who `@` can complete to, and which issues `#` can. */
+  prMentions: (root: string) =>
+    get<{ ok: boolean; data?: { users: string[]; issues: { number: number; title: string }[] }; error?: string }>(
+      `/prs/mentions?root=${encodeURIComponent(root)}`),
+  /** One line comment, posted on its own — no review, no verdict. */
+  prLineComment: (root: string, number: number, c: { path: string; line: number; startLine?: number; side?: "LEFT" | "RIGHT"; body: string }) =>
+    post<PrActionResult>("/prs/line-comment", { root, number, ...c }),
+  /** One CI job's log, read in the app instead of sending you to a browser. */
+  prJobLog: (root: string, job: string) =>
+    get<{ ok: boolean; text?: string; truncated?: boolean; error?: string }>(
+      `/prs/job-log?root=${encodeURIComponent(root)}&job=${encodeURIComponent(job)}`),
+  prCheckJobs: (root: string, number: number) =>
+    get<{ ok: boolean; jobs?: PrCheckJob[]; error?: string }>(
+      `/prs/check-jobs?root=${encodeURIComponent(root)}&number=${number}`),
+  /** Re-run everything, only the failures, or a single job. */
+  prRerunJobs: (root: string, what: "all" | "failed" | "job", id: string) =>
+    post<PrActionResult>("/prs/rerun-jobs", { root, what, id }),
   /** Exact totals for every saved view, in one request. */
   prCounts: (root: string, state: "open" | "closed" | "all") =>
     get<{ ok: boolean; counts?: { review: number; mine: number; failing: number; ready: number; all: number }; error?: string }>(
@@ -383,7 +400,7 @@ const realApi = {
    *  request — GitHub's "pending review", which arrives as one notification
    *  instead of a scatter. */
   prReviewWith: (root: string, number: number, verb: "approve" | "request_changes" | "comment", body: string,
-    comments: { path: string; line: number; side?: "LEFT" | "RIGHT"; body: string }[]) =>
+    comments: { path: string; line: number; startLine?: number; side?: "LEFT" | "RIGHT"; startSide?: "LEFT" | "RIGHT"; body: string }[]) =>
     post<PrActionResult>("/prs/review-with", { root, number, verb, body, comments }),
   prComment: (root: string, number: number, body: string) => post<PrActionResult>("/prs/comment", { root, number, body }),
   prReply: (root: string, number: number, commentId: number, body: string) => post<PrActionResult>("/prs/reply", { root, number, commentId, body }),
@@ -567,6 +584,11 @@ const demoApi: typeof realApi = {
   // page calls out as new was dead in the demo that page links to.
   prCapability: (_force?: boolean) => D(demo.prCapability()),
   prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean, _after?: string) => D<PrListResponse>(demo.prList(root, filter)),
+  prMentions: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; data?: { users: string[]; issues: { number: number; title: string }[] }; error?: string }),
+  prLineComment: () => D(demoPrAction()),
+  prJobLog: () => D({ ok: false, error: "not available in the demo" }),
+  prCheckJobs: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; jobs?: PrCheckJob[]; error?: string }),
+  prRerunJobs: () => D(demoPrAction()),
   prCounts: (_r: string, _s: "open" | "closed" | "all") => D({ ok: false, error: "not available in the demo" } as { ok: boolean; counts?: { review: number; mine: number; failing: number; ready: number; all: number }; error?: string }),
   prDetail: (_root: string, number: number, _force?: boolean) => D(demo.prDetail(number)),
   prDiff: (_root: string, number: number) => D(demo.prDiff(number)),

--- a/web/src/lib/prBody.ts
+++ b/web/src/lib/prBody.ts
@@ -39,7 +39,18 @@ function decodeEntities(s: string): string {
  */
 const SLOT = "";
 
-export function renderInline(raw: string): string {
+/** The shortcodes that actually turn up in pull requests. Not the whole set —
+ *  a thousand-entry table for a handful of real uses is weight for nothing. */
+const EMOJI: Record<string, string> = {
+  tada: "🎉", rocket: "🚀", sparkles: "✨", bug: "🐛", fire: "🔥", warning: "⚠️",
+  white_check_mark: "✅", heavy_check_mark: "✔️", x: "❌", "+1": "👍", "-1": "👎",
+  eyes: "👀", heart: "❤️", pray: "🙏", clap: "👏", wrench: "🔧", hammer: "🔨",
+  memo: "📝", books: "📚", lock: "🔒", zap: "⚡", boom: "💥", art: "🎨",
+  recycle: "♻️", construction: "🚧", bulb: "💡", mag: "🔍", package: "📦",
+  robot: "🤖", ok_hand: "👌",
+};
+
+export function renderInline(raw: string, autolinkRepo?: string): string {
   const spans: string[] = [];
   let s = decodeEntities(raw).replace(/`([^`]+)`/g, (_m, code: string) => {
     spans.push(`<code>${escapeHtml(code)}</code>`);
@@ -57,6 +68,22 @@ export function renderInline(raw: string): string {
   s = s.replace(/(^|[\s(])((?:https?:\/\/)[^\s<)]+)/g,
     (_m, pre: string, href: string) => `${pre}<a href="${href}" target="_blank" rel="noreferrer noopener">${href}</a>`);
 
+  // `:tada:` and friends. GitHub renders these everywhere and a bot's release
+  // notes are full of them; unrendered they read as punctuation soup.
+  s = s.replace(/:([a-z0-9_+-]{2,32}):/g, (m, name: string) => EMOJI[name] ?? m);
+
+  // `#123`, `owner/repo#123`, and bare SHAs — the references a pull request
+  // body is mostly made of. Linked against the repo this body belongs to, which
+  // the caller supplies; without it they stay as text rather than guessing.
+  if (autolinkRepo) {
+    s = s.replace(/(^|[\s(])(?:([\w.-]+\/[\w.-]+))?#(\d+)\b/g,
+      (_m, pre: string, repo: string | undefined, num: string) =>
+        `${pre}<a href="https://github.com/${repo ?? autolinkRepo}/issues/${num}" target="_blank" rel="noreferrer noopener">${repo ?? ""}#${num}</a>`);
+    s = s.replace(/(^|[\s(])([0-9a-f]{7,40})\b/g,
+      (_m, pre: string, sha: string) =>
+        `${pre}<a href="https://github.com/${autolinkRepo}/commit/${sha}" target="_blank" rel="noreferrer noopener"><code>${sha.slice(0, 7)}</code></a>`);
+  }
+
   return s.replace(new RegExp(`${SLOT}(\\d+)${SLOT}`, "g"), (_m, i: string) => spans[Number(i)] ?? "");
 }
 
@@ -70,29 +97,76 @@ export type MdBlock =
   | { kind: "table"; head: string[]; rows: string[][] }
   | { kind: "quote"; html: string }
   | { kind: "image"; src: string; alt: string }
+  /** `<details><summary>…` — what every bot folds its output into. Rendered as
+   *  a real disclosure rather than escaped tags. */
+  | { kind: "details"; summary: string; blocks: MdBlock[] }
+  /** GitHub's callouts: `> [!NOTE]`, `[!TIP]`, `[!IMPORTANT]`, `[!WARNING]`,
+   *  `[!CAUTION]`. */
+  | { kind: "alert"; level: "note" | "tip" | "important" | "warning" | "caution"; html: string }
+  /** A ```suggestion block: the replacement the author is proposing for the
+   *  lines the comment is anchored to. Its own kind because it is a change to
+   *  accept, not a snippet to read. */
+  | { kind: "suggestion"; text: string }
   | { kind: "rule" };
 
 /** A table cell is markdown too. Returning the raw text put `**Drift**` on
  *  screen with its asterisks — the bold that a RED/GREEN comparison leans on
  *  was exactly what stopped rendering. */
-const cells = (l: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => renderInline(c.trim()));
+const cells = (l: string, repo?: string) => l.trim().replace(/^\|/, "").replace(/\|$/, "").split("|").map((c) => renderInline(c.trim(), repo));
 const isDivider = (l: string) => /^\s*\|?\s*:?-{2,}:?\s*(\|\s*:?-{2,}:?\s*)*\|?\s*$/.test(l);
 const IMG_MD = /^\s*!\[([^\]]*)\]\((https?:\/\/[^\s)]+)\)\s*$/;
 const IMG_HTML = /<img[^>]*\bsrc="(https?:\/\/[^"]+)"[^>]*>/i;
 
-export function parseBody(body: string): MdBlock[] {
+export function parseBody(body: string, autolinkRepo?: string): MdBlock[] {
   const out: MdBlock[] = [];
   const lines = (body || "").split(/\r?\n/);
   let para: string[] = [];
 
   const flushPara = () => {
     if (!para.length) return;
-    out.push({ kind: "para", html: para.map(renderInline).join(" ") });
+    out.push({ kind: "para", html: para.map((x) => renderInline(x, autolinkRepo)).join(" ") });
     para = [];
   };
 
   for (let i = 0; i < lines.length; i++) {
     const line = lines[i]!;
+
+    // <details>: take everything up to the matching </details> and parse it as
+    // its own little document, so a folded bot comment keeps its lists and code.
+    const det = line.match(/^\s*<details[^>]*>\s*$/i);
+    if (det) {
+      flushPara();
+      let summary = "";
+      const inner: string[] = [];
+      let depth = 1;
+      i++;
+      for (; i < lines.length; i++) {
+        const l = lines[i]!;
+        if (/^\s*<details[^>]*>\s*$/i.test(l)) depth++;
+        if (/^\s*<\/details>\s*$/i.test(l)) { depth--; if (depth === 0) break; }
+        const sum = l.match(/<summary[^>]*>([\s\S]*?)<\/summary>/i);
+        if (sum && !summary) { summary = sum[1]!.replace(/<[^>]+>/g, "").trim(); continue; }
+        inner.push(l);
+      }
+      out.push({ kind: "details", summary: summary || "Details", blocks: parseBody(inner.join("\n"), autolinkRepo) });
+      continue;
+    }
+
+    // > [!NOTE] and friends. The first line names the kind; the rest is the body.
+    const alert = line.match(/^\s*>\s*\[!(NOTE|TIP|IMPORTANT|WARNING|CAUTION)\]\s*$/i);
+    if (alert) {
+      flushPara();
+      const body: string[] = [];
+      while (i + 1 < lines.length && /^\s*>/.test(lines[i + 1]!)) {
+        body.push(lines[++i]!.replace(/^\s*>\s?/, ""));
+      }
+      out.push({
+        kind: "alert",
+        level: alert[1]!.toLowerCase() as "note",
+        html: body.map((x) => renderInline(x, autolinkRepo)).join(" "),
+      });
+      continue;
+    }
 
     const fence = line.match(/^\s*```+\s*(\S*)/);
     if (fence) {
@@ -101,7 +175,9 @@ export function parseBody(body: string): MdBlock[] {
       const buf: string[] = [];
       i++;
       while (i < lines.length && !/^\s*```/.test(lines[i]!)) { buf.push(lines[i]!); i++; }
-      out.push({ kind: "code", text: buf.join("\n"), lang });
+      // ```suggestion is a proposal, not a sample.
+      if ((lang || "").toLowerCase() === "suggestion") out.push({ kind: "suggestion", text: buf.join("\n") });
+      else out.push({ kind: "code", text: buf.join("\n"), lang });
       continue;
     }
 
@@ -110,7 +186,7 @@ export function parseBody(body: string): MdBlock[] {
     if (/^\s*([-*_])(\s*\1){2,}\s*$/.test(line)) { flushPara(); out.push({ kind: "rule" }); continue; }
 
     const h = line.match(/^(#{1,6})\s+(.*)$/);
-    if (h) { flushPara(); out.push({ kind: "heading", level: h[1]!.length, html: renderInline(h[2]!) }); continue; }
+    if (h) { flushPara(); out.push({ kind: "heading", level: h[1]!.length, html: renderInline(h[2]!, autolinkRepo) }); continue; }
 
     const img = line.match(IMG_MD);
     if (img) { flushPara(); out.push({ kind: "image", src: img[2]!, alt: img[1]! }); continue; }
@@ -125,10 +201,10 @@ export function parseBody(body: string): MdBlock[] {
     // is not a table, and treating it as one ate the sentence.
     if (line.includes("|") && i + 1 < lines.length && isDivider(lines[i + 1]!)) {
       flushPara();
-      const head = cells(line);
+      const head = cells(line, autolinkRepo);
       const rows: string[][] = [];
       i += 2;
-      while (i < lines.length && lines[i]!.includes("|") && lines[i]!.trim()) { rows.push(cells(lines[i]!)); i++; }
+      while (i < lines.length && lines[i]!.includes("|") && lines[i]!.trim()) { rows.push(cells(lines[i]!, autolinkRepo)); i++; }
       i--;
       out.push({ kind: "table", head, rows });
       continue;
@@ -139,7 +215,7 @@ export function parseBody(body: string): MdBlock[] {
       const quoted: string[] = [];
       while (i < lines.length && /^\s*>\s?/.test(lines[i]!)) { quoted.push(lines[i]!.replace(/^\s*>\s?/, "")); i++; }
       i--;
-      out.push({ kind: "quote", html: quoted.map(renderInline).join(" ") });
+      out.push({ kind: "quote", html: quoted.map((x) => renderInline(x, autolinkRepo)).join(" ") });
       continue;
     }
 
@@ -154,7 +230,7 @@ export function parseBody(body: string): MdBlock[] {
           // An indented continuation belongs to the item above it — GitHub's
           // own checklist wraps this way and it read as a stray paragraph.
           if (items.length && lines[i]!.trim() && /^\s{2,}\S/.test(lines[i]!)) {
-            items[items.length - 1]!.html += " " + renderInline(lines[i]!.trim());
+            items[items.length - 1]!.html += " " + renderInline(lines[i]!.trim(), autolinkRepo);
             i++;
             continue;
           }
@@ -163,8 +239,8 @@ export function parseBody(body: string): MdBlock[] {
         const depth = Math.min(4, Math.floor(m[1]!.replace(/\t/g, "  ").length / 2));
         const task = m[3]!.match(/^\[([ xX])\]\s+(.*)$/);
         items.push(task
-          ? { html: renderInline(task[2]!), checked: task[1]!.toLowerCase() === "x", depth }
-          : { html: renderInline(m[3]!), depth });
+          ? { html: renderInline(task[2]!, autolinkRepo), checked: task[1]!.toLowerCase() === "x", depth }
+          : { html: renderInline(m[3]!, autolinkRepo), depth });
         i++;
       }
       i--;

--- a/web/src/lib/prBody.ts
+++ b/web/src/lib/prBody.ts
@@ -87,6 +87,28 @@ export function renderInline(raw: string, autolinkRepo?: string): string {
   return s.replace(new RegExp(`${SLOT}(\\d+)${SLOT}`, "g"), (_m, i: string) => spans[Number(i)] ?? "");
 }
 
+/**
+ * The text inside a `<summary>`, with any markup taken out.
+ *
+ * Stripping tags in one pass is the classic incomplete sanitisation: `<scr` +
+ * `<b>` + `ipt>` survives as `<script>`, because removing the inner tag closes
+ * the outer one up. Repeating until the string stops changing is what actually
+ * removes them. The result is rendered as a React text child (escaped again on
+ * the way out), so this is belt and braces rather than the only guard — but a
+ * function that looks like a sanitiser has to be one.
+ */
+export function stripTags(raw: string): string {
+  let prev = "";
+  let out = raw;
+  // Bounded, so a pathological input cannot spin here.
+  for (let i = 0; i < 20 && out !== prev; i++) {
+    prev = out;
+    out = out.replace(/<[^<>]*>/g, "");
+  }
+  // Anything left that still looks like a tag opener is neutralised outright.
+  return out.replace(/[<>]/g, "");
+}
+
 export type MdListItem = { html: string; checked?: boolean; depth: number };
 
 export type MdBlock =
@@ -145,7 +167,7 @@ export function parseBody(body: string, autolinkRepo?: string): MdBlock[] {
         if (/^\s*<details[^>]*>\s*$/i.test(l)) depth++;
         if (/^\s*<\/details>\s*$/i.test(l)) { depth--; if (depth === 0) break; }
         const sum = l.match(/<summary[^>]*>([\s\S]*?)<\/summary>/i);
-        if (sum && !summary) { summary = sum[1]!.replace(/<[^>]+>/g, "").trim(); continue; }
+        if (sum && !summary) { summary = stripTags(sum[1]!).trim(); continue; }
         inner.push(l);
       }
       out.push({ kind: "details", summary: summary || "Details", blocks: parseBody(inner.join("\n"), autolinkRepo) });

--- a/web/test/pr-markdown.test.ts
+++ b/web/test/pr-markdown.test.ts
@@ -6,7 +6,7 @@
 // as punctuation. The escaping tests are the ones with teeth — a body is a
 // string a stranger wrote.
 import { describe, expect, test } from "bun:test";
-import { parseBody, renderInline } from "../src/lib/prBody.ts";
+import { parseBody, renderInline, stripTags } from "../src/lib/prBody.ts";
 
 describe("<details>", () => {
   test("folds into a details block, with its summary and its inner markdown", () => {
@@ -130,5 +130,34 @@ describe("suggested changes", () => {
 
   test("the language match is case-insensitive and survives a longer fence", () => {
     expect(parseBody("````SUGGESTION\nz\n````")[0]!.kind).toBe("suggestion");
+  });
+});
+
+describe("summary sanitisation", () => {
+  // The old strip was a single `replace(/<[^>]+>/g, "")`, which is what CodeQL
+  // called incomplete multi-character sanitization. Verified against it: each
+  // of these came out with `<script` still in the string.
+  test("an unclosed tag does not survive — the one-pass strip left it whole", () => {
+    for (const evil of ["report <script", "a <script src=x", "<b>ok</b> <script"]) {
+      expect(stripTags(evil)).not.toContain("<script");
+      expect(stripTags(evil)).not.toContain("<");
+    }
+  });
+
+  test("nested tags cannot reassemble into one", () => {
+    expect(stripTags("<scr<b>ipt>alert(1)</scr</b>ipt>")).not.toContain("<script");
+    expect(stripTags("<scr<b>ipt>")).not.toContain("<");
+  });
+
+  test("a <details> summary comes through as plain text, whatever was in it", () => {
+    const blocks = parseBody("<details>\n<summary>report <script</summary>\nbody\n</details>");
+    const d = blocks[0]!;
+    if (d.kind !== "details") throw new Error("not details");
+    expect(d.summary).not.toContain("<");
+    expect(d.summary).not.toContain(">");
+  });
+
+  test("ordinary markup inside a summary is simply removed", () => {
+    expect(stripTags("<b>Coverage</b> report")).toBe("Coverage report");
   });
 });

--- a/web/test/pr-markdown.test.ts
+++ b/web/test/pr-markdown.test.ts
@@ -1,0 +1,134 @@
+// The markdown a pull request is actually written in.
+//
+// Each case here is something that turned up in a real body or bot comment and
+// rendered wrong: a folded <details> that came through as escaped tags, a
+// GitHub callout that read as a quote, `#123` that stayed plain text, `:tada:`
+// as punctuation. The escaping tests are the ones with teeth — a body is a
+// string a stranger wrote.
+import { describe, expect, test } from "bun:test";
+import { parseBody, renderInline } from "../src/lib/prBody.ts";
+
+describe("<details>", () => {
+  test("folds into a details block, with its summary and its inner markdown", () => {
+    const blocks = parseBody([
+      "<details>",
+      "<summary>Coverage report</summary>",
+      "",
+      "- lines: 91%",
+      "- branches: 84%",
+      "</details>",
+    ].join("\n"));
+    expect(blocks).toHaveLength(1);
+    const d = blocks[0]!;
+    expect(d.kind).toBe("details");
+    if (d.kind !== "details") throw new Error("not details");
+    expect(d.summary).toBe("Coverage report");
+    // The body is parsed, not dumped: a list inside stays a list.
+    expect(d.blocks.some((b) => b.kind === "list")).toBe(true);
+  });
+
+  test("a missing summary still renders, with a name of its own", () => {
+    const blocks = parseBody("<details>\n\nplain\n</details>");
+    const d = blocks[0]!;
+    expect(d.kind).toBe("details");
+    if (d.kind !== "details") throw new Error("not details");
+    expect(d.summary).toBe("Details");
+  });
+
+  test("nested details close at the right place", () => {
+    const blocks = parseBody([
+      "<details>",
+      "<summary>outer</summary>",
+      "<details>",
+      "<summary>inner</summary>",
+      "deep",
+      "</details>",
+      "outer tail",
+      "</details>",
+      "after",
+    ].join("\n"));
+    // Two blocks: the details, then the paragraph that follows it. If the
+    // nesting were mishandled, "after" would be swallowed.
+    expect(blocks[0]!.kind).toBe("details");
+    expect(blocks[blocks.length - 1]!.kind).toBe("para");
+  });
+});
+
+describe("alerts", () => {
+  test("> [!WARNING] becomes an alert, not a quote", () => {
+    const blocks = parseBody("> [!WARNING]\n> This drops the table.");
+    const a = blocks[0]!;
+    expect(a.kind).toBe("alert");
+    if (a.kind !== "alert") throw new Error("not alert");
+    expect(a.level).toBe("warning");
+    expect(a.html).toContain("drops the table");
+  });
+
+  test("every level GitHub defines is recognised, case-insensitively", () => {
+    for (const [raw, want] of [["NOTE", "note"], ["TIP", "tip"], ["IMPORTANT", "important"], ["WARNING", "warning"], ["CAUTION", "caution"], ["note", "note"]] as const) {
+      const b = parseBody(`> [!${raw}]\n> body`)[0]!;
+      expect(b.kind).toBe("alert");
+      if (b.kind !== "alert") throw new Error("not alert");
+      expect(b.level).toBe(want);
+    }
+  });
+
+  test("an ordinary quote is still a quote", () => {
+    expect(parseBody("> just quoting you")[0]!.kind).toBe("quote");
+  });
+});
+
+describe("inline", () => {
+  test("emoji shortcodes render, unknown ones are left alone", () => {
+    expect(renderInline("ship it :rocket:")).toContain("🚀");
+    expect(renderInline(":not_a_real_emoji:")).toContain(":not_a_real_emoji:");
+  });
+
+  test("#123 links to the repo it belongs to, and only when we know it", () => {
+    expect(renderInline("fixes #123", "acme/orbit")).toContain('href="https://github.com/acme/orbit/issues/123"');
+    // No repo in hand: leave it as text rather than link somewhere invented.
+    expect(renderInline("fixes #123")).not.toContain("<a");
+  });
+
+  test("owner/repo#123 keeps its own repo", () => {
+    const html = renderInline("see other/thing#7", "acme/orbit");
+    expect(html).toContain("https://github.com/other/thing/issues/7");
+  });
+
+  test("a bare sha links to the commit and is shown short", () => {
+    const html = renderInline("broke in 4a459f5c9b1", "acme/orbit");
+    expect(html).toContain("/commit/4a459f5c9b1");
+    expect(html).toContain("<code>4a459f5</code>");
+  });
+
+  test("still escapes, and still refuses to make a javascript: link clickable", () => {
+    expect(renderInline("<script>alert(1)</script>")).not.toContain("<script>");
+    // The text survives (escaped) — what must not happen is it becoming an
+    // anchor. Only http(s) is ever linked.
+    const html = renderInline("[x](javascript:alert(1))");
+    expect(html).not.toContain("<a");
+    expect(html).not.toContain('href="javascript:');
+  });
+
+  test("code spans are left verbatim — no emoji or autolink inside them", () => {
+    const html = renderInline("`:rocket:` and `#123`", "acme/orbit");
+    expect(html).toContain("<code>:rocket:</code>");
+    expect(html).not.toContain("🚀");
+  });
+});
+
+describe("suggested changes", () => {
+  test("a ```suggestion fence is its own kind, not an ordinary code block", () => {
+    const blocks = parseBody("Try this:\n\n```suggestion\nconst x = 2;\n```");
+    const sug = blocks.find((b) => b.kind === "suggestion");
+    expect(sug).toBeTruthy();
+    if (!sug || sug.kind !== "suggestion") throw new Error("no suggestion");
+    expect(sug.text).toBe("const x = 2;");
+    // and a normal fence is still a normal fence
+    expect(parseBody("```ts\nconst y = 1;\n```")[0]!.kind).toBe("code");
+  });
+
+  test("the language match is case-insensitive and survives a longer fence", () => {
+    expect(parseBody("````SUGGESTION\nz\n````")[0]!.kind).toBe("suggestion");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Five things the panel could not do, and one it did badly.

**Line and range comments.** There was one `+ Comment` **per hunk**, anchored to that hunk's last added line, and it disappeared entirely in Split view. Every line now has its own target in the gutter, on both sides and in both view modes, and **shift-click covers a range** — which the server could not express either: it only ever sent `line`, so a multi-line remark collapsed onto its last line. It now sends `start_line`/`start_side`, and a comment can be posted **on its own without opening a review** (GitHub's "Add single comment", which had no equivalent here).

**CI logs, in the app.** The panel used to say *"the log itself lives on GitHub — this panel does not download run logs"*, which sent you to a browser for the one thing you opened the check to read. The log is now here, folded by the `##[group]` markers Actions writes, with the per-line timestamps stripped and **the failing step already open**. Re-run gained the two variants GitHub has and this did not: **a single job**, and **the whole run**.

**Suggested changes** render as what they are — a proposal, shown as a change — rather than an ordinary code block that hid the fact there was anything on offer.

**The composer completes** `@` people, `#` issues and `:` emoji, so a mention no longer means leaving the panel to look a login up.

**Markdown**: `<details>/<summary>` (what every bot folds its output into — it came through as escaped tags), GitHub's `> [!NOTE]`-style alerts, `:emoji:`, and autolinked `#123`, `owner/repo#123` and bare SHAs pointing at the right repo.

## How was it tested?

- `bunx tsc --noEmit` in `server/` and `web/`; `bun test` (**server 635**, **web 308** — 14 new for the markdown, including the escaping cases and the refusal to make a `javascript:` link clickable); `bunx vite build`; `bun scripts/smoke.ts`; `bun scripts/perfbudget.ts` (loop p99 2ms).
- Jobs and logs exercised live against this repository before wiring any UI: 4 jobs on a run, a 1966-line log read end to end, and the collaborator/issue lists behind the composer.
- The panel driven by hand in the desktop app: commenting on a single line and on a shift-click range, in Unified and in Split; opening a check's log and watching the failed step unfold; a bot comment with `<details>` and alerts in it.

---

<sub>CI runs typecheck, tests and the production build for you. If you changed the server↔web contract update `shared/types.ts`; if behavior or config changed, update the docs. See [CONTRIBUTING.md](../CONTRIBUTING.md).</sub>
