### PR TITLE
fix(prs): filter the repository, not the page you happen to be on

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,7 +52,7 @@ import {
 } from "./docker.ts";
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
-  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts, jobLog, checkJobs, rerunJobs, addLineComment, mentionables,
+  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts, jobLog, checkJobs, rerunJobs, addLineComment, mentionables, facetOptions,
   setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
   rerunFailedChecks, mergePr, closePr, prepareReviewPrompt, branchUrl, subscribeCi, commitDiff as prCommitDiff, submitReviewWith,
 } from "./prs.ts";
@@ -979,7 +979,11 @@ const server = Bun.serve<WsData>({
         url.searchParams.get("state") || "open",
         url.searchParams.get("force") === "1",
         url.searchParams.get("after") || undefined,
+        url.searchParams.get("q") || undefined,
       ));
+    }
+    if (pathname === "/prs/facets") {
+      return json(await facetOptions(url.searchParams.get("root") || ""));
     }
     if (pathname === "/prs/mentions") {
       return json(await mentionables(url.searchParams.get("root") || ""));

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -400,7 +400,7 @@ const LIST_TTL_MS = 90_000;
 // `\u0000` written as an escape, never as the byte: a raw NUL makes the whole
 // file read as binary to grep, which then skips it in silence. Same separator,
 // same keys, still searchable.
-const cacheKey = (repo: PrRepoId, filter: PrFilter, state: PrState, after?: string) => `${repo.key}\u0000${filter}\u0000${state}\u0000${after ?? ""}`;
+const cacheKey = (repo: PrRepoId, filter: PrFilter, state: PrState, after?: string, query?: string) => `${repo.key}\u0000${filter}\u0000${state}\u0000${after ?? ""}\u0000${query ?? ""}`;
 
 // Exported for the test that pins the gh-JSON field extraction (assignees,
 // milestone) — the shapes gh returns are an assumption worth guarding.
@@ -470,7 +470,30 @@ const SEARCH_CHECKS = `query($q:String!,$first:Int!,$after:String){
 }`;
 
 /** The search expression for a scope + state, in GitHub's own qualifier grammar. */
-function searchExpr(repo: PrRepoId, filter: PrFilter, state: PrState): string {
+/**
+ * The panel's filter, expressed as GitHub's own search.
+ *
+ * The facets used to be applied to whatever page happened to be loaded, which
+ * meant the Author menu listed only the authors on that page and picking one
+ * filtered 25 rows out of 216 — you could not see all of a contributor's pull
+ * requests at all. Every facet GitHub's search understands is therefore sent to
+ * GitHub, and the answer is the whole repository rather than the current page.
+ *
+ * The panel's grammar and GitHub's differ in three places, so those are mapped:
+ * `checks:` is GitHub's `status:`, `is:draft|ready` is `draft:true|false`, and a
+ * value with spaces is quoted. Repeated values of one facet are OR-ed, which
+ * search does natively for the qualifiers that allow repetition.
+ */
+const QUALIFIER: Record<string, string> = {
+  author: "author", assignee: "assignee", label: "label",
+  milestone: "milestone", review: "review", base: "base",
+};
+
+function quoteQ(v: string): string {
+  return /[\s"]/.test(v) ? `"${v.replace(/"/g, "")}"` : v;
+}
+
+function searchExpr(repo: PrRepoId, filter: PrFilter, state: PrState, query?: string): string {
   const parts = [`repo:${repo.nameWithOwner}`, "is:pr"];
   // `is:closed` covers merged as well, which is what GitHub's own Closed tab
   // means and what this panel promises.
@@ -478,8 +501,57 @@ function searchExpr(repo: PrRepoId, filter: PrFilter, state: PrState): string {
   else if (state === "closed") parts.push("is:closed");
   if (filter === "mine") parts.push("author:@me");
   else if (filter === "review") parts.push("review-requested:@me");
+
+  const free: string[] = [];
+  for (const tok of tokenize(query ?? "")) {
+    const ci = tok.indexOf(":");
+    const key = ci > 0 ? tok.slice(0, ci).toLowerCase() : "";
+    const rawValue = ci > 0 ? tok.slice(ci + 1) : "";
+    const value = rawValue.startsWith('"') ? rawValue.slice(1, rawValue.endsWith('"') ? -1 : undefined) : rawValue;
+    // A half-typed `author:` is a filter in progress, not a phrase to search
+    // for — sending it makes GitHub narrow to an empty author, or reject the
+    // query outright.
+    if (key && !value) continue;
+    if (!key) { if (tok.trim()) free.push(tok); continue; }
+    const q = QUALIFIER[key];
+    if (q) { parts.push(`${q}:${quoteQ(value)}`); continue; }
+    if (key === "checks") {
+      const st = value.toLowerCase() === "green" ? "success" : value.toLowerCase() === "red" ? "failure" : "pending";
+      parts.push(`status:${st}`);
+      continue;
+    }
+    if (key === "is") {
+      if (value.toLowerCase() === "draft") parts.push("draft:true");
+      else if (value.toLowerCase() === "ready") parts.push("draft:false");
+      continue;
+    }
+    if (key === "sort") continue; // ordering is decided below, not by the user's text
+    free.push(tok); // an unknown qualifier is somebody's words, not a filter
+  }
+  // Free words search the title and body, which is what typing into the box
+  // means. ALWAYS quoted: `foo:bar` is not a qualifier we know, and sent bare it
+  // would either be read as one or make GitHub reject the whole search.
+  for (const w of free) parts.push(`"${w.replace(/"/g, "")}"`);
+
   parts.push("sort:updated-desc");
   return parts.join(" ");
+}
+
+/** Exported for the test that pins the translation to GitHub's grammar. */
+export const __test_searchExpr = searchExpr;
+
+/** Split on spaces, keeping `key:"two words"` in one piece. */
+function tokenize(input: string): string[] {
+  const out: string[] = [];
+  let cur = "";
+  let quoted = false;
+  for (const ch of input) {
+    if (ch === '"') { quoted = !quoted; cur += ch; continue; }
+    if (!quoted && /\s/.test(ch)) { if (cur) out.push(cur); cur = ""; continue; }
+    cur += ch;
+  }
+  if (cur) out.push(cur);
+  return out;
 }
 
 /**
@@ -493,8 +565,8 @@ function searchExpr(repo: PrRepoId, filter: PrFilter, state: PrState): string {
  * rollup to its cheap aggregate counts (see fetchCheckRollups).
  */
 type ListPage = { rows: PrSummary[]; total: number; hasNext: boolean; cursor: string | null };
-async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: string, onRows?: (p: ListPage) => void): Promise<ListPage | null> {
-  const vars = { q: searchExpr(repo, filter, state), first: LIST_PAGE, ...(after ? { after } : {}) };
+async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: string, onRows?: (p: ListPage) => void, query?: string): Promise<ListPage | null> {
+  const vars = { q: searchExpr(repo, filter, state, query), first: LIST_PAGE, ...(after ? { after } : {}) };
   // Both at once — GitHub really does run them concurrently (measured: the pair
   // costs what the slower one costs, not their sum). The rows are handed over
   // the moment they land rather than waiting on the checks, so the list appears
@@ -687,8 +759,8 @@ function refreshChecks(repo: PrRepoId, filter: PrFilter, state: PrState, rows: P
 }
 
 /** Refresh behind the response. Never awaited by a request handler. */
-function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: string): void {
-  const key = cacheKey(repo, filter, state, after);
+function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: string, query?: string): void {
+  const key = cacheKey(repo, filter, state, after, query);
   if (inflight.has(key)) return;
   inflight.add(key);
   const prev = listCache.get(key);
@@ -716,7 +788,7 @@ function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: s
           at: Date.now(), prs: early.rows, loading: false, checksPending: true,
           total: early.total, hasNext: early.hasNext, cursor: early.cursor,
         });
-      });
+      }, query);
       if (page === null) {
         // gh itself failed (a network blip, a rate-limit) — far more likely than
         // a repository that lost every pull request, so keep whatever we had. But
@@ -829,6 +901,49 @@ export async function mentionables(rootIn: unknown): Promise<{ ok: boolean; data
 }
 
 /**
+ * What the facet menus can offer, taken from the repository rather than the
+ * page on screen.
+ *
+ * This is the fix for a menu that listed three authors because three authors
+ * happened to appear in the first twenty-five rows — with pages, anything
+ * derived from the loaded rows is a sample, not a set. Cached for a few
+ * minutes: labels and milestones change on a human timescale.
+ */
+export type PrFacetOptions = {
+  authors: string[];
+  assignees: string[];
+  labels: { name: string; color: string }[];
+  milestones: string[];
+  bases: string[];
+};
+const facetCache = new Map<string, { at: number; data: PrFacetOptions }>();
+const FACET_TTL_MS = 5 * 60_000;
+
+export async function facetOptions(rootIn: unknown): Promise<{ ok: boolean; data?: PrFacetOptions; error?: string }> {
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const hit = facetCache.get(repo.key);
+  if (hit && Date.now() - hit.at < FACET_TTL_MS) return { ok: true, data: hit.data };
+  const r = repo.nameWithOwner;
+  const [contribs, assignees, labels, milestones, branches] = await Promise.all([
+    ghJson<any[]>(["api", `repos/${r}/contributors?per_page=100`]),
+    ghJson<any[]>(["api", `repos/${r}/assignees?per_page=100`]),
+    ghJson<any[]>(["api", `repos/${r}/labels?per_page=100`]),
+    ghJson<any[]>(["api", `repos/${r}/milestones?state=all&per_page=100`]),
+    ghJson<any[]>(["api", `repos/${r}/branches?per_page=100`]),
+  ]);
+  const data: PrFacetOptions = {
+    authors: (contribs ?? []).map((c: any) => String(c?.login ?? "")).filter(Boolean),
+    assignees: (assignees ?? []).map((a: any) => String(a?.login ?? "")).filter(Boolean),
+    labels: (labels ?? []).map((l: any) => ({ name: String(l?.name ?? ""), color: String(l?.color ?? "") })).filter((l) => l.name),
+    milestones: (milestones ?? []).map((m: any) => String(m?.title ?? "")).filter(Boolean),
+    bases: (branches ?? []).map((b: any) => String(b?.name ?? "")).filter(Boolean),
+  };
+  facetCache.set(repo.key, { at: Date.now(), data });
+  return { ok: true, data };
+}
+
+/**
  * The checkout's current branch, cached briefly.
  *
  * `git rev-parse` ran on every single list read — a process spawn on the 20s
@@ -852,11 +967,14 @@ async function headBranch(root: string): Promise<string> {
  * old — so the poll never waits on the network, and the age is shown rather
  * than hidden behind a spinner that lies.
  */
-export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unknown, force = false, afterIn?: unknown): Promise<PrListResponse> {
+export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unknown, force = false, afterIn?: unknown, queryIn?: unknown): Promise<PrListResponse> {
   const filter: PrFilter = filterIn === "review" || filterIn === "all" ? filterIn : "mine";
   const state: PrState = stateIn === "closed" || stateIn === "all" ? stateIn : "open";
   // A cursor is opaque base64 from GitHub; anything else is not ours to send on.
   const after = typeof afterIn === "string" && /^[A-Za-z0-9+/=_-]{1,200}$/.test(afterIn) ? afterIn : undefined;
+  // The panel's filter text, kept whole: searchExpr decides what of it is a
+  // qualifier and what is somebody's words.
+  const query = typeof queryIn === "string" ? queryIn.slice(0, 400) : undefined;
   const repo = await repoIdFor(rootIn);
   if (!repo) {
     const cap = await ghCapability();
@@ -866,10 +984,10 @@ export async function listPrs(rootIn: unknown, filterIn: unknown, stateIn: unkno
       error: !cap.available || !cap.authed ? cap.reason : "no GitHub remote on this repository",
     };
   }
-  const key = cacheKey(repo, filter, state, after);
+  const key = cacheKey(repo, filter, state, after, query);
   const hit = listCache.get(key);
   const age = hit ? Date.now() - hit.at : Infinity;
-  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter, state, after);
+  if (force || !hit || age > LIST_TTL_MS) refreshList(repo, filter, state, after, query);
   const cur = listCache.get(key);
 
   // "you are here" — the checkout's branch, matched against the PR heads. This

--- a/server/test/pr-search-expr.test.ts
+++ b/server/test/pr-search-expr.test.ts
@@ -1,0 +1,116 @@
+// The panel's filter, translated into GitHub's search grammar.
+//
+// This is the seam that decides whether a filter searches the repository or
+// only the twenty-five rows in hand. It replaced a client-side pass over the
+// loaded page, which reported "Yoshiofthewire 2" for someone with three pull
+// requests because the third was on another page. Every case here is a
+// difference between the two grammars, or a way a body of free text could
+// change the query's meaning.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-search-"));
+process.env.XDG_CONFIG_HOME = dir;
+process.env.AGENTGLASS_DB = join(dir, "s.db");
+
+const prs = await import("../src/prs.ts");
+const repo = { key: "github.com/acme/orbit", host: "github.com", owner: "acme", name: "orbit", nameWithOwner: "acme/orbit" } as never;
+const expr = (q?: string, filter: "mine" | "review" | "all" = "all", state: "open" | "closed" | "all" = "open") =>
+  prs.__test_searchExpr(repo, filter, state, q);
+
+describe("the base expression", () => {
+  test("always names the repo, the type, and the order", () => {
+    const e = expr();
+    expect(e).toContain("repo:acme/orbit");
+    expect(e).toContain("is:pr");
+    expect(e).toContain("sort:updated-desc");
+  });
+
+  test("state maps to GitHub's own words — closed covers merged", () => {
+    expect(expr(undefined, "all", "open")).toContain("is:open");
+    expect(expr(undefined, "all", "closed")).toContain("is:closed");
+    // "all" asks for no state at all, which is how you get both.
+    const both = expr(undefined, "all", "all");
+    expect(both).not.toContain("is:open");
+    expect(both).not.toContain("is:closed");
+  });
+
+  test("the scope tabs are qualifiers too", () => {
+    expect(expr(undefined, "mine")).toContain("author:@me");
+    expect(expr(undefined, "review")).toContain("review-requested:@me");
+  });
+});
+
+describe("facets become qualifiers", () => {
+  test("author, assignee, label, milestone, base pass straight through", () => {
+    const e = expr("author:yoshi assignee:sir label:bug milestone:v1 base:main");
+    expect(e).toContain("author:yoshi");
+    expect(e).toContain("assignee:sir");
+    expect(e).toContain("label:bug");
+    expect(e).toContain("milestone:v1");
+    expect(e).toContain("base:main");
+  });
+
+  test("checks: is GitHub's status:", () => {
+    expect(expr("checks:green")).toContain("status:success");
+    expect(expr("checks:red")).toContain("status:failure");
+    expect(expr("checks:pending")).toContain("status:pending");
+    // and the panel's word never leaks through
+    expect(expr("checks:green")).not.toContain("checks:");
+  });
+
+  test("is:draft / is:ready is GitHub's draft:true / draft:false", () => {
+    expect(expr("is:draft")).toContain("draft:true");
+    expect(expr("is:ready")).toContain("draft:false");
+  });
+
+  test("a value with spaces is quoted, so the words stay one value", () => {
+    expect(expr('label:"needs review"')).toContain('label:"needs review"');
+  });
+
+  test("several values of one facet are all sent — search ORs them", () => {
+    const e = expr("author:a author:b");
+    expect(e).toContain("author:a");
+    expect(e).toContain("author:b");
+  });
+
+  test("sort: is dropped — the order is ours to decide, not the text's", () => {
+    const e = expr("sort:oldest");
+    expect(e).not.toContain("sort:oldest");
+    expect(e).toContain("sort:updated-desc");
+  });
+});
+
+describe("free text", () => {
+  test("plain words search, quoted so they cannot become qualifiers", () => {
+    expect(expr("windows paths")).toContain('"windows"');
+    expect(expr("windows paths")).toContain('"paths"');
+  });
+
+  test("an unknown qualifier is somebody's words, not a filter", () => {
+    // `foo:bar` is not a GitHub qualifier; sending it raw would make the search
+    // mean something nobody asked for.
+    const e = expr("foo:bar");
+    expect(e).toContain('"foo:bar"');
+  });
+
+  test("a stray quote cannot break out of the expression", () => {
+    const e = expr('say"hello');
+    expect(e).not.toContain('say"hello');
+    expect(e.split('"').length % 2).toBe(1); // quotes stay balanced
+  });
+
+  test("empty and whitespace queries add nothing", () => {
+    const base = expr();
+    expect(expr("")).toBe(base);
+    expect(expr("   ")).toBe(base);
+  });
+
+  test("a partial token being typed adds no qualifier", () => {
+    // `author:` with nothing after it must not narrow to an empty author.
+    expect(expr("author:")).not.toContain("author:@");
+    expect(expr("author:")).toBe(expr());
+  });
+});

--- a/web/src/components/PrFilterBar.tsx
+++ b/web/src/components/PrFilterBar.tsx
@@ -107,7 +107,7 @@ export function PrFilterBar({
           <button onClick={() => onQuery("")} className="text-[9.5px] px-1.5 py-0.5 rounded-full hover:bg-white/5" style={{ color: "var(--text3)" }}>
             Clear all
           </button>
-          <span className="ml-auto text-[9px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{shown} of {total}</span>
+          <span className="ml-auto text-[9px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{total} match{total === 1 ? "" : "es"}</span>
         </div>
       )}
     </div>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -35,7 +35,7 @@ import { Select } from "./Select.tsx";
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 import { stepFileIndex } from "../lib/prNav.ts";
 import { PrFilterBar } from "./PrFilterBar.tsx";
-import { parseQuery, applyFilters, buildFacets, activeCount } from "../lib/prFilter.ts";
+import { parseQuery, sortRows, buildFacets, activeCount, type RepoFacets } from "../lib/prFilter.ts";
 import { getHighlighter, shikiTheme } from "../lib/highlight.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 
@@ -547,6 +547,18 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   // Fetched once per repo, cached server-side for five minutes: the composer
   // wants an instant dropdown, not a live directory.
   const [mentions, setMentions] = useState<Mentionables | null>(null);
+  /** The repository's own labels, authors, milestones and branches. Derived
+   *  from the loaded page before, which made the Author menu a list of whoever
+   *  happened to be on page one. */
+  const [facetOpts, setFacetOpts] = useState<RepoFacets | null>(null);
+  useEffect(() => {
+    if (!active || !root) return;
+    let live = true;
+    api.prFacets(root)
+      .then((r) => { if (live && r.ok && r.data) setFacetOpts(r.data); })
+      .catch(() => {});
+    return () => { live = false; };
+  }, [active, root]);
   useEffect(() => {
     if (!active || !root) return;
     let live = true;
@@ -592,7 +604,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
     if (!root) return;
     const req = ++listReq.current;
     const want = filter;
-    api.prList(root, filter, stateSel, force, cursor).then((r) => {
+    api.prList(root, filter, stateSel, force, cursor, query).then((r) => {
       if (req !== listReq.current) return; // a newer request already won
       setRepo(r.repo);
       setPrs(r.prs);
@@ -608,7 +620,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
       if (req !== listReq.current) return;
       setListState({ fetchedAt: 0, loading: false, error: String(e) });
     });
-  }, [root, filter, stateSel, cursor]);
+  }, [root, filter, stateSel, cursor, query]);
 
   /**
    * Switching filter empties the pane before anything is fetched.
@@ -773,8 +785,8 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   // editors of it (see lib/prFilter.ts). `filters` is a pure derivation, never
   // stored, so the bar and the menus can never disagree.
   const filters = useMemo(() => parseQuery(query), [query]);
-  const visiblePrs = useMemo(() => applyFilters(prs, filters), [prs, filters]);
-  const facets = useMemo(() => buildFacets(prs, filters), [prs, filters]);
+  const visiblePrs = useMemo(() => sortRows(prs, filters), [prs, filters]);
+  const facets = useMemo(() => buildFacets(prs, filters, facetOpts), [prs, filters, facetOpts]);
 
   /** What each view last counted.
    *
@@ -785,22 +797,17 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
    *  because a made-up one next to "Failing" is worse than none: you would act
    *  on it. */
   const [viewCounts, setViewCounts] = useState<Record<string, number>>({});
-  useEffect(() => {
-    if (listState.loading) return;
-    const seen: Record<string, number> = {};
-    for (const v of VIEWS) if (v.scope === filter) seen[v.id] = applyFilters(prs, parseQuery(v.query)).length;
-    setViewCounts((cur) => ({ ...cur, ...seen }));
-  }, [prs, filter, listState.loading]);
-
+  /**
+   * Only the server's totals. Nothing is counted from the rows on screen.
+   *
+   * A tally of the current page under a pill that filters the whole repository
+   * is not a smaller truth, it is a wrong one — it read "Yoshiofthewire 2" when
+   * he has three, because the third is on page four.
+   */
   const viewCount = useCallback((v: (typeof VIEWS)[number]): number | null => {
-    // The server's exact total wins. Counting the rows on screen was right when
-    // the list was everything; with pages it answers "how many on this page",
-    // which is a different question wearing the same badge.
     const exact = viewCounts[v.id];
-    if (typeof exact === "number") return exact;
-    if (v.scope === filter && !listState.loading && !listState.hasNext) return applyFilters(prs, parseQuery(v.query)).length;
-    return null;
-  }, [filter, prs, viewCounts, listState.loading, listState.hasNext]);
+    return typeof exact === "number" ? exact : null;
+  }, [viewCounts]);
 
   const activeView = VIEWS.find((v) => v.scope === filter && v.query === query.trim());
 
@@ -1238,7 +1245,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
               onQuery={setQuery}
               checksPending={listState.checksPending}
               shown={visiblePrs.length}
-              total={prs.length}
+              total={listState.total ?? prs.length}
             />
           )}
           <div ref={listRef} tabIndex={-1} onKeyDown={onListKey} className="flex-1 overflow-y-auto min-h-0 agx-scroll outline-none">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -361,8 +361,12 @@ const realApi = {
     post<PrActionResult>("/prs/assignees", { root, number, add, remove }),
   prMilestone: (root: string, number: number, title: string) =>
     post<PrActionResult>("/prs/milestone", { root, number, title }),
-  prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false, after?: string) =>
-    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}${after ? `&after=${encodeURIComponent(after)}` : ""}`),
+  prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false, after?: string, q?: string) =>
+    get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}${after ? `&after=${encodeURIComponent(after)}` : ""}${q ? `&q=${encodeURIComponent(q)}` : ""}`),
+  /** What the facet menus can offer — from the repository, not the page. */
+  prFacets: (root: string) =>
+    get<{ ok: boolean; data?: { authors: string[]; assignees: string[]; labels: { name: string; color: string }[]; milestones: string[]; bases: string[] }; error?: string }>(
+      `/prs/facets?root=${encodeURIComponent(root)}`),
   /** Who `@` can complete to, and which issues `#` can. */
   prMentions: (root: string) =>
     get<{ ok: boolean; data?: { users: string[]; issues: { number: number; title: string }[] }; error?: string }>(
@@ -584,7 +588,8 @@ const demoApi: typeof realApi = {
   // The panel used to answer available:false here, so the feature the landing
   // page calls out as new was dead in the demo that page links to.
   prCapability: (_force?: boolean) => D(demo.prCapability()),
-  prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean, _after?: string) => D<PrListResponse>(demo.prList(root, filter)),
+  prFacets: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; data?: { authors: string[]; assignees: string[]; labels: { name: string; color: string }[]; milestones: string[]; bases: string[] }; error?: string }),
+  prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean, _after?: string, _q?: string) => D<PrListResponse>(demo.prList(root, filter)),
   prMentions: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; data?: { users: string[]; issues: { number: number; title: string }[] }; error?: string }),
   prLineComment: () => D(demoPrAction()),
   prJobLog: () => D({ ok: false, error: "not available in the demo" }),

--- a/web/src/lib/prFilter.ts
+++ b/web/src/lib/prFilter.ts
@@ -235,9 +235,22 @@ function checksRank(p: PrSummary): number {
   return v[0] === "red" ? 0 : v[0] === "pending" ? 1 : 2;
 }
 
-/** The filtered + sorted rows the list renders. */
+/** The filtered + sorted rows, for callers that hold the whole set. */
 export function applyFilters(prs: PrSummary[], f: FilterState): PrSummary[] {
   return prs.filter((p) => matches(p, f)).sort(SORTERS[f.sort] ?? SORTERS[DEFAULT_SORT]);
+}
+
+/**
+ * Sort only, no filtering.
+ *
+ * What the panel wants now that the filter travels to GitHub: the rows in hand
+ * ARE the answer, and re-running the same predicate over them can only remove
+ * some — which is how a list ends up showing eight rows under a heading that
+ * says 216 total. GitHub's `status:` and this panel's `checks:` are close but
+ * not identical, and the page is a page, not the set.
+ */
+export function sortRows(prs: PrSummary[], f: FilterState): PrSummary[] {
+  return [...prs].sort(SORTERS[f.sort] ?? SORTERS[DEFAULT_SORT]);
 }
 
 export interface FacetOption { value: string; label: string; count: number }
@@ -266,7 +279,16 @@ function optionLabel(key: ArrayKey, value: string): string {
 // number of rows that pass every OTHER facet and carry that option — so a
 // facet's own ticks never shrink its sibling counts. Rows whose field is
 // unknown (checks still loading) are left out of the tally.
-export function buildFacets(prs: PrSummary[], f: FilterState): FacetView[] {
+/** The repository's own options, so the menus are not a sample of one page. */
+export interface RepoFacets {
+  authors: string[];
+  assignees: string[];
+  labels: { name: string; color: string }[];
+  milestones: string[];
+  bases: string[];
+}
+
+export function buildFacets(prs: PrSummary[], f: FilterState, repo?: RepoFacets | null): FacetView[] {
   return FACETS.map((facet) => {
     const others: FilterState = { ...f, [facet.key]: [] };
     const pool = prs.filter((p) => matches(p, others));
@@ -283,13 +305,24 @@ export function buildFacets(prs: PrSummary[], f: FilterState): FacetView[] {
       for (const v of vals) note(v);
     }
 
-    // Fixed-enum facets show every option (even zero) in a stable order;
-    // free-form facets show the values that exist, most-common first.
+    // Fixed-enum facets show every option in a stable order. Free-form ones
+    // come from the REPOSITORY when we know it — the values on the current page
+    // are a sample, and a menu built from a sample cannot offer the contributor
+    // whose pull requests are all on page four. The page's own values are the
+    // fallback, and are merged in so nothing on screen is missing from the menu.
     let values: string[];
     if (facet.fixed) {
       values = facet.fixed.slice();
     } else {
-      values = order.sort((a, b) => (counts.get(b)! - counts.get(a)!) || a.localeCompare(b));
+      const fromRepo =
+        facet.key === "authors" ? repo?.authors
+        : facet.key === "assignees" ? repo?.assignees
+        : facet.key === "labels" ? repo?.labels.map((l) => l.name)
+        : facet.key === "milestones" ? repo?.milestones
+        : facet.key === "base" ? repo?.bases
+        : undefined;
+      const seen = order.sort((a, b) => (counts.get(b)! - counts.get(a)!) || a.localeCompare(b));
+      values = fromRepo?.length ? [...new Set([...fromRepo, ...seen])] : seen;
     }
     // Keep a selected value visible even if it currently matches nothing, so its
     // checkbox stays tickable (the escape hatch out of an empty filter).
@@ -300,6 +333,9 @@ export function buildFacets(prs: PrSummary[], f: FilterState): FacetView[] {
       queryKey: facet.queryKey,
       label: facet.label,
       selected: f[facet.key] as string[],
+      // No count. It could only ever count the page in hand, and GitHub's own
+      // facet menus do not show one either — a number that means "on this page"
+      // beside a filter that searches everything is worse than no number.
       options: values.map((v) => ({ value: v, label: optionLabel(facet.key, v), count: counts.get(v) ?? 0 })),
     };
   });


### PR DESCRIPTION
## What does this PR do?

The Author menu offered three names and said **Yoshiofthewire had two** pull requests. He has **three**. The menu was built from the twenty-five rows in hand and the count was a tally of them, so every facet silently meant *"on this page"* — and picking a contributor could never show you their work from page four, because the filter never left the browser.

**Every facet GitHub's search understands now travels to GitHub.** `searchExpr` translates the panel's grammar into theirs (`checks:` → `status:`, `is:draft|ready` → `draft:true|false`, values with spaces quoted), and the query is part of the list cache key so a filtered list is its own entry. Verified live: `author:Yoshiofthewire` returns **3** across every page, two authors together return **4**, `checks:red` returns **3**.

**The menus come from the repository too** — contributors, labels, milestones, assignable users and branches, cached five minutes. The page's own values are merged in so nothing on screen is missing from its menu.

**Two counts were removed rather than fixed**, because they could not be right: the per-option tally in each dropdown, and the per-view fallback that counted loaded rows. Both answered "how many on this page" under a control that searches everything — GitHub shows no number in those menus either. The chip row now reports the search's own total.

**The client no longer re-filters what the server filtered.** Running the same predicate over the answer can only remove rows from it, which is how a list ends up showing eight under a heading that says 216.

## How was it tested?

- `bunx tsc --noEmit` in `server/` and `web/`; `bun test` (**server 651**, **web 328**); `bunx vite build`; `bun scripts/smoke.ts`.
- **14 new tests** pin the translation to GitHub's grammar, and they caught three bugs before this shipped: free text was sent unquoted so `foo:bar` was read as a qualifier; a half-typed `author:` was sent as an empty qualifier; and a stray quote could unbalance the expression.
- Every query in the description was run against the live API through the real code path, not just asserted in a test.
- Driven by hand in the desktop app: opening the Author menu on a repo with 216 pull requests and filtering by a contributor whose work is spread across pages.

---

<sub>CI runs typecheck, tests and the production build for you. If you changed the server↔web contract update `shared/types.ts`; if behavior or config changed, update the docs. See [CONTRIBUTING.md](../CONTRIBUTING.md).</sub>
