### PR TITLE
fix(prs): drop the numbers from the facet menus, and put faces in them

### DIFF
--- a/web/src/components/Avatar.tsx
+++ b/web/src/components/Avatar.tsx
@@ -1,0 +1,28 @@
+import { useState } from "react";
+import { api } from "../lib/api.ts";
+
+/**
+ * GitHub's avatar for a login, through the server's allowlisted proxy.
+ *
+ * Its own module because both the pull request panel and the facet menus want
+ * it, and importing it from the panel would close a cycle: the panel imports
+ * the filter bar, which imports the menus. The name is always beside it — the
+ * picture is recognition, not identification — and a login that has no picture
+ * (or whose picture will not load) falls back to its initials rather than an
+ * empty hole.
+ */
+export function Avatar({ login, size = 18 }: { login: string; size?: number }) {
+  const [failed, setFailed] = useState(false);
+  const initials = (login || "?").replace(/\[bot\]$/, "").slice(0, 2).toUpperCase();
+  if (failed || !login) {
+    return (
+      <span className="shrink-0 rounded-full inline-flex items-center justify-center"
+        style={{ width: size, height: size, background: "var(--primary)", color: "var(--bg)", fontSize: size * 0.42 }}>{initials}</span>
+    );
+  }
+  return (
+    <img src={api.prAssetUrl(`https://avatars.githubusercontent.com/${encodeURIComponent(login.replace(/\[bot\]$/, ""))}?size=48`)}
+      alt="" aria-hidden width={size} height={size} onError={() => setFailed(true)}
+      className="shrink-0 rounded-full" style={{ width: size, height: size, objectFit: "cover" }} />
+  );
+}

--- a/web/src/components/FacetMenu.tsx
+++ b/web/src/components/FacetMenu.tsx
@@ -1,6 +1,7 @@
 import { useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
+import { Avatar } from "./Avatar.tsx";
 
 /**
  * A multi-select facet dropdown, GitHub-style: a pill that opens a checkbox list
@@ -14,7 +15,13 @@ import { Portal } from "./Portal.tsx";
  * `mode="radio"`, used for Sort), each row shows a count, a real search box
  * appears once the list is long, and there is a "Clear" footer.
  */
-export interface FacetMenuOption { value: string; label: string; count: number }
+export interface FacetMenuOption {
+  value: string;
+  label: string;
+  count: number;
+  /** A GitHub login, when this option is a person. */
+  avatar?: string;
+}
 
 export function FacetMenu({
   label, options, selected, onToggle, onClear, mode = "multi", align = "left", note, disabled, pillActive,
@@ -182,8 +189,13 @@ export function FacetMenu({
                           }}>
                           {on ? (mode === "radio" ? "●" : "✓") : ""}
                         </span>
+                        {/* The person, when the facet is about people — the face
+                            is how you find a name in a list of twelve. */}
+                        {o.avatar && <Avatar login={o.avatar} size={16} />}
                         <span className="flex-1 truncate" style={{ color: on ? "var(--text)" : "var(--text2)" }}>{o.label}</span>
-                        <span className="text-[9.5px] tabular-nums shrink-0" style={{ color: "var(--text3)" }}>{o.count}</span>
+                        {/* No count. It could only ever count the page in hand,
+                            and the filter searches the whole repository; GitHub
+                            shows no number in these menus for the same reason. */}
                       </button>
                     );
                   })}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -35,6 +35,7 @@ import { Select } from "./Select.tsx";
 import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 import { stepFileIndex } from "../lib/prNav.ts";
 import { PrFilterBar } from "./PrFilterBar.tsx";
+import { Avatar } from "./Avatar.tsx";
 import { parseQuery, sortRows, buildFacets, activeCount, type RepoFacets } from "../lib/prFilter.ts";
 import { getHighlighter, shikiTheme } from "../lib/highlight.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
@@ -132,23 +133,6 @@ function Bar({ parts }: { parts: { pct: number; tint: string }[] }) {
   );
 }
 
-/** GitHub's avatar for a login, through the server's allowlisted proxy. The
- *  name is always beside it — the picture is recognition, not identification. */
-function Avatar({ login, size = 18 }: { login: string; size?: number }) {
-  const [failed, setFailed] = useState(false);
-  const initials = (login || "?").replace(/\[bot\]$/, "").slice(0, 2).toUpperCase();
-  if (failed || !login) {
-    return (
-      <span className="shrink-0 rounded-full inline-flex items-center justify-center"
-        style={{ width: size, height: size, background: "var(--primary)", color: "var(--bg)", fontSize: size * 0.42 }}>{initials}</span>
-    );
-  }
-  return (
-    <img src={api.prAssetUrl(`https://avatars.githubusercontent.com/${encodeURIComponent(login.replace(/\[bot\]$/, ""))}?size=48`)}
-      alt="" aria-hidden width={size} height={size} onError={() => setFailed(true)}
-      className="shrink-0 rounded-full" style={{ width: size, height: size, objectFit: "cover" }} />
-  );
-}
 
 function Btn({ children, onClick, disabled, danger, primary, ok, warn, title, small }: {
   children: React.ReactNode; onClick?: () => void; disabled?: boolean;

--- a/web/src/lib/prFilter.ts
+++ b/web/src/lib/prFilter.ts
@@ -253,7 +253,13 @@ export function sortRows(prs: PrSummary[], f: FilterState): PrSummary[] {
   return [...prs].sort(SORTERS[f.sort] ?? SORTERS[DEFAULT_SORT]);
 }
 
-export interface FacetOption { value: string; label: string; count: number }
+export interface FacetOption {
+  value: string;
+  label: string;
+  count: number;
+  /** The GitHub login this option stands for, when it is a person. */
+  avatar?: string;
+}
 export interface FacetView {
   key: ArrayKey;
   queryKey: string;
@@ -336,7 +342,14 @@ export function buildFacets(prs: PrSummary[], f: FilterState, repo?: RepoFacets 
       // No count. It could only ever count the page in hand, and GitHub's own
       // facet menus do not show one either — a number that means "on this page"
       // beside a filter that searches everything is worse than no number.
-      options: values.map((v) => ({ value: v, label: optionLabel(facet.key, v), count: counts.get(v) ?? 0 })),
+      options: values.map((v) => ({
+        value: v,
+        label: optionLabel(facet.key, v),
+        count: counts.get(v) ?? 0,
+        // Authors and assignees are people; a face finds a name in a list of a
+        // dozen faster than reading down it does.
+        ...(facet.key === "authors" || facet.key === "assignees" ? { avatar: v } : {}),
+      })),
     };
   });
 }


### PR DESCRIPTION
## What does this PR do?

The Author menu listed a number beside every name — `22`, `0`, `0`, `2` — and every one of them was counted from the twenty-five rows in hand, while the filter itself searches the whole repository. A contributor with three pull requests read **2**, and eleven people read **0** for no reason other than not appearing on page one. **GitHub shows no number in these menus**, for exactly this reason.

The number is **removed rather than fixed**: a true per-option count means one search per option, which is a dozen round trips to put a digit next to a name that never needed one.

**Authors and assignees now carry their avatar**, as GitHub's do — a face finds a name in a list of a dozen faster than reading down it does. `Avatar` moves to its own module to make that possible: the menus could not import it from the panel, because the panel imports the filter bar, which imports the menus.

## How was it tested?

- `bunx tsc --noEmit`, `bun test` (**web 328**), `bunx vite build`.
- Opened the Author and Assignee menus by hand in the desktop app on a repository with a dozen contributors: faces present, no numbers, and picking a name still filters across every page.

---

<sub>CI runs typecheck, tests and the production build for you. If you changed the server↔web contract update `shared/types.ts`; if behavior or config changed, update the docs. See [CONTRIBUTING.md](../CONTRIBUTING.md).</sub>
