### PR TITLE
fix(db): give tests a scratch database instead of the developer's own

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1,6 +1,6 @@
 import { Database } from "bun:sqlite";
-import { existsSync, mkdirSync, chmodSync } from "node:fs";
-import { homedir } from "node:os";
+import { existsSync, mkdirSync, mkdtempSync, chmodSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import type {
   WatchEvent,
@@ -43,7 +43,33 @@ function defaultDbPath(): string {
   }
 }
 
-const DB_PATH = process.env.AGENTGLASS_DB || defaultDbPath();
+/**
+ * Where a test's database lives, which is never the developer's.
+ *
+ * Several test files set AGENTGLASS_DB to a scratch file and only then import
+ * this module, which is the right instinct and does not survive contact with a
+ * full run: this file opens its Database at module load, so whichever test file
+ * imports it first decides the path for the whole process. Everyone after that
+ * silently reads and writes the real history instead. That is how 69 fixture
+ * events ("scoped", "other", "mono") ended up in a developer's own database,
+ * and why `whole-machine discovery` failed on a working machine while passing
+ * in CI: it was being handed the machine's actual repositories.
+ *
+ * So under `bun test`, which sets NODE_ENV=test, a scratch file is the floor.
+ * A test that asked for a specific path under the scratch directory still gets
+ * it; anything else, including asking for nothing, gets a fresh empty database
+ * that no import order can turn back into the real one.
+ */
+function testDbPath(): string {
+  const asked = process.env.AGENTGLASS_DB;
+  const scratch = tmpdir();
+  if (asked && (asked === scratch || asked.startsWith(scratch + "/"))) return asked;
+  return join(mkdtempSync(join(scratch, "agx-test-db-")), "agentglass.db");
+}
+
+const DB_PATH = process.env.NODE_ENV === "test"
+  ? testDbPath()
+  : process.env.AGENTGLASS_DB || defaultDbPath();
 const db = new Database(DB_PATH, { create: true });
 // The DB holds full prompts, file contents and command output in cleartext.
 // Default file perms (0644) leave it world-readable; only $HOME being 0700


### PR DESCRIPTION
## What does this PR do?

`bun test` was green in CI and red on a working machine: six failures that no clean checkout could reproduce.

```
open-tool memo > a PreToolUse write invalidates it and the tool shows on the next read
open-tool pairing without a tool_use_id (legacy path) > ...2 tests
whole-machine discovery no longer walks the disk > ...3 tests
```

They were not flaky. They were reading the developer's real history. `whole-machine-discovery` asserts on repositories it creates in a scratch `$HOME`, and was instead handed the machine's actual ones (`skia`, `ladybird`, `dotfiles`, `obs`), so it failed precisely on the machines that had work on them.

`db.ts` opens its `Database` at module load, which means the first test file to import it decides the path for the whole process. Several files do exactly the right thing and set `AGENTGLASS_DB` to a scratch file before their dynamic import, but any file that sorts earlier and reaches `db.ts` transitively has already opened the real one, and everything after that reads and writes it. The damage is not hypothetical: the database on the machine where this was found still holds 69 fixture events written last week, under `source_app` `"scoped"`, `"other"` and `"mono"`.

Under `NODE_ENV=test` a scratch file is now the floor. A test that asked for a path inside `os.tmpdir()` still gets exactly that, so the files already doing this keep working unchanged. Anything else, including asking for nothing, gets a fresh empty database, and no import order can turn that back into the real one.

This is the second instance of one shape today, after the theme sync in #315: module-level resolution plus a single-process test run means a test's environment arrives too late to protect anything. Worth remembering when adding any module that resolves a real path at import.

## How was it tested?

- `bunx tsc --noEmit` in `server/`, clean.
- `bun test` on the machine where the six were failing: **979 pass, 0 fail**, including the six, with no change to any assertion.
- Counted rows in the real database before and after a full run: no fixture rows added (the only delta was the running app ingesting live events).
- Branch merged with latest `main` and the suite re-run green before pushing.