### PR TITLE
fix(metrics): a subagent finishing is not the session ending (#248 F11, F17)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -591,7 +591,16 @@ function safeJson(s: string): Record<string, unknown> {
 }
 
 const isToolPost = (t: string) => t === "PostToolUse" || t === "PostToolUseFailure";
-const isTerminal = (t: string) => t === "Stop" || t === "SessionEnd" || t === "SubagentStop";
+/**
+ * The events that end a *session*.
+ *
+ * `SubagentStop` is not one of them, though it used to be listed here. It fires
+ * in the parent session every time a Task subagent finishes, which in a long run
+ * is many times before anything is over. Treating it as terminal stamped an
+ * `ended_at` on a session that was still working: the fleet drew it as finished
+ * and its duration stopped mid-run.
+ */
+const isTerminal = (t: string) => t === "Stop" || t === "SessionEnd";
 
 // ---------------------------------------------------------------------------
 // Retention — keep at least a full week of history so the 7d window is always
@@ -720,7 +729,17 @@ const upsertStmt = db.query(`
     provider = COALESCE(excluded.provider, sessions.provider),
     project_path = COALESCE(excluded.project_path, sessions.project_path),
     cwd_path = COALESCE(excluded.cwd_path, sessions.cwd_path),
-    ended_at = COALESCE(excluded.ended_at, sessions.ended_at),
+    -- An end can be taken back. A session that speaks after the moment it was
+    -- said to have ended plainly did not end there: claude --resume picks a
+    -- session back up, and a Stop is followed by more turns. COALESCE alone
+    -- latched the first end for ever, so a resumed session stayed dead on the
+    -- board. An event older than the recorded end is a late-arriving hook
+    -- rather than new work, and leaves it standing.
+    ended_at = CASE
+      WHEN excluded.ended_at IS NOT NULL THEN excluded.ended_at
+      WHEN sessions.ended_at IS NOT NULL AND excluded.last_seen > sessions.ended_at THEN NULL
+      ELSE sessions.ended_at
+    END,
     last_seen = excluded.last_seen,
     event_count = sessions.event_count + 1,
     tool_count = sessions.tool_count + $tool,
@@ -1528,9 +1547,15 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     // The checkout it ran in, when that isn't the repo root — what a resume has
     // to use, and what names the worktree in the header.
     cwd_path: roll?.cwd_path ?? agg.cwd_path ?? null,
-    started_at: agg.started_at,
+    // All three from the session row, falling back to the events only for a
+    // session with no row at all. Mixing the two sources is how one session
+    // reported two different durations: `ended_at` came from the row while the
+    // start came from the events, and retention deletes events. Every prune
+    // walked the start forward and left the end where it was, so the deep dive
+    // disagreed with the list it was opened from.
+    started_at: roll?.started_at ?? agg.started_at,
     ended_at: roll?.ended_at ?? null,
-    last_seen: agg.last_seen,
+    last_seen: roll?.last_seen ?? agg.last_seen,
     events: agg.events,
     tools: agg.tools ?? 0,
     errors: agg.errors ?? 0,

--- a/server/test/session-lifecycle.test.ts
+++ b/server/test/session-lifecycle.test.ts
@@ -1,0 +1,121 @@
+// When a session is over, and when it only looks over (#248, F11 and F17).
+//
+// Two defects, one subject: the moment a session is called finished.
+//
+// F11 — a `SubagentStop` fires in the *parent* session every time a Task
+// subagent finishes, several times in a long run. It was treated as terminal,
+// so the parent got an `ended_at` while it went right on working: the deep dive
+// showed a duration that stopped mid-run, and the fleet drew a live session as
+// ended. Nothing ever cleared it, because the upsert only ever COALESCEd the
+// old value forward.
+//
+// F17 — the detail read `started_at` from the events (MIN(timestamp)) and
+// `ended_at` from the session row. Retention prunes events, so the start
+// walked forward while the end stayed put, and one session reported two
+// different durations depending on which panel you asked.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-lifecycle-"));
+const PROJ = join(dir, "proj");
+mkdirSync(PROJ, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "lifecycle.db");
+process.env.AGENTGLASS_ROOT = PROJ;
+process.env.XDG_CONFIG_HOME = dir;
+
+// Imported here rather than in a hook because the retention window has to be
+// readable while the tests are being declared. db.ts reads it once, at import,
+// and a whole-suite run may have imported the module before this file was
+// reached — so the window is asked for rather than assumed.
+const db = await import("../src/db.ts");
+const ing = await import("../src/ingest.ts");
+
+const DAY = 86_400_000;
+/** Old enough that retention will take it, whatever the window is set to. */
+const PRUNABLE_DAYS = db.RETENTION_DAYS + 2;
+
+/** One event, from a session, at a moment. */
+const ev = (session: string, type: string, timestamp: number) => ({
+  source_app: "app",
+  session_id: session,
+  hook_event_type: type,
+  model_name: "claude-opus-5",
+  payload: { project_path: PROJ },
+  timestamp,
+});
+
+/** Insert, and hand back the session row the write itself returned. Not
+ *  `getSessions`, which memoizes for a second and would answer with the state
+ *  before the event under test. */
+const put = (session: string, type: string, timestamp: number) =>
+  db.insertEvent(ing.normalize(ev(session, type, timestamp) as any)).session;
+
+describe("a subagent finishing does not end the session it ran in", () => {
+  test("SubagentStop leaves the session open, and later work keeps it open", () => {
+    const now = Date.now();
+    put("sub", "UserPromptSubmit", now - 5000);
+    expect(put("sub", "SubagentStop", now - 4000).ended_at).toBeNull();
+
+    const s = put("sub", "PostToolUse", now - 1000);
+    expect(s.ended_at).toBeNull();
+    // What the fleet actually asks: no end, and seen recently.
+    expect(s.last_seen).toBeGreaterThan(s.started_at);
+  });
+
+  test("Stop and SessionEnd do end it", () => {
+    const now = Date.now();
+    put("stopped", "UserPromptSubmit", now - 3000);
+    expect(put("stopped", "Stop", now - 2000).ended_at).toBe(now - 2000);
+
+    put("closed", "UserPromptSubmit", now - 3000);
+    expect(put("closed", "SessionEnd", now - 1500).ended_at).toBe(now - 1500);
+  });
+});
+
+describe("a session that speaks again is not over", () => {
+  test("an event after the end clears it", () => {
+    const now = Date.now();
+    put("resumed", "UserPromptSubmit", now - 9000);
+    expect(put("resumed", "Stop", now - 8000).ended_at).toBe(now - 8000);
+
+    // `claude --resume`, or simply a turn that arrives after the Stop.
+    expect(put("resumed", "UserPromptSubmit", now - 7000).ended_at).toBeNull();
+  });
+
+  test("an event that predates the end does not", () => {
+    const now = Date.now();
+    put("late", "UserPromptSubmit", now - 9000);
+    expect(put("late", "Stop", now - 5000).ended_at).toBe(now - 5000);
+    // Arrives now, but happened before the Stop: a delayed hook, not new work.
+    expect(put("late", "PostToolUse", now - 6000).ended_at).toBe(now - 5000);
+  });
+});
+
+describe("the deep dive agrees with the list", () => {
+  // Retention off (AGENTGLASS_RETENTION_DAYS=0) means nothing is ever deleted,
+  // and the disagreement this covers cannot arise.
+  test.skipIf(db.RETENTION_DAYS === 0)("start and end survive retention pruning together", () => {
+    const now = Date.now();
+    const first = now - PRUNABLE_DAYS * DAY;
+    put("pruned", "SessionStart", first);
+    const row = put("pruned", "PostToolUse", now - 1000);
+
+    const before = db.getSession("pruned")!;
+    expect(before.started_at).toBe(first);
+
+    // Retention deletes the old event. The session row is untouched: its
+    // last_seen is now.
+    const gone = db.pruneOldRows();
+    expect(gone.events).toBeGreaterThan(0);
+
+    const after = db.getSession("pruned")!;
+    // The start is the session's, not the oldest surviving event's, so the
+    // duration does not shrink because history aged out.
+    expect(after.started_at).toBe(first);
+    // And it is the same number the list shows: the session row's own.
+    expect(after.started_at).toBe(row.started_at);
+    expect(after.last_seen).toBe(row.last_seen);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Two of the session-lifecycle defects from the data reliability audit in #248: **F11** and **F17**. Both are cases where the cockpit reported something about a session that was not true.

**F11 — a subagent finishing was ending the session.** `SubagentStop` was in `isTerminal`, so it stamped `ended_at` on the session it fired in. That hook fires in the *parent* session every time a Task subagent completes, which in a long run is many times before anything is over. The consequences were visible: a session still working was drawn as finished, and its duration stopped at whichever subagent happened to finish first. Nothing ever undid it, because the upsert only ever COALESCEd the old value forward.

Two changes. `SubagentStop` is no longer terminal. And an end can now be taken back: an event whose timestamp is *after* the recorded end proves the session did not end there, so it is cleared. That covers `claude --resume` picking a session back up as well as the subagent case. An event *older* than the recorded end is a late-arriving hook rather than new work, and leaves the end standing.

**F17 — the deep dive and the list disagreed about the same session.** `getSession` read `started_at` from the events (`MIN(timestamp)`) but `ended_at` from the session row. Retention deletes events; the session row survives. So every prune walked the start forward while the end stayed put, and the same session reported two different durations depending on which panel you opened it from. `started_at`, `ended_at` and `last_seen` now all come from the session row, falling back to the events only for a session with no row at all.

While verifying **F16** from the same issue (`totals.sessions` vs the Sessions panel counting different populations) it turned out to have no UI consumer at all: nothing in `web/` reads `stats.totals.sessions`. Left alone here and reported on the issue rather than changed blind.

## How was it tested?

- New `server/test/session-lifecycle.test.ts`, 5 tests: `SubagentStop` leaves the session open and later work keeps it open; `Stop` and `SessionEnd` do end it; an event after the end clears it; an event that predates the end does not; start, end and last_seen survive a retention prune together and match the row the list shows.
- The retention test asks `db.ts` for `RETENTION_DAYS` rather than setting it, and skips if pruning is disabled. Setting the env var in the test file is not enough: `db.ts` reads it once at import, and in a whole-suite run another file may have imported the module first. The first version of this test passed alone and failed in the suite for exactly that reason.
- `bun test` — 970 pass, 0 fail, both standalone and as part of the full suite.
- `bunx tsc --noEmit` in `server/` and `web/`.

Closes nothing on its own: #248 is a tracking issue, and this ticks F11 and F17 on it.
