### PR TITLE
feat(terminal): find in scrollback, and clickable URLs (#8)

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "electron": {
       "name": "agentglass-electron",
-      "version": "0.4.0",
+      "version": "0.5.0",
       "devDependencies": {
         "electron": "^33.2.0",
         "electron-builder": "^25.1.8",
@@ -32,6 +32,8 @@
       "dependencies": {
         "@number-flow/react": "^0.6.1",
         "@xterm/addon-fit": "^0.11.0",
+        "@xterm/addon-search": "^0.16.0",
+        "@xterm/addon-web-links": "^0.12.0",
         "@xterm/addon-webgl": "^0.19.0",
         "@xterm/xterm": "^6.0.0",
         "motion": "^12.42.2",
@@ -342,6 +344,10 @@
     "@xmldom/xmldom": ["@xmldom/xmldom@0.9.10", "", {}, "sha512-A9gOqLdi6cV4ibazAjcQufGj0B1y/vDqYrcuP6d/6x8P27gRS8643Dj9o1dEKtB6O7fwxb2FgBmJS2mX7gpvdw=="],
 
     "@xterm/addon-fit": ["@xterm/addon-fit@0.11.0", "", {}, "sha512-jYcgT6xtVYhnhgxh3QgYDnnNMYTcf8ElbxxFzX0IZo+vabQqSPAjC3c1wJrKB5E19VwQei89QCiZZP86DCPF7g=="],
+
+    "@xterm/addon-search": ["@xterm/addon-search@0.16.0", "", {}, "sha512-9OeuBFu0/uZJPu+9AHKY6g/w0Czyb/Ut0A5t79I4ULoU4IfU5BEpPFVGQxP4zTTMdfZEYkVIRYbHBX1xWwjeSA=="],
+
+    "@xterm/addon-web-links": ["@xterm/addon-web-links@0.12.0", "", {}, "sha512-4Smom3RPyVp7ZMYOYDoC/9eGJJJqYhnPLGGqJ6wOBfB8VxPViJNSKdgRYb8NpaM6YSelEKbA2SStD7lGyqaobw=="],
 
     "@xterm/addon-webgl": ["@xterm/addon-webgl@0.19.0", "", {}, "sha512-b3fMOsyLVuCeNJWxolACEUED0vm7qC0cy4wRvf3oURSzDTYVQiGPhTnhWZwIHdvC48Y+oLhvYXnY4XDXPoJo6A=="],
 

--- a/web/package.json
+++ b/web/package.json
@@ -12,6 +12,8 @@
   "dependencies": {
     "@number-flow/react": "^0.6.1",
     "@xterm/addon-fit": "^0.11.0",
+    "@xterm/addon-search": "^0.16.0",
+    "@xterm/addon-web-links": "^0.12.0",
     "@xterm/addon-webgl": "^0.19.0",
     "@xterm/xterm": "^6.0.0",
     "motion": "^12.42.2",

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -11,12 +11,16 @@ import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/Vi
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
+import { SearchAddon } from "@xterm/addon-search";
+import { WebLinksAddon } from "@xterm/addon-web-links";
 import "@xterm/xterm/css/xterm.css";
+import { openExternal } from "../lib/externalUrl.ts";
 import type { GitRepoRef, TerminalCommands, TmuxWindow } from "../../../shared/types.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
 import { CommandBar, loadCommands } from "./CommandBar.tsx";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 import { wantsWebgl, fallBackToDom } from "../lib/termRenderer.ts";
+import { isFindChord } from "../lib/termKeys.ts";
 
 const ROOT_KEY = "agentglass.terminalRoot";
 /** The repo the terminal view last used — what a docked console should open
@@ -85,6 +89,9 @@ type Sess = {
   title: string;
   term: Terminal;
   fit: FitAddon;
+  /** Per shell, because a match is a position in *this* scrollback: the find
+   *  bar in the header drives whichever pane has the focus. */
+  search: SearchAddon;
   holder: HTMLDivElement; // xterm's home element — reparented into the panel
   ws: WebSocket | null;
   status: SessStatus;
@@ -179,6 +186,16 @@ export function liveSessionCount() { return liveCount; }
 const rosterChanged = () => { const before = liveCount; recount(); if (before !== liveCount) rosterSubs.forEach((fn) => fn()); };
 // Set by the mounted panel so the terminal itself can close it (Shift+Esc).
 let panelClose: () => void = () => {};
+
+/**
+ * Open the find bar, when there is one to open.
+ *
+ * Set by the terminal view while it is mounted, the same way `panelClose` is.
+ * It stays a no-op returning false everywhere else — a shell in the docked
+ * console strip has no find bar in front of it, and swallowing the key there
+ * would take a chord away from the program running in it and give nothing back.
+ */
+let panelFind: () => boolean = () => false;
 
 // The panel is built to keep many shells open at once, so eviction is a last
 // resort rather than routine: it only runs at the server's own ceiling, and it
@@ -374,6 +391,19 @@ function createSession(root: string): Sess {
   });
   const fit = new FitAddon();
   term.loadAddon(fit);
+  const search = new SearchAddon();
+  term.loadAddon(search);
+  /*
+   * URLs in output become clickable, and open where the user's links open.
+   *
+   * `openExternal` rather than the addon's default handler: it is the one path
+   * the whole app already uses, which the desktop shell intercepts
+   * (`setWindowOpenHandler` in electron/main.js) to hand the URL to the OS
+   * browser instead of opening a chromeless window inside the app. It also
+   * refuses anything that is not http(s), which matters more here than
+   * anywhere else — the text being linkified is whatever a program printed.
+   */
+  term.loadAddon(new WebLinksAddon((_e, uri) => { openExternal(uri); }));
   /*
    * Draw on the GPU when the machine will let us.
    *
@@ -402,7 +432,9 @@ function createSession(root: string): Sess {
   }
   // Shift+Esc closes the panel — plain Esc belongs to the shell (vim, fzf…).
   term.attachCustomKeyEventHandler((e) => {
-    if (e.type === "keydown" && e.key === "Escape" && e.shiftKey) { panelClose(); return false; }
+    if (e.type !== "keydown") return true;
+    if (e.key === "Escape" && e.shiftKey) { panelClose(); return false; }
+    if (isFindChord(e) && panelFind()) return false;
     return true;
   });
   const holder = document.createElement("div");
@@ -411,7 +443,7 @@ function createSession(root: string): Sess {
   // background colour instead of a white flash.
   holder.style.cssText = "width:100%;height:100%;background:var(--bg)";
   const id = `t${++seq}-${Date.now().toString(36)}`;
-  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, tmuxWindows: [], tmuxSession: null, tmuxPrefix: [], tmuxPrefixAt: 0, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
+  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, search, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, tmuxWindows: [], tmuxSession: null, tmuxPrefix: [], tmuxPrefixAt: 0, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
   term.onData((d) => {
     sess.lastUsed = Date.now();
     /*
@@ -503,6 +535,82 @@ function killSession(s: Sess) {
   s.holder.remove();
   sessions.delete(s.id);
   rosterChanged();
+}
+
+/**
+ * Find in scrollback, for whichever pane has the focus.
+ *
+ * Lives in the header rather than floating over the terminal: the shell below
+ * is a fixed grid of cells, and an overlay would cover output while you are
+ * reading it looking for the very thing you searched for.
+ *
+ * The highlight colours are the app's own tokens rather than xterm's defaults,
+ * which are a fixed yellow that disappears on the light themes.
+ */
+function FindBar({ sess, onClose }: { sess: Sess | undefined; onClose: () => void }) {
+  const [q, setQ] = useState("");
+  const [at, setAt] = useState<{ index: number; count: number } | null>(null);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => { inputRef.current?.focus(); inputRef.current?.select(); }, []);
+
+  // `onDidChangeResults` is the only honest source for "3 of 17": the addon
+  // counts as it walks the buffer, and a running shell keeps adding to it.
+  useEffect(() => {
+    if (!sess) return;
+    const sub = sess.search.onDidChangeResults((r) => setAt(r ? { index: r.resultIndex + 1, count: r.resultCount } : null));
+    return () => { sub.dispose(); };
+  }, [sess]);
+
+  const opts = {
+    decorations: {
+      matchBackground: "#00000000",
+      matchOverviewRuler: readVar(rootStyle(), "--warning", "#fbbf24"),
+      activeMatchBackground: readVar(rootStyle(), "--primary", "#a78bfa"),
+      activeMatchColorOverviewRuler: readVar(rootStyle(), "--primary", "#a78bfa"),
+      matchBorder: readVar(rootStyle(), "--warning", "#fbbf24"),
+    },
+  };
+
+  const step = (back: boolean) => {
+    if (!sess || !q) return;
+    if (back) sess.search.findPrevious(q, opts); else sess.search.findNext(q, opts);
+  };
+
+  // Clearing the term clears the highlights with it — leaving them on screen
+  // after the box is empty is the kind of stale state nobody can dismiss.
+  const change = (v: string) => {
+    setQ(v);
+    if (!sess) return;
+    if (!v) { sess.search.clearDecorations(); setAt(null); return; }
+    sess.search.findNext(v, { ...opts, incremental: true });
+  };
+
+  const close = () => { try { sess?.search.clearDecorations(); } catch { /* disposed */ } onClose(); };
+
+  return (
+    <div className="flex items-center gap-1" onMouseDown={(e) => e.stopPropagation()}>
+      <input
+        ref={inputRef}
+        value={q}
+        onChange={(e) => change(e.target.value)}
+        onKeyDown={(e) => {
+          if (e.key === "Enter") { e.preventDefault(); step(e.shiftKey); }
+          if (e.key === "Escape") { e.preventDefault(); close(); }
+        }}
+        placeholder="Find in scrollback…"
+        aria-label="Find in scrollback"
+        className="px-2 py-1 rounded-md text-[11px] outline-none"
+        style={{ width: 190, background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
+      />
+      <span className="text-[10px] tabular-nums t-dim2" style={{ minWidth: 46 }}>
+        {q ? (at?.count ? `${at.index}/${at.count}` : "none") : ""}
+      </span>
+      <button onClick={() => step(true)} disabled={!q} title="Previous match (Shift+Enter)" className="text-[11px] px-1.5 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>↑</button>
+      <button onClick={() => step(false)} disabled={!q} title="Next match (Enter)" className="text-[11px] px-1.5 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>↓</button>
+      <button onClick={close} title="Close find (Esc)" className="text-[11px] px-1.5 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>✕</button>
+    </div>
+  );
 }
 
 /** Type a command into the repo's shell (starting one if needed). */
@@ -804,9 +912,17 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const closeRef = useRef(onClose);
   useEffect(() => { closeRef.current = onClose; }, [onClose]);
 
+  /** The find bar is open over the focused pane. Reset when the repo changes:
+   *  a search is about one shell's scrollback, not about the panel. */
+  const [findOpen, setFindOpen] = useState(false);
+  useEffect(() => { setFindOpen(false); }, [root]);
+
   useEffect(() => {
     if (!open || IS_DEMO) return;
     panelClose = () => closeRef.current();
+    // Claim the find chord only while this view is on screen and has a pane to
+    // search — see `panelFind`.
+    panelFind = () => { setFindOpen(true); return true; };
     const mounted: { s: Sess; el: HTMLDivElement; ro: ResizeObserver; unTheme: () => void; stopFit: () => void }[] = [];
     paneIds.forEach((id, i) => {
       const s = sessions.get(id);
@@ -833,6 +949,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     if (focused) requestAnimationFrame(() => focused.term.focus());
     return () => {
       panelClose = () => {};
+      panelFind = () => false;
       for (const { s, el, ro, unTheme, stopFit } of mounted) {
         ro.disconnect();
         stopFit();
@@ -1112,7 +1229,16 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   {/* keepTermFocus so none of these buttons — split, restart,
                       clear, the status pill — steals the shell's cursor on
                       press; they act and the terminal keeps the keyboard. */}
-                  <div className="ml-auto flex items-center gap-1.5 shrink-0" onMouseDown={keepTermFocus}>
+                  {/* Find sits outside the keepTermFocus group on purpose: its
+                      input is the one control here that has to take the cursor
+                      off the shell, and closing it hands the cursor back. */}
+                  <div className="ml-auto flex items-center gap-1.5 shrink-0">
+                    {findOpen
+                      ? <FindBar sess={sessions.get(paneIds[focusIdx] ?? "")} onClose={() => { setFindOpen(false); focusTerm(); }} />
+                      : <button onMouseDown={keepTermFocus} onClick={() => setFindOpen(true)} disabled={!root || IS_DEMO || disabled} title="Find in scrollback (Ctrl+Shift+F)" className="text-[11px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>⌕ Find</button>}
+                  </div>
+
+                  <div className="flex items-center gap-1.5 shrink-0" onMouseDown={keepTermFocus}>
                     <span onClick={status === "unauthorized" ? reauthPrompt : undefined}
                       className={`flex items-center gap-1.5 text-[10px] t-dim2 mr-1 ${status === "unauthorized" ? "cursor-pointer" : ""}`}
                       title={status === "unauthorized" ? "This server needs an access token — click to enter it" : "Shell status"}>

--- a/web/src/lib/termKeys.ts
+++ b/web/src/lib/termKeys.ts
@@ -1,0 +1,29 @@
+// Which keys the terminal panel takes, and which belong to the shell.
+//
+// The panel sits around a real PTY, so any chord it claims is a chord the
+// program inside no longer gets. That makes this a short list, kept here rather
+// than inline in the panel so it can be read — and tested — on its own.
+
+/**
+ * The key that opens find: Ctrl+Shift+F, or Cmd+F where Cmd is not the shell's
+ * to begin with.
+ *
+ * Deliberately not plain Ctrl+F. #8 asked for it, and every other app binds it,
+ * but in a terminal it is already taken: readline reads it as forward-char, and
+ * less, vim and emacs all page forward on it. Binding it here would break the
+ * program running in the shell to add a feature to the panel around it. The
+ * terminals that have solved this — VS Code, GNOME Terminal, Konsole — settled
+ * on Ctrl+Shift+F for the same reason.
+ */
+export function isFindChord(e: {
+  key: string;
+  ctrlKey?: boolean;
+  metaKey?: boolean;
+  shiftKey?: boolean;
+  altKey?: boolean;
+}): boolean {
+  if (e.key !== "f" && e.key !== "F") return false;
+  if (e.altKey) return false; // Alt+F is forward-word
+  if (e.metaKey) return true; // macOS, where Cmd is the app's
+  return !!e.ctrlKey && !!e.shiftKey;
+}

--- a/web/test/terminal-find-chord.test.ts
+++ b/web/test/terminal-find-chord.test.ts
@@ -1,0 +1,42 @@
+// Which key opens find in the terminal, and which keys belong to the shell (#8).
+//
+// The panel sits around a real PTY, so any chord it takes is a chord the
+// program inside no longer gets. Ctrl+F is the obvious one to bind and the one
+// that cannot be bound: readline reads it as forward-char, and less, vim and
+// emacs page forward on it.
+import { describe, expect, test } from "bun:test";
+import { isFindChord } from "../src/lib/termKeys.ts";
+
+const key = (k: string, mods: Partial<{ ctrlKey: boolean; metaKey: boolean; shiftKey: boolean; altKey: boolean }> = {}) =>
+  ({ key: k, ...mods });
+
+describe("the find chord", () => {
+  test("Ctrl+Shift+F opens find", () => {
+    expect(isFindChord(key("F", { ctrlKey: true, shiftKey: true }))).toBe(true);
+    // Some layouts report the unshifted key alongside the shift flag.
+    expect(isFindChord(key("f", { ctrlKey: true, shiftKey: true }))).toBe(true);
+  });
+
+  test("Cmd+F opens find, because Cmd is the app's and not the shell's", () => {
+    expect(isFindChord(key("f", { metaKey: true }))).toBe(true);
+  });
+
+  test("plain Ctrl+F stays with the shell", () => {
+    expect(isFindChord(key("f", { ctrlKey: true }))).toBe(false);
+  });
+
+  test("Alt+F stays with the shell, shift or not", () => {
+    expect(isFindChord(key("f", { altKey: true }))).toBe(false);
+    expect(isFindChord(key("F", { altKey: true, ctrlKey: true, shiftKey: true }))).toBe(false);
+  });
+
+  test("f on its own is just typing", () => {
+    expect(isFindChord(key("f"))).toBe(false);
+    expect(isFindChord(key("F", { shiftKey: true }))).toBe(false);
+  });
+
+  test("another letter with the same modifiers is not find", () => {
+    expect(isFindChord(key("g", { ctrlKey: true, shiftKey: true }))).toBe(false);
+    expect(isFindChord(key("c", { ctrlKey: true, shiftKey: true }))).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Closes #8: the two official xterm addons the panel never loaded, plus the small amount of UI that makes the first one usable.

**Search.** A find bar in the terminal header, opened with `Ctrl+Shift+F` or the new **⌕ Find** button. Enter and Shift+Enter walk the matches, Escape closes it and hands the cursor back to the shell, and the count beside the box (`3/17`, or `none`) comes from the addon's own `onDidChangeResults` rather than a guess — a running shell keeps adding to the buffer it is counting.

It searches whichever pane has the focus, because a match is a position in *that* shell's scrollback, and the addon is per session for the same reason. The bar lives in the header rather than floating over the terminal: the shell below is a fixed grid of cells, and an overlay would cover the output you searched for while you are reading it. Highlight colours are the app's theme tokens; xterm's default is a fixed yellow that disappears on the light themes.

**Not `Ctrl+F`, which the issue asked for.** In a terminal that key is already spoken for: readline reads it as forward-char, and less, vim and emacs all page forward on it. Binding it here would break the program running in the shell to add a feature to the panel around it. This follows VS Code, GNOME Terminal and Konsole to `Ctrl+Shift+F`, with `Cmd+F` on macOS where Cmd is the app's to take. The chord predicate lives in `web/src/lib/termKeys.ts` with its reasoning and its tests rather than inline in a 1200-line component, and the panel only claims the chord while the terminal view is actually mounted — a shell in the docked console strip has no find bar in front of it, so the key falls through to the program instead of being swallowed.

**Links.** URLs in output (a dev server's `http://localhost:5173`, a CI run, a stack-trace link) are clickable. They go through `openExternal`, the path the rest of the app already uses: the desktop shell intercepts it (`setWindowOpenHandler` in `electron/main.js`) and hands the URL to the real browser instead of opening a chromeless window inside the app, and it refuses anything that is not http(s). That last part matters more here than anywhere else, because the text being linkified is whatever a program decided to print.

## How was it tested?

- New `web/test/terminal-find-chord.test.ts`, 6 tests pinning what the panel takes and what it leaves alone: Ctrl+Shift+F and Cmd+F open find; plain Ctrl+F, Alt+F, bare `f` and Ctrl+Shift+other do not.
- `bun test` — 990 pass, 0 fail.
- `bunx tsc --noEmit` in `web/` and `server/`, and `bun run build`.
- **Not exercised in a running UI.** The addon API surface is checked by the typechecker against the real types, and the chord logic by tests, but nobody has yet dragged 10k lines into a shell and searched them. That is the QA step worth doing on the branch build.
