### PR TITLE
fix(terminal): a one-click command no longer types into vim (#4)

### DIFF
--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -21,6 +21,7 @@ import { CommandBar, loadCommands } from "./CommandBar.tsx";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 import { wantsWebgl, fallBackToDom } from "../lib/termRenderer.ts";
 import { isFindChord } from "../lib/termKeys.ts";
+import { typingWouldLandInApp } from "../lib/termForeground.ts";
 
 const ROOT_KEY = "agentglass.terminalRoot";
 /** The repo the terminal view last used — what a docked console should open
@@ -196,6 +197,17 @@ let panelClose: () => void = () => {};
  * would take a chord away from the program running in it and give nothing back.
  */
 let panelFind: () => boolean = () => false;
+
+/**
+ * Tell the docked console that a command aimed at it was refused.
+ *
+ * `runInConsole` is called from other panels — the Docker one opens a shell
+ * into a container this way — and those callers have nowhere to put the news.
+ * The strip is where the shell is, so the strip is where the notice belongs.
+ * A no-op while no strip is mounted, in which case the boolean return is the
+ * only answer and the caller may ignore it.
+ */
+let consoleBlocked: (cmd: string) => void = () => {};
 
 // The panel is built to keep many shells open at once, so eviction is a last
 // resort rather than routine: it only runs at the server's own ceiling, and it
@@ -613,13 +625,45 @@ function FindBar({ sess, onClose }: { sess: Sess | undefined; onClose: () => voi
   );
 }
 
-/** Type a command into the repo's shell (starting one if needed). */
-function runInShell(s: Sess, cmd: string) {
+/**
+ * "That did not go anywhere, and here is what to do about it."
+ *
+ * Shown when a command was refused because a full-screen program had the
+ * screen. Silence would be worse than the old behaviour: a chip that does
+ * nothing reads as broken, where a chip that types into vim at least tells you
+ * what happened, eventually, badly.
+ */
+function BlockedNotice({ cmd, onSend, onDismiss }: { cmd: string; onSend: () => void; onDismiss: () => void }) {
+  return (
+    <div className="flex items-center gap-2 text-[10.5px] px-2 py-1 rounded-lg min-w-0"
+      style={{ color: "var(--text2)", background: "color-mix(in srgb, var(--warning) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 35%, transparent)" }}>
+      <span className="truncate" title={`Not sent: ${cmd}`}>
+        A full-screen program is running — <b className="font-mono">{cmd}</b> was not typed
+      </span>
+      <button onClick={onSend} className="shrink-0 px-1.5 py-0.5 rounded" style={{ color: "var(--text)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>Send anyway</button>
+      <button onClick={onDismiss} className="shrink-0 px-1 t-dim2" aria-label="Dismiss">✕</button>
+    </div>
+  );
+}
+
+/**
+ * Type a command into the repo's shell (starting one if needed).
+ *
+ * Returns false without typing anything when a full-screen program has the
+ * screen — vim, htop, lazygit — because the keystrokes would land in it rather
+ * than at a prompt: `:wq` typed into a buffer, `git status` inserted into the
+ * file you were editing. `force` sends it anyway, which is what the notice the
+ * caller shows offers, since only the person watching knows whether the program
+ * on screen wants that line.
+ */
+function runInShell(s: Sess, cmd: string, force = false): boolean {
+  if (!force && typingWouldLandInApp(s.term.buffer.active)) return false;
   const line = cmd + "\r";
   s.lastUsed = Date.now();
   if (s.status === "live" && s.ws?.readyState === WebSocket.OPEN) s.ws.send(JSON.stringify({ t: "in", d: line }));
   else { s.pending.push(line); if (!s.ws) connect(s); }
   s.term.focus();
+  return true;
 }
 
 /**
@@ -629,13 +673,19 @@ function runInShell(s: Sess, cmd: string) {
  * calling this before the strip has mounted converges on one shell rather than
  * racing it into two. `runInShell` queues into `pending` when the socket is not
  * up yet, so the command still runs once it connects.
+ *
+ * Returns false when a full-screen program is holding that shell and the
+ * command was therefore not typed. Callers from other panels get a plain answer
+ * rather than a command that vanished into somebody's editor.
  */
-export function runInConsole(root: string, cmd: string) {
-  if (!root || IS_DEMO) return;
+export function runInConsole(root: string, cmd: string): boolean {
+  if (!root || IS_DEMO) return false;
   const existing = sessionsFor(root).find((x) => x.title === CONSOLE_TITLE);
   const s = existing ?? createSession(root);
   s.title = CONSOLE_TITLE;
-  runInShell(s, cmd);
+  const sent = runInShell(s, cmd);
+  if (!sent) consoleBlocked(cmd);
+  return sent;
 }
 
 // --- the panel ---------------------------------------------------------------
@@ -696,10 +746,19 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
     setRepoOpen(false); setRepoQuery("");
     focusConsole();
   };
-  const runHere = useCallback((cmd: string) => {
+  /** Same guard as the terminal view: a chip must not type into vim. */
+  const [blocked, setBlocked] = useState<string | null>(null);
+  // Also carries refusals from `runInConsole`, which other panels call.
+  useEffect(() => {
+    if (!open) return;
+    consoleBlocked = setBlocked;
+    return () => { consoleBlocked = () => {}; };
+  }, [open]);
+  const runHere = useCallback((cmd: string, force = false) => {
     const s = sessions.get(sid);
     if (!s || IS_DEMO) return;
-    runInShell(s, cmd);
+    if (runInShell(s, cmd, force)) setBlocked(null);
+    else setBlocked(cmd);
   }, [sid]);
 
   // One console shell per repo, reused. `sessionsFor` already orders by
@@ -825,6 +884,12 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
         <div className="flex items-center gap-2 min-w-0" onMouseDown={(e) => e.stopPropagation()}>
           <CommandBar root={root} disabled={!sid} font={TERM_FONT} onRun={runHere} onClose={focusConsole} dropUp />
         </div>
+
+        {blocked && (
+          <div className="min-w-0" onMouseDown={(e) => e.stopPropagation()}>
+            <BlockedNotice cmd={blocked} onSend={() => { runHere(blocked, true); setBlocked(null); }} onDismiss={() => setBlocked(null)} />
+          </div>
+        )}
 
         <span className="ml-auto text-[9px] t-dim2 shrink-0">Drag to resize</span>
         <button onClick={(e) => { e.stopPropagation(); onClose(); }} onMouseDown={(e) => e.stopPropagation()} className="text-[12px] leading-none px-1.5 t-dim2 hover:opacity-70 shrink-0" title="Hide the console (the shell keeps running)">✕</button>
@@ -1096,10 +1161,13 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     setFocusIdx(0);
   }, []);
 
-  const run = useCallback((cmd: string) => {
+  /** The command a full-screen program stopped, kept so it can still be sent. */
+  const [blocked, setBlocked] = useState<string | null>(null);
+  const run = useCallback((cmd: string, force = false) => {
     if (!root || IS_DEMO) return;
     const s = sessions.get(paneIds[focusIdx] ?? "") ?? createSession(root);
-    runInShell(s, cmd);
+    if (runInShell(s, cmd, force)) setBlocked(null);
+    else setBlocked(cmd);
   }, [root, paneIds, focusIdx]);
 
   const restart = useCallback(() => {
@@ -1232,6 +1300,8 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   {/* Find sits outside the keepTermFocus group on purpose: its
                       input is the one control here that has to take the cursor
                       off the shell, and closing it hands the cursor back. */}
+                  {blocked && <BlockedNotice cmd={blocked} onSend={() => { run(blocked, true); setBlocked(null); }} onDismiss={() => setBlocked(null)} />}
+
                   <div className="ml-auto flex items-center gap-1.5 shrink-0">
                     {findOpen
                       ? <FindBar sess={sessions.get(paneIds[focusIdx] ?? "")} onClose={() => { setFindOpen(false); focusTerm(); }} />

--- a/web/src/lib/termForeground.ts
+++ b/web/src/lib/termForeground.ts
@@ -1,0 +1,29 @@
+// Is the shell at a prompt, or is something else holding the screen?
+//
+// The panel's one-click commands type into the live shell, which is the right
+// model for a terminal and the wrong one when vim is up: the text lands in the
+// buffer instead of at a prompt (#4).
+//
+// The tell is the alternate screen buffer. A full-screen program switches to it
+// on entry (DECSET 1049) and back on exit, which is precisely the set of
+// programs this goes wrong for: vim, htop, lazygit, less, tmux, fzf's
+// full-screen mode. xterm.js tracks which buffer is active, so the question is
+// answerable on the client with no shell integration at all.
+//
+// What this deliberately does not detect: a foreground program that stays on
+// the normal screen — a running `npm install`, a `python` REPL. Typing during
+// those is what a terminal does; the line queues on stdin and runs when the
+// program is done with it, which is the behaviour a user of a real terminal
+// expects. The damage case is the one where the keystrokes are eaten by an
+// editor and silently change a file.
+//
+// OSC 133 prompt marking (what #4 originally proposed, and what #297 needs for
+// per-command telemetry) would answer the general question, at the cost of
+// injecting shell integration into whatever shell the user runs and surviving
+// their rc files. Worth it for the telemetry; not needed for this.
+
+/** Whether typing now would land inside a full-screen program rather than at a
+ *  prompt. `undefined` (no terminal yet) is not a full-screen program. */
+export function typingWouldLandInApp(buffer: { type?: string } | null | undefined): boolean {
+  return buffer?.type === "alternate";
+}

--- a/web/test/terminal-foreground.test.ts
+++ b/web/test/terminal-foreground.test.ts
@@ -1,0 +1,27 @@
+// A one-click command must not be typed into vim (#4).
+//
+// The panel injects `cmd + "\r"` into the live shell, which is right at a
+// prompt and wrong while a full-screen program owns the screen: the keystrokes
+// land in the editor. The tell is the alternate screen buffer, which every such
+// program switches to on entry and away from on exit.
+import { describe, expect, test } from "bun:test";
+import { typingWouldLandInApp } from "../src/lib/termForeground.ts";
+
+describe("what counts as a full-screen program", () => {
+  test("the alternate buffer is one: vim, htop, lazygit, less", () => {
+    expect(typingWouldLandInApp({ type: "alternate" })).toBe(true);
+  });
+
+  test("the normal buffer is a prompt, or something that shares stdin with one", () => {
+    expect(typingWouldLandInApp({ type: "normal" })).toBe(false);
+  });
+
+  test("no terminal yet is not a full-screen program", () => {
+    // A shell that has not connected still accepts a command: it queues, and
+    // runs when the socket comes up. Refusing there would break the ordinary
+    // path of clicking a chip on a cold panel.
+    expect(typingWouldLandInApp(undefined)).toBe(false);
+    expect(typingWouldLandInApp(null)).toBe(false);
+    expect(typingWouldLandInApp({})).toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Closes #4. The QUICK chips and the commands dropdown work by injecting `cmd + "\r"` into the live shell. That is the right model for a terminal and the wrong one when a full-screen program has the screen: the keystrokes land in *it* rather than at a prompt, so clicking `git status` over an open vim inserts it into the file you were editing.

`runInShell` now refuses when the alternate screen buffer is active, and returns false instead of typing. Every program this goes wrong for switches to that buffer on entry and back on exit — vim, htop, lazygit, less, tmux, fzf's full-screen mode — so xterm.js can answer the question on the client with no shell integration at all.

Refusing silently would be its own bug (a chip that does nothing reads as broken), so the panel says what happened and offers **Send anyway**: only the person watching knows whether the program on screen wants that line. `runInConsole` returns the same answer and routes the notice to the docked strip, so the Docker panel's "open a shell in this container" cannot vanish into somebody's editor either.

**Deliberately not OSC 133**, which is what the issue proposed. Prompt marking answers the general question, including a program that stays on the normal screen, at the cost of injecting shell integration into whatever shell the user runs and surviving their rc files, on three platforms. That cost buys something real for #297 (per-command duration, exit code and cwd as telemetry, which the alternate-screen check cannot give) and nothing extra here: typing while `npm install` runs queues on stdin, which is what a terminal does and what someone using one expects. The damage case is the editor, and the alternate screen *is* the editor. Noted on both issues so #297 still carries the OSC 133 work.

## How was it tested?

- New `web/test/terminal-foreground.test.ts`: the alternate buffer blocks, the normal buffer does not, and a shell that has not connected yet still accepts a command (it queues and runs on connect, which is the ordinary path of clicking a chip on a cold panel).
- `bun test` — 993 pass, 0 fail.
- `bunx tsc --noEmit` in `web/` and `server/`, and `bun run build`.
- **Not exercised in a running UI.** The predicate and the plumbing are tested, but nobody has yet opened vim in the panel and clicked a chip at it. That is the QA step worth doing on the branch build: open vim, click a QUICK command, expect the notice and an untouched buffer, then Send anyway and expect the old behaviour.
