### PR TITLE
fix(chat): make the engine setting apply, and let a waiting reply show it is alive

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -254,6 +254,20 @@ function ChatRow({ chat, active, onPick, onClose }: { chat: Chat; active: boolea
   );
 }
 
+/** The reply is coming but has not started.
+ *
+ *  Announced once to assistive tech, because the visual signal here is motion
+ *  and motion alone — there is no text to read until the answer begins. */
+function TypingDots() {
+  return (
+    <span className="inline-flex items-center gap-[3.5px] align-middle py-1" role="status" aria-label="Waiting for a reply">
+      {[0, 1, 2].map((i) => (
+        <span key={i} className="agx-typing-dot rounded-full" style={{ width: 5, height: 5, background: "var(--text3)" }} />
+      ))}
+    </span>
+  );
+}
+
 /** A header button that copies something and says it did.
  *
  *  The confirmation is the whole point: a copy that succeeds looks exactly like
@@ -1007,8 +1021,8 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                                 {m.imagesDropped} image{m.imagesDropped > 1 ? "s" : ""} sent with this turn, not kept when the chat was restored
                               </div>
                             )}
-                            {m.text ? <Markdown text={m.text} /> : (m.streaming ? <span className="t-dim2">▍</span> : "")}
-                            {m.streaming && m.text && <span className="t-dim2">▍</span>}
+                            {m.text ? <Markdown text={m.text} /> : (m.streaming ? <TypingDots /> : "")}
+                            {m.streaming && m.text && <span className="t-dim2 agx-caret">▍</span>}
                           </div>
                           </div>
                         </div>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -28,6 +28,7 @@ import { worktreeTag, sessionWorktree, sessionCwd } from "../lib/worktree.ts";
 import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
+  engineFor,
   DEFAULT_MODEL, DEFAULT_MODE, addAttachments, dropAttachment, renameChat, clearAttention, type Chat,
   restoredActiveId, setActiveChatId, chatFocusRequest,
 } from "../lib/chatStore.ts";
@@ -883,12 +884,27 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         {/* Pushed right so the two copy actions sit together at
                             the end of the header rather than between pickers. */}
                         <span className="ml-auto flex items-center gap-1.5">
-                          {active.attachCommand && (
-                            <CopyButton
-                              label="⧉ tmux"
-                              title={`This chat runs in a tmux pane. Copy the command that opens it in your own terminal, where you can keep typing:\n\n${active.attachCommand}`}
-                              text={() => active.attachCommand!}
-                            />
+                          {/* Where this chat runs, stated before its first turn
+                              rather than after. Shown only for the pane engine:
+                              `claude -p` is the long-standing behaviour and a
+                              badge on every chat saying "normal" is noise. The
+                              chip is the only way to tell the two apart from the
+                              outside, and without it a preference that had not
+                              taken effect looked exactly like one that had. */}
+                          {engineFor(active) === "tmux" && (
+                            active.attachCommand ? (
+                              <CopyButton
+                                label="⧉ tmux"
+                                title={`This chat runs in a tmux pane. Copy the command that opens it in your own terminal, where you can keep typing:\n\n${active.attachCommand}`}
+                                text={() => active.attachCommand!}
+                              />
+                            ) : (
+                              <span
+                                className="text-[10px] px-2 py-1 rounded-md shrink-0"
+                                style={{ color: "var(--text3)", border: "1px dashed color-mix(in srgb, var(--border) 35%, transparent)" }}
+                                title="This chat will run in a tmux pane. The pane starts with the first message, and this turns into a button that copies the command to open it in your terminal."
+                              >⧉ tmux on send</span>
+                            )
                           )}
                           <CopyButton
                             label="Copy chat"

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -568,6 +568,39 @@
 }
 :root[data-idle="1"] .agx-pip { animation-play-state: paused !important; }
 
+/* A reply that has been asked for and has not started arriving.
+
+   This was a single static caret, which says "something is here" and nothing
+   more — indistinguishable from a turn that has quietly stalled, which is the
+   one thing you actually want to rule out while waiting. Dots that keep time
+   say the far end is alive.
+
+   Opacity on three small spans, nothing else: no layout, no repaint of what is
+   behind them. A turn can run for minutes, and on a software-composited stack
+   an animation that touches layout is a per-frame CPU tax for all of it. */
+@keyframes agx-typing {
+  0%, 60%, 100% { opacity: 0.2; }
+  30%           { opacity: 0.95; }
+}
+.agx-typing-dot { animation: agx-typing 1.25s ease-in-out infinite; }
+.agx-typing-dot:nth-child(2) { animation-delay: 0.16s; }
+.agx-typing-dot:nth-child(3) { animation-delay: 0.32s; }
+
+/* The caret that trails text as it streams. Same reasoning, quieter: here the
+   arriving words are already proof of life, so this only has to look like a
+   cursor rather than carry the signal on its own. */
+@keyframes agx-caret { 0%, 45% { opacity: 1; } 55%, 100% { opacity: 0.15; } }
+.agx-caret { animation: agx-caret 1.1s steps(1, end) infinite; }
+
+@media (prefers-reduced-motion: reduce) {
+  /* Still visibly "waiting", just not moving. Removing them entirely would
+     leave the reply looking like it had not been sent. */
+  .agx-typing-dot { animation: none; opacity: 0.6; }
+  .agx-caret { animation: none; opacity: 0.7; }
+}
+:root[data-idle="1"] .agx-typing-dot,
+:root[data-idle="1"] .agx-caret { animation-play-state: paused !important; }
+
 /* A chat that replied while you were elsewhere. Deliberately a slow, low-
    contrast breath rather than a hard blink: it sits in a header you look at
    all day, and something that flashes urgently for a message that can wait

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -113,6 +113,24 @@ export type ChatUsage = {
 /** A message typed during someone else's turn, waiting for its own. */
 export type QueuedTurn = { id: string; text: string; images: ChatImage[] };
 
+/** The engine this chat's next turn will actually use.
+ *
+ *  A chat with no session yet has nothing to strand, so the current preference
+ *  wins — that is what makes changing the setting take effect on the chat you
+ *  are already looking at instead of only on the next one you remember to
+ *  create. Once a session exists the answer is fixed: it lives in a pane or it
+ *  does not.
+ *
+ *  `undefined` means "whatever the server is configured to do", which is a real
+ *  third answer and not a missing one.
+ *
+ *  Shared by the send path and the header so the two can never disagree — the
+ *  header claiming one engine while the turn used the other is the bug this
+ *  whole function exists to end. */
+export function engineFor(chat: Pick<Chat, "sessionId" | "engine">): ChatEngine | undefined {
+  return chat.sessionId ? chat.engine : (chatEnginePref() ?? undefined);
+}
+
 export type Chat = {
   id: string;
   cwd: string;
@@ -737,9 +755,27 @@ export async function send(id: string, text: string, isActive: () => boolean, al
     }
   };
 
+  /*
+   * Which engine this turn runs on.
+   *
+   * Freezing it when the chat object was created was wrong in the one case that
+   * matters: the panel opens a chat for you before you have touched anything, so
+   * the chat that is already on screen when you change the preference keeps the
+   * old engine — and says nothing about it. Changing the setting then appeared
+   * to do nothing at all, which is exactly how it was first reported.
+   *
+   * So the preference wins right up until the chat has a session. After that the
+   * engine is frozen for real: the session lives in a pane or it does not, and
+   * moving a running conversation between the two would strand one or the other.
+   */
+  const engine = engineFor(chat);
+  // Recorded on the chat as the turn starts, so the header can say where this
+  // conversation runs before its first reply rather than after.
+  if (engine !== chat.engine) update(id, (c) => { c.engine = engine; });
+
   let broke = false;
   try {
-    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools, images, engine: chat.engine }, onEvent, ac.signal);
+    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools, images, engine }, onEvent, ac.signal);
   } catch (e) {
     // A queue must not keep firing into a turn that failed or one you just
     // interrupted — the rest of it stays put, visible, for you to decide on.

--- a/web/test/chat-engine-pick.test.ts
+++ b/web/test/chat-engine-pick.test.ts
@@ -1,0 +1,66 @@
+// Which engine a chat's next turn runs on.
+//
+// This exists because the first version froze the answer when the chat object
+// was created, and the panel creates a chat for you before you have touched
+// anything. So the chat already on screen when you changed the setting kept the
+// old engine and said nothing — changing the preference looked like it did
+// nothing at all.
+import { test, expect, beforeAll, beforeEach } from "bun:test";
+
+// Same harness the other store tests use: chatStore pulls in api.ts, which reads
+// `location` at module load and is not there under bun test.
+const cell = new Map<string, string>();
+let engineFor: typeof import("../src/lib/chatStore.ts")["engineFor"];
+let setChatEnginePref: typeof import("../src/lib/chatEnginePref.ts")["setChatEnginePref"];
+let KEY: string;
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  ({ engineFor } = await import("../src/lib/chatStore.ts"));
+  const pref = await import("../src/lib/chatEnginePref.ts");
+  setChatEnginePref = pref.setChatEnginePref;
+  KEY = pref.CHAT_ENGINE_KEY;
+});
+
+beforeEach(() => { localStorage.removeItem(KEY); });
+
+test("a chat with no session follows the preference, whenever it was created", () => {
+  // The reported bug, pinned: the chat existed first, the preference came after.
+  const chat = { sessionId: "", engine: undefined };
+  expect(engineFor(chat)).toBeUndefined();
+  setChatEnginePref("tmux");
+  expect(engineFor(chat)).toBe("tmux");
+});
+
+test("the preference can also move a not-yet-started chat back to the old engine", () => {
+  setChatEnginePref("process");
+  // Not merely "undefined becomes tmux": a chat born under one preference must
+  // follow a later change in either direction while it still has nothing to lose.
+  expect(engineFor({ sessionId: "", engine: "tmux" })).toBe("process");
+});
+
+test("a chat that has a session is frozen, and the preference cannot move it", () => {
+  setChatEnginePref("tmux");
+  // The session lives in a pane or it does not. Switching a running conversation
+  // would strand either the warm CLI or the turn in flight.
+  expect(engineFor({ sessionId: "abcd-1234", engine: "process" })).toBe("process");
+  setChatEnginePref("process");
+  expect(engineFor({ sessionId: "abcd-1234", engine: "tmux" })).toBe("tmux");
+});
+
+test("a started chat that predates the setting keeps deferring to the server", () => {
+  setChatEnginePref("tmux");
+  // Chats saved before the engine existed have no field. They are already
+  // running somewhere, so they must not be reinterpreted by a new preference.
+  expect(engineFor({ sessionId: "old-session-1", engine: undefined })).toBeUndefined();
+});
+
+test("no preference means the server decides, which is a real answer", () => {
+  // Deliberately not defaulted to "process" here: the server has its own
+  // configurable default and the browser must not silently override it.
+  expect(engineFor({ sessionId: "", engine: undefined })).toBeUndefined();
+});


### PR DESCRIPTION
## What does this PR do?

Follow-up to #324, reported immediately after it landed: switching **Settings → Preferences → How new chats run** to *tmux panes* appeared to do nothing.

It was doing nothing. The engine was frozen when the chat object was created, and the panel opens a chat for you before you have touched any setting — so the chat already on screen kept the old engine, ran `claude -p` as before, and gave no sign of it. Confirmed on a real machine rather than inferred: the preference was correctly stored as `tmux`, the saved chat carried no `engine` field at all, no pane had ever been created on the agentglass socket, and the same server given `engine: "tmux"` directly created a pane exactly as it should.

Two changes, and the second is what would have made the first unnecessary:

- **The preference wins until the chat has a session.** A chat that has never run has nothing to strand, so freezing its engine at creation bought nothing. Once a session exists it is fixed for real — the conversation lives in a pane or it does not, and moving a running one would strand either the warm CLI or the turn in flight. `engineFor()` is shared by the send path and the header, so the two cannot disagree about where a turn actually went.
- **The header says where a chat runs before its first turn, not after.** The attach button only appeared once a pane existed, which meant a preference that had not taken effect looked identical to one that had. A chat bound for a pane now shows `⧉ tmux on send`, which becomes the copy-the-attach-command button once the pane is up.

Only the pane engine is badged: `claude -p` is the long-standing behaviour, and a badge on every chat saying "normal" is noise.


**Second, unrelated but reported in the same breath:** while a turn was being waited on, the reply bubble showed a single static caret. That is indistinguishable from a turn that has quietly stalled — and stalling is a real state here, not a hypothetical, since a pane that never accepted its prompt looks exactly like this. The empty reply now shows three dots keeping time, and the caret trailing streaming text blinks instead of sitting still.

Both are opacity-only on small spans: no layout, no repaint of what is behind them. A turn can run for minutes, and on a software-composited stack an animation that touches layout is a per-frame CPU tax for all of it. Both honour `prefers-reduced-motion` (kept visible, just still) and pause with the rest of the app when the window goes idle.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/`; full suite **1016 pass / 0 fail**.
- 5 new tests in `web/test/chat-engine-pick.test.ts` pinning the rule from both directions: a chat created before the preference picks it up, a not-yet-started chat can also be moved *back* to the old engine, a chat with a session cannot be moved either way, a chat saved before the engine existed keeps deferring to the server, and no preference stays "let the server decide" rather than silently becoming `process`.
- `bunx vite build` clean, and the typing indicator was checked against the app's existing animation idioms (`agx-` keyframes, reduced-motion override, idle pause) rather than invented alongside them.
- The underlying engine was verified end to end against the running desktop app's own sidecar before writing the fix: `POST /chat/send` with `engine: "tmux"` created the pane and returned its attach command, which is what localised the fault to the client.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
