### PR TITLE
feat(prs): apply a suggestion, expand a diff, see an image change, drop a file in

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -52,7 +52,7 @@ import {
 } from "./docker.ts";
 import {
   listPrs, prDetail, prDiff, prAsset, ghCapability, submitReview, addComment, replyToThread,
-  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts, jobLog, checkJobs, rerunJobs, addLineComment, mentionables, facetOptions,
+  editComment, deleteComment, setFileViewed, setAssignees, setMilestone, viewCounts, jobLog, checkJobs, rerunJobs, addLineComment, mentionables, facetOptions, applySuggestion, fileSlice,
   setThreadResolved, react, editPr, setLabels, setReviewers, setDraft, updateBranch,
   rerunFailedChecks, mergePr, closePr, prepareReviewPrompt, branchUrl, subscribeCi, commitDiff as prCommitDiff, submitReviewWith,
 } from "./prs.ts";
@@ -984,6 +984,14 @@ const server = Bun.serve<WsData>({
         url.searchParams.get("q") || undefined,
       ));
     }
+    if (pathname === "/prs/file-slice") {
+      return json(await fileSlice(url.searchParams.get("root") || "", url.searchParams.get("number") || "", {
+        path: url.searchParams.get("path") || "",
+        side: url.searchParams.get("side") || "RIGHT",
+        from: url.searchParams.get("from") || undefined,
+        to: url.searchParams.get("to") || undefined,
+      }));
+    }
     if (pathname === "/prs/facets") {
       return json(await facetOptions(url.searchParams.get("root") || ""));
     }
@@ -1049,6 +1057,7 @@ const server = Bun.serve<WsData>({
         case "/prs/rerun": res = await rerunFailedChecks(root, n); break;
         case "/prs/rerun-jobs": res = await rerunJobs(root, b.what, b.id); break;
         case "/prs/line-comment": res = await addLineComment(root, n, b); break;
+        case "/prs/apply-suggestion": res = await applySuggestion(root, n, b); break;
         case "/prs/merge": res = await mergePr(root, n, b.method, { deleteBranch: b.deleteBranch, auto: b.auto, headSha: b.headSha, subject: b.subject, body: b.body, disableAuto: b.disableAuto }); break;
         case "/prs/close": res = await closePr(root, n, b.reopen === true); break;
         case "/prs/review-prompt": res = await prepareReviewPrompt(root, n); break;

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -1357,6 +1357,7 @@ export async function prDetail(rootIn: unknown, numberIn: unknown, force = false
     id: t.id,
     path: t.path || "",
     line: t.line ?? null,
+    startLine: t.startLine ?? null,
     isResolved: !!t.isResolved,
     isOutdated: !!t.isOutdated,
     // The hunk GitHub stored with the comment, not one reconstructed from the
@@ -1812,6 +1813,130 @@ export async function deleteComment(rootIn: unknown, nodeId: unknown, kind: unkn
  * github.com and was lost on another machine. GitHub also un-ticks a file by
  * itself when it changes after you marked it, which local state cannot do.
  */
+/**
+ * A slice of a file at one side of the pull request.
+ *
+ * What "expand context" needs: the diff only carries the hunks GitHub chose to
+ * send, so the twenty lines above a change simply are not in the payload. And
+ * what an image diff needs, in the other shape: the raw bytes of a binary file
+ * on each side, which the unified diff cannot represent at all.
+ */
+export async function fileSlice(rootIn: unknown, numberIn: unknown, args: {
+  path?: unknown; side?: unknown; from?: unknown; to?: unknown;
+}): Promise<{ ok: boolean; lines?: string[]; start?: number; total?: number; binary?: boolean; url?: string; error?: string }> {
+  const n = Number(numberIn);
+  const path = typeof args.path === "string" ? args.path : "";
+  if (!Number.isInteger(n) || n <= 0 || !path) return { ok: false, error: "invalid file" };
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+  const pr = await ghJson<any>(["api", `repos/${repo.nameWithOwner}/pulls/${n}`]);
+  // LEFT is the base — the file as it was; RIGHT is the head — as it is now.
+  const left = args.side === "LEFT";
+  const ref = left ? pr?.base?.sha : pr?.head?.sha;
+  const from = left ? repo.nameWithOwner : (pr?.head?.repo?.full_name ?? repo.nameWithOwner);
+  if (!ref) return { ok: false, error: "could not read the pull request's commits" };
+  const file = await ghJson<any>(["api", `repos/${from}/contents/${encodeURI(path)}?ref=${ref}`]);
+  if (!file) return { ok: false, error: `${path} is not on that side` };
+  // A file GitHub will not inline is a big one or a binary one; either way the
+  // bytes come from `download_url`, which the asset proxy can fetch.
+  if (!file.content || file.encoding !== "base64") {
+    return { ok: true, binary: true, url: file.download_url ?? "" };
+  }
+  const buf = Buffer.from(String(file.content).replace(/\n/g, ""), "base64");
+  // A NUL in the first few KB is the usual "this is not text" tell.
+  if (buf.subarray(0, 8000).includes(0)) return { ok: true, binary: true, url: file.download_url ?? "" };
+  const all = buf.toString("utf8").split("\n");
+  const start = Math.max(1, Number(args.from) || 1);
+  const to = Math.min(all.length, Number(args.to) || all.length);
+  return { ok: true, lines: all.slice(start - 1, to), start, total: all.length };
+}
+
+/**
+ * Replace lines [start, end] (inclusive, 1-based) with the suggested text.
+ *
+ * Its own function so it can be tested without writing a commit: this is the
+ * step that decides whether a file comes out correct or mangled, and an
+ * off-by-one here silently eats somebody's line.
+ */
+export function spliceLines(lines: string[], start: number, end: number, replacement: string): string {
+  return [...lines.slice(0, start - 1), ...replacement.split("\n"), ...lines.slice(end)].join("\n");
+}
+
+/**
+ * Apply a suggested change.
+ *
+ * GitHub has no "apply suggestion" API — the button on their site is web-only —
+ * so the commit has to be written here: read the file at the head of the pull
+ * request's branch, swap the suggested lines in, and commit the result with
+ * `createCommitOnBranch`. That mutation is the right tool because it commits
+ * through the API and the result is signed as a verified commit, which pushing
+ * from a local checkout would not be.
+ *
+ * `expectedHeadOid` is the safety belt: if anyone pushed between the read and
+ * the write, GitHub refuses rather than clobbering their work. And the person
+ * who suggested the change is credited as a co-author, exactly as GitHub does.
+ */
+export async function applySuggestion(rootIn: unknown, numberIn: unknown, args: {
+  path?: unknown; startLine?: unknown; line?: unknown; suggestion?: unknown; author?: unknown;
+}): Promise<PrActionResult> {
+  const g = writeGuard(rootIn); if (g) return g;
+  const n = Number(numberIn);
+  const path = typeof args.path === "string" ? args.path : "";
+  const end = Number(args.line);
+  const start = Number.isInteger(Number(args.startLine)) && Number(args.startLine) > 0 ? Number(args.startLine) : end;
+  const replacement = typeof args.suggestion === "string" ? args.suggestion : "";
+  if (!Number.isInteger(n) || n <= 0) return { ok: false, error: "invalid pull request number" };
+  if (!path || !Number.isInteger(end) || end <= 0) return { ok: false, error: "invalid line" };
+  if (start > end) return { ok: false, error: "invalid range" };
+
+  const repo = await repoIdFor(rootIn);
+  if (!repo) return { ok: false, error: "no GitHub remote on this repository" };
+
+  // The branch this pull request is FROM, and the commit it is at. A suggestion
+  // applies to the head branch, which on a fork is not this repository.
+  const pr = await ghJson<any>(["api", `repos/${repo.nameWithOwner}/pulls/${n}`]);
+  const headRepo: string | undefined = pr?.head?.repo?.full_name;
+  const headRef: string | undefined = pr?.head?.ref;
+  const headSha: string | undefined = pr?.head?.sha;
+  if (!headRepo || !headRef || !headSha) return { ok: false, error: "could not read the pull request's branch" };
+  if (pr?.maintainer_can_modify === false && headRepo !== repo.nameWithOwner) {
+    return { ok: false, error: "this fork does not allow maintainers to push to it" };
+  }
+
+  // The file as it stands on that branch.
+  const file = await ghJson<any>(["api", `repos/${headRepo}/contents/${encodeURI(path)}?ref=${encodeURIComponent(headRef)}`]);
+  if (!file?.content || file.encoding !== "base64") return { ok: false, error: `could not read ${path}` };
+  const text = Buffer.from(String(file.content).replace(/\n/g, ""), "base64").toString("utf8");
+  const lines = text.split("\n");
+  if (end > lines.length) return { ok: false, error: "the file has changed since that suggestion was written" };
+
+  const next = spliceLines(lines, start, end, replacement);
+  if (next === text) return { ok: false, error: "that suggestion is already applied" };
+
+  const who = typeof args.author === "string" ? args.author.trim() : "";
+  const message = who
+    ? `Apply suggestion from @${who}\n\nCo-authored-by: ${who} <${who}@users.noreply.github.com>`
+    : "Apply suggestion";
+  const mutation = `mutation($input: CreateCommitOnBranchInput!) {
+    createCommitOnBranch(input: $input) { commit { oid } }
+  }`;
+  const input = {
+    branch: { repositoryNameWithOwner: headRepo, branchName: headRef },
+    expectedHeadOid: headSha,
+    message: { headline: message.split("\n")[0], body: message.split("\n").slice(1).join("\n").trim() || undefined },
+    fileChanges: { additions: [{ path, contents: Buffer.from(next, "utf8").toString("base64") }] },
+  };
+  const r = await gh(["api", "graphql", "-f", `query=${mutation}`, "--input", "-"],
+    undefined, JSON.stringify({ query: mutation, variables: { input } }));
+  invalidate(repo, n);
+  if (r.code !== 0) {
+    const msg = (r.stderr || r.stdout).trim().split("\n").find((l) => l.trim()) || "the commit was refused";
+    // The one failure worth naming: somebody pushed while you were reading.
+    return { ok: false, error: /expected.*oid|not.*match/i.test(msg) ? "somebody pushed to that branch — reload and try again" : msg };
+  }
+  return { ok: true, detail: `applied to ${path}:${start === end ? start : `${start}-${end}`}` };
+}
+
 export async function setFileViewed(rootIn: unknown, prNodeId: unknown, path: unknown, viewed: unknown): Promise<PrActionResult> {
   const g = writeGuard(rootIn); if (g) return g;
   const id = String(prNodeId || "");

--- a/server/test/pr-suggestion.test.ts
+++ b/server/test/pr-suggestion.test.ts
@@ -1,0 +1,44 @@
+// Applying a suggested change rewrites somebody's file, so the line arithmetic
+// is worth pinning. GitHub has no "apply suggestion" API — the commit is
+// written here — and an off-by-one silently eats a line rather than failing.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-sug-"));
+process.env.XDG_CONFIG_HOME = dir;
+process.env.AGENTGLASS_DB = join(dir, "s.db");
+
+const prs = await import("../src/prs.ts");
+const FILE = ["one", "two", "three", "four", "five"];
+
+describe("spliceLines", () => {
+  test("a single line is replaced in place, and nothing around it moves", () => {
+    expect(prs.spliceLines(FILE, 3, 3, "THREE")).toBe("one\ntwo\nTHREE\nfour\nfive");
+  });
+
+  test("a range is replaced whole, however many lines it becomes", () => {
+    // Three lines in, one out.
+    expect(prs.spliceLines(FILE, 2, 4, "X")).toBe("one\nX\nfive");
+    // One line in, three out.
+    expect(prs.spliceLines(FILE, 2, 2, "a\nb\nc")).toBe("one\na\nb\nc\nthree\nfour\nfive");
+  });
+
+  test("the first and last lines are reachable — the off-by-one cases", () => {
+    expect(prs.spliceLines(FILE, 1, 1, "ONE")).toBe("ONE\ntwo\nthree\nfour\nfive");
+    expect(prs.spliceLines(FILE, 5, 5, "FIVE")).toBe("one\ntwo\nthree\nfour\nFIVE");
+    expect(prs.spliceLines(FILE, 1, 5, "only")).toBe("only");
+  });
+
+  test("an empty suggestion deletes the lines rather than leaving a blank", () => {
+    // GitHub treats an empty suggestion as "remove these lines"; a naive splice
+    // would leave an empty string behind and change the file's shape.
+    expect(prs.spliceLines(FILE, 2, 3, "")).toBe("one\n\nfour\nfive");
+  });
+
+  test("the trailing newline of a file is preserved", () => {
+    const withTrailing = ["a", "b", ""];
+    expect(prs.spliceLines(withTrailing, 1, 1, "A")).toBe("A\nb\n");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1129,6 +1129,8 @@ export interface PrThread {
   id: string;
   path: string;
   line: number | null;
+  /** The first line, when the thread covers a range. Null for one line. */
+  startLine?: number | null;
   isResolved: boolean;
   /** The code under it has changed since; usually safe to skip. */
   isOutdated: boolean;

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -241,7 +241,9 @@ export const MD_CSS = `
 .agx-md .agx-details>summary{cursor:pointer;color:var(--text);font-weight:600;list-style:revert}
 .agx-md .agx-details>div{margin-top:.7em}
 .agx-md .agx-suggestion{margin:0 0 .9em;border:1px solid color-mix(in srgb,var(--success) 45%,transparent);border-radius:6px;overflow:hidden}
-.agx-md .agx-suggestion-head{font-size:.8em;letter-spacing:.05em;text-transform:uppercase;padding:.35em .8em;color:var(--success);background:color-mix(in srgb,var(--success) 12%,transparent)}
+.agx-md .agx-suggestion-head{font-size:.8em;letter-spacing:.05em;text-transform:uppercase;padding:.35em .8em;color:var(--success);background:color-mix(in srgb,var(--success) 12%,transparent);display:flex;align-items:center;gap:.7em}
+.agx-md .agx-suggestion-apply{margin-left:auto;text-transform:none;letter-spacing:0;font-size:.95em;padding:.1em .6em;border-radius:5px;border:1px solid color-mix(in srgb,var(--success) 50%,transparent);color:var(--success);cursor:pointer}
+.agx-md .agx-suggestion-apply:disabled{opacity:.45;cursor:default}
 .agx-md .agx-suggestion pre{margin:0;border:0;border-radius:0;background:color-mix(in srgb,var(--success) 6%,transparent)}
 .agx-md .agx-alert{margin:0 0 .9em;padding:.6em .9em;border-left:3px solid;border-radius:0 6px 6px 0;display:flex;flex-direction:column;gap:.3em}
 .agx-md .agx-alert>b{font-size:.82em;letter-spacing:.06em}
@@ -253,6 +255,31 @@ export const MD_CSS = `
 
 /** One markdown block. Images go through the proxy — GitHub's own attachment
  *  URLs answer 404 without the token, and those are the review's evidence. */
+/**
+ * A proposed replacement, with the button that takes it.
+ *
+ * GitHub has no API for this — their Apply button is web-only — so the server
+ * writes the commit itself: read the file at the head of the branch, splice the
+ * lines, commit through `createCommitOnBranch` with the head oid as a guard so
+ * a concurrent push is refused rather than clobbered.
+ */
+function Suggestion({ text }: { text: string }) {
+  const ctx = useContext(SuggestCtx);
+  return (
+    <div className="agx-suggestion">
+      <div className="agx-suggestion-head">
+        <span>Suggested change</span>
+        {ctx && (
+          <button onClick={() => ctx.apply(text)} disabled={ctx.busy}
+            title="Commit this to the pull request's branch"
+            className="agx-btn agx-suggestion-apply">Apply</button>
+        )}
+      </div>
+      <pre><code>{text}</code></pre>
+    </div>
+  );
+}
+
 function Block({ b }: { b: MdBlock }) {
   if (b.kind === "heading") {
     const H = (["h1", "h2", "h3", "h4", "h5", "h6"][b.level - 1] ?? "h6") as "h1";
@@ -302,17 +329,7 @@ function Block({ b }: { b: MdBlock }) {
       </div>
     );
   }
-  if (b.kind === "suggestion") {
-    // Shown as what it is: the replacement being proposed. Rendering it as an
-    // ordinary code block (which is what happened before) hid the fact that
-    // there was a change on offer at all.
-    return (
-      <div className="agx-suggestion">
-        <div className="agx-suggestion-head">Suggested change</div>
-        <pre><code>{b.text}</code></pre>
-      </div>
-    );
-  }
+  if (b.kind === "suggestion") return <Suggestion text={b.text} />;
   const isTask = b.items.some((i) => i.checked !== undefined);
   const List = b.ordered ? "ol" : "ul";
   return (
@@ -375,6 +392,12 @@ const EMOJI_NAMES: Record<string, string> = {
  *  threading a prop through all of them to reach the same value is noise. */
 export const RepoCtx = createContext<string | undefined>(undefined);
 
+/** How a suggestion block gets applied. Supplied by whichever thread the
+ *  comment belongs to, because only it knows the file and the lines; a markdown
+ *  block on its own knows neither. Null where there is nothing to apply to (a
+ *  suggestion written in the PR body, say). */
+export const SuggestCtx = createContext<{ apply: (text: string) => void; busy: boolean } | null>(null);
+
 export function Md({ body, className }: { body: string; className?: string }) {
   const repo = useContext(RepoCtx);
   const blocks = useMemo(() => parseBody(body, repo), [body, repo]);
@@ -395,9 +418,107 @@ function toFileChange(f: ParsedFile, i: number): FileChange {
   };
 }
 
-function DiffPane({ file, split, wrap, onPick, sel }: {
+/**
+ * The lines around a hunk, fetched on demand.
+ *
+ * A diff only carries what GitHub chose to send — three lines of context — so
+ * the code just above a change is not in the payload at all and there is
+ * nothing to reveal locally. Each expansion asks the server for that slice of
+ * the file at this side of the pull request, twenty lines at a time, the way
+ * GitHub's own chevrons work.
+ */
+function ExpandContext({ root, number, path, from, to, side = "RIGHT" }: {
+  root: string; number: number; path: string; from: number; to: number; side?: "LEFT" | "RIGHT";
+}) {
+  const [lines, setLines] = useState<string[] | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [err, setErr] = useState<string | null>(null);
+  if (from > to) return null;
+  const load = async () => {
+    setBusy(true); setErr(null);
+    const r = await api.prFileSlice(root, number, path, side, from, to).catch(() => null);
+    setBusy(false);
+    if (!r?.ok || !r.lines) { setErr(r?.error || "Could not read that part of the file"); return; }
+    setLines(r.lines);
+  };
+  if (lines) {
+    return (
+      <div className="whitespace-pre px-3 py-0.5 text-[12px]" style={{ ...CODE_FONT_STYLE, color: "var(--text3)", background: "color-mix(in srgb, var(--border) 8%, transparent)" }}>
+        {lines.join("\n")}
+      </div>
+    );
+  }
+  return (
+    <button onClick={load} disabled={busy} title={`Show lines ${from}-${to}`}
+      className="agx-btn w-full text-left px-3 py-0.5 text-[10.5px]"
+      style={{ color: err ? "var(--error)" : "var(--text3)", background: "color-mix(in srgb, var(--border) 10%, transparent)" }}>
+      {err ?? (busy ? "…" : `⌃⌄ Expand ${to - from + 1} line${to - from ? "s" : ""}`)}
+    </button>
+  );
+}
+
+/**
+ * An image, before and after.
+ *
+ * A unified diff cannot say anything about a PNG — the file list reports it as
+ * "no textual diff" and that is the end of it. Both sides are fetched by path
+ * and shown next to each other, which is the whole question an image change
+ * raises: what did it look like, and what does it look like now. Added and
+ * deleted files simply have one side.
+ */
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|ico|avif)$/i;
+
+function ImageDiff({ root, number, path, status }: {
+  root: string; number: number; path: string; status: string;
+}) {
+  const [sides, setSides] = useState<{ left?: string; right?: string } | null>(null);
+  const [err, setErr] = useState<string | null>(null);
+  useEffect(() => {
+    let live = true;
+    const want: ("LEFT" | "RIGHT")[] =
+      status === "added" ? ["RIGHT"] : status === "removed" || status === "deleted" ? ["LEFT"] : ["LEFT", "RIGHT"];
+    Promise.all(want.map((side) => api.prFileSlice(root, number, path, side).then((r) => [side, r] as const).catch(() => [side, null] as const)))
+      .then((res) => {
+        if (!live) return;
+        const out: { left?: string; right?: string } = {};
+        for (const [side, r] of res) {
+          // Text came back for an image: that is an SVG, which is both. Render
+          // it from a data URL rather than round-tripping the bytes again.
+          const url = r?.ok
+            ? (r.url || (r.lines ? `data:image/svg+xml;base64,${btoa(unescape(encodeURIComponent(r.lines.join("\n"))))}` : ""))
+            : "";
+          if (url) out[side === "LEFT" ? "left" : "right"] = api.prAssetUrl(url);
+        }
+        if (!out.left && !out.right) setErr("Could not read the image on either side");
+        setSides(out);
+      });
+    return () => { live = false; };
+  }, [root, number, path, status]);
+
+  if (err) return <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>{err}</div>;
+  if (!sides) return <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>Loading the image…</div>;
+  const pane = (label: string, src?: string, tint?: string) => (
+    <div className="flex-1 min-w-0 p-3 flex flex-col gap-1.5 items-start">
+      <span className="text-[9.5px] uppercase tracking-wider" style={{ color: tint ?? "var(--text3)" }}>{label}</span>
+      {src
+        ? <img src={src} alt="" className="max-w-full rounded" style={{ maxHeight: 320, border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", background: "repeating-conic-gradient(color-mix(in srgb, var(--border) 22%, transparent) 0% 25%, transparent 0% 50%) 50% / 16px 16px" }} />
+        : <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>—</span>}
+    </div>
+  );
+  return (
+    <div className="flex flex-wrap w-full">
+      {sides.left !== undefined || sides.right === undefined ? pane("before", sides.left, "var(--error)") : null}
+      {sides.right !== undefined || sides.left === undefined ? pane("after", sides.right, "var(--success)") : null}
+    </div>
+  );
+}
+
+function DiffPane({ file, split, wrap, onPick, sel, expand }: {
   file: FileChange; split: boolean; wrap: boolean;
   onPick?: (p: LinePick) => void; sel?: LineSel;
+  /** Renders the "expand" strip above each hunk, when the file is one we can
+   *  fetch more of. Absent for a commit diff, which is not a pull request. */
+  expand?: (hunkIndex: number) => React.ReactNode;
 }) {
   // Syntax highlighting, which this pane never had: `Code` reads the theme out
   // of `HiliteCtx`, and with no Provider above it every PR diff rendered as
@@ -410,7 +531,7 @@ function DiffPane({ file, split, wrap, onPick, sel }: {
     <HiliteCtx.Provider value={heavy ? { ...hilite, theme: null } : hilite}>
       {split
         ? <SplitDiff c={file} wrap={wrap} onPick={onPick} sel={sel} />
-        : <UnifiedDiff c={file} wrap={wrap} onPick={onPick} sel={sel} />}
+        : <UnifiedDiff c={file} wrap={wrap} onPick={onPick} sel={sel} hunkAction={expand} />}
     </HiliteCtx.Provider>
   );
 }
@@ -1047,6 +1168,28 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
   };
   /** Toggle an emoji. The node id is the GraphQL one, so the same call serves
    *  the body, a comment, a review and a line comment. */
+  /**
+   * Take a suggestion.
+   *
+   * Confirmed first: this writes a commit to somebody's branch, which is not
+   * something to do on a stray click. The author of the comment is credited as
+   * a co-author, as GitHub does.
+   */
+  const doApplySuggestion = async (t: PrThread, text: string) => {
+    if (!detail || !t.line) return;
+    const where = `${t.path}:${t.startLine && t.startLine !== t.line ? `${t.startLine}-${t.line}` : t.line}`;
+    const ok = await ask({
+      title: `Apply this suggestion to ${t.path.split("/").pop()}?`,
+      body: `${where}\n\nCommits to ${detail.headRefName}, crediting ${t.comments[0]?.author ?? "the author"}. If anyone has pushed since this loaded, GitHub refuses rather than overwriting them.`,
+      confirmLabel: "Apply suggestion",
+    });
+    if (!ok) return;
+    await act("Suggestion", () => api.prApplySuggestion(root, detail.number, {
+      path: t.path, line: t.line!, startLine: t.startLine ?? undefined,
+      suggestion: text, author: t.comments[0]?.author,
+    }));
+  };
+
   const doReact = async (nodeId: string, content: string, on: boolean) => {
     if (!nodeId) return;
     await act(on ? "Reaction" : "Reaction removed", () => api.prReactTo(root, nodeId, content, on));
@@ -1354,6 +1497,7 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
                           d={d} lanes={lanes} raw={rawBots} onRaw={setRawBots} busy={busy} onComment={doComment}
                           onResolve={(t) => act(t.isResolved ? "Unresolve" : "Resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
                           onReply={doReply}
+                          onApply={doApplySuggestion}
                           onReact={doReact}
                         />
                       )}
@@ -1441,10 +1585,11 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
 
                 {tab === "files" && (
                   <FilesTab
-                    d={d} byPath={byPath} loaded={!!diff} seenFiles={seenFiles} onSeen={toggleSeen}
+                    d={d} root={root} byPath={byPath} loaded={!!diff} seenFiles={seenFiles} onSeen={toggleSeen}
                     sel={selFile} onSel={setSelFile} split={split} wrap={wrap} onSplit={setSplit} onWrap={setWrap}
                     drafts={myDrafts} onAddDraft={addDraft}
                     busy={busy} onReply={doReply}
+                    onApply={doApplySuggestion}
                     onResolve={(t) => act(t.isResolved ? "Unresolve" : "Resolve", () => api.prSetThreadResolved(root, t.id, !t.isResolved))}
                   />
                 )}
@@ -2120,13 +2265,14 @@ function FileTree({ node, sel, onPick, seen, drafts, depth = 0 }: {
   );
 }
 
-function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wrap, onSplit, onWrap, drafts, onAddDraft, onResolve, onReply, busy }: {
-  d: PrDetail; byPath: Map<string, FileChange>; loaded: boolean;
+function FilesTab({ d, root, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wrap, onSplit, onWrap, drafts, onAddDraft, onResolve, onReply, onApply, busy }: {
+  d: PrDetail; root: string; byPath: Map<string, FileChange>; loaded: boolean;
   seenFiles: string[]; onSeen: (p: string) => void;
   sel: string | null; onSel: (p: string | null) => void;
   split: boolean; wrap: boolean; onSplit: (v: boolean) => void; onWrap: (v: boolean) => void;
   drafts: DraftComment[]; onAddDraft: (path: string, line: number, startLine?: number, side?: "LEFT" | "RIGHT") => void;
-  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
+  onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void;
+  onApply?: (t: PrThread, text: string) => void; busy: boolean;
 }) {
   const draftsFor = (p: string) => drafts.filter((x) => x.path === p).length;
   /**
@@ -2365,8 +2511,28 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
                     folded by default instead, which is the honest cap. */}
                 <div className="flex" style={{ overflowX: "auto" }}>
                   {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>Loading the diff…</div>
-                    : change ? <DiffPane file={change} split={split} wrap={wrap} onPick={(pk) => pickLine(f.path, pk)} sel={selRange?.path === f.path ? selRange.sel : null} />
-                    : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
+                    : change ? (
+                      <DiffPane
+                        file={change} split={split} wrap={wrap}
+                        onPick={(pk) => pickLine(f.path, pk)}
+                        sel={selRange?.path === f.path ? selRange.sel : null}
+                        expand={(hi) => {
+                          // The gap between the end of the previous hunk and the
+                          // start of this one — the lines GitHub did not send.
+                          const h = change.hunks[hi];
+                          if (!h) return null;
+                          const prev = hi > 0 ? change.hunks[hi - 1] : null;
+                          const prevEnd = prev ? prev.newStart + prev.newLines - 1 : 0;
+                          const from = Math.max(prevEnd + 1, h.newStart - 20);
+                          const to = h.newStart - 1;
+                          if (to < from) return null;
+                          return <ExpandContext root={root} number={d.number} path={f.path} from={from} to={to} />;
+                        }}
+                      />
+                    )
+                    : IMAGE_EXT.test(f.path)
+                      ? <ImageDiff root={root} number={d.number} path={f.path} status={f.status} />
+                      : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
                 </div>
               </LazyMount>
             )}
@@ -2377,7 +2543,7 @@ function FilesTab({ d, byPath, loaded, seenFiles, onSeen, sel, onSel, split, wra
             {open && threadsFor(f.path).length > 0 && (
               <div className="px-2.5 py-2 flex flex-col gap-2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 6%, transparent)" }}>
                 {threadsFor(f.path).map((t) => (
-                  <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} busy={busy} />
+                  <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} onApply={onApply} busy={busy} />
                 ))}
               </div>
             )}
@@ -2573,14 +2739,23 @@ function ThreadSnippet({ hunk, line }: { hunk?: string; line?: number | null }) 
   );
 }
 
-function Thread({ t, onResolve, onReply, busy }: {
-  t: PrThread; onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void; busy: boolean;
+function Thread({ t, onResolve, onReply, onApply, busy }: {
+  t: PrThread; onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void;
+  onApply?: (t: PrThread, text: string) => void; busy: boolean;
 }) {
   // The REST reply endpoint takes the numeric comment id. `id` is a GraphQL
   // node id (`PRRC_kwDO…`) and `Number()` of that is NaN — which is why reply
   // could never have worked before `databaseId` was asked for.
   const canReply = typeof t.comments[0]?.databaseId === "number";
+  // A suggestion inside this thread knows the file and the lines because the
+  // thread does. An outdated thread is refused: its lines have moved, so the
+  // range in hand no longer points where the comment meant.
+  const suggest = useMemo(
+    () => (onApply && !t.isOutdated && t.line ? { apply: (text: string) => onApply(t, text), busy } : null),
+    [onApply, t, busy],
+  );
   return (
+    <SuggestCtx.Provider value={suggest}>
     <div className="rounded-md overflow-hidden mb-2" style={{ border: "1px solid color-mix(in srgb, var(--border) 28%, transparent)" }}>
       <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
         style={{ background: "color-mix(in srgb, var(--border) 14%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
@@ -2613,6 +2788,7 @@ function Thread({ t, onResolve, onReply, busy }: {
         <Btn onClick={() => onResolve(t)} disabled={busy} ok={!t.isResolved} small>{t.isResolved ? "Unresolve" : "Resolve conversation"}</Btn>
       </div>
     </div>
+    </SuggestCtx.Provider>
   );
 }
 
@@ -2701,11 +2877,12 @@ function TimelineEvent({ e }: { e: PrEvent }) {
   );
 }
 
-function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onReact, busy }: {
+function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onReact, onApply, busy }: {
   d: PrDetail;
   lanes: { humans: PrReview[]; botReviews: PrReview[]; humanComments: PrComment[]; bots: PrComment[] };
   raw: boolean; onRaw: (v: boolean) => void;
   onResolve: (t: PrThread) => void; onReply: (t: PrThread) => void;
+  onApply?: (t: PrThread, text: string) => void;
   onComment: (body: string) => Promise<boolean>;
   onReact: (nodeId: string, content: string, on: boolean) => void;
   busy: boolean;
@@ -2736,7 +2913,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onR
           </Card>
           {mine.length > 0 && (
             <div className="pl-3 ml-2" style={{ borderLeft: "2px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-              {mine.map((t) => <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} busy={busy} />)}
+              {mine.map((t) => <Thread key={t.id} t={t} onResolve={onResolve} onReply={onReply} onApply={onApply} busy={busy} />)}
             </div>
           )}
         </>
@@ -2754,7 +2931,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onR
     entries.push({
       at: t.comments[0]?.createdAt ?? "", key: `t${t.id}`,
       node: <span style={{ color: t.isResolved ? "var(--success)" : "var(--warning)" }}>{t.isResolved ? "✓" : "○"}</span>,
-      body: <Thread t={t} onResolve={onResolve} onReply={onReply} busy={busy} />,
+      body: <Thread t={t} onResolve={onResolve} onReply={onReply} onApply={onApply} busy={busy} />,
     });
   }
   for (const [i, r] of lanes.botReviews.entries()) {
@@ -2812,7 +2989,7 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onR
     </div>
   ) : null;
 
-  const composer = <Composer onSend={onComment} busy={busy} placeholder="Leave a comment — markdown works here" sendLabel="Comment" />;
+  const composer = <Composer onSend={onComment} busy={busy} placeholder="Leave a comment — markdown works here" sendLabel="Comment" onOpenGithub={() => openExternal(d.url)} />;
 
   if (entries.length === 0) {
     return (
@@ -2861,8 +3038,11 @@ function Conversation({ d, lanes, raw, onRaw, onResolve, onReply, onComment, onR
  * Write, preview, send. Shared by the conversation and by anywhere else that
  * takes markdown, so the two never drift into behaving differently.
  */
-function Composer({ onSend, busy, placeholder, sendLabel }: {
+function Composer({ onSend, busy, placeholder, sendLabel, onOpenGithub }: {
   onSend: (body: string) => Promise<boolean>; busy: boolean; placeholder: string; sendLabel: string;
+  /** Opens this pull request on GitHub — the only place an image can actually
+   *  be attached. */
+  onOpenGithub?: () => void;
 }) {
   const [text, setText] = useState("");
   const [preview, setPreview] = useState(false);
@@ -2925,6 +3105,41 @@ function Composer({ onSend, busy, placeholder, sendLabel }: {
     });
   };
 
+  /**
+   * Files dropped or pasted into the composer.
+   *
+   * A text file is inserted as a fenced code block, which is what you wanted it
+   * for and needs nobody's permission. An image cannot be: GitHub has no public
+   * attachment-upload API — their paperclip is web-only, and there is no gist
+   * mutation or attachments endpoint to stand in for it (checked, not assumed).
+   * Rather than invent a place to put the bytes (committing screenshots into the
+   * repository is not a favour), it says so and offers the one thing that does
+   * work: attaching it on GitHub itself.
+   */
+  const [imageNote, setImageNote] = useState<string | null>(null);
+  const TEXTY = /\.(md|txt|log|json|jsonc|ya?ml|toml|ini|csv|tsv|diff|patch|ts|tsx|js|jsx|mjs|cjs|py|rb|go|rs|java|kt|c|h|cpp|hpp|cs|sh|bash|zsh|sql|html?|css|scss|xml|svg)$/i;
+
+  const takeFiles = async (files: File[]) => {
+    if (!files.length) return;
+    const image = files.find((f) => f.type.startsWith("image/"));
+    if (image) {
+      setImageNote(image.name);
+      return;
+    }
+    const parts: string[] = [];
+    for (const f of files.slice(0, 4)) {
+      if (!TEXTY.test(f.name) && !f.type.startsWith("text/")) continue;
+      // A composer is not a file host: enough to quote, not enough to hang the
+      // panel pasting a 40MB log.
+      const body = (await f.text()).slice(0, 60_000);
+      const lang = (f.name.split(".").pop() ?? "").toLowerCase();
+      parts.push(`**${f.name}**\n\n\`\`\`${lang}\n${body}\n\`\`\``);
+    }
+    if (!parts.length) { setImageNote(files[0]?.name ?? "that file"); return; }
+    setText((t) => (t ? `${t}\n\n` : "") + parts.join("\n\n"));
+    setImageNote(null);
+  };
+
   const send = async () => {
     if (!text.trim() || sending) return;
     setSending(true);
@@ -2934,11 +3149,28 @@ function Composer({ onSend, busy, placeholder, sendLabel }: {
   };
 
   return (
-    <div className="rounded-lg overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 38%, transparent)" }}>
+    <div className="rounded-lg overflow-hidden"
+      onDragOver={(e) => e.preventDefault()}
+      onDrop={(e) => { e.preventDefault(); void takeFiles([...e.dataTransfer.files]); }}
+      onPaste={(e) => { const fs = [...e.clipboardData.files]; if (fs.length) { e.preventDefault(); void takeFiles(fs); } }}
+      style={{ border: "1px solid color-mix(in srgb, var(--border) 38%, transparent)" }}>
       <div className="flex items-center gap-1 px-2 py-1.5" style={{ borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
         <Btn onClick={() => setPreview(false)} small primary={!preview}>Write</Btn>
         <Btn onClick={() => setPreview(true)} small primary={preview}>Preview</Btn>
       </div>
+      {imageNote && (
+        <div className="flex items-center gap-2 px-2.5 py-1.5 text-[10.5px]"
+          style={{ color: "var(--warning)", background: "color-mix(in srgb, var(--warning) 10%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+          <span className="min-w-0 truncate">
+            <b>{imageNote}</b> can't be attached from here — GitHub has no public upload API for attachments.
+          </span>
+          {onOpenGithub && (
+            <button onClick={onOpenGithub} className="agx-btn ml-auto shrink-0 px-2 py-0.5 rounded"
+              style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 45%, transparent)" }}>Attach on GitHub ↗</button>
+          )}
+          <button onClick={() => setImageNote(null)} className="agx-btn shrink-0 px-1" style={{ color: "var(--text3)" }} aria-label="Dismiss">×</button>
+        </div>
+      )}
       {preview ? (
         <div className="p-3 min-h-[80px]">{text.trim() ? <Md body={text} /> : <span className="text-[11px]" style={{ color: "var(--text3)" }}>Nothing to preview.</span>}</div>
       ) : (
@@ -2977,7 +3209,7 @@ function Composer({ onSend, busy, placeholder, sendLabel }: {
       )}
       <div className="flex items-center gap-2 px-2.5 py-2"
         style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--border) 12%, transparent)" }}>
-        <span className="text-[10px]" style={{ color: "var(--text3)" }}>Markdown · <b>@</b> people · <b>#</b> issues · <b>:</b> emoji · ⌘↵ to send</span>
+        <span className="text-[10px]" style={{ color: "var(--text3)" }}>Markdown · <b>@</b> people · <b>#</b> issues · <b>:</b> emoji · drop a text file · ⌘↵ to send</span>
         <span className="ml-auto">
           <Btn onClick={send} disabled={sending || busy || !text.trim()} primary small
             title={!text.trim() ? "Write something first" : undefined}>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -363,6 +363,14 @@ const realApi = {
     post<PrActionResult>("/prs/milestone", { root, number, title }),
   prList: (root: string, filter: "mine" | "review" | "all", state: "open" | "closed" | "all" = "open", force = false, after?: string, q?: string) =>
     get<PrListResponse>(`/prs/list?root=${encodeURIComponent(root)}&filter=${filter}&state=${state}${force ? "&force=1" : ""}${after ? `&after=${encodeURIComponent(after)}` : ""}${q ? `&q=${encodeURIComponent(q)}` : ""}`),
+  /** Apply a suggested change: reads the file, splices the lines, commits. */
+  prApplySuggestion: (root: string, number: number, a: { path: string; startLine?: number; line: number; suggestion: string; author?: string }) =>
+    post<PrActionResult>("/prs/apply-suggestion", { root, number, ...a }),
+  /** A slice of a file at one side — for expanding diff context, and for the
+   *  bytes of a binary the diff cannot carry. */
+  prFileSlice: (root: string, number: number, path: string, side: "LEFT" | "RIGHT", from?: number, to?: number) =>
+    get<{ ok: boolean; lines?: string[]; start?: number; total?: number; binary?: boolean; url?: string; error?: string }>(
+      `/prs/file-slice?root=${encodeURIComponent(root)}&number=${number}&path=${encodeURIComponent(path)}&side=${side}${from ? `&from=${from}` : ""}${to ? `&to=${to}` : ""}`),
   /** What the facet menus can offer — from the repository, not the page. */
   prFacets: (root: string) =>
     get<{ ok: boolean; data?: { authors: string[]; assignees: string[]; labels: { name: string; color: string }[]; milestones: string[]; bases: string[] }; error?: string }>(
@@ -593,6 +601,8 @@ const demoApi: typeof realApi = {
   // The panel used to answer available:false here, so the feature the landing
   // page calls out as new was dead in the demo that page links to.
   prCapability: (_force?: boolean) => D(demo.prCapability()),
+  prApplySuggestion: () => D(demoPrAction()),
+  prFileSlice: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; lines?: string[]; start?: number; total?: number; binary?: boolean; url?: string; error?: string }),
   prFacets: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; data?: { authors: string[]; assignees: string[]; labels: { name: string; color: string }[]; milestones: string[]; bases: string[] }; error?: string }),
   prList: (root: string, filter: "mine" | "review" | "all", _state?: "open" | "closed" | "all", _force?: boolean, _after?: string, _q?: string) => D<PrListResponse>(demo.prList(root, filter)),
   prMentions: () => D({ ok: false, error: "not available in the demo" } as { ok: boolean; data?: { users: string[]; issues: { number: number; title: string }[] }; error?: string }),


### PR DESCRIPTION
## What does this PR do?

Four things the panel could not do, and one it can only be honest about.

**Apply a suggestion.** GitHub has no API for this — their button is web-only — so the commit is written here: read the file at the head of the branch, splice the suggested lines in, and commit through `createCommitOnBranch`, which produces a **verified** commit where a local push would not. `expectedHeadOid` is the guard: if anyone pushed between the read and the write, GitHub refuses rather than clobbering them, and the error says so in those words. The suggester is credited as a **co-author**, as GitHub does. Forks are handled, and refused when maintainer-can-modify is off. An **outdated** thread offers no button at all — its lines have moved, so the range no longer points where it meant.

**Expand context.** A diff only carries the three lines around a change, so the code above it is not in the payload and there was nothing to reveal locally. Each chevron now asks the server for that slice of the file at this side of the pull request, twenty lines at a time.

**Image diffs.** A unified diff cannot say anything about a PNG — the file just read *"no textual diff"*. Both sides are fetched and shown side by side, which is the only question an image change raises. Added and deleted files show one side; SVG renders as the image it is rather than as its markup.

**Files in the composer.** A text file dropped or pasted is inserted as a fenced code block. An **image cannot be**, and the panel says why rather than inventing somewhere to put the bytes: GitHub has **no public attachment-upload API** — verified, there is no attachments endpoint and no gist mutation to stand in for it — so it offers the one thing that does work, opening the PR on GitHub to attach it there. Committing screenshots into the repository would not have been a favour.

## How was it tested?

- `bunx tsc --noEmit` in `server/` and `web/`; `bun test` (**server 671**, **web 345**); `bunx vite build`; `bun scripts/smoke.ts`.
- **5 new tests** pin the line arithmetic that rewrites somebody's file — single line, range, both ends, an empty suggestion (which means *delete these lines*), and a preserved trailing newline. An off-by-one there eats a line silently rather than failing.
- `fileSlice` exercised live against this repository: text on both sides, an SVG, and a path that is not there.

---

<sub>CI runs typecheck, tests and the production build for you. If you changed the server↔web contract update `shared/types.ts`; if behavior or config changed, update the docs. See [CONTRIBUTING.md](../CONTRIBUTING.md).</sub>
