### PR TITLE
fix(prs): let a body fill the card it was given

### DIFF
--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -176,9 +176,13 @@ export const MD_CSS = `
 .agx-btn:active:not(:disabled){transform:translateY(1px) scale(.99)}
 .agx-btn:focus-visible{outline:2px solid var(--primary);outline-offset:2px}
 .agx-btn[data-busy]{pointer-events:none;opacity:.6}
-/* margin:0, not "0 auto". The measure is still capped for reading, but a
-   centred column inside a card sets the body 380px away from the author name
-   above it, which reads as a layout fault rather than as typography. */
+/* A body fills the box it was given. There used to be a 78ch measure here,
+   borrowed from prose typography, and it was the wrong rule twice over: this
+   panel renders in a monospace face, so ch is a fixed pixel wall (measured at
+   584px) rather than a measure that breathes, and it left a third of a card
+   empty beside text that stopped in mid-air. GitHub caps nothing here either,
+   so the same pull request read narrower in the app than on the page it came
+   from. Reading comfort on a wide display is what the panel width is for. */
 /* One timeline, one rail. The node says what kind of thing happened; the
    rail says they happened in an order. */
 .agx-tl{position:relative;padding-left:26px}
@@ -209,7 +213,7 @@ export const MD_CSS = `
 .agx-hl pre{margin:0;padding:10px 12px;border-radius:8px;overflow-x:auto;background:color-mix(in srgb,#000 42%,transparent) !important;border:1px solid color-mix(in srgb,var(--border) 30%,transparent)}
 .agx-hl code{font-size:11.5px;line-height:1.65}
 .agx-md .agx-hl{margin:0 0 .85em}
-.agx-md{max-width:78ch;margin:0;line-height:1.7;font-size:12.5px;color:var(--text2)}
+.agx-md{margin:0;line-height:1.7;font-size:12.5px;color:var(--text2)}
 .agx-md>*:first-child{margin-top:0}
 .agx-md>*:last-child{margin-bottom:0}
 .agx-md p{margin:0 0 .85em}


### PR DESCRIPTION
## What does this PR do?

The description and every rendered comment in the PR panel stopped at 584px inside a card three times that wide, leaving a column of empty space beside text that broke in mid-air. The same pull request read narrower in the app than on the page it came from.

`.agx-md` carried `max-width:78ch`. That is a prose measure, borrowed into a surface that renders in a monospace face, where `ch` is not a measure that breathes with the type but a fixed pixel wall: 78 of them at 12.5px is 584.6px, which is exactly what the element measured in devtools. GitHub caps nothing in a comment body, and this panel invites that comparison directly.

One line removed, and the comment above it rewritten, since it still argued for keeping a measure that had stopped earning its place.

This reaches every body the panel renders through `Md`, not only the description: review comments, thread replies and timeline comments all use `.agx-md`, and all of them now match the card. Narrow layouts are unaffected, since the container was already below the old cap there.

## How was it tested?

- `bunx tsc --noEmit` in `web/`, clean. Full suite: 1021 pass, 0 fail, re-run green after merging latest `main`.
- Built and installed locally, then read a real pull request in the panel: description, comments and threads all run the full width of the card.
- Confirmed the cause by measurement rather than by eye: `div.agx-md` reported 584.6px wide inside a wider parent, matching `78ch` at the panel's font size.