### PR TITLE
fix(chat): closing a chat gives its tmux pane back

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -60,7 +60,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, type PtyWsData } from "./terminal.ts";
 import { chatSend, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
-import { paneAlive, startPaneSweeper } from "./tmuxpane.ts";
+import { paneAlive, killPane, forgetPane, startPaneSweeper } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, inScope } from "./config.ts";
 import { hookStatus, applyHooks } from "./hooksetup.ts";
@@ -1101,6 +1101,21 @@ const server = Bun.serve<WsData>({
     // The command that hands a chat to the user's own terminal. Server-side
     // because the socket name and flags are the engine's business, and a string
     // the UI assembled itself would drift the first time either changed.
+    // Closing a chat gives its warm CLI back. Safe because it destroys nothing:
+    // the conversation is on disk in the transcript, and resuming relaunches the
+    // pane with `--resume`. Without this the ~380MB sits there until the idle
+    // sweeper notices, half an hour after you said you were done with it.
+    if (pathname === "/chat/pane/close" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: any = {};
+      try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
+      const id = typeof b.session === "string" ? b.session : "";
+      if (!validPaneName(id)) return json({ error: "invalid session id" }, 400);
+      const was = await paneAlive(id);
+      if (was) await killPane(id);
+      forgetPane(id);
+      return json({ killed: was });
+    }
     if (pathname === "/chat/attach") {
       const id = url.searchParams.get("session") || "";
       const pane = paneEngineCapability();

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -16,6 +16,7 @@ import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
 import { ToolFeed } from "./ToolFeed.tsx";
+import { useDialogs } from "./ConfirmDialog.tsx";
 import { buildRows } from "../lib/toolTree.ts";
 import { chatToMarkdown } from "../lib/chatTranscript.ts";
 import { fmtTime } from "../lib/format.ts";
@@ -489,6 +490,8 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   const [activeId, setActiveId] = useState(restoredActiveId);
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [enabled, setEnabled] = useState(true);
+  // Only used on one path: closing a chat that is still mid-turn.
+  const { ask, dialog } = useDialogs();
   // The server silently downgrades bypassPermissions unless the operator opted
   // in (AGENTGLASS_CHAT_BYPASS=1) — don't offer a mode that wouldn't stick.
   const [bypassAllowed, setBypassAllowed] = useState(false);
@@ -658,11 +661,27 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [active]);
 
-  const drop = useCallback((id: string) => {
-    const rest = listChats().filter((c) => c.id !== id);
+  const drop = useCallback(async (id: string) => {
+    // Closing a chat also releases its tmux pane, which costs nothing when the
+    // chat is idle — the transcript survives and Resume relaunches it. Mid-turn
+    // is the one case that throws away real work: the agent may be halfway
+    // through editing files or running a build, and nothing else in the app
+    // would say so. Ask, and only here.
+    const c = getChat(id);
+    if (c?.sending) {
+      const ok = await ask({
+        title: "Close this chat while it is still working?",
+        body: `"${c.title}" has a turn in progress. Closing stops it, and anything it was part-way through is left as it is.\n\nThe conversation itself is kept — you can pick it back up from Resume.`,
+        confirmLabel: "Close and stop",
+        cancelLabel: "Keep it open",
+        danger: true,
+      });
+      if (!ok) return;
+    }
+    const rest = listChats().filter((x) => x.id !== id);
     closeChat(id);
     if (activeIdRef.current === id) setActiveId(rest[rest.length - 1]?.id ?? "");
-  }, []);
+  }, [ask]);
 
   const submit = () => {
     if (!active) return;
@@ -1204,6 +1223,9 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                   </div>
                 </div>
                 </div>
+      {/* The mid-turn close confirmation. Mounted here so it renders whether or
+          not the panel is the active view. */}
+      {dialog}
     </div>
   );
 }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -447,6 +447,9 @@ const realApi = {
    *  pane is up right now. Assembled server-side so the socket name never has to
    *  be duplicated here. */
   chatAttach: (session: string) => get<{ command: string; live: boolean }>(`/chat/attach?session=${encodeURIComponent(session)}`),
+  /** Give a chat's warm CLI back. Destroys no conversation — the transcript
+   *  stays on disk and resuming relaunches the pane with `--resume`. */
+  chatPaneClose: (session: string) => post<{ killed: boolean }>("/chat/pane/close", { session }),
   chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
     let res: Response;
     // A fetch that throws before a response has arrived never reached the
@@ -584,6 +587,7 @@ const demoApi: typeof realApi = {
   terminalCommands: (_root: string) => D({ enabled: false, make: [], scripts: [] } as TerminalCommands),
   chatEnabled: () => D({ enabled: false, tmuxEngine: { available: false, reason: "the demo runs no local processes", defaultOn: false } }),
   chatAttach: (_session: string) => D({ command: "", live: false }),
+  chatPaneClose: (_session: string) => D({ killed: false }),
   chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine }, onEvent: (o: Record<string, unknown>) => void) => {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -558,6 +558,27 @@ export function closeChat(id: string) {
   const c = chats.get(id);
   if (!c) return;
   c.abort?.abort(); // a closed tab must not keep a stream running
+  /*
+   * Give the pane engine's warm CLI back.
+   *
+   * Closing a tab is the clearest "done with this" there is, and a pane holds
+   * ~380MB for as long as it lives. Left alone it survives until the idle
+   * sweeper reaches it half an hour later, which is a long time to hold memory
+   * for a chat the user has already dismissed — and it is visible: `tmux -L
+   * agentglass ls` keeps listing sessions for chats that are gone.
+   *
+   * Done without asking because it destroys nothing. The conversation is on
+   * disk in the session's transcript; Resume brings it back and relaunches the
+   * pane with `--resume`. The only thing thrown away is the warm process, which
+   * costs one slower turn to rebuild. A confirmation for that would be a dialog
+   * on every close for a decision with no downside — the one case that DOES
+   * lose work, closing mid-turn, is confirmed by the caller instead.
+   *
+   * Fire and forget: a chat must close instantly whether or not the server is
+   * reachable, and a pane nobody reclaimed is exactly the state the idle
+   * sweeper already exists to handle.
+   */
+  if (c.sessionId && c.engine === "tmux") void api.chatPaneClose(c.sessionId).catch(() => {});
   for (const a of c.attachments) URL.revokeObjectURL(a.url);
   chats.delete(id);
   emit();

--- a/web/test/chat-close-pane.test.ts
+++ b/web/test/chat-close-pane.test.ts
@@ -1,0 +1,87 @@
+// Closing a chat gives its warm CLI back.
+//
+// A pane holds ~380MB for as long as it lives, and closing the tab is the
+// clearest "done with this" there is. Left alone the pane survived until the
+// idle sweeper reached it half an hour later, which was visible from outside —
+// `tmux -L agentglass ls` kept listing sessions for chats that no longer
+// existed, which is what prompted this.
+import { test, expect, beforeAll, beforeEach } from "bun:test";
+
+const cell = new Map<string, string>();
+let store: typeof import("../src/lib/chatStore.ts");
+let api: typeof import("../src/lib/api.ts")["api"];
+let closed: string[];
+
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  // Assigned, not `??=`. Several other test files install a NO-OP localStorage
+  // (`setItem: () => {}`), and under `bun test` all of them share one process —
+  // so whichever loads first decides whether writes here go anywhere at all.
+  // This test reads back what it writes, so it has to own the store.
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  api = (await import("../src/lib/api.ts")).api;
+  store = await import("../src/lib/chatStore.ts");
+});
+
+beforeEach(() => {
+  closed = [];
+  api.chatPaneClose = ((session: string) => {
+    closed.push(session);
+    return Promise.resolve({ killed: true });
+  }) as typeof api.chatPaneClose;
+  for (const c of store.listChats()) store.closeChat(c.id);
+  closed = [];
+});
+
+test("closing a pane chat releases its pane", () => {
+  const c = store.newChat("/repo");
+  store.update(c.id, (x) => { x.engine = "tmux"; x.sessionId = "6f1c9b52-0000-4000-8000-0123456789ab"; });
+  store.closeChat(c.id);
+  expect(closed).toEqual(["6f1c9b52-0000-4000-8000-0123456789ab"]);
+});
+
+test("a chat on the old engine asks the server for nothing", () => {
+  // `claude -p` leaves no process between turns, so there is nothing to release
+  // and a request would be pure noise on every close.
+  const c = store.newChat("/repo");
+  store.update(c.id, (x) => { x.engine = "process"; x.sessionId = "6f1c9b52-0000-4000-8000-0123456789ab"; });
+  store.closeChat(c.id);
+  expect(closed).toEqual([]);
+});
+
+test("a pane chat that never ran has no pane to release", () => {
+  // No session means the pane was never launched. Asking to kill it would be a
+  // request for a name the server has never heard of.
+  const c = store.newChat("/repo");
+  store.update(c.id, (x) => { x.engine = "tmux"; });
+  store.closeChat(c.id);
+  expect(closed).toEqual([]);
+});
+
+test("the chat closes even when the server cannot be reached", async () => {
+  // The tab must never hang on a cleanup call. A pane nobody reclaimed is
+  // exactly what the idle sweeper already exists for.
+  api.chatPaneClose = (() => Promise.reject(new Error("down"))) as typeof api.chatPaneClose;
+  const c = store.newChat("/repo");
+  store.update(c.id, (x) => { x.engine = "tmux"; x.sessionId = "6f1c9b52-0000-4000-8000-0123456789ab"; });
+  store.closeChat(c.id);
+  expect(store.getChat(c.id)).toBeUndefined();
+  // And the rejection is swallowed rather than surfacing as an unhandled one.
+  await Promise.resolve();
+});
+
+test("closing still stops a turn that was streaming", () => {
+  // Unchanged behaviour, pinned because the close path grew a second job and
+  // this is the one that was already load-bearing.
+  const c = store.newChat("/repo");
+  let aborted = false;
+  const ac = new AbortController();
+  ac.signal.addEventListener("abort", () => { aborted = true; });
+  store.update(c.id, (x) => { x.abort = ac; x.sending = true; });
+  store.closeChat(c.id);
+  expect(aborted).toBe(true);
+});

--- a/web/test/chat-engine-pick.test.ts
+++ b/web/test/chat-engine-pick.test.ts
@@ -15,7 +15,11 @@ let setChatEnginePref: typeof import("../src/lib/chatEnginePref.ts")["setChatEng
 let KEY: string;
 beforeAll(async () => {
   (globalThis as any).location ??= new URL("http://localhost:5173/");
-  (globalThis as any).localStorage ??= {
+  // Assigned, not `??=`. Several other test files install a NO-OP localStorage
+  // (`setItem: () => {}`), and under `bun test` all of them share one process —
+  // so whichever loads first decides whether writes here go anywhere at all.
+  // This test reads back what it writes, so it has to own the store.
+  (globalThis as any).localStorage = {
     getItem: (k: string) => cell.get(k) ?? null,
     setItem: (k: string, v: string) => { cell.set(k, v); },
     removeItem: (k: string) => { cell.delete(k); },


### PR DESCRIPTION
## What does this PR do?

Reported straight after #325 landed: with the pane engine on, `tmux -L agentglass ls` keeps listing sessions for chats that have been closed. It does — a pane held its warm `claude` (~380MB, growing with use) until the idle sweeper reached it half an hour later.

Closing a chat now releases its pane, and does it **without asking**, because it destroys nothing: the conversation lives in the session's transcript on disk, and Resume brings it back and relaunches with `--resume`. The only thing thrown away is the warm process, worth one slower turn. A confirmation for that would be a dialog on every close for a decision with no downside.

The one close that *does* lose work is mid-turn — the agent may be part-way through an edit or a build, and nothing in the app said so. That one asks, and only that one.

The release is fire-and-forget: a tab must close instantly whether or not the server answers, and a pane nobody reclaimed is exactly the state the idle sweeper already exists to handle.

**Also fixes a latent flake this exposed rather than caused.** Several web tests install a no-op `localStorage` with `??=`, and `bun test` shares one process — so whichever file loads first decides whether writes go anywhere at all. Adding a test file reordered them and #325's engine-preference tests started reading back nothing (they pass alone, and passed in their own CI run). The two files that read back what they write now own their store. Same class as #315 / #319 / #321.

New endpoint: `POST /chat/pane/close`, guarded by the same uuid-shaped pane-name check as `/chat/attach`.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/` and `server/`; full suite **1026 pass / 0 fail** (and the two tests that had started failing are green again for the right reason, not by reordering).
- 5 new tests in `web/test/chat-close-pane.test.ts`: a pane chat releases its pane; a `process` chat asks the server for nothing; a pane chat that never ran has no pane to release; the tab still closes when the server is unreachable, with the rejection swallowed; and closing still aborts a streaming turn, which is the behaviour that was already load-bearing on this path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)