### PR TITLE
fix(prs): say what to do when "Merge when green" is refused

### DIFF
--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -2139,6 +2139,22 @@ export async function rerunFailedChecks(rootIn: unknown, number: unknown): Promi
  * would merge a commit you never saw. The caller passes the head it showed you,
  * and GitHub refuses if that is no longer the tip.
  */
+/**
+ * What "Merge when green" actually means when it fails.
+ *
+ * gh relays GitHub's GraphQL error verbatim: "Auto merge is not allowed for
+ * this repository (enablePullRequestAutoMerge)". Every word of that is true
+ * and none of it is actionable in the panel it lands in. The setting is not
+ * anything about this pull request, it is a repository option that is off by
+ * default, and the person reading the message is the person who can turn it
+ * on. Say where it lives instead of quoting the mutation that failed.
+ */
+export function autoMergeHint(error: string): string | null {
+  return /auto[- ]?merge is not allowed/i.test(error)
+    ? "auto-merge is off for this repository: turn on Settings > General > Pull requests > Allow auto-merge, then arm it again"
+    : null;
+}
+
 export async function mergePr(rootIn: unknown, number: unknown, method: unknown, opts: { deleteBranch?: unknown; auto?: unknown; headSha?: unknown; subject?: unknown; body?: unknown; disableAuto?: unknown }): Promise<PrActionResult> {
   // Cancelling an armed auto-merge is its own verb, not a merge with a flag —
   // and it was missing entirely, so a "merge when green" could be armed and
@@ -2149,7 +2165,8 @@ export async function mergePr(rootIn: unknown, number: unknown, method: unknown,
   const flag = method === "merge" ? "--merge" : method === "rebase" ? "--rebase" : method === "squash" ? "--squash" : null;
   if (!flag) return { ok: false, error: "choose squash, merge or rebase" };
   const args = ["pr", "merge", String(Number(number)), flag];
-  if (opts.auto === true || opts.auto === "true") args.push("--auto");
+  const auto = opts.auto === true || opts.auto === "true";
+  if (auto) args.push("--auto");
   if (opts.deleteBranch === true || opts.deleteBranch === "true") args.push("--delete-branch");
   if (typeof opts.headSha === "string" && /^[0-9a-f]{7,40}$/i.test(opts.headSha)) args.push("--match-head-commit", opts.headSha);
   // The commit this writes onto the base branch is permanent and public; being
@@ -2159,7 +2176,12 @@ export async function mergePr(rootIn: unknown, number: unknown, method: unknown,
     if (typeof opts.subject === "string" && opts.subject.trim()) args.push("--subject", opts.subject.trim());
     if (typeof opts.body === "string" && opts.body.trim()) args.push("--body", opts.body);
   }
-  return runPr(rootIn, Number(number), args);
+  const res = await runPr(rootIn, Number(number), args);
+  if (!res.ok && auto) {
+    const hint = autoMergeHint(res.error || "");
+    if (hint) return { ...res, error: hint };
+  }
+  return res;
 }
 
 export async function closePr(rootIn: unknown, number: unknown, reopen = false): Promise<PrActionResult> {

--- a/server/test/prs.test.ts
+++ b/server/test/prs.test.ts
@@ -323,6 +323,32 @@ describe("asset proxy allowlist", () => {
   });
 });
 
+describe("arming auto-merge on a repository that has it switched off", () => {
+  /**
+   * The error the panel used to show was gh quoting the failed mutation:
+   * "Auto merge is not allowed for this repository (enablePullRequestAutoMerge)".
+   * Accurate, and it leaves the reader looking for a setting on the pull
+   * request that is actually a repository option.
+   */
+  test("names the setting and where it lives", () => {
+    const hint = prs.autoMergeHint("GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)");
+    expect(hint).toContain("Allow auto-merge");
+    expect(hint).toContain("Settings");
+  });
+
+  test("matches the hyphenated wording too, since GitHub has used both", () => {
+    expect(prs.autoMergeHint("auto-merge is not allowed for this repository")).not.toBeNull();
+  });
+
+  /** Every other merge failure must reach the user unchanged: "not mergeable",
+   *  a head that moved, a protected branch. Rewriting those would hide them. */
+  test("leaves any other failure alone", () => {
+    expect(prs.autoMergeHint("Pull request is not mergeable")).toBeNull();
+    expect(prs.autoMergeHint("failed to run git: exit status 1")).toBeNull();
+    expect(prs.autoMergeHint("")).toBeNull();
+  });
+});
+
 describe("who may see the GitHub token", () => {
   /**
    * Narrower than the fetch allowlist on purpose: being allowed to serve us an


### PR DESCRIPTION
## What does this PR do?

Pressing **Merge when green** put this in the panel:

```
GraphQL: Auto merge is not allowed for this repository (enablePullRequestAutoMerge)
```

That is gh relaying GitHub's mutation error word for word. Every word is true, and it sends the reader hunting for a setting on the pull request. There is no such setting: auto-merge is a repository option, off by default, under Settings > General > Pull requests. The person reading the message in the panel is usually the person who can turn it on, so the message now says that instead of naming the mutation that failed.

Deliberately narrow. `autoMergeHint` only rewrites this one refusal, and only when `--auto` was actually asked for. Everything else reaches the user exactly as GitHub phrased it, because "Pull request is not mergeable" and a head commit that moved are precisely the errors that must not be paraphrased.

(The repository this was found on has had `allow_auto_merge` switched on, so the button works there now. This is for the next person, and for the same repository if the option is ever turned back off.)

## How was it tested?

- `bunx tsc --noEmit` in `server/`, clean. Full suite: 1029 pass, 0 fail.
- Three new tests in `server/test/prs.test.ts`: the refusal is rewritten and names both the setting and where it lives, the hyphenated spelling GitHub also uses is matched, and every other failure (`not mergeable`, a git error, an empty string) passes through untouched.
- Confirmed the cause against the live API first: `allow_auto_merge` read back `false` on the repository while all six checks were passing, which is exactly the state that produces this error.