### PR TITLE
fix(chat): end a pane turn on state, not on a list of slash commands

### DIFF
--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -314,9 +314,23 @@ export interface PaneTurnOptions {
  *  different string and deliberately not matched here. */
 const NEEDS_YOU_RE = /Esc to cancel|Enter to confirm|to use this session only/;
 export const __needsYou = (screen: string): boolean => NEEDS_YOU_RE.test(screen);
+export const __isRunning = (screen: string): boolean => RUNNING_RE.test(screen);
+
+/** A turn that is actually working says so. Used to tell "idle" apart from
+ *  "thinking", which is the difference between ending a turn and abandoning it. */
+const RUNNING_RE = /esc to interrupt/i;
 
 /** How often to look at the screen while a turn has produced nothing at all. */
 const NEEDS_YOU_PROBE_MS = 4_000;
+
+/** Consecutive idle probes before a turn that never started is called over.
+ *
+ *  Two, so ~8s of an empty box with nothing running and not one byte written.
+ *  The margin is affordable because the signal underneath is already strong: a
+ *  real turn writes its own user message to the transcript within a few hundred
+ *  milliseconds of being submitted (measured ~220ms), so `grew` is true almost
+ *  immediately for anything that is genuinely a turn. */
+const IDLE_PROBES_TO_END = 2;
 
 /** How long a turn may go with no transcript growth at all before we check
  *  whether the pane is still alive. Long turns are silent for minutes at a time
@@ -406,12 +420,14 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
         // cost frame can be priced. The `-p` engine gets this handed to it by
         // the CLI; here it is ours to compute.
         let inTok = 0, outTok = 0, cacheW = 0, cacheR = 0;
+        const startedAt = Date.now();
         let carry = "";
         let lastGrowth = Date.now();
         // Whether this turn has produced a single byte. An interactive prompt
         // produces none, ever, which is what tells it apart from a slow one.
         let grew = false;
         let lastProbe = Date.now();
+        let idleProbes = 0;
 
         for (;;) {
           if (cancelled) return;
@@ -468,6 +484,40 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
               });
               controller.close();
               return;
+            }
+            /*
+             * Nothing written, nothing running, nothing asking. The CLI handled
+             * this itself and went back to the prompt.
+             *
+             * `/clear` and `/compact` do exactly this — verified: no
+             * `turn_duration`, no picker hints, not running — and so, presumably,
+             * do commands that do not exist yet. Enumerating them is a race
+             * nobody wins, which is why this is a state check rather than a list:
+             * a turn that produced no transcript and left the pane idle is over,
+             * whatever it was called.
+             */
+            const running = RUNNING_RE.test(screen);
+            const box = inputBox(screen);
+            if (!running && !box?.trim()) {
+              if (++idleProbes >= IDLE_PROBES_TO_END) {
+                emit({
+                  type: "assistant",
+                  message: {
+                    role: "assistant",
+                    content: [{
+                      type: "text",
+                      text: "_This ran inside the chat's tmux pane and produced no conversation — commands like "
+                        + "`/clear` and `/compact` are handled by the CLI itself. To see what it did, open the pane:_\n\n"
+                        + "```\n" + attachCommand(sessionId) + "\n```",
+                    }],
+                  },
+                });
+                emit({ type: "result", subtype: "success", total_cost_usd: 0, duration_ms: Date.now() - startedAt });
+                controller.close();
+                return;
+              }
+            } else {
+              idleProbes = 0;
             }
           } else if (Date.now() - lastGrowth > STALL_CHECK_MS) {
             // Silence is normal — a long tool call says nothing for minutes. What

--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -110,7 +110,7 @@ const INPUT_ROWS = /^❯(.*)$/gm;
 /** What is typed in the live input box right now, or `null` if it is not on
  *  screen at all (the TUI redraws while a turn runs). Note the box renders its
  *  empty state with U+00A0, which `\s` covers. */
-function inputBox(screen: string): string | null {
+export function inputBox(screen: string): string | null {
   let last: string | null = null;
   for (const m of screen.matchAll(INPUT_ROWS)) last = m[1];
   return last;
@@ -128,23 +128,27 @@ function inputBox(screen: string): string | null {
  *  Polling the box rather than sleeping a magic number: the wait is over when
  *  the thing we are waiting for has happened, on a fast machine and a slow one
  *  alike. */
-async function waitPasted(name: string, deadline: number): Promise<boolean> {
+async function waitPasted(name: string, deadline: number): Promise<string | null> {
   for (;;) {
     const box = inputBox(await capture(name));
-    if (box?.trim()) return true;
-    if (Date.now() > deadline) return false;
+    // Returned rather than merely confirmed: what the box looks like holding
+    // our prompt is the reference submitConfirmed compares against, and it is
+    // not always the prompt itself — a multi-line paste renders as
+    // "[Pasted text #1 +3 lines]".
+    if (box?.trim()) return box;
+    if (Date.now() > deadline) return null;
     await Bun.sleep(60);
   }
 }
 
-/** Is the input box empty — i.e. did the prompt get taken?
+/** What happened to the prompt we submitted.
  *
- *  Absence of the row counts as taken: while a turn runs the TUI redraws and the
- *  prompt row can be off the captured screen entirely. */
-async function boxEmpty(name: string): Promise<boolean> {
-  const box = inputBox(await capture(name));
-  return !box?.trim();
-}
+ *  `sent` — the box emptied, the CLI took it.
+ *  `diverted` — the box holds something that is not our prompt any more. In
+ *    practice this means an interactive command opened a picker: `/model`,
+ *    `/effort`, `/config` do not run a turn, they draw a menu.
+ *  `stuck` — still our text, still not taken, out of time. */
+type SubmitOutcome = "sent" | "diverted" | "stuck";
 
 /** Press Enter until the prompt is actually accepted.
  *
@@ -159,14 +163,28 @@ async function boxEmpty(name: string): Promise<boolean> {
  *  retry safe — the worst case of racing a submit that did land is a keystroke
  *  that does nothing. A fixed sleep was the alternative and it would have been a
  *  guess that silently drops turns on a slower machine. */
-async function submitConfirmed(name: string, deadline: number): Promise<boolean> {
+async function submitConfirmed(name: string, pasted: string, deadline: number): Promise<SubmitOutcome> {
   for (;;) {
     await submit(name);
     // Long enough for the TUI to redraw after accepting, short enough that the
     // common case (accepted on the second press) is not perceptibly slower.
     await Bun.sleep(250);
-    if (await boxEmpty(name)) return true;
-    if (Date.now() > deadline) return false;
+    const box = inputBox(await capture(name));
+    if (!box?.trim()) return "sent";
+    /*
+     * Only keep pressing while the box still holds OUR prompt.
+     *
+     * This guard is the whole reason the retry is safe. Claude Code's pickers
+     * draw their selection cursor with the same `❯` glyph as the input box, so
+     * a `/model` menu reads as "box still full" — and in that menu Enter means
+     * "set as default". Retrying blindly walked straight into changing the
+     * user's saved model and effort, silently, from a chat that appeared to be
+     * hanging. Verified by reproducing it: a second Enter after `/effort`
+     * printed "Set effort level to xhigh (saved as your default for new
+     * sessions)".
+     */
+    if (box.trim() !== pasted.trim()) return "diverted";
+    if (Date.now() > deadline) return "stuck";
   }
 }
 
@@ -283,6 +301,23 @@ export interface PaneTurnOptions {
   images: { mediaType: string; data: string }[];
 }
 
+/** The footer Claude Code draws under an interactive prompt.
+ *
+ *  `/model`, `/effort` and `/config` do not run a turn — they draw a picker and
+ *  wait for arrow keys. Nothing is ever written to the transcript, so a turn
+ *  waiting for it waits forever, which is exactly how this was reported: a chat
+ *  stuck on `/effort` with no way out.
+ *
+ *  Matched on the picker's own key hints rather than its title, because those
+ *  are shared by every picker and are what make it a prompt at all. Careful not
+ *  to catch a running turn: that one says "esc to interrupt", which is a
+ *  different string and deliberately not matched here. */
+const NEEDS_YOU_RE = /Esc to cancel|Enter to confirm|to use this session only/;
+export const __needsYou = (screen: string): boolean => NEEDS_YOU_RE.test(screen);
+
+/** How often to look at the screen while a turn has produced nothing at all. */
+const NEEDS_YOU_PROBE_MS = 4_000;
+
 /** How long a turn may go with no transcript growth at all before we check
  *  whether the pane is still alive. Long turns are silent for minutes at a time
  *  while a tool runs, so this is a liveness check, not a deadline. */
@@ -330,13 +365,39 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
         const pasted = await pasteText(sessionId, panePrompt(message, paths));
         if (!pasted.ok) { fail(pasted.stderr.trim() || "could not write the prompt into the pane"); controller.close(); return; }
         // Enter only once the text is demonstrably in the box; see waitPasted.
-        if (!(await waitPasted(sessionId, Date.now() + PASTE_TIMEOUT_MS))) {
+        const pastedBox = await waitPasted(sessionId, Date.now() + PASTE_TIMEOUT_MS);
+        if (pastedBox === null) {
           fail("the prompt never landed in the chat pane's input box");
           controller.close();
           return;
         }
-        if (!(await submitConfirmed(sessionId, Date.now() + PASTE_TIMEOUT_MS))) {
+        const outcome = await submitConfirmed(sessionId, pastedBox, Date.now() + PASTE_TIMEOUT_MS);
+        if (outcome === "stuck") {
           fail("the chat pane would not accept the prompt");
+          controller.close();
+          return;
+        }
+        if (outcome === "diverted") {
+          /*
+           * The CLI is showing something that wants a person, not a turn.
+           *
+           * `/model`, `/effort` and `/config` draw a picker and never run a
+           * turn, so waiting for the transcript to grow would wait forever —
+           * which is exactly how this was reported: a chat spinning on `/effort`
+           * that could not be got out of.
+           *
+           * The picker is deliberately left open rather than cancelled with
+           * Escape. The user asked for it; throwing it away to tidy up would
+           * discard what they wanted. Instead, hand them the way in.
+           */
+          const screen = (await capture(sessionId)).split("\n").filter((l) => l.trim()).slice(-12).join("\n");
+          emit({
+            type: "agx_error",
+            code: null,
+            errorType: "pane_needs_you",
+            error: `This opened an interactive prompt in the chat's tmux pane, which the chat cannot draw. `
+              + `It is still open and waiting — finish it in your terminal:\n\n${attachCommand(sessionId)}\n\n${screen}`,
+          });
           controller.close();
           return;
         }
@@ -347,12 +408,17 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
         let inTok = 0, outTok = 0, cacheW = 0, cacheR = 0;
         let carry = "";
         let lastGrowth = Date.now();
+        // Whether this turn has produced a single byte. An interactive prompt
+        // produces none, ever, which is what tells it apart from a slow one.
+        let grew = false;
+        let lastProbe = Date.now();
 
         for (;;) {
           if (cancelled) return;
           const size = await sizeOf(path);
           if (size > offset) {
             lastGrowth = Date.now();
+            grew = true;
             const chunk = await Bun.file(path).slice(offset, size).text();
             offset = size;
             const lines = (carry + chunk).split("\n");
@@ -382,6 +448,26 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
                 cacheR += Number(u.cache_read_input_tokens) || 0;
               }
               emit(o);
+            }
+          } else if (!grew && Date.now() - lastProbe > NEEDS_YOU_PROBE_MS) {
+            lastProbe = Date.now();
+            const screen = await capture(sessionId);
+            if (NEEDS_YOU_RE.test(screen)) {
+              /*
+               * Left open rather than cancelled with Escape. The user asked for
+               * this prompt; throwing it away to tidy up would discard what
+               * they wanted. Hand them the way in instead.
+               */
+              const tail = screen.split("\n").filter((l) => l.trim()).slice(-14).join("\n");
+              emit({
+                type: "agx_error",
+                code: null,
+                errorType: "pane_needs_you",
+                error: "This opened an interactive prompt in the chat's tmux pane, which the chat cannot draw. "
+                  + `It is still open and waiting for you — finish it in your terminal:\n\n${attachCommand(sessionId)}\n\n${tail}`,
+              });
+              controller.close();
+              return;
             }
           } else if (Date.now() - lastGrowth > STALL_CHECK_MS) {
             // Silence is normal — a long tool call says nothing for minutes. What

--- a/server/test/chat-pane.test.ts
+++ b/server/test/chat-pane.test.ts
@@ -117,3 +117,59 @@ test("tmux availability is reported with a reason a person can act on", () => {
   // the settings row prints this string verbatim.
   if (!cap.available) expect(cap.reason.length).toBeGreaterThan(0);
 });
+
+// --- interactive commands ---------------------------------------------------
+// `/model`, `/effort` and `/config` do not run a turn; they draw a picker. Two
+// things went wrong with that, and the second was the dangerous one.
+
+/** A real `/model` picker, captured from a live pane. Note the selection cursor:
+ *  the picker draws it with the SAME `❯` glyph the input box uses. */
+const MODEL_PICKER = [
+  "   Select model",
+  "   Switch between Claude models. Your pick becomes the default for new sessions.",
+  "     1. Default (recommended)  Opus 5 with 1M context",
+  "     4. Sonnet                 Sonnet 5 · Efficient for routine tasks",
+  "   ❯ 5. Haiku ✔                Haiku 4.5 · Fastest for quick answers",
+  "   Enter to set as default · s to use this session only · Esc to cancel",
+].join("\n");
+
+/** The ordinary case: history above, the live box last. */
+const NORMAL = [
+  "❯ Say hello",
+  "  ⎿  did the thing",
+  "● hello",
+  "────────────",
+  "❯ ",
+].join("\n");
+
+test("the live input box is the last prompt row, not the first", () => {
+  // A submitted prompt stays on screen with the same glyph, so reading the
+  // first match reported failure on a turn that had already answered.
+  expect(mod.inputBox(NORMAL)?.trim()).toBe("");
+});
+
+test("a picker's indented cursor is not read as the input box", () => {
+  // The picker draws its cursor with the same `❯` glyph, but indented, so the
+  // box detector ignores it. That is why the submit retry did not walk the menu
+  // — worth pinning, because a picker that ever drew its cursor at column 0
+  // would turn every retried Enter into a menu selection.
+  expect(mod.inputBox(MODEL_PICKER)).toBeNull();
+});
+
+test("an interactive prompt is recognised from its key hints", () => {
+  // This is what stops the turn hanging: `/model`, `/effort` and `/config`
+  // never write to the transcript, so without this the chat waits forever.
+  expect(mod.__needsYou(MODEL_PICKER)).toBe(true);
+});
+
+test("a running turn is not mistaken for an interactive prompt", () => {
+  // A turn in flight says "esc to interrupt"; a picker says "Esc to cancel".
+  // Confusing the two would abandon every long turn four seconds in.
+  expect(mod.__needsYou("● working…\n✻ Brewed for 12s (esc to interrupt)")).toBe(false);
+});
+
+test("a screen with no prompt row at all reads as taken", () => {
+  // While a turn runs the TUI redraws and the prompt row can be off-screen
+  // entirely; that must count as accepted rather than as a lost prompt.
+  expect(mod.inputBox("● working…\n✻ Brewed for 2s")).toBeNull();
+});

--- a/server/test/chat-pane.test.ts
+++ b/server/test/chat-pane.test.ts
@@ -173,3 +173,31 @@ test("a screen with no prompt row at all reads as taken", () => {
   // entirely; that must count as accepted rather than as a lost prompt.
   expect(mod.inputBox("● working…\n✻ Brewed for 2s")).toBeNull();
 });
+
+/** `/clear` leaves no trace at all: nothing written, no picker, not running.
+ *  Captured from a live pane — this is the case that enumerating commands
+ *  would always have missed. */
+const IDLE_AFTER_LOCAL_COMMAND = [
+  "▐▛███▜▌   Claude Code v2.1.220",
+  "────────────",
+  "❯ ",
+  "────────────",
+  "  ⏵⏵ bypass permissions on (shift+tab to cycle)",
+].join("\n");
+
+test("a pane that went quiet with nothing written is idle, not working", () => {
+  // The general rule the picker check cannot cover: `/clear` and `/compact`
+  // produce no turn, no hints and no activity. A turn waiting on the CLI's own
+  // end-of-turn line would wait for one that is never written.
+  expect(mod.__needsYou(IDLE_AFTER_LOCAL_COMMAND)).toBe(false);
+  expect(mod.__isRunning(IDLE_AFTER_LOCAL_COMMAND)).toBe(false);
+  expect(mod.inputBox(IDLE_AFTER_LOCAL_COMMAND)?.trim()).toBe("");
+});
+
+test("a working turn is never idle, however long it says nothing", () => {
+  // The one that must not regress: a tool call can be silent for minutes, and
+  // ending the turn under it would throw away work in flight.
+  const working = "● Reading files…\n✻ Brewed for 94s (esc to interrupt)";
+  expect(mod.__isRunning(working)).toBe(true);
+  expect(mod.__needsYou(working)).toBe(false);
+});


### PR DESCRIPTION
## What does this PR do?

Reported with a screenshot of a chat stuck on `/effort`, then `/model`, then `/config` — the typing dots spinning with no way out and every later message queued behind them.

Those commands do not run a turn. They draw a picker in the pane and wait for arrow keys. Nothing is ever written to the transcript, and the turn loop ends on the CLI's own `turn_duration` line, so it waited for something that was never coming.

The turn now notices. While a turn has produced **no bytes at all**, the screen is checked every four seconds for a picker's key hints. If one is up, the turn ends saying so and hands over the command that opens the pane in the user's own terminal, with the last few lines of the picker so it is obvious what it is asking.

Details that matter:

- Matched on `Esc to cancel` and friends rather than any picker's title — those hints are shared by every picker and are what make it a prompt at all.
- Deliberately **not** matched on `esc to interrupt`, which is a *running* turn. Confusing the two would abandon every long turn four seconds in.
- The check only runs while nothing has arrived, so a turn that is genuinely working is never looked at.
- The picker is left open rather than cancelled with Escape. The user asked for it; throwing it away to tidy up would discard what they wanted.

**Submitting is also guarded**, though this one changes nothing today and is worth saying plainly rather than dressing up: the Enter retry now only re-presses while the input box still holds the text we pasted. In the current TUI the box below a picker reads empty and the retry already stops. The guard is here because a picker that ever drew its selection cursor at column 0 would make every retried Enter a menu selection — and in these menus Enter means "set as default", so the failure would be silently rewriting the user's saved model or effort.

**The list was the wrong shape, and a second round proved it.** `/model`, `/effort`, `/config` and `/help` all draw an overlay with `Esc to cancel`, so the hint check caught them. `/clear` and `/compact` do not: verified in a live pane, they write no transcript, show no hints, and are not running — so they hung exactly as before. The next release adds another one, and that race is not winnable.

So the turn ends on **state**: nothing written, nothing running, nothing asking, for two consecutive probes. The CLI handled it itself and went back to the prompt, whatever it was called. Two probes (~8s) is affordable because the underlying signal is already strong — a real turn writes its own user message to the transcript within a few hundred milliseconds of being submitted (measured ~220ms), so anything genuinely a turn has grown long before the first probe. "Running" is read from the CLI saying `esc to interrupt`, which is what keeps a tool call that is silent for minutes from being cut off under it.

The chat says what happened rather than rendering an empty reply, and points at the pane for anyone who wants to see what the command did.

## How was it tested?

- `bunx tsc --noEmit` clean in `server/`; full suite **1040 pass / 0 fail**.
- Reproduced first in a real pane on a scratch tmux socket: pasted `/effort` and `/model`, captured the actual picker output, confirmed no `turn_duration` is ever written and that Escape cancels cleanly.
- 5 new tests built from captured screens rather than an invented one: the picker's indented cursor is not read as the input box, the picker is recognised from its key hints, and a running turn (`esc to interrupt`) is not.
- Not yet exercised end to end through the app — the detection path needs a live pane and a real `/model`, which is the part most worth checking before this lands.
