### PR TITLE
fix(theme): stop the tmux theme replacing what is in the status bar

### DIFF
--- a/server/src/themesync.ts
+++ b/server/src/themesync.ts
@@ -424,14 +424,22 @@ setw -g window-status-separator ""
 setw -g window-status-format " #[fg=${v.text4}]#I #[fg=${v.text3}]#W "
 setw -g window-status-current-format " #[fg=${v.primary},bold]#I #[fg=${v.text}]#W "
 
-# Left: the session, as the app renders the open project.
-set -g status-left " #[fg=${v.primary},bold]#S #[fg=${v.border2}]│"
+# The two status segments are deliberately NOT set here.
+#
+# They used to be: a session name on the left, a clock on the right. Both
+# replaced whatever the user already had, and people put working things in
+# those segments — a git branch, a battery, and in at least one real case the
+# #(continuum_save.sh) interpolation that IS tmux-continuum's entire timer.
+# Overwriting that silently turned off session persistence: continuum kept
+# reporting a 15-minute interval and had not saved for days, and it came back
+# every time the theme was re-sourced, which is on every theme change and every
+# new server. The user only found out by wondering why their layout was stale
+# after a reboot.
+#
+# So this file colours the bar and does not decide what is in it. The styles
+# above still theme whatever is there, which was the part worth having.
 set -g status-left-length 30
-
-# Right: kept quiet. The cockpit already shows the clock, the branch and the
-# plan meters, and repeating them here is noise competing with itself.
-set -g status-right "#[fg=${v.text4}]#{?client_prefix,#[fg=${v.warning}]^b ,}%H:%M "
-set -g status-right-length 40
+set -g status-right-length 60
 set -g status-justify left
 
 # Borders: the inactive one a hairline against the panel, the active one the

--- a/server/test/themesync-nondestructive.test.ts
+++ b/server/test/themesync-nondestructive.test.ts
@@ -140,3 +140,20 @@ describe("syncTheme never edits the user's own config", () => {
     expect(readFileSync(userNvim, "utf8")).toBe(nvimBefore);
   });
 });
+
+// --- the status bar belongs to the user -------------------------------------
+
+test("the theme colours the status bar without deciding what is in it", async () => {
+  const { tmuxTheme, normalizeVars } = await import("../src/themesync.ts");
+  const conf = tmuxTheme(normalizeVars({}), "Midnight Purple");
+  // Styles: ours to set. They theme whatever the user has there.
+  expect(conf).toContain("status-left-style");
+  expect(conf).toContain("status-right-style");
+  // Content: not ours. Setting it replaced whatever was already in those
+  // segments, and people put working interpolations there — a git branch, a
+  // battery, and in one real case `#(continuum_save.sh)`, which IS
+  // tmux-continuum's entire save timer. Overwriting it silently turned off
+  // session persistence and came back on every theme re-source.
+  expect(conf).not.toMatch(/^set -g status-left "/m);
+  expect(conf).not.toMatch(/^set -g status-right "/m);
+});


### PR DESCRIPTION
## What does this PR do?

`themesync` wrote both status segments — a session name on the left, a clock on the right — replacing whatever was already there. It does that on every theme change and on every new tmux server that sources the file.

People put **working** things in those segments. Found on a real machine while chasing an unrelated report: the right segment held `#(continuum_save.sh)`. That is not decoration. It is tmux-continuum's entire save timer — continuum has no timer of its own, it prepends that interpolation to `status-right` and relies on the status refresh to run it.

So agentglass had silently turned off the user's session persistence. Continuum went on reporting its configured 15-minute interval and had not written a save in **days**; the owner found out by wondering why their layout came back stale after a reboot. Re-arming it by hand worked for about twenty minutes — exactly as long as it took for the theme to be re-sourced, which is what made it so confusing to track down.

The fix is to hold the line a theme should have held anyway: **colour the bar, do not decide what is in it.** `status-left-style` and `status-right-style` already theme whatever the user has there, which was the part worth having. The lengths stay, because a segment that is too short truncates its own content. Anyone who wants the clock back can set `status-right` themselves — and now it will survive.

Worth knowing for review: this changes the out-of-the-box look for anyone whose tmux sets neither segment. They get their tmux default rather than our clock. That seemed clearly the better trade against silently disabling other people's tooling, but it is a visible change and not only an internal one.

## How was it tested?

- `bunx tsc --noEmit` clean in `server/`; full suite **1041 pass / 0 fail**.
- New test in `server/test/themesync-nondestructive.test.ts` pinning both halves of the rule: the generated config still carries `status-left-style` / `status-right-style`, and no longer carries `set -g status-left "` / `set -g status-right "`.
- Diagnosed on a live server rather than from reading: confirmed the hook was present after re-arming, gone again twenty minutes later, and that the value it had been replaced with matched this file's output for the active theme (the accent colour gave it away).

🤖 Generated with [Claude Code](https://claude.com/claude-code)