### PR TITLE
feat(chat): answer a pane's prompt from the chat, not from a terminal

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -60,7 +60,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, type PtyWsData } from "./terminal.ts";
 import { chatSend, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
-import { paneAlive, killPane, forgetPane, startPaneSweeper } from "./tmuxpane.ts";
+import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, inScope } from "./config.ts";
 import { hookStatus, applyHooks } from "./hooksetup.ts";
@@ -1115,6 +1115,24 @@ const server = Bun.serve<WsData>({
       if (was) await killPane(id);
       forgetPane(id);
       return json({ killed: was });
+    }
+    // Answer an interactive prompt without leaving the chat. The pane already
+    // takes Enter and Escape from us; arrows are the rest of what a picker
+    // needs, and sending them here beats telling someone to open a terminal to
+    // move a cursor one step.
+    if (pathname === "/chat/pane/key" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: any = {};
+      try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
+      const id = typeof b.session === "string" ? b.session : "";
+      if (!validPaneName(id)) return json({ error: "invalid session id" }, 400);
+      if (!sendableKey(b.key)) return json({ error: "key not allowed" }, 400);
+      if (!(await paneAlive(id))) return json({ error: "that chat's pane is gone" }, 409);
+      const r = await sendKey(id, b.key);
+      if (!r.ok) return json({ error: r.stderr.trim() || "could not send the key" }, 500);
+      // Hand back what the pane shows now, so the chat can redraw the prompt
+      // the keystroke just moved rather than guessing at it.
+      return json({ screen: await capturePane(id) });
     }
     if (pathname === "/chat/attach") {
       const id = url.searchParams.get("session") || "";

--- a/server/src/tmuxpane.ts
+++ b/server/src/tmuxpane.ts
@@ -235,6 +235,24 @@ export async function interrupt(name: string): Promise<TmuxResult> {
   return tmux(["send-keys", "-t", paneTarget(name), "Escape"]);
 }
 
+/** Keys a chat may send to its own pane.
+ *
+ *  An allowlist of tmux's own key names, not free text. These reach the server
+ *  from a browser request and land in a live terminal running an agent with
+ *  tools: anything unbounded here would be a way to type arbitrary commands
+ *  into it. Navigation and the two answers a prompt takes is the whole job —
+ *  ordinary text still goes through the paste path, which cannot be mistaken
+ *  for a keystroke. */
+const SENDABLE = new Set(["Up", "Down", "Left", "Right", "Enter", "Escape", "Space", "Tab", "BSpace"]);
+export const sendableKey = (k: unknown): k is string => typeof k === "string" && SENDABLE.has(k);
+
+/** Press one key in the chat's pane. */
+export async function sendKey(name: string, key: string): Promise<TmuxResult> {
+  if (!validPaneName(name)) return { ok: false, stdout: "", stderr: "invalid pane name" };
+  if (!sendableKey(key)) return { ok: false, stdout: "", stderr: "key not allowed" };
+  return tmux(["send-keys", "-t", paneTarget(name), key]);
+}
+
 /** What the pane currently shows. Only for diagnostics and for the "why is this
  *  stuck" path — the conversation itself is read from the transcript, never
  *  scraped from here. */

--- a/server/test/chat-pane.test.ts
+++ b/server/test/chat-pane.test.ts
@@ -201,3 +201,32 @@ test("a working turn is never idle, however long it says nothing", () => {
   expect(mod.__isRunning(working)).toBe(true);
   expect(mod.__needsYou(working)).toBe(false);
 });
+
+// --- answering a prompt in the pane -----------------------------------------
+
+test("only navigation keys may be sent into a live pane", () => {
+  // These arrive on an HTTP request and land in a terminal running an agent
+  // with tools. An unbounded key channel would be a way to type commands into
+  // it, so this is an allowlist rather than a sanitiser. Ordinary text still
+  // goes through the paste path, which cannot be mistaken for a keystroke.
+  for (const k of ["Up", "Down", "Left", "Right", "Enter", "Escape"]) {
+    expect(pane.sendableKey(k)).toBe(true);
+  }
+  for (const k of ["C-c", "rm -rf /", "q", "", "Enter Enter", "M-x", 5, null, "escape"]) {
+    expect(pane.sendableKey(k as unknown)).toBe(false);
+  }
+});
+
+test("a key for an invalid pane name is refused before tmux is reached", async () => {
+  // Same reasoning as every other pane entry point: the name decides the tmux
+  // target, so a crafted one must never get as far as being resolved.
+  const r = await pane.sendKey("other:1.0", "Enter");
+  expect(r.ok).toBe(false);
+  expect(r.stderr).toContain("invalid pane name");
+});
+
+test("a disallowed key is refused even for a valid pane", async () => {
+  const r = await pane.sendKey("6f1c9b52-0000-4000-8000-0123456789ab", "C-c");
+  expect(r.ok).toBe(false);
+  expect(r.stderr).toContain("not allowed");
+});

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -269,6 +269,60 @@ function TypingDots() {
   );
 }
 
+/** An interactive prompt waiting in a chat's tmux pane, and the keys to answer it.
+ *
+ *  The pane is the only thing that can render a `/model` picker properly, so
+ *  this shows what it drew and forwards the few keys a picker takes. Each press
+ *  returns the next frame, which is what makes it feel like using the menu
+ *  rather than firing keys into the dark.
+ *
+ *  Escape both cancels the prompt and clears this, because a cancelled picker
+ *  leaves nothing to answer. */
+function PanePrompt({ chat }: { chat: Chat }) {
+  const [busy, setBusy] = useState(false);
+  const screen = chat.paneNeedsYou?.screen ?? "";
+  const press = async (key: string) => {
+    if (busy || !chat.sessionId) return;
+    setBusy(true);
+    try {
+      const r = await api.chatPaneKey(chat.sessionId, key);
+      // Enter and Escape both end a picker. Rather than guess which, the next
+      // frame decides: no key hints left means nothing is waiting any more.
+      const done = key === "Escape" || !/Esc to cancel|Enter to confirm|to use this session only/.test(r.screen);
+      update(chat.id, (c) => {
+        if (done) { c.paneNeedsYou = undefined; c.attention = "none"; }
+        else c.paneNeedsYou = { screen: r.screen };
+      });
+    } catch {
+      // The pane may have been reclaimed under us. Clearing is the honest
+      // outcome: there is nothing left to answer.
+      update(chat.id, (c) => { c.paneNeedsYou = undefined; c.attention = "none"; });
+    } finally { setBusy(false); }
+  };
+  const key = (label: string, k: string, title: string) => (
+    <button onClick={() => press(k)} disabled={busy} title={title}
+      className="text-[11px] px-2 py-1 rounded-md disabled:opacity-40"
+      style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>{label}</button>
+  );
+  return (
+    <div className="mb-2 px-2.5 py-2 rounded-lg text-[11px]"
+      style={{ background: "color-mix(in srgb, var(--warning) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", color: "var(--text2)" }}>
+      <div style={{ color: "var(--text)" }}>This chat's pane is asking you something.</div>
+      <pre className="agx-scroll mt-1.5 mb-2 px-2 py-1.5 rounded overflow-x-auto whitespace-pre text-[10.5px] leading-[1.45]"
+        style={{ ...CODE_FONT_STYLE, background: "color-mix(in srgb, var(--bg3) 60%, transparent)", color: "var(--text)", maxHeight: 220 }}>{screen}</pre>
+      <div className="flex items-center gap-1.5 flex-wrap">
+        {key("←", "Left", "Left")}
+        {key("→", "Right", "Right")}
+        {key("↑", "Up", "Up")}
+        {key("↓", "Down", "Down")}
+        {key("Enter", "Enter", "Confirm")}
+        {key("Esc", "Escape", "Cancel and close this")}
+        <span className="ml-auto t-dim2 text-[10px]">or open it in a terminal: <code style={CODE_FONT_STYLE}>{chat.attachCommand || "tmux -L agentglass attach"}</code></span>
+      </div>
+    </div>
+  );
+}
+
 /** A header button that copies something and says it did.
  *
  *  The confirmation is the whole point: a copy that succeeds looks exactly like
@@ -1102,6 +1156,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           </div>
                         ))}
                       </div>
+                    )}
+                    {active?.paneNeedsYou && (
+                      // Answerable from here. The alternative shipped first and
+                      // was telling someone to open a terminal to move a cursor
+                      // one step, which is a dead end wearing instructions.
+                      <PanePrompt chat={active} />
                     )}
                     {active?.setupNeeded && (
                       // The CLI never started. Retrying is pointless until the

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -450,6 +450,10 @@ const realApi = {
   /** Give a chat's warm CLI back. Destroys no conversation — the transcript
    *  stays on disk and resuming relaunches the pane with `--resume`. */
   chatPaneClose: (session: string) => post<{ killed: boolean }>("/chat/pane/close", { session }),
+  /** Press one key in a chat's pane, and get back what it shows afterwards.
+   *  Only navigation and the two answers a prompt takes — the server keeps its
+   *  own allowlist, since this reaches a live terminal running an agent. */
+  chatPaneKey: (session: string, key: string) => post<{ screen: string }>("/chat/pane/key", { session, key }),
   chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
     let res: Response;
     // A fetch that throws before a response has arrived never reached the
@@ -588,6 +592,7 @@ const demoApi: typeof realApi = {
   chatEnabled: () => D({ enabled: false, tmuxEngine: { available: false, reason: "the demo runs no local processes", defaultOn: false } }),
   chatAttach: (_session: string) => D({ command: "", live: false }),
   chatPaneClose: (_session: string) => D({ killed: false }),
+  chatPaneKey: (_session: string, _key: string) => D({ screen: "" }),
   chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine }, onEvent: (o: Record<string, unknown>) => void) => {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -185,6 +185,11 @@ export type Chat = {
    *  `claude` that has never been logged in. Distinct from a failed turn:
    *  retrying changes nothing until the command is run. */
   setupNeeded?: { command: string; why: string };
+  /** An interactive prompt waiting in this chat's pane — a `/model` picker and
+   *  the like. Held as state rather than left as text in the reply, because it
+   *  is a thing to answer, not a thing to read: the screen redraws as keys are
+   *  sent to it. */
+  paneNeedsYou?: { screen: string };
   /** Timestamp of the newest thing already on screen from the session's own
    *  transcript. The live socket replays a window of recent events on every
    *  connect, so without a watermark reopening the panel would re-append the
@@ -768,6 +773,21 @@ export async function send(id: string, text: string, isActive: () => boolean, al
         // started, and it will fail identically every time until you do the one
         // thing it names. Raise it as attention so the chat says it needs you
         // rather than just going quiet.
+        // A picker in the pane is answerable from here, so it is raised as
+        // something to act on rather than appended to the reply as prose. The
+        // screen the server sent is the starting frame; each key sent back
+        // returns the next one.
+        if (o.errorType === "pane_needs_you") {
+          const text = String(o.error ?? "");
+          const screen = text.slice(text.indexOf("\n\n") + 2);
+          c.paneNeedsYou = { screen: screen.slice(screen.indexOf("\n\n") + 2) || screen };
+          c.attention = "blocked";
+          const last = c.messages[c.messages.length - 1];
+          // The prose above the screen is worth keeping; the screen itself is
+          // about to be drawn properly, so it does not belong in the text too.
+          if (last?.role === "assistant") last.text = last.text.split("\n\n")[0];
+          return;
+        }
         if (typeof o.setupCommand === "string") {
           c.setupNeeded = { command: o.setupCommand, why: String(o.error ?? "") };
           c.attention = "blocked";


### PR DESCRIPTION
## What does this PR do?

#335 stopped `/model`, `/effort` and `/config` hanging a pane chat forever. Its answer, though, was *"it is still open and waiting — finish it in your terminal"*. For moving a cursor one step along a slider, that is a dead end wearing instructions, and it was the first thing asked about it.

The pane already takes Enter and Escape from us. Arrows are the rest of what a picker needs. So the prompt is now shown where it happened, with the keys to answer it, and each press returns the next frame — which is what makes it feel like using the menu rather than firing keys into the dark. The attach command stays alongside for anything this cannot draw.

Decisions worth reviewing:

- **Keys are an allowlist, not a sanitiser.** They arrive on an HTTP request and land in a live terminal running an agent with tools, so the channel is navigation plus the two answers a prompt takes, and nothing else. Ordinary text still goes through the paste path, which cannot be mistaken for a keystroke.
- **The prompt is chat state, not reply text.** It is a thing to answer, not a thing to read, and the screen redraws under it as keys are sent.
- **What counts as "done" is read from the next frame** rather than inferred from which key was pressed. Enter and Escape can both end a picker, and some pickers stay open after Enter; the frame knows and we do not.
- The route refuses a dead pane with a 409 rather than silently doing nothing, and the client clears the prompt when that happens — there is genuinely nothing left to answer.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/` and `server/`, `bunx vite build` clean, full suite **1044 pass / 0 fail**.
- 3 new tests on the part with real surface: the key allowlist accepts the six navigation keys and rejects `C-c`, `M-x`, shell text, empty, non-strings and wrong case; an invalid pane name is refused before tmux is reached; a disallowed key is refused even for a valid pane.
- The behaviour this builds on was verified end to end in the running app first — the screenshot that prompted this shows #335's detection firing correctly on a real `/effort`, with the picker rendered and the pane still waiting.
- **Not yet exercised in the app:** the key round-trip itself. That needs a live picker and a build, and is the part most worth checking before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)