### PR TITLE
feat(settings): say which outside tools are missing, and where to get them

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ gate. No install, no server. *(Everything there is fake; it's a showcase.)*
 - [Every project, one cockpit](#every-project-one-cockpit)
 - [More than a dashboard — a workspace](#more-than-a-dashboard--a-workspace)
 - [Why](#why) · [Themes](#themes)
-- [Quickstart](#quickstart)
+- [Quickstart](#quickstart) · [Requirements](#requirements-what-agentglass-expects-to-find)
 - [Desktop app](#desktop-app) · [Updating](#updating)
 - [Security model — read this before installing](#security-model--read-this-before-installing)
 - [Control plane — approve / deny remotely](#control-plane--approve--deny-tool-calls-remotely-opt-in)
@@ -315,7 +315,10 @@ python3 hooks/seed_demo.py            # optional: streams demo agents for ~30s
 ### Running from source
 
 For hacking on agentglass, or for a headless box. Requires
-[Bun](https://bun.sh) ≥ 1.1 and Python 3 (for the hook forwarder).
+[Bun](https://bun.sh) ≥ 1.1 and Python 3 (the hook forwarder and the terminal's
+pseudo-terminal both run under it). Everything else agentglass shells out to is
+listed under [Requirements](#requirements-what-agentglass-expects-to-find), and
+checked for you in Settings ▸ Requirements.
 
 ```bash
 bun install
@@ -386,6 +389,53 @@ Both use a dependency-free Python forwarder that POSTs to the server; `Stop` /
 `SubagentStop` / `SessionEnd` pass `--add-chat` so token usage can be read from
 the transcript. The raw hook blocks also live in
 [`hooks/settings.example.json`](hooks/settings.example.json) for manual setups.
+
+---
+
+## Requirements: what agentglass expects to find
+
+agentglass drives the tools you already have rather than bundling its own. The
+app itself is self-contained (the server ships inside it), so this list is about
+**what each feature shells out to**, and what stands down when it isn't there.
+
+**The app checks all of it for you: Settings ▸ Requirements** shows every tool,
+whether this machine has it, what stops working without it, and a link to the
+project's own install page. Nothing there installs anything, and the guidance is
+deliberately generic: there is one macOS, one Windows and an unbounded number of
+Linux distributions, so how you install software is yours to know.
+
+**Needed**
+
+| Tool | Why | Without it |
+| --- | --- | --- |
+| [git](https://git-scm.com/downloads) | Source control, file changes, pull requests, worktrees; the terminal uses it to decide where to open | Those panels stay empty and the terminal cannot open in a repo |
+| [Claude Code CLI](https://docs.claude.com/en/docs/claude-code/setup) | The chat panel runs `claude`: every turn, the pane engine, Review with Claude, the walkthrough | No chatting from the app. Sessions still appear: the transcript scanner reads `~/.claude/projects` regardless |
+| [Python 3](https://www.python.org/downloads/) | Runs the hook forwarder, and backs the terminal's pseudo-terminal | Hooks stay wired and fail on every event, so nothing streams live and nothing says why. The terminal still opens, in a mode where full-screen programs do not render. Windows hooks use `py` or `python` |
+
+**Per feature**
+
+| Tool | Gives you | Without it |
+| --- | --- | --- |
+| [tmux](https://github.com/tmux/tmux/wiki/Installing) | Chats as live panes you can attach to, your tmux windows as tabs, theme sync | Chats run one process per turn instead: slower to start, nothing left running |
+| [GitHub CLI](https://cli.github.com) | The whole pull-requests panel | No PRs. It also has to be logged in (`gh auth login`), which is the step people miss |
+| [Docker](https://docs.docker.com/get-started/get-docker/) | Containers, images, volumes, logs | No docker panel. The daemon has to be running, not just the CLI installed |
+| [Neovim](https://neovim.io) | Sending a file to a live editor, theme sync | The app hands you a command to paste instead |
+| setsid, script ([util-linux](https://github.com/util-linux/util-linux)) | Process groups per shell, and the fallback pseudo-terminal | A closed terminal can leave background processes behind |
+| [D-Bus tools](https://www.freedesktop.org/wiki/Software/dbus/), [libnotify](https://gitlab.gnome.org/GNOME/libnotify), [xdg-utils](https://www.freedesktop.org/wiki/Software/xdg-utils/) | Mirroring desktop notifications onto the notch, alerts when no window is open, opening their links (Linux) | Those notifications simply do not appear |
+| [polkit](https://gitlab.freedesktop.org/polkit/polkit) | Handing a worktree back to you when a container left root-owned files in it | That one repair button fails |
+
+**Two more that are not binaries**
+
+- **Linux `.AppImage`**: needs FUSE, which some distributions no longer install
+  by default. The `.deb` has no such requirement.
+- **Self-update** ("Install & restart" in Settings ▸ About) builds the new
+  version on your machine, so it wants `git`, [Bun](https://bun.sh) and a
+  working build toolchain. It is opt-in and never automatic.
+
+**On Windows**, the terminal, tmux chat panes, the notification mirror and
+self-update are off by design rather than broken: they need a POSIX
+pseudo-terminal, a Unix shell and a D-Bus session respectively. Everything else,
+including the transcript scanner and the git and PR panels, works.
 
 ---
 

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -210,7 +210,7 @@ export type TurnPlan =
 
 export function planTurn(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, allowedTools?: unknown, images?: unknown): TurnPlan {
   const no = (r: Response): TurnPlan => ({ ok: false, response: r });
-  if (!claudeBin()) return no(err("no local `claude` CLI — install Claude Code to chat", 403));
+  if (!claudeBin()) return no(err("no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)", 403));
   if (process.env.AGENTGLASS_CHAT_DISABLED === "1") return no(err("chat is disabled (AGENTGLASS_CHAT_DISABLED=1)", 403));
   const dir = safeAbs(cwd);
   if (!dir || !repoRootOf(dir)) {

--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -180,7 +180,7 @@ async function ensurePane(
   sessionId: string, cwd: string, model: string, mode: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const bin = claudeBin();
-  if (!bin) return { ok: false, error: "no local `claude` CLI — install Claude Code to chat" };
+  if (!bin) return { ok: false, error: "no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)" };
 
   const alive = await paneAlive(sessionId);
   const spec = specs.get(sessionId);
@@ -427,7 +427,7 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
 export function paneEngineCapability(): { available: boolean; reason: string } {
   const t = tmuxCapability();
   if (!t.available) return t;
-  if (!claudeBin()) return { available: false, reason: "no local `claude` CLI — install Claude Code to chat" };
+  if (!claudeBin()) return { available: false, reason: "no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)" };
   return { available: true, reason: "" };
 }
 

--- a/server/src/deps.ts
+++ b/server/src/deps.ts
@@ -1,0 +1,124 @@
+// One answer to "what am I still missing?".
+//
+// The probes themselves are not new: git, docker, gh, tmux and the notification
+// bus each had a capability endpoint already, because each panel needs its own
+// answer to render. What did not exist was the sum of them, and the three that
+// nothing ever reported at all: python3, setsid and `script`. Those three are
+// the ones that fail quietly, which is exactly why they belong on a list. A
+// missing python3 leaves the hooks installed and dead (nothing streams, nothing
+// says why) and drops the terminal into a mode where full-screen programs do
+// not render; a missing setsid leaves stray processes behind a closed shell.
+//
+// Read-only throughout: this route probes and reports, it never installs.
+import { DEPS, usedOn, type DepReport, type DepSpec, type DepStatus, type DepsResponse } from "../../shared/deps.ts";
+import { gitCapability } from "./git.ts";
+import { dockerCapability } from "./docker.ts";
+import { ghCapability } from "./prs.ts";
+import { tmuxCapability } from "./tmuxpane.ts";
+import { notifyCapability } from "./notifications.ts";
+import { HAS_NVIM } from "./editor.ts";
+import { PTY_BACKEND } from "./terminal.ts";
+
+/** The interpreter the hook forwarder is written against, resolved the way
+ *  hooksetup.ts resolves it: python3 everywhere but Windows, where python3 is
+ *  usually absent and `py`/`python` is what exists. */
+function pythonBin(): string | null {
+  const order = process.platform === "win32" ? ["py", "python", "python3"] : ["python3", "python"];
+  for (const c of order) { const p = Bun.which(c); if (p) return p; }
+  return null;
+}
+
+/** A plain PATH lookup, for the tools whose only question is "is it there". */
+const found = (bin: string): boolean => !!Bun.which(bin);
+
+const ok = (detail?: string) => ({ status: "ok" as DepStatus, detail });
+const missing = (detail?: string) => ({ status: "missing" as DepStatus, detail });
+const attention = (detail: string) => ({ status: "attention" as DepStatus, detail });
+
+/**
+ * Probe one tool.
+ *
+ * Everything that already has a capability function uses it rather than a
+ * second `Bun.which`, so this list can never disagree with the panel it is
+ * describing. The subprocess-backed ones (docker, gh) cache inside their own
+ * modules, so asking here costs at most what the panel would have cost.
+ */
+async function probe(spec: DepSpec): Promise<{ status: DepStatus; detail?: string }> {
+  switch (spec.id) {
+    case "git": {
+      const c = gitCapability();
+      return c.available ? ok(c.version) : missing(c.reason);
+    }
+    case "claude":
+      return found("claude") ? ok() : missing("not on PATH");
+    case "python": {
+      const py = pythonBin();
+      if (!py) return missing("no python3 on PATH: hooks cannot forward events, and the terminal has no pseudo-terminal");
+      // Present, but the terminal may still be degraded: the bridge needs a
+      // python that can import `pty`, and the backend was resolved at boot.
+      return PTY_BACKEND === "pty"
+        ? ok(py)
+        : attention(`${py} is on PATH, but the terminal is running in ${PTY_BACKEND} mode`);
+    }
+    case "tmux": {
+      const c = tmuxCapability();
+      return c.available ? ok() : missing(c.reason);
+    }
+    case "gh": {
+      const c = await ghCapability();
+      if (!c.available) return missing(c.reason);
+      return c.authed ? ok(c.login ? `logged in as ${c.login}` : undefined) : attention(c.reason || "not logged in yet");
+    }
+    case "docker": {
+      const c = await dockerCapability();
+      if (!c.available) return missing(c.reason);
+      return c.version ? ok(c.version) : attention(c.reason || "the daemon is not responding");
+    }
+    case "nvim":
+      return HAS_NVIM ? ok() : missing("not on PATH");
+    case "dbus-monitor": {
+      const c = notifyCapability();
+      // `supported` folds two causes together, and only one of them is an
+      // install: no session bus is a headless box, not a missing package.
+      if (c.supported) return ok();
+      return found("dbus-monitor") ? attention(c.reason || "no session bus") : missing(c.reason);
+    }
+    case "opener":
+      // Only Linux has anything to install here; the other two ship an opener.
+      return found("xdg-open") ? ok() : missing("no xdg-open on PATH");
+    case "script":
+      // Wanted only as the fallback, so a machine with python3 is not lacking
+      // anything by not having it.
+      return found("script") ? ok() : PTY_BACKEND === "pty" ? ok("not needed: python3 is backing the terminal") : missing("not on PATH");
+    default:
+      return found(spec.bin) ? ok() : missing("not on PATH");
+  }
+}
+
+// Probing costs a handful of PATH lookups plus, at worst, two cached
+// subprocess answers. Cheap, but the pane can be opened and closed repeatedly
+// and nothing here changes between two clicks: a binary does not appear
+// mid-session. Long enough to make reopening free, short enough that "install
+// it, then press Recheck" tells the truth.
+const TTL_MS = 10_000;
+let cache: { at: number; res: DepsResponse } | null = null;
+
+export async function dependencyReport(force = false): Promise<DepsResponse> {
+  if (!force && cache && Date.now() - cache.at < TTL_MS) return cache.res;
+  const platform = process.platform;
+  const deps: DepReport[] = await Promise.all(
+    DEPS.map(async (spec): Promise<DepReport> => {
+      if (!usedOn(spec, platform)) {
+        return { ...spec, status: "unsupported", detail: `not used on ${platform}` };
+      }
+      const r = await probe(spec);
+      return { ...spec, ...r };
+    }),
+  );
+  const res: DepsResponse = { platform, deps };
+  cache = { at: Date.now(), res };
+  return res;
+}
+
+/** Cleared by the tests, which install their own fake PATH entries. */
+export function resetDependencyCache(): void { cache = null; }

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,6 +28,7 @@ import { parseControlCmd } from "./control.ts";
 import { otlpTracesToEvents, otlpLogsToEvents } from "./otlp.ts";
 import { decodeOtlpTraces, decodeOtlpLogs } from "./otlp_pb.ts";
 import { statusForPaths, commit as gitCommit, COMMIT_ENABLED, gitAsync, gitCapability } from "./git.ts";
+import { dependencyReport } from "./deps.ts";
 import {
   workingTree, discoverRepos, stage, unstage, stageAll, unstageAll, discard,
   commitStaged, push as gitPush, pull as gitPull, fetch as gitFetch,
@@ -57,7 +58,7 @@ import {
   rerunFailedChecks, mergePr, closePr, prepareReviewPrompt, branchUrl, subscribeCi, commitDiff as prCommitDiff, submitReviewWith,
 } from "./prs.ts";
 import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
-import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, type PtyWsData } from "./terminal.ts";
+import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
 import { chatSend, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper } from "./tmuxpane.ts";
@@ -728,6 +729,12 @@ const server = Bun.serve<WsData>({
     // Is git even installed? A plain read like the rest of /git/*, so the
     // surface-wide origin/rebinding gate is the whole authorisation story.
     if (pathname === "/git/capability") return json(gitCapability());
+    // Every outside tool at once, for the Requirements pane. The per-panel
+    // capability routes above stay: each panel needs its own answer to render,
+    // and this one exists for the question none of them can answer alone.
+    // `force=1` is the Recheck button, which is the only reason a caller would
+    // want to pay for the probes again inside the cache window.
+    if (pathname === "/dependencies") return json(await dependencyReport(url.searchParams.get("force") === "1"));
     if (pathname === "/git/repos") {
       // `all=1` is the project picker: it needs the whole machine even when the
       // cockpit is currently scoped to one project, or there'd be no way out.
@@ -1466,4 +1473,11 @@ watchLoop();
 {
   const gc = gitCapability();
   if (!gc.available) console.warn(`⚠  git not found on PATH — the git, diff, pull-request and terminal panels will not work. Install git to enable them.`);
+  // Said for the same reason, and it is the quieter failure of the two: with no
+  // python3 the hooks stay wired and fail on every event, so the dashboard is
+  // simply empty and nothing anywhere names the cause. Settings ▸ Requirements
+  // is the same list for anyone who never sees this log.
+  if (PTY_BACKEND !== "pty" && !Bun.which("python3") && !Bun.which("python")) {
+    console.warn(`⚠  python3 not found on PATH — the Claude Code hooks cannot forward events (nothing will stream live), and the terminal falls back to ${PTY_BACKEND} mode.`);
+  }
 }

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -48,6 +48,16 @@ export const TERMINAL_ENABLED = TERMINAL_DISABLED_REASON === null;
 const HAS_SETSID = !!Bun.which("setsid");
 const PYTHON = Bun.which("python3") || Bun.which("python");
 const HAS_SCRIPT = process.platform === "linux" && !!Bun.which("script");
+/**
+ * Which of the three backends below a new shell will get.
+ *
+ * Resolved here because this is where the choice is made, and exported because
+ * "pipe" is the one degraded state the user cannot see coming: the shell opens,
+ * and only a full-screen program not rendering says anything is wrong. The
+ * requirements report reads this to name the cause (no python3) rather than
+ * leaving the terminal to mention it in grey, inside itself, after the fact.
+ */
+export const PTY_BACKEND: "pty" | "script" | "pipe" = PYTHON ? "pty" : HAS_SCRIPT ? "script" : "pipe";
 // Embedded rather than resolved from import.meta.url: once the server is
 // compiled into a standalone binary there is no pty_bridge.py on disk next to
 // it, and the terminal would die on a path that never existed.

--- a/server/test/deps.test.ts
+++ b/server/test/deps.test.ts
@@ -1,0 +1,116 @@
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { DEPS, depSpec, usedOn, type DepStatus } from "../../shared/deps.ts";
+import { dependencyReport, resetDependencyCache } from "../src/deps.ts";
+
+/**
+ * The requirements catalog, and the report built from it.
+ *
+ * Two things are worth pinning here. The first is that the list stays a list:
+ * duplicated ids or a required tool marked Linux-only would put a wrong answer
+ * in front of someone trying to work out why the app is half dead.
+ *
+ * The second is the rule this whole feature exists under, and the one most
+ * likely to be broken by a well-meaning edit: the guidance must stay GENERIC.
+ * There is one macOS, one Windows and an unbounded number of Linux
+ * distributions, so `apt install git` is wrong for most readers and stale for
+ * the rest. The test greps the catalog and the panels that quote it, because
+ * "we agreed to keep it generic" is not something a reviewer reliably catches.
+ */
+const PKG_MANAGER_CMD =
+  /\b(apt|apt-get|brew|dnf|yum|pacman|zypper|apk|winget|choco|scoop|snap|port|emerge|nix-env|pkg)\s+(install|add|-S\b)/i;
+
+const ROOT = join(import.meta.dir, "..", "..");
+const read = (rel: string) => readFileSync(join(ROOT, rel), "utf8");
+
+describe("dependency catalog", () => {
+  it("has no duplicate ids, and every id resolves", () => {
+    const ids = DEPS.map((d) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const id of ids) expect(depSpec(id)?.id).toBe(id);
+  });
+
+  it("gives every tool a name, a consequence and an official page", () => {
+    for (const d of DEPS) {
+      expect(d.bin.length).toBeGreaterThan(0);
+      expect(d.title.length).toBeGreaterThan(0);
+      // The "what" is the whole point of the row: a category name would leave
+      // the reader deciding whether they care, which is the question we set out
+      // to answer for them.
+      expect(d.what.length).toBeGreaterThan(20);
+      expect(d.url.startsWith("https://")).toBe(true);
+    }
+  });
+
+  it("keeps required tools platform-agnostic", () => {
+    // A tool the app cannot work without has to be one every platform can get.
+    // Anything narrower is an optional feature wearing the wrong label.
+    for (const d of DEPS.filter((x) => x.required)) expect(d.platforms).toBeUndefined();
+  });
+
+  it("names no package manager anywhere, in the catalog or the panels quoting it", () => {
+    const surfaces = [
+      "shared/deps.ts",
+      "web/src/components/GitMissingBanner.tsx",
+      "web/src/components/DockerPanel.tsx",
+      "web/src/components/PrPanel.tsx",
+      "web/src/components/SettingsModal.tsx",
+    ];
+    for (const rel of surfaces) {
+      const hit = PKG_MANAGER_CMD.exec(read(rel));
+      // The message names the file and the offending line, because the fix is
+      // to replace it with the project's own page, not to loosen the rule.
+      expect(hit ? `${rel}: ${hit[0]}` : null).toBeNull();
+    }
+  });
+
+  it("knows which platforms a tool is used on", () => {
+    expect(usedOn({ ...DEPS[0]!, platforms: undefined }, "win32")).toBe(true);
+    expect(usedOn({ ...DEPS[0]!, platforms: ["linux"] }, "darwin")).toBe(false);
+    expect(usedOn({ ...DEPS[0]!, platforms: ["linux", "darwin"] }, "darwin")).toBe(true);
+  });
+});
+
+describe("dependency report", () => {
+  const STATUSES: DepStatus[] = ["ok", "attention", "missing", "unsupported"];
+
+  it("answers for every tool in the catalog, once each", async () => {
+    resetDependencyCache();
+    const r = await dependencyReport(true);
+    expect(r.platform).toBe(process.platform);
+    expect(r.deps.map((d) => d.id).sort()).toEqual(DEPS.map((d) => d.id).sort());
+    for (const d of r.deps) expect(STATUSES).toContain(d.status);
+  });
+
+  it("says 'not used here' for a tool this platform never reaches for, and only for those", async () => {
+    resetDependencyCache();
+    const r = await dependencyReport(true);
+    for (const d of r.deps) {
+      const spec = depSpec(d.id)!;
+      // The two must agree in both directions: an unsupported row on a platform
+      // that does use the tool would hide a real problem, and a probed row on a
+      // platform that never uses it invents one.
+      expect(d.status === "unsupported").toBe(!usedOn(spec, process.platform));
+    }
+  });
+
+  it("mirrors the panels rather than probing a second time: git is found here because the panels find it", async () => {
+    resetDependencyCache();
+    const r = await dependencyReport(true);
+    const git = r.deps.find((d) => d.id === "git")!;
+    // CI and any dev machine running this suite has git; the interesting part
+    // is that this row is the same answer /git/capability gives, not a new one.
+    expect(git.status).toBe("ok");
+    expect(git.required).toBe(true);
+  });
+
+  it("serves a repeated ask from cache, and re-probes when asked to", async () => {
+    resetDependencyCache();
+    const a = await dependencyReport();
+    const b = await dependencyReport();
+    expect(a).toBe(b); // same object: the pane reopening costs nothing
+    const c = await dependencyReport(true);
+    expect(c).not.toBe(a); // Recheck means recheck
+  });
+});

--- a/shared/deps.ts
+++ b/shared/deps.ts
@@ -1,0 +1,173 @@
+// The outside tools agentglass shells out to, in one place.
+//
+// Every panel that needs a binary already probes for it and says so on its own
+// (git, docker, gh, tmux). What nobody could answer was the whole question:
+// "what am I still missing for this app to work end to end?" That answer needs
+// a list, and a list needs a single source, or the wording drifts between the
+// six places that already tell part of the story.
+//
+// GENERIC ON PURPOSE. There is one macOS, one Windows and an unbounded number
+// of Linux distributions, so a package-manager line is wrong for most readers
+// and stale for the rest. Each entry names the tool, says what stops working
+// without it, and links the project's own page. How the reader installs
+// software on their machine is theirs to know, not ours to guess.
+
+/** Platforms a tool is used on at all. Anywhere else the row reads "not used
+ *  here" rather than "missing", because a mac with no `pkexec` is not broken. */
+export type DepPlatform = "linux" | "darwin" | "win32";
+
+export type DepId =
+  | "git" | "claude" | "python" | "tmux" | "gh" | "docker" | "nvim"
+  | "setsid" | "script" | "dbus-monitor" | "notify-send" | "opener" | "pkexec" | "bash";
+
+export interface DepSpec {
+  id: DepId;
+  /** The command as it has to appear on PATH. Shown as-is, so it is also the
+   *  string a reader searches for. */
+  bin: string;
+  /** Sentence case, the way it is written on screen. */
+  title: string;
+  /** What stops working without it. Written as a consequence, not a category:
+   *  "the terminal cannot open" beats "terminal support". */
+  what: string;
+  /** Required means the app is visibly broken without it. Optional means one
+   *  feature stands down and the rest carries on. */
+  required: boolean;
+  /** The project's own page. Never a package-manager command. */
+  url: string;
+  /** Absent means every platform. */
+  platforms?: DepPlatform[];
+  /** One extra thing a reader cannot infer from the name, when there is one. */
+  note?: string;
+}
+
+/** The catalog. Order is the reading order: the things that break the app
+ *  first, then what each feature wants, then the small POSIX pieces. */
+export const DEPS: DepSpec[] = [
+  {
+    id: "git", bin: "git", title: "Git", required: true,
+    what: "Source control, file changes, pull requests and worktrees all shell out to it, and the terminal uses it to decide where to open.",
+    url: "https://git-scm.com/downloads",
+  },
+  {
+    id: "claude", bin: "claude", title: "Claude Code CLI", required: true,
+    what: "The chat panel runs it: every turn, the tmux pane engine, Review with Claude, and the walkthrough.",
+    url: "https://docs.claude.com/en/docs/claude-code/setup",
+    note: "agentglass reads Claude Code's own transcripts either way, so sessions still show up without it. Only chatting from the app needs the CLI.",
+  },
+  {
+    id: "python", bin: "python3", title: "Python 3", required: true,
+    what: "Two separate jobs: it runs the hook forwarder that streams sessions here live, and it backs the terminal's pseudo-terminal.",
+    url: "https://www.python.org/downloads/",
+    note: "Without it the hooks stay written but fail on every event, so nothing arrives live and nothing says why. The terminal keeps opening, in a degraded mode where full-screen programs do not render. On Windows the hooks use `py` or `python`.",
+  },
+  {
+    id: "tmux", bin: "tmux", title: "tmux", required: false,
+    what: "Runs each chat as a live pane you can attach to from your own terminal, shows your tmux windows as tabs in the terminal panel, and takes the app's theme.",
+    url: "https://github.com/tmux/tmux/wiki/Installing",
+    platforms: ["linux", "darwin"],
+    note: "Without it chats still run, one process per turn, which is slower to start but costs nothing while idle.",
+  },
+  {
+    id: "gh", bin: "gh", title: "GitHub CLI", required: false,
+    what: "Everything in the pull requests panel: the list, the diff, reviews, checks and merges.",
+    url: "https://cli.github.com",
+    note: "Installing it is half the job. It also has to be logged in before the panel can read anything.",
+  },
+  {
+    id: "docker", bin: "docker", title: "Docker", required: false,
+    what: "The containers, images, volumes and logs panel.",
+    url: "https://docs.docker.com/get-started/get-docker/",
+    note: "The CLI on its own is not enough: the daemon has to be running for the panel to show anything.",
+  },
+  {
+    id: "nvim", bin: "nvim", title: "Neovim", required: false,
+    what: "Sends a file straight to a running editor from the diff and file panels, and keeps it on the app's theme.",
+    url: "https://neovim.io",
+    note: "With any other $EDITOR the app hands you the command to paste instead.",
+  },
+  {
+    id: "setsid", bin: "setsid", title: "setsid (util-linux)", required: false,
+    what: "Gives every shell and chat its own process group, so closing one takes its children with it.",
+    url: "https://github.com/util-linux/util-linux",
+    // Used wherever it is found, not only on Linux: the terminal prepends it
+    // whenever `Bun.which` turns one up. macOS simply does not ship one, which
+    // is why a Mac shows this row as absent rather than as not applicable.
+    platforms: ["linux", "darwin"],
+    note: "Without it a closed terminal or chat can leave background processes behind. macOS does not ship it.",
+  },
+  {
+    id: "script", bin: "script", title: "script (util-linux)", required: false,
+    what: "The terminal's fallback pseudo-terminal, used when Python 3 is absent.",
+    url: "https://github.com/util-linux/util-linux",
+    platforms: ["linux"],
+  },
+  {
+    id: "dbus-monitor", bin: "dbus-monitor", title: "D-Bus tools", required: false,
+    what: "Mirrors your desktop notifications onto the notch, so Slack and the rest stay visible in fullscreen.",
+    url: "https://www.freedesktop.org/wiki/Software/dbus/",
+    platforms: ["linux"],
+    note: "It also needs a session bus, which a headless box or an SSH session does not have.",
+  },
+  {
+    id: "notify-send", bin: "notify-send", title: "notify-send (libnotify)", required: false,
+    what: "Raises a desktop alert when an agent needs you and no agentglass window is open to show it.",
+    url: "https://gitlab.gnome.org/GNOME/libnotify",
+    platforms: ["linux"],
+  },
+  {
+    id: "opener", bin: "xdg-open", title: "Desktop opener", required: false,
+    what: "Opens the link behind a mirrored notification in your browser.",
+    url: "https://www.freedesktop.org/wiki/Software/xdg-utils/",
+    platforms: ["linux"],
+    note: "macOS and Windows use their built-in openers, so there is nothing to install there.",
+  },
+  {
+    id: "pkexec", bin: "pkexec", title: "polkit", required: false,
+    what: "Hands a worktree back to you when its files ended up owned by another user, for example after a container wrote into it.",
+    url: "https://gitlab.freedesktop.org/polkit/polkit",
+    platforms: ["linux"],
+  },
+  {
+    id: "bash", bin: "bash", title: "Bash", required: false,
+    what: "The shell the terminal falls back to when $SHELL is not set, and what the self-update script runs under.",
+    url: "https://www.gnu.org/software/bash/",
+    platforms: ["linux", "darwin"],
+  },
+];
+
+export const depSpec = (id: DepId): DepSpec | undefined => DEPS.find((d) => d.id === id);
+
+// --- what the server found (the wire shape) ---------------------------------
+//
+// These live here rather than in types.ts because they are the answer to this
+// catalog, and types.ts is kept dependency-free: it could not name a DepId
+// without importing this file.
+
+/** Four states, because "not here" is three different problems on screen.
+ *
+ *  `ok`          usable right now.
+ *  `attention`   installed, but not usable yet: gh with no login, a docker CLI
+ *                with no daemon behind it. The fix is not another install.
+ *  `missing`     not on PATH.
+ *  `unsupported` not used on this platform, so there is nothing to do. */
+export type DepStatus = "ok" | "attention" | "missing" | "unsupported";
+
+export interface DepReport extends DepSpec {
+  status: DepStatus;
+  /** A version when we have one cheaply, otherwise why it is not usable.
+   *  Written for a reader, and it is the server's words, not a code. */
+  detail?: string;
+}
+
+export interface DepsResponse {
+  /** `process.platform`, so the UI can say "on Linux" without guessing from
+   *  the browser, which may not be the machine the server runs on. */
+  platform: string;
+  deps: DepReport[];
+}
+
+/** Whether a tool is used on this platform at all. */
+export function usedOn(spec: DepSpec, platform: string): boolean {
+  return !spec.platforms || (spec.platforms as string[]).includes(platform);
+}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -4,6 +4,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type { DockerOverview, DockerContainer, DockerStat, DockerCapability } from "../../../shared/types.ts";
+import { depSpec } from "../../../shared/deps.ts";
 import { api } from "../lib/api.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
@@ -263,9 +264,12 @@ function DockerMissing({ reason }: { reason?: string }) {
         <span className="text-[11.5px]" style={{ color: "var(--text2)" }}>
           {reason || "The docker CLI isn't on your PATH"}. Containers, images, volumes and logs stay empty until it is.
         </span>
+        {/* Generic: one macOS, one Windows, an unbounded number of Linux
+            distributions. Docker's own page covers every one of them, and
+            Settings ▸ Requirements is the same check for every other tool. */}
         <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>
-          Get it from <code>docker.com/get-started</code> (Docker Desktop), or your package manager:{" "}
-          <code>apt install docker.io</code>, <code>brew install docker</code> — then reopen.
+          Install it however you install software here (<code>{depSpec("docker")?.url}</code>), then reopen.
+          Settings ▸ Requirements checks this and every other tool agentglass uses.
         </span>
       </div>
     </div>

--- a/web/src/components/GitMissingBanner.tsx
+++ b/web/src/components/GitMissingBanner.tsx
@@ -12,6 +12,7 @@
 // server-origin check there is nothing to poll back to health.
 import { useEffect, useState } from "react";
 import { api, IS_DEMO } from "../lib/api.ts";
+import { depSpec } from "../../../shared/deps.ts";
 import type { GitCapability } from "../../../shared/types.ts";
 
 export default function GitMissingBanner() {
@@ -41,9 +42,13 @@ export default function GitMissingBanner() {
         {cap.reason || "git is not installed"}. The source-control, diff and pull-request panels stay empty, and the
         terminal cannot open, until it is on your <code>PATH</code>.
       </span>
+      {/* Generic guidance on purpose: naming one package manager is wrong for
+          most readers, since there is one macOS, one Windows and an unbounded
+          number of Linux distributions. The project's own page covers all of
+          them, and Settings ▸ Requirements lists the rest of the tools. */}
       <span style={{ color: "var(--text3)" }}>
-        Install it from <code>git-scm.com/downloads</code> (or your package manager: <code>apt install git</code>,{" "}
-        <code>brew install git</code>), then reopen.
+        Install it however you install software here (<code>{depSpec("git")?.url}</code>), then reopen. Settings ▸ Requirements
+        checks this and every other tool agentglass uses.
       </span>
     </div>
   );

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -26,6 +26,7 @@ import type {
   PrReaction, PrAuthorAssociation, PrEvent, PrCommit, PrFile, PrCheckJob,
 } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
+import { depSpec } from "../../../shared/deps.ts";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
@@ -1383,7 +1384,14 @@ export function PrView({ active, onOpenChatWith }: { active: boolean; onOpenChat
             {listState.needsAuth ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>
                 <div style={{ color: "var(--warning)" }}>{listState.error || "The GitHub CLI is not set up"}</div>
-                <div className="mt-2">Pull requests come from <code>gh</code>. Install it, run <code>gh auth login</code>, then refresh.</div>
+                {/* Two steps, and the second is the one people miss: an
+                    installed gh that has never logged in reads exactly like a
+                    missing one from here. The link is the project's own page,
+                    not a package-manager line, because the reader's system is
+                    not knowable from here. */}
+                <div className="mt-2">
+                  Pull requests come from <code>gh</code>. Install it (<code>{depSpec("gh")?.url}</code>), run <code>gh auth login</code>, then refresh.
+                </div>
               </div>
             ) : !repo ? (
               <div className="p-3 text-[11px]" style={{ color: "var(--text3)" }}>{listState.error || "No GitHub remote on this repository"}</div>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -19,10 +19,12 @@ import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESK
 import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRenderer.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
+import { externalUrl } from "../lib/externalUrl.ts";
 import type { UpdateStatus, ReleaseNotes, HookSetupStatus } from "../../../shared/types.ts";
 import { sysNotifyMode, setSysNotifyMode, notifyCapability, notifyQuiet, setNotifyQuiet, type SysNotifyMode, type NotifyCapability } from "../lib/sysNotify.ts";
 import { chatEnginePref, setChatEnginePref, type ChatEnginePref } from "../lib/chatEnginePref.ts";
 import type { TmuxEngineInfo } from "../../../shared/types.ts";
+import type { DepReport, DepStatus } from "../../../shared/deps.ts";
 import { clock24, setClock24 } from "../lib/clockPref.ts";
 import { bindings, rebind, resetBindings, subscribeBindings, isCustomised, LABELS, DEFAULTS, type ActionId,
          chordFor, rebindChord, clearChord, resetChords, chordsCustomised, chordFromEvent, chordLabel } from "../lib/keybindings.ts";
@@ -122,13 +124,14 @@ function Row({ label, hint, kbd, href, download, onClick }: { label: string; hin
     : <button onClick={onClick} className={cls}>{body}</button>;
 }
 
-type Pane = "prefs" | "keys" | "open" | "export" | "hooks" | "about";
+type Pane = "prefs" | "keys" | "open" | "export" | "hooks" | "reqs" | "about";
 const TABS: { id: Pane; label: string }[] = [
   { id: "prefs", label: "Preferences" },
   { id: "keys", label: "Shortcuts" },
   { id: "open", label: "Open" },
   { id: "export", label: "Export" },
   { id: "hooks", label: "Hooks" },
+  { id: "reqs", label: "Requirements" },
   { id: "about", label: "About" },
 ];
 
@@ -461,6 +464,145 @@ function HooksPane({ open }: { open: boolean }) {
   );
 }
 
+/**
+ * What agentglass needs from the machine, and what it found.
+ *
+ * The panels have always said this one tool at a time, in the panel that needs
+ * it, and only once you opened that panel. Two of them never said it at all:
+ * python3 and setsid fail quietly, which is exactly the failure worth a list.
+ *
+ * Guidance is deliberately generic. There is one macOS, one Windows and an
+ * unbounded number of Linux distributions, so a package-manager line would be
+ * wrong for most readers. Each row names the tool, says what it costs to be
+ * without it, and links the project's own page. Nothing here installs anything.
+ */
+const STATUS_LABEL: Record<DepStatus, string> = {
+  ok: "Ready",
+  attention: "Needs setup",
+  missing: "Not installed",
+  unsupported: "Not used here",
+};
+
+function statusColor(d: DepReport): string {
+  if (d.status === "ok") return "var(--success)";
+  if (d.status === "attention") return "var(--warning)";
+  if (d.status === "unsupported") return "var(--text3)";
+  return d.required ? "var(--error)" : "var(--text3)";
+}
+
+/** Worst first: what is broken, then what is merely unconfigured, then the
+ *  rest. Someone opening this pane is looking for the problem, not the list. */
+const RANK: Record<DepStatus, number> = { missing: 0, attention: 1, ok: 2, unsupported: 3 };
+const byUrgency = (a: DepReport, b: DepReport) =>
+  (RANK[a.status] - RANK[b.status]) || (Number(b.required) - Number(a.required));
+
+function DepRow({ d }: { d: DepReport }) {
+  const color = statusColor(d);
+  const href = externalUrl(d.url);
+  return (
+    <div className="px-3 py-2 rounded-lg flex items-start gap-2.5 hover:bg-white/5">
+      <span className="mt-[5px] shrink-0 w-[7px] h-[7px] rounded-full" style={{ background: color }} aria-hidden />
+      <span className="min-w-0 flex-1">
+        <span className="flex items-center gap-2 flex-wrap">
+          <span className="text-[12.5px]" style={{ color: "var(--text)" }}>{d.title}</span>
+          <code className="text-[10px] t-mono t-dim2">{d.bin}</code>
+          <span className="text-[10px]" style={{ color }}>{STATUS_LABEL[d.status]}</span>
+          {d.status !== "ok" && d.status !== "unsupported" && d.required && (
+            <span className="chip text-[9px]" style={{ color: "var(--error)" }}>needed</span>
+          )}
+        </span>
+        <span className="block text-[10.5px] t-dim2 mt-0.5">{d.what}</span>
+        {d.detail && d.status !== "ok" && (
+          <span className="block text-[10.5px] mt-0.5" style={{ color }}>{d.detail}</span>
+        )}
+        {d.note && d.status !== "ok" && d.status !== "unsupported" && (
+          <span className="block text-[10px] t-dim2 mt-0.5">{d.note}</span>
+        )}
+      </span>
+      {/* Only where there is something to do about it. A row that is already
+          ready does not need a link, and a tool this platform never uses has
+          nothing to install. */}
+      {href && d.status !== "unsupported" && d.status !== "ok" && (
+        <a href={href} target="_blank" rel="noreferrer noopener"
+          className="shrink-0 text-[10.5px] px-2 py-1 rounded-lg"
+          style={{ color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 34%, transparent)" }}>
+          Install guide
+        </a>
+      )}
+    </div>
+  );
+}
+
+function RequirementsPane({ open }: { open: boolean }) {
+  const [deps, setDeps] = useState<DepReport[] | null>(null);
+  const [platform, setPlatform] = useState<string>("");
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = (force: boolean) => {
+    setBusy(true); setErr(null);
+    return api.dependencies(force)
+      .then((r) => { setDeps(r.deps); setPlatform(r.platform); })
+      .catch(() => setErr("Could not reach the server, so nothing could be checked."))
+      .finally(() => setBusy(false));
+  };
+
+  // Probed on open rather than at startup: it costs a handful of PATH lookups
+  // plus two cached subprocess answers, and nothing outside this pane wants it.
+  useEffect(() => { if (open) void load(false); }, [open]);
+
+  if (err) return <Section title="Requirements"><div className="px-3 py-2 text-[11px]" style={{ color: "var(--error)" }}>{err}</div></Section>;
+  if (!deps) return <Section title="Requirements"><div className="px-3 py-2 text-[11px] t-dim2">Checking this machine…</div></Section>;
+
+  const live = deps.filter((d) => d.status !== "unsupported");
+  const idle = deps.filter((d) => d.status === "unsupported");
+  const needed = live.filter((d) => d.required).sort(byUrgency);
+  const optional = live.filter((d) => !d.required).sort(byUrgency);
+  const broken = live.filter((d) => d.status === "missing" && d.required).length;
+  const wanting = live.filter((d) => d.status === "attention" || (d.status === "missing" && !d.required)).length;
+
+  return (
+    <Section title="Requirements">
+      <div className="px-3 pb-2 flex flex-col gap-2">
+        <div className="text-[11.5px]" style={{ color: "var(--text2)" }}>
+          agentglass drives the tools you already have rather than bundling its own. This is what it looks for
+          {platform && platform !== "demo" ? <> on this machine (<span className="t-mono text-[10.5px]">{platform}</span>)</> : null}, and what stops
+          working when one is absent. Install whatever is missing however you normally install software here, then recheck.
+        </div>
+        <div className="flex items-center gap-2 flex-wrap">
+          <span className="text-[11px]" style={{ color: broken ? "var(--error)" : wanting ? "var(--warning)" : "var(--success)" }}>
+            {broken
+              ? `${broken} needed ${broken === 1 ? "tool is" : "tools are"} missing`
+              : wanting
+                ? `Everything needed is here. ${wanting} optional ${wanting === 1 ? "feature is" : "features are"} standing down.`
+                : "Everything agentglass looks for is here."}
+          </span>
+          <button onClick={() => void load(true)} disabled={busy}
+            className="ml-auto text-[10.5px] px-2.5 py-1 rounded-lg"
+            style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", opacity: busy ? 0.5 : 1 }}>
+            {busy ? "Checking…" : "Recheck"}
+          </button>
+        </div>
+      </div>
+
+      <div className="panel-eyebrow px-3 pt-1 pb-1">Needed</div>
+      {needed.map((d) => <DepRow key={d.id} d={d} />)}
+
+      <div className="panel-eyebrow px-3 pt-2 pb-1">Per feature</div>
+      {optional.map((d) => <DepRow key={d.id} d={d} />)}
+
+      {idle.length > 0 && (
+        <>
+          <div className="panel-eyebrow px-3 pt-2 pb-1">Not used on {platform}</div>
+          <div className="px-3 pb-2 text-[10.5px] t-dim2">
+            {idle.map((d) => d.title).join(", ")}. Nothing to do about these here.
+          </div>
+        </>
+      )}
+    </Section>
+  );
+}
+
 export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, onOpenStats, onOpenHelp }: {
   open: boolean; onClose: () => void; sound: boolean; onSound: () => void;
   scale: number; onZoom: (dir: 1 | -1 | 0) => void;
@@ -660,11 +802,14 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                       label="How new chats run"
                       hint={
                         tmuxEngine && !tmuxEngine.available
-                          ? `tmux panes unavailable — ${tmuxEngine.reason}`
+                          // A reason on its own leaves "tmux is not installed"
+                          // as a dead end inside a settings dialog that has the
+                          // install guidance one tab away. Say where it is.
+                          ? `tmux panes unavailable: ${tmuxEngine.reason}. Chats still run, one process per turn. See Requirements for how to add tmux.`
                           : "Panes keep a warm claude per chat: faster turns, and you can attach from your terminal. Separate takes longer per turn and leaves nothing running."
                       }
                       disabled={tmuxEngine ? !tmuxEngine.available : true}
-                      disabledHint={tmuxEngine ? `Unavailable — ${tmuxEngine.reason}` : "Checking…"}
+                      disabledHint={tmuxEngine ? `Unavailable: ${tmuxEngine.reason}` : "Checking…"}
                       value={enginePref ?? "server"}
                       onPick={(v) => {
                         const next = v === "server" ? null : v;
@@ -762,6 +907,8 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                   )}
 
                   {pane === "hooks" && <HooksPane open={open} />}
+
+                  {pane === "reqs" && <RequirementsPane open={open} />}
 
                   {pane === "about" && <AboutPane open={open} />}
                   </div>

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -278,7 +278,10 @@ function connect(s: Sess) {
     if (f.t === "ready") {
       reconnected(s);
       s.status = "live"; s.mode = f.mode ?? null; s.shell = f.shell || "shell"; s.canResize = f.resize !== false;
-      if (f.mode === "pipe") s.term.writeln("\x1b[2m(no pty available on this host — plain-pipe shell: TUI apps won't render)\x1b[0m");
+      // Names the cure, not only the symptom: this mode is what a host with no
+      // python3 gets, and "TUI apps won't render" alone left people believing
+      // the terminal itself was broken.
+      if (f.mode === "pipe") s.term.writeln("\x1b[2m(no pty on this host: plain-pipe shell, full-screen programs won't render. Install python3 and reopen; Settings ▸ Requirements has the details.)\x1b[0m");
       for (const d of s.pending.splice(0)) ws.send(JSON.stringify({ t: "in", d }));
       // the fit that ran while connecting may not have reached the server
       ws.send(JSON.stringify({ t: "resize", cols: s.term.cols, rows: s.term.rows }));

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,5 @@
 import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo } from "../../../shared/types.ts";
+import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
 export const IS_DEMO = demo.IS_DEMO;
@@ -241,6 +242,10 @@ const realApi = {
   fsComplete: (prefix: string) => get<FsCompletion>(`/fs/complete?prefix=${encodeURIComponent(prefix)}`),
   // --- live git panel (lazygit-style) ---
   gitCapability: () => get<GitCapability>("/git/capability"),
+  /** Every outside tool the app shells out to, and what this machine has.
+   *  `force` is the Recheck button: it re-probes inside the server's cache
+   *  window, which is the only case where a stale answer is the wrong one. */
+  dependencies: (force = false) => get<DepsResponse>(`/dependencies${force ? "?force=1" : ""}`),
   gitRepos: () => get<{ repos: GitRepoRef[] }>("/git/repos"),
   /** Every repo on the machine — for the project picker, even when scoped. */
   gitReposAll: () => get<{ repos: GitRepoRef[] }>("/git/repos?all=1"),
@@ -515,6 +520,12 @@ const demoApi: typeof realApi = {
   // The demo has no filesystem to browse, so completion is simply always empty.
   fsComplete: (_prefix: string) => D({ base: "", entries: [], truncated: false }),
   gitCapability: () => D({ available: true } as GitCapability),
+  // The demo runs no local processes, so it has nothing to probe. The catalog
+  // is still the honest thing to show: it is what the real app would check.
+  dependencies: (_force = false) => D({
+    platform: "demo",
+    deps: DEPS.map((d) => ({ ...d, status: "unsupported" as const, detail: "the demo runs no local processes, so nothing here is probed" })),
+  } as DepsResponse),
   gitRepos: () => D(demo.gitRepos()),
   gitReposAll: () => D(demo.gitRepos()),
   gitTree: (root: string) => D(demo.gitTree(root)),


### PR DESCRIPTION
## What does this PR do?

agentglass shells out to a dozen tools it does not ship, and until now the app
could only answer for them one panel at a time. Each panel probed for its own
(git, docker, gh, tmux) and said so in its own words, but only once you opened
that panel, and three tools were never reported at all: `python3`, `setsid` and
`script`. Those three are the quiet ones. With no `python3` the Claude Code
hooks stay wired and fail on every event, so nothing streams live and nothing
anywhere names the cause, and the terminal silently drops to a mode where
full-screen programs do not render. With no `setsid` a closed shell can leave
its children running.

**Settings ▸ Requirements** is the missing answer: every tool, whether this
machine has it, what stops working without it, and a link to the project's own
install page. Four states, because "not here" is three different problems on
screen: ready, needs setup (an installed `gh` with no login, a docker CLI with
no daemon behind it), not installed, and not used on this platform.

The guidance is generic on purpose. There is one macOS, one Windows and an
unbounded number of Linux distributions, so a package-manager line is wrong for
most readers and stale for the rest. The git and docker banners no longer name
one either, and a test greps the catalog and the panels quoting it so the rule
survives future editing.

Nothing here installs anything, and no behaviour changed: this is a read-only
probe, a new pane, and the wording around five dead ends that previously left
you nowhere.

- `shared/deps.ts` is the single source: what each tool powers, whether it is
  required, its official page, which platforms reach for it.
- `server/src/deps.ts` reuses the existing capability functions rather than
  forming a second opinion, so this list can never disagree with the panel it
  describes. `GET /dependencies`; `force=1` is the Recheck button.
- The dead ends now point somewhere: the greyed-out tmux chat engine, the chat
  with no `claude` CLI, the terminal's pipe-mode line, and a boot warning for a
  missing `python3` alongside the one git already had.
- README gains a Requirements section, including the two requirements that are
  not binaries: the Linux AppImage needs FUSE, and self-update builds on your
  machine.

## How was it tested?

- `bun test` at the repo root: 1042 pass, 0 fail (9 of them new, in
  `server/test/deps.test.ts`: catalog invariants, the unsupported-iff-unused
  rule, cache versus Recheck, and the package-manager grep).
- `bunx tsc --noEmit` in `web/` and `server/`, and `bunx vite build`.
- Installed the desktop app from this branch with `electron/install-local.sh`
  and exercised Settings ▸ Requirements, plus `GET /dependencies` against the
  running sidecar: 14 rows, correct versions and the `gh` login state.
