### PR TITLE
fix(chat): never press Enter a second time into a menu

### DIFF
--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -166,23 +166,30 @@ type SubmitOutcome = "sent" | "diverted" | "stuck";
 async function submitConfirmed(name: string, pasted: string, deadline: number): Promise<SubmitOutcome> {
   for (;;) {
     await submit(name);
-    // Long enough for the TUI to redraw after accepting, short enough that the
-    // common case (accepted on the second press) is not perceptibly slower.
-    await Bun.sleep(250);
-    const box = inputBox(await capture(name));
-    if (!box?.trim()) return "sent";
+    // Long enough for the TUI to redraw after accepting. Deliberately generous:
+    // the cost of waiting is a slower turn, the cost of looking too early is a
+    // second Enter, and those two are not the same size at all — see below.
+    await Bun.sleep(600);
+    const screen = await capture(name);
     /*
-     * Only keep pressing while the box still holds OUR prompt.
+     * A picker on screen means the prompt was ACCEPTED and opened something.
+     * Never press again.
      *
-     * This guard is the whole reason the retry is safe. Claude Code's pickers
-     * draw their selection cursor with the same `❯` glyph as the input box, so
-     * a `/model` menu reads as "box still full" — and in that menu Enter means
-     * "set as default". Retrying blindly walked straight into changing the
-     * user's saved model and effort, silently, from a chat that appeared to be
-     * hanging. Verified by reproducing it: a second Enter after `/effort`
-     * printed "Set effort level to xhigh (saved as your default for new
-     * sessions)".
+     * This check has to come before the box check, and that ordering is the
+     * whole fix. `/model` and `/effort` open a menu in which Enter means "set
+     * as default" — it writes to the user's real settings.json. The previous
+     * version looked only at the input box, and a capture taken 250ms after
+     * Enter could still show the frame from before the menu drew: box still
+     * holds "/effort", so it pressed Enter again, and that second press
+     * confirmed the menu. It changed a real machine's saved effort from `high`
+     * to `xhigh` twice before anyone noticed, once from a chat that looked like
+     * it was simply thinking.
      */
+    if (NEEDS_YOU_RE.test(screen)) return "diverted";
+    const box = inputBox(screen);
+    if (!box?.trim()) return "sent";
+    // Still our text, nothing opened: the Enter really was swallowed (the TUI
+    // folds the first one into the bracketed paste). Safe to press again.
     if (box.trim() !== pasted.trim()) return "diverted";
     if (Date.now() > deadline) return "stuck";
   }
@@ -315,6 +322,17 @@ export interface PaneTurnOptions {
 const NEEDS_YOU_RE = /Esc to cancel|Enter to confirm|to use this session only/;
 export const __needsYou = (screen: string): boolean => NEEDS_YOU_RE.test(screen);
 export const __isRunning = (screen: string): boolean => RUNNING_RE.test(screen);
+
+/** The submit loop's decision for one observed frame, without the tmux round
+ *  trip. Exported so the ordering that matters — picker before input box — is
+ *  pinned by a test rather than by a comment. */
+export function __submitVerdict(screen: string, pasted: string): SubmitOutcome | "retry" {
+  if (NEEDS_YOU_RE.test(screen)) return "diverted";
+  const box = inputBox(screen);
+  if (!box?.trim()) return "sent";
+  if (box.trim() !== pasted.trim()) return "diverted";
+  return "retry";
+}
 
 /** A turn that is actually working says so. Used to tell "idle" apart from
  *  "thinking", which is the difference between ending a turn and abandoning it. */

--- a/server/test/chat-pane.test.ts
+++ b/server/test/chat-pane.test.ts
@@ -230,3 +230,34 @@ test("a disallowed key is refused even for a valid pane", async () => {
   expect(r.ok).toBe(false);
   expect(r.stderr).toContain("not allowed");
 });
+
+// --- never press Enter twice into a menu ------------------------------------
+// Enter in a `/model` or `/effort` picker means "set as default": it writes the
+// user's real settings.json. This happened on a live machine, twice, once from
+// a chat that merely looked like it was thinking.
+
+/** The frame that caused it: the menu has drawn, but the input box row above it
+ *  still shows the command from before the redraw. */
+const PICKER_WITH_STALE_BOX = [
+  "❯ /effort",
+  "   Effort",
+  "   low   medium   high   xhigh   max",
+  "   ←/→ to adjust · Enter to confirm · Esc to cancel",
+].join("\n");
+
+test("a menu on screen stops the retry even when the box looks unsent", () => {
+  // The ordering IS the fix. Reading the box first sees "/effort" still there,
+  // concludes the Enter was swallowed, and presses again — confirming the menu.
+  expect(mod.__submitVerdict(PICKER_WITH_STALE_BOX, "/effort")).toBe("diverted");
+});
+
+test("a genuinely swallowed Enter is still retried", () => {
+  // The behaviour this must not break: the TUI folds the first Enter into the
+  // bracketed paste, so without a retry ordinary turns are silently lost.
+  const stillWaiting = ["❯ write me a test", "────────", "  ⏵⏵ bypass permissions on"].join("\n");
+  expect(mod.__submitVerdict(stillWaiting, "write me a test")).toBe("retry");
+});
+
+test("an emptied box is taken as sent", () => {
+  expect(mod.__submitVerdict("● thinking…\n❯ \n────────", "write me a test")).toBe("sent");
+});


### PR DESCRIPTION
## What does this PR do?

Enter in a `/model` or `/effort` picker means **"set as default"** — it writes the user's real `~/.claude/settings.json`. The submit loop pressed Enter twice, and that changed a live machine's saved effort from `high` to `xhigh`. Twice. The second time from a chat that looked like it was simply thinking, which is why it went unnoticed.

The mechanism, from the pane's own scrollback:

```
❯ /effort
  ⎿  Set effort level to xhigh (saved as your default for new sessions)
```

The first Enter submits and the menu opens. The capture taken 250ms later can still show the frame from *before* the menu drew — the box still holds `/effort` — so the loop concluded the Enter had been swallowed and pressed again. That second press confirmed the menu.

The retry itself has to stay: the TUI folds the first Enter into the bracketed paste, so without it ordinary turns are silently lost (measured — a prompt sat unchanged through 10s of polling and a second Enter submitted it at once). What was missing is that **a menu on screen is proof the prompt was accepted**. That check now runs before the input box is looked at, and the ordering is the whole fix. The settle time also goes 250ms → 600ms, because the two failure modes are not the same size: looking too late costs a slower turn, looking too early rewrites settings.

**I claimed in #335 that this guard "changes nothing in practice".** That was wrong, and wrong in the direction that touches real files. Worth knowing when reviewing the reasoning here, not just the diff.

## How was it tested?

- `bunx tsc --noEmit` clean in `server/`; full suite **1056 pass / 0 fail**.
- 3 new tests built from the exact frame that caused it — a drawn menu with a stale box row above it. They pin the ordering (menu wins over box), that a genuinely swallowed Enter is still retried, and that an emptied box still reads as sent.
- The bug was found by reading the pane's scrollback after the user reported the chat still spinning, not by reasoning about the code — the settings change was visible there in plain text.
- The affected machine's `effortLevel` was restored to `high` from its own backup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)