### PR TITLE
feat(chat): Up recalls what you sent, the way a shell does

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -747,6 +747,11 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
 
   const submit = () => {
     if (!active) return;
+    // Sending ends the browse. Anything stashed has been superseded by the
+    // message going out, and the next Up should start from the newest again —
+    // which is what a shell does too.
+    setRecallAt(-1);
+    stashed.current = "";
     const text = active.draft;
     // Mid-turn, Enter queues instead of sending. The composer used to go dead
     // for the length of a reply, so a long tool-running turn meant watching it
@@ -861,6 +866,48 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     setHint(await addAttachments(active.id, files));
   };
 
+  /*
+   * Where recall currently sits, and what it interrupted.
+   *
+   * `-1` means not browsing. The stash is what was in the box when browsing
+   * started, so coming all the way forward returns it rather than leaving you
+   * staring at an empty composer wondering where your half-written message
+   * went. Both reset when the chat changes: history is per conversation, and
+   * an index into someone else's messages is meaningless.
+   */
+  const [recallAt, setRecallAt] = useState(-1);
+  const stashed = useRef("");
+  useEffect(() => { setRecallAt(-1); stashed.current = ""; }, [active?.id]);
+
+  /** This chat's own sent messages, newest first. Queued turns are deliberately
+   *  absent: they have not been said yet, and recalling one would put the same
+   *  text in the box twice over. */
+  const history = useMemo(
+    () => (active?.messages ?? []).filter((m) => m.role === "user" && m.text.trim()).map((m) => m.text).reverse(),
+    [active?.messages]
+  );
+
+  /** Step back one. Returns null when there is nothing older, so the caller can
+   *  let the keystroke through and the caret moves as it normally would. */
+  const recallOlder = (chat: Chat): string | null => {
+    const next = recallAt + 1;
+    if (next >= history.length) return null;
+    if (recallAt === -1) stashed.current = chat.draft;
+    setRecallAt(next);
+    update(chat.id, (c) => { c.draft = history[next]; });
+    return history[next];
+  };
+
+  /** Step forward one, landing back on the stashed draft past the newest. */
+  const recallNewer = (chat: Chat): string | null => {
+    if (recallAt < 0) return null;
+    const next = recallAt - 1;
+    setRecallAt(next);
+    const text = next < 0 ? stashed.current : history[next];
+    update(chat.id, (c) => { c.draft = text; });
+    return text;
+  };
+
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
     // The skill menu owns the arrows, Tab and Enter while it is showing, or
     // Enter would send `/rev` as a message instead of completing it.
@@ -874,6 +921,34 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // A focused textarea can swallow Escape before it reaches the global
     // handler, stranding the panel open. Close it here instead.
     if (e.key === "Escape") { e.preventDefault(); onClose(); return; }
+    /*
+     * Shell-style recall: Up walks back through what you have sent in this
+     * chat, Down comes forward again and lands back on whatever you were part
+     * way through typing.
+     *
+     * Gated on the caret being on the first or last line, because a composer
+     * that ate the arrow keys would make a multi-line message impossible to
+     * edit. On the first line there is nothing above to move to, so Up is free
+     * to mean something else — which is the same rule a shell uses.
+     */
+    if ((e.key === "ArrowUp" || e.key === "ArrowDown") && !e.shiftKey && !e.altKey && active) {
+      const el = e.currentTarget;
+      const before = el.value.slice(0, el.selectionStart ?? 0);
+      const after = el.value.slice(el.selectionEnd ?? 0);
+      const atFirstLine = !before.includes("\n");
+      const atLastLine = !after.includes("\n");
+      const moved = e.key === "ArrowUp"
+        ? (atFirstLine ? recallOlder(active) : null)
+        : (atLastLine ? recallNewer(active) : null);
+      if (moved !== null) {
+        e.preventDefault();
+        // Caret to the end, so the recalled text is ready to be added to
+        // rather than typed over from wherever the cursor happened to sit.
+        requestAnimationFrame(() => { const n = el.value.length; el.setSelectionRange(n, n); });
+        return;
+      }
+      return;
+    }
     if (e.key !== "Enter" || e.shiftKey) return;
     e.preventDefault();
     // send() returns early in both these cases; without saying so, Enter just

--- a/web/test/composer-history.test.ts
+++ b/web/test/composer-history.test.ts
@@ -1,0 +1,73 @@
+// Shell-style recall in the composer: Up walks back through what you sent.
+//
+// The rules are small but each one is there because the obvious version of it
+// is wrong: history is per chat, it is built from sent messages only, and
+// coming forward past the newest has to return the draft you interrupted rather
+// than an empty box.
+import { test, expect, beforeAll, beforeEach } from "bun:test";
+import type { ChatMsg } from "../src/lib/chatStore.ts";
+
+const cell = new Map<string, string>();
+let store: typeof import("../src/lib/chatStore.ts");
+
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  store = await import("../src/lib/chatStore.ts");
+});
+
+beforeEach(() => { for (const c of store.listChats()) store.closeChat(c.id); });
+
+const msg = (role: "user" | "assistant", text: string): ChatMsg =>
+  ({ role, text, tools: [], ts: 1 }) as ChatMsg;
+
+/** The same derivation the composer uses: this chat's sent messages, newest
+ *  first. Kept here rather than imported because it is one expression, and
+ *  pinning it is the point. */
+const historyOf = (messages: ChatMsg[]) =>
+  messages.filter((m) => m.role === "user" && m.text.trim()).map((m) => m.text).reverse();
+
+test("history is what you said, newest first", () => {
+  const h = historyOf([
+    msg("user", "first"),
+    msg("assistant", "sure"),
+    msg("user", "second"),
+    msg("assistant", "done"),
+  ]);
+  // Newest first, so one press of Up gets the thing you most recently sent.
+  expect(h).toEqual(["second", "first"]);
+});
+
+test("the model's replies are not in your history", () => {
+  // Recalling Claude's own words into your composer would be nonsense, and it
+  // is the obvious bug if the role filter is forgotten.
+  const h = historyOf([msg("user", "hi"), msg("assistant", "hello there")]);
+  expect(h).toEqual(["hi"]);
+});
+
+test("empty turns are skipped", () => {
+  // An image-only turn has no text. Recalling it would look like the recall had
+  // silently cleared the box.
+  const h = historyOf([msg("user", "real"), msg("user", "   ")]);
+  expect(h).toEqual(["real"]);
+});
+
+test("history belongs to one chat, not to the panel", () => {
+  // Two chats, two conversations. An index into the other one's messages would
+  // put someone else's words in this box.
+  const a = store.newChat("/repo");
+  const b = store.newChat("/repo");
+  store.update(a.id, (c) => { c.messages = [msg("user", "in A")]; });
+  store.update(b.id, (c) => { c.messages = [msg("user", "in B")]; });
+  expect(historyOf(store.getChat(a.id)!.messages)).toEqual(["in A"]);
+  expect(historyOf(store.getChat(b.id)!.messages)).toEqual(["in B"]);
+});
+
+test("a chat with nothing sent has nothing to recall", () => {
+  // Up must fall through to moving the caret, not clear the box.
+  expect(historyOf([])).toEqual([]);
+});


### PR DESCRIPTION
## What does this PR do?

The composer looks like a terminal input and did not behave like one: there was no way back to something you had already sent, short of scrolling up and retyping it.

Up now walks back through this chat's sent messages. Down comes forward again and lands on whatever you were part way through typing when you started browsing — losing that half-written message is exactly what makes shell history annoying when it is done badly.

Two rules worth reviewing rather than skimming:

- **Gated on caret position.** Up recalls only when the caret is on the first line, Down only on the last. A composer that swallowed the arrows outright would make a multi-line message impossible to edit. On the first line there is nothing above to move to, so Up is free to mean something else — the same rule a shell uses.
- **History is per chat, and sent messages only.** The model's replies are not yours to recall; an image-only turn has no text and recalling it would read as the box being silently cleared; queued turns have not been said yet and would put the same text in the box twice. An index into another chat's messages would be someone else's words in your box, so browsing resets when the chat changes.

Sending ends the browse and clears the stash, so the next Up starts from the newest again.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/`, `bunx vite build` clean, full suite **1058 pass / 0 fail**.
- 5 new tests in `web/test/composer-history.test.ts` on the derivation the composer uses: newest first, replies excluded, empty turns skipped, per chat rather than per panel, and an empty history so Up falls through to moving the caret instead of clearing the box.
- **Not yet exercised in the app.** The keyboard path — caret gating, the caret landing at the end of recalled text, and not fighting the slash-command menu which already owns the arrows — needs a build and real typing. That is the part most worth checking before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)