### PR TITLE
feat(chat): an effort dial and a config button, so the pickers stay shut

### DIFF
--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -14,7 +14,8 @@
 import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
 import { inScope, chatBypassAllowed } from "./config.ts";
 import { paneTurnStream, paneEngineCapability } from "./chatpane.ts";
-import type { ChatImage, ChatImageMediaType } from "../../shared/types.ts";
+import { CHAT_EFFORTS } from "../../shared/types.ts";
+import type { ChatImage, ChatImageMediaType, ChatEffort } from "../../shared/types.ts";
 
 const claudeBin = () => Bun.which("claude");
 export const CHAT_ENABLED = !!claudeBin();
@@ -65,6 +66,19 @@ const MAX_ALLOWED = 40;
  *  raise a permission dialog is simply refused — the chat reports "requires
  *  approval" and there is no way to grant it from inside. This is the way out:
  *  the caller says up front what may run without asking. */
+/** How hard to think, as `--effort` takes it.
+ *
+ *  `""` means "say nothing", which is a real answer rather than a missing one:
+ *  someone who set an effort in their own settings.json should not have every
+ *  chat quietly overriding it.
+ *
+ *  Anything outside the CLI's own list is dropped rather than forwarded. This
+ *  value lands on a `claude` command line, so a level invented by a caller
+ *  would either be rejected there or, worse, quietly mean something else. */
+export function effortLevel(v: unknown): ChatEffort | "" {
+  return (CHAT_EFFORTS as readonly string[]).includes(v as string) ? (v as ChatEffort) : "";
+}
+
 export function allowList(v: unknown): string[] {
   if (!Array.isArray(v)) return [];
   return v.filter((t): t is string => typeof t === "string" && TOOL_RE.test(t.trim())).map((t) => t.trim()).slice(0, MAX_ALLOWED);
@@ -206,9 +220,9 @@ export function turnEnvelope(text: string, images: ChatImage[]): string {
  *  the whole of what keeps "open project" from being decorative. */
 export type TurnPlan =
   | { ok: false; response: Response }
-  | { ok: true; dir: string; text: string; model: string; mode: string; resumeId: string; images: ChatImage[]; allow: string[] };
+  | { ok: true; dir: string; text: string; model: string; mode: string; effort: ChatEffort | ""; resumeId: string; images: ChatImage[]; allow: string[] };
 
-export function planTurn(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, allowedTools?: unknown, images?: unknown): TurnPlan {
+export function planTurn(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, allowedTools?: unknown, images?: unknown, effort?: unknown): TurnPlan {
   const no = (r: Response): TurnPlan => ({ ok: false, response: r });
   if (!claudeBin()) return no(err("no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)", 403));
   if (process.env.AGENTGLASS_CHAT_DISABLED === "1") return no(err("chat is disabled (AGENTGLASS_CHAT_DISABLED=1)", 403));
@@ -237,7 +251,7 @@ export function planTurn(cwd: unknown, message: unknown, model: unknown, resumeI
   if (pm === "bypassPermissions" && !BYPASS_ALLOWED) pm = "default"; // opt-in only
   const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";
   const allow = pm === "bypassPermissions" ? [] : allowList(allowedTools);
-  return { ok: true, dir, text: message, model: m, mode: pm, resumeId: rid, images: imgs, allow };
+  return { ok: true, dir, text: message, model: m, mode: pm, effort: effortLevel(effort), resumeId: rid, images: imgs, allow };
 }
 
 /** Which engine a chat uses when the request does not say.
@@ -256,7 +270,7 @@ export const CHAT_ENGINE_DEFAULT = process.env.AGENTGLASS_CHAT_ENGINE === "tmux"
  *  Validation happens once, before the split, so neither engine can be reached
  *  with a directory the other would have refused. */
 export function chatSend(b: Record<string, unknown>): Response {
-  const plan = planTurn(b.cwd, b.message, b.model, b.resumeId, b.mode, b.allowedTools, b.images);
+  const plan = planTurn(b.cwd, b.message, b.model, b.resumeId, b.mode, b.allowedTools, b.images, b.effort);
   if (!plan.ok) return plan.response;
   const want = b.engine === "tmux" || b.engine === "process" ? b.engine : CHAT_ENGINE_DEFAULT;
   if (want !== "tmux") return chatStreamPlanned(plan);
@@ -270,6 +284,7 @@ export function chatSend(b: Record<string, unknown>): Response {
     message: plan.text,
     model: plan.model,
     mode: plan.mode,
+    effort: plan.effort,
     // A chat with no session yet gets its id decided here rather than discovered
     // from the CLI: the pane has to be named something before it is launched,
     // and `--session-id` is what makes the two agree.
@@ -289,6 +304,10 @@ function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
   const { dir, text: msgText, model: m, mode: pm, resumeId: rid, images: imgs } = plan;
 
   const args = [bin, "-p", "--output-format", "stream-json", "--verbose", "--model", m];
+  // Same flag both engines use. Verified it applies to `-p` as well as to an
+  // interactive session, which is what makes the chat's dial mean the same
+  // thing whichever engine a chat happens to run on.
+  if (plan.effort) args.push("--effort", plan.effort);
   // Structured input is only switched on for a turn that actually needs it.
   // Plain text is the overwhelmingly common case and its path through `claude`
   // is the well-trodden one; `--input-format stream-json` is comparatively

--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -66,7 +66,7 @@ async function sizeOf(path: string): Promise<number> {
 // mid-conversation cannot be honoured by an already-running CLI — both are
 // process-level here — so the pane is relaunched with `--resume`, which costs
 // one slow turn and keeps the conversation intact.
-interface PaneSpec { model: string; mode: string; cwd: string }
+interface PaneSpec { model: string; mode: string; effort: string; cwd: string }
 const specs = new Map<string, PaneSpec>();
 
 /** How long to wait for the TUI to draw its input box before giving up.
@@ -202,7 +202,7 @@ async function submitConfirmed(name: string, pasted: string, deadline: number): 
  *  `--session-id` on an existing session is a hard error ("Session ID is already
  *  in use"), so getting this backwards does not degrade, it fails the turn. */
 async function ensurePane(
-  sessionId: string, cwd: string, model: string, mode: string,
+  sessionId: string, cwd: string, model: string, mode: string, effort: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
   const bin = claudeBin();
   if (!bin) return { ok: false, error: "no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)" };
@@ -211,7 +211,7 @@ async function ensurePane(
   const spec = specs.get(sessionId);
   // A live pane whose model or mode no longer matches what the chat is asking
   // for cannot be re-flagged in place; take it down and bring it back resumed.
-  if (alive && spec && (spec.model !== model || spec.mode !== mode)) {
+  if (alive && spec && (spec.model !== model || spec.mode !== mode || spec.effort !== effort)) {
     await killPane(sessionId);
     specs.delete(sessionId);
   } else if (alive) {
@@ -221,6 +221,7 @@ async function ensurePane(
 
   const fresh = (await sizeOf(transcriptFor(cwd, sessionId))) === 0;
   const argv = [bin, "--model", model];
+  if (effort) argv.push("--effort", effort);
   if (fresh) argv.push("--session-id", sessionId);
   else argv.push("--resume", sessionId);
   if (mode === "bypassPermissions") argv.push("--dangerously-skip-permissions");
@@ -236,7 +237,7 @@ async function ensurePane(
     const screen = (await capture(sessionId)).trim().split("\n").filter(Boolean).slice(-6).join("\n");
     return { ok: false, error: `the chat pane never became ready in ${Math.round(READY_TIMEOUT_MS / 1000)}s.\n${screen}` };
   }
-  specs.set(sessionId, { model, mode, cwd });
+  specs.set(sessionId, { model, mode, effort, cwd });
   touchPane(sessionId);
   return { ok: true };
 }
@@ -304,6 +305,8 @@ export interface PaneTurnOptions {
   message: string;
   model: string;
   mode: string;
+  /** Empty means "leave the CLI's own setting alone". */
+  effort: string;
   sessionId: string;
   images: { mediaType: string; data: string }[];
 }
@@ -358,7 +361,7 @@ const STALL_CHECK_MS = 15_000;
 /** Run one turn in the chat's pane, streaming the same ndjson the `-p` engine
  *  streams so the browser needs no new parsing. */
 export function paneTurnStream(opts: PaneTurnOptions): Response {
-  const { cwd, message, model, mode, sessionId, images } = opts;
+  const { cwd, message, model, mode, effort, sessionId, images } = opts;
   const enc = new TextEncoder();
   let cancelled = false;
 
@@ -373,7 +376,7 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
       };
 
       try {
-        const ready = await ensurePane(sessionId, cwd, model, mode);
+        const ready = await ensurePane(sessionId, cwd, model, mode, effort);
         if (!ready.ok) {
           // A pane that will not come up fails identically on every retry until
           // someone does something about it, which is exactly what the setup

--- a/server/test/chat-effort.test.ts
+++ b/server/test/chat-effort.test.ts
@@ -1,0 +1,38 @@
+// The effort dial, server side.
+//
+// `--effort` reaches a real CLI and changes what the user is billed for, so the
+// value is taken from the CLI's own list or not passed at all. "Absent" is a
+// deliberate third answer, not a missing one: someone who set an effort in
+// their settings.json should not have every chat quietly overriding it.
+import { test, expect } from "bun:test";
+import { effortLevel } from "../src/chat.ts";
+import { CHAT_EFFORTS } from "../../shared/types.ts";
+
+// The pure validator rather than planTurn, following allowList's example: the
+// whole plan depends on ambient git and workspace scope, which under `bun test`
+// belongs to whichever file loaded config.ts first.
+
+test("every level the CLI offers is accepted", () => {
+  for (const e of CHAT_EFFORTS) expect(effortLevel(e)).toBe(e);
+});
+
+test("no effort means the CLI's own setting is left alone", () => {
+  // Not defaulted to "high" or anything else — passing a flag the user never
+  // asked for would silently override what they configured themselves.
+  for (const absent of [undefined, null, ""]) expect(effortLevel(absent)).toBe("");
+});
+
+test("anything outside the list is dropped rather than forwarded", () => {
+  // This lands on a `claude` command line. A value invented by a caller would
+  // either be rejected by the CLI or, worse, quietly mean something else.
+  for (const bad of ["highest", "HIGH", "max ", "; rm -rf /", 3, {}, ["max"]]) expect(effortLevel(bad)).toBe("");
+});
+
+test("the levels are ordered lowest first, because the UI reads position", () => {
+  // The dial fills bars up to the index. If this array were ever reordered
+  // alphabetically the meter would show `high` as more than `xhigh`.
+  expect(CHAT_EFFORTS[0]).toBe("low");
+  expect(CHAT_EFFORTS.indexOf("high")).toBeLessThan(CHAT_EFFORTS.indexOf("xhigh"));
+  expect(CHAT_EFFORTS.indexOf("xhigh")).toBeLessThan(CHAT_EFFORTS.indexOf("max"));
+  expect(CHAT_EFFORTS[CHAT_EFFORTS.length - 1]).toBe("ultracode");
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -910,6 +910,18 @@ export type ChatImageMediaType = "image/png" | "image/jpeg" | "image/gif" | "ima
  *              The trade is memory: a warm CLI is ~380MB and grows with use. */
 export type ChatEngine = "process" | "tmux";
 
+/** How hard the model is asked to think, lowest first.
+ *
+ *  The order is the whole point: this is a dial, not a set of unrelated
+ *  choices, and everything that renders it — the meter in the chat header —
+ *  reads the position from this array rather than carrying its own copy.
+ *
+ *  Taken from the CLI's own `/effort` picker. `ultracode` sits past `max` and
+ *  is described there as "xhigh + workflows", so it is last rather than
+ *  alphabetical. */
+export const CHAT_EFFORTS = ["low", "medium", "high", "xhigh", "max", "ultracode"] as const;
+export type ChatEffort = (typeof CHAT_EFFORTS)[number];
+
 /** Whether the pane engine can be offered here, and why not when it cannot.
  *
  *  The reason is carried rather than derived in the UI because the two causes

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -11,7 +11,8 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { ViewHeader } from "./workspace/ViewHeader.tsx";
 import { motion, AnimatePresence } from "motion/react";
-import type { GitRepoRef, SessionRollup } from "../../../shared/types.ts";
+import { CHAT_EFFORTS } from "../../../shared/types.ts";
+import type { GitRepoRef, SessionRollup, ChatEffort } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
@@ -320,6 +321,57 @@ function PanePrompt({ chat }: { chat: Chat }) {
         <span className="ml-auto t-dim2 text-[10px]">or open it in a terminal: <code style={CODE_FONT_STYLE}>{chat.attachCommand || "tmux -L agentglass attach"}</code></span>
       </div>
     </div>
+  );
+}
+
+/** How hard the model is asked to think, as a dial you can read at a glance.
+ *
+ *  Bars rather than a dropdown because the values are ordered — the useful
+ *  question is "more or less than now", and a list of six words makes you read
+ *  all six to answer it. Filled bars carry the level; the label names it, since
+ *  bars alone cannot tell `xhigh` from `max`.
+ *
+ *  "Default" is a real seventh state and deliberately first: it means the CLI's
+ *  own configured effort is left alone, which is what someone who set it in
+ *  their settings.json wants. Anything else passes `--effort`. */
+function EffortDial({ chat }: { chat: Chat }) {
+  const [open, setOpen] = useState(false);
+  const at = chat.effort ? CHAT_EFFORTS.indexOf(chat.effort) : -1;
+  const label = chat.effort ?? "default";
+  const pick = (v: ChatEffort | undefined) => {
+    update(chat.id, (c) => { c.effort = v; });
+    setOpen(false);
+  };
+  return (
+    <span className="relative shrink-0">
+      <button onClick={() => setOpen((v) => !v)} aria-expanded={open} aria-haspopup="listbox"
+        title={"How hard the model thinks, sent as --effort.\n\nDefault leaves the CLI's own setting alone.\nChanging this restarts the chat's session, keeping the conversation."}
+        className="flex items-center gap-1.5 text-[10px] px-2 py-1 rounded-md"
+        style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+        <span className="flex items-end gap-[2px]" aria-hidden>
+          {CHAT_EFFORTS.map((_, i) => (
+            <span key={i} style={{
+              width: 3, height: 4 + i * 2, borderRadius: 1,
+              background: i <= at ? "var(--primary-hover)" : "color-mix(in srgb, var(--border) 70%, transparent)",
+            }} />
+          ))}
+        </span>
+        <span>{label}</span>
+      </button>
+      {open && (
+        <div role="listbox" className="absolute z-20 mt-1 right-0 rounded-lg py-1 min-w-[150px]"
+          style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 8px 24px rgba(0,0,0,.35)" }}>
+          <button onClick={() => pick(undefined)} role="option" aria-selected={!chat.effort}
+            className="w-full text-left px-2.5 py-1 text-[11px] hover:bg-white/5"
+            style={{ color: !chat.effort ? "var(--text)" : "var(--text3)" }}>Default</button>
+          {CHAT_EFFORTS.map((v) => (
+            <button key={v} onClick={() => pick(v)} role="option" aria-selected={chat.effort === v}
+              className="w-full text-left px-2.5 py-1 text-[11px] hover:bg-white/5"
+              style={{ color: chat.effort === v ? "var(--text)" : "var(--text3)" }}>{v}</button>
+          ))}
+        </div>
+      )}
+    </span>
   );
 }
 
@@ -979,6 +1031,22 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             className="text-[10px] px-2 py-1 rounded-md outline-none min-w-0 flex-1 max-w-[280px]"
                             style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
                           />
+                        )}
+                        <EffortDial chat={active} />
+                        {/* Claude Code's own settings, which are global rather
+                            than per chat — so a button rather than something
+                            you have to remember is a slash command. Only in
+                            pane mode: `claude -p` has no interactive config to
+                            open, and offering a button that cannot work is
+                            worse than not offering one. */}
+                        {engineFor(active) === "tmux" && active.sessionId && (
+                          <button
+                            onClick={() => send(active.id, "/config", () => openRef.current && activeIdRef.current === active.id, [])}
+                            disabled={active.sending}
+                            title="Open Claude Code's own settings in this chat's pane. They apply to every chat, not just this one."
+                            className="text-[10px] px-2 py-1 rounded-md shrink-0 disabled:opacity-40"
+                            style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}
+                          >⚙ Config</button>
                         )}
                         {active.sessionId && <span className="text-[9.5px] t-dim2 tabular-nums" title="Resuming this session">↻ {active.sessionId.slice(0, 8)}</span>}
                         {/* Pushed right so the two copy actions sit together at

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -459,7 +459,7 @@ const realApi = {
    *  Only navigation and the two answers a prompt takes — the server keeps its
    *  own allowlist, since this reaches a live terminal running an agent. */
   chatPaneKey: (session: string, key: string) => post<{ screen: string }>("/chat/pane/key", { session, key }),
-  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
+  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine; effort?: ChatEffort }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
     let res: Response;
     // A fetch that throws before a response has arrived never reached the
     // server, which is a different problem from one that dies mid-turn — the
@@ -604,7 +604,7 @@ const demoApi: typeof realApi = {
   chatAttach: (_session: string) => D({ command: "", live: false }),
   chatPaneClose: (_session: string) => D({ killed: false }),
   chatPaneKey: (_session: string, _key: string) => D({ screen: "" }),
-  chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine }, onEvent: (o: Record<string, unknown>) => void) => {
+  chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine; effort?: ChatEffort }, onEvent: (o: Record<string, unknown>) => void) => {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });
     onEvent({ type: "result", result: "" });

--- a/web/src/lib/chatPersist.ts
+++ b/web/src/lib/chatPersist.ts
@@ -33,7 +33,7 @@ const MAX_BYTES = 2_000_000;
 type StoredChat = Pick<Chat,
   | "id" | "cwd" | "model" | "resolvedModel" | "mode" | "title" | "sessionId" | "draft"
   | "queued" | "createdAt" | "unread" | "renamed" | "attention" | "usage" | "liveFrom"
-  | "engine" | "attachCommand">
+  | "engine" | "attachCommand" | "effort">
   & { messages: ChatMsg[] };
 
 type Stored = { v: 1; activeId: string; chats: StoredChat[] };
@@ -81,7 +81,7 @@ function pack(c: Chat): StoredChat {
     // Which engine this chat runs on has to survive a reload, or a warm tmux
     // chat silently becomes a `-p` chat after a refresh and the terminal command
     // the user was shown stops matching anything.
-    engine: c.engine, attachCommand: c.attachCommand,
+    engine: c.engine, attachCommand: c.attachCommand, effort: c.effort,
     messages: messages.slice(-MAX_MESSAGES).map(packMsg),
   };
 }

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -8,7 +8,7 @@
 import { api, ChatStreamError } from "./api.ts";
 import { loadChats, saveChats } from "./chatPersist.ts";
 import { chatEnginePref } from "./chatEnginePref.ts";
-import type { ChatImage, WatchEvent, ChatEngine } from "../../../shared/types.ts";
+import type { ChatImage, WatchEvent, ChatEngine, ChatEffort } from "../../../shared/types.ts";
 
 /** A pasted image waiting in the composer. `url` is an object URL for the
  *  thumbnail; it is revoked when the attachment is dropped or sent, since
@@ -143,6 +143,12 @@ export type Chat = {
    *  first turn has started. */
   resolvedModel?: string;
   mode: string;
+  /** How hard to think, passed to the CLI as `--effort`.
+   *
+   *  Absent means "leave whatever the CLI is configured with alone" — a real
+   *  answer, not a missing one: someone who set an effort in their own
+   *  settings.json should not have every chat quietly overriding it. */
+  effort?: ChatEffort;
   /** How this chat's turns are run. Per chat rather than global because the
    *  trade is per chat: the one you are working in all afternoon is worth a warm
    *  CLI, the five you opened to ask one question each are not. Absent on chats
@@ -816,7 +822,7 @@ export async function send(id: string, text: string, isActive: () => boolean, al
 
   let broke = false;
   try {
-    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId, allowedTools, images, engine }, onEvent, ac.signal);
+    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, effort: chat.effort, resumeId: chat.sessionId, allowedTools, images, engine }, onEvent, ac.signal);
   } catch (e) {
     // A queue must not keep firing into a turn that failed or one you just
     // interrupted — the rest of it stays put, visible, for you to decide on.


### PR DESCRIPTION
## What does this PR do?

Three of the four commands that opened an unanswerable menu in a pane — `/effort`, `/model`, `/config` — are **settings, not conversation**. Two of them the chat already owned as dropdowns. This adds the third and a way to reach the fourth, so there is no reason to type them into a chat at all.

**Effort is a real control**, not a shortcut for typing the command: `--effort <level>` takes it on the command line, verified working on both engines, so the dial sets it at launch exactly the way `--model` does. Changing it mid-chat relaunches the pane with `--resume`, which is what the model and mode pickers already do.

Drawn as bars rather than a dropdown because the values are ordered: the useful question is *"more or less than now"*, and a list of six words makes you read all six to answer it. The label names the level, since bars alone cannot tell `xhigh` from `max`.

**"Default" is a deliberate seventh state**, and comes first. No flag is passed at all, leaving whatever the CLI is configured with. Someone who set an effort in their own `settings.json` should not have every chat quietly overriding it — and this app has already written to that file by accident once (#340), which is a good reason not to be casual about it.

**Config gets a button** rather than a slash command, because those settings are global and the chat is where you are when you want them. Pane mode only: `claude -p` has no interactive config to open, and a button that cannot work is worse than no button. It sends `/config` into the pane, which #337 then renders inline with arrow keys.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/` and `server/`, `bunx vite build` clean, full suite **1060 pass / 0 fail**.
- `--effort low` verified against a real `claude -p` before any of this was written — the flag exists and applies to both engines, which is what makes the dial meaningful rather than decorative.
- 4 new tests on the validator: every level the CLI offers is accepted, absent stays absent (not defaulted to something), anything outside the list is dropped rather than forwarded onto a command line, and the array stays ordered lowest-first because the meter reads position from it.
- The validator is a **pure exported function** tested on its own, following `allowList`'s example. The first draft tested `planTurn` and passed alone while failing in the full suite: the plan depends on ambient git and workspace scope, which under `bun test` belongs to whichever file loaded `config.ts` first. Same class as #319 / #321.
- **Not yet exercised in the app:** the dial's own interaction and the relaunch-on-change path. Worth a look before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)