### PR TITLE
fix(chat): your arrow keys answer the pane, and the prompt stops looking like a core dump

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -20,6 +20,7 @@ import { ToolFeed } from "./ToolFeed.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
 import { buildRows } from "../lib/toolTree.ts";
 import { chatToMarkdown } from "../lib/chatTranscript.ts";
+import { tidyPaneScreen } from "../lib/paneScreen.ts";
 import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
@@ -31,7 +32,7 @@ import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
   engineFor,
-  DEFAULT_MODEL, DEFAULT_MODE, addAttachments, dropAttachment, renameChat, clearAttention, type Chat,
+  DEFAULT_MODEL, DEFAULT_MODE, addAttachments, answerPane, dropAttachment, renameChat, clearAttention, type Chat,
   restoredActiveId, setActiveChatId, chatFocusRequest,
 } from "../lib/chatStore.ts";
 import { peekChatIntent, subscribeChatIntent, takeChatIntent } from "../lib/chatIntent.ts";
@@ -280,45 +281,38 @@ function TypingDots() {
  *  Escape both cancels the prompt and clears this, because a cancelled picker
  *  leaves nothing to answer. */
 function PanePrompt({ chat }: { chat: Chat }) {
-  const [busy, setBusy] = useState(false);
-  const screen = chat.paneNeedsYou?.screen ?? "";
-  const press = async (key: string) => {
-    if (busy || !chat.sessionId) return;
-    setBusy(true);
-    try {
-      const r = await api.chatPaneKey(chat.sessionId, key);
-      // Enter and Escape both end a picker. Rather than guess which, the next
-      // frame decides: no key hints left means nothing is waiting any more.
-      const done = key === "Escape" || !/Esc to cancel|Enter to confirm|to use this session only/.test(r.screen);
-      update(chat.id, (c) => {
-        if (done) { c.paneNeedsYou = undefined; c.attention = "none"; }
-        else c.paneNeedsYou = { screen: r.screen };
-      });
-    } catch {
-      // The pane may have been reclaimed under us. Clearing is the honest
-      // outcome: there is nothing left to answer.
-      update(chat.id, (c) => { c.paneNeedsYou = undefined; c.attention = "none"; });
-    } finally { setBusy(false); }
-  };
-  const key = (label: string, k: string, title: string) => (
-    <button onClick={() => press(k)} disabled={busy} title={title}
-      className="text-[11px] px-2 py-1 rounded-md disabled:opacity-40"
-      style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>{label}</button>
+  const screen = useMemo(() => tidyPaneScreen(chat.paneNeedsYou?.screen ?? ""), [chat.paneNeedsYou?.screen]);
+  const press = (k: string) => void answerPane(chat.id, k);
+  // Small, quiet, and second to the real keys. These exist so the keys are
+  // discoverable and for anyone who reaches for the mouse — not as the way in.
+  const Key = ({ label, k }: { label: string; k: string }) => (
+    <button onClick={() => press(k)} title={`Send ${k} to the pane`}
+      className="text-[10px] leading-none px-1.5 py-1 rounded"
+      style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>{label}</button>
   );
   return (
-    <div className="mb-2 px-2.5 py-2 rounded-lg text-[11px]"
-      style={{ background: "color-mix(in srgb, var(--warning) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)", color: "var(--text2)" }}>
-      <div style={{ color: "var(--text)" }}>This chat's pane is asking you something.</div>
-      <pre className="agx-scroll mt-1.5 mb-2 px-2 py-1.5 rounded overflow-x-auto whitespace-pre text-[10.5px] leading-[1.45]"
-        style={{ ...CODE_FONT_STYLE, background: "color-mix(in srgb, var(--bg3) 60%, transparent)", color: "var(--text)", maxHeight: 220 }}>{screen}</pre>
-      <div className="flex items-center gap-1.5 flex-wrap">
-        {key("←", "Left", "Left")}
-        {key("→", "Right", "Right")}
-        {key("↑", "Up", "Up")}
-        {key("↓", "Down", "Down")}
-        {key("Enter", "Enter", "Confirm")}
-        {key("Esc", "Escape", "Cancel and close this")}
-        <span className="ml-auto t-dim2 text-[10px]">or open it in a terminal: <code style={CODE_FONT_STYLE}>{chat.attachCommand || "tmux -L agentglass attach"}</code></span>
+    <div className="mb-2 rounded-lg overflow-hidden"
+      style={{ border: "1px solid color-mix(in srgb, var(--warning) 45%, transparent)" }}>
+      <div className="px-2.5 py-1.5 flex items-center gap-2 text-[11px]"
+        style={{ background: "color-mix(in srgb, var(--warning) 14%, transparent)", color: "var(--text)" }}>
+        <span>Waiting on you</span>
+        {/* The keys the prompt itself names, shown as keys. */}
+        <span className="flex items-center gap-1 ml-auto">
+          <Key label="←" k="Left" /><Key label="→" k="Right" />
+          <Key label="↑" k="Up" /><Key label="↓" k="Down" />
+          <Key label="Enter" k="Enter" /><Key label="Esc" k="Escape" />
+        </span>
+      </div>
+      <pre className="agx-scroll px-2.5 py-2 overflow-x-auto whitespace-pre text-[11px] leading-[1.5] m-0"
+        style={{ ...CODE_FONT_STYLE, background: "color-mix(in srgb, var(--bg3) 45%, transparent)", color: "var(--text2)", maxHeight: 260 }}>{screen}</pre>
+      <div className="px-2.5 py-1 text-[9.5px] t-dim2 flex items-center gap-1.5"
+        style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+        <span>Your arrow keys work here.</span>
+        {chat.attachCommand && (
+          <button onClick={() => navigator.clipboard?.writeText(chat.attachCommand!)}
+            className="ml-auto hover:opacity-70" title={chat.attachCommand}
+            style={{ color: "var(--text3)" }}>Copy the tmux command</button>
+        )}
       </div>
     </div>
   );
@@ -960,7 +954,27 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     return text;
   };
 
+  const PANE_KEYS: Record<string, string> = {
+    ArrowUp: "Up", ArrowDown: "Down", ArrowLeft: "Left", ArrowRight: "Right",
+    Enter: "Enter", Escape: "Escape", Tab: "Tab",
+  };
+
   const onKey = (e: React.KeyboardEvent<HTMLTextAreaElement>) => {
+    /*
+     * A prompt waiting in the pane owns the keyboard, and this has to be the
+     * first thing checked.
+     *
+     * The picker itself says "←/→ to adjust · Enter to confirm". Shipping that
+     * instruction next to buttons you had to click instead was the wrong way
+     * round — the keys it names are the ones that should work. The buttons stay
+     * as the discoverable version, and for anyone who reaches for the mouse.
+     */
+    if (active?.paneNeedsYou) {
+      const k = PANE_KEYS[e.key];
+      if (k) { e.preventDefault(); void answerPane(active.id, k); return; }
+      // Anything else is someone typing a message instead of answering. Let it
+      // through rather than swallowing it — the prompt is not a modal.
+    }
     // The skill menu owns the arrows, Tab and Enter while it is showing, or
     // Enter would send `/rev` as a message instead of completing it.
     if (slashMatches.length) {

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -8,6 +8,7 @@
 import { api, ChatStreamError } from "./api.ts";
 import { loadChats, saveChats } from "./chatPersist.ts";
 import { chatEnginePref } from "./chatEnginePref.ts";
+import { paneStillAsking } from "./paneScreen.ts";
 import type { ChatImage, WatchEvent, ChatEngine, ChatEffort } from "../../../shared/types.ts";
 
 /** A pasted image waiting in the composer. `url` is an object URL for the
@@ -112,6 +113,34 @@ export type ChatUsage = {
 
 /** A message typed during someone else's turn, waiting for its own. */
 export type QueuedTurn = { id: string; text: string; images: ChatImage[] };
+
+/** Press one key in a chat's pane and take in what it drew next.
+ *
+ *  Lives here rather than in the panel because two things call it: the buttons
+ *  under the prompt, and the composer forwarding the real arrow keys. Those had
+ *  better behave identically — a picker that answers a click but not the key
+ *  the picker itself is telling you to press is worse than one with no buttons
+ *  at all.
+ *
+ *  Whether the prompt is over is read from the next frame rather than inferred
+ *  from the key: Enter and Escape can both end one, and some pickers stay open
+ *  after Enter. */
+export async function answerPane(id: string, key: string): Promise<void> {
+  const chat = chats.get(id);
+  if (!chat?.sessionId || !chat.paneNeedsYou) return;
+  try {
+    const r = await api.chatPaneKey(chat.sessionId, key);
+    const stillAsking = paneStillAsking(r.screen);
+    update(id, (c) => {
+      if (key === "Escape" || !stillAsking) { c.paneNeedsYou = undefined; c.attention = "none"; }
+      else c.paneNeedsYou = { screen: r.screen };
+    });
+  } catch {
+    // The pane may have been reclaimed under us. Clearing is the honest
+    // outcome: there is nothing left to answer.
+    update(id, (c) => { c.paneNeedsYou = undefined; c.attention = "none"; });
+  }
+}
 
 /** The engine this chat's next turn will actually use.
  *

--- a/web/src/lib/paneScreen.ts
+++ b/web/src/lib/paneScreen.ts
@@ -1,0 +1,65 @@
+// Making a captured tmux pane readable inside a chat.
+//
+// `capture-pane` hands back the whole terminal: the height it was given, blank
+// padding rows, and full-width box rules drawn to the pane's 200 columns. Shown
+// raw, a six-line question arrived as a mostly-empty slab with a horizontal
+// scrollbar — which is what it looked like when this was first shipped.
+//
+// So the frame is trimmed to the part that is actually the question. Nothing is
+// reworded or reordered: this is the CLI's own drawing, and rewriting what a
+// prompt says would be a good way to have someone confirm something else.
+
+/** A rule the TUI draws to fill the width — `────`, `▔▔▔▔`, `━━━`. Long runs
+ *  only, so an em-dash inside a sentence survives. */
+const RULE = /^[\s]*[─━▁▔═_-]{12,}[\s]*$/;
+
+/** The key hints a picker prints at the bottom. Dropped from the body because
+ *  the UI shows them as real keys you can press — repeating them as text is the
+ *  same instruction twice, in the less useful form. */
+const HINTS = /^[\s]*(←\/→|↑\/↓|[←→↑↓\s\/]*)?\s*to (adjust|move|select|navigate)\b.*$|^[\s]*(Enter|Esc|Tab)\b.*(confirm|cancel|select|set as default|session only).*$/i;
+
+/**
+ * The readable part of a captured pane.
+ *
+ * Blank padding goes, rules go, hint lines go, and runs of blank lines collapse
+ * to one. Trailing whitespace goes too — every captured row is padded to the
+ * pane width, which is what produced the horizontal scrollbar.
+ *
+ * `max` caps how much is kept, counting from the END: a picker is drawn at the
+ * bottom of the screen, and the interesting rows are the last ones, not the
+ * banner from when the session started.
+ */
+export function tidyPaneScreen(screen: string, max = 14): string {
+  const rows = screen
+    .split("\n")
+    .map((l) => l.replace(/\s+$/, ""))
+    .filter((l) => !RULE.test(l) && !HINTS.test(l));
+
+  const out: string[] = [];
+  for (const row of rows) {
+    // Collapse runs of blank lines rather than dropping them all: the gap
+    // between a heading and its options is part of how a picker reads.
+    if (!row.trim() && !out[out.length - 1]?.trim()) continue;
+    out.push(row);
+  }
+  while (out.length && !out[0].trim()) out.shift();
+  while (out.length && !out[out.length - 1].trim()) out.pop();
+
+  const kept = out.slice(-max);
+  // Say when something was cut, rather than silently showing a fragment of a
+  // question someone is about to answer.
+  if (kept.length < out.length) kept.unshift(`… ${out.length - kept.length} earlier line${out.length - kept.length === 1 ? "" : "s"}`);
+
+  // Every row is indented by the same amount when the TUI draws inside a box.
+  // Removing that shared margin buys back real width on a narrow panel.
+  const indents = kept.filter((l) => l.trim()).map((l) => l.match(/^ */)![0].length);
+  const shared = indents.length ? Math.min(...indents) : 0;
+  return kept.map((l) => l.slice(shared)).join("\n");
+}
+
+/** Is this frame still asking something?
+ *
+ *  Read from the frame rather than inferred from which key was pressed: Enter
+ *  and Escape can both end a prompt, and some pickers stay open after Enter. */
+export const paneStillAsking = (screen: string): boolean =>
+  /Esc to cancel|Enter to confirm|to use this session only/.test(screen);

--- a/web/test/pane-screen.test.ts
+++ b/web/test/pane-screen.test.ts
@@ -1,0 +1,79 @@
+// Making a captured tmux pane readable inside a chat.
+//
+// `capture-pane` returns the whole terminal — the height it was given, blank
+// padding, and box rules drawn to 200 columns. Shown raw, a six-line question
+// arrived as a mostly-empty slab with a horizontal scrollbar. These pin the
+// trimming, and just as importantly that it only ever REMOVES: this is the
+// CLI's own drawing, and rewording a prompt someone is about to confirm would
+// be a very bad way to be helpful.
+import { test, expect } from "bun:test";
+import { tidyPaneScreen, paneStillAsking } from "../src/lib/paneScreen.ts";
+
+/** A real `/effort` frame, as captured. */
+const EFFORT = [
+  "",
+  "",
+  "▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔▔",
+  "   Effort                                                       ",
+  "",
+  "   Faster                                    Smarter            ",
+  "   low   medium   high   xhigh   max   ultracode                ",
+  "",
+  "   ←/→ to adjust · Enter to confirm · Esc to cancel             ",
+  "",
+].join("\n");
+
+test("the padding, rules and trailing spaces go", () => {
+  const out = tidyPaneScreen(EFFORT);
+  expect(out.startsWith("Effort")).toBe(true);
+  expect(out).not.toContain("▔");
+  // Trailing spaces on every row are what produced the horizontal scrollbar.
+  expect(out.split("\n").every((l) => l === l.replace(/\s+$/, ""))).toBe(true);
+  expect(out.endsWith("\n")).toBe(false);
+});
+
+test("the key hints go, because the UI shows them as keys you can press", () => {
+  // The same instruction twice, and the text version is the useless one.
+  expect(tidyPaneScreen(EFFORT)).not.toContain("to adjust");
+  expect(tidyPaneScreen(EFFORT)).not.toContain("Esc to cancel");
+});
+
+test("the question itself is never reworded", () => {
+  // The one thing this must not do. Every option has to survive intact.
+  const out = tidyPaneScreen(EFFORT);
+  for (const level of ["low", "medium", "high", "xhigh", "max", "ultracode"]) {
+    expect(out).toContain(level);
+  }
+  expect(out).toContain("Faster");
+  expect(out).toContain("Smarter");
+});
+
+test("the shared indent is removed, not the shape", () => {
+  // Every row inside a TUI box carries the same margin; dropping it buys real
+  // width on a narrow panel. Relative indentation still has to survive.
+  const out = tidyPaneScreen(["    Title", "      nested", "    back"].join("\n"));
+  expect(out).toBe(["Title", "  nested", "back"].join("\n"));
+});
+
+test("runs of blank lines collapse to one", () => {
+  // Not dropped entirely: the gap between a heading and its options is part of
+  // how a picker reads.
+  expect(tidyPaneScreen("a\n\n\n\n\nb")).toBe("a\n\nb");
+});
+
+test("a long frame is cut from the top, and says so", () => {
+  // A picker is drawn at the bottom, so the last rows are the interesting ones.
+  // Silently showing a fragment of a question is the failure to avoid.
+  const long = Array.from({ length: 40 }, (_, i) => `line ${i}`).join("\n");
+  const out = tidyPaneScreen(long, 5);
+  expect(out.split("\n")[0]).toContain("earlier lines");
+  expect(out).toContain("line 39");
+  expect(out).not.toContain("line 0\n");
+});
+
+test("still-asking is read from the frame, not from the key that was pressed", () => {
+  // Enter and Escape can both end a prompt, and some pickers stay open after
+  // Enter. The frame knows; the keystroke does not.
+  expect(paneStillAsking("  Enter to confirm · Esc to cancel")).toBe(true);
+  expect(paneStillAsking("● done\n❯ ")).toBe(false);
+});


### PR DESCRIPTION
## What does this PR do?

Two things were wrong with the prompt shipped in #337, and the first is the embarrassing one.

**The picker prints `←/→ to adjust · Enter to confirm` and the only way to obey it was to click a button with the mouse.** The keys it names now work. The buttons stay, smaller and secondary, so the keys are discoverable and so anyone reaching for the mouse still has one.

The key handler runs before everything else in the composer, because while a prompt is up the composer is effectively inside it — Enter has to confirm the picker, not send a turn. Anything that is not one of those keys falls through, so the prompt is not a modal and you can still type a message past it. Both the keys and the buttons call one `answerPane` in the store: a picker that answers a click but not the key it is telling you to press is worse than one with no buttons at all, and two copies of that logic is exactly how you get there.

**Second, it looked like a core dump.** `capture-pane` returns the whole terminal — the height it was given, blank padding rows, and box rules drawn to the pane's 200 columns. A six-line question arrived as a mostly-empty slab with a horizontal scrollbar. The frame is now trimmed to the part that is the question: rules, padding, trailing spaces and the shared box indent go, runs of blank lines collapse to one, and a long frame is cut from the top — a picker is drawn at the bottom, so the last rows are the interesting ones — with a line saying how much was cut.

The key hints are dropped from the body too, since the UI now shows them as keys you can actually press. The same instruction twice, and the text version is the useless one.

**The trimming only ever removes.** This is the CLI's own drawing, and rewording a prompt someone is about to confirm would be a very bad way to be helpful. There is a test for exactly that.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/`, `bunx vite build` clean, full suite **1072 pass / 0 fail**.
- 7 new tests in `web/test/pane-screen.test.ts`, built from a real captured `/effort` frame: padding and rules go, trailing spaces go (they were what produced the scrollbar), hints go, **every option survives verbatim**, the shared indent is removed without flattening relative indentation, blank runs collapse rather than vanish, and a long frame is cut from the top with a note.
- **Not yet exercised in the app:** the keyboard path itself. It has to take precedence over the slash-command menu, which already owns the arrows, and over Enter-to-send. That ordering is the part most worth checking before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)