### PR TITLE
feat(chat): a row of the skills you actually use, above the composer

### DIFF
--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -21,6 +21,7 @@ import { useDialogs } from "./ConfirmDialog.tsx";
 import { buildRows } from "../lib/toolTree.ts";
 import { chatToMarkdown } from "../lib/chatTranscript.ts";
 import { tidyPaneScreen } from "../lib/paneScreen.ts";
+import { quickSkills, pinnedSkills, togglePinnedSkill } from "../lib/quickSkills.ts";
 import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
@@ -610,11 +611,19 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // --disable-slash-commands is passed, which we never do. What was missing is
   // knowing they exist: you had to remember the exact name with no way to look
   // it up without leaving the chat.
-  const [skills, setSkills] = useState<{ name: string; description: string }[]>([]);
+  // `calls` and `last_used` are kept, not mapped away: the quick strip ranks on
+  // them, and asking the server twice for the same list to get two views of it
+  // would be silly.
+  const [skills, setSkills] = useState<{ name: string; description: string; calls: number; last_used: number | null }[]>([]);
   useEffect(() => {
     if (!open || skills.length) return;
-    api.skills().then((r) => setSkills(r.skills.map((k) => ({ name: k.name, description: k.when_to_use || k.description })))).catch(() => {});
+    api.skills().then((r) => setSkills(r.skills.map((k) => ({
+      name: k.name, description: k.when_to_use || k.description, calls: k.calls, last_used: k.last_used,
+    })))).catch(() => {});
   }, [open, skills.length]);
+  const [pinnedNames, setPinnedNames] = useState<string[]>(() => pinnedSkills());
+  const quick = useMemo(() => quickSkills(skills, pinnedNames), [skills, pinnedNames]);
+  const togglePin = (name: string) => setPinnedNames(togglePinnedSkill(name));
 
   // Looked up in the scoped list, not the store, so a restored tab belonging to
   // another project never renders even for the frame before the effect below
@@ -1314,6 +1323,25 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         ))}
                       </div>
                     )}
+                    {quick.length > 0 && active && !active.sending && (
+                      // What you pinned, then what you actually run. The `/`
+                      // menu already lists everything, but fifty entries behind
+                      // a keystroke you have to remember is a reference, not a
+                      // shortcut. Hidden mid-turn: the composer is for queueing
+                      // then, and a row of one-click starters invites the wrong
+                      // thing.
+                      <div className="mb-2 flex items-center gap-1.5 flex-wrap">
+                        {quick.map((k) => (
+                          <button key={k.name} onClick={() => pickSkill(k.name)}
+                            title={`${k.description}${k.calls ? `\n\nRun ${k.calls} time${k.calls === 1 ? "" : "s"}` : ""}`}
+                            className="text-[10.5px] px-2 py-1 rounded-md shrink-0 flex items-center gap-1"
+                            style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                            {pinnedNames.includes(k.name) && <span style={{ color: "var(--primary-hover)" }}>★</span>}
+                            /{k.name}
+                          </button>
+                        ))}
+                      </div>
+                    )}
                     {active?.paneNeedsYou && (
                       // Answerable from here. The alternative shipped first and
                       // was telling someone to open a terminal to move a cursor
@@ -1374,6 +1402,16 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             style={{ background: i === slashIdx ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent" }}>
                             <span className="text-[11.5px] shrink-0" style={{ color: "var(--primary-hover)" }}>/{k.name}</span>
                             <span className="text-[10px] t-dim2 truncate">{k.description}</span>
+                            {/* Pinning lives here because this is the one place
+                                every skill is listed. onMouseDown, and stopped,
+                                so pinning does not also insert the command. */}
+                            <button
+                              onMouseDown={(ev) => { ev.preventDefault(); ev.stopPropagation(); togglePin(k.name); }}
+                              title={pinnedNames.includes(k.name) ? `Unpin /${k.name}` : `Pin /${k.name} to the quick strip`}
+                              aria-label={pinnedNames.includes(k.name) ? `Unpin ${k.name}` : `Pin ${k.name}`}
+                              className="ml-auto shrink-0 text-[10px] px-1 leading-none hover:opacity-100"
+                              style={{ color: pinnedNames.includes(k.name) ? "var(--primary-hover)" : "var(--text3)", opacity: pinnedNames.includes(k.name) ? 1 : 0.55 }}
+                            >★</button>
                           </div>
                         ))}
                         <div className="px-2.5 py-1 text-[9.5px] t-dim2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>

--- a/web/src/lib/quickSkills.ts
+++ b/web/src/lib/quickSkills.ts
@@ -1,0 +1,68 @@
+// The handful of skills worth putting one click away.
+//
+// The chat already knows every skill on the machine — the `/` menu lists them —
+// but knowing they exist and reaching for one are different problems. Fifty
+// entries behind a keystroke you have to remember is a reference, not a
+// shortcut.
+
+const PINS_KEY = "agentglass.chat.pinnedSkills";
+
+/** Skills pinned by hand, in the order they were pinned.
+ *
+ *  Order is preserved rather than sorted, because a pin is a statement about
+ *  where you want something to be. Re-sorting them by usage would defeat the
+ *  point of having pinned them in the first place. */
+export function pinnedSkills(): string[] {
+  try {
+    const raw = JSON.parse(localStorage.getItem(PINS_KEY) ?? "[]");
+    return Array.isArray(raw) ? raw.filter((n): n is string => typeof n === "string") : [];
+  } catch { return []; }
+}
+
+export function setPinnedSkills(names: string[]): void {
+  try { localStorage.setItem(PINS_KEY, JSON.stringify(names)); } catch { /* private mode */ }
+}
+
+/** Pin or unpin one, returning the new list. */
+export function togglePinnedSkill(name: string): string[] {
+  const cur = pinnedSkills();
+  const next = cur.includes(name) ? cur.filter((n) => n !== name) : [...cur, name];
+  setPinnedSkills(next);
+  return next;
+}
+
+/** What a skill needs to be rankable. Deliberately narrow so the strip does not
+ *  care where the data came from — the server's `SkillInfo` satisfies it. */
+export interface RankableSkill { name: string; calls: number; last_used?: number | null }
+
+/**
+ * The strip's contents: what you pinned, then what you actually use.
+ *
+ * Pins come first and in full, even past the limit — you asked for those by
+ * name, and silently dropping the fifth one you pinned would be worse than a
+ * slightly longer strip. Usage fills whatever is left.
+ *
+ * A skill with no recorded runs is never auto-suggested. Ranking on `calls`
+ * alone would otherwise put fifty never-used skills in an arbitrary order and
+ * call the first five "most used", which is a claim the data does not support.
+ * Ties break on recency, then name, so the strip does not reshuffle itself
+ * between renders for no reason.
+ */
+export function quickSkills<T extends RankableSkill>(all: T[], pinned: string[], limit = 5): T[] {
+  const byName = new Map(all.map((s) => [s.name, s]));
+  const out: T[] = [];
+  for (const name of pinned) {
+    const s = byName.get(name);
+    // A pin for a skill that no longer exists is dropped rather than rendered
+    // as a chip that inserts a command nothing will answer.
+    if (s) out.push(s);
+  }
+  const used = all
+    .filter((s) => s.calls > 0 && !pinned.includes(s.name))
+    .sort((a, b) => b.calls - a.calls || (b.last_used ?? 0) - (a.last_used ?? 0) || a.name.localeCompare(b.name));
+  for (const s of used) {
+    if (out.length >= Math.max(limit, pinned.length)) break;
+    out.push(s);
+  }
+  return out;
+}

--- a/web/test/quick-skills.test.ts
+++ b/web/test/quick-skills.test.ts
@@ -1,0 +1,83 @@
+// The handful of skills the chat puts one click away.
+//
+// Two things are being balanced: what you asked for by name, and what you
+// actually run. Getting the precedence wrong either buries a pin or fills the
+// strip with skills nobody has ever used.
+import { test, expect, beforeAll, beforeEach } from "bun:test";
+
+const cell = new Map<string, string>();
+let m: typeof import("../src/lib/quickSkills.ts");
+
+beforeAll(async () => {
+  // Assigned rather than `??=`: other files install a no-op localStorage and
+  // `bun test` shares one process, so the first loader would otherwise decide
+  // whether anything written here is readable.
+  (globalThis as any).localStorage = {
+    getItem: (k: string) => cell.get(k) ?? null,
+    setItem: (k: string, v: string) => { cell.set(k, v); },
+    removeItem: (k: string) => { cell.delete(k); },
+  };
+  m = await import("../src/lib/quickSkills.ts");
+});
+
+beforeEach(() => cell.clear());
+
+const s = (name: string, calls: number, last_used: number | null = null) => ({ name, calls, last_used });
+
+test("what you use most, and only what you have used", () => {
+  const out = m.quickSkills([s("a", 1), s("b", 9), s("c", 4), s("never", 0)], []);
+  expect(out.map((x) => x.name)).toEqual(["b", "c", "a"]);
+  // Ranking on calls alone would put every never-used skill in an arbitrary
+  // order and call the first five "most used" — a claim the data cannot back.
+  expect(out.map((x) => x.name)).not.toContain("never");
+});
+
+test("pins come first, in the order they were pinned", () => {
+  // A pin is a statement about where you want something. Re-sorting pins by
+  // usage would defeat the point of having pinned them.
+  const out = m.quickSkills([s("a", 1), s("b", 99), s("c", 50)], ["c", "a"]);
+  expect(out.slice(0, 2).map((x) => x.name)).toEqual(["c", "a"]);
+  expect(out[2].name).toBe("b");
+});
+
+test("a pinned skill is never listed twice", () => {
+  const out = m.quickSkills([s("a", 99)], ["a"]);
+  expect(out.map((x) => x.name)).toEqual(["a"]);
+});
+
+test("more pins than the limit are all kept", () => {
+  // Silently dropping the sixth thing you pinned is worse than a slightly
+  // longer strip — you asked for those by name.
+  const all = ["p1", "p2", "p3", "p4", "p5", "p6"].map((n) => s(n, 0));
+  const out = m.quickSkills([...all, s("used", 10)], ["p1", "p2", "p3", "p4", "p5", "p6"], 5);
+  expect(out.map((x) => x.name)).toEqual(["p1", "p2", "p3", "p4", "p5", "p6"]);
+});
+
+test("a pin for a skill that no longer exists is dropped", () => {
+  // Otherwise it renders as a chip that inserts a command nothing will answer.
+  const out = m.quickSkills([s("still-here", 3)], ["gone", "still-here"]);
+  expect(out.map((x) => x.name)).toEqual(["still-here"]);
+});
+
+test("ties break on recency then name, so the strip does not reshuffle", () => {
+  const out = m.quickSkills([s("b", 5, 100), s("a", 5, 100), s("c", 5, 999)], []);
+  expect(out.map((x) => x.name)).toEqual(["c", "a", "b"]);
+});
+
+test("pinning toggles and persists", () => {
+  expect(m.pinnedSkills()).toEqual([]);
+  expect(m.togglePinnedSkill("review")).toEqual(["review"]);
+  expect(m.pinnedSkills()).toEqual(["review"]);
+  expect(m.togglePinnedSkill("review")).toEqual([]);
+});
+
+test("a corrupt or foreign stored value reads as no pins", () => {
+  // localStorage is shared with anything else on the origin and survives
+  // versions of this app that stored something else under the same key.
+  cell.set("agentglass.chat.pinnedSkills", '{"not":"an array"}');
+  expect(m.pinnedSkills()).toEqual([]);
+  cell.set("agentglass.chat.pinnedSkills", "not json at all");
+  expect(m.pinnedSkills()).toEqual([]);
+  cell.set("agentglass.chat.pinnedSkills", '["ok", 5, null]');
+  expect(m.pinnedSkills()).toEqual(["ok"]);
+});


### PR DESCRIPTION
## What does this PR do?

The chat already knew every skill on the machine — the `/` menu lists them — but knowing they exist and reaching for one are different problems. Fifty entries behind a keystroke you have to remember is a reference, not a shortcut.

So: up to five chips above the composer. **What you pinned first, in the order you pinned it, then what you actually run.** Clicking one puts it in the box exactly the way picking it from the menu does. Pinning lives on the `/` menu rows, which is the one place every skill is listed.

The rules, each there because the obvious version is wrong:

- **Pins come first and in full, even past the limit.** You asked for those by name; silently dropping the sixth one you pinned is worse than a slightly longer row.
- **A skill with no recorded runs is never auto-suggested.** Ranking on `calls` alone would put fifty never-used skills in an arbitrary order and call the first five "most used" — a claim the data does not support.
- **Ties break on recency, then name**, so the row does not reshuffle itself between renders for no reason.
- **A pin for a skill that no longer exists is dropped**, rather than rendered as a chip that inserts a command nothing will answer.
- **Hidden while a turn is running.** The composer is for queueing then, and a row of one-click starters invites the wrong thing.
- A corrupt or foreign value under the storage key reads as no pins rather than throwing — `localStorage` is shared with everything else on the origin.

No new endpoint: the usage counts were already on the list the chat fetches, and were being mapped away before they got here.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/`, `bunx vite build` clean, full suite **1080 pass / 0 fail**.
- 8 new tests in `web/test/quick-skills.test.ts` covering every rule above, including the two that are easy to get backwards: pins keeping their own order rather than being re-sorted by usage, and never-used skills staying out of a list that claims to be "most used".
- **Not yet exercised in the app:** the strip's placement and the pin toggle sitting inside a menu row that is itself clickable. The toggle stops propagation so pinning does not also insert the command — that is the interaction most worth checking before this lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)