### PR TITLE
feat(mobile): talk to your agents from the phone, and install it

### DIFF
--- a/web/index.html
+++ b/web/index.html
@@ -7,6 +7,25 @@
     <meta name="description" content="Real-time observability for AI agent workflows — any provider." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!--
+      Installable on a phone.
+
+      The remote-access flow ends with someone scanning a QR code, and a link
+      opened from a camera lands in a browser tab that they will lose. With a
+      manifest the same page can be added to the home screen and opens
+      standalone, which is what makes it a companion rather than a bookmark —
+      and `theme_color` is what stops iOS drawing a white status bar over a
+      dark UI. `start_url` is relative on purpose: the token is stripped from
+      the URL on first load and kept in storage, so the installed copy must
+      resolve against whatever host it was installed from, not a baked-in one.
+    -->
+    <link rel="manifest" href="./manifest.webmanifest" />
+    <meta name="theme-color" content="#0f0a1a" />
+    <meta name="mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-capable" content="yes" />
+    <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
+    <meta name="apple-mobile-web-app-title" content="agentglass" />
+    <link rel="apple-touch-icon" href="/favicon.svg" />
+    <!--
       What fills the window before React does.
 
       The bundle is ~1.8 MB of JS and CSS that has to arrive, parse and execute

--- a/web/public/manifest.webmanifest
+++ b/web/public/manifest.webmanifest
@@ -1,0 +1,14 @@
+{
+  "name": "agentglass",
+  "short_name": "agentglass",
+  "description": "Approve what your agents are blocked on, talk to them, and watch the fleet — from your phone.",
+  "start_url": "./",
+  "scope": "./",
+  "display": "standalone",
+  "orientation": "portrait",
+  "background_color": "#0f0a1a",
+  "theme_color": "#0f0a1a",
+  "icons": [
+    { "src": "./favicon.svg", "sizes": "any", "type": "image/svg+xml", "purpose": "any maskable" }
+  ]
+}

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
 import { useStats } from "../lib/useStats.ts";
 import { fmtUsd, fmtTokens, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
-import { writeOverride } from "../lib/viewport.ts";
+import { MobileChats } from "./MobileChats.tsx";
 import type { PendingGate, SessionRollup } from "../../../shared/types.ts";
 
 /**
@@ -19,18 +19,22 @@ import type { PendingGate, SessionRollup } from "../../../shared/types.ts";
  *
  *   Needs you — approve or deny what an agent is blocked on. The one thing
  *               that is time-critical and takes one tap.
+ *   Chats     — read what an agent has been doing, reply to it, take over a
+ *               session started at the desk, or start a new one. Monitoring
+ *               without this is only half a companion: seeing that an agent
+ *               stopped and being unable to say "carry on" is the same as not
+ *               knowing.
  *   Fleet     — is it running, is it burning money, is anything failing.
- *   Sessions  — what each agent is doing, and what it has cost.
  *
- * Everything else is absent rather than broken. There is a way back to the
- * full dashboard at the bottom for someone on a tablet who wants it, and it is
- * remembered — but it is a choice made once, not the default.
+ * Everything else is absent rather than broken, and there is deliberately no
+ * way back to the desktop layout from here: it does not work on this screen,
+ * so offering it would only be a route to a worse version of the same thing.
  *
  * Nothing heavy mounts here: no xterm, no charts, no radar. On a phone that is
  * a battery decision as much as a layout one.
  */
 
-type Tab = "gates" | "fleet" | "sessions";
+type Tab = "gates" | "chats" | "fleet";
 
 const WINDOWS: { label: string; ms: number }[] = [
   { label: "1h", ms: 3_600_000 },
@@ -85,7 +89,7 @@ export function MobileApp() {
         </span>
       </header>
 
-      <main className="flex-1 px-4 pb-28 pt-3">
+      <main className="flex-1 px-4 pb-24 pt-3">
         {tab === "gates" && <GatesTab gates={gates} onDecided={(id) => setGates((g) => g.filter((x) => x.id !== id))} />}
         {tab === "fleet" && (
           <FleetTab
@@ -96,15 +100,15 @@ export function MobileApp() {
             sessions={live}
           />
         )}
-        {tab === "sessions" && <SessionsTab sessions={sessions} />}
+        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={load} />}
       </main>
 
       {/* Fixed, thumb-height, and out of the way of the home indicator. */}
-      <nav className="fixed bottom-0 left-0 right-0 flex"
+      <nav className="fixed bottom-0 left-0 right-0 flex z-20"
         style={{ background: "color-mix(in srgb, var(--bg2) 94%, transparent)", backdropFilter: "blur(10px)", borderTop: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", paddingBottom: "env(safe-area-inset-bottom)" }}>
         <TabButton id="gates" tab={tab} onPick={setTab} label="Needs you" badge={gates.length} />
+        <TabButton id="chats" tab={tab} onPick={setTab} label="Chats" badge={live.length} subtle />
         <TabButton id="fleet" tab={tab} onPick={setTab} label="Fleet" />
-        <TabButton id="sessions" tab={tab} onPick={setTab} label="Sessions" badge={live.length} subtle />
       </nav>
     </div>
   );
@@ -251,21 +255,6 @@ function FleetTab({ stats, live, windowMs, onWindow, sessions }: {
         )}
       </div>
 
-      <BackToDesktop />
-    </div>
-  );
-}
-
-function SessionsTab({ sessions }: { sessions: SessionRollup[] }) {
-  const [openId, setOpenId] = useState<string | null>(null);
-  if (!sessions.length) return <Empty title="No sessions yet" body="Start an agent and it appears here." />;
-  return (
-    <div className="flex flex-col gap-2">
-      {sessions.map((s) => (
-        <SessionRow key={s.session_id} s={s} open={openId === s.session_id}
-          onToggle={() => setOpenId((id) => (id === s.session_id ? null : s.session_id))} />
-      ))}
-      <BackToDesktop />
     </div>
   );
 }
@@ -326,17 +315,5 @@ function Empty({ title, body, compact }: { title: string; body: string; compact?
       <div className="text-[14px]" style={{ color: "var(--text)" }}>{title}</div>
       <div className="text-[12px] mt-1.5 leading-snug" style={{ color: "var(--text2)" }}>{body}</div>
     </div>
-  );
-}
-
-/** For a tablet, or for someone who really does want the whole cockpit here. */
-function BackToDesktop() {
-  return (
-    <button
-      onClick={() => { writeOverride("desktop"); location.reload(); }}
-      className="self-center mt-2 mb-1 text-[11.5px] underline underline-offset-4"
-      style={{ color: "var(--text3)", minHeight: 44 }}>
-      Open the full dashboard instead
-    </button>
   );
 }

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { api, ChatStreamError } from "../lib/api.ts";
+import { toolTarget } from "../lib/chatStore.ts";
+import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
+import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
+
+/**
+ * Agents you can actually talk to, from a phone.
+ *
+ * Monitoring from the sofa is only half of it: seeing that an agent has stopped
+ * and being unable to say "yes, carry on" is the same as not knowing. So this
+ * is the part that talks back — read what a session has been doing, send it
+ * another turn, take one over that was started at the desk, or start a new one.
+ *
+ * A chat here is a **session**, not a browser-local object. The desktop panel
+ * keeps its chats in localStorage, which is per-origin and per-device: a phone
+ * could never see them. Sessions are the server's own truth, they cover every
+ * agent — the ones started from the app, from a terminal, from anywhere — and
+ * resuming one by id is exactly what "take over from the phone" means. It also
+ * means the conversation you continue on the phone is the same conversation
+ * when you sit back down.
+ */
+
+const MODELS = [
+  { id: "claude-opus-5", label: "Opus 5" },
+  { id: "claude-sonnet-5", label: "Sonnet 5" },
+  { id: "claude-haiku-4-5", label: "Haiku 4.5" },
+];
+
+/** A turn being streamed right now, before the transcript catches up. */
+type Live = { text: string; tools: string[]; error: string | null };
+
+export function MobileChats({ sessions, onRefresh }: { sessions: SessionRollup[]; onRefresh: () => void }) {
+  const [openId, setOpenId] = useState<string | null>(null);
+  const [composing, setComposing] = useState(false);
+
+  if (composing) return <NewChat onCancel={() => setComposing(false)} onStarted={(id) => { setComposing(false); setOpenId(id); onRefresh(); }} />;
+  if (openId) return <Conversation id={openId} onBack={() => { setOpenId(null); onRefresh(); }} />;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <button onClick={() => setComposing(true)}
+        className="rounded-xl text-[15px] font-medium"
+        style={{ minHeight: 52, color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>
+        + New chat
+      </button>
+
+      {!sessions.length && (
+        <div className="rounded-2xl px-5 py-12 text-center" style={{ background: "color-mix(in srgb, var(--bg2) 45%, transparent)", border: "1px dashed color-mix(in srgb, var(--border) 45%, transparent)" }}>
+          <div className="text-[14px]">No agents yet</div>
+          <div className="text-[12px] mt-1.5" style={{ color: "var(--text2)" }}>Start one above and it keeps running on your machine.</div>
+        </div>
+      )}
+
+      {sessions.map((s) => {
+        const running = !s.ended_at && Date.now() - s.last_seen < 120_000;
+        return (
+          <button key={s.session_id} onClick={() => setOpenId(s.session_id)}
+            className="w-full text-left rounded-xl px-3.5 py-3 flex flex-col gap-1.5"
+            style={{ background: "color-mix(in srgb, var(--bg2) 60%, transparent)", border: `1px solid color-mix(in srgb, var(--border) ${running ? 55 : 32}%, transparent)` }}>
+            <div className="flex items-center gap-2">
+              <span className="inline-block rounded-full shrink-0" style={{ width: 8, height: 8, background: running ? "var(--success)" : s.error_count ? "var(--error)" : "var(--text3)" }} />
+              <span className="text-[13.5px] leading-tight truncate">{sessionTitle(s)}</span>
+              <span className="ml-auto text-[10.5px] shrink-0" style={{ color: "var(--text3)" }}>{fmtAgo(s.last_seen)}</span>
+            </div>
+            <div className="flex items-center gap-x-3 text-[11px] tabular-nums" style={{ color: "var(--text2)" }}>
+              <span className="truncate">{baseName(s.cwd_path || s.project_path || s.source_app)}</span>
+              <span className="ml-auto shrink-0">{modelLabelOf(s.model_name)}</span>
+              <span className="shrink-0">{fmtUsd(s.cost_usd)}</span>
+            </div>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+/** One session: what it has done, and a box to answer it. */
+function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
+  const [detail, setDetail] = useState<SessionDetail | null>(null);
+  const [draft, setDraft] = useState("");
+  const [live, setLive] = useState<Live | null>(null);
+  const [sent, setSent] = useState<string | null>(null);
+  const abort = useRef<AbortController | null>(null);
+  const foot = useRef<HTMLDivElement | null>(null);
+
+  const load = useCallback(() => {
+    api.session(id).then(setDetail).catch(() => { /* keep what is on screen */ });
+  }, [id]);
+
+  useEffect(() => {
+    load();
+    // While a turn of ours is streaming the transcript is behind by a scan, so
+    // polling then would show a stale copy of what is already on screen.
+    const t = setInterval(() => { if (!live) load(); }, 5000);
+    return () => clearInterval(t);
+  }, [load, live]);
+
+  useEffect(() => { foot.current?.scrollIntoView({ block: "end" }); }, [detail?.conversation.length, live?.text, sent]);
+
+  const cwd = detail?.cwd_path || detail?.project_path || "";
+  const running = !!detail && !detail.ended_at && Date.now() - detail.last_seen < 120_000;
+
+  const send = async () => {
+    const message = draft.trim();
+    if (!message || !cwd) return;
+    setDraft("");
+    setSent(message);
+    setLive({ text: "", tools: [], error: null });
+    const ac = new AbortController();
+    abort.current = ac;
+    try {
+      await api.chatStream(
+        { cwd, message, model: detail?.model_name && MODELS.some((m) => detail.model_name!.includes(m.id.split("-")[1]!)) ? MODELS[0]!.id : MODELS[0]!.id, mode: "default", resumeId: id },
+        (o) => setLive((prev) => reduce(prev, o)),
+        ac.signal
+      );
+    } catch (e) {
+      if (!(e instanceof DOMException && e.name === "AbortError")) {
+        const why = e instanceof ChatStreamError ? e.message : String(e);
+        setLive((p) => ({ text: p?.text ?? "", tools: p?.tools ?? [], error: why }));
+      }
+    } finally {
+      abort.current = null;
+      // Let the transcript take over: it is the same turn, written by the
+      // scanner, and keeping our copy as well would show it twice.
+      setTimeout(() => { setLive(null); setSent(null); load(); }, 1200);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="sticky top-11 z-10 flex items-center gap-2 -mx-4 px-4 py-1.5"
+        style={{ background: "var(--bg)", borderBottom: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+        <button onClick={onBack} className="text-[13px] px-2 py-2" style={{ color: "var(--text2)", minHeight: 44 }}>← Chats</button>
+        <div className="min-w-0 flex-1 text-right">
+          <div className="text-[12.5px] truncate">{detail ? sessionTitle(detail) : "…"}</div>
+          <div className="text-[10.5px] truncate" style={{ color: "var(--text3)" }}>{baseName(cwd)}</div>
+        </div>
+        <span className="inline-block rounded-full shrink-0" style={{ width: 8, height: 8, background: running ? "var(--success)" : "var(--text3)" }} />
+      </div>
+
+      {detail && (
+        <div className="flex items-center gap-x-3 text-[10.5px] tabular-nums px-0.5" style={{ color: "var(--text3)" }}>
+          <span>{detail.tools} tools</span>
+          {!!detail.errors && <span style={{ color: "var(--error)" }}>{detail.errors} errors</span>}
+          <span>{fmtUsd(detail.cost_usd)}</span>
+          {!!detail.changes.length && <span>{detail.changes.length} files touched</span>}
+        </div>
+      )}
+
+      <div className="flex flex-col gap-2.5 pb-2">
+        {detail?.conversation.slice(-40).map((m, i) => <Bubble key={`${m.ts}-${i}`} role={m.role} text={m.text} ts={m.ts} />)}
+        {sent && <Bubble role="user" text={sent} />}
+        {live && (
+          <Bubble role="assistant" text={live.text || "…"} streaming tools={live.tools} error={live.error} />
+        )}
+        <div ref={foot} />
+      </div>
+
+      {/* Sticky, thumb-height, 16px type so iOS does not zoom the page when it
+          takes focus. */}
+      {/* Sits directly on top of the tab bar rather than under it: the nav is
+          fixed, so a composer at bottom-0 would be hidden behind it exactly
+          when the keyboard is open and it matters most. */}
+      <div className="sticky -mx-4 px-4 pt-2 pb-2 z-10"
+        style={{ bottom: "calc(56px + env(safe-area-inset-bottom))", background: "var(--bg)", borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
+        {!cwd ? (
+          <div className="text-[11px] px-1 pb-2" style={{ color: "var(--text3)" }}>
+            This session did not record where it ran, so it cannot be resumed from here.
+          </div>
+        ) : (
+          <div className="flex items-end gap-2">
+            <textarea
+              value={draft} onChange={(e) => setDraft(e.target.value)}
+              placeholder={live ? "Working…" : "Reply to this agent"}
+              rows={1}
+              className="flex-1 rounded-xl px-3 py-2.5 resize-none"
+              style={{ fontSize: 16, minHeight: 48, maxHeight: 140, color: "var(--text)", background: "color-mix(in srgb, var(--bg2) 80%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
+            />
+            {live ? (
+              <button onClick={() => abort.current?.abort()}
+                className="rounded-xl px-4 text-[14px]"
+                style={{ minHeight: 48, color: "var(--error)", background: "color-mix(in srgb, var(--error) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>
+                Stop
+              </button>
+            ) : (
+              <button onClick={send} disabled={!draft.trim()}
+                className="rounded-xl px-4 text-[14px] font-medium"
+                style={{ minHeight: 48, opacity: draft.trim() ? 1 : 0.4, color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 18%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>
+                Send
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function Bubble({ role, text, ts, streaming, tools, error }: {
+  role: "user" | "assistant"; text: string; ts?: number; streaming?: boolean; tools?: string[]; error?: string | null;
+}) {
+  const mine = role === "user";
+  return (
+    <div className={`flex ${mine ? "justify-end" : "justify-start"}`}>
+      <div className="max-w-[86%] rounded-2xl px-3.5 py-2.5" style={{
+        background: mine ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "color-mix(in srgb, var(--bg2) 70%, transparent)",
+        border: `1px solid color-mix(in srgb, var(--border) ${mine ? 45 : 32}%, transparent)`,
+      }}>
+        {/* Tool runs are named, not expanded: on a phone the useful signal is
+            "it is editing files / running commands", not the diff. */}
+        {!!tools?.length && (
+          <div className="text-[10.5px] pb-1.5 flex flex-col gap-0.5" style={{ color: "var(--text3)" }}>
+            {tools.slice(-4).map((t, i) => <span key={i} className="truncate">· {t}</span>)}
+          </div>
+        )}
+        <div className="text-[13.5px] leading-snug whitespace-pre-wrap break-words">{text}</div>
+        {streaming && <span className="inline-block ml-0.5 animate-pulse">▍</span>}
+        {error && <div className="text-[11px] pt-1" style={{ color: "var(--error)" }}>{error}</div>}
+        {ts && <div className="text-[9.5px] pt-1" style={{ color: "var(--text3)" }}>{fmtAgo(ts)}</div>}
+      </div>
+    </div>
+  );
+}
+
+/** Start something new: a repo and a first message is the whole form. */
+function NewChat({ onCancel, onStarted }: { onCancel: () => void; onStarted: (sessionId: string) => void }) {
+  const [repos, setRepos] = useState<GitRepoRef[]>([]);
+  const [cwd, setCwd] = useState("");
+  const [model, setModel] = useState(MODELS[0]!.id);
+  const [message, setMessage] = useState("");
+  const [live, setLive] = useState<Live | null>(null);
+  const [failed, setFailed] = useState<string | null>(null);
+  const started = useRef(false);
+
+  useEffect(() => {
+    api.gitRepos()
+      .then((r) => { setRepos(r.repos); if (r.repos[0]) setCwd(r.repos[0].root); })
+      .catch(() => setRepos([]));
+  }, []);
+
+  const start = async () => {
+    const text = message.trim();
+    if (!text || !cwd) return;
+    setFailed(null);
+    setLive({ text: "", tools: [], error: null });
+    try {
+      await api.chatStream({ cwd, message: text, model, mode: "default", resumeId: "" }, (o) => {
+        // The first frame carries the session id claude assigned. That id is
+        // the chat from here on: it is what the list shows and what a reply
+        // resumes, on this phone or at the desk.
+        if (!started.current && o.type === "system" && typeof o.session_id === "string") {
+          started.current = true;
+          onStarted(o.session_id);
+        }
+        setLive((prev) => reduce(prev, o));
+      });
+    } catch (e) {
+      const why = e instanceof ChatStreamError ? e.message : String(e);
+      setFailed(why);
+      setLive(null);
+    }
+  };
+
+  return (
+    <div className="flex flex-col gap-3">
+      <div className="flex items-center gap-2 -mt-1">
+        <button onClick={onCancel} className="text-[13px] px-2 py-2" style={{ color: "var(--text2)", minHeight: 44 }}>← Chats</button>
+        <span className="ml-auto text-[12.5px]">New chat</span>
+      </div>
+
+      <label className="text-[10.5px] px-0.5" style={{ color: "var(--text3)" }}>Where it runs</label>
+      <select value={cwd} onChange={(e) => setCwd(e.target.value)}
+        className="rounded-xl px-3"
+        style={{ fontSize: 16, minHeight: 48, color: "var(--text)", background: "color-mix(in srgb, var(--bg2) 80%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>
+        {!repos.length && <option value="">No repos found</option>}
+        {repos.map((r) => <option key={r.root} value={r.root}>{baseName(r.root)}{r.branch ? ` · ${r.branch}` : ""}</option>)}
+      </select>
+
+      <label className="text-[10.5px] px-0.5" style={{ color: "var(--text3)" }}>Model</label>
+      <div className="flex gap-1.5">
+        {MODELS.map((m) => (
+          <button key={m.id} onClick={() => setModel(m.id)}
+            className="flex-1 rounded-lg text-[12px]"
+            style={{
+              minHeight: 42,
+              color: model === m.id ? "var(--primary-hover)" : "var(--text2)",
+              background: model === m.id ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent",
+              border: `1px solid color-mix(in srgb, var(--border) ${model === m.id ? 60 : 30}%, transparent)`,
+            }}>
+            {m.label}
+          </button>
+        ))}
+      </div>
+
+      <textarea value={message} onChange={(e) => setMessage(e.target.value)} rows={4}
+        placeholder="What should it do?"
+        className="rounded-xl px-3 py-2.5 resize-none"
+        style={{ fontSize: 16, color: "var(--text)", background: "color-mix(in srgb, var(--bg2) 80%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }} />
+
+      {failed && <div className="text-[11.5px]" style={{ color: "var(--error)" }}>{failed}</div>}
+
+      <button onClick={start} disabled={!message.trim() || !cwd || !!live}
+        className="rounded-xl text-[15px] font-medium"
+        style={{ minHeight: 52, opacity: message.trim() && cwd && !live ? 1 : 0.45, color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 18%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>
+        {live ? "Starting…" : "Start"}
+      </button>
+
+      {live && <Bubble role="assistant" text={live.text || "…"} streaming tools={live.tools} error={live.error} />}
+    </div>
+  );
+}
+
+/** Fold one ndjson frame into what is on screen. */
+function reduce(prev: Live | null, o: Record<string, unknown>): Live {
+  const cur: Live = prev ?? { text: "", tools: [], error: null };
+  const t = o.type;
+  if (t === "assistant") {
+    const blocks = (((o.message as Record<string, unknown>)?.content) ?? []) as Array<Record<string, unknown>>;
+    let text = cur.text;
+    const tools = [...cur.tools];
+    for (const b of blocks) {
+      if (b.type === "text" && typeof b.text === "string") text += b.text;
+      else if (b.type === "tool_use") {
+        const name = String(b.name ?? "tool");
+        const target = toolTarget(name, (b.input ?? {}) as Record<string, unknown>);
+        tools.push(target ? `${name} ${target}` : name);
+      }
+    }
+    return { ...cur, text, tools };
+  }
+  if (t === "agx_error") return { ...cur, error: String(o.error ?? "something went wrong") };
+  return cur;
+}
+
+const baseName = (p: string) => (p ? p.split("/").filter(Boolean).pop() || p : "");


### PR DESCRIPTION
## What does this PR do?

Makes the phone view an actual companion instead of a read-only dial: **you can talk to your agents from it**. Follows #344, which added the phone application; this is the half that was missing.

**Chats.** A chat here is a **session**, not a browser-local object. The desktop panel keeps its chats in `localStorage`, which is per-origin and per-device, so a phone could never see them. Sessions are the server's own truth, they cover agents started anywhere (the app, a terminal, another machine), and resuming one by id is exactly what "take over from the phone" means — the conversation you continue on the phone is the same one when you sit back down.

- List every session, running first, with project, model, cost and age.
- Open one and read the **real transcript** — `/session` already returns the conversation, the tool mix and the files touched.
- **Reply.** The turn streams into the bubble as it arrives, with tool runs named rather than expanded (on a phone the signal is "it is editing files", not the diff). **Stop** interrupts it.
- **New chat**: pick a repo, pick a model, type the first message. The session id from the opening `system` frame becomes the chat.

The Sessions tab is gone, because a session *is* the chat and having both was the same list twice. Tabs are now Needs you · Chats · Fleet.

**No way back to the desktop layout.** #344 left a link to it for tablets; on a phone the cockpit does not work, so offering it was only a route to a worse version of the same thing.

**Installable.** A web app manifest plus the iOS meta tags, so the link from the QR code can be added to the home screen and opens standalone with a dark status bar instead of living as a tab someone loses. `start_url` is relative on purpose: the token is stripped from the URL on first load and kept in storage, so an installed copy must resolve against the host it was installed from.

## How was it tested?

- **1127 tests pass**, `bunx tsc --noEmit` clean in `web/` and `server/`.
- Driven in headless Chrome emulating an iPhone 14 (390×844, iOS user agent) against a **real server on the LAN**: the chat list renders live sessions with their projects and costs, opening one renders its actual transcript (`19 tools · 1 error · $1.26`, real messages), the new-chat form offers the three checkouts with their branches, `/manifest.webmanifest` serves 200, and the console is clean.
- Layout checked by screenshot at phone width, which is how three real problems were found and fixed: the composer sat *under* the fixed tab bar (worst exactly when the keyboard is open), the last message hid behind the composer, and the back button scrolled away on a long transcript. The composer now sits on top of the tab bar, and the conversation header is sticky.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
