### PR TITLE
fix(prs): show the image, not an empty diff pane

### DIFF
--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -33,7 +33,7 @@ import { useDialogs } from "./ConfirmDialog.tsx";
 import { SCROLLBAR_CSS, LINEBTN_CSS, CODE_FONT_STYLE, UnifiedDiff, SplitDiff, Toggle, type LinePick, type LineSel } from "./ChangesModal.tsx";
 import { HiliteCtx, useDiffHighlight } from "../lib/diffHighlight.ts";
 import { Select } from "./Select.tsx";
-import { parseBody, parseUnifiedDiff, newLineNumbers, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
+import { parseBody, parseUnifiedDiff, newLineNumbers, diffKind, type MdBlock, type ParsedFile } from "../lib/prBody.ts";
 import { stepFileIndex } from "../lib/prNav.ts";
 import { PrFilterBar } from "./PrFilterBar.tsx";
 import { Avatar } from "./Avatar.tsx";
@@ -471,7 +471,6 @@ function ExpandContext({ root, number, path, from, to, side = "RIGHT" }: {
  * raises: what did it look like, and what does it look like now. Added and
  * deleted files simply have one side.
  */
-const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|ico|avif)$/i;
 
 function ImageDiff({ root, number, path, status }: {
   root: string; number: number; path: string; status: string;
@@ -2522,8 +2521,17 @@ function FilesTab({ d, root, byPath, loaded, seenFiles, onSeen, sel, onSel, spli
                     scroll, and it is not what GitHub does. Long files are
                     folded by default instead, which is the honest cap. */}
                 <div className="flex" style={{ overflowX: "auto" }}>
+                  {/* An image first, and a file with no hunks second.
+                      `gh pr diff` still emits a header for a binary file — just
+                      "Binary files … differ" and nothing else — so the parser
+                      produces an entry with zero hunks. Testing `change` before
+                      the image put every PNG down the text path and rendered an
+                      empty diff pane, which is why the image viewer never
+                      appeared at all. */}
                   {!loaded ? <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>Loading the diff…</div>
-                    : change ? (
+                    : diffKind(f.path, change?.hunks.length ?? 0) === "image"
+                      ? <ImageDiff root={root} number={d.number} path={f.path} status={f.status} />
+                    : change?.hunks.length ? (
                       <DiffPane
                         file={change} split={split} wrap={wrap}
                         onPick={(pk) => pickLine(f.path, pk)}
@@ -2542,9 +2550,7 @@ function FilesTab({ d, root, byPath, loaded, seenFiles, onSeen, sel, onSel, spli
                         }}
                       />
                     )
-                    : IMAGE_EXT.test(f.path)
-                      ? <ImageDiff root={root} number={d.number} path={f.path} status={f.status} />
-                      : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
+                    : <div className="p-3 text-[10.5px]" style={{ color: "var(--text3)" }}>No textual diff — binary, renamed, or too large to show</div>}
                 </div>
               </LazyMount>
             )}

--- a/web/src/lib/prBody.ts
+++ b/web/src/lib/prBody.ts
@@ -317,6 +317,23 @@ export function splitDiff(text: string): Map<string, string> {
 export interface ParsedHunk { oldStart: number; oldLines: number; newStart: number; newLines: number; lines: string[] }
 export interface ParsedFile { path: string; additions: number; deletions: number; hunks: ParsedHunk[] }
 
+const IMAGE_EXT = /\.(png|jpe?g|gif|webp|bmp|svg|ico|avif)$/i;
+
+/**
+ * Which viewer a changed file needs.
+ *
+ * The subtlety, and the bug this exists to stop coming back: `gh pr diff` still
+ * emits a header for a binary file — `Binary files a/x and b/x differ`, and
+ * nothing else — so the parser yields an entry with ZERO hunks rather than no
+ * entry at all. Deciding on "is there a parsed file" therefore sent every PNG
+ * down the text path and drew an empty diff, which is why the image viewer
+ * never appeared. The count of hunks is the honest question.
+ */
+export function diffKind(path: string, hunks: number): "image" | "text" | "none" {
+  if (hunks > 0) return "text";
+  return IMAGE_EXT.test(path) ? "image" : "none";
+}
+
 /**
  * A unified diff, in the shape the app's own diff viewer already speaks.
  *

--- a/web/test/pr-markdown.test.ts
+++ b/web/test/pr-markdown.test.ts
@@ -6,7 +6,7 @@
 // as punctuation. The escaping tests are the ones with teeth — a body is a
 // string a stranger wrote.
 import { describe, expect, test } from "bun:test";
-import { parseBody, renderInline, stripTags } from "../src/lib/prBody.ts";
+import { parseBody, renderInline, stripTags, diffKind } from "../src/lib/prBody.ts";
 
 describe("<details>", () => {
   test("folds into a details block, with its summary and its inner markdown", () => {
@@ -159,5 +159,34 @@ describe("summary sanitisation", () => {
 
   test("ordinary markup inside a summary is simply removed", () => {
     expect(stripTags("<b>Coverage</b> report")).toBe("Coverage report");
+  });
+});
+
+describe("which viewer a changed file needs", () => {
+  test("a binary image is an image, even though the parser gave it an entry", () => {
+    // The bug this pins: `gh pr diff` emits a header for a binary file with no
+    // hunks under it, so the parser yields an entry. Deciding on "is there a
+    // parsed file" sent every PNG down the text path and drew an empty pane.
+    expect(diffKind(".github/assets/pr.png", 0)).toBe("image");
+    expect(diffKind("landing/hero.gif", 0)).toBe("image");
+    expect(diffKind("web/public/favicon.svg", 0)).toBe("image");
+  });
+
+  test("a file with hunks is text, whatever it is called", () => {
+    // An SVG that came through as a real textual diff should be read, not
+    // rendered — the diff is the answer there.
+    expect(diffKind("web/public/favicon.svg", 3)).toBe("text");
+    expect(diffKind("server/src/prs.ts", 1)).toBe("text");
+  });
+
+  test("a binary that is not an image has nothing to show", () => {
+    expect(diffKind("bun.lock", 0)).toBe("none");
+    expect(diffKind("assets/font.woff2", 0)).toBe("none");
+  });
+
+  test("the extension test is case-insensitive and anchored to the end", () => {
+    expect(diffKind("A/B/Shot.PNG", 0)).toBe("image");
+    // `.png` in the middle of a name is not an image.
+    expect(diffKind("src/png-encoder.ts", 0)).toBe("none");
   });
 });


### PR DESCRIPTION
## What does this PR do?

An image changed in a pull request rendered as an empty diff pane: the image viewer that was written for exactly this case never appeared.

The cause is a detail of `gh pr diff`. It still emits a header for a binary file, with the single line `Binary files a/x and b/x differ` and nothing under it, so the parser yields an entry with **zero hunks** rather than no entry at all. The file router asked "is there a parsed file for this path", which was true for every PNG, so images took the text path and drew nothing.

This asks the honest question instead. A new `diffKind(path, hunks)` in `web/src/lib/prBody.ts` returns `image`, `text` or `none`: hunk count first, extension second. An SVG that did arrive as a real textual diff still reads as text, because the diff is the answer there. The routing lives next to the parser that causes the subtlety, with the reason written down so it does not come back.

No server change: `/prs/file-slice` already reports `binary: true` with a `download_url`, and `/prs/asset` already proxies the bytes with the token GitHub needs.

## How was it tested?

- `bun test`: 1131 pass, 0 fail. Four new tests in `web/test/pr-markdown.test.ts` pin the routing, including the zero-hunk binary that started this, a case-insensitive extension, and `src/png-encoder.ts` not being mistaken for an image.
- `bunx tsc --noEmit` in `web/`: clean.
- Desktop app rebuilt from this branch and installed locally. Opened the PRs panel, Files tab, on pull requests that changed images (#302, #305): before and after thumbnails render on a checkerboard, and an added or deleted file shows the one side it has.