### PR TITLE
fix(mobile): let the phone scroll, and stop revoke reloading the app

### DIFF
--- a/electron/main.js
+++ b/electron/main.js
@@ -382,8 +382,15 @@ async function restartSidecar() {
   // killed the server; anything still answering is either the corpse above or
   // something that is not ours to hand the app to.
   await ensureServer(false);
+  // Tell the page where the server is now, rather than reloading it.
+  //
+  // A reload was the first version of this and it was awful: flipping a setting
+  // threw away every terminal, every unsent chat draft and every scroll
+  // position in the app. The renderer reads the origin and the token through
+  // live bindings (web/src/lib/api.ts), so handing it the new pair is enough —
+  // the next fetch and the next socket connect use them.
   for (const w of BrowserWindow.getAllWindows()) {
-    try { w.webContents.reload(); } catch { /* window went away mid-toggle */ }
+    try { w.webContents.send("ag:server-changed", { origin: apiOrigin, token: currentToken() }); } catch { /* window went away mid-toggle */ }
   }
 }
 

--- a/electron/preload.js
+++ b/electron/preload.js
@@ -29,6 +29,13 @@ contextBridge.exposeInMainWorld("agentglass", {
   remoteEnabled: () => ipcRenderer.invoke("ag:remoteEnabled"),
   setRemote: (on) => ipcRenderer.invoke("ag:setRemote", on),
   revokeRemote: () => ipcRenderer.invoke("ag:revokeRemote"),
+  // Fired when the sidecar has been restarted under the app: a new port, a new
+  // token, or both. Carries them rather than asking the page to reload.
+  onServerChanged: (fn) => {
+    const h = (_e, payload) => { try { fn(payload); } catch { /* renderer's problem */ } };
+    ipcRenderer.on("ag:server-changed", h);
+    return () => ipcRenderer.removeListener("ag:server-changed", h);
+  },
   setFullscreen: (on) => ipcRenderer.invoke("ag:setFullscreen", on),
   isFullscreen: () => ipcRenderer.invoke("ag:isFullscreen"),
   setZoom: (factor) => ipcRenderer.invoke("ag:setZoom", factor),

--- a/web/src/components/RemoteAccessPane.tsx
+++ b/web/src/components/RemoteAccessPane.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { api } from "../lib/api.ts";
 import { IS_DESKTOP, remoteAccessEnabled, setRemoteAccess, revokeRemoteAccess } from "../lib/desktop.ts";
 import { qrMatrix, qrSvgPath } from "../lib/qr.ts";
@@ -33,6 +33,10 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
   const [confirming, setConfirming] = useState(false);
   const [revokeNote, setRevokeNote] = useState<string | null>(null);
 
+  const load = useCallback(() => {
+    api.remoteStatus().then(setSt).catch(() => setSt(null));
+  }, []);
+
   useEffect(() => {
     if (!open) return;
     let live = true;
@@ -49,12 +53,12 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
 
   const toggle = async () => {
     setBusy(true);
-    // The shell restarts the sidecar and reloads this window, so in the normal
-    // case nothing below ever runs. The state update is for the case where it
-    // declines.
+    // The shell restarts the sidecar and hands the page its new origin and
+    // token; nothing reloads, so this has to refresh its own state afterwards.
     const next = await setRemoteAccess(!enabled);
     setBusy(false);
     if (next !== null) setEnabled(next);
+    load();
   };
 
   const revoke = async () => {
@@ -62,9 +66,10 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
     const ok = await revokeRemoteAccess();
     setBusy(false);
     setConfirming(false);
-    // In the ordinary case the shell restarts the server and reloads this
-    // window, so nothing below is ever seen. The messages are for the two cases
-    // where it declines.
+    // The new code is already on its way to this page over the bridge; asking
+    // the server again is what puts it in the QR.
+    if (ok) load();
+    // The messages below are for the two cases where the shell declines.
     if (ok === false) setRevokeNote("AGENTGLASS_TOKEN is set in this app's environment, so the app cannot rotate it. Change it where it is set.");
     else if (ok === null) setRevokeNote("This shell cannot rotate the access code.");
   };

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -34,6 +34,30 @@
     color: var(--text);
     @apply font-mono antialiased overflow-hidden;
   }
+  /*
+   * The phone application scrolls; the cockpit does not.
+   *
+   * `overflow: hidden` with everything pinned to 100% height is right for a
+   * desk UI made of panels that scroll internally — and it is why the phone
+   * view could not be scrolled at all: its content ran past the viewport into
+   * a body that had been told never to move. The attribute is set on <html> by
+   * main.tsx at the same moment it picks which application to render, so the
+   * two can never disagree.
+   *
+   * Letting the *body* scroll rather than an inner container is deliberate: it
+   * is what gives a phone its native behaviour — the address bar collapsing on
+   * scroll, momentum, and the overscroll bounce landing where the OS expects.
+   */
+  html[data-layout="phone"],
+  html[data-layout="phone"] body,
+  html[data-layout="phone"] #root {
+    height: auto;
+    min-height: 100%;
+  }
+  html[data-layout="phone"] body {
+    overflow-x: hidden;
+    overflow-y: auto;
+  }
   ::-webkit-scrollbar {
     width: 7px;
     height: 7px;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -21,7 +21,7 @@ const DESKTOP_API: string | undefined =
     ? (window as unknown as { agentglass?: { apiOrigin?: string } }).agentglass?.apiOrigin
     : undefined;
 
-export const SERVER: string =
+export let SERVER: string =
   (import.meta.env.VITE_CW_SERVER as string | undefined)?.replace(/\/$/, "") ||
   DESKTOP_API?.replace(/\/$/, "") ||
   (SERVED_BY_API ? location.origin : `http://${location.hostname}:4000`);
@@ -91,7 +91,7 @@ export async function probeServer(timeoutMs = 2500): Promise<ServerIdentity> {
  *  once from `?token=` — then stripped from the URL bar so it isn't shoulder-
  *  surfed or copied around — or from a prior localStorage save. Empty on the
  *  usual local box, where every call below is a no-op passthrough. */
-const TOKEN: string = (() => {
+let TOKEN: string = (() => {
   try {
     const u = new URL(location.href);
     const fromUrl = u.searchParams.get("token");
@@ -178,7 +178,36 @@ export function reauthPrompt(): void {
   }
 }
 
-export const WS_URL = withToken(SERVER.replace(/^http/, "ws") + "/stream");
+export let WS_URL = withToken(SERVER.replace(/^http/, "ws") + "/stream");
+
+/**
+ * Point this client at a (possibly new) server, without reloading the page.
+ *
+ * Turning remote access on or off, and revoking a link, all restart the sidecar
+ * with a different environment: it may come back on another port, and it comes
+ * back demanding a token the page did not have when it loaded. The obvious way
+ * to deal with that is to reload the window, which is what this replaced — and
+ * reloading the whole cockpit because a setting changed is a jarring answer to
+ * a small question. Terminals, drafts and scroll positions are not worth a
+ * rotated secret.
+ *
+ * `SERVER`, `TOKEN` and `WS_URL` are live bindings for exactly this reason:
+ * every consumer reads them at call time, so the next fetch and the next socket
+ * connect go to the right place with the right credential.
+ */
+export function adoptServer(next: { origin?: string | null; token?: string | null }): void {
+  if (next.origin) SERVER = next.origin.replace(/\/$/, "");
+  if (next.token !== undefined) {
+    TOKEN = next.token ?? "";
+    // Keep storage in step, so a genuine reload later does not fall back to a
+    // secret that has been revoked.
+    try {
+      if (TOKEN) localStorage.setItem("agentglass_token", TOKEN);
+      else localStorage.removeItem("agentglass_token");
+    } catch { /* private mode */ }
+  }
+  WS_URL = withToken(SERVER.replace(/^http/, "ws") + "/stream");
+}
 
 /** WebSocket URL for a real PTY shell in `root` (the in-browser terminal). */
 export const ptyWsUrl = (root: string, cols: number, rows: number) =>

--- a/web/src/lib/desktop.ts
+++ b/web/src/lib/desktop.ts
@@ -1,3 +1,5 @@
+import { adoptServer } from "./api.ts";
+
 // Desktop-only capabilities.
 //
 // The same bundle runs in a browser tab and inside the Electron window, so
@@ -16,6 +18,7 @@ type DesktopBridge = {
   remoteEnabled?: () => Promise<boolean>;
   setRemote?: (on: boolean) => Promise<boolean>;
   revokeRemote?: () => Promise<boolean>;
+  onServerChanged?: (fn: (p: { origin?: string | null; token?: string | null }) => void) => () => void;
 };
 
 function bridge(): DesktopBridge | null {
@@ -172,4 +175,23 @@ export async function revokeRemoteAccess(): Promise<boolean | null> {
   } catch {
     return null;
   }
+}
+
+/**
+ * Follow the sidecar when the shell restarts it.
+ *
+ * Toggling remote access and revoking a link both bring the server back with a
+ * different token, and possibly on a different port. This is what lets that
+ * happen under a running app: the shell hands over the new pair, the api module
+ * adopts it, and a `agentglass:server-changed` event lets anything holding a
+ * socket reconnect. No reload, so terminals, drafts and scroll positions
+ * survive a setting change.
+ */
+export function followServerChanges(): () => void {
+  const b = bridge();
+  if (!b?.onServerChanged) return () => {};
+  return b.onServerChanged((p) => {
+    adoptServer(p);
+    window.dispatchEvent(new CustomEvent("agentglass:server-changed"));
+  });
 }

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -282,10 +282,31 @@ export function useLive(paused = false): LiveData {
         connect();
       }
     };
+    /**
+     * The shell moved the server under us: a new port, a new token, or both,
+     * after remote access was toggled or a link revoked.
+     *
+     * The old socket is already dead — its server is gone — but the backoff
+     * would keep the app disconnected for seconds over a change the user just
+     * made and is watching. Reconnect at once, against the URL the api module
+     * has just rebuilt. `unauthorized` is cleared deliberately: a rotated token
+     * is exactly the case where the previous refusal no longer applies.
+     */
+    const onServerChanged = () => {
+      if (disposed.current) return;
+      if (reconnectTimer.current) { clearTimeout(reconnectTimer.current); reconnectTimer.current = null; }
+      retry.current = 0;
+      firstFailAt.current = 0;
+      try { wsRef.current?.close(); } catch { /* already gone */ }
+      wsRef.current = null;
+      connect();
+    };
     document.addEventListener("visibilitychange", onVis);
+    window.addEventListener("agentglass:server-changed", onServerChanged);
     return () => {
       disposed.current = true;
       document.removeEventListener("visibilitychange", onVis);
+      window.removeEventListener("agentglass:server-changed", onServerChanged);
       if (timer.current) clearTimeout(timer.current);
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
       wsRef.current?.close();

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -3,6 +3,7 @@ import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import { MobileApp } from "./mobile/MobileApp.tsx";
 import { phoneLayoutNow } from "./lib/viewport.ts";
+import { followServerChanges } from "./lib/desktop.ts";
 import { applyTheme, initialTheme, watchThemeStorage } from "./lib/themes.ts";
 import { restoreScale } from "./lib/uiScale.ts";
 import "./index.css";
@@ -23,7 +24,16 @@ restoreScale();
  * Rendering one tree or the other is also what keeps the phone UI honest — it
  * cannot quietly grow a dependency on desktop state it does not have.
  */
-const Root = phoneLayoutNow() ? MobileApp : App;
+const phone = phoneLayoutNow();
+// The stylesheet needs to know too: the cockpit pins html/body/#root to the
+// viewport and hides overflow, which is correct for panels that scroll
+// internally and fatal for a page that is meant to scroll as a whole.
+document.documentElement.dataset.layout = phone ? "phone" : "desktop";
+const Root = phone ? MobileApp : App;
+
+// The shell restarts its sidecar when remote access is toggled or a link is
+// revoked. Adopt the new origin/token in place rather than reloading the app.
+followServerChanges();
 
 ReactDOM.createRoot(document.getElementById("root")!).render(
   <React.StrictMode>


### PR DESCRIPTION
## What does this PR do?

Fixes the two things that made the phone view feel broken, reported from a real Pixel.

**The page could not be scrolled at all.** `index.css` pins `html`, `body` and `#root` to 100% height and sets `overflow: hidden` on the body. That is right for the cockpit, whose panels scroll internally, and fatal for a page meant to scroll as a whole — the phone content simply ran past the viewport into a body that had been told never to move. `main.tsx` now stamps `data-layout="phone"` on `<html>` at the same moment it picks which application to render, so the stylesheet and the tree cannot disagree, and the body scrolls in that layout. Letting the *body* scroll rather than an inner container is deliberate: it is what gives a phone the collapsing address bar, momentum and the overscroll bounce the OS expects.

**Revoking a link reloaded the whole desktop app.** The restart of the sidecar is unavoidable (a bind cannot change under a listening socket), but the reload afterwards was not: it existed only because `api.ts` read the origin and the token once, at module load. Throwing away every terminal, unsent chat draft and scroll position because a secret was rotated is a bad trade for a small change.

The shell now hands the page its new origin and token over the preload bridge (`ag:server-changed`) and the page adopts them in place: `SERVER`, the token and `WS_URL` became live bindings, so the next fetch and the next socket connect use them, and `useLive` reconnects immediately rather than waiting out its backoff — the server it is about to reach is the one the user just asked for. The Remote panel refreshes its own state instead of riding on the reload.

## How was it tested?

- **1127 tests pass**, `bunx tsc --noEmit` clean in `web/` and `server/`.
- **Scrolling**, on headless Chrome emulating a phone (390×844, touch enabled) against a real server: `data-layout` is `phone`, computed `body { overflow-y: auto }`, page 2921px in an 844px viewport, and a dispatched touch swipe moves `scrollTop` to 2077.
- **No reload**, on the packaged desktop build driven over CDP: a marker set on `window` survives both a remote-access toggle and a revoke, `Page.frameNavigated` fires **zero** times for the main frame across the whole run, the token rotates on disk, the previous token then returns 401, the new one 200, and the page keeps reaching its server (`/health` 200) with the panel still live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
