### PR TITLE
mobile: make the phone a companion rather than a smaller dashboard

### DIFF
--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -1,319 +1,341 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
 import { useStats } from "../lib/useStats.ts";
-import { fmtUsd, fmtTokens, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
+import { fmtUsd, fmtTokens } from "../lib/format.ts";
 import { MobileChats } from "./MobileChats.tsx";
-import type { PendingGate, SessionRollup } from "../../../shared/types.ts";
+import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act } from "./mobileUi.tsx";
+import { DIFF_CSS } from "./MobileDiff.tsx";
+import { NOW_CSS, NowHero, NowStream, type NowAction } from "./MobileNow.tsx";
+import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
+import { MobilePr } from "./MobilePr.tsx";
+import { buildQueue, type NowItem } from "./nowQueue.ts";
+import type {
+  PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef,
+} from "../../../shared/types.ts";
 
 /**
- * agentglass on a phone.
+ * agentglass away from the desk.
  *
- * Deliberately a different application, not a reflow of the cockpit. The
- * desktop UI is six workspace views around a real terminal, hunk-level staging
- * and a docker table — none of which anyone wants to drive with a thumb, and
- * the terminal in particular is unusable there however it is styled. Shrinking
- * it produces something that technically renders and practically cannot be
- * used, which is worse than saying no.
+ * Not a smaller cockpit, and not a dashboard: a companion. The first pass at
+ * this was three tabs, two of which you could only read. The obvious next move
+ * was to add git, docker and pull requests as three more tabs — but a tab bar
+ * claims its entries are equal and independent, and those three are neither.
+ * They are facets of a repository, and none of them is somewhere you browse
+ * to: you arrive at them because something happened.
  *
- * So this is the part of agentglass that is genuinely better from the sofa:
+ * So the home is a queue of things that want a decision, each carrying its own
+ * action, and answering one takes it out of the list. That is the whole
+ * difference from a dashboard — a dashboard is something you re-read, and this
+ * is something you can empty.
  *
- *   Needs you — approve or deny what an agent is blocked on. The one thing
- *               that is time-critical and takes one tap.
- *   Chats     — read what an agent has been doing, reply to it, take over a
- *               session started at the desk, or start a new one. Monitoring
- *               without this is only half a companion: seeing that an agent
- *               stopped and being unable to say "carry on" is the same as not
- *               knowing.
- *   Fleet     — is it running, is it burning money, is anything failing.
+ *   Now    — what wants you, in order. Allow, reply, merge, restart.
+ *   Chats  — say something back. This part was already right.
+ *   Repos  — go looking, for when you want to rather than need to.
  *
- * Everything else is absent rather than broken, and there is deliberately no
- * way back to the desktop layout from here: it does not work on this screen,
- * so offering it would only be a route to a worse version of the same thing.
- *
- * Nothing heavy mounts here: no xterm, no charts, no radar. On a phone that is
- * a battery decision as much as a layout one.
+ * Nothing heavy mounts: no xterm, no charts, no radar. On a phone that is a
+ * battery decision as much as a layout one, and it is why the fleet's pulse is
+ * fourteen CSS-animated bars rather than a canvas.
  */
 
-type Tab = "gates" | "chats" | "fleet";
+type Tab = "now" | "chats" | "repos";
 
-const WINDOWS: { label: string; ms: number }[] = [
-  { label: "1h", ms: 3_600_000 },
-  { label: "24h", ms: 86_400_000 },
-  { label: "7d", ms: 7 * 86_400_000 },
-];
+/** A gate is the only thing here that has an agent stopped dead, so it gets
+ *  the fastest poll. Everything else moves on human timescales. */
+const GATE_MS = 4_000;
+const TREE_MS = 30_000;
+const DOCKER_MS = 15_000;
+const PR_MS = 60_000;
 
 export function MobileApp() {
-  const [tab, setTab] = useState<Tab>("gates");
-  const [windowMs, setWindowMs] = useState(WINDOWS[1]!.ms);
-  const { stats } = useStats(windowMs);
-  const [sessions, setSessions] = useState<SessionRollup[]>([]);
-  const [gates, setGates] = useState<PendingGate[]>([]);
-  const [reachable, setReachable] = useState(true);
+  const [tab, setTab] = useState<Tab>("now");
+  const { toasts, toast } = useToasts();
+  const { stats } = useStats(86_400_000);
 
-  // Polled rather than streamed. The live socket exists and works, but a phone
-  // spends most of its life with the screen off, and a reconnecting socket in
-  // the background is a worse deal than two small requests when you look at it.
-  const load = useCallback(() => {
-    api.gatePending()
-      .then((r) => { setGates(r.gates); setReachable(true); })
-      .catch(() => setReachable(false));
+  const [gates, setGates] = useState<PendingGate[]>([]);
+  const [sessions, setSessions] = useState<SessionRollup[]>([]);
+  const [reachable, setReachable] = useState(true);
+  const [repos, setRepos] = useState<GitRepoRef[]>([]);
+  const [trees, setTrees] = useState<Record<string, { branch: string; dirty: number; ahead: number; behind: number }>>({});
+  const [containers, setContainers] = useState<DockerContainer[]>([]);
+  const [dstats, setDstats] = useState<DockerStat[]>([]);
+  const [prs, setPrs] = useState<{ root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[]>([]);
+  const [me, setMe] = useState("");
+
+  const [openRepo, setOpenRepo] = useState<RepoSummary | null>(null);
+  const [openPr, setOpenPr] = useState<{ root: string; number: number } | null>(null);
+  const [settings, setSettings] = useState(false);
+  const [dismissed, setDismissed] = useState<string[]>([]);
+
+  // ── polling ──────────────────────────────────────────────────────────
+  // Polled rather than streamed, deliberately. The live socket exists and
+  // works, but a phone spends most of its life with the screen off, and a
+  // socket reconnecting in the background is a worse deal than a few small
+  // requests at the moment you look at it.
+  const loadFast = useCallback(() => {
+    api.gatePending().then((r) => { setGates(r.gates); setReachable(true); }).catch(() => setReachable(false));
     api.sessions(40).then(setSessions).catch(() => { /* the gate poll reports reachability */ });
   }, []);
 
+  const loadDocker = useCallback(() => {
+    api.dockerOverview().then((o) => setContainers(o.available ? o.containers : [])).catch(() => setContainers([]));
+    api.dockerStats().then((r) => setDstats(r.stats)).catch(() => setDstats([]));
+  }, []);
+
+  const loadTrees = useCallback((list: GitRepoRef[]) => {
+    for (const r of list) {
+      api.gitTree(r.root).then((t) => setTrees((cur) => ({
+        ...cur,
+        [r.root]: {
+          branch: t.branch.name,
+          // A file part-staged appears in both lists; counting it twice would
+          // report more work outstanding than there is.
+          dirty: new Set([...t.staged, ...t.unstaged].map((f) => f.file_path)).size,
+          ahead: t.branch.ahead, behind: t.branch.behind,
+        },
+      }))).catch(() => { /* a repo that will not open is not worth a toast on a poll */ });
+    }
+  }, []);
+
+  const loadPrs = useCallback((list: GitRepoRef[]) => {
+    Promise.all(list.flatMap((r) => (["mine", "review"] as const).map((scope) =>
+      api.prList(r.root, scope, "open")
+        .then((res) => res.prs.map((pr) => ({ root: r.root, repo: repoName(r), pr, scope })))
+        .catch(() => [] as { root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[])
+    ))).then((groups) => setPrs(groups.flat()));
+  }, []);
+
   useEffect(() => {
-    load();
-    const t = setInterval(load, 4000);
+    loadFast();
+    const t = setInterval(loadFast, GATE_MS);
     // Catching up the moment the screen comes back is what makes a poll feel
     // live: a phone returning from sleep would otherwise show the last frame it
-    // painted before it slept.
-    const wake = () => { if (document.visibilityState === "visible") load(); };
+    // managed to paint before it slept.
+    const wake = () => { if (document.visibilityState === "visible") loadFast(); };
     document.addEventListener("visibilitychange", wake);
     return () => { clearInterval(t); document.removeEventListener("visibilitychange", wake); };
-  }, [load]);
+  }, [loadFast]);
 
+  useEffect(() => {
+    api.prCapability().then((c) => setMe(c.login || "")).catch(() => {});
+    api.gitRepos().then(({ repos: list }) => { setRepos(list); loadTrees(list); loadPrs(list); }).catch(() => {});
+    loadDocker();
+  }, [loadDocker, loadTrees, loadPrs]);
+
+  useEffect(() => {
+    if (!repos.length) return;
+    const a = setInterval(() => loadTrees(repos), TREE_MS);
+    const b = setInterval(() => loadPrs(repos), PR_MS);
+    const c = setInterval(loadDocker, DOCKER_MS);
+    return () => { clearInterval(a); clearInterval(b); clearInterval(c); };
+  }, [repos, loadTrees, loadPrs, loadDocker]);
+
+  const refreshAll = useCallback(() => {
+    loadFast(); loadDocker();
+    if (repos.length) { loadTrees(repos); loadPrs(repos); }
+  }, [loadFast, loadDocker, loadTrees, loadPrs, repos]);
+
+  // ── derived ──────────────────────────────────────────────────────────
   const live = useMemo(
     () => sessions.filter((s) => !s.ended_at && Date.now() - s.last_seen < 120_000),
     [sessions]
   );
 
+  const queue = useMemo(
+    () => buildQueue({ gates, sessions, prs, containers, me, now: Date.now() })
+      .filter((i) => !dismissed.includes(i.id)),
+    [gates, sessions, prs, containers, me, dismissed]
+  );
+
+  const repoSummaries: RepoSummary[] = useMemo(() => repos.map((r) => {
+    const t = trees[r.root];
+    const name = repoName(r);
+    return {
+      ref: r, name,
+      branch: t?.branch ?? "—",
+      dirty: t?.dirty ?? 0, ahead: t?.ahead ?? 0, behind: t?.behind ?? 0,
+      prs: prs.filter((p) => p.root === r.root).length,
+      down: containers.filter((c) => (c.project ?? "") === name && c.state !== "running" && c.state !== "created").length,
+    };
+  }), [repos, trees, prs, containers]);
+
+  /** An answered item leaves the queue at once, before the next poll confirms
+   *  it. Waiting four seconds to watch your own tap take effect is what makes
+   *  a companion feel like a web page. */
+  const drop = (id: string) => setDismissed((d) => [...d, id]);
+
+  const decide = async (id: string, d: "allow" | "deny", itemId: string) => {
+    try {
+      await api.gateDecide(id, d);
+      drop(itemId);
+      toast(d === "allow" ? "Allowed — the agent is moving again" : "Denied — the agent was told no");
+    } catch {
+      // An answer that did not arrive must not look like one that did: the
+      // agent is still blocked, and saying otherwise is the worst outcome here.
+      toast("That did not reach the server — the agent is still waiting", true);
+    }
+  };
+  const settle = async (label: string, run: () => Promise<{ ok: boolean; error?: string }>, itemId?: string) => {
+    const r = await run();
+    toast(r.ok ? label : (r.error || `${label} failed`), !r.ok);
+    if (r.ok) { if (itemId) drop(itemId); refreshAll(); }
+  };
+  /** A container belongs to a repo, so open its repo rather than inventing a
+   *  second route to the same screen. */
+  const openContainerRepo = (c: DockerContainer) => {
+    const r = repoSummaries.find((x) => x.name === (c.project ?? ""));
+    if (r) setOpenRepo(r); else toast("That container is not in a repo agentglass knows", true);
+  };
+
+  const actionsFor = (it: NowItem): NowAction[] => {
+    const o = it.origin;
+    switch (o.t) {
+      case "gate":
+        return [
+          { label: "Allow", kind: "ok", run: () => decide(o.gate.id, "allow", it.id) },
+          { label: "Deny", kind: "no", run: () => decide(o.gate.id, "deny", it.id) },
+        ];
+      case "session":
+        return [
+          { label: "Open chat", kind: "acc", run: () => { setTab("chats"); drop(it.id); } },
+          { label: "Later", run: () => { drop(it.id); toast("Snoozed"); } },
+        ];
+      case "pr-red":
+        return [
+          { label: "See the log", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
+          { label: "Re-run", kind: "acc", run: () => settle("Re-running the failed checks", () => api.prRerun(o.root, o.pr.number)) },
+        ];
+      case "pr-ready":
+        return [
+          {
+            label: "Squash & merge", kind: "ok",
+            run: () => settle(`Merged #${o.pr.number}`, () => api.prMerge(o.root, o.pr.number, "squash", { deleteBranch: true }), it.id),
+          },
+          { label: "Review", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
+        ];
+      case "pr-review":
+        return [{ label: "Review", kind: "acc", run: () => setOpenPr({ root: o.root, number: o.pr.number }) }];
+      case "container":
+        return [
+          { label: "Logs", run: () => openContainerRepo(o.container) },
+          { label: "Restart", kind: "acc", run: () => settle(`Restarted ${o.container.name}`, () => api.dockerRestart(o.container.id)) },
+        ];
+    }
+  };
+
+  const openItem = (it: NowItem) => {
+    const o = it.origin;
+    if (o.t === "pr-red" || o.t === "pr-ready" || o.t === "pr-review") setOpenPr({ root: o.root, number: o.pr.number });
+    else if (o.t === "container") openContainerRepo(o.container);
+    else if (o.t === "session") setTab("chats");
+  };
+
+  const stacked = !!openRepo || !!openPr;
+  const spend = stats?.totals ? fmtUsd(stats.totals.cost_usd) : "—";
+
   return (
-    <div className="min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
-      <header className="sticky top-0 z-10 px-4 pt-3 pb-2 flex items-center gap-2"
-        style={{ background: "color-mix(in srgb, var(--bg) 92%, transparent)", backdropFilter: "blur(8px)", borderBottom: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-        <span className="text-[17px] font-semibold tracking-tight">
+    <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
+      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}</style>
+      <div className="mb-sky" />
+
+      <header className="sticky top-0 z-40 flex items-center gap-2 px-4"
+        style={{
+          paddingTop: "calc(env(safe-area-inset-top) + 11px)", paddingBottom: 10,
+          background: "color-mix(in srgb, var(--bg) 80%, transparent)", backdropFilter: "blur(16px) saturate(1.4)",
+          borderBottom: "1px solid var(--mb-line)",
+        }}>
+        <span className="text-[17.5px] font-bold tracking-tight">
           agent<span style={{ color: "var(--primary-hover)" }}>glass</span>
         </span>
-        <span className="ml-auto flex items-center gap-1.5 text-[11px]" style={{ color: reachable ? "var(--success)" : "var(--error)" }}>
-          <span className="inline-block rounded-full" style={{ width: 7, height: 7, background: "currentColor" }} />
+        <span className="flex-1" />
+        <span className="flex items-center gap-1.5 text-[11px]" style={{ color: reachable ? "var(--success)" : "var(--error)" }}>
+          <span className="mb-dot pulse" style={{ background: "currentColor", color: "currentColor" }} />
           {reachable ? "Live" : "Offline"}
         </span>
+        <button className="mb-press grid place-items-center" aria-label="Settings"
+          style={{ minHeight: 40, minWidth: 40, borderRadius: 11, fontSize: 15, color: "var(--text3)", background: "transparent" }}
+          onClick={() => setSettings(true)}>⚙</button>
       </header>
 
-      <main className="flex-1 px-4 pb-24 pt-3">
-        {tab === "gates" && <GatesTab gates={gates} onDecided={(id) => setGates((g) => g.filter((x) => x.id !== id))} />}
-        {tab === "fleet" && (
-          <FleetTab
-            stats={stats}
-            live={live.length}
-            windowMs={windowMs}
-            onWindow={setWindowMs}
-            sessions={live}
-          />
+      <main className="flex-1 relative" style={{ zIndex: 1, padding: "14px 15px calc(var(--nav) + env(safe-area-inset-bottom) + 22px)" }}>
+        {tab === "now" && (
+          <>
+            <NowHero
+              pending={queue.length} working={live.length}
+              // The bars breathe at rates derived from each agent's own tool
+              // count, so the strip reads as several things working rather than
+              // one animation looping.
+              rates={live.map((s) => 1 + ((s.tool_count % 5) * 0.35))}
+              spend={spend}
+              repos={[...new Set(live.map((s) => (s.project_path || "").split("/").filter(Boolean).pop() || s.source_app))]}
+            />
+            <NowStream items={queue} actionsFor={actionsFor} onOpen={openItem} />
+          </>
         )}
-        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={load} />}
+        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} />}
+        {tab === "repos" && <RepoList repos={repoSummaries} onOpen={setOpenRepo} />}
       </main>
 
-      {/* Fixed, thumb-height, and out of the way of the home indicator. */}
-      <nav className="fixed bottom-0 left-0 right-0 flex z-20"
-        style={{ background: "color-mix(in srgb, var(--bg2) 94%, transparent)", backdropFilter: "blur(10px)", borderTop: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", paddingBottom: "env(safe-area-inset-bottom)" }}>
-        <TabButton id="gates" tab={tab} onPick={setTab} label="Needs you" badge={gates.length} />
-        <TabButton id="chats" tab={tab} onPick={setTab} label="Chats" badge={live.length} subtle />
-        <TabButton id="fleet" tab={tab} onPick={setTab} label="Fleet" />
+      <nav className="fixed left-0 right-0 bottom-0 z-40 flex"
+        style={{
+          background: "color-mix(in srgb, var(--bg2) 84%, transparent)", backdropFilter: "blur(20px) saturate(1.5)",
+          borderTop: "1px solid color-mix(in srgb, var(--border) 48%, transparent)",
+          paddingBottom: "env(safe-area-inset-bottom)",
+        }}>
+        <TabBtn id="now" tab={tab} onPick={setTab} glyph="◎" label="Now" badge={queue.length} />
+        <TabBtn id="chats" tab={tab} onPick={setTab} glyph="▤" label="Chats" />
+        <TabBtn id="repos" tab={tab} onPick={setTab} glyph="◇" label="Repos" />
       </nav>
+
+      <RepoScreen open={!!openRepo && !openPr} repo={openRepo} containers={containers} stats={dstats}
+        onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll} />
+
+      <MobilePr open={!!openPr} root={openPr?.root ?? ""} number={openPr?.number ?? null}
+        onBack={() => { setOpenPr(null); refreshAll(); }} toast={toast} />
+
+      <Sheet open={settings} title="Settings" sub="This device only." onClose={() => setSettings(false)}>
+        <div className="flex flex-col gap-2.5">
+          <Row title="Spend today" sub={stats?.totals ? `${fmtTokens(stats.totals.input_tokens + stats.totals.output_tokens)} tokens` : "—"} right={spend} />
+          <Row title="Sessions" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.sessions) : "—"} />
+          <Row title="Tool errors" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.errors) : "—"} />
+        </div>
+        <div className="mb-eyebrow" style={{ margin: "16px 0 9px" }}>Queue</div>
+        <Row title="Snoozed" sub={dismissed.length ? `${dismissed.length} hidden until they change` : "Nothing snoozed"}
+          right={dismissed.length
+            ? <Act small onAct={() => { setDismissed([]); toast("Queue restored"); }}>Restore</Act>
+            : undefined} />
+        <p className="text-[10.5px] mt-4 leading-relaxed" style={{ color: "var(--text3)" }}>
+          The cockpit stays at the desk. This is the part of agentglass worth having in a pocket.
+        </p>
+      </Sheet>
+
+      <Toasts toasts={toasts} raised={stacked} />
     </div>
   );
 }
 
-function TabButton({ id, tab, onPick, label, badge, subtle }: {
-  id: Tab; tab: Tab; onPick: (t: Tab) => void; label: string; badge?: number; subtle?: boolean;
+function TabBtn({ id, tab, onPick, glyph, label, badge }: {
+  id: Tab; tab: Tab; onPick: (t: Tab) => void; glyph: string; label: string; badge?: number;
 }) {
   const on = tab === id;
   return (
     <button onClick={() => onPick(id)} aria-current={on}
-      className="flex-1 flex flex-col items-center justify-center gap-0.5 py-3 text-[12px]"
-      style={{ color: on ? "var(--primary-hover)" : "var(--text2)", minHeight: 56 }}>
-      <span className="flex items-center gap-1.5">
-        {label}
-        {!!badge && (
-          <span className="text-[10px] px-1.5 py-0.5 rounded-full tabular-nums" style={{
-            color: subtle ? "var(--text2)" : "var(--bg)",
-            background: subtle ? "color-mix(in srgb, var(--border) 60%, transparent)" : "var(--primary-hover)",
-          }}>{badge}</span>
-        )}
-      </span>
-      <span className="rounded-full" style={{ width: 18, height: 2, background: on ? "var(--primary-hover)" : "transparent" }} />
-    </button>
-  );
-}
-
-/** The reason to have this on a phone at all. */
-function GatesTab({ gates, onDecided }: { gates: PendingGate[]; onDecided: (id: string) => void }) {
-  if (!gates.length) {
-    return (
-      <Empty
-        title="Nothing is waiting on you"
-        body="When an agent asks permission to run something, it appears here and the fleet waits until you answer."
-      />
-    );
-  }
-  return (
-    <div className="flex flex-col gap-3">
-      {gates.map((g) => <GateCard key={g.id} gate={g} onDecided={onDecided} />)}
-    </div>
-  );
-}
-
-function GateCard({ gate, onDecided }: { gate: PendingGate; onDecided: (id: string) => void }) {
-  const [busy, setBusy] = useState<"allow" | "deny" | null>(null);
-  const [failed, setFailed] = useState(false);
-
-  const decide = async (decision: "allow" | "deny") => {
-    setBusy(decision);
-    setFailed(false);
-    try {
-      await api.gateDecide(gate.id, decision);
-      onDecided(gate.id);
-    } catch {
-      // An answer that did not arrive must not look like one that did: the
-      // agent is still blocked, and saying otherwise is the worst outcome here.
-      setFailed(true);
-      setBusy(null);
-    }
-  };
-
-  return (
-    <section className="rounded-2xl p-4 flex flex-col gap-3" style={{
-      background: "color-mix(in srgb, var(--bg2) 70%, transparent)",
-      border: "1px solid color-mix(in srgb, var(--warning) 35%, transparent)",
-    }}>
-      <div className="flex items-baseline gap-2">
-        <span className="text-[15px] font-semibold">{gate.tool_name}</span>
-        <span className="text-[11px] ml-auto" style={{ color: "var(--text2)" }}>{fmtAgo(gate.created)}</span>
-      </div>
-      <p className="text-[13px] leading-snug break-words" style={{ color: "var(--text)" }}>{gate.summary}</p>
-      <div className="text-[11px] t-mono break-all" style={{ color: "var(--text3)" }}>{gate.source_app}</div>
-      {failed && (
-        <div className="text-[11.5px]" style={{ color: "var(--error)" }}>
-          That did not reach the server. The agent is still waiting — try again.
-        </div>
-      )}
-      {/* Big, far apart, and deny is not the one under your thumb by accident. */}
-      <div className="flex gap-2.5 pt-0.5">
-        <button onClick={() => decide("allow")} disabled={!!busy}
-          className="flex-1 rounded-xl text-[15px] font-medium"
-          style={{ minHeight: 52, color: "var(--success)", background: "color-mix(in srgb, var(--success) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 45%, transparent)", opacity: busy ? 0.6 : 1 }}>
-          {busy === "allow" ? "Allowing…" : "Allow"}
-        </button>
-        <button onClick={() => decide("deny")} disabled={!!busy}
-          className="flex-1 rounded-xl text-[15px] font-medium"
-          style={{ minHeight: 52, color: "var(--error)", background: "color-mix(in srgb, var(--error) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)", opacity: busy ? 0.6 : 1 }}>
-          {busy === "deny" ? "Denying…" : "Deny"}
-        </button>
-      </div>
-    </section>
-  );
-}
-
-function FleetTab({ stats, live, windowMs, onWindow, sessions }: {
-  stats: ReturnType<typeof useStats>["stats"];
-  live: number;
-  windowMs: number;
-  onWindow: (ms: number) => void;
-  sessions: SessionRollup[];
-}) {
-  const t = stats?.totals;
-  return (
-    <div className="flex flex-col gap-4">
-      <div className="flex gap-1.5">
-        {WINDOWS.map((w) => (
-          <button key={w.label} onClick={() => onWindow(w.ms)}
-            className="px-3 py-1.5 rounded-lg text-[12px]"
-            style={{
-              minHeight: 38,
-              color: windowMs === w.ms ? "var(--primary-hover)" : "var(--text2)",
-              background: windowMs === w.ms ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent",
-              border: `1px solid color-mix(in srgb, var(--border) ${windowMs === w.ms ? 60 : 30}%, transparent)`,
-            }}>
-            {w.label}
-          </button>
-        ))}
-      </div>
-
-      <div className="rounded-2xl p-4" style={{ background: "color-mix(in srgb, var(--bg2) 65%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
-        <div className="panel-eyebrow">Spend · this window</div>
-        <div className="text-[34px] font-semibold tabular-nums leading-tight" style={{ color: "var(--success)" }}>
-          {t ? fmtUsd(t.cost_usd) : "—"}
-        </div>
-        <div className="text-[11.5px]" style={{ color: "var(--text2)" }}>
-          {t ? `${fmtTokens(t.input_tokens + t.output_tokens)} tokens · ${fmtTokens(t.cache_read_tokens)} cached` : "…"}
-        </div>
-      </div>
-
-      <div className="grid grid-cols-2 gap-2.5">
-        <Tile label="Working" value={String(live)} hint="Live agents" tone={live ? "var(--success)" : undefined} />
-        <Tile label="Tools run" value={t ? String(t.tool_calls) : "—"} hint={t ? `${t.events} events` : ""} />
-        <Tile label="Sessions" value={t ? String(t.sessions) : "—"} hint="In this window" />
-        <Tile label="Failed" value={t ? String(t.errors) : "—"} hint="Tool errors" tone={t?.errors ? "var(--error)" : undefined} />
-      </div>
-
-      <div>
-        <div className="panel-eyebrow px-1 pb-1.5">What the fleet is doing</div>
-        {sessions.length ? (
-          <div className="flex flex-col gap-2">{sessions.slice(0, 6).map((s) => <SessionRow key={s.session_id} s={s} />)}</div>
-        ) : (
-          <Empty title="Nothing running" body="No agent has reported in the last two minutes." compact />
-        )}
-      </div>
-
-    </div>
-  );
-}
-
-function SessionRow({ s, open, onToggle }: { s: SessionRollup; open?: boolean; onToggle?: () => void }) {
-  const running = !s.ended_at && Date.now() - s.last_seen < 120_000;
-  return (
-    <button onClick={onToggle} disabled={!onToggle}
-      className="w-full text-left rounded-xl px-3.5 py-3 flex flex-col gap-1.5"
-      style={{ background: "color-mix(in srgb, var(--bg2) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
-      <div className="flex items-center gap-2">
-        <span className="inline-block rounded-full shrink-0" style={{
-          width: 8, height: 8,
-          background: running ? "var(--success)" : s.error_count ? "var(--error)" : "var(--text3)",
-        }} />
-        <span className="text-[13.5px] leading-tight truncate">{sessionTitle(s)}</span>
-      </div>
-      <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-[11px] tabular-nums" style={{ color: "var(--text2)" }}>
-        <span>{modelLabelOf(s.model_name)}</span>
-        <span>{s.tool_count} tools</span>
-        {!!s.error_count && <span style={{ color: "var(--error)" }}>{s.error_count} err</span>}
-        <span>{fmtUsd(s.cost_usd)}</span>
-        <span className="ml-auto">{fmtAgo(s.last_seen)}</span>
-      </div>
-      {open && (
-        <div className="pt-1.5 mt-1 flex flex-col gap-1 text-[11.5px]" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)", color: "var(--text2)" }}>
-          <Line k="Project" v={s.project_path || s.source_app} mono />
-          <Line k="Tokens" v={`${fmtTokens(s.input_tokens + s.output_tokens)} · ${fmtTokens(s.cache_read_tokens)} cached`} />
-          <Line k="Events" v={String(s.event_count)} />
-          <Line k="Started" v={fmtAgo(s.started_at)} />
-        </div>
+      className="flex-1 flex flex-col items-center justify-center gap-1 relative"
+      style={{ minHeight: "var(--nav)", fontSize: 10.5, color: on ? "var(--primary-hover)" : "var(--text3)", background: "transparent" }}>
+      <span style={{ fontSize: 17, lineHeight: 1, transform: on ? "translateY(-2px) scale(1.12)" : undefined, transition: "transform .3s cubic-bezier(.3,1.4,.5,1)" }}>{glyph}</span>
+      {label}
+      {on && <span style={{ position: "absolute", top: 0, width: 30, height: 2, borderRadius: "0 0 3px 3px", background: "var(--primary-hover)", boxShadow: "0 0 12px var(--primary)" }} />}
+      {!!badge && (
+        <span className="mb-tnum" style={{
+          position: "absolute", top: 10, right: "calc(50% - 23px)", minWidth: 17, height: 17, borderRadius: 9,
+          fontSize: 9.5, display: "grid", placeItems: "center", padding: "0 5px", fontWeight: 700,
+          background: "var(--warning)", color: "#2a1d02", boxShadow: "0 0 0 2px color-mix(in srgb, var(--bg2) 88%, transparent)",
+        }}>{badge}</span>
       )}
     </button>
   );
 }
 
-const Line = ({ k, v, mono }: { k: string; v: string; mono?: boolean }) => (
-  <div className="flex gap-2">
-    <span className="shrink-0" style={{ color: "var(--text3)" }}>{k}</span>
-    <span className={`min-w-0 break-all text-right ml-auto ${mono ? "t-mono text-[10.5px]" : ""}`} style={{ color: "var(--text)" }}>{v}</span>
-  </div>
-);
-
-function Tile({ label, value, hint, tone }: { label: string; value: string; hint?: string; tone?: string }) {
-  return (
-    <div className="rounded-xl px-3.5 py-3" style={{ background: "color-mix(in srgb, var(--bg2) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
-      <div className="panel-eyebrow">{label}</div>
-      <div className="text-[26px] font-semibold tabular-nums leading-tight" style={{ color: tone ?? "var(--text)" }}>{value}</div>
-      {hint && <div className="text-[10.5px]" style={{ color: "var(--text3)" }}>{hint}</div>}
-    </div>
-  );
-}
-
-function Empty({ title, body, compact }: { title: string; body: string; compact?: boolean }) {
-  return (
-    <div className={`rounded-2xl text-center ${compact ? "px-4 py-6" : "px-5 py-12"}`}
-      style={{ background: "color-mix(in srgb, var(--bg2) 45%, transparent)", border: "1px dashed color-mix(in srgb, var(--border) 45%, transparent)" }}>
-      <div className="text-[14px]" style={{ color: "var(--text)" }}>{title}</div>
-      <div className="text-[12px] mt-1.5 leading-snug" style={{ color: "var(--text2)" }}>{body}</div>
-    </div>
-  );
+/** The last path segment is what anybody calls a repo. */
+function repoName(r: GitRepoRef): string {
+  return r.root.split("/").filter(Boolean).pop() || r.root;
 }

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, ChatStreamError } from "../lib/api.ts";
 import { toolTarget } from "../lib/chatStore.ts";
 import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
+import { MODELS, resumeModel } from "./resumeModel.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
 
 /**
@@ -21,11 +22,10 @@ import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/t
  * when you sit back down.
  */
 
-const MODELS = [
-  { id: "claude-opus-5", label: "Opus 5" },
-  { id: "claude-sonnet-5", label: "Sonnet 5" },
-  { id: "claude-haiku-4-5", label: "Haiku 4.5" },
-];
+/** How long a stream may say nothing before we stop trusting it and let the
+ *  transcript speak again. Long enough for a slow tool call, short enough that
+ *  a connection that died quietly does not leave you watching a dead screen. */
+const STALL_MS = 45_000;
 
 /** A turn being streamed right now, before the transcript catches up. */
 type Live = { text: string; tools: string[]; error: string | null };
@@ -82,19 +82,50 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
   const [live, setLive] = useState<Live | null>(null);
   const [sent, setSent] = useState<string | null>(null);
   const abort = useRef<AbortController | null>(null);
+  const handover = useRef<ReturnType<typeof setTimeout> | null>(null);
   const foot = useRef<HTMLDivElement | null>(null);
+
+  // Leaving mid-turn must not leave a request or a timer running behind the
+  // screen you just left.
+  useEffect(() => () => {
+    abort.current?.abort();
+    if (handover.current) clearTimeout(handover.current);
+  }, []);
 
   const load = useCallback(() => {
     api.session(id).then(setDetail).catch(() => { /* keep what is on screen */ });
   }, [id]);
 
+  /**
+   * Whether a turn of ours is streaming, readable from the interval without
+   * being a dependency of it.
+   *
+   * This was `live` itself, in the effect's dependency array — which meant
+   * every token that arrived tore the interval down, re-ran the effect, and
+   * called `load()` on the way in. A long answer fired one full transcript
+   * fetch per streamed chunk, which is the opposite of the "do not poll while
+   * streaming" the guard inside was written to achieve, and it is what made
+   * replying from the phone crawl.
+   */
+  const streaming = useRef(false);
+  /** When the stream last said anything. A turn that has gone silent for a
+   *  long time may have died in a way the socket never reported, so the
+   *  transcript takes back over rather than leaving you on a dead screen. */
+  const lastEvent = useRef(0);
+  const [stalled, setStalled] = useState(false);
+
   useEffect(() => {
     load();
-    // While a turn of ours is streaming the transcript is behind by a scan, so
-    // polling then would show a stale copy of what is already on screen.
-    const t = setInterval(() => { if (!live) load(); }, 5000);
+    const t = setInterval(() => {
+      // While our own turn is streaming the transcript is a scan behind, so
+      // polling would paint a stale copy of what is already on screen. Once it
+      // has gone quiet past the threshold that stops being true.
+      const quiet = streaming.current && Date.now() - lastEvent.current > STALL_MS;
+      if (!streaming.current || quiet) load();
+      if (streaming.current) setStalled(quiet);
+    }, 5000);
     return () => clearInterval(t);
-  }, [load, live]);
+  }, [load]);
 
   useEffect(() => { foot.current?.scrollIntoView({ block: "end" }); }, [detail?.conversation.length, live?.text, sent]);
 
@@ -107,24 +138,34 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
     setDraft("");
     setSent(message);
     setLive({ text: "", tools: [], error: null });
+    setStalled(false);
+    streaming.current = true;
+    lastEvent.current = Date.now();
     const ac = new AbortController();
     abort.current = ac;
     try {
       await api.chatStream(
-        { cwd, message, model: detail?.model_name && MODELS.some((m) => detail.model_name!.includes(m.id.split("-")[1]!)) ? MODELS[0]!.id : MODELS[0]!.id, mode: "default", resumeId: id },
-        (o) => setLive((prev) => reduce(prev, o)),
+        { cwd, message, model: resumeModel(detail?.model_name), mode: "default", resumeId: id },
+        (o) => { lastEvent.current = Date.now(); setStalled(false); setLive((prev) => reduce(prev, o)); },
         ac.signal
       );
     } catch (e) {
       if (!(e instanceof DOMException && e.name === "AbortError")) {
+        // A dropped connection is not a failed turn: the agent is very likely
+        // still working, and telling someone their message failed when it did
+        // not is how they end up sending it twice.
         const why = e instanceof ChatStreamError ? e.message : String(e);
         setLive((p) => ({ text: p?.text ?? "", tools: p?.tools ?? [], error: why }));
       }
     } finally {
+      streaming.current = false;
       abort.current = null;
+      setStalled(false);
       // Let the transcript take over: it is the same turn, written by the
-      // scanner, and keeping our copy as well would show it twice.
-      setTimeout(() => { setLive(null); setSent(null); load(); }, 1200);
+      // scanner, and keeping our copy as well would show it twice. Held in a
+      // ref so leaving the conversation cancels it rather than waking a
+      // component that is gone.
+      handover.current = setTimeout(() => { setLive(null); setSent(null); load(); }, 1200);
     }
   };
 
@@ -154,6 +195,14 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
         {sent && <Bubble role="user" text={sent} />}
         {live && (
           <Bubble role="assistant" text={live.text || "…"} streaming tools={live.tools} error={live.error} />
+        )}
+        {stalled && !live?.error && (
+          // Silence is ambiguous — a long tool call and a dead socket look
+          // identical. Say which one we cannot tell rather than leaving a
+          // spinner turning over nothing.
+          <div className="text-[11px] px-1" style={{ color: "var(--warning)" }}>
+            Nothing for a while. The turn may still be running — the transcript below is live again.
+          </div>
         )}
         <div ref={foot} />
       </div>

--- a/web/src/mobile/MobileDiff.tsx
+++ b/web/src/mobile/MobileDiff.tsx
@@ -1,0 +1,151 @@
+import { useMemo, useState } from "react";
+import { Screen } from "./mobileUi.tsx";
+import type { DiffHunk } from "../../../shared/types.ts";
+
+/**
+ * A diff you can actually read on a phone.
+ *
+ * Everyone says this cannot be done, and it can — but only by giving up the
+ * right things rather than shrinking the desktop one:
+ *
+ *   · Unified, always. Two columns on a 390px screen gives each side twenty
+ *     characters, which is not reading, it is guessing.
+ *   · Wrapped by default, with a hanging indent, so a line that ran on is
+ *     never mistaken for a new one. Scrolling is one tap away for the times
+ *     you need to see the real shape of the code.
+ *   · A `+` / `−` glyph as well as the tint. At 11.5px, outdoors, in one hand,
+ *     colour alone is not a signal you can rely on — and it is no signal at
+ *     all to a good number of people.
+ *   · Prev / next file in the footer, because the alternative is going back to
+ *     a list and finding your place in it again.
+ */
+export const DIFF_CSS = `
+.mb-diff{font-size:11.5px;line-height:1.62;border-radius:14px;overflow:hidden;
+  border:1px solid color-mix(in srgb,var(--border) 32%,transparent);
+  background:color-mix(in srgb,#000 30%,transparent)}
+.mb-dl{display:flex;width:100%;text-align:left;align-items:flex-start;background:transparent}
+.mb-dl .g{flex:none;width:34px;padding:1px 7px 1px 0;text-align:right;color:var(--text4);opacity:.5;
+  user-select:none;font-size:10px;font-variant-numeric:tabular-nums}
+.mb-dl .s{flex:none;width:12px;user-select:none;opacity:.9}
+.mb-dl .c{flex:1;min-width:0;padding-right:9px;white-space:pre-wrap;overflow-wrap:break-word;
+  text-indent:-1.6ch;padding-left:1.6ch}
+.mb-diff.nowrap{overflow-x:auto}
+.mb-diff.nowrap .c{white-space:pre;overflow-wrap:normal;text-indent:0;padding-left:0}
+.mb-diff.nowrap .mb-dl{min-width:max-content}
+.mb-dl.add{background:color-mix(in srgb,var(--success) 13%,transparent)}
+.mb-dl.add .g,.mb-dl.add .s{color:var(--success);opacity:.95}
+.mb-dl.del{background:color-mix(in srgb,var(--error) 12%,transparent)}
+.mb-dl.del .g,.mb-dl.del .s{color:var(--error);opacity:.95}
+.mb-dl.hdr{background:color-mix(in srgb,var(--primary) 10%,transparent);color:var(--text4);
+  font-size:10.5px;padding:4px 0}
+`;
+
+type Line = { kind: "ctx" | "add" | "del" | "hdr"; n: string; text: string };
+
+/** Anything carrying hunks: a working-tree change or a parsed pull request
+ *  diff. Both already speak this shape, so neither needs translating. */
+export type Hunked = { hunks: DiffHunk[] };
+
+/** Flatten hunks into the one column this screen shows. */
+function toLines(f: Hunked | undefined): Line[] {
+  if (!f?.hunks?.length) return [];
+  const out: Line[] = [];
+  for (const h of f.hunks) {
+    out.push({ kind: "hdr", n: "", text: `@@ -${h.oldStart},${h.oldLines} +${h.newStart},${h.newLines} @@` });
+    let oldN = h.oldStart, newN = h.newStart;
+    for (const raw of h.lines) {
+      const c = raw[0];
+      if (c === "+") out.push({ kind: "add", n: String(newN++), text: raw.slice(1) });
+      else if (c === "-") out.push({ kind: "del", n: String(oldN++), text: raw.slice(1) });
+      else { out.push({ kind: "ctx", n: String(newN), text: raw.slice(1) }); oldN++; newN++; }
+    }
+  }
+  return out;
+}
+
+export function MobileDiff({ open, file, files, index, onIndex, onBack, onLine, extra }: {
+  open: boolean;
+  file: Hunked | undefined;
+  /** Paths in order, for prev/next and for the "3 of 11" the footer shows. */
+  files: string[];
+  index: number;
+  onIndex: (i: number) => void;
+  onBack: () => void;
+  /** Tapping a line — a review comment on a pull request, nothing on a working
+   *  tree diff, where the line has no stable identity to hang a comment on. */
+  onLine?: (path: string, line: number) => void;
+  extra?: React.ReactNode;
+}) {
+  const [wrap, setWrap] = useState(true);
+  const path = files[index] ?? "";
+  const lines = useMemo(() => toLines(file), [file]);
+  const name = path.split("/").pop() || path;
+  const dir = path.slice(0, path.length - name.length).replace(/\/$/, "");
+
+  return (
+    <Screen
+      open={open} title={name} sub={dir || undefined} onBack={onBack}
+      right={
+        <button className="mb-press" style={{ minHeight: 42, padding: "0 11px", fontSize: 11, color: "var(--primary-hover)", background: "transparent" }}
+          onClick={() => setWrap((w) => !w)}>{wrap ? "Wrap" : "Scroll"}</button>
+      }
+      foot={files.length > 1 ? (
+        <>
+          <button className="mb-btn sm mb-press" onClick={() => onIndex((index - 1 + files.length) % files.length)}>‹ Prev</button>
+          <span className="flex-1 text-center text-[10.5px] mb-tnum" style={{ color: "var(--text3)" }}>
+            File {index + 1} of {files.length}
+          </span>
+          <button className="mb-btn sm mb-press" onClick={() => onIndex((index + 1) % files.length)}>Next ›</button>
+        </>
+      ) : undefined}
+    >
+      {lines.length === 0 ? (
+        <div className="mb-empty"><div className="g">◇</div><b>No textual diff</b>
+          <span>Binary, renamed, or too large to show.</span></div>
+      ) : (
+        <div className={`mb-diff${wrap ? "" : " nowrap"}`}>
+          {lines.map((l, i) => {
+            const sign = l.kind === "add" ? "+" : l.kind === "del" ? "−" : " ";
+            if (l.kind === "hdr") {
+              return <div key={i} className="mb-dl hdr"><span className="g" /><span className="s" /><span className="c">{l.text}</span></div>;
+            }
+            const body = <><span className="g">{l.n}</span><span className="s">{sign}</span><span className="c">{l.text}</span></>;
+            return onLine
+              ? <button key={i} className={`mb-dl ${l.kind} mb-press`} onClick={() => onLine(path, Number(l.n) || 0)}>{body}</button>
+              : <div key={i} className={`mb-dl ${l.kind}`}>{body}</div>;
+          })}
+        </div>
+      )}
+      {extra && <div className="flex gap-2 flex-wrap mt-3">{extra}</div>}
+      <p className="mt-3 text-[10.5px] leading-relaxed" style={{ color: "var(--text3)" }}>
+        {onLine ? "Tap a line to comment on it. " : ""}
+        <b style={{ color: "var(--text2)" }}>Wrap</b> trades sideways scrolling for taller lines.
+      </p>
+    </Screen>
+  );
+}
+
+/** Shared by the pull request and the working tree: one row per file, its size,
+ *  and a switch for the state you are keeping about it. */
+export function FileRow({ path, add, del, note, on, onToggle, switchLabel, onOpen }: {
+  path: string; add: number; del: number; note?: string;
+  on: boolean; onToggle: () => void; switchLabel: string; onOpen: () => void;
+}) {
+  return (
+    <div className="mb-row" style={{ padding: 13 }}>
+      <button className="mb-press flex items-center gap-3 min-w-0 flex-1 text-left self-stretch" style={{ background: "transparent" }} onClick={onOpen}>
+        <span className="i">
+          <b>{path}</b>
+          {note && <span>{note}</span>}
+        </span>
+        <span className="r mb-tnum">
+          <i className="not-italic block" style={{ color: "var(--success)" }}>+{add}</i>
+          <i className="not-italic block" style={{ color: "var(--error)" }}>−{del}</i>
+        </span>
+      </button>
+      <button className="mb-sw mb-press" data-on={on ? "1" : "0"} role="switch" aria-checked={on}
+        aria-label={switchLabel} onClick={onToggle} />
+    </div>
+  );
+}
+

--- a/web/src/mobile/MobileNow.tsx
+++ b/web/src/mobile/MobileNow.tsx
@@ -1,0 +1,146 @@
+import { Act, Empty } from "./mobileUi.tsx";
+import { fmtAgo } from "../lib/format.ts";
+import type { NowItem, NowTone } from "./nowQueue.ts";
+
+/**
+ * The queue, and the hero above it.
+ *
+ * Every card is one decision with its action on it, and answering one takes it
+ * out of the list. That is the whole difference between this and a dashboard:
+ * a dashboard is something you re-read, and this is something you can empty.
+ *
+ * The stripe down the left encodes urgency in width as well as colour, so the
+ * ordering is legible at a glance and not only to someone who can tell amber
+ * from pink at arm's length in the sun.
+ */
+export const NOW_CSS = `
+.mb-hero{position:relative;border-radius:20px;overflow:hidden;margin-bottom:16px;
+  background:linear-gradient(165deg,color-mix(in srgb,var(--bg3) 60%,transparent),color-mix(in srgb,var(--bg2) 72%,transparent));
+  border:1px solid color-mix(in srgb,var(--border) 46%,transparent);box-shadow:var(--mb-edge),var(--mb-drop)}
+.mb-hero::after{content:"";position:absolute;inset:0;pointer-events:none;
+  background:linear-gradient(180deg,color-mix(in srgb,var(--primary) 7%,transparent),transparent 42%)}
+.mb-hero .in{position:relative;z-index:1;padding:17px 17px 0;display:flex;align-items:flex-end;gap:12px}
+.mb-hero .n{font-size:50px;color:var(--text)}
+.mb-hero.calm .n{font-size:38px;color:var(--success)}
+.mb-hero .w{padding-bottom:7px;min-width:0}
+.mb-hero .w b{display:block;font-size:14px;font-weight:600;line-height:1.25}
+.mb-hero .w span{display:block;font-size:11.5px;color:var(--text3);margin-top:2px}
+
+/* Vitals: one bar per live agent, each on its own period, so the strip reads
+   as several things working rather than as one animation looping. */
+.mb-vitals{display:flex;align-items:flex-end;gap:3px;height:46px;margin:16px 17px 0;padding-bottom:7px;
+  position:relative;z-index:1;border-bottom:1px solid color-mix(in srgb,var(--border) 40%,transparent)}
+.mb-vitals i{flex:1;height:100%;border-radius:2px 2px 0 0;transform-origin:bottom;
+  background:linear-gradient(180deg,var(--primary-hover),color-mix(in srgb,var(--primary) 26%,transparent));
+  animation:mb-vit var(--p) ease-in-out infinite;animation-delay:var(--d);
+  box-shadow:0 0 10px -2px color-mix(in srgb,var(--primary) 60%,transparent)}
+@keyframes mb-vit{0%,100%{transform:scaleY(.14)}50%{transform:scaleY(1)}}
+.mb-vitals i.idle{background:color-mix(in srgb,var(--border) 48%,transparent);animation:none;
+  transform:scaleY(.1);box-shadow:none}
+.mb-vlabel{display:flex;align-items:center;gap:8px;padding:11px 17px 16px;font-size:10.5px;
+  color:var(--text3);position:relative;z-index:1}
+.mb-vlabel b{color:var(--text2);font-weight:500}
+
+.mb-item{position:relative;border-radius:18px;overflow:hidden;background:var(--mb-card);
+  border:1px solid color-mix(in srgb,var(--border) 38%,transparent);
+  box-shadow:var(--mb-edge),var(--mb-drop);animation:mb-rise .42s cubic-bezier(.2,.85,.25,1) backwards}
+@keyframes mb-rise{from{opacity:0;transform:translateY(14px) scale(.985)}}
+.mb-item::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--text3)}
+.mb-item.crit{border-color:color-mix(in srgb,var(--warning) 52%,transparent);
+  background:color-mix(in srgb,var(--warning) 10%,var(--bg2));
+  box-shadow:var(--mb-edge),0 14px 34px -18px color-mix(in srgb,var(--warning) 55%,#000)}
+.mb-item.crit::before{width:5px;background:var(--warning)}
+.mb-item.bad::before{background:var(--error)}
+.mb-item.good::before{background:var(--success)}
+.mb-item .ih{display:flex;align-items:baseline;gap:9px;padding:13px 14px 0 17px}
+.mb-item .k{font-size:9.5px;letter-spacing:.15em;text-transform:uppercase;color:var(--text3);font-weight:600}
+.mb-item.crit .k{color:var(--warning)}
+.mb-item.bad .k{color:var(--error)}
+.mb-item.good .k{color:var(--success)}
+.mb-item .at{margin-left:auto;font-size:10.5px;color:var(--text3);white-space:nowrap}
+.mb-item .t{padding:6px 14px 0 17px;font-size:14.5px;line-height:1.38;color:var(--text);text-wrap:balance;
+  overflow-wrap:anywhere}
+.mb-item .s{padding:6px 14px 0 17px;font-size:11.5px;color:var(--text3);line-height:1.5;overflow-wrap:anywhere}
+.mb-item .code{margin:9px 14px 0 17px;padding:9px 11px;border-radius:9px;font-size:11px;color:var(--warning);
+  background:color-mix(in srgb,#000 40%,transparent);overflow-wrap:anywhere;
+  border-left:2px solid color-mix(in srgb,var(--warning) 55%,transparent)}
+.mb-item .acts{display:flex;gap:9px;padding:13px 14px 14px 17px}
+.mb-item .acts>*{flex:1;min-height:50px;border-radius:13px}
+`;
+
+export interface NowAction {
+  label: string;
+  kind?: "acc" | "ok" | "no" | "dang";
+  run: () => Promise<string | void> | string | void;
+}
+
+export function NowHero({ pending, working, rates, spend, repos }: {
+  pending: number; working: number; rates: number[]; spend: string; repos: string[];
+}) {
+  const calm = pending === 0;
+  // A fixed number of slots, so the strip has the same shape whether one agent
+  // is running or six — it reads as capacity, not as a bar chart that resizes.
+  const SLOTS = 14;
+  return (
+    <div className={`mb-hero${calm ? " calm" : ""}`}>
+      <div className="in">
+        <span className="mb-fig n">{calm ? "✓" : pending}</span>
+        <span className="w">
+          <b>{calm ? "Nothing needs you" : `${pending} thing${pending > 1 ? "s" : ""} want${pending > 1 ? "" : "s"} you`}</b>
+          <span>{calm ? "The fleet is running clean" : "Answer one and it leaves the queue"}</span>
+        </span>
+      </div>
+      <div className="mb-vitals" aria-hidden="true">
+        {Array.from({ length: SLOTS }, (_, i) => {
+          const r = rates[i];
+          return r == null
+            ? <i key={i} className="idle" />
+            : <i key={i} style={{ ["--p" as string]: `${(1.6 / r).toFixed(2)}s`, ["--d" as string]: `${(i * 0.23).toFixed(2)}s` }} />;
+        })}
+      </div>
+      <div className="mb-vlabel">
+        <span className="mb-dot pulse" style={{ background: working ? "var(--success)" : "var(--text3)", color: "var(--success)" }} />
+        <b>{working} working</b><span>·</span><span>{spend} today</span>
+        <span className="flex-1" />
+        <span className="truncate">{repos.slice(0, 2).join(", ")}</span>
+      </div>
+    </div>
+  );
+}
+
+export function NowStream({ items, actionsFor, onOpen }: {
+  items: NowItem[];
+  actionsFor: (it: NowItem) => NowAction[];
+  onOpen: (it: NowItem) => void;
+}) {
+  if (!items.length) {
+    return (
+      <Empty glyph="◎" title="The queue is empty"
+        body="You will hear about it when an agent stops, asks permission, turns something red, or opens something worth your eyes." />
+    );
+  }
+  return (
+    <div className="flex flex-col gap-3">
+      {items.map((it, i) => (
+        <div key={it.id} className={`mb-item ${toneClass(it.tone)}`} style={{ animationDelay: `${i * 55}ms` }}>
+          <div className="ih">
+            <span className="k">{it.kind}</span>
+            <span className="at">{fmtAgo(it.ts)}</span>
+          </div>
+          <button className="t mb-press w-full text-left" style={{ background: "transparent" }} onClick={() => onOpen(it)}>
+            {it.title}
+          </button>
+          <div className="s">{it.sub}</div>
+          {it.code && <div className="code">{it.code}</div>}
+          <div className="acts">
+            {actionsFor(it).map((a) => (
+              <Act key={a.label} kind={a.kind} onAct={a.run}>{a.label}</Act>
+            ))}
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+const toneClass = (t: NowTone) => (t === "plain" ? "" : t);

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -1,0 +1,383 @@
+import { useEffect, useMemo, useState } from "react";
+import { api } from "../lib/api.ts";
+import { parseUnifiedDiff } from "../lib/prBody.ts";
+import { Screen, Sheet, Seg, Empty, Act } from "./mobileUi.tsx";
+import { MobileDiff, FileRow } from "./MobileDiff.tsx";
+import { fmtAgo } from "../lib/format.ts";
+import type { PrDetail, PrCheck } from "../../../shared/types.ts";
+
+/**
+ * Reviewing a pull request from a phone.
+ *
+ * The desktop panel has six sections and a masthead that survives them. Here
+ * there are four, and the masthead only appears on Overview: the sticky header
+ * already carries the number, the author and the branch, and on Files or Talk
+ * those three hundred pixels are worth more as content than as repetition.
+ *
+ * Merge and approve live in a pinned footer rather than at the bottom of a
+ * scroll, because they are what you came to do. When merge is off it says why
+ * directly above itself — a greyed-out primary with no reason is the commonest
+ * lie a review UI tells.
+ */
+
+type Tab = "overview" | "files" | "checks" | "talk";
+
+const MERGE_WHY: Record<string, string> = {
+  BLOCKED: "A required review or check has not passed",
+  BEHIND: "The base branch has moved — update the branch first",
+  DIRTY: "There are conflicts with the base branch",
+  UNSTABLE: "A check is failing",
+  DRAFT: "This is a draft",
+  HAS_HOOKS: "A repository hook is blocking the merge",
+  UNKNOWN: "GitHub has not finished working it out",
+};
+
+export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: {
+  open: boolean; root: string; number: number | null; onBack: () => void;
+  toast: (m: string, bad?: boolean) => void;
+  onOpenChatWith?: (cwd: string, prompt: string) => void;
+}) {
+  const [tab, setTab] = useState<Tab>("overview");
+  const [d, setD] = useState<PrDetail | null>(null);
+  const [err, setErr] = useState("");
+  const [diff, setDiff] = useState("");
+  const [seen, setSeen] = useState<string[]>([]);
+  const [diffAt, setDiffAt] = useState<number | null>(null);
+  const [more, setMore] = useState(false);
+  const [openLog, setOpenLog] = useState<string | null>(null);
+  const [comment, setComment] = useState("");
+
+  useEffect(() => {
+    if (!open || number == null) return;
+    setTab("overview"); setD(null); setErr(""); setDiff(""); setSeen([]); setComment("");
+    api.prDetail(root, number).then((r) => {
+      if (r.ok && r.detail) setD(r.detail); else setErr(r.error || "Could not load it");
+    }).catch((e) => setErr(String(e)));
+    api.prDiff(root, number).then((r) => setDiff(r.text || "")).catch(() => setDiff(""));
+  }, [open, root, number]);
+
+  const byPath = useMemo(
+    () => new Map(parseUnifiedDiff(diff).map((f) => [f.path, f])),
+    [diff],
+  );
+  const paths = d?.files.map((f) => f.path) ?? [];
+
+  const reload = () => {
+    if (number == null) return;
+    api.prDetail(root, number, true).then((r) => { if (r.ok && r.detail) setD(r.detail); }).catch(() => {});
+  };
+  const act = async (label: string, run: () => Promise<{ ok: boolean; error?: string; detail?: string }>) => {
+    try {
+      const r = await run();
+      toast(r.ok ? (r.detail || label) : (r.error || `${label} failed`), !r.ok);
+      if (r.ok) reload();
+    } catch (e) { toast(String(e), true); }
+  };
+
+  const canMerge = d?.mergeState === "CLEAN";
+  const openThreads = d?.threads.filter((t) => !t.isResolved).length ?? 0;
+
+  return (
+    <>
+      <Screen
+        open={open && diffAt == null}
+        title={d ? `#${d.number} · ${d.author}` : number != null ? `#${number}` : ""}
+        sub={d ? `${d.headRefName} → ${d.baseRefName}` : undefined}
+        onBack={onBack}
+        right={<button className="mb-press" style={{ minHeight: 42, minWidth: 42, fontSize: 17, color: "var(--text3)", background: "transparent" }}
+          onClick={() => setMore(true)} aria-label="More">⋯</button>}
+        foot={d ? (
+          <>
+            {!canMerge && (
+              <div className="absolute left-0 right-0 text-center text-[10.5px] px-4"
+                style={{ top: -21, color: "var(--text3)" }}>
+                {MERGE_WHY[d.mergeState] ?? "Not mergeable"}
+              </div>
+            )}
+            <Act small onAct={() => act("Approved", () => api.prReview(root, d.number, "approve", ""))}
+              disabled={d.viewerDidAuthor} title={d.viewerDidAuthor ? "You cannot approve your own pull request" : undefined}>
+              ✓ Approve
+            </Act>
+            <Act kind="acc" full disabled={!canMerge}
+              title={canMerge ? undefined : MERGE_WHY[d.mergeState]}
+              onAct={() => act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true }))}>
+              {canMerge ? "Squash & merge" : "Blocked"}
+            </Act>
+          </>
+        ) : undefined}
+      >
+        {err ? <Empty glyph="✕" title="Could not open it" body={err} />
+        : !d ? <div className="text-[11.5px] p-3" style={{ color: "var(--text3)" }}>Loading #{number}…</div>
+        : (
+          <>
+            {tab === "overview" && (
+              <div className="pb-3 mb-3" style={{ borderBottom: "1px solid var(--mb-line)" }}>
+                <h1 className="text-[16px] font-semibold leading-snug mb-2.5" style={{ textWrap: "balance" }}>
+                  <span style={{ color: "var(--text3)", fontWeight: 400 }}>#{d.number}</span> {d.title}
+                </h1>
+                <dl className="grid gap-y-1.5 gap-x-3 text-[11.5px]" style={{ gridTemplateColumns: "auto 1fr" }}>
+                  <dt style={{ color: "var(--text3)" }}>Author</dt><dd style={{ color: "var(--text2)" }}>{d.author}</dd>
+                  <dt style={{ color: "var(--text3)" }}>Changes</dt>
+                  <dd className="mb-tnum" style={{ color: "var(--text2)" }}>
+                    <span style={{ color: "var(--success)" }}>+{d.additions}</span>{" "}
+                    <span style={{ color: "var(--error)" }}>−{d.deletions}</span> · {d.changedFiles} files
+                  </dd>
+                  {d.reviewers.length > 0 && (<><dt style={{ color: "var(--text3)" }}>Reviewers</dt>
+                    <dd style={{ color: "var(--text2)" }}>{d.reviewers.join(", ")}</dd></>)}
+                </dl>
+              </div>
+            )}
+
+            <Seg sticky value={tab} onPick={setTab} options={[
+              { id: "overview", label: "Overview" },
+              { id: "files", label: "Files", n: d.files.length },
+              { id: "checks", label: "Checks", n: d.checks.total || null },
+              { id: "talk", label: "Talk", n: (d.comments.length + d.reviews.length + d.threads.length) || null },
+            ]} />
+
+            {tab === "overview" && (
+              <>
+                <div className="mb-card overflow-hidden mb-3">
+                  <div className="flex gap-3 items-start p-3.5">
+                    <span className="shrink-0 grid place-items-center rounded-full font-bold"
+                      style={{ width: 28, height: 28, background: canMerge ? "var(--success)" : "var(--error)", color: "var(--bg)" }}>
+                      {canMerge ? "✓" : "!"}
+                    </span>
+                    <span>
+                      <b className="block text-[14.5px]">{canMerge ? "Ready to merge" : "Merging is blocked"}</b>
+                      <span className="block text-[11.5px] mt-0.5" style={{ color: "var(--text3)" }}>
+                        {canMerge ? "Nothing is standing in the way" : (MERGE_WHY[d.mergeState] ?? "Not mergeable")}
+                      </span>
+                    </span>
+                  </div>
+                  {openThreads > 0 && (
+                    <Why glyph="○" tint="var(--warning)" onGo={() => setTab("talk")}>
+                      {openThreads} review thread{openThreads === 1 ? "" : "s"} still open
+                    </Why>
+                  )}
+                  {d.checks.failure > 0 && (
+                    <Why glyph="✕" tint="var(--error)" onGo={() => setTab("checks")}>
+                      {d.checks.failing.slice(0, 2).map((c) => c.name).join(", ")} failing
+                    </Why>
+                  )}
+                  {d.checks.failure === 0 && d.checks.total > 0 && (
+                    <Why glyph="✓" tint="var(--success)">{d.checks.total} checks passed</Why>
+                  )}
+                </div>
+                <div className="mb-eyebrow mb-2">Description</div>
+                <div className="mb-card p-3.5 text-[12.5px] leading-relaxed whitespace-pre-wrap break-words"
+                  style={{ color: "var(--text2)" }}>
+                  {d.body.trim() || "No description."}
+                </div>
+                {onOpenChatWith && (
+                  <Act kind="acc" full small onAct={() => handOver(root, d.number, `Review pull request #${d.number}`, onOpenChatWith, toast)}>
+                    ✦ Review locally with Claude
+                  </Act>
+                )}
+              </>
+            )}
+
+            {tab === "files" && (
+              <>
+                <div className="flex items-center gap-2 mb-2.5 text-[11px]" style={{ color: "var(--text3)" }}>
+                  <span className="mb-tnum">{seen.length} of {d.files.length} viewed</span>
+                </div>
+                <div className="flex flex-col gap-2.5">
+                  {d.files.map((f, i) => (
+                    <FileRow key={f.path} path={f.path} add={f.additions} del={f.deletions}
+                      note={`${f.status}${f.comments ? ` · ${f.comments} open thread` : ""}`}
+                      on={seen.includes(f.path)} switchLabel={`Mark ${f.path} viewed`}
+                      onToggle={() => setSeen((s) => s.includes(f.path) ? s.filter((x) => x !== f.path) : [...s, f.path])}
+                      onOpen={() => setDiffAt(i)} />
+                  ))}
+                </div>
+              </>
+            )}
+
+            {tab === "checks" && <Checks d={d} openLog={openLog} onOpenLog={setOpenLog}
+              onRerun={() => act("Re-running the failed checks", () => api.prRerun(root, d.number))}
+              onAsk={onOpenChatWith ? (c) => handOver(root, d.number,
+                `The check "${c.name}" is failing on pull request #${d.number} (${d.title}). Work out why and propose the fix.`,
+                onOpenChatWith, toast) : undefined} />}
+
+            {tab === "talk" && (
+              <>
+                <Talk d={d} />
+                <div className="mb-card overflow-hidden mt-3">
+                  <textarea value={comment} onChange={(e) => setComment(e.target.value)}
+                    placeholder="Leave a comment…"
+                    className="w-full p-3 text-[13px] resize-none bg-transparent outline-none"
+                    style={{ minHeight: 76, color: "var(--text)", lineHeight: 1.6 }} />
+                  <div className="flex px-3 py-2.5" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>
+                    <span className="flex-1" />
+                    <Act small kind="acc" disabled={!comment.trim()} title={comment.trim() ? undefined : "Write something first"}
+                      onAct={async () => { await act("Comment posted", () => api.prComment(root, d.number, comment)); setComment(""); }}>
+                      Comment
+                    </Act>
+                  </div>
+                </div>
+              </>
+            )}
+          </>
+        )}
+      </Screen>
+
+      <MobileDiff open={diffAt != null} files={paths} index={diffAt ?? 0} onIndex={setDiffAt}
+        file={diffAt != null ? byPath.get(paths[diffAt] ?? "") : undefined}
+        onBack={() => setDiffAt(null)} />
+
+      <Sheet open={more} title="Pull request" sub="Things you do to it, rather than in it."
+        onClose={() => setMore(false)}>
+        <div className="flex flex-col gap-2.5">
+          {d && (
+            <>
+              <Act full small onAct={async () => {
+                try { await navigator.clipboard.writeText(d.url); toast("Link copied"); }
+                catch { toast("Could not reach the clipboard", true); }
+                setMore(false);
+              }}>Copy link</Act>
+              <Act full small onAct={() => { window.open(d.url, "_blank", "noopener,noreferrer"); setMore(false); }}>
+                Open on GitHub ↗
+              </Act>
+              <Act full small onAct={() => act(d.isDraft ? "Marked ready" : "Converted to draft",
+                () => api.prDraft(root, d.number, !d.isDraft)).then(() => setMore(false))}>
+                {d.isDraft ? "Mark ready for review" : "Convert to draft"}
+              </Act>
+              <Act full small kind="dang" onAct={() => act("Pull request closed",
+                () => api.prClose(root, d.number)).then(() => { setMore(false); onBack(); })}>
+                Close pull request
+              </Act>
+            </>
+          )}
+        </div>
+      </Sheet>
+    </>
+  );
+}
+
+function Why({ glyph, tint, children, onGo }: { glyph: string; tint: string; children: React.ReactNode; onGo?: () => void }) {
+  return (
+    <div className="flex gap-2.5 items-center px-3 py-3 text-[12px]"
+      style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 22%, transparent)", color: "var(--text2)" }}>
+      <span className="shrink-0 w-3.5 text-center" style={{ color: tint }}>{glyph}</span>
+      <span className="min-w-0">{children}</span>
+      {onGo && <button onClick={onGo} className="ml-auto shrink-0 text-[11px] pl-2.5 mb-press"
+        style={{ minHeight: 36, color: "var(--primary-hover)", background: "transparent" }}>Open ›</button>}
+    </div>
+  );
+}
+
+function Checks({ d, openLog, onOpenLog, onRerun, onAsk }: {
+  d: PrDetail; openLog: string | null; onOpenLog: (k: string | null) => void;
+  onRerun: () => void; onAsk?: (c: PrCheck) => void;
+}) {
+  const groups = useMemo(() => {
+    const m = new Map<string, PrCheck[]>();
+    for (const k of d.checksAll) {
+      const g = k.workflow || "Checks";
+      if (!m.has(g)) m.set(g, []);
+      m.get(g)!.push(k);
+    }
+    const rank = (l: PrCheck[]) => l.some((k) => k.state === "failure") ? 0 : l.some((k) => k.state === "pending") ? 1 : 2;
+    return [...m.entries()].sort((a, b) => rank(a[1]) - rank(b[1]) || a[0].localeCompare(b[0]));
+  }, [d.checksAll]);
+
+  if (!d.checksAll.length) return <Empty glyph="○" title="No checks" body="Nothing runs on this pull request yet." />;
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      {groups.map(([name, list]) => (
+        <div key={name} className="rounded-2xl overflow-hidden" style={{ border: "1px solid color-mix(in srgb, var(--border) 32%, transparent)" }}>
+          <div className="flex items-center gap-2 px-3 py-2.5 text-[11.5px]" style={{ background: "color-mix(in srgb, var(--bg3) 46%, transparent)" }}>
+            <b>{name}</b><span style={{ color: "var(--text3)" }}>· {list.length}</span>
+          </div>
+          {list.map((k, i) => {
+            const bad = k.state === "failure";
+            const id = `${name}:${k.name}:${i}`;
+            const on = openLog === id;
+            return (
+              <div key={id} style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 20%, transparent)", background: bad ? "color-mix(in srgb, var(--error) 9%, transparent)" : "color-mix(in srgb, var(--bg2) 55%, transparent)" }}>
+                <button className="w-full flex items-center gap-2.5 px-3 py-3 text-[12.5px] mb-press"
+                  style={{ minHeight: 48, background: "transparent" }}
+                  onClick={() => bad && onOpenLog(on ? null : id)} disabled={!bad}>
+                  <span style={{ color: bad ? "var(--error)" : k.state === "success" ? "var(--success)" : "var(--text3)" }}>
+                    {bad ? "✕" : k.state === "success" ? "✓" : k.state === "pending" ? "•" : "⊘"}
+                  </span>
+                  <span className="min-w-0 truncate">{k.name}</span>
+                  <span className="flex-1" />
+                  <span className="text-[9.5px] uppercase tracking-wide shrink-0"
+                    style={{ color: bad ? "var(--error)" : "var(--text3)" }}>{k.state}</span>
+                </button>
+                {on && (
+                  <div className="px-3 pb-3 flex gap-2 flex-wrap">
+                    {onAsk && <Act small kind="acc" onAct={() => onAsk(k)}>✦ Ask Claude why</Act>}
+                    {k.url && <Act small onAct={() => { window.open(k.url, "_blank", "noopener,noreferrer"); }}>Open run ↗</Act>}
+                    <Act small onAct={onRerun}>↻ Re-run failed</Act>
+                    <div className="text-[10px] w-full mt-1" style={{ color: "var(--text3)" }}>
+                      The log itself lives on GitHub — the phone does not download run logs.
+                    </div>
+                  </div>
+                )}
+              </div>
+            );
+          })}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** One timeline, oldest first — the order the replies were written in. */
+function Talk({ d }: { d: PrDetail }) {
+  const entries = useMemo(() => {
+    const out: { at: string; who: string; verdict?: string; body: string; bot: boolean }[] = [];
+    for (const r of d.reviews) {
+      if (!r.body.trim() && r.state === "COMMENTED") continue;
+      out.push({
+        at: r.submittedAt, who: r.author, bot: r.isBot,
+        verdict: r.state === "CHANGES_REQUESTED" ? "requested changes" : r.state === "APPROVED" ? "approved" : undefined,
+        body: r.body.trim() || `(${r.state.toLowerCase().replace("_", " ")}, no note)`,
+      });
+    }
+    for (const c of d.comments) out.push({ at: c.createdAt, who: c.author, bot: c.isBot, body: c.digest || c.body });
+    for (const t of d.threads) {
+      const first = t.comments[0];
+      if (first) out.push({ at: first.createdAt, who: first.author, bot: first.isBot, body: `${t.path}${t.line ? `:${t.line}` : ""} — ${first.body}` });
+    }
+    return out.sort((a, b) => a.at.localeCompare(b.at));
+  }, [d]);
+
+  if (!entries.length) return <Empty glyph="▤" title="Nobody has said anything" body="No reviews, comments or line threads on this pull request yet." />;
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      {entries.map((e, i) => (
+        <div key={i} className="mb-card overflow-hidden">
+          <div className="flex items-center gap-2 px-3 py-2.5 text-[11.5px]" style={{ background: "color-mix(in srgb, var(--bg3) 44%, transparent)" }}>
+            <b className="font-semibold">{e.who}</b>
+            {e.bot && <span className="mb-chip" style={{ color: "var(--info)" }}>bot</span>}
+            {e.verdict && <span className="mb-chip" style={{ color: e.verdict === "approved" ? "var(--success)" : "var(--error)" }}>{e.verdict}</span>}
+            <span className="ml-auto" style={{ color: "var(--text3)" }}>{fmtAgo(Date.parse(e.at))}</span>
+          </div>
+          <div className="p-3 text-[12.5px] leading-relaxed whitespace-pre-wrap break-words" style={{ color: "var(--text2)" }}>{e.body}</div>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+/** Hand the job to the chat with the right working directory and prompt, so
+ *  the answer is written against the code rather than guessed at. Reads only —
+ *  nothing is fetched and nothing is left behind. */
+async function handOver(
+  root: string, number: number, prompt: string,
+  onOpenChatWith: (cwd: string, prompt: string) => void,
+  toast: (m: string, bad?: boolean) => void,
+) {
+  try {
+    const r = await api.prReviewPrompt(root, number);
+    if (!r.ok || !r.cwd) { toast(r.error || "Could not check it out", true); return; }
+    onOpenChatWith(r.cwd, r.prompt && prompt.startsWith("Review pull request") ? r.prompt : prompt);
+    toast(`Checked out #${number} — it is waiting in chat`);
+  } catch (e) { toast(String(e), true); }
+}

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -1,0 +1,334 @@
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { api } from "../lib/api.ts";
+import { Screen, Sheet, Seg, Empty, Row, Act } from "./mobileUi.tsx";
+import { MobileDiff, FileRow } from "./MobileDiff.tsx";
+import { MobilePr } from "./MobilePr.tsx";
+import type {
+  GitRepoRef, WorkingTree, GitBranch, DockerContainer, DockerStat, PrSummary, GitFileChange,
+} from "../../../shared/types.ts";
+
+/**
+ * A repository, and the three things you can be doing to one.
+ *
+ * The first pass put git, docker and pull requests on the tab bar next to
+ * Chats, which claimed they were four equal, independent destinations. They
+ * are not: all three are facets of a repository, and a tab bar cannot say so.
+ * Picking the repo once and then the facet is also fewer decisions than three
+ * separate panels each asking which repo you meant.
+ */
+
+type Facet = "changes" | "prs" | "containers";
+
+export interface RepoSummary {
+  ref: GitRepoRef;
+  name: string;
+  branch: string;
+  dirty: number;
+  ahead: number;
+  behind: number;
+  prs: number;
+  down: number;
+}
+
+export function RepoList({ repos, onOpen }: { repos: RepoSummary[]; onOpen: (r: RepoSummary) => void }) {
+  if (!repos.length) {
+    return <Empty glyph="◇" title="No repositories yet"
+      body="agentglass finds these from the projects your agents have worked in. Run one, and it appears here." />;
+  }
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="mb-eyebrow">Repositories</div>
+      {repos.map((r) => (
+        <Row key={r.ref.root}
+          tint={r.down ? "var(--error)" : r.dirty || r.ahead ? "var(--warning)" : "var(--success)"}
+          title={r.name}
+          sub={`${r.branch}${r.ahead ? ` · ↑${r.ahead}` : ""}${r.behind ? ` ↓${r.behind}` : ""}`}
+          right={[
+            r.dirty ? `${r.dirty} changed` : "",
+            r.prs ? `${r.prs} PR${r.prs > 1 ? "s" : ""}` : "",
+            r.down ? `${r.down} down` : "",
+          ].filter(Boolean).join(" · ") || "clean"}
+          onClick={() => onOpen(r)}
+        />
+      ))}
+    </div>
+  );
+}
+
+export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRefresh, onOpenChatWith }: {
+  open: boolean;
+  repo: RepoSummary | null;
+  containers: DockerContainer[];
+  stats: DockerStat[];
+  onBack: () => void;
+  toast: (m: string, bad?: boolean) => void;
+  onRefresh: () => void;
+  onOpenChatWith?: (cwd: string, prompt: string) => void;
+}) {
+  const root = repo?.ref.root ?? "";
+  const [facet, setFacet] = useState<Facet>("changes");
+  const [tree, setTree] = useState<WorkingTree | null>(null);
+  const [prs, setPrs] = useState<PrSummary[]>([]);
+  const [prsLoading, setPrsLoading] = useState(false);
+  const [msg, setMsg] = useState("");
+  const [branches, setBranches] = useState<GitBranch[] | null>(null);
+  const [openPr, setOpenPr] = useState<number | null>(null);
+  const [ctr, setCtr] = useState<DockerContainer | null>(null);
+  const [diffAt, setDiffAt] = useState<number | null>(null);
+
+  const mine = useMemo(() => containers.filter((c) => (c.project ?? "") === repo?.name), [containers, repo]);
+
+  // Open on whatever is wrong: a container down beats uncommitted work beats
+  // the pull request list. Landing on an empty tab is a wasted screen.
+  useEffect(() => {
+    if (!repo) return;
+    setFacet(repo.down ? "containers" : repo.dirty ? "changes" : "prs");
+    setTree(null); setPrs([]); setMsg(""); setBranches(null);
+  }, [repo]);
+
+  const loadTree = useCallback(() => {
+    if (!root) return;
+    api.gitTree(root).then(setTree).catch(() => setTree(null));
+  }, [root]);
+
+  useEffect(() => { if (open && facet === "changes") loadTree(); }, [open, facet, loadTree]);
+  useEffect(() => {
+    if (!open || facet !== "prs" || !root) return;
+    setPrsLoading(true);
+    api.prList(root, "all", "open").then((r) => setPrs(r.prs)).catch(() => setPrs([]))
+      .finally(() => setPrsLoading(false));
+  }, [open, facet, root]);
+
+  // The tree hands staged and unstaged back separately; the phone shows one
+  // list with a switch per row, so they are merged and deduplicated here —
+  // a file can be in both when only part of it is staged.
+  const changed = useMemo(() => {
+    const m = new Map<string, GitFileChange>();
+    for (const f of tree?.unstaged ?? []) m.set(f.file_path, f);
+    for (const f of tree?.staged ?? []) m.set(f.file_path, f);
+    return [...m.values()].sort((a, b) => a.file_path.localeCompare(b.file_path));
+  }, [tree]);
+  const staged = changed.filter((f) => f.staged);
+  const byPath = useMemo(() => new Map(changed.map((f) => [f.file_path, f])), [changed]);
+  const paths = changed.map((f) => f.file_path);
+  /** Repo-relative. The absolute prefix is the one part of a path you already
+   *  know, and on a 390px row it is the part that crowds out the rest. */
+  const rel = (abs: string) => (root && abs.startsWith(root) ? abs.slice(root.length).replace(/^\//, "") : abs);
+
+  const act = async (label: string, run: () => Promise<{ ok: boolean; error?: string }>) => {
+    try {
+      const r = await run();
+      toast(r.ok ? label : (r.error || `${label} failed`), !r.ok);
+      if (r.ok) { loadTree(); onRefresh(); }
+    } catch (e) { toast(String(e), true); }
+  };
+
+  return (
+    <>
+      <Screen open={open && !openPr && !ctr && diffAt == null} title={repo?.name ?? ""} sub={repo?.branch} onBack={onBack}>
+        <Seg sticky value={facet} onPick={setFacet} options={[
+          { id: "changes", label: "Changes", n: repo?.dirty || null },
+          { id: "prs", label: "Pull requests", n: prs.length || null },
+          { id: "containers", label: "Containers", n: mine.length || null },
+        ]} />
+
+        {facet === "changes" && (
+          changed.length === 0 ? (
+            <Empty glyph="◈" title="Nothing to commit"
+              body={`The working tree is clean${repo?.ahead ? ` — but you are ${repo.ahead} commit${repo.ahead > 1 ? "s" : ""} ahead of the remote.` : " and level with the remote."}`} />
+          ) : (
+            <>
+              <div className="flex gap-2 mb-3">
+                <Act small full onAct={() => act("Pulled", () => api.gitPull(root))}>↓ Pull</Act>
+                <Act small full onAct={() => act("Pushed", () => api.gitPush(root))}>↑ Push{repo?.ahead ? ` ${repo.ahead}` : ""}</Act>
+                <Act small full onAct={async () => {
+                  const r = await api.gitBranches(root); setBranches(r.branches);
+                }}>Branch ▾</Act>
+              </div>
+
+              <div className="flex items-center gap-2 mb-2.5 text-[11px]" style={{ color: "var(--text3)" }}>
+                <span className="mb-tnum">{staged.length} of {changed.length} staged</span>
+                <span className="flex-1" />
+                <Act small onAct={() => staged.length === changed.length
+                  ? act("Unstaged everything", () => api.gitUnstageAll(root))
+                  : act("Staged everything", () => api.gitStageAll(root))}>
+                  {staged.length === changed.length ? "Unstage all" : "Stage all"}
+                </Act>
+              </div>
+
+              <div className="flex flex-col gap-2.5 mb-3">
+                {changed.map((f, i) => (
+                  <FileRow key={f.file_path} path={rel(f.file_path)} add={f.additions} del={f.deletions}
+                    note={f.status} on={f.staged} switchLabel={`Stage ${f.file_path}`}
+                    onToggle={() => act(f.staged ? "Unstaged" : "Staged",
+                      () => f.staged ? api.gitUnstage(root, [f.file_path]) : api.gitStage(root, [f.file_path]))}
+                    onOpen={() => setDiffAt(i)} />
+                ))}
+              </div>
+
+              <div className="mb-card overflow-hidden">
+                <textarea value={msg} onChange={(e) => setMsg(e.target.value)}
+                  placeholder="What changed, and why…"
+                  className="w-full p-3 text-[13px] resize-none bg-transparent outline-none"
+                  style={{ minHeight: 78, color: "var(--text)", lineHeight: 1.55 }} />
+                <div className="flex gap-2 items-center px-3 py-2.5"
+                  style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)", background: "color-mix(in srgb, var(--bg3) 34%, transparent)" }}>
+                  <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>
+                    {staged.length ? `${staged.length} file${staged.length > 1 ? "s" : ""} staged` : "Nothing staged"}
+                  </span>
+                  <span className="flex-1" />
+                  <Act small disabled={!staged.length || !msg.trim()}
+                    title={!staged.length ? "Stage something first" : !msg.trim() ? "Say what changed" : undefined}
+                    onAct={async () => { await act("Committed", () => api.gitCommitStaged(root, msg.trim(), "")); setMsg(""); }}>
+                    Commit
+                  </Act>
+                  <Act small kind="acc" disabled={!staged.length || !msg.trim()}
+                    title={!staged.length ? "Stage something first" : !msg.trim() ? "Say what changed" : undefined}
+                    onAct={async () => {
+                      const c = await api.gitCommitStaged(root, msg.trim(), "");
+                      if (!c.ok) { toast(c.error || "Commit failed", true); return; }
+                      setMsg("");
+                      await act("Committed and pushed", () => api.gitPush(root));
+                    }}>
+                    Commit &amp; push
+                  </Act>
+                </div>
+              </div>
+            </>
+          )
+        )}
+
+        {facet === "prs" && (
+          prsLoading && !prs.length ? <div className="text-[11.5px] p-3" style={{ color: "var(--text3)" }}>Loading pull requests…</div>
+          : prs.length === 0 ? <Empty glyph="⑂" title="No open pull requests" body={`Nothing is waiting to land on ${repo?.name}.`} />
+          : (
+            <div className="flex flex-col gap-2.5">
+              {prs.map((p) => (
+                <Row key={p.number}
+                  tint={!p.checksLoaded ? "var(--text3)" : p.checks.failure ? "var(--error)" : p.checks.pending ? "var(--warning)" : "var(--success)"}
+                  title={`#${p.number} ${p.title}`}
+                  sub={`${p.author} · ${!p.checksLoaded ? "checks…" : p.checks.failure ? `${p.checks.failure} failing` : p.checks.pending ? `${p.checks.pending} running` : "green"}${p.isDraft ? " · draft" : ""}`}
+                  right={`+${p.additions} −${p.deletions}`}
+                  onClick={() => setOpenPr(p.number)} />
+              ))}
+            </div>
+          )
+        )}
+
+        {facet === "containers" && (
+          mine.length === 0
+            ? <Empty glyph="▣" title="No containers" body={`Nothing from ${repo?.name} is running under Docker.`} />
+            : (
+              <div className="flex flex-col gap-2.5">
+                {mine.map((c) => {
+                  const st = stats.find((s) => s.id === c.id);
+                  const up = c.state === "running";
+                  return (
+                    <Row key={c.id} pulse={up}
+                      tint={up ? "var(--success)" : c.state === "restarting" ? "var(--warning)" : "var(--text3)"}
+                      title={c.service || c.name}
+                      sub={`${c.status}${c.ports ? " · " + c.ports : ""}`}
+                      right={up && st ? `${Math.round(st.cpu)}% cpu` : c.state}
+                      onClick={() => setCtr(c)} />
+                  );
+                })}
+              </div>
+            )
+        )}
+      </Screen>
+
+      <MobileDiff
+        open={diffAt != null} files={paths.map(rel)} index={diffAt ?? 0} onIndex={setDiffAt}
+        file={diffAt != null ? byPath.get(paths[diffAt] ?? "") : undefined}
+        onBack={() => setDiffAt(null)}
+        extra={diffAt != null && (
+          <>
+            <Act small onAct={() => act("Staged", () => api.gitStage(root, [paths[diffAt]!]))}>Stage this file</Act>
+            <Act small kind="dang" onAct={() => act("Discarded — back to HEAD", () => api.gitDiscard(root, [paths[diffAt]!]))}>Discard</Act>
+          </>
+        )}
+      />
+
+      <MobilePr open={openPr != null} root={root} number={openPr} onBack={() => setOpenPr(null)}
+        toast={toast} onOpenChatWith={onOpenChatWith} />
+
+      <ContainerScreen open={!!ctr} c={ctr} stat={stats.find((s) => s.id === ctr?.id)}
+        onBack={() => setCtr(null)} toast={toast} onRefresh={onRefresh} />
+
+      <Sheet open={!!branches} title="Switch branch" sub="Uncommitted changes come with you."
+        onClose={() => setBranches(null)}>
+        <div className="flex flex-col gap-2.5">
+          {(branches ?? []).slice(0, 30).map((b) => (
+            <Row key={b.name} tint={b.current ? "var(--success)" : "var(--text3)"}
+              title={b.name} sub={b.upstream ?? "no upstream"}
+              right={b.current ? "here" : undefined}
+              onClick={b.current ? undefined : async () => {
+                const r = await api.gitCheckout(root, b.name);
+                toast(r.ok ? `Switched to ${b.name}` : (r.error || "Could not switch"), !r.ok);
+                setBranches(null);
+                if (r.ok) { loadTree(); onRefresh(); }
+              }} />
+          ))}
+        </div>
+      </Sheet>
+    </>
+  );
+}
+
+/** One container: how hard it is working, what it has been saying, and the two
+ *  or three things you would actually do to it from a phone. */
+function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
+  open: boolean; c: DockerContainer | null; stat?: DockerStat;
+  onBack: () => void; toast: (m: string, bad?: boolean) => void; onRefresh: () => void;
+}) {
+  const [logs, setLogs] = useState("");
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!open || !c) return;
+    setLoading(true);
+    api.dockerLogs(c.id, 300)
+      .then((r) => setLogs(r.ok ? r.text : (r.error || "No logs")))
+      .catch((e) => setLogs(String(e)))
+      .finally(() => setLoading(false));
+  }, [open, c]);
+
+  const run = async (label: string, fn: () => Promise<{ ok: boolean; error?: string }>) => {
+    const r = await fn();
+    toast(r.ok ? label : (r.error || `${label} failed`), !r.ok);
+    if (r.ok) onRefresh();
+  };
+  const up = c?.state === "running";
+
+  return (
+    <Screen open={open} title={c?.name ?? ""} sub={c ? `${c.image} · ${c.status}` : undefined} onBack={onBack}
+      foot={c ? (up ? (
+        <>
+          <Act small full onAct={() => run(`Restarted ${c.name}`, () => api.dockerRestart(c.id))}>Restart</Act>
+          <Act small full kind="dang" onAct={() => run(`Stopped ${c.name}`, () => api.dockerStop(c.id))}>Stop</Act>
+        </>
+      ) : (
+        <>
+          <Act small full kind="ok" onAct={() => run(`Started ${c.name}`, () => api.dockerStart(c.id))}>Start</Act>
+          <Act small full kind="dang" onAct={() => run(`Removed ${c.name}`, () => api.dockerRm(c.id))}>Remove</Act>
+        </>
+      )) : undefined}>
+      <div className="grid grid-cols-2 gap-2.5 mb-3">
+        <div className="mb-card px-3.5 py-3">
+          <div className="mb-eyebrow">CPU</div>
+          <div className="mb-fig" style={{ fontSize: 26 }}>{stat ? Math.round(stat.cpu) : "—"}<span style={{ fontSize: 14, color: "var(--text3)" }}>%</span></div>
+        </div>
+        <div className="mb-card px-3.5 py-3">
+          <div className="mb-eyebrow">Memory</div>
+          <div className="mb-fig" style={{ fontSize: 26 }}>{stat ? Math.round(stat.mem) : "—"}<span style={{ fontSize: 14, color: "var(--text3)" }}>%</span></div>
+          {stat && <div className="text-[10px] mt-1" style={{ color: "var(--text3)" }}>{stat.memUsage}</div>}
+        </div>
+      </div>
+      <div className="mb-eyebrow mb-2">Logs · last 300 lines</div>
+      <pre className="mb-card p-3 text-[11px] leading-relaxed overflow-x-auto whitespace-pre-wrap break-words"
+        style={{ maxHeight: "44vh", overflowY: "auto", background: "color-mix(in srgb, #000 44%, transparent)", color: "var(--text3)" }}>
+        {loading ? "Reading the log…" : logs || "Nothing logged."}
+      </pre>
+    </Screen>
+  );
+}

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -1,0 +1,337 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+/**
+ * The phone's own visual language, and the few primitives every screen needs.
+ *
+ * It shares agentglass's palette variables — this has to feel like the same
+ * product — but not its density. A cockpit is read at arm's length with a
+ * mouse; this is read at half that with a thumb, so targets are 44px and up,
+ * surfaces are rounder, and figures are set as display type because figures
+ * are what this app is made of.
+ *
+ * The CSS lives here as a string rather than in a stylesheet for the same
+ * reason `MD_CSS` does in the pull request panel: the rules are meaningless
+ * without the components below, and splitting them across two files is how
+ * they drift.
+ */
+export const MOBILE_CSS = `
+.mb{
+  --tap:44px;
+  --nav:64px;
+  --mb-line:color-mix(in srgb,var(--border) 34%,transparent);
+  --mb-card:color-mix(in srgb,var(--bg2) 70%,transparent);
+  /* A raised surface catches light along its top edge and drops a shadow
+     under it. Two declarations, and nothing looks like a flat rectangle. */
+  --mb-edge:inset 0 1px 0 color-mix(in srgb,var(--primary-hover) 15%,transparent);
+  --mb-drop:0 12px 28px -18px rgba(0,0,0,.9);
+}
+/* One fixed wash, so the app has a horizon instead of a flat backdrop. */
+.mb-sky{position:fixed;inset:0;z-index:0;pointer-events:none;
+  background:
+    radial-gradient(120% 55% at 50% -12%,color-mix(in srgb,var(--primary) 13%,transparent),transparent 62%),
+    radial-gradient(80% 40% at 100% 100%,color-mix(in srgb,var(--border) 18%,transparent),transparent 60%)}
+
+.mb-fig{font-variant-numeric:tabular-nums;font-weight:700;letter-spacing:-.045em;line-height:1}
+.mb-tnum{font-variant-numeric:tabular-nums}
+.mb-eyebrow{font-size:9.5px;letter-spacing:.15em;text-transform:uppercase;color:var(--text3);font-weight:600}
+
+/* Every press answers inside one frame. */
+.mb-press{transition:transform .09s cubic-bezier(.2,.9,.3,1),background .14s,border-color .14s,opacity .14s}
+.mb-press:active:not(:disabled){transform:scale(.972)}
+.mb-press:focus-visible{outline:2px solid var(--primary);outline-offset:2px}
+.mb-press:disabled{opacity:.38}
+
+.mb-btn{min-height:46px;padding:0 16px;border-radius:13px;font-size:13px;display:inline-flex;align-items:center;
+  justify-content:center;gap:7px;border:1px solid color-mix(in srgb,var(--border) 50%,transparent);color:var(--text2);
+  background:transparent}
+.mb-btn.sm{min-height:42px;padding:0 13px;font-size:11.5px;border-radius:11px}
+.mb-btn.acc{background:var(--primary-hover);border-color:var(--primary-hover);color:var(--bg);font-weight:700;
+  box-shadow:0 6px 20px -8px var(--primary)}
+.mb-btn.ok{background:var(--success);border-color:var(--success);color:#06231a;font-weight:700}
+.mb-btn.no{color:var(--error);background:color-mix(in srgb,var(--error) 12%,transparent);
+  border-color:color-mix(in srgb,var(--error) 42%,transparent)}
+.mb-btn.dang{color:var(--error);border-color:color-mix(in srgb,var(--error) 45%,transparent)}
+
+.mb-card{border-radius:16px;background:var(--mb-card);
+  border:1px solid color-mix(in srgb,var(--border) 38%,transparent);box-shadow:var(--mb-edge)}
+.mb-row{display:flex;align-items:center;gap:12px;width:100%;padding:13px;border-radius:15px;min-height:58px;
+  background:var(--mb-card);border:1px solid color-mix(in srgb,var(--border) 32%,transparent);
+  box-shadow:var(--mb-edge);text-align:left}
+.mb-row .i{min-width:0;flex:1}
+.mb-row .i b{display:block;font-size:13px;font-weight:500;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mb-row .i span{display:block;font-size:10.5px;color:var(--text3);margin-top:3px;
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mb-row .r{flex:none;font-size:11px;color:var(--text3);text-align:right}
+
+.mb-dot{width:8px;height:8px;border-radius:50%;flex:none}
+.mb-dot.pulse{animation:mb-dp 2s ease-out infinite}
+@keyframes mb-dp{0%{box-shadow:0 0 0 0 color-mix(in srgb,currentColor 55%,transparent)}100%{box-shadow:0 0 0 8px transparent}}
+.mb-chip{font-size:10px;padding:2px 8px;border-radius:20px;border:1px solid currentColor;white-space:nowrap}
+
+.mb-seg{display:flex;gap:7px;overflow-x:auto;scrollbar-width:none}
+.mb-seg::-webkit-scrollbar{display:none}
+.mb-seg button{flex:none;min-height:40px;padding:0 15px;border-radius:22px;font-size:12px;color:var(--text3);
+  border:1px solid color-mix(in srgb,var(--border) 36%,transparent);display:flex;align-items:center;gap:6px;
+  transition:all .2s cubic-bezier(.3,1.2,.5,1);background:transparent}
+.mb-seg button[aria-pressed="true"]{color:var(--bg);background:var(--primary-hover);border-color:var(--primary-hover);
+  font-weight:700;box-shadow:0 4px 16px -6px var(--primary)}
+/* The sections stay reachable however far down a long list you are. */
+.mb-sticky{position:sticky;top:0;z-index:5;margin:0 -15px 13px;padding:9px 15px;
+  background:color-mix(in srgb,var(--bg) 84%,transparent);backdrop-filter:blur(14px);
+  border-bottom:1px solid color-mix(in srgb,var(--border) 24%,transparent)}
+
+.mb-empty{border-radius:20px;padding:40px 22px;text-align:center;
+  border:1px dashed color-mix(in srgb,var(--border) 45%,transparent);
+  background:color-mix(in srgb,var(--bg2) 40%,transparent)}
+.mb-empty .g{font-size:25px;opacity:.7;margin-bottom:9px}
+.mb-empty b{display:block;font-size:15px;font-weight:600}
+.mb-empty span{display:block;font-size:12px;color:var(--text2);margin-top:7px;line-height:1.6}
+
+/* A switch, not a tick: viewed and staged are states you keep for the length
+   of a review, and a checkbox does not say that. */
+/* Drawn 42x25 and hit at 44px tall: a switch this size is comfortable to read
+   and uncomfortable to hit, so the target grows without the shape growing. */
+.mb-sw{position:relative;width:42px;height:25px;border-radius:14px;flex:none;
+  background:color-mix(in srgb,var(--border) 52%,transparent);transition:background .2s;
+  box-sizing:content-box;border-top:10px solid transparent;border-bottom:9px solid transparent;
+  background-clip:padding-box}
+.mb-sw::after{content:"";position:absolute;top:3px;left:3px;width:19px;height:19px;border-radius:50%;
+  background:var(--text3);transition:transform .24s cubic-bezier(.3,1.5,.5,1),background .2s}
+.mb-sw[data-on="1"]{background:color-mix(in srgb,var(--success) 58%,transparent)}
+.mb-sw[data-on="1"]::after{transform:translateX(17px);background:var(--success)}
+
+/* ── screens ──────────────────────────────────────────────────────── */
+.mb-screen{position:fixed;inset:0;z-index:60;background:var(--bg);display:flex;flex-direction:column;
+  transform:translateX(100%);transition:transform .3s cubic-bezier(.32,.72,0,1);will-change:transform}
+.mb-screen.on{transform:none}
+.mb-screen .hd{display:flex;align-items:center;gap:10px;padding:calc(env(safe-area-inset-top) + 11px) 13px 10px;
+  border-bottom:1px solid var(--mb-line);background:color-mix(in srgb,var(--bg) 84%,transparent);backdrop-filter:blur(16px)}
+.mb-screen .hd .back{min-height:42px;min-width:42px;display:grid;place-items:center;font-size:20px;
+  color:var(--primary-hover);margin-left:-6px;background:transparent}
+.mb-screen .hd .t{min-width:0;flex:1}
+.mb-screen .hd .t b{display:block;font-size:13.5px;font-weight:600;overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mb-screen .hd .t span{display:block;font-size:10.5px;color:var(--text3);overflow:hidden;text-overflow:ellipsis;white-space:nowrap}
+.mb-screen .bd{flex:1;overflow-y:auto;-webkit-overflow-scrolling:touch;
+  padding:14px 15px calc(env(safe-area-inset-bottom) + 20px)}
+.mb-screen .ft{border-top:1px solid var(--mb-line);background:color-mix(in srgb,var(--bg2) 88%,transparent);
+  backdrop-filter:blur(16px);padding:11px 15px calc(env(safe-area-inset-bottom) + 11px);
+  display:flex;gap:9px;align-items:center}
+
+/* ── sheet ────────────────────────────────────────────────────────── */
+.mb-scrim{position:fixed;inset:0;z-index:70;background:rgba(4,1,10,.66);opacity:0;pointer-events:none;
+  transition:opacity .24s;backdrop-filter:blur(3px)}
+.mb-scrim.on{opacity:1;pointer-events:auto}
+.mb-sheet{position:fixed;left:0;right:0;bottom:0;z-index:71;border-radius:24px 24px 0 0;
+  background:linear-gradient(180deg,color-mix(in srgb,var(--bg3) 50%,var(--bg2)),var(--bg2));
+  border-top:1px solid color-mix(in srgb,var(--primary) 38%,transparent);transform:translateY(100%);
+  transition:transform .3s cubic-bezier(.32,.72,0,1);max-height:88vh;display:flex;flex-direction:column;
+  box-shadow:0 -20px 50px -20px #000}
+.mb-sheet.on{transform:none}
+.mb-sheet .grab{width:40px;height:4px;border-radius:3px;flex:none;margin:10px auto 5px;
+  background:color-mix(in srgb,var(--border) 72%,transparent)}
+.mb-sheet .in{padding:7px 16px calc(env(safe-area-inset-bottom) + 18px);overflow-y:auto}
+.mb-sheet h3{font-size:16px;font-weight:600}
+
+/* ── toasts ───────────────────────────────────────────────────────── */
+.mb-toasts{position:fixed;left:14px;right:14px;z-index:90;display:flex;flex-direction:column;gap:9px;
+  pointer-events:none;bottom:calc(var(--nav) + env(safe-area-inset-bottom) + 14px)}
+.mb-toasts.raised{bottom:calc(env(safe-area-inset-bottom) + 112px)}
+.mb-toast{border-radius:14px;padding:12px 15px;font-size:12.5px;display:flex;align-items:center;gap:10px;
+  background:linear-gradient(180deg,color-mix(in srgb,var(--bg3) 80%,var(--bg2)),var(--bg2));
+  border:1px solid color-mix(in srgb,var(--primary) 46%,transparent);
+  box-shadow:0 16px 40px -16px #000,var(--mb-edge);animation:mb-tin .3s cubic-bezier(.2,1.2,.3,1)}
+.mb-toast .g{font-weight:700;font-size:14px;flex:none;color:var(--success)}
+.mb-toast.bad .g{color:var(--error)}
+@keyframes mb-tin{from{transform:translateY(18px) scale(.94);opacity:0}}
+
+.mb-spin{width:13px;height:13px;border-radius:50%;flex:none;
+  border:1.8px solid color-mix(in srgb,currentColor 26%,transparent);border-top-color:currentColor;
+  animation:mb-sp .6s linear infinite}
+@keyframes mb-sp{to{transform:rotate(360deg)}}
+
+@media(prefers-reduced-motion:reduce){
+  .mb *,.mb-screen,.mb-sheet,.mb-scrim,.mb-toast{animation-duration:.01ms !important;
+    animation-iteration-count:1 !important;transition-duration:.01ms !important}
+}
+`;
+
+// ---------------------------------------------------------------------------
+// toasts
+// ---------------------------------------------------------------------------
+
+export type Toast = { id: number; msg: string; bad?: boolean };
+
+/** Says what happened, in the past tense, after it happened. */
+export function useToasts() {
+  const [toasts, setToasts] = useState<Toast[]>([]);
+  const seq = useRef(0);
+  const toast = useCallback((msg: string, bad = false) => {
+    const id = ++seq.current;
+    setToasts((t) => [...t, { id, msg, bad }]);
+    setTimeout(() => setToasts((t) => t.filter((x) => x.id !== id)), 2800);
+  }, []);
+  return { toasts, toast };
+}
+
+export function Toasts({ toasts, raised }: { toasts: Toast[]; raised?: boolean }) {
+  return (
+    <div className={`mb-toasts${raised ? " raised" : ""}`} aria-live="polite">
+      {toasts.map((t) => (
+        <div key={t.id} className={`mb-toast${t.bad ? " bad" : ""}`}>
+          <span className="g">{t.bad ? "✕" : "✓"}</span><span>{t.msg}</span>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// screens
+// ---------------------------------------------------------------------------
+
+/**
+ * Makes the phone's own back gesture close whatever is on top.
+ *
+ * Without it, back leaves agentglass entirely from a diff three levels deep,
+ * which is the fastest way to make a companion feel broken.
+ */
+export function useBackClose(open: boolean, close: () => void) {
+  const armed = useRef(false);
+  useEffect(() => {
+    if (open && !armed.current) {
+      armed.current = true;
+      history.pushState({ mb: true }, "");
+    }
+    if (!open && armed.current) {
+      armed.current = false;
+      // Closed by a button rather than by the gesture: drop the entry we added
+      // so the next back press does not have to be pressed twice.
+      if (history.state?.mb) history.back();
+    }
+  }, [open]);
+  useEffect(() => {
+    if (!open) return;
+    const pop = () => { armed.current = false; close(); };
+    window.addEventListener("popstate", pop);
+    return () => window.removeEventListener("popstate", pop);
+  }, [open, close]);
+}
+
+export function Screen({ open, title, sub, onBack, right, foot, children }: {
+  open: boolean; title: string; sub?: string; onBack: () => void;
+  right?: React.ReactNode; foot?: React.ReactNode; children: React.ReactNode;
+}) {
+  useBackClose(open, onBack);
+  const body = useRef<HTMLDivElement>(null);
+  return (
+    <div className={`mb-screen${open ? " on" : ""}`} aria-hidden={!open}>
+      <div className="hd">
+        <button className="back mb-press" onClick={onBack} aria-label="Back">‹</button>
+        <span className="t"><b>{title}</b>{sub && <span>{sub}</span>}</span>
+        {right}
+      </div>
+      <div className="bd" ref={body}>{open && children}</div>
+      {foot && <div className="ft">{foot}</div>}
+    </div>
+  );
+}
+
+export function Sheet({ open, title, sub, onClose, children }: {
+  open: boolean; title: string; sub?: string; onClose: () => void; children: React.ReactNode;
+}) {
+  useBackClose(open, onClose);
+  return (
+    <>
+      <div className={`mb-scrim${open ? " on" : ""}`} onClick={onClose} />
+      <div className={`mb-sheet${open ? " on" : ""}`} role="dialog" aria-hidden={!open} aria-label={title}>
+        <div className="grab" />
+        <div className="in">
+          <h3>{title}</h3>
+          {sub && <div className="text-[11px] mt-1 mb-3" style={{ color: "var(--text3)" }}>{sub}</div>}
+          {open && children}
+        </div>
+      </div>
+    </>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// controls
+// ---------------------------------------------------------------------------
+
+/**
+ * A button that shows its own work.
+ *
+ * `onAct` returns a message; the button spins until it resolves and the caller
+ * toasts what happened. The label stays put while it spins, so the row does not
+ * jump under the thumb that pressed it.
+ */
+export function Act({ children, onAct, kind, small, disabled, title, full }: {
+  children: React.ReactNode;
+  onAct: () => Promise<string | void> | string | void;
+  kind?: "acc" | "ok" | "no" | "dang"; small?: boolean; disabled?: boolean; title?: string; full?: boolean;
+}) {
+  const [busy, setBusy] = useState(false);
+  const alive = useRef(true);
+  useEffect(() => () => { alive.current = false; }, []);
+  return (
+    <button
+      className={`mb-btn mb-press${kind ? " " + kind : ""}${small ? " sm" : ""}`}
+      style={full ? { width: "100%" } : undefined}
+      disabled={disabled || busy} title={title}
+      onClick={async () => {
+        if (busy) return;
+        setBusy(true);
+        try { await onAct(); } finally { if (alive.current) setBusy(false); }
+      }}>
+      {busy && <span className="mb-spin" />}
+      {children}
+    </button>
+  );
+}
+
+export function Switch({ on, onToggle, label }: { on: boolean; onToggle: () => void; label: string }) {
+  return (
+    <button className="mb-sw mb-press" data-on={on ? "1" : "0"}
+      role="switch" aria-checked={on} aria-label={label} onClick={onToggle} />
+  );
+}
+
+export function Seg<T extends string>({ value, options, onPick, sticky }: {
+  value: T; options: { id: T; label: string; n?: number | null }[]; onPick: (v: T) => void; sticky?: boolean;
+}) {
+  return (
+    <div className={`mb-seg${sticky ? " mb-sticky" : ""}`}>
+      {options.map((o) => (
+        <button key={o.id} aria-pressed={o.id === value} className="mb-press" onClick={() => onPick(o.id)}>
+          {o.label}{o.n != null && <span className="mb-tnum">{o.n}</span>}
+        </button>
+      ))}
+    </div>
+  );
+}
+
+export function Empty({ glyph, title, body }: { glyph: string; title: string; body: string }) {
+  return (
+    <div className="mb-empty">
+      <div className="g">{glyph}</div>
+      <b>{title}</b><span>{body}</span>
+    </div>
+  );
+}
+
+export function Row({ tint, title, sub, right, onClick, pulse }: {
+  tint?: string; title: React.ReactNode; sub?: React.ReactNode; right?: React.ReactNode;
+  onClick?: () => void; pulse?: boolean;
+}) {
+  const inner = (
+    <>
+      {tint && <span className={`mb-dot${pulse ? " pulse" : ""}`} style={{ background: tint, color: tint }} />}
+      <span className="i"><b>{title}</b>{sub && <span>{sub}</span>}</span>
+      {right && <span className="r">{right}</span>}
+    </>
+  );
+  return onClick
+    ? <button className="mb-row mb-press" onClick={onClick}>{inner}</button>
+    : <div className="mb-row">{inner}</div>;
+}

--- a/web/src/mobile/nowQueue.ts
+++ b/web/src/mobile/nowQueue.ts
@@ -1,0 +1,172 @@
+import type { PendingGate, SessionRollup, PrSummary, DockerContainer } from "../../../shared/types.ts";
+import { sessionTitle } from "../lib/format.ts";
+
+/**
+ * "What wants me right now", for a phone.
+ *
+ * Deliberately not `collectAttention()`. That merges the desktop's sources —
+ * the live event stream, and chats kept in localStorage — and a phone has
+ * neither: the socket is not subscribed here (a reconnecting socket behind a
+ * dark screen is a worse deal than a poll), and localStorage is per-device, so
+ * the phone has never seen those chats. What a phone *does* have is the four
+ * things below, and they are the ones worth waking up for.
+ *
+ * The output is data, not JSX: what each item means is worth a test, and what
+ * it looks like is not.
+ */
+
+export type NowTone = "crit" | "bad" | "good" | "plain";
+
+/** What produced an item, so the view can offer the right buttons and the
+ *  right screen to open. */
+export type NowOrigin =
+  | { t: "gate"; gate: PendingGate }
+  | { t: "session"; session: SessionRollup }
+  | { t: "pr-red"; pr: PrSummary; root: string }
+  | { t: "pr-ready"; pr: PrSummary; root: string }
+  | { t: "pr-review"; pr: PrSummary; root: string }
+  | { t: "container"; container: DockerContainer };
+
+export interface NowItem {
+  id: string;
+  tone: NowTone;
+  /** The eyebrow: what kind of thing this is, in the user's words. */
+  kind: string;
+  title: string;
+  sub: string;
+  /** A command or other verbatim string worth showing exactly as it is. */
+  code?: string;
+  ts: number;
+  origin: NowOrigin;
+}
+
+/** Blocked first: an agent waiting on a permission is stopped dead, and every
+ *  second of that is wasted. Then things that are broken, then things that are
+ *  finished and only need a nod. Recency breaks ties inside a band. */
+const RANK: Record<NowTone, number> = { crit: 0, bad: 1, good: 2, plain: 3 };
+
+/** An agent that has said nothing for this long, without having ended, has
+ *  almost certainly stopped and is waiting on a human. Under it, it is
+ *  probably just thinking. */
+const QUIET_MS = 4 * 60_000;
+/** Past this, it is not "just stopped" any more, it is yesterday's business
+ *  and it does not belong in a queue you are meant to be able to empty. */
+const STALE_MS = 12 * 60 * 60_000;
+
+export interface NowInput {
+  gates: PendingGate[];
+  sessions: SessionRollup[];
+  /** Pull requests already scoped to a repo, tagged with which server-side
+   *  filter produced them. `review` is the server's own answer to "waiting on
+   *  your review", so it is what that claim rests on rather than a guess. */
+  prs: { root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[];
+  containers: DockerContainer[];
+  /** Logins the viewer answers to, for "is this mine". */
+  me: string;
+  now: number;
+}
+
+export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInput): NowItem[] {
+  const out: NowItem[] = [];
+
+  for (const g of gates) {
+    out.push({
+      id: `gate:${g.id}`, tone: "crit",
+      kind: "Blocked · waiting on you",
+      title: g.summary || g.tool_name,
+      sub: `${g.source_app} · the agent is stopped until you answer`,
+      code: g.summary && g.summary !== g.tool_name ? undefined : g.tool_name,
+      ts: g.created, origin: { t: "gate", gate: g },
+    });
+  }
+
+  for (const s of sessions) {
+    if (s.ended_at) continue;
+    const quiet = now - s.last_seen;
+    if (quiet < QUIET_MS || quiet > STALE_MS) continue;
+    out.push({
+      id: `session:${s.session_id}`, tone: "plain",
+      kind: "Stopped · wants direction",
+      title: sessionTitle(s),
+      sub: `${projectName(s)} · idle ${Math.round(quiet / 60_000)}m`,
+      ts: s.last_seen, origin: { t: "session", session: s },
+    });
+  }
+
+  for (const { root, repo, pr, scope } of prs) {
+    const mine = scope === "mine" || pr.author === me;
+    const red = pr.checksLoaded && pr.checks.failure > 0;
+    const green = pr.checksLoaded && pr.checks.failure === 0 && pr.checks.pending === 0 && pr.checks.total > 0;
+    const at = Date.parse(pr.updatedAt) || now;
+
+    // Yours and broken: nobody else is going to fix it.
+    if (mine && red) {
+      out.push({
+        id: `red:${repo}#${pr.number}`, tone: "bad",
+        kind: "CI went red",
+        title: `${pr.checks.failing[0]?.name ?? "A check"} is failing on #${pr.number}`,
+        sub: `${pr.title} · ${repo}`,
+        ts: at, origin: { t: "pr-red", pr, root },
+      });
+      continue;
+    }
+    // Yours, green and approved: it only needs a nod, and it is the one thing
+    // here that finishes rather than starts work.
+    if (mine && green && pr.reviewDecision === "APPROVED" && !pr.isDraft) {
+      out.push({
+        id: `ready:${repo}#${pr.number}`, tone: "good",
+        kind: "Ready to merge",
+        title: `#${pr.number} ${pr.title}`,
+        sub: `Approved · ${pr.checks.total} checks green · ${repo}`,
+        ts: at, origin: { t: "pr-ready", pr, root },
+      });
+      continue;
+    }
+    // Somebody asked for your eyes.
+    if (!mine && scope === "review") {
+      out.push({
+        id: `review:${repo}#${pr.number}`, tone: "plain",
+        kind: "Review requested",
+        title: `#${pr.number} ${pr.title}`,
+        sub: `${pr.author} asked you · +${pr.additions} −${pr.deletions} across ${pr.changedFiles} files`,
+        ts: at, origin: { t: "pr-review", pr, root },
+      });
+    }
+  }
+
+  for (const c of containers) {
+    if (!containerIsWrong(c)) continue;
+    const looping = c.state === "restarting";
+    out.push({
+      id: `ctr:${c.id}`, tone: "bad",
+      kind: "Container down",
+      title: looping ? `${c.name} is restarting in a loop` : `${c.name} is ${c.state}`,
+      sub: `${c.project ? c.project + " · " : ""}${c.status}`,
+      ts: now, origin: { t: "container", container: c },
+    });
+  }
+
+  return out.sort((a, b) => RANK[a.tone] - RANK[b.tone] || b.ts - a.ts);
+}
+
+/**
+ * Whether a container being not-running is a problem.
+ *
+ * Most of them are not. A migration or a seed job runs once and exits 0, and
+ * that is it doing its job — nagging about it means the queue can never be
+ * emptied, which is the one thing a queue has to be able to do. So: a
+ * restart loop always, a non-zero exit always, and a clean exit never.
+ * "created" has never run at all, which is not a thing that broke.
+ */
+export function containerIsWrong(c: DockerContainer): boolean {
+  if (c.state === "running" || c.state === "created") return false;
+  if (c.state === "restarting" || c.state === "dead") return true;
+  // Docker writes the code into the status: "Exited (0) 3 hours ago".
+  const code = c.status.match(/\((\d+)\)/)?.[1];
+  return code == null ? true : code !== "0";
+}
+
+function projectName(s: SessionRollup): string {
+  const p = s.project_path || "";
+  return p.split("/").filter(Boolean).pop() || s.source_app || "unknown";
+}

--- a/web/src/mobile/resumeModel.ts
+++ b/web/src/mobile/resumeModel.ts
@@ -1,0 +1,23 @@
+/** The models a chat can be started or resumed with, newest first. */
+export const MODELS = [
+  { id: "claude-opus-5", label: "Opus 5", family: "opus" },
+  { id: "claude-sonnet-5", label: "Sonnet 5", family: "sonnet" },
+  { id: "claude-haiku-4-5", label: "Haiku 4.5", family: "haiku" },
+];
+
+/**
+ * Which model to resume a session with.
+ *
+ * This used to be a ternary whose two branches were the same expression, so
+ * replying from the phone silently moved every session to Opus — including the
+ * Haiku ones, which is somebody's bill and not a thing the phone gets to
+ * decide. Matching on the family keeps a session on the model it was started
+ * with, and anything unrecognised stays on the default rather than guessing.
+ *
+ * Its own module, with no imports, so a test of it does not drag the whole
+ * application's module graph in behind it.
+ */
+export function resumeModel(name: string | null | undefined): string {
+  const n = (name || "").toLowerCase();
+  return MODELS.find((m) => n.includes(m.family))?.id ?? MODELS[0]!.id;
+}

--- a/web/test/now-queue.test.ts
+++ b/web/test/now-queue.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from "bun:test";
+import { buildQueue, type NowInput } from "../src/mobile/nowQueue.ts";
+import type { PendingGate, SessionRollup, PrSummary, DockerContainer } from "../../shared/types.ts";
+
+const NOW = 1_700_000_000_000;
+
+const base: NowInput = { gates: [], sessions: [], prs: [], containers: [], me: "me", now: NOW };
+
+const gate = (over: Partial<PendingGate> = {}): PendingGate => ({
+  id: "g1", tool_name: "Bash", summary: "Run the production backfill",
+  source_app: "claude-code", created: NOW - 5_000, session_id: "s1", ...over,
+} as PendingGate);
+
+const session = (over: Partial<SessionRollup> = {}): SessionRollup => ({
+  session_id: "s1", source_app: "claude-code", model_name: "opus",
+  project_path: "/home/me/shop-api", ai_title: "Round prices at the boundary",
+  started_at: NOW - 3_600_000, ended_at: null, last_seen: NOW - 6 * 60_000,
+  event_count: 10, tool_count: 4, error_count: 0,
+  input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: 1,
+  ...over,
+});
+
+const rollup = (over: Partial<PrSummary["checks"]> = {}) => ({
+  total: 5, success: 5, failure: 0, skipped: 0, pending: 0,
+  allDone: true, verdict: "green" as const, failing: [], ...over,
+});
+
+const pr = (over: Partial<PrSummary> = {}): PrSummary => ({
+  number: 482, title: "Round prices at the cart boundary", author: "someone",
+  state: "OPEN", isDraft: false, headRefName: "fix/x", baseRefName: "main",
+  url: "https://github.com/a/b/pull/482", updatedAt: new Date(NOW - 60_000).toISOString(),
+  reviewDecision: null, additions: 84, deletions: 31, changedFiles: 6,
+  labels: [], assignees: [], milestone: null, checks: rollup(), checksLoaded: true, ...over,
+});
+
+const ctr = (over: Partial<DockerContainer> = {}): DockerContainer => ({
+  id: "c1", name: "otel-collector", image: "otel/collector", state: "running",
+  status: "Up 2 hours", ports: "", project: "infra", service: "otel",
+  runningFor: "2 hours", size: "0B", ...over,
+});
+
+describe("buildQueue", () => {
+  it("puts a blocked agent above everything else", () => {
+    const q = buildQueue({
+      ...base,
+      gates: [gate()],
+      containers: [ctr({ state: "exited" })],
+      prs: [{ root: "/r", repo: "shop-api", scope: "review", pr: pr() }],
+    });
+    expect(q[0]!.tone).toBe("crit");
+    expect(q[0]!.id).toBe("gate:g1");
+  });
+
+  it("only calls an agent stopped once it has actually gone quiet", () => {
+    const busy = buildQueue({ ...base, sessions: [session({ last_seen: NOW - 30_000 })] });
+    expect(busy).toHaveLength(0);
+
+    const quiet = buildQueue({ ...base, sessions: [session({ last_seen: NOW - 6 * 60_000 })] });
+    expect(quiet).toHaveLength(1);
+    expect(quiet[0]!.kind).toContain("Stopped");
+  });
+
+  it("drops an agent that went quiet yesterday", () => {
+    // A queue you cannot empty is a dashboard, and this is the item that would
+    // never leave it.
+    const q = buildQueue({ ...base, sessions: [session({ last_seen: NOW - 20 * 60 * 60_000 })] });
+    expect(q).toHaveLength(0);
+  });
+
+  it("ignores an ended session however long ago it spoke", () => {
+    const q = buildQueue({ ...base, sessions: [session({ ended_at: NOW - 60_000 })] });
+    expect(q).toHaveLength(0);
+  });
+
+  it("raises your own red pull request, and not somebody else's", () => {
+    const red = rollup({ failure: 1, success: 4, verdict: "red", failing: [{ name: "e2e", workflow: "CI", state: "failure", done: true }] });
+    const mine = buildQueue({ ...base, prs: [{ root: "/r", repo: "shop-api", scope: "mine", pr: pr({ checks: red }) }] });
+    expect(mine).toHaveLength(1);
+    expect(mine[0]!.title).toContain("e2e");
+
+    const theirs = buildQueue({ ...base, prs: [{ root: "/r", repo: "shop-api", scope: "review", pr: pr({ checks: red, author: "other" }) }] });
+    expect(theirs.every((i) => i.kind !== "CI went red")).toBe(true);
+  });
+
+  it("offers a merge only when it is approved, green and not a draft", () => {
+    const ready = (over: Partial<PrSummary>) =>
+      buildQueue({ ...base, prs: [{ root: "/r", repo: "s", scope: "mine", pr: pr({ reviewDecision: "APPROVED", ...over }) }] });
+
+    expect(ready({})).toHaveLength(1);
+    expect(ready({})[0]!.kind).toBe("Ready to merge");
+    expect(ready({ isDraft: true })).toHaveLength(0);
+    expect(ready({ checks: rollup({ pending: 1 }) })).toHaveLength(0);
+    expect(ready({ reviewDecision: "REVIEW_REQUIRED" })).toHaveLength(0);
+  });
+
+  it("does not claim a merge is ready before the checks have been fetched", () => {
+    // `checksLoaded` false means "not asked yet", which is a different claim
+    // from "nothing failed" — offering a merge on it would be a guess.
+    const q = buildQueue({
+      ...base,
+      prs: [{ root: "/r", repo: "s", scope: "mine", pr: pr({ reviewDecision: "APPROVED", checksLoaded: false }) }],
+    });
+    expect(q).toHaveLength(0);
+  });
+
+  it("reports a container that fell over, but not one that never started", () => {
+    const down = buildQueue({ ...base, containers: [ctr({ state: "exited", status: "Exited (1) 2m ago" })] });
+    expect(down).toHaveLength(1);
+    expect(down[0]!.tone).toBe("bad");
+
+    const never = buildQueue({ ...base, containers: [ctr({ state: "created" })] });
+    expect(never).toHaveLength(0);
+
+    const fine = buildQueue({ ...base, containers: [ctr()] });
+    expect(fine).toHaveLength(0);
+  });
+
+  it("leaves a job that finished alone", () => {
+    // A migration exits 0 and stays exited. Calling that "down" means the
+    // queue can never be emptied, which is the one thing it has to do.
+    const done = buildQueue({ ...base, containers: [ctr({ name: "shop-migrate", state: "exited", status: "Exited (0) 3 hours ago" })] });
+    expect(done).toHaveLength(0);
+
+    const crashed = buildQueue({ ...base, containers: [ctr({ state: "exited", status: "Exited (137) 1 minute ago" })] });
+    expect(crashed).toHaveLength(1);
+
+    const looping = buildQueue({ ...base, containers: [ctr({ state: "restarting", status: "Restarting (1) 8 seconds ago" })] });
+    expect(looping).toHaveLength(1);
+
+    // No code to read is not proof it is fine, so it still gets raised.
+    const opaque = buildQueue({ ...base, containers: [ctr({ state: "exited", status: "Exited recently" })] });
+    expect(opaque).toHaveLength(1);
+  });
+
+  it("orders blocked, then broken, then finished, then the rest", () => {
+    const red = rollup({ failure: 1, verdict: "red", failing: [{ name: "e2e", workflow: "CI", state: "failure", done: true }] });
+    const q = buildQueue({
+      ...base,
+      gates: [gate()],
+      sessions: [session()],
+      containers: [ctr({ state: "exited" })],
+      prs: [
+        { root: "/r", repo: "s", scope: "mine", pr: pr({ number: 1, checks: red }) },
+        { root: "/r", repo: "s", scope: "mine", pr: pr({ number: 2, reviewDecision: "APPROVED" }) },
+        { root: "/r", repo: "s", scope: "review", pr: pr({ number: 3, author: "other" }) },
+      ],
+    });
+    expect(q.map((i) => i.tone)).toEqual(["crit", "bad", "bad", "good", "plain", "plain"]);
+  });
+});

--- a/web/test/resume-model.test.ts
+++ b/web/test/resume-model.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "bun:test";
+import { resumeModel } from "../src/mobile/resumeModel.ts";
+
+/**
+ * Replying to a session from the phone must not move it to another model.
+ *
+ * The ternary this replaces had the same expression on both branches, so every
+ * resume went out as Opus — including sessions started on Haiku, which is
+ * somebody's bill and not a detail the phone gets to decide.
+ */
+describe("resumeModel", () => {
+  it("keeps a session on the family it was started with", () => {
+    expect(resumeModel("claude-haiku-4-5-20251001")).toBe("claude-haiku-4-5");
+    expect(resumeModel("claude-sonnet-5")).toBe("claude-sonnet-5");
+    expect(resumeModel("claude-opus-5")).toBe("claude-opus-5");
+  });
+
+  it("matches however the model name was written down", () => {
+    expect(resumeModel("Claude Haiku 4.5")).toBe("claude-haiku-4-5");
+    expect(resumeModel("anthropic/claude-sonnet-5-20250219")).toBe("claude-sonnet-5");
+  });
+
+  it("falls back to the default rather than guessing", () => {
+    expect(resumeModel(null)).toBe("claude-opus-5");
+    expect(resumeModel(undefined)).toBe("claude-opus-5");
+    expect(resumeModel("")).toBe("claude-opus-5");
+    expect(resumeModel("some-other-model")).toBe("claude-opus-5");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The phone had three tabs and you could only read two of them. The obvious next move was to add git, docker and pull requests as three more — but a tab bar claims its entries are equal and independent, and those three are neither. They are facets of a repository, and none of them is somewhere you browse to: you arrive because something happened.

So the home is a **queue**. Every card is one decision with its action on it, and answering one takes it out of the list — that is the whole difference from a dashboard, which is something you re-read rather than something you can empty.

**Now** collects gates, agents that stopped without finishing, your pull requests that went red, the ones approved and green, reviews somebody asked you for, and containers that fell over — ranked by what it costs to ignore them. `buildQueue()` is a pure function with its own tests, because what each item *means* is worth being sure about. Deliberately not `collectAttention()`: that merges the desktop's live event stream and its localStorage chats, and a phone has neither.

**Repos** carries the other three, scoped to the repository they belong to: git with staging, commit and push; pull requests with an overview / files / checks / talk flow; containers with logs and start / stop / restart.

**The diff** is unified always, wrapped by default with a hanging indent so a line that ran on is never mistaken for a new one, and carries a `+`/`−` glyph as well as a tint — at 11.5px outdoors in one hand, colour alone is not a signal you can rely on, and for some people it is no signal at all.

### Three bugs found in the chat while checking it holds up

- **The lag.** The transcript poll had `live` in its dependency array, so every streamed chunk tore the interval down, re-ran the effect and fetched the whole transcript on the way in. A long answer fired one full fetch per chunk — the exact opposite of the "do not poll while streaming" the guard inside was written for. Now behind a ref.
- **It silently changed your model.** `resumeModel` was a ternary with the same expression on both branches, so replying from the phone moved every session to Opus, including the Haiku ones. That is somebody's bill, and not a thing the phone gets to decide. Extracted to its own module with tests.
- **It could hang.** A stream that went quiet left you on a dead screen with no way to tell a slow tool call from a dropped connection. It now says so after 45s and lets the transcript take back over, and leaving mid-turn aborts the request instead of waking a screen that is gone.

Also: a container that exited 0 is a job that finished, not a fault. Flagging those meant the queue could never be emptied, which is the one thing a queue has to be able to do.

The desktop cockpit is untouched.

## How was it tested?

- `bunx tsc --noEmit` in `web/` and `server/` — both clean.
- `bun test` in `web/` — 419 pass, 0 fail (11 new across `now-queue` and `resume-model`).
- `bunx vite build`, plus the demo bundle.
- Rendered headless at 390×844 (Chromium via Playwright, mobile emulation) across Now, Chats, Repos and a repo's three facets: no horizontal overflow, no page errors, and no tap target under 40px. That last check is what caught the switch's hit area, the `sm` buttons at 38px, and file paths rendering centred — a `<button>` brings `text-align:center` from the UA sheet and it was beating the row's `text-align:left`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_