### PR TITLE
docs: document the phone companion, not only release-note it

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ gate. No install, no server. *(Everything there is fake; it's a showcase.)*
 
 - [Every project, one cockpit](#every-project-one-cockpit)
 - [More than a dashboard — a workspace](#more-than-a-dashboard--a-workspace)
+- [Away from the desk — the phone companion](#away-from-the-desk--the-phone-companion)
 - [Why](#why) · [Themes](#themes)
 - [Quickstart](#quickstart) · [Requirements](#requirements-what-agentglass-expects-to-find)
 - [Desktop app](#desktop-app) · [Updating](#updating)
@@ -231,6 +232,73 @@ discoverable).
 ---
 
 ![chat panel](.github/assets/chat.png)
+
+---
+
+## Away from the desk — the phone companion
+
+The cockpit stays at the desk. A terminal, a hunk-level diff and a docker table
+are not things anybody drives with a thumb, and a narrower version of them is
+not a phone app — it is the wrong app, smaller. So **a phone gets a different
+application**, not a different stylesheet: `main.tsx` chooses one tree or the
+other before React mounts. That is also what keeps the phone build honest —
+nothing heavy can leak into it. No terminal, no charts, no radar; the fleet's
+pulse is fourteen CSS-animated bars rather than a canvas, which on a phone is a
+battery decision as much as a layout one.
+
+**What decides.** Width under 768px, or a coarse pointer up to 900px — that
+second rule catches the phone held sideways, where the width alone would say
+"small laptop". A tablet in landscape is a perfectly good desk and keeps the
+cockpit. An explicit choice, stored per device, always wins over both.
+
+### The home screen is a queue, not a dashboard
+
+That is the whole difference: a dashboard is something you re-read, and this is
+something you can **empty**. Every card is one decision carrying its own action,
+and answering it takes the card out of the list.
+
+| Card | What it is, and what you can do about it |
+|---|---|
+| **Blocked · waiting on you** | A gate. The agent is stopped dead until you answer, so this outranks everything: allow or deny, with the command it wants to run in front of you. |
+| **Container down** | A container that exited non-zero, is restarting, or is dead. Tail the log, restart it, or hand it to Claude. |
+| **CI went red** | The failing check on one of your pull requests. Open the log, or re-run it. |
+| **Ready to merge** | Approved, checks green, nothing in the way. The one card that finishes work rather than starting it. |
+| **Review requested** | Somebody asked for your eyes. Opens the pull request, diff and all. |
+| **Stopped · wants direction** | A session that ended its turn and has gone quiet — between four minutes and twelve hours. Under four it is probably still thinking; over twelve it is yesterday's problem, not tonight's. |
+
+Ordered by what it costs you to be away: blocking a person first, then broken,
+then finished-and-waiting, then everything else — and within a rank, newest
+first. A card you are not going to deal with tonight can be snoozed, and it
+comes back when it changes.
+
+### Three tabs, and no more
+
+- **Now** — the queue above.
+- **Chats** — say something back. The same conversation you left at the desk,
+  and still the same one when you sit back down: the session lives on the
+  server, not in a browser tab. Turns stream in as they happen, with the tools
+  the agent runs named as it runs them.
+- **Repos** — for when you want to look rather than need to. Pick a repository,
+  then the facet: **Changes** (a switch per file *is* the staging, then commit
+  and push), **Pull requests**, **Containers**. It opens on whatever is wrong.
+
+The diff is unified, wrapped, with a `+` or `−` glyph on every line as well as
+the tint — at 11.5px, outdoors, in one hand, colour alone is not a signal to
+rely on, and for a good number of people it is not a signal at all.
+
+### Getting it onto your phone
+
+**Settings ▸ Remote access**, one switch. It prints a QR code, because the URL
+is an IP, a port and a 32-character secret and nobody is typing that. Scan it
+and the phone remembers the code; the link only carries it once.
+
+It is **your network only** — the server binds to the LAN, the code is required,
+and a phone that scanned it once keeps working until you rotate it. The same
+pane will tell you when a host firewall is dropping the packets, because
+otherwise the phone shows a white page and nothing anywhere says why.
+
+The page ships a web manifest, so **Add to home screen** gives you an icon that
+opens without browser chrome.
 
 ## Why
 


### PR DESCRIPTION
## What does this PR do?

Adds a README section for the phone companion. **Rebased onto v0.6.0** — #350 landed while this was open and already did two of the three things the first version of this PR did, so those were dropped and only the section remains.

What #350 fixed: the phone is in *Recently shipped* under v0.6.0 and #7 is off the roadmap. That is the right record of what shipped, but it is not documentation — the contents list still goes straight from the workspace panels to *Why*, and nothing anywhere tells a new reader what the phone application **is** or how to reach it. Release notes say something happened; they do not say what you get.

The section is written around the thing that makes it a companion rather than a smaller cockpit — the home screen is a queue you can empty, not a dashboard you re-read — so each card is documented by what you can do about it, and the ordering by what it costs you to be away from the desk. It also states the two things a reader needs and cannot guess:

- **the layout rule** — width under 768px, or a coarse pointer up to 900px, with an explicit per-device choice winning over both (`web/src/lib/viewport.ts`);
- **how you actually reach it** — Settings ▸ Remote access, one switch and a QR code, LAN-only and tokenised.

The roadmap and the shipped list are left untouched.

## How was it tested?

Documentation only — one file, +68 −0, no source, config or contract changes, so nothing to typecheck or build. Verified by reading:

- the new heading's anchor matches the contents entry (`#away-from-the-desk--the-phone-companion`), consistent with the existing em-dash anchors in the same list;
- every card kind, tone and threshold against `nowQueue.ts` (`crit` → `bad` → `good` → `plain`, newest first within a rank; the 4-minute / 12-hour window on a quiet session);
- the layout rule against `wantsPhoneLayout()`;
- the remote-access description against `RemoteAccessPane.tsx`, including the LAN bind, the one-time code in the link and the rotate path;
- the tab and facet names against `MobileApp.tsx` and `MobileRepo.tsx`.
