### PR TITLE
feat: make external ingest retry-safe and map Codex usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -824,7 +824,7 @@ cannot be configured by `export` at all.
 
 | Route | Description |
 |---|---|
-| `POST /ingest` | Ingest an event `{source_app, session_id, hook_event_type, event_id?, reported_cost_usd?, payload?, chat?, model_name?}`. `event_id` makes retries idempotent; reported cost overrides estimated cost for that event. |
+| `POST /ingest` | Ingest an event `{source_app, session_id, hook_event_type, event_id?, reported_cost_usd?, payload?, chat?, model_name?}`. A high-entropy `event_id` makes retries idempotent; reported cost (maximum `$100,000`) overrides estimated cost for that event. |
 | `POST /v1/traces` | OTLP/HTTP (JSON + protobuf) — maps OpenTelemetry `gen_ai.*` spans to events (any provider). |
 | `POST /v1/logs` | OTLP/HTTP (JSON + protobuf) — maps OpenTelemetry GenAI log records to events (e.g. Codex CLI). |
 | `GET /events/recent?limit=` | Latest events. |

--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ cannot be configured by `export` at all.
 
 | Route | Description |
 |---|---|
-| `POST /ingest` | Ingest an event `{source_app, session_id, hook_event_type, payload?, chat?, model_name?}`. |
+| `POST /ingest` | Ingest an event `{source_app, session_id, hook_event_type, event_id?, reported_cost_usd?, payload?, chat?, model_name?}`. `event_id` makes retries idempotent; reported cost overrides estimated cost for that event. |
 | `POST /v1/traces` | OTLP/HTTP (JSON + protobuf) — maps OpenTelemetry `gen_ai.*` spans to events (any provider). |
 | `POST /v1/logs` | OTLP/HTTP (JSON + protobuf) — maps OpenTelemetry GenAI log records to events (e.g. Codex CLI). |
 | `GET /events/recent?limit=` | Latest events. |

--- a/README.md
+++ b/README.md
@@ -741,7 +741,10 @@ The provider and model are **auto-detected from the spans** (`gen_ai.system`,
 
 Some agents (OpenAI Codex CLI) export OpenTelemetry **logs** rather than traces —
 those go to **`/v1/logs`**, which maps each GenAI log record (tool decision/result,
-inference, prompt) to an event the same way.
+inference, prompt) to an event the same way. Codex's native `event.kind`,
+`input_token_count`, `output_token_count`, `cached_token_count`, and
+`cache_write_token_count` fields are recognized directly; cached input is kept
+in its own buckets rather than charged again as ordinary input.
 
 > Non-GenAI spans/records are ignored — this is an agent-observability lens, not a
 > general trace or log store.

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -22,16 +22,30 @@ curl -sS http://localhost:4000/ingest \
   -d '{
     "source_app": "my-harness",
     "session_id": "sess-001",
+    "event_id": "sess-001:tool-42:result",
     "hook_event_type": "PostToolUse",
     "payload": { "tool_name": "Bash", "tool_response": "ok" },
-    "model_name": "gpt-4.1-mini"
+    "model_name": "gpt-4.1-mini",
+    "reported_cost_usd": 0.00042
   }'
 ```
 
 Required fields: `source_app`, `session_id`, `hook_event_type`.
-Optional: `payload`, `chat`, `model_name`. Invalid JSON returns `400`; missing
-required fields returns `400`. If a Claude transcript scanner already owns the
-session id, the event is accepted but skipped (no double-count).
+Optional: `payload`, `chat`, `model_name`, `event_id`, `reported_cost_usd`.
+Invalid JSON, missing required fields, an empty / over-512-character `event_id`,
+or a negative / non-finite cost returns `400`.
+
+`event_id` is an opaque retry key, unique within one `source_app` + `session_id`.
+The first write wins. Reposting it returns the original event id as
+`{"ok":true,"id":123,"duplicate":true}` without changing session totals,
+search, alerts, or the live stream.
+
+`reported_cost_usd` is an authoritative cost for this one event. Use it when the
+harness already knows what the provider charged; `0` is valid. Without it,
+agentglass derives cost from token usage and its pricing table.
+
+If a Claude transcript scanner already owns the session id, the event is
+accepted but skipped (no double-count).
 
 ### OTLP (any provider)
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -37,7 +37,7 @@ Invalid JSON, missing required fields, an empty / over-512-character `event_id`,
 or a cost outside the finite `$0`–`$100,000` range returns `400`.
 
 `event_id` is an opaque retry key, unique within one `source_app` + `session_id`.
-Generate it with at least 128 bits of randomness (a UUID is a good default);
+Generate it with at least 128 bits of randomness (UUIDv4 is a good default);
 `/ingest` is a local telemetry endpoint, so predictable keys can be claimed by
 another local process before the real event arrives. The first write wins.
 Reposting it returns the original event id as

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -22,7 +22,7 @@ curl -sS http://localhost:4000/ingest \
   -d '{
     "source_app": "my-harness",
     "session_id": "sess-001",
-    "event_id": "sess-001:tool-42:result",
+    "event_id": "550e8400-e29b-41d4-a716-446655440000",
     "hook_event_type": "PostToolUse",
     "payload": { "tool_name": "Bash", "tool_response": "ok" },
     "model_name": "gpt-4.1-mini",
@@ -30,13 +30,17 @@ curl -sS http://localhost:4000/ingest \
   }'
 ```
 
-Required fields: `source_app`, `session_id`, `hook_event_type`.
+Required fields: `source_app`, `session_id`, `hook_event_type`. Each must be a
+non-empty string no longer than 64 KiB.
 Optional: `payload`, `chat`, `model_name`, `event_id`, `reported_cost_usd`.
 Invalid JSON, missing required fields, an empty / over-512-character `event_id`,
-or a negative / non-finite cost returns `400`.
+or a cost outside the finite `$0`–`$100,000` range returns `400`.
 
 `event_id` is an opaque retry key, unique within one `source_app` + `session_id`.
-The first write wins. Reposting it returns the original event id as
+Generate it with at least 128 bits of randomness (a UUID is a good default);
+`/ingest` is a local telemetry endpoint, so predictable keys can be claimed by
+another local process before the real event arrives. The first write wins.
+Reposting it returns the original event id as
 `{"ok":true,"id":123,"duplicate":true}` without changing session totals,
 search, alerts, or the live stream.
 

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -134,7 +134,8 @@ CREATE TABLE IF NOT EXISTS sessions (
   output_tokens INTEGER NOT NULL DEFAULT 0,
   cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
   cache_read_tokens INTEGER NOT NULL DEFAULT 0,
-  cost_usd REAL NOT NULL DEFAULT 0
+  cost_usd REAL NOT NULL DEFAULT 0,
+  pricing_baseline_usd REAL NOT NULL DEFAULT 0
 );
 CREATE INDEX IF NOT EXISTS idx_sessions_seen ON sessions(last_seen);
 
@@ -147,6 +148,16 @@ CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(text);
 // pre-existing sessions table, so ALTER it in before any statement referencing
 // it is prepared. Harmless (throws "duplicate column") once it already exists.
 try { db.exec("ALTER TABLE sessions ADD COLUMN provider TEXT"); } catch { /* already present */ }
+
+// Keep local pricing state separate from the authoritative cost shown to the
+// user. Existing databases predate reported per-event costs, so their current
+// total is the correct starting baseline. The backfill runs only when ALTER
+// actually adds the column; later startups leave legitimate zero baselines
+// alone.
+try {
+  db.exec("ALTER TABLE sessions ADD COLUMN pricing_baseline_usd REAL NOT NULL DEFAULT 0");
+  db.exec("UPDATE sessions SET pricing_baseline_usd = cost_usd");
+} catch { /* already present */ }
 
 // Optional idempotency key for external harnesses. Scoped to the sender and
 // session so independent agents can use the same local counter safely.
@@ -579,10 +590,12 @@ interface SessionTokenRow {
   cache_creation_tokens: number;
   cache_read_tokens: number;
   cost_usd: number;
+  pricing_baseline_usd: number;
   model_name: string | null;
 }
 const getSessionTokens = db.query<SessionTokenRow, [string]>(
-  `SELECT input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_usd, model_name
+  `SELECT input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+          cost_usd, pricing_baseline_usd, model_name
    FROM sessions WHERE session_id = ?`
 );
 
@@ -674,23 +687,17 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
     dCw = Math.max(0, dCw - prior.cache_creation_tokens);
     dCr = Math.max(0, dCr - prior.cache_read_tokens);
   }
-  // The token delta above still feeds the token counters, but its COST is priced
-  // from the transcript when we have one. cost_cumulative is the whole
-  // transcript priced per message at its own model, so charging its difference
-  // against the session's recorded cost bills a mid-run model switch at the
-  // right rates — the plain delta would put the whole thing on the current
-  // event's model. The per-turn (payload usage) path is already one model, so it
-  // keeps pricing the delta directly.
-  const eventCost =
-    n.reported_cost_usd
-    ?? (
-      n.usage_is_cumulative && n.cost_cumulative != null
-        ? Math.max(0, n.cost_cumulative - (prior?.cost_usd ?? 0))
-        : costUsd(
-            { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
-            model
-          )
-    );
+  // Track what local pricing has already accounted for separately from what
+  // the provider actually charged. Otherwise one exact reported cost changes
+  // the baseline used by the next cumulative transcript and corrupts its delta.
+  const estimatedEventCost =
+    n.usage_is_cumulative && n.cost_cumulative != null
+      ? Math.max(0, n.cost_cumulative - (prior?.pricing_baseline_usd ?? 0))
+      : costUsd(
+          { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
+          model
+        );
+  const eventCost = n.reported_cost_usd ?? estimatedEventCost;
 
   // --- latency pairing ----------------------------------------------------
   let duration_ms: number | null = null;
@@ -736,7 +743,7 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
 
     const event = parseEventRow(rowToEvent.get(inserted.id));
     try { ftsInsert.run({ $id: inserted.id, $text: ftsText({ ...n, payload: n.payload }) }); } catch { /* fts best-effort */ }
-    const session = upsertSession(n, dIn, dOut, dCw, dCr, eventCost);
+    const session = upsertSession(n, dIn, dOut, dCw, dCr, eventCost, estimatedEventCost);
     return { event, session, inserted: true };
   };
 
@@ -765,11 +772,12 @@ const upsertStmt = db.query(`
   INSERT INTO sessions (
     session_id, source_app, model_name, provider, project_path, cwd_path, started_at, ended_at, last_seen,
     event_count, tool_count, error_count,
-    input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens, cost_usd
+    input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+    cost_usd, pricing_baseline_usd
   ) VALUES (
     $sid, $src, $model, $provider, $project, $cwd, $ts, $ended, $ts,
     1, $tool, $err,
-    $in, $out, $cw, $cr, $cost
+    $in, $out, $cw, $cr, $cost, $estimated
   )
   ON CONFLICT(session_id) DO UPDATE SET
     source_app = excluded.source_app,
@@ -796,7 +804,8 @@ const upsertStmt = db.query(`
     output_tokens = sessions.output_tokens + $out,
     cache_creation_tokens = sessions.cache_creation_tokens + $cw,
     cache_read_tokens = sessions.cache_read_tokens + $cr,
-    cost_usd = sessions.cost_usd + $cost
+    cost_usd = sessions.cost_usd + $cost,
+    pricing_baseline_usd = sessions.pricing_baseline_usd + $estimated
   RETURNING *
 `);
 
@@ -806,7 +815,8 @@ function upsertSession(
   dOut: number,
   dCw: number,
   dCr: number,
-  cost: number
+  cost: number,
+  estimatedCost: number
 ): SessionRollup {
   // cost is the event's cost computed once in insertEvent (transcript-priced for
   // the cumulative path); the session total must add exactly that, not a second,
@@ -832,6 +842,7 @@ function upsertSession(
     $cw: dCw,
     $cr: dCr,
     $cost: cost,
+    $estimated: estimatedCost,
   }) as SessionRollup;
   return row;
 }
@@ -1049,7 +1060,11 @@ export function getSessions(limit = 100, provider?: string): SessionRollup[] {
     .query<SessionRollup, any[]>(
       `SELECT * FROM sessions WHERE 1=1${prov.clause}${s.clause} ORDER BY last_seen DESC LIMIT ?`
     )
-    .all(...prov.args, ...s.args, limit);
+    .all(...prov.args, ...s.args, limit)
+    .map((row) => {
+      const { pricing_baseline_usd: _internal, ...session } = row as SessionRollup & { pricing_baseline_usd: number };
+      return session;
+    });
   sessionsCache.set(key, { at: Date.now(), data });
   // One entry per (limit, provider, scope); the limit set is tiny and scope
   // rarely changes, so prune stale entries anyway so a long-lived server cannot

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -151,13 +151,18 @@ try { db.exec("ALTER TABLE sessions ADD COLUMN provider TEXT"); } catch { /* alr
 
 // Keep local pricing state separate from the authoritative cost shown to the
 // user. Existing databases predate reported per-event costs, so their current
-// total is the correct starting baseline. The backfill runs only when ALTER
-// actually adds the column; later startups leave legitimate zero baselines
-// alone.
-try {
-  db.exec("ALTER TABLE sessions ADD COLUMN pricing_baseline_usd REAL NOT NULL DEFAULT 0");
-  db.exec("UPDATE sessions SET pricing_baseline_usd = cost_usd");
-} catch { /* already present */ }
+// total is the correct starting baseline. ALTER and backfill are one transaction:
+// a crash cannot leave the column present with every old baseline still zero.
+const hasPricingBaseline = db
+  .query<{ name: string }, []>("PRAGMA table_info(sessions)")
+  .all()
+  .some((column) => column.name === "pricing_baseline_usd");
+if (!hasPricingBaseline) {
+  db.transaction(() => {
+    db.exec("ALTER TABLE sessions ADD COLUMN pricing_baseline_usd REAL NOT NULL DEFAULT 0");
+    db.exec("UPDATE sessions SET pricing_baseline_usd = cost_usd");
+  })();
+}
 
 // Optional idempotency key for external harnesses. Scoped to the sender and
 // session so independent agents can use the same local counter safely.
@@ -603,13 +608,18 @@ const rowToEvent = db.query<any, [number]>(`SELECT * FROM events WHERE id = ?`);
 const eventByExternalId = db.query<any, [string, string, string]>(
   `SELECT * FROM events WHERE source_app = ? AND session_id = ? AND event_id = ? LIMIT 1`
 );
-const sessionById = db.query<SessionRollup, [string]>(`SELECT * FROM sessions WHERE session_id = ?`);
+const sessionById = db.query<Record<string, unknown>, [string]>(`SELECT * FROM sessions WHERE session_id = ?`);
 
 function parseEventRow(r: any): WatchEvent {
   return {
     ...r,
     payload: safeJson(r.payload),
   } as WatchEvent;
+}
+
+function parseSessionRow(r: Record<string, unknown>): SessionRollup {
+  const { pricing_baseline_usd: _internal, ...session } = r;
+  return session as unknown as SessionRollup;
 }
 
 function safeJson(s: string): Record<string, unknown> {
@@ -659,9 +669,9 @@ export interface InsertResult {
 
 function duplicateResult(row: any): InsertResult {
   const event = parseEventRow(row);
-  const session = sessionById.get(event.session_id);
-  if (!session) throw new Error(`event ${event.id} exists without session ${event.session_id}`);
-  return { event, session, inserted: false };
+  const sessionRow = sessionById.get(event.session_id);
+  if (!sessionRow) throw new Error(`event ${event.id} exists without session ${event.session_id}`);
+  return { event, session: parseSessionRow(sessionRow), inserted: false };
 }
 
 /**
@@ -843,8 +853,8 @@ function upsertSession(
     $cr: dCr,
     $cost: cost,
     $estimated: estimatedCost,
-  }) as SessionRollup;
-  return row;
+  }) as Record<string, unknown>;
+  return parseSessionRow(row);
 }
 
 // ---------------------------------------------------------------------------
@@ -1057,14 +1067,11 @@ export function getSessions(limit = 100, provider?: string): SessionRollup[] {
       ? { clause: " AND session_id IN (SELECT session_id FROM events WHERE provider IS NULL)", args: [] as string[] }
       : { clause: " AND session_id IN (SELECT session_id FROM events WHERE provider = ?)", args: [provider] };
   const data = db
-    .query<SessionRollup, any[]>(
+    .query<Record<string, unknown>, any[]>(
       `SELECT * FROM sessions WHERE 1=1${prov.clause}${s.clause} ORDER BY last_seen DESC LIMIT ?`
     )
     .all(...prov.args, ...s.args, limit)
-    .map((row) => {
-      const { pricing_baseline_usd: _internal, ...session } = row as SessionRollup & { pricing_baseline_usd: number };
-      return session;
-    });
+    .map(parseSessionRow);
   sessionsCache.set(key, { at: Date.now(), data });
   // One entry per (limit, provider, scope); the limit set is tiny and scope
   // rarely changes, so prune stale entries anyway so a long-lived server cannot

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -93,6 +93,7 @@ CREATE TABLE IF NOT EXISTS events (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   source_app TEXT NOT NULL,
   session_id TEXT NOT NULL,
+  event_id TEXT,
   hook_event_type TEXT NOT NULL,
   tool_name TEXT,
   tool_use_id TEXT,
@@ -146,6 +147,15 @@ CREATE VIRTUAL TABLE IF NOT EXISTS events_fts USING fts5(text);
 // pre-existing sessions table, so ALTER it in before any statement referencing
 // it is prepared. Harmless (throws "duplicate column") once it already exists.
 try { db.exec("ALTER TABLE sessions ADD COLUMN provider TEXT"); } catch { /* already present */ }
+
+// Optional idempotency key for external harnesses. Scoped to the sender and
+// session so independent agents can use the same local counter safely.
+try { db.exec("ALTER TABLE events ADD COLUMN event_id TEXT"); } catch { /* already present */ }
+db.exec(`
+  CREATE UNIQUE INDEX IF NOT EXISTS idx_events_ingest_idempotency
+  ON events(source_app, session_id, event_id)
+  WHERE event_id IS NOT NULL
+`);
 
 // What this session is *called*. Claude Code writes both into the transcript:
 // `custom-title` when you rename a session by hand, `ai-title` for the one it
@@ -534,16 +544,19 @@ const ftsInsert = db.query("INSERT INTO events_fts(rowid, text) VALUES ($id, $te
 
 const insertStmt = db.query(`
   INSERT INTO events (
-    source_app, session_id, hook_event_type, tool_name, tool_use_id,
+    source_app, session_id, event_id, hook_event_type, tool_name, tool_use_id,
     agent_id, agent_type, model_name, provider, is_error, error_text, duration_ms,
     input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
     cost_usd, summary, payload, timestamp
   ) VALUES (
-    $source_app, $session_id, $hook_event_type, $tool_name, $tool_use_id,
+    $source_app, $session_id, $event_id, $hook_event_type, $tool_name, $tool_use_id,
     $agent_id, $agent_type, $model_name, $provider, $is_error, $error_text, $duration_ms,
     $input_tokens, $output_tokens, $cache_creation_tokens, $cache_read_tokens,
     $cost_usd, $summary, $payload, $timestamp
-  ) RETURNING id
+  )
+  ON CONFLICT(source_app, session_id, event_id) WHERE event_id IS NOT NULL
+  DO NOTHING
+  RETURNING id
 `);
 
 // Find the matching PreToolUse for a Post event: by tool_use_id when present,
@@ -574,6 +587,10 @@ const getSessionTokens = db.query<SessionTokenRow, [string]>(
 );
 
 const rowToEvent = db.query<any, [number]>(`SELECT * FROM events WHERE id = ?`);
+const eventByExternalId = db.query<any, [string, string, string]>(
+  `SELECT * FROM events WHERE source_app = ? AND session_id = ? AND event_id = ? LIMIT 1`
+);
+const sessionById = db.query<SessionRollup, [string]>(`SELECT * FROM sessions WHERE session_id = ?`);
 
 function parseEventRow(r: any): WatchEvent {
   return {
@@ -624,6 +641,14 @@ export function pruneOldRows(): { events: number; sessions: number } {
 export interface InsertResult {
   event: WatchEvent;
   session: SessionRollup;
+  inserted: boolean;
+}
+
+function duplicateResult(row: any): InsertResult {
+  const event = parseEventRow(row);
+  const session = sessionById.get(event.session_id);
+  if (!session) throw new Error(`event ${event.id} exists without session ${event.session_id}`);
+  return { event, session, inserted: false };
 }
 
 /**
@@ -634,11 +659,6 @@ export interface InsertResult {
  */
 export function insertEvent(n: NormalizedEvent): InsertResult {
   const model = n.model_name;
-  // A path nobody has recorded before means the scope set is stale — a new
-  // worktree must appear in a scoped dashboard on its first event, not on the
-  // first event after a cache expiry.
-  notePath(n.payload?.project_path);
-  notePath((n.payload as { cwd?: unknown } | undefined)?.cwd);
 
   // --- token delta computation -------------------------------------------
   let dIn = n.usage.input_tokens ?? 0;
@@ -662,12 +682,15 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
   // event's model. The per-turn (payload usage) path is already one model, so it
   // keeps pricing the delta directly.
   const eventCost =
-    n.usage_is_cumulative && n.cost_cumulative != null
-      ? Math.max(0, n.cost_cumulative - (prior?.cost_usd ?? 0))
-      : costUsd(
-          { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
-          model
-        );
+    n.reported_cost_usd
+    ?? (
+      n.usage_is_cumulative && n.cost_cumulative != null
+        ? Math.max(0, n.cost_cumulative - (prior?.cost_usd ?? 0))
+        : costUsd(
+            { input_tokens: dIn, output_tokens: dOut, cache_creation_tokens: dCw, cache_read_tokens: dCr },
+            model
+          )
+    );
 
   // --- latency pairing ----------------------------------------------------
   let duration_ms: number | null = null;
@@ -678,39 +701,64 @@ export function insertEvent(n: NormalizedEvent): InsertResult {
     if (pre) duration_ms = Math.max(0, n.timestamp - pre.timestamp);
   }
 
-  const { id } = insertStmt.get({
-    $source_app: n.source_app,
-    $session_id: n.session_id,
-    $hook_event_type: n.hook_event_type,
-    $tool_name: n.tool_name,
-    $tool_use_id: n.tool_use_id,
-    $agent_id: n.agent_id,
-    $agent_type: n.agent_type,
-    $model_name: model,
-    $provider: providerOf(model),
-    $is_error: n.is_error,
-    $error_text: n.error_text,
-    $duration_ms: duration_ms,
-    $input_tokens: dIn,
-    $output_tokens: dOut,
-    $cache_creation_tokens: dCw,
-    $cache_read_tokens: dCr,
-    $cost_usd: eventCost,
-    $summary: n.summary,
-    $payload: JSON.stringify(n.payload ?? {}),
-    $timestamp: n.timestamp,
-  }) as { id: number };
+  const write = (): InsertResult => {
+    const inserted = insertStmt.get({
+      $source_app: n.source_app,
+      $session_id: n.session_id,
+      $event_id: n.event_id,
+      $hook_event_type: n.hook_event_type,
+      $tool_name: n.tool_name,
+      $tool_use_id: n.tool_use_id,
+      $agent_id: n.agent_id,
+      $agent_type: n.agent_type,
+      $model_name: model,
+      $provider: providerOf(model),
+      $is_error: n.is_error,
+      $error_text: n.error_text,
+      $duration_ms: duration_ms,
+      $input_tokens: dIn,
+      $output_tokens: dOut,
+      $cache_creation_tokens: dCw,
+      $cache_read_tokens: dCr,
+      $cost_usd: eventCost,
+      $summary: n.summary,
+      $payload: JSON.stringify(n.payload ?? {}),
+      $timestamp: n.timestamp,
+    }) as { id: number } | null;
 
-  const event = parseEventRow(rowToEvent.get(id));
-  try { ftsInsert.run({ $id: id, $text: ftsText({ ...n, payload: n.payload }) }); } catch { /* fts best-effort */ }
-  const session = upsertSession(n, dIn, dOut, dCw, dCr, eventCost);
+    if (!inserted) {
+      const existing = n.event_id
+        ? eventByExternalId.get(n.source_app, n.session_id, n.event_id)
+        : null;
+      if (!existing) throw new Error("event insert returned no row");
+      return duplicateResult(existing);
+    }
+
+    const event = parseEventRow(rowToEvent.get(inserted.id));
+    try { ftsInsert.run({ $id: inserted.id, $text: ftsText({ ...n, payload: n.payload }) }); } catch { /* fts best-effort */ }
+    const session = upsertSession(n, dIn, dOut, dCw, dCr, eventCost);
+    return { event, session, inserted: true };
+  };
+
+  // A retry key makes the event row and its session rollup one atomic write.
+  // Existing no-key scanner/hook events keep their original fast path.
+  const result = n.event_id !== null ? db.transaction(write)() : write();
+  if (!result.inserted) return result;
+  const { event } = result;
+
+  // A path nobody has recorded before means the scope set is stale — a new
+  // worktree must appear in a scoped dashboard on its first event, not on the
+  // first event after a cache expiry. This stays after the successful insert so
+  // an idempotent retry has no cache side effects.
+  notePath(n.payload?.project_path);
+  notePath((n.payload as { cwd?: unknown } | undefined)?.cwd);
   // A Pre opens a call and a Post closes one, so the open-tool memo the fleet
   // draws from just went stale. Drop it here, the single write chokepoint, so
   // the next read — the push that fires right after this returns — is fresh,
   // while an idle machine with no tool traffic never invalidates and so never
   // re-runs that scoped scan on the tick.
   if (n.hook_event_type === "PreToolUse" || isToolPost(n.hook_event_type)) invalidateOpenTools();
-  return { event, session };
+  return result;
 }
 
 const upsertStmt = db.query(`

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -559,9 +559,6 @@ const server = Bun.serve<WsData>({
       } catch {
         return json({ error: "invalid json" }, 400);
       }
-      if (!body?.source_app || !body?.session_id || !body?.hook_event_type) {
-        return json({ error: "source_app, session_id, hook_event_type required" }, 400);
-      }
       const ingestError = externalIngestError(body);
       if (ingestError) return json({ error: ingestError }, 400);
       // A Claude Code session with a transcript on disk is already covered by

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,6 +1,6 @@
 import type { ServerWebSocket } from "bun";
 import type { IngestBody, WsFrame, WorkingTree } from "../../shared/types.ts";
-import { normalize, detectError, clampIngestTimestamp } from "./ingest.ts";
+import { normalize, detectError, clampIngestTimestamp, externalIngestError } from "./ingest.ts";
 import { db } from "./db.ts";
 import {
   insertEvent,
@@ -394,7 +394,11 @@ function ingestBody(body: IngestBody) {
   // Live seam only: a skewed sender's clock must not decide which time window
   // its events land in. Backfill inserts elsewhere and keeps its real times.
   n.timestamp = clampIngestTimestamp(n.timestamp, Date.now());
-  const { event, session } = insertEvent(n);
+  const result = insertEvent(n);
+  // A retry returns the first event. Nothing downstream should run twice:
+  // no cache invalidation, WebSocket frame, open-tool push, or alert.
+  if (!result.inserted) return result;
+  const { event, session } = result;
   // The session just grew, so its cached detail is stale — drop it so a live
   // session refreshes on the next open, while static sessions keep serving from
   // cache. Cheap: one Map delete on a path already doing a DB write.
@@ -406,7 +410,7 @@ function ingestBody(body: IngestBody) {
   // moment a tool starts is exactly when the card should say so.
   if (event.hook_event_type === "PreToolUse" || event.hook_event_type.startsWith("PostToolUse")) pushOpenTools();
   maybeAlert(event);
-  return event;
+  return result;
 }
 
 function csvEscape(v: unknown): string {
@@ -558,12 +562,18 @@ const server = Bun.serve<WsData>({
       if (!body?.source_app || !body?.session_id || !body?.hook_event_type) {
         return json({ error: "source_app, session_id, hook_event_type required" }, 400);
       }
+      const ingestError = externalIngestError(body);
+      if (ingestError) return json({ error: ingestError }, 400);
       // A Claude Code session with a transcript on disk is already covered by
       // the scanner, which reads the same turns in richer form. Taking the hook
       // copy too would count every tool call and every token twice.
       if (ownsSession(body.session_id)) return json({ ok: true, skipped: "scanner owns this session" });
-      const event = ingestBody(body);
-      return json({ ok: true, id: event.id });
+      const result = ingestBody(body);
+      return json({
+        ok: true,
+        id: result.event.id,
+        ...(!result.inserted ? { duplicate: true } : {}),
+      });
     }
 
     // --- OpenTelemetry OTLP/HTTP (JSON) trace receiver ---

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -2,6 +2,9 @@
 import type { IngestBody } from "../../shared/types.ts";
 import { costUsd, type TokenUsage } from "./pricing.ts";
 
+const MAX_FIELD = 64 * 1024;
+export const MAX_REPORTED_COST_USD = 100_000;
+
 export interface NormalizedEvent {
   source_app: string;
   session_id: string;
@@ -41,18 +44,33 @@ function str(v: unknown): string | null {
   return typeof v === "string" && v.length ? v : null;
 }
 
-/** Validate optional fields that only the public POST /ingest boundary accepts. */
-export function externalIngestError(body: IngestBody): string | null {
-  const eventId = (body as { event_id?: unknown }).event_id;
+/** Validate fields that only the public POST /ingest boundary accepts. */
+export function externalIngestError(body: unknown): string | null {
+  if (!body || typeof body !== "object" || Array.isArray(body)) {
+    return "request body must be an object";
+  }
+  const fields = body as Record<string, unknown>;
+  for (const name of ["source_app", "session_id", "hook_event_type"] as const) {
+    const value = fields[name];
+    if (typeof value !== "string" || value.length === 0 || value.length > MAX_FIELD) {
+      return `${name} must be a non-empty string no longer than ${MAX_FIELD} characters`;
+    }
+  }
+  const eventId = fields.event_id;
   if (eventId !== undefined && (typeof eventId !== "string" || eventId.length === 0 || eventId.length > 512)) {
     return "event_id must be a non-empty string no longer than 512 characters";
   }
-  const reportedCost = (body as { reported_cost_usd?: unknown }).reported_cost_usd;
+  const reportedCost = fields.reported_cost_usd;
   if (
     reportedCost !== undefined
-    && (typeof reportedCost !== "number" || !Number.isFinite(reportedCost) || reportedCost < 0)
+    && (
+      typeof reportedCost !== "number"
+      || !Number.isFinite(reportedCost)
+      || reportedCost < 0
+      || reportedCost > MAX_REPORTED_COST_USD
+    )
   ) {
-    return "reported_cost_usd must be a finite non-negative number";
+    return `reported_cost_usd must be a finite number from 0 to ${MAX_REPORTED_COST_USD}`;
   }
   return null;
 }
@@ -202,7 +220,6 @@ export function sumTranscriptCost(chat: unknown[] | undefined, fallbackModel: st
   return cost;
 }
 
-const MAX_FIELD = 64 * 1024;
 // Deep enough for the nested shapes hooks actually send (tool_input.content,
 // tool_response.stdout, a chat turn's content blocks) without letting a
 // pathological payload recurse without end.

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -5,6 +5,7 @@ import { costUsd, type TokenUsage } from "./pricing.ts";
 export interface NormalizedEvent {
   source_app: string;
   session_id: string;
+  event_id: string | null;
   hook_event_type: string;
   tool_name: string | null;
   tool_use_id: string | null;
@@ -28,6 +29,8 @@ export interface NormalizedEvent {
    * right rates rather than the whole delta at the current model. Null otherwise.
    */
   cost_cumulative: number | null;
+  /** Sender-authoritative per-event cost; null falls back to local pricing. */
+  reported_cost_usd: number | null;
   summary: string | null;
   timestamp: number;
   payload: Record<string, unknown>;
@@ -36,6 +39,22 @@ export interface NormalizedEvent {
 
 function str(v: unknown): string | null {
   return typeof v === "string" && v.length ? v : null;
+}
+
+/** Validate optional fields that only the public POST /ingest boundary accepts. */
+export function externalIngestError(body: IngestBody): string | null {
+  const eventId = (body as { event_id?: unknown }).event_id;
+  if (eventId !== undefined && (typeof eventId !== "string" || eventId.length === 0 || eventId.length > 512)) {
+    return "event_id must be a non-empty string no longer than 512 characters";
+  }
+  const reportedCost = (body as { reported_cost_usd?: unknown }).reported_cost_usd;
+  if (
+    reportedCost !== undefined
+    && (typeof reportedCost !== "number" || !Number.isFinite(reportedCost) || reportedCost < 0)
+  ) {
+    return "reported_cost_usd must be a finite non-negative number";
+  }
+  return null;
 }
 
 /** Read a nested key from an object safely. */
@@ -295,6 +314,7 @@ export function normalize(body: IngestBody): NormalizedEvent {
   return {
     source_app: capField(String(body.source_app ?? "unknown")),
     session_id: capField(String(body.session_id ?? "unknown")),
+    event_id: typeof body.event_id === "string" ? body.event_id : null,
     hook_event_type: capField(type),
     tool_name: capField(tool_name),
     tool_use_id: capField(tool_use_id),
@@ -308,6 +328,7 @@ export function normalize(body: IngestBody): NormalizedEvent {
     // Only the cumulative (transcript-summed) path can span models; the per-turn
     // payload path is already one turn at one model, so it prices as before.
     cost_cumulative: hasPayloadUsage ? null : sumTranscriptCost(chat ?? undefined, model_name),
+    reported_cost_usd: typeof body.reported_cost_usd === "number" ? body.reported_cost_usd : null,
     summary: capField(str(body.summary)),
     timestamp: typeof body.timestamp === "number" ? body.timestamp : Date.now(),
     payload,

--- a/server/src/otlp.ts
+++ b/server/src/otlp.ts
@@ -218,7 +218,8 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
   const a = flatten(rec.attributes);
   const isGenAI =
     Object.keys(a).some((k) => k.startsWith("gen_ai.") || k.startsWith("codex.") || k.startsWith("llm.")) ||
-    a["gen_ai.system"] !== undefined || a["event.name"] !== undefined || rec.eventName !== undefined;
+    a["gen_ai.system"] !== undefined || a["event.name"] !== undefined
+    || a["event.kind"] !== undefined || rec.eventName !== undefined;
   if (!isGenAI) return null;
 
   const system = firstStr(a, ["gen_ai.system", "gen_ai.provider.name"]);
@@ -229,14 +230,37 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
   );
   const ms = nanoToMs(rec.timeUnixNano) ?? nanoToMs(rec.observedTimeUnixNano) ?? Date.now();
   const isError = typeof rec.severityNumber === "number" && rec.severityNumber >= 17; // ERROR range
-  const eventName = String(a["event.name"] ?? rec.eventName ?? "").toLowerCase();
+  const eventName = String(a["event.name"] ?? a["event.kind"] ?? rec.eventName ?? "").toLowerCase();
   const bodyText = bodyToString(rec.body);
   const base = { source_app, session_id, model_name: model, timestamp: ms } as const;
 
   const toolName = firstStr(a, ["gen_ai.tool.name", "tool.name", "tool_name"]);
   const toolCallId = firstStr(a, ["gen_ai.tool.call.id", "tool.call.id", "tool_call_id", "call_id"]);
-  const input = firstNum(a, ["gen_ai.usage.input_tokens", "gen_ai.usage.prompt_tokens", "input_tokens", "prompt_tokens"]);
-  const output = firstNum(a, ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens", "output_tokens", "completion_tokens"]);
+  const cacheRead = firstNum(a, [
+    "gen_ai.usage.cache_read_input_tokens",
+    "gen_ai.usage.cache_read_tokens",
+    "cached_token_count",
+  ]);
+  const cacheCreation = firstNum(a, [
+    "gen_ai.usage.cache_creation_input_tokens",
+    "gen_ai.usage.cache_creation_tokens",
+    "cache_write_token_count",
+  ]);
+  // Codex reports input_token_count as the whole input, including cache reads
+  // and writes. Agentglass stores those buckets separately, so subtract them
+  // only for that Codex-specific field. Standard gen_ai input is already the
+  // non-cached bucket and keeps its existing semantics.
+  const codexInput = a["input_token_count"] !== undefined;
+  const input = codexInput
+    ? Math.max(0, firstNum(a, ["input_token_count"]) - cacheRead - cacheCreation)
+    : firstNum(a, ["gen_ai.usage.input_tokens", "gen_ai.usage.prompt_tokens", "input_tokens", "prompt_tokens"]);
+  const output = firstNum(a, [
+    "gen_ai.usage.output_tokens",
+    "gen_ai.usage.completion_tokens",
+    "output_token_count",
+    "output_tokens",
+    "completion_tokens",
+  ]);
 
   // Tool decision/result → a tool event (Pre if a call, else Post so it counts).
   if (toolName || eventName.includes("tool")) {
@@ -255,8 +279,8 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
         usage: {
           input_tokens: input,
           output_tokens: output,
-          cache_read_tokens: firstNum(a, ["gen_ai.usage.cache_read_input_tokens", "gen_ai.usage.cache_read_tokens"]),
-          cache_creation_tokens: firstNum(a, ["gen_ai.usage.cache_creation_input_tokens", "gen_ai.usage.cache_creation_tokens"]),
+          cache_read_tokens: cacheRead,
+          cache_creation_tokens: cacheCreation,
         },
         gen_ai_system: system,
         event: eventName || undefined,

--- a/server/src/otlp.ts
+++ b/server/src/otlp.ts
@@ -95,6 +95,42 @@ const LLM_OPS = new Set(["chat", "text_completion", "completion", "generate_cont
 // because index.ts must stay out of this batch's shape.
 export const MAX_OTLP_EVENTS_PER_REQUEST = 10_000;
 
+function tokenUsageFromAttributes(a: Record<string, unknown>) {
+  const cacheRead = firstNum(a, [
+    "gen_ai.usage.cache_read.input_tokens",
+    "gen_ai.usage.cache_read_input_tokens",
+    "gen_ai.usage.cache_read_tokens",
+    "cached_token_count",
+  ]);
+  const cacheCreation = firstNum(a, [
+    "gen_ai.usage.cache_creation.input_tokens",
+    "gen_ai.usage.cache_creation_input_tokens",
+    "gen_ai.usage.cache_creation_tokens",
+    "cache_write_token_count",
+  ]);
+  const totalInput = firstNum(a, [
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.prompt_tokens",
+    "input_token_count",
+    "input_tokens",
+    "prompt_tokens",
+    "llm.usage.prompt_tokens",
+  ]);
+  return {
+    input_tokens: Math.max(0, totalInput - cacheRead - cacheCreation),
+    output_tokens: firstNum(a, [
+      "gen_ai.usage.output_tokens",
+      "gen_ai.usage.completion_tokens",
+      "output_token_count",
+      "output_tokens",
+      "completion_tokens",
+      "llm.usage.completion_tokens",
+    ]),
+    cache_read_tokens: cacheRead,
+    cache_creation_tokens: cacheCreation,
+  };
+}
+
 function spanToEvents(span: OtlpSpan, resAttrs: Record<string, unknown>): IngestBody[] {
   const a = flatten(span.attributes);
   const isGenAI =
@@ -131,12 +167,7 @@ function spanToEvents(span: OtlpSpan, resAttrs: Record<string, unknown>): Ingest
   }
 
   // LLM inference — one event carrying per-call token usage.
-  const usage = {
-    input_tokens: firstNum(a, ["gen_ai.usage.input_tokens", "gen_ai.usage.prompt_tokens", "llm.usage.prompt_tokens"]),
-    output_tokens: firstNum(a, ["gen_ai.usage.output_tokens", "gen_ai.usage.completion_tokens", "llm.usage.completion_tokens"]),
-    cache_read_tokens: firstNum(a, ["gen_ai.usage.cache_read_input_tokens", "gen_ai.usage.cache_read_tokens"]),
-    cache_creation_tokens: firstNum(a, ["gen_ai.usage.cache_creation_input_tokens", "gen_ai.usage.cache_creation_tokens"]),
-  };
+  const usage = tokenUsageFromAttributes(a);
   return [
     {
       ...base,
@@ -242,34 +273,14 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
 
   const toolName = firstStr(a, ["gen_ai.tool.name", "tool.name", "tool_name"]);
   const toolCallId = firstStr(a, ["gen_ai.tool.call.id", "tool.call.id", "tool_call_id", "call_id"]);
-  const cacheRead = firstNum(a, [
-    "gen_ai.usage.cache_read_input_tokens",
-    "gen_ai.usage.cache_read_tokens",
-    "cached_token_count",
-  ]);
-  const cacheCreation = firstNum(a, [
-    "gen_ai.usage.cache_creation_input_tokens",
-    "gen_ai.usage.cache_creation_tokens",
-    "cache_write_token_count",
-  ]);
   // Both Codex and the OpenTelemetry GenAI conventions report total input
-  // including cached tokens. Agentglass stores cache reads/writes separately,
-  // so remove both buckets from ordinary input to avoid charging them twice.
-  const totalInput = firstNum(a, [
-    "gen_ai.usage.input_tokens",
-    "gen_ai.usage.prompt_tokens",
-    "input_token_count",
-    "input_tokens",
-    "prompt_tokens",
-  ]);
-  const input = Math.max(0, totalInput - cacheRead - cacheCreation);
-  const output = firstNum(a, [
-    "gen_ai.usage.output_tokens",
-    "gen_ai.usage.completion_tokens",
-    "output_token_count",
-    "output_tokens",
-    "completion_tokens",
-  ]);
+  // including cached tokens. The shared mapper keeps traces and logs on the
+  // same official semantics and stores cached input in its own buckets.
+  const usage = tokenUsageFromAttributes(a);
+  const input = usage.input_tokens;
+  const output = usage.output_tokens;
+  const cacheRead = usage.cache_read_tokens;
+  const cacheCreation = usage.cache_creation_tokens;
 
   // Tool decision/result → a tool event (Pre if a call, else Post so it counts).
   if (toolName || eventName.includes("tool")) {
@@ -285,12 +296,7 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
       ...base,
       hook_event_type: "Turn complete",
       payload: {
-        usage: {
-          input_tokens: input,
-          output_tokens: output,
-          cache_read_tokens: cacheRead,
-          cache_creation_tokens: cacheCreation,
-        },
+        usage,
         gen_ai_system: system,
         event: eventName || undefined,
         ...(isError ? { is_error: true, error: bodyText } : {}),

--- a/server/src/otlp.ts
+++ b/server/src/otlp.ts
@@ -216,10 +216,16 @@ function bodyToString(body: AnyVal | undefined): string {
 
 function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>): IngestBody | null {
   const a = flatten(rec.attributes);
+  const serviceName = String(resAttrs["service.name"] ?? "").toLowerCase();
+  const hasCodexEvidence =
+    serviceName.includes("codex")
+    || Object.keys(a).some((k) => k.startsWith("codex."))
+    || ["input_token_count", "output_token_count", "cached_token_count", "cache_write_token_count"]
+      .some((k) => a[k] !== undefined);
   const isGenAI =
     Object.keys(a).some((k) => k.startsWith("gen_ai.") || k.startsWith("codex.") || k.startsWith("llm.")) ||
     a["gen_ai.system"] !== undefined || a["event.name"] !== undefined
-    || a["event.kind"] !== undefined || rec.eventName !== undefined;
+    || (a["event.kind"] !== undefined && hasCodexEvidence) || rec.eventName !== undefined;
   if (!isGenAI) return null;
 
   const system = firstStr(a, ["gen_ai.system", "gen_ai.provider.name"]);
@@ -246,14 +252,17 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
     "gen_ai.usage.cache_creation_tokens",
     "cache_write_token_count",
   ]);
-  // Codex reports input_token_count as the whole input, including cache reads
-  // and writes. Agentglass stores those buckets separately, so subtract them
-  // only for that Codex-specific field. Standard gen_ai input is already the
-  // non-cached bucket and keeps its existing semantics.
-  const codexInput = a["input_token_count"] !== undefined;
-  const input = codexInput
-    ? Math.max(0, firstNum(a, ["input_token_count"]) - cacheRead - cacheCreation)
-    : firstNum(a, ["gen_ai.usage.input_tokens", "gen_ai.usage.prompt_tokens", "input_tokens", "prompt_tokens"]);
+  // Both Codex and the OpenTelemetry GenAI conventions report total input
+  // including cached tokens. Agentglass stores cache reads/writes separately,
+  // so remove both buckets from ordinary input to avoid charging them twice.
+  const totalInput = firstNum(a, [
+    "gen_ai.usage.input_tokens",
+    "gen_ai.usage.prompt_tokens",
+    "input_token_count",
+    "input_tokens",
+    "prompt_tokens",
+  ]);
+  const input = Math.max(0, totalInput - cacheRead - cacheCreation);
   const output = firstNum(a, [
     "gen_ai.usage.output_tokens",
     "gen_ai.usage.completion_tokens",
@@ -271,7 +280,7 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
     return { ...base, hook_event_type: "PostToolUse", payload: { tool_name, tool_use_id, ...(isError ? { is_error: true, error: bodyText } : {}) } };
   }
   // Token-bearing record → a costed turn.
-  if (input + output > 0) {
+  if (input + output + cacheRead + cacheCreation > 0) {
     return {
       ...base,
       hook_event_type: "Turn complete",

--- a/server/test/db-pricing-baseline-migration.test.ts
+++ b/server/test/db-pricing-baseline-migration.test.ts
@@ -1,0 +1,61 @@
+// The pricing baseline was added after sessions already existed in the wild.
+// Start a fresh Bun process on the old schema so this test exercises module-load
+// migration exactly as an upgraded installation does.
+import { expect, test } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { pathToFileURL } from "node:url";
+
+test("backfills an existing session's pricing baseline during migration", () => {
+  const dir = mkdtempSync(join(tmpdir(), "agx-pricing-migration-"));
+  const dbPath = join(dir, "legacy.db");
+  const legacy = new Database(dbPath, { create: true });
+  legacy.exec(`
+    CREATE TABLE sessions (
+      session_id TEXT PRIMARY KEY,
+      source_app TEXT NOT NULL,
+      model_name TEXT,
+      provider TEXT,
+      started_at INTEGER NOT NULL,
+      ended_at INTEGER,
+      last_seen INTEGER NOT NULL,
+      event_count INTEGER NOT NULL DEFAULT 0,
+      tool_count INTEGER NOT NULL DEFAULT 0,
+      error_count INTEGER NOT NULL DEFAULT 0,
+      input_tokens INTEGER NOT NULL DEFAULT 0,
+      output_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+      cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+      cost_usd REAL NOT NULL DEFAULT 0
+    );
+    INSERT INTO sessions (
+      session_id, source_app, started_at, last_seen, cost_usd
+    ) VALUES ('legacy-session', 'claude-code', 1, 1, 1.2345);
+  `);
+  legacy.close();
+
+  const moduleUrl = pathToFileURL(join(import.meta.dir, "..", "src", "db.ts")).href;
+  const script = `
+    process.env.NODE_ENV = "production";
+    process.env.AGENTGLASS_DB = ${JSON.stringify(dbPath)};
+    process.env.AGENTGLASS_ROOT = ${JSON.stringify(dir)};
+    process.env.XDG_CONFIG_HOME = ${JSON.stringify(dir)};
+    const { db } = await import(${JSON.stringify(moduleUrl)});
+    const row = db.query("SELECT cost_usd, pricing_baseline_usd FROM sessions WHERE session_id = 'legacy-session'").get();
+    process.stdout.write(JSON.stringify(row));
+    db.close();
+  `;
+  const child = Bun.spawnSync([process.execPath, "--eval", script], {
+    cwd: join(import.meta.dir, ".."),
+    stdout: "pipe",
+    stderr: "pipe",
+  });
+
+  expect(child.exitCode).toBe(0);
+  expect(JSON.parse(child.stdout.toString())).toEqual({
+    cost_usd: 1.2345,
+    pricing_baseline_usd: 1.2345,
+  });
+});

--- a/server/test/ingest-reliability.test.ts
+++ b/server/test/ingest-reliability.test.ts
@@ -40,11 +40,18 @@ describe("external ingest extensions", () => {
   });
 
   test("rejects malformed ids and costs at the HTTP boundary", () => {
+    expect(ingest.externalIngestError(null)).toContain("object");
+    expect(ingest.externalIngestError(body({ source_app: ["external-harness"] }) as any)).toContain("source_app");
+    expect(ingest.externalIngestError(body({ session_id: "x".repeat(64 * 1024 + 1) }) as any)).toContain("session_id");
+    expect(ingest.externalIngestError(body({ hook_event_type: {} }) as any)).toContain("hook_event_type");
     expect(ingest.externalIngestError(body({ event_id: "" }) as any)).toContain("event_id");
     expect(ingest.externalIngestError(body({ event_id: "x".repeat(513) }) as any)).toContain("event_id");
     expect(ingest.externalIngestError(body({ event_id: 42 }) as any)).toContain("event_id");
     expect(ingest.externalIngestError(body({ reported_cost_usd: -1 }) as any)).toContain("reported_cost_usd");
     expect(ingest.externalIngestError(body({ reported_cost_usd: Infinity }) as any)).toContain("reported_cost_usd");
+    expect(ingest.externalIngestError(body({ reported_cost_usd: ingest.MAX_REPORTED_COST_USD }) as any)).toBeNull();
+    expect(ingest.externalIngestError(body({ reported_cost_usd: ingest.MAX_REPORTED_COST_USD + 1 }) as any)).toContain("reported_cost_usd");
+    expect(ingest.externalIngestError(body({ reported_cost_usd: Number.MAX_VALUE }) as any)).toContain("reported_cost_usd");
     expect(ingest.externalIngestError(body({ reported_cost_usd: "0.12" }) as any)).toContain("reported_cost_usd");
   });
 });
@@ -138,5 +145,33 @@ describe("reported cost precedence", () => {
     expect(exact.session.input_tokens).toBe(2_000);
     expect(exact.session.output_tokens).toBe(200);
     expect(exact.session.cost_usd).toBeCloseTo(0.456789, 10);
+  });
+
+  test("keeps cumulative local pricing independent from earlier reported costs", () => {
+    const firstBody = body({
+      event_id: "mixed-cost-reported",
+      session_id: "mixed-cost-session",
+      reported_cost_usd: 7,
+    });
+    const first = db.insertEvent(ingest.normalize(firstBody as any));
+    const second = db.insertEvent(ingest.normalize({
+      ...firstBody,
+      event_id: "mixed-cost-cumulative",
+      reported_cost_usd: undefined,
+      payload: { project_path: root, message: "cumulative follow-up" },
+      chat: [{
+        type: "assistant",
+        message: {
+          model: "gpt-5.1",
+          usage: { input_tokens: 2_000, output_tokens: 200 },
+        },
+      }],
+    } as any));
+
+    const firstLocalEstimate = pricing.costUsd({ input_tokens: 1_000, output_tokens: 100 }, "gpt-5.1");
+    const fullLocalEstimate = pricing.costUsd({ input_tokens: 2_000, output_tokens: 200 }, "gpt-5.1");
+    expect(first.event.cost_usd).toBe(7);
+    expect(second.event.cost_usd).toBeCloseTo(fullLocalEstimate - firstLocalEstimate, 10);
+    expect(second.session.cost_usd).toBeCloseTo(7 + fullLocalEstimate - firstLocalEstimate, 10);
   });
 });

--- a/server/test/ingest-reliability.test.ts
+++ b/server/test/ingest-reliability.test.ts
@@ -1,0 +1,142 @@
+// External harnesses retry when a POST times out, and some already know the
+// exact provider charge. The ingest seam must make retries safe and prefer an
+// authoritative per-event cost without changing the existing token counters.
+import { describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-reliable-ingest-"));
+const root = join(dir, "project");
+mkdirSync(root, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "events.db");
+process.env.AGENTGLASS_ROOT = root;
+process.env.XDG_CONFIG_HOME = dir;
+
+const ingest = await import("../src/ingest.ts");
+const db = await import("../src/db.ts");
+const pricing = await import("../src/pricing.ts");
+
+const body = (over: Record<string, unknown> = {}) => ({
+  source_app: "external-harness",
+  session_id: "reliable-session",
+  hook_event_type: "Notification",
+  model_name: "gpt-5.1",
+  timestamp: Date.now(),
+  payload: {
+    project_path: root,
+    usage: { input_tokens: 1_000, output_tokens: 100 },
+    message: "firstwriteuniquemarker",
+  },
+  ...over,
+});
+
+describe("external ingest extensions", () => {
+  test("accepts an opaque event id and a zero reported cost", () => {
+    expect(ingest.externalIngestError(body({ event_id: "  opaque id  ", reported_cost_usd: 0 }) as any)).toBeNull();
+    const normalized = ingest.normalize(body({ event_id: "  opaque id  ", reported_cost_usd: 0 }) as any);
+    expect(normalized.event_id).toBe("  opaque id  ");
+    expect(normalized.reported_cost_usd).toBe(0);
+  });
+
+  test("rejects malformed ids and costs at the HTTP boundary", () => {
+    expect(ingest.externalIngestError(body({ event_id: "" }) as any)).toContain("event_id");
+    expect(ingest.externalIngestError(body({ event_id: "x".repeat(513) }) as any)).toContain("event_id");
+    expect(ingest.externalIngestError(body({ event_id: 42 }) as any)).toContain("event_id");
+    expect(ingest.externalIngestError(body({ reported_cost_usd: -1 }) as any)).toContain("reported_cost_usd");
+    expect(ingest.externalIngestError(body({ reported_cost_usd: Infinity }) as any)).toContain("reported_cost_usd");
+    expect(ingest.externalIngestError(body({ reported_cost_usd: "0.12" }) as any)).toContain("reported_cost_usd");
+  });
+});
+
+describe("idempotent event writes", () => {
+  test("keeps the first write and returns it on retry without changing rollups or FTS", () => {
+    const first = db.insertEvent(ingest.normalize(body({
+      event_id: "retry-safe-1",
+      reported_cost_usd: 0.1234,
+    }) as any));
+    const retry = db.insertEvent(ingest.normalize(body({
+      event_id: "retry-safe-1",
+      reported_cost_usd: 99,
+      summary: "retry-should-not-replace-first",
+      payload: {
+        project_path: root,
+        usage: { input_tokens: 999_999, output_tokens: 999_999 },
+        message: "retryonlyuniquemarker",
+      },
+    }) as any));
+
+    expect(first.inserted).toBe(true);
+    expect(retry.inserted).toBe(false);
+    expect(retry.event.id).toBe(first.event.id);
+    expect(retry.event.cost_usd).toBeCloseTo(0.1234, 10);
+    const session = db.getSession("reliable-session")!;
+    expect(session.events).toBe(1);
+    expect(session.input_tokens).toBe(1_000);
+    expect(session.output_tokens).toBe(100);
+    expect(session.cost_usd).toBeCloseTo(0.1234, 10);
+    expect(db.getRecent(100).filter((e) => e.event_id === "retry-safe-1")).toHaveLength(1);
+    expect(db.searchEvents("firstwriteuniquemarker")).toHaveLength(1);
+    expect(db.searchEvents("retryonlyuniquemarker")).toHaveLength(0);
+  });
+
+  test("scopes an event id to its source and session", () => {
+    const sameId = "shared-id";
+    const a = db.insertEvent(ingest.normalize(body({
+      event_id: sameId,
+      session_id: "scope-a",
+      reported_cost_usd: 0,
+    }) as any));
+    const b = db.insertEvent(ingest.normalize(body({
+      event_id: sameId,
+      session_id: "scope-b",
+      reported_cost_usd: 0,
+    }) as any));
+    const c = db.insertEvent(ingest.normalize(body({
+      event_id: sameId,
+      source_app: "another-harness",
+      session_id: "scope-a",
+      reported_cost_usd: 0,
+    }) as any));
+
+    expect([a.inserted, b.inserted, c.inserted]).toEqual([true, true, true]);
+  });
+
+  test("keeps the existing append-only behavior when event_id is absent", () => {
+    const first = db.insertEvent(ingest.normalize(body({ session_id: "append-only" }) as any));
+    const second = db.insertEvent(ingest.normalize(body({ session_id: "append-only" }) as any));
+    expect(first.inserted).toBe(true);
+    expect(second.inserted).toBe(true);
+    expect(second.event.id).not.toBe(first.event.id);
+    expect(second.session.event_count).toBe(2);
+  });
+});
+
+describe("reported cost precedence", () => {
+  test("keeps pricing-table estimation when reported_cost_usd is absent", () => {
+    const result = db.insertEvent(ingest.normalize(body({ session_id: "estimated-cost" }) as any));
+    expect(result.event.cost_usd).toBeCloseTo(
+      pricing.costUsd({ input_tokens: 1_000, output_tokens: 100 }, "gpt-5.1"),
+      10,
+    );
+  });
+
+  test("zero and non-zero reported costs override pricing while tokens still accumulate", () => {
+    const zero = db.insertEvent(ingest.normalize(body({
+      event_id: "reported-zero",
+      session_id: "reported-cost-session",
+      reported_cost_usd: 0,
+    }) as any));
+    const exact = db.insertEvent(ingest.normalize(body({
+      event_id: "reported-exact",
+      session_id: "reported-cost-session",
+      reported_cost_usd: 0.456789,
+    }) as any));
+
+    expect(zero.event.cost_usd).toBe(0);
+    expect(exact.event.cost_usd).toBeCloseTo(0.456789, 10);
+    expect(exact.session.input_tokens).toBe(2_000);
+    expect(exact.session.output_tokens).toBe(200);
+    expect(exact.session.cost_usd).toBeCloseTo(0.456789, 10);
+  });
+});

--- a/server/test/ingest-reliability.test.ts
+++ b/server/test/ingest-reliability.test.ts
@@ -77,6 +77,8 @@ describe("idempotent event writes", () => {
     expect(retry.inserted).toBe(false);
     expect(retry.event.id).toBe(first.event.id);
     expect(retry.event.cost_usd).toBeCloseTo(0.1234, 10);
+    expect((first.session as any).pricing_baseline_usd).toBeUndefined();
+    expect((retry.session as any).pricing_baseline_usd).toBeUndefined();
     const session = db.getSession("reliable-session")!;
     expect(session.events).toBe(1);
     expect(session.input_tokens).toBe(1_000);
@@ -85,6 +87,7 @@ describe("idempotent event writes", () => {
     expect(db.getRecent(100).filter((e) => e.event_id === "retry-safe-1")).toHaveLength(1);
     expect(db.searchEvents("firstwriteuniquemarker")).toHaveLength(1);
     expect(db.searchEvents("retryonlyuniquemarker")).toHaveLength(0);
+    expect((db.getSessions().find((s) => s.session_id === "reliable-session") as any).pricing_baseline_usd).toBeUndefined();
   });
 
   test("scopes an event id to its source and session", () => {

--- a/server/test/otlp-codex.test.ts
+++ b/server/test/otlp-codex.test.ts
@@ -1,0 +1,70 @@
+// Codex CLI emits OTLP logs with its own stable field names rather than the
+// gen_ai.* aliases used by traces. Keep a real response.completed fixture here
+// so a telemetry rename cannot silently make Codex sessions disappear.
+import { describe, expect, test } from "bun:test";
+import { otlpLogsToEvents } from "../src/otlp.ts";
+
+const kv = (key: string, value: string | number) => ({
+  key,
+  value: typeof value === "number" ? { intValue: value } : { stringValue: value },
+});
+
+const logs = (attributes: ReturnType<typeof kv>[]) => ({
+  resourceLogs: [{
+    resource: { attributes: [kv("service.name", "codex_cli_rs")] },
+    scopeLogs: [{
+      logRecords: [{
+        timeUnixNano: "1700000000000000000",
+        attributes,
+      }],
+    }],
+  }],
+});
+
+describe("Codex OTLP logs", () => {
+  test("maps response.completed token fields without charging cached input twice", () => {
+    const [event] = otlpLogsToEvents(logs([
+      kv("event.kind", "response.completed"),
+      kv("conversation.id", "codex-session"),
+      kv("model", "gpt-5.1-codex"),
+      kv("input_token_count", 1_000),
+      kv("output_token_count", 120),
+      kv("cached_token_count", 600),
+      kv("cache_write_token_count", 50),
+    ]));
+
+    expect(event).toBeDefined();
+    expect(event.hook_event_type).toBe("Turn complete");
+    expect(event.session_id).toBe("codex-session");
+    expect(event.payload?.event).toBe("response.completed");
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 350,
+      output_tokens: 120,
+      cache_read_tokens: 600,
+      cache_creation_tokens: 50,
+    });
+  });
+
+  test("never produces negative non-cached input when cache counters exceed the total", () => {
+    const [event] = otlpLogsToEvents(logs([
+      kv("event.kind", "response.completed"),
+      kv("input_token_count", 100),
+      kv("output_token_count", 1),
+      kv("cached_token_count", 120),
+      kv("cache_write_token_count", 20),
+    ]));
+    expect((event.payload?.usage as Record<string, number>).input_tokens).toBe(0);
+  });
+
+  test("leaves standard gen_ai input semantics unchanged", () => {
+    const [event] = otlpLogsToEvents(logs([
+      kv("event.name", "gen_ai.response.completed"),
+      kv("gen_ai.system", "openai"),
+      kv("gen_ai.usage.input_tokens", 1_000),
+      kv("gen_ai.usage.output_tokens", 120),
+      kv("gen_ai.usage.cache_read_tokens", 600),
+    ]));
+    expect((event.payload?.usage as Record<string, number>).input_tokens).toBe(1_000);
+    expect((event.payload?.usage as Record<string, number>).cache_read_tokens).toBe(600);
+  });
+});

--- a/server/test/otlp-codex.test.ts
+++ b/server/test/otlp-codex.test.ts
@@ -9,9 +9,9 @@ const kv = (key: string, value: string | number) => ({
   value: typeof value === "number" ? { intValue: value } : { stringValue: value },
 });
 
-const logs = (attributes: ReturnType<typeof kv>[]) => ({
+const logs = (attributes: ReturnType<typeof kv>[], serviceName = "codex_cli_rs") => ({
   resourceLogs: [{
-    resource: { attributes: [kv("service.name", "codex_cli_rs")] },
+    resource: { attributes: [kv("service.name", serviceName)] },
     scopeLogs: [{
       logRecords: [{
         timeUnixNano: "1700000000000000000",
@@ -56,7 +56,7 @@ describe("Codex OTLP logs", () => {
     expect((event.payload?.usage as Record<string, number>).input_tokens).toBe(0);
   });
 
-  test("leaves standard gen_ai input semantics unchanged", () => {
+  test("separates cached input from standard gen_ai totals", () => {
     const [event] = otlpLogsToEvents(logs([
       kv("event.name", "gen_ai.response.completed"),
       kv("gen_ai.system", "openai"),
@@ -64,7 +64,29 @@ describe("Codex OTLP logs", () => {
       kv("gen_ai.usage.output_tokens", 120),
       kv("gen_ai.usage.cache_read_tokens", 600),
     ]));
-    expect((event.payload?.usage as Record<string, number>).input_tokens).toBe(1_000);
+    expect((event.payload?.usage as Record<string, number>).input_tokens).toBe(400);
     expect((event.payload?.usage as Record<string, number>).cache_read_tokens).toBe(600);
+  });
+
+  test("keeps a fully cached response with zero output", () => {
+    const [event] = otlpLogsToEvents(logs([
+      kv("event.kind", "response.completed"),
+      kv("input_token_count", 600),
+      kv("output_token_count", 0),
+      kv("cached_token_count", 600),
+    ]));
+    expect(event.hook_event_type).toBe("Turn complete");
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 0,
+      output_tokens: 0,
+      cache_read_tokens: 600,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  test("ignores a generic event.kind log without Codex or GenAI evidence", () => {
+    expect(otlpLogsToEvents(logs([
+      kv("event.kind", "job.completed"),
+    ], "background-worker"))).toEqual([]);
   });
 });

--- a/server/test/otlp-codex.test.ts
+++ b/server/test/otlp-codex.test.ts
@@ -2,7 +2,7 @@
 // gen_ai.* aliases used by traces. Keep a real response.completed fixture here
 // so a telemetry rename cannot silently make Codex sessions disappear.
 import { describe, expect, test } from "bun:test";
-import { otlpLogsToEvents } from "../src/otlp.ts";
+import { otlpLogsToEvents, otlpTracesToEvents } from "../src/otlp.ts";
 
 const kv = (key: string, value: string | number) => ({
   key,
@@ -62,10 +62,44 @@ describe("Codex OTLP logs", () => {
       kv("gen_ai.system", "openai"),
       kv("gen_ai.usage.input_tokens", 1_000),
       kv("gen_ai.usage.output_tokens", 120),
-      kv("gen_ai.usage.cache_read_tokens", 600),
+      kv("gen_ai.usage.cache_read.input_tokens", 600),
+      kv("gen_ai.usage.cache_creation.input_tokens", 50),
     ]));
-    expect((event.payload?.usage as Record<string, number>).input_tokens).toBe(400);
-    expect((event.payload?.usage as Record<string, number>).cache_read_tokens).toBe(600);
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 350,
+      output_tokens: 120,
+      cache_read_tokens: 600,
+      cache_creation_tokens: 50,
+    });
+  });
+
+  test("separates official cache buckets from standard GenAI traces", () => {
+    const [event] = otlpTracesToEvents({
+      resourceSpans: [{
+        resource: { attributes: [kv("service.name", "openai-sdk")] },
+        scopeSpans: [{
+          spans: [{
+            name: "chat",
+            startTimeUnixNano: "1000000",
+            endTimeUnixNano: "2000000",
+            attributes: [
+              kv("gen_ai.system", "openai"),
+              kv("gen_ai.operation.name", "chat"),
+              kv("gen_ai.usage.input_tokens", 1_000),
+              kv("gen_ai.usage.output_tokens", 120),
+              kv("gen_ai.usage.cache_read.input_tokens", 600),
+              kv("gen_ai.usage.cache_creation.input_tokens", 50),
+            ],
+          }],
+        }],
+      }],
+    });
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 350,
+      output_tokens: 120,
+      cache_read_tokens: 600,
+      cache_creation_tokens: 50,
+    });
   });
 
   test("keeps a fully cached response with zero output", () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -20,6 +20,10 @@ export interface IngestBody {
   source_app: string;
   session_id: string;
   hook_event_type: HookEventType | string;
+  /** Opaque retry key, unique within one source_app + session_id. */
+  event_id?: string;
+  /** Authoritative cost for this event when the sender already knows it. */
+  reported_cost_usd?: number;
   payload?: Record<string, unknown>;
   /** Optional transcript array (assistant/user messages with `usage`). */
   chat?: unknown[];
@@ -33,6 +37,7 @@ export interface WatchEvent {
   id: number;
   source_app: string;
   session_id: string;
+  event_id?: string | null;
   hook_event_type: string;
   tool_name: string | null;
   tool_use_id: string | null;


### PR DESCRIPTION
## What does this PR do?

External harnesses can now send an optional `event_id` and `reported_cost_usd` to `POST /ingest`. Keyed retries are transactionally deduplicated, so a timed-out retry cannot duplicate the event, full-text search row, session totals, alert, or live update. Sender-reported cost wins for that event, while a separate local-pricing baseline keeps later cumulative transcript costs accurate.

Codex CLI OTLP logs now recognize `event.kind=response.completed` and its native token-count fields. Traces and logs share one OpenTelemetry usage mapper, including the official dotted cache attributes, so cached input is separated instead of charged twice and fully cached turns no longer disappear. Generic `event.kind` logs still require Codex evidence.

The public boundary also rejects malformed identity fields and non-finite or unrealistic costs, keeps internal pricing state out of API/WebSocket session data, and documents UUIDv4 retry keys. Existing unkeyed senders keep their append-only behavior.

Found while adapting AgentGlass as the observation layer for [AgentHost](https://agenthost.space)'s supervised Claude/Codex/Hermes room. This PR contains only provider-neutral ingest and telemetry improvements, with no AgentHost branding or visual customization.

## How was it tested?

- `bun test server/test/db-pricing-baseline-migration.test.ts server/test/ingest.test.ts server/test/ingest-usage.test.ts server/test/ingest-reliability.test.ts server/test/cumulative-cost.test.ts server/test/pricing.test.ts server/test/otlp-cap.test.ts server/test/otlp-codex.test.ts server/test/session-lifecycle.test.ts` - 61 passed
- `bunx tsc --noEmit -p server/tsconfig.json` - passed
- `bun run build` - production build passed (existing large-chunk warning only)
- Three independent read-only QA worktrees reviewed exact commit `64b2a7d` for code correctness, security, and TypeScript/data-model behavior - all passed
