### PR TITLE
docs: the glass is the cockpit's, not a jeweller's

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # agentglass
 
-**A loupe for your agents** — a real-time Mission-Control **dashboard _and_ workspace** for AI coding agents, across every provider and every project on your machine.
+**A glass cockpit for your agents** — a real-time Mission-Control **dashboard _and_ workspace** for AI coding agents, across every provider and every project on your machine.
 
 [![▶ Live demo](https://img.shields.io/badge/▶%20Live%20demo-try%20it%20now-6366f1?style=for-the-badge)](https://sirallap.github.io/agentglass/demo/)
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -277,7 +277,7 @@ hooks / OTLP / POST /ingest
 ## Dashboard vs harness (one paragraph)
 
 agentglass does **not** replace Claude Code, Codex, Gemini CLI, LangChain, or
-your custom runner. Those remain the harness. agentglass is the loupe and the
-optional remote control: ingest telemetry, render the fleet, and (if you wire
-it) hold tool calls until a human clicks allow/deny. Point things at it; keep
-shipping with whatever you already run.
+your custom runner. Those remain the harness. agentglass is the glass in front
+of them and the optional remote control: ingest telemetry, render the fleet,
+and (if you wire it) hold tool calls until a human clicks allow/deny. Point
+things at it; keep shipping with whatever you already run.


### PR DESCRIPTION
## What does this PR do?

Two sentences still called agentglass a loupe. That stopped being true when the mark became a satellite pass in #358 — but it had been drifting before that, and the fix turns out to need no rebrand at all.

**The landing page settled this a while ago and nothing carried it over.** Its hero is a curved HUD combiner you drag over the live demo, and the comment above the shader says so in as many words:

> `THE GLASS — a curved combiner, not a magnifier.`

Everything around it is aviation — symbology, fresnel, rim, glare — and the app agrees: *mission control*, *the cockpit*, *the live radar*, *the fleet*.

So dropping the loupe never orphaned the name. **"Glass" is the glass cockpit**: the screen that replaced the dials. That reading fits a world with an orbit over it better than a jeweller's loupe ever fit a radar lens, and it costs no rename, no asset and no logo work.

Two lines change:

- `README.md` — "A loupe for your agents" → "A glass cockpit for your agents"
- `docs/EXTENDING.md` — "agentglass is the loupe and the optional remote control" → "the glass in front of them", with the paragraph reflowed

README's "agent-observability **lens**" stays as it is. A lens is what the combiner is; a loupe is what it is not.

## How was it tested?

Prose only — no code paths touched. `grep -ri loupe` across `README.md`, `docs/`, `landing/`, `web/src`, `server/src` and `electron/` returns nothing, and the reflowed paragraph in `EXTENDING.md` was re-read in place rather than trusted to the edit.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_