### PR TITLE
feat(ingest): add Kimi K3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -699,11 +699,12 @@ proceeding, and remember agentglass being down then blocks every gated call.
 
 ### Kimi Code CLI and Kimi K3
 
-Kimi Code CLI can stream its session and tool lifecycle through the bundled
-hook forwarder. Agentglass recognizes the real K3 names (`k3`, `kimi-k3`, and
-`kimi-code/k3`) as **Moonshot / K3**, understands both Moonshot cache-token
-formats, and applies K3's input, output, and cache-hit rates without counting
-cached prompt tokens twice.
+[Kimi Code CLI hooks](https://moonshotai.github.io/kimi-code/en/customization/hooks)
+can stream its session and tool lifecycle through the bundled hook forwarder.
+Agentglass recognizes the real K3 names (`k3`, `kimi-k3`, and `kimi-code/k3`)
+as **Moonshot / K3**, understands both Moonshot cache-token formats, and applies
+K3's input, output, and cache-hit rates without counting cached prompt tokens
+twice.
 
 Kimi's hook payload does not carry token usage, so hooks populate the live
 session/tool views; a Kimi/Moonshot adapter can send its final `usage` object to

--- a/README.md
+++ b/README.md
@@ -697,6 +697,21 @@ proceeding, and remember agentglass being down then blocks every gated call.
 
 ## Any provider — via OpenTelemetry (OpenAI, Gemini, Bedrock, …)
 
+### Kimi Code CLI and Kimi K3
+
+Kimi Code CLI can stream its session and tool lifecycle through the bundled
+hook forwarder. Agentglass recognizes the real K3 names (`k3`, `kimi-k3`, and
+`kimi-code/k3`) as **Moonshot / K3**, understands both Moonshot cache-token
+formats, and applies K3's input, output, and cache-hit rates without counting
+cached prompt tokens twice.
+
+Kimi's hook payload does not carry token usage, so hooks populate the live
+session/tool views; a Kimi/Moonshot adapter can send its final `usage` object to
+`POST /ingest` for exact token and cost charts. Copy the ready-to-use
+`config.toml` hook blocks from [the extension guide](docs/EXTENDING.md#kimi-code-cli-and-kimi-k3).
+
+### OpenTelemetry
+
 agentglass isn't Claude-only. It exposes an **OTLP/HTTP** trace receiver that
 maps OpenTelemetry **GenAI** spans (the `gen_ai.*` semantic conventions) into the
 same events the dashboard already understands — so anything emitting GenAI

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -51,6 +51,81 @@ agentglass derives cost from token usage and its pricing table.
 If a Claude transcript scanner already owns the session id, the event is
 accepted but skipped (no double-count).
 
+### Kimi Code CLI and Kimi K3
+
+Kimi Code CLI's hook JSON already supplies `hook_event_name` and `session_id`,
+and Kimi runs the command in the session's project directory. Point Kimi at
+`hooks/send_event.py`; `--model-name` supplies the model because Kimi's hook
+payload does not include it.
+
+Add one block per event to `~/.kimi-code/config.toml` (or
+`$KIMI_CODE_HOME/config.toml`). Replace `/absolute/path/to/agentglass` with this
+checkout's real path:
+
+```toml
+[[hooks]]
+event = "SessionStart"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+
+[[hooks]]
+event = "UserPromptSubmit"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+
+[[hooks]]
+event = "PreToolUse"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+
+[[hooks]]
+event = "PostToolUse"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+
+[[hooks]]
+event = "PostToolUseFailure"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+
+[[hooks]]
+event = "Stop"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+
+[[hooks]]
+event = "SessionEnd"
+command = "python3 \"/absolute/path/to/agentglass/hooks/send_event.py\" --model-name kimi-code/k3"
+```
+
+The source app defaults to the current project directory's name. Pass
+`--source-app NAME` to override it. On Windows, use `py` or `python` instead of
+`python3`.
+
+Hooks provide the live lifecycle and tool stream. Kimi's hook payload currently
+does not include token usage. A Kimi/Moonshot adapter can add exact tokens and
+cost through `/ingest` using either supported API shape:
+
+```json
+{
+  "source_app": "my-project",
+  "session_id": "kimi-session-1",
+  "hook_event_type": "Stop",
+  "model_name": "kimi-k3",
+  "payload": {
+    "usage": {
+      "prompt_tokens": 1200,
+      "completion_tokens": 300,
+      "cached_tokens": 800
+    }
+  }
+}
+```
+
+The OpenAI-compatible nested form
+`prompt_tokens_details.cached_tokens` is supported too. Cached tokens are split
+out of `prompt_tokens` before cost math, so they are not charged twice.
+Agentglass recognizes `k3`, `kimi-k3`, and `kimi-code/k3` as **Moonshot / K3**.
+The built-in K3 API rate follows
+[Kimi's published pricing](https://www.kimi.com/help/kimi-api/api-pricing):
+$3 / MTok input, $15 / MTok output, and $0.30 / MTok cache reads. Use
+`reported_cost_usd` for Kimi Code subscription usage or whenever the provider
+reports the exact charge.
+
 ### OTLP (any provider)
 
 Point an OTLP/HTTP exporter at the same port. Both **protobuf** (SDK default)

--- a/hooks/send_event.py
+++ b/hooks/send_event.py
@@ -1,12 +1,13 @@
 #!/usr/bin/env python3
 """agentglass event forwarder.
 
-Reads a Claude Code hook payload on stdin and POSTs a normalized event to the
-agentglass server. Zero third-party deps (stdlib only).
+Reads a Claude Code or Kimi Code CLI hook payload on stdin and POSTs a
+normalized event to the agentglass server. Zero third-party deps (stdlib only).
 
 Usage (from a Claude Code hook command):
     send_event.py --source-app my-project --event-type PreToolUse
     send_event.py --source-app my-project --event-type Stop --add-chat
+    send_event.py --model-name kimi-code/k3
 
 Env:
     AGENTGLASS_SERVER   server base url (default http://localhost:4000)
@@ -66,6 +67,8 @@ def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--source-app", default=os.path.basename(os.getcwd()))
     ap.add_argument("--event-type", default=None)
+    ap.add_argument("--model-name", default=None,
+                    help="fallback model when the hook payload omits it")
     ap.add_argument("--server", default=DEFAULT_SERVER)
     ap.add_argument("--add-chat", action="store_true",
                     help="attach the transcript so tokens/cost can be computed")
@@ -80,7 +83,7 @@ def main():
 
     session_id = payload.get("session_id") or payload.get("sessionId") or "unknown"
     event_type = args.event_type or payload.get("hook_event_name") or "Unknown"
-    model_name = payload.get("model") or payload.get("model_name")
+    model_name = payload.get("model") or payload.get("model_name") or args.model_name
 
     chat = None
     if args.add_chat:

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -411,6 +411,7 @@ export function providerOf(model: string | null | undefined): string | null {
   if (/opus|sonnet|haiku|fable|claude|anthropic/.test(m)) return "Anthropic";
   if (/gpt|davinci|openai|\bo1\b|\bo3\b|\bo4\b/.test(m)) return "OpenAI";
   if (/gemini|palm|bison|flash|google|vertex/.test(m)) return "Google";
+  if (/kimi|moonshot/.test(m) || m === "k3" || m.startsWith("k3[")) return "Moonshot";
   if (/deepseek/.test(m)) return "DeepSeek";
   if (/grok|xai/.test(m)) return "xAI";
   if (/mistral|mixtral|codestral/.test(m)) return "Mistral";

--- a/server/src/ingest.ts
+++ b/server/src/ingest.ts
@@ -87,11 +87,23 @@ function pick(obj: Record<string, unknown> | undefined, ...keys: string[]): unkn
 /** Extract token usage from a single message/usage-like object (tolerant of shapes). */
 function usageFrom(u: Record<string, unknown> | undefined): TokenUsage {
   if (!u || typeof u !== "object") return {};
+  const details = pick(u, "prompt_tokens_details");
+  const nestedCached =
+    details && typeof details === "object" && !Array.isArray(details)
+      ? pick(details as Record<string, unknown>, "cached_tokens")
+      : undefined;
+  const cacheRead = num(
+    pick(u, "cache_read_input_tokens", "cache_read_tokens", "cached_tokens") ?? nestedCached,
+  );
+  const explicitInput = pick(u, "input_tokens");
+  const promptInput = num(pick(u, "prompt_tokens"));
   return {
-    input_tokens: num(pick(u, "input_tokens", "prompt_tokens")),
+    // OpenAI-compatible APIs (including Kimi/Moonshot) include cache hits in
+    // prompt_tokens. Split them out so the same tokens are not priced twice.
+    input_tokens: explicitInput == null ? Math.max(0, promptInput - cacheRead) : num(explicitInput),
     output_tokens: num(pick(u, "output_tokens", "completion_tokens")),
     cache_creation_tokens: num(pick(u, "cache_creation_input_tokens", "cache_creation_tokens")),
-    cache_read_tokens: num(pick(u, "cache_read_input_tokens", "cache_read_tokens")),
+    cache_read_tokens: cacheRead,
   };
 }
 

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -13,6 +13,7 @@
 
 export interface ModelPrice {
   match: string[]; // substrings matched against lowercased model_name
+  exact?: string[]; // exact lowercased model names that are unsafe as substrings
   label: string;
   input: number;
   output: number;
@@ -57,6 +58,10 @@ export const PRICE_TABLE: ModelPrice[] = [
   { match: ["flash-lite"], label: "Gemini Flash-Lite", input: 0.075, output: 0.3, cache_write: 0, cache_read: 0.01875 },
   { match: ["gemini", "flash"], label: "Gemini Flash", input: 0.15, output: 0.6, cache_write: 0, cache_read: 0.0375 },
 
+  // --- Moonshot AI (Kimi) ---
+  // K3: cache misses use the normal input rate; cache hits are discounted 90%.
+  { match: ["kimi-code/k3", "kimi-k3", "moonshot/k3"], exact: ["k3", "k3[1m]"], label: "K3", input: 3, output: 15, cache_write: 3, cache_read: 0.3 },
+
   // --- others (approx) ---
   { match: ["deepseek"], label: "DeepSeek", input: 0.27, output: 1.1, cache_write: 0, cache_read: 0.07 },
   { match: ["grok"], label: "Grok", input: 2, output: 10, cache_write: 0, cache_read: 0 },
@@ -84,7 +89,7 @@ export function priceFor(modelName: string | null | undefined): ModelPrice | nul
   if (!modelName) return null;
   const m = modelName.toLowerCase();
   for (const p of table) {
-    if (p.match.some((frag) => m.includes(frag))) return p;
+    if (p.exact?.includes(m) || p.match.some((frag) => m.includes(frag))) return p;
   }
   return null;
 }

--- a/server/test/ingest-usage.test.ts
+++ b/server/test/ingest-usage.test.ts
@@ -20,4 +20,35 @@ describe("payload usage detection", () => {
     const ev = normalize(body({ payload: { prompt: "hi" } }));
     expect(ev.usage_is_cumulative).toBe(true);
   });
+
+  test("Kimi's direct cached_tokens are split out of prompt_tokens", () => {
+    const ev = normalize(body({
+      model_name: "kimi-k3",
+      payload: { usage: { prompt_tokens: 1_200, completion_tokens: 300, cached_tokens: 800 } },
+    }));
+    expect(ev.usage).toEqual({
+      input_tokens: 400,
+      output_tokens: 300,
+      cache_creation_tokens: 0,
+      cache_read_tokens: 800,
+    });
+    expect(ev.usage_is_cumulative).toBe(false);
+  });
+
+  test("Kimi's OpenAI-compatible nested cached tokens are split out too", () => {
+    const ev = normalize(body({
+      model_name: "kimi-code/k3",
+      payload: {
+        usage: {
+          prompt_tokens: 1_200,
+          completion_tokens: 300,
+          prompt_tokens_details: { cached_tokens: 800 },
+        },
+      },
+    }));
+    expect(ev.usage.input_tokens).toBe(400);
+    expect(ev.usage.output_tokens).toBe(300);
+    expect(ev.usage.cache_read_tokens).toBe(800);
+    expect(ev.usage_is_cumulative).toBe(false);
+  });
 });

--- a/server/test/kimi-hook.test.ts
+++ b/server/test/kimi-hook.test.ts
@@ -1,0 +1,61 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { join } from "node:path";
+
+const python = ["python3", "python", "py"].find(
+  (exe) => spawnSync(exe, ["--version"], { stdio: "ignore" }).status === 0,
+);
+const servers: ReturnType<typeof Bun.serve>[] = [];
+
+afterEach(() => {
+  for (const server of servers.splice(0)) server.stop(true);
+});
+
+describe("Kimi Code hook forwarding", () => {
+  test.if(!!python)("uses --model-name when Kimi's hook payload omits the model", async () => {
+    let resolveBody!: (body: any) => void;
+    const received = Promise.race([
+      new Promise<any>((resolve) => { resolveBody = resolve; }),
+      Bun.sleep(3_000).then(() => { throw new Error("Kimi hook event was not received"); }),
+    ]);
+    const server = Bun.serve({
+      hostname: "127.0.0.1",
+      port: 0,
+      async fetch(req) {
+        resolveBody(await req.json());
+        return new Response("ok");
+      },
+    });
+    servers.push(server);
+
+    const proc = Bun.spawn(
+      [
+        python!,
+        join(import.meta.dir, "..", "..", "hooks", "send_event.py"),
+        "--server",
+        `http://127.0.0.1:${server.port}`,
+        "--source-app",
+        "kimi-project",
+        "--model-name",
+        "kimi-code/k3",
+      ],
+      { stdin: "pipe", stdout: "pipe", stderr: "pipe" },
+    );
+    proc.stdin.write(JSON.stringify({
+      hook_event_name: "PostToolUse",
+      session_id: "kimi-session-1",
+      cwd: "/workspace/kimi-project",
+      tool_name: "Bash",
+    }));
+    proc.stdin.end();
+
+    expect(await proc.exited).toBe(0);
+    expect(await received).toMatchObject({
+      source_app: "kimi-project",
+      session_id: "kimi-session-1",
+      hook_event_type: "PostToolUse",
+      model_name: "kimi-code/k3",
+      payload: { tool_name: "Bash" },
+    });
+  });
+});

--- a/server/test/pricing.test.ts
+++ b/server/test/pricing.test.ts
@@ -33,6 +33,18 @@ describe("priceFor", () => {
     expect(priceFor("gemini-2.0-flash")?.label).toBe("Gemini Flash");
   });
 
+  test("Kimi K3 aliases use Moonshot's published API rates", () => {
+    for (const model of ["k3", "kimi-k3", "kimi-code/k3"]) {
+      expect(priceFor(model)).toMatchObject({
+        label: "K3",
+        input: 3,
+        output: 15,
+        cache_read: 0.3,
+      });
+    }
+    expect(priceFor("task3-custom-model")).toBeNull();
+  });
+
   test("unknown and empty model names return null", () => {
     expect(priceFor(null)).toBeNull();
     expect(priceFor(undefined)).toBeNull();
@@ -55,6 +67,19 @@ describe("costUsd", () => {
       "claude-3-5-haiku",
     );
     expect(cost).toBeCloseTo(1.25 + 0.1, 10);
+  });
+
+  test("prices Kimi cache misses, cache hits, and output separately", () => {
+    const cost = costUsd(
+      {
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_creation_tokens: 1_000_000,
+        cache_read_tokens: 1_000_000,
+      },
+      "kimi-k3",
+    );
+    expect(cost).toBeCloseTo(3 + 15 + 3 + 0.3, 10);
   });
 
   test("unknown model falls back to DEFAULT_PRICE, never NaN", () => {

--- a/server/test/provider-parity.test.ts
+++ b/server/test/provider-parity.test.ts
@@ -18,10 +18,13 @@ process.env.AGENTGLASS_DB = join(mkdtempSync(join(tmpdir(), "agx-prov-")), "p.db
 
 let serverProviderOf: (m: string | null | undefined) => string | null;
 let webProviderOf: (m: string | null | undefined) => string;
+let webModelLabelOf: (m: string | null | undefined) => string;
 
 beforeAll(async () => {
   serverProviderOf = (await import("../src/db.ts")).providerOf;
-  webProviderOf = (await import("../../web/src/lib/format.ts")).providerOf;
+  const format = await import("../../web/src/lib/format.ts");
+  webProviderOf = format.providerOf;
+  webModelLabelOf = format.modelLabelOf;
 });
 
 // One real id per branch of the mapping, plus the ones that must fall through.
@@ -31,6 +34,7 @@ const MODELS = [
   "gemini-2.5-pro", "models/gemini-1.5-flash", "text-bison", "palm-2", "vertex_ai/gemini",
   "deepseek-chat", "grok-2", "xai/grok", "mistral-large", "mixtral-8x7b", "codestral",
   "llama-3.1-70b", "meta-llama/Llama-3", "command-r-plus", "cohere.command",
+  "k3", "kimi-k3", "kimi-code/k3", "moonshot-v1-128k",
   // fall-through cases — must be the miss bucket on both sides
   "some-unknown-model", "qwen-2.5", "", "   ", "MODEL-WITH-NO-MATCH",
 ];
@@ -47,5 +51,13 @@ describe("providerOf agrees between the server and the web copy", () => {
   test("null / undefined agree (the miss bucket)", () => {
     expect(norm(serverProviderOf(null))).toBe(webProviderOf(null));
     expect(norm(serverProviderOf(undefined))).toBe(webProviderOf(undefined));
+  });
+
+  test("Kimi K3 aliases resolve to Moonshot and the K3 display label", () => {
+    for (const model of ["k3", "kimi-k3", "kimi-code/k3"]) {
+      expect(serverProviderOf(model)).toBe("Moonshot");
+      expect(webProviderOf(model)).toBe("Moonshot");
+      expect(webModelLabelOf(model)).toBe("K3");
+    }
   });
 });

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -101,6 +101,7 @@ export const typeColor = (t: string) => TYPE_COLORS[t] ?? "#64748b";
 // "claude-sonnet-5" → "Sonnet", "gpt-4o-2024-08-06" → "GPT-4o", "gemini-2.0-flash" → "Gemini Flash".
 // First substring hit wins, so order specific → general. Unknown names pass through.
 const MODEL_LABELS: [string, string][] = [
+  ["kimi-code/k3", "K3"], ["kimi-k3", "K3"], ["moonshot/k3", "K3"],
   ["opus", "Opus"], ["sonnet", "Sonnet"], ["haiku", "Haiku"], ["fable", "Fable"],
   ["gpt-4o-mini", "GPT-4o mini"], ["gpt-4o", "GPT-4o"], ["gpt-4.1", "GPT-4.1"],
   ["gpt-4", "GPT-4"], ["gpt-3.5", "GPT-3.5"], ["gpt-5-mini", "GPT-5 mini"], ["gpt-5", "GPT-5"],
@@ -112,6 +113,7 @@ const MODEL_LABELS: [string, string][] = [
 export function modelLabelOf(raw: string | null | undefined): string {
   if (!raw) return "unknown";
   const m = raw.toLowerCase();
+  if (m === "k3" || m.startsWith("k3[")) return "K3";
   for (const [frag, label] of MODEL_LABELS) if (m.includes(frag)) return label;
   return raw;
 }
@@ -124,6 +126,7 @@ export function providerOf(raw: string | null | undefined): string {
   if (/opus|sonnet|haiku|fable|claude|anthropic/.test(m)) return "Anthropic";
   if (/gpt|davinci|openai|\bo1\b|\bo3\b|\bo4\b/.test(m)) return "OpenAI";
   if (/gemini|palm|bison|flash|google|vertex/.test(m)) return "Google";
+  if (/kimi|moonshot/.test(m) || m === "k3" || m.startsWith("k3[")) return "Moonshot";
   if (/deepseek/.test(m)) return "DeepSeek";
   if (/grok|xai/.test(m)) return "xAI";
   if (/mistral|mixtral|codestral/.test(m)) return "Mistral";


### PR DESCRIPTION
## What does this PR do?

Adds first-class Kimi K3 ingestion support without introducing any AgentHost branding or customization.

- recognizes `k3`, `kimi-k3`, `kimi-code/k3`, and Moonshot model names as **Moonshot / K3** in both server and web provider buckets
- supports Kimi/Moonshot's direct `cached_tokens` field and OpenAI-compatible `prompt_tokens_details.cached_tokens`
- subtracts cache hits from `prompt_tokens` before pricing, preventing the same tokens from being charged as both ordinary input and cached input
- adds K3 API pricing and preserves `reported_cost_usd` as the authoritative value when a caller knows the exact charge
- extends the bundled Python hook forwarder with a `--model-name` fallback for Kimi Code hook payloads
- documents ready-to-copy Kimi Code `config.toml` hook blocks and external usage ingestion

## Why the cache split matters

Kimi's OpenAI-compatible usage shape includes cached tokens inside `prompt_tokens`. For a response reporting 1,200 prompt tokens and 800 cached tokens, AgentGlass now records:

- 400 ordinary input tokens
- 800 cache-read tokens

That keeps token totals and cost charts accurate instead of pricing 2,000 input-side tokens.

## Hook scope

Kimi Code hooks provide the live session and tool lifecycle. Their hook payload does not currently include token usage, so exact token and cost charts still require a Kimi/Moonshot adapter to send the final `usage` object to `POST /ingest`, or to supply `reported_cost_usd`.

## Pricing source

K3 rates follow Kimi's published API pricing:
https://www.kimi.com/help/kimi-api/api-pricing

- input / cache miss: $3 per million tokens
- cache hit: $0.30 per million tokens
- output: $15 per million tokens

## How was it tested?

- focused ingest, pricing, provider, cumulative-cost, reliability, lifecycle, and real-hook suite: **99 passed, 0 failed, 216 assertions**
- real Python hook process posts an official Kimi-shaped event to a live loopback Bun receiver
- production web build passes with `bun run build`
- regression coverage confirms an unrelated model such as `task3-custom-model` does not accidentally match exact `k3`
- upstream CI build, JavaScript/TypeScript CodeQL, Python CodeQL, and GitGuardian checks pass on commit `91181e3`

## Files of interest

- `hooks/send_event.py`
- `server/src/ingest.ts`
- `server/src/pricing.ts`
- `server/src/db.ts`
- `web/src/lib/format.ts`
- `docs/EXTENDING.md`
- `server/test/kimi-hook.test.ts`