### PR TITLE
docs: say the same thing everywhere, and say the useful thing

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 # agentglass
 
-**A glass cockpit for your agents** — a real-time Mission-Control **dashboard _and_ workspace** for AI coding agents, across every provider and every project on your machine.
+**Every AI coding agent on your machine, on one screen** — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go. From your desk or your phone.
 
 [![▶ Live demo](https://img.shields.io/badge/▶%20Live%20demo-try%20it%20now-6366f1?style=for-the-badge)](https://sirallap.github.io/agentglass/demo/)
 
@@ -18,7 +18,7 @@
 
 </div>
 
-Point any AI coding agent at agentglass — via Claude Code hooks or any OpenTelemetry GenAI exporter (OpenAI Codex, Gemini CLI, Bedrock, LangChain, LiteLLM…) — and watch every agent, tool call, token, and dollar move in real time. Cost tracking, tool-latency percentiles, error timelines, session lifecycles, a filter-the-whole-cockpit-by-provider switch, and 22 themes. It persists across reloads (unlike a pure in-browser stream).
+Point any AI coding agent at agentglass — via Claude Code hooks or any OpenTelemetry GenAI exporter (OpenAI Codex, Gemini CLI, Bedrock, LangChain, LiteLLM…) — and watch every agent, tool call, token, and dollar move in real time. Cost tracking, tool-latency percentiles, error timelines, session lifecycles, one switch that filters the whole cockpit by provider, and 22 themes. It persists across reloads (unlike a pure in-browser stream).
 
 And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **pull-request** panel that reviews and merges without opening a browser, a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Ships as a **native desktop app**, server included.
 

--- a/electron/package.json
+++ b/electron/package.json
@@ -2,7 +2,7 @@
   "name": "agentglass-electron",
   "private": true,
   "version": "0.6.0",
-  "description": "agentglass desktop shell (Electron)",
+  "description": "Every AI coding agent on your machine, on one screen — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go.",
   "author": "SirAllap",
   "homepage": "https://github.com/SirAllap/agentglass",
   "repository": { "type": "git", "url": "https://github.com/SirAllap/agentglass.git" },

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "agentglass",
   "version": "0.6.0",
   "private": true,
-  "description": "Real-time observability dashboard for Claude Code multi-agent workflows — cost, tokens, tool latency, error rates, and session timelines.",
+  "description": "Every AI coding agent on your machine, on one screen — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go. From your desk or your phone.",
   "license": "MIT",
   "type": "module",
   "workspaces": ["server", "web", "electron"],

--- a/web/index.html
+++ b/web/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>agentglass</title>
-    <meta name="description" content="Real-time observability for AI agent workflows — any provider." />
+    <meta name="description" content="Every AI coding agent on your machine, on one screen — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go. From your desk or your phone." />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <!--
       Installable on a phone.


### PR DESCRIPTION
## What does this PR do?

The README's opening line described the *architecture* — "a real-time Mission-Control **dashboard _and_ workspace**" — and after #360 it stacked two aviation metaphors, with "glass cockpit" sitting directly in front of "Mission-Control". Neither version said the thing that separates this from the other dozen agent dashboards: it will **hold a dangerous tool call until a human decides**, and that human can now be holding a phone.

The replacement is not a new voice. It is the landing page's line, near enough verbatim — the landing has led with it for a while and the README was the one out of step:

> **Every AI coding agent on your machine, on one screen** — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go. From your desk or your phone.

Four surfaces now carry it word for word:

| file | what it was |
|---|---|
| `README.md` | the masthead line |
| `package.json` | "Real-time observability dashboard for **Claude Code** multi-agent workflows…" — single-provider, and untrue since |
| `web/index.html` | "Real-time observability for AI agent workflows — any provider." True, but thin |
| `electron/package.json` | "agentglass desktop shell (Electron)" — a component's description where electron-builder wants a product's |

Two more were already right and are deliberately untouched: the landing's own `meta`/`og`/`twitter` tags, and `web/public/manifest.webmanifest`, whose line is phone-specific on purpose because that is the context an installed copy shows it in.

Also cut a six-word hyphenated noun in the first paragraph: "a filter-the-whole-cockpit-by-provider switch" now reads "one switch that filters the whole cockpit by provider".

## ⚠️ One surface this PR cannot reach

The repository's **GitHub description** still reads:

> 🛰 A loupe for your agents — a real-time Mission-Control dashboard and workspace for AI coding agents, across every provider and every project on your machine

That is the most-read copy of the line — it sits above the README on the repo page and in every search result — but it is a repository setting rather than a file, and writing it is not permitted from here. It needs changing by hand, to:

```
🛰 Every AI coding agent on your machine, on one screen — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go. From your desk or your phone.
```

## How was it tested?

- All three touched JSON files re-parsed with `JSON.parse` — a trailing-comma typo in `package.json` would break `bun install` and nothing else here would catch it
- `bunx tsc --noEmit` in `web/` — clean
- `bunx vite build`, then the **built** `web/dist/index.html` read back to confirm the new `<meta name="description">` actually survives into the bundle, rather than assuming Vite copies it
- `bun scripts/logo.mjs --check` — still in sync
- `grep -rni "loupe|glass cockpit|Real-time observability dashboard|filter-the-whole"` across `README.md`, `docs/`, `web/`, `server/`, `electron/`, `landing/` and `package.json` — no matches left