### PR TITLE
fix(pricing): a K3 context suffix is the same model, not an unknown one

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ gate. No install, no server. *(Everything there is fake; it's a showcase.)*
 - [Desktop app](#desktop-app) · [Updating](#updating)
 - [Security model — read this before installing](#security-model--read-this-before-installing)
 - [Control plane — approve / deny remotely](#control-plane--approve--deny-tool-calls-remotely-opt-in)
-- [Any provider — via OpenTelemetry](#any-provider--via-opentelemetry-openai-gemini-bedrock-)
+- [Any provider — Kimi, OpenAI, Gemini, Bedrock …](#any-provider--kimi-openai-gemini-bedrock-)
 - [Configuration](#configuration-env) · [API](#api) · [Architecture](#architecture)
 - [Extending / make it yours](docs/EXTENDING.md)
 - [Roadmap](#roadmap) · [Contributing](#contributing) · [License](#license)
@@ -695,9 +695,12 @@ proceeding, and remember agentglass being down then blocks every gated call.
 
 ---
 
-## Any provider — via OpenTelemetry (OpenAI, Gemini, Bedrock, …)
+## Any provider — Kimi, OpenAI, Gemini, Bedrock, …
 
-### Kimi Code CLI and Kimi K3
+Two ways in: an agent with hooks can post through the bundled forwarder, and
+anything that speaks OpenTelemetry can point its exporter here.
+
+### Kimi Code CLI and Kimi K3 — via hooks
 
 [Kimi Code CLI hooks](https://moonshotai.github.io/kimi-code/en/customization/hooks)
 can stream its session and tool lifecycle through the bundled hook forwarder.

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -13,7 +13,11 @@
 
 export interface ModelPrice {
   match: string[]; // substrings matched against lowercased model_name
-  exact?: string[]; // exact lowercased model names that are unsafe as substrings
+  // Whole model names, for ids too short to be safe as substrings ("k3" would
+  // otherwise price "task3-custom-model"). A context suffix still counts as the
+  // same model: "k3" matches `k3[1m]` too, the way providerOf and modelLabelOf
+  // already treat it, so a new window never has to be added in three places.
+  exact?: string[];
   label: string;
   input: number;
   output: number;
@@ -60,7 +64,8 @@ export const PRICE_TABLE: ModelPrice[] = [
 
   // --- Moonshot AI (Kimi) ---
   // K3: cache misses use the normal input rate; cache hits are discounted 90%.
-  { match: ["kimi-code/k3", "kimi-k3", "moonshot/k3"], exact: ["k3", "k3[1m]"], label: "K3", input: 3, output: 15, cache_write: 3, cache_read: 0.3 },
+  // Flat across the whole 1M window — there is no long-context tier to add.
+  { match: ["kimi-code/k3", "kimi-k3", "moonshot/k3"], exact: ["k3"], label: "K3", input: 3, output: 15, cache_write: 3, cache_read: 0.3 },
 
   // --- others (approx) ---
   { match: ["deepseek"], label: "DeepSeek", input: 0.27, output: 1.1, cache_write: 0, cache_read: 0.07 },
@@ -89,7 +94,8 @@ export function priceFor(modelName: string | null | undefined): ModelPrice | nul
   if (!modelName) return null;
   const m = modelName.toLowerCase();
   for (const p of table) {
-    if (p.exact?.includes(m) || p.match.some((frag) => m.includes(frag))) return p;
+    const exact = p.exact?.some((id) => m === id || m.startsWith(`${id}[`));
+    if (exact || p.match.some((frag) => m.includes(frag))) return p;
   }
   return null;
 }

--- a/server/test/pricing.test.ts
+++ b/server/test/pricing.test.ts
@@ -45,6 +45,17 @@ describe("priceFor", () => {
     expect(priceFor("task3-custom-model")).toBeNull();
   });
 
+  // K3's rate is flat across its whole window, so a context suffix is the same
+  // model at the same price. It used to be spelled out one window at a time
+  // here while providerOf and modelLabelOf already took any suffix, so a name
+  // could read "Moonshot / K3" in the UI and still be billed at the fallback.
+  test("a K3 context suffix is the same model, not an unknown one", () => {
+    for (const model of ["k3[1m]", "k3[512k]", "K3[1M]"]) {
+      expect(priceFor(model)?.label).toBe("K3");
+      expect(priceFor(model)).toBe(priceFor("k3"));
+    }
+  });
+
   test("unknown and empty model names return null", () => {
     expect(priceFor(null)).toBeNull();
     expect(priceFor(undefined)).toBeNull();


### PR DESCRIPTION
## What does this PR do?

Follow-up polish on #361, which landed Kimi K3 support.

The three places that recognise K3 didn't agree on the context suffix. `providerOf` (server and web) and `modelLabelOf` all accept anything starting with `k3[`, but the price table listed whole names one window at a time. So a model reported as `k3[512k]` read as **Moonshot / K3** in the UI while being billed by the fallback rate behind it:

```
k3[512k]   provider=Moonshot   label=K3   price=NULL -> DEFAULT
```

Harmless today, because `DEFAULT_PRICE` happens to be 3 / 15 / 0.3 as well and only `cache_write` differs, and quietly wrong the moment either number moves. A price that disagrees with the label it is shown next to is the kind of bug nobody reports.

`exact` now matches a whole-name id with its context suffix, the way the other two already do, so a new window never has to be added in three places. K3's published rate is flat across the entire 1M window, so there is no long-context tier a suffix could legitimately select.

Also stops the "any provider" section claiming to be the OpenTelemetry section: Kimi arrives through hooks rather than OTLP, and it now sits under a heading that says so, with the contents anchor updated to match.

## How was it tested?

- `bun test server/test` — 751 pass, 0 fail
- `bunx tsc -p web/tsconfig.json --noEmit` — clean
- New test pins `k3[1m]`, `k3[512k]` and `K3[1M]` to the same `ModelPrice` object as `k3`, and the existing guard that `task3-custom-model` stays unpriced still holds
- Checked by hand that the three sites now agree, and that Anthropic's disjoint token shape is untouched by #361's split (the subtraction only fires when `input_tokens` is absent, including the fully cached `input_tokens: 0` case)

Kimi's published rates were confirmed against several independent trackers before trusting the table: $3 / MTok input, $15 / MTok output, $0.30 / MTok cache hit.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185oPxEs6TkCphraS2MKn92

---
_Generated by [Claude Code](https://claude.ai/code/session_0185oPxEs6TkCphraS2MKn92)_