### PR TITLE
fix(metrics): one model, one name — unweld the label from the price row (#248)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -16,6 +16,7 @@ import type {
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
 import { costUsd, modelLabel } from "./pricing.ts";
+import { providerOf as sharedProviderOf, UNKNOWN as UNKNOWN_MODEL } from "../../shared/models.ts";
 import { workspaceRoot, scopeRoots, isWithin } from "./config.ts";
 
 /**
@@ -405,19 +406,19 @@ export function gateHistory(limit = 50): GateRow[] {
 /** Coarse vendor for a model name — the provider dimension. Returns null for an
  *  unknown/absent model so a session's known provider is never overwritten.
  *  Kept in sync with the web's providerOf() in web/src/lib/format.ts. */
+/**
+ * The vendor behind a model name, as this tier wants it.
+ *
+ * The rules live in shared/models.ts, shared with the web copy — they were two
+ * hand-kept transcriptions of each other, which #282 pinned with a test after
+ * they drifted. The only difference that survives is the miss value: the web
+ * needs a string to put in a filter option, this tier writes NULL into the
+ * `provider` column, and UNKNOWN_PROVIDER below is what makes the two
+ * correspond.
+ */
 export function providerOf(model: string | null | undefined): string | null {
-  if (!model) return null;
-  const m = model.toLowerCase();
-  if (/opus|sonnet|haiku|fable|claude|anthropic/.test(m)) return "Anthropic";
-  if (/gpt|davinci|openai|\bo1\b|\bo3\b|\bo4\b/.test(m)) return "OpenAI";
-  if (/gemini|palm|bison|flash|google|vertex/.test(m)) return "Google";
-  if (/kimi|moonshot/.test(m) || m === "k3" || m.startsWith("k3[")) return "Moonshot";
-  if (/deepseek/.test(m)) return "DeepSeek";
-  if (/grok|xai/.test(m)) return "xAI";
-  if (/mistral|mixtral|codestral/.test(m)) return "Mistral";
-  if (/llama|meta-/.test(m)) return "Meta";
-  if (/command|cohere/.test(m)) return "Cohere";
-  return null;
+  const p = sharedProviderOf(model);
+  return p === UNKNOWN_MODEL ? null : p;
 }
 
 /**
@@ -1173,15 +1174,54 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
        GROUP BY model_name`
     )
     .all(...A);
-  const by_model: CostByModel[] = modelRows.map((r) => ({
-    model_name: modelLabel(r.model_name),
-    input_tokens: r.input_tokens ?? 0,
-    output_tokens: r.output_tokens ?? 0,
-    cache_creation_tokens: r.cache_creation_tokens ?? 0,
-    cache_read_tokens: r.cache_read_tokens ?? 0,
-    cost_usd: r.cost_usd ?? 0,
-    sessions: r.sessions ?? 0,
-  }));
+  /**
+   * Fold the raw ids into their labels before the panel sees them.
+   *
+   * The SQL groups by `model_name`, which is the raw id, and the label is
+   * applied after — so two ids that share a label ("claude-opus-4-1" and
+   * "claude-opus-4-5" both being Opus) arrived as two rows reading "Opus",
+   * each carrying part of that model's spend, under the same name and the
+   * same colour. The donut's centre was right and no legend row was.
+   *
+   * `sessions` is the one column that cannot be summed: it is a
+   * COUNT(DISTINCT session_id) per raw id, so a session that switched model
+   * version mid-run counts once in each row and twice in the fold. It is
+   * counted over distinct pairs instead, below.
+   */
+  const sessionRows = db
+    .query<{ model_name: string | null; session_id: string }, any[]>(
+      `SELECT DISTINCT model_name, session_id FROM events
+       WHERE timestamp >= ? AND model_name IS NOT NULL${pf}`
+    )
+    .all(...A);
+  const sessionsByLabel = new Map<string, Set<string>>();
+  for (const r of sessionRows) {
+    const label = modelLabel(r.model_name);
+    const set = sessionsByLabel.get(label) ?? new Set<string>();
+    set.add(r.session_id);
+    sessionsByLabel.set(label, set);
+  }
+
+  const modelFold = new Map<string, CostByModel>();
+  for (const r of modelRows) {
+    const label = modelLabel(r.model_name);
+    const e = modelFold.get(label) ?? {
+      model_name: label,
+      input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0,
+      cost_usd: 0, sessions: 0,
+    };
+    e.input_tokens += r.input_tokens ?? 0;
+    e.output_tokens += r.output_tokens ?? 0;
+    e.cache_creation_tokens += r.cache_creation_tokens ?? 0;
+    e.cache_read_tokens += r.cache_read_tokens ?? 0;
+    e.cost_usd += r.cost_usd ?? 0;
+    modelFold.set(label, e);
+  }
+  for (const [label, e] of modelFold) e.sessions = sessionsByLabel.get(label)?.size ?? 0;
+  // Ordered on the way out: the query has no ORDER BY, and the panel renders
+  // the array in the order it arrives, so without this the donut's slices
+  // reshuffle between refreshes for no reason the viewer can see.
+  const by_model: CostByModel[] = [...modelFold.values()].sort((a, b) => b.cost_usd - a.cost_usd);
 
   // Tool latency — pull durations per tool and compute percentiles in JS.
   const durRows = db

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -117,7 +117,19 @@ export function costUsd(usage: TokenUsage, modelName: string | null | undefined)
   );
 }
 
-export function modelLabel(modelName: string | null | undefined): string {
-  const p = priceFor(modelName);
-  return p?.label ?? (modelName ? modelName : "unknown");
-}
+/**
+ * What to call a model on screen.
+ *
+ * This used to return `priceFor(m)?.label`, which welded display naming to
+ * price bucketing — and those two want opposite things. A price row groups
+ * several ids on purpose, because they share a rate; a name identifies one
+ * model. So a GPT-5 session was labelled "GPT-4.1" by every server-rendered
+ * surface (the cost donut) while the client-rendered ones (fleet card, session
+ * chip, phone) called it "GPT-5", and modelColor() — which hashes the label —
+ * drew the same model in two colours.
+ *
+ * Naming lives in shared/models.ts now, alongside providerOf, so both tiers
+ * answer it identically. `ModelPrice.label` survives as the name of a *rate
+ * row*, which is what it always really was: it names a bucket, not a model.
+ */
+export { modelLabelOf as modelLabel } from "../../shared/models.ts";

--- a/server/test/provider-parity.test.ts
+++ b/server/test/provider-parity.test.ts
@@ -19,9 +19,11 @@ process.env.AGENTGLASS_DB = join(mkdtempSync(join(tmpdir(), "agx-prov-")), "p.db
 let serverProviderOf: (m: string | null | undefined) => string | null;
 let webProviderOf: (m: string | null | undefined) => string;
 let webModelLabelOf: (m: string | null | undefined) => string;
+let serverModelLabel: (m: string | null | undefined) => string;
 
 beforeAll(async () => {
   serverProviderOf = (await import("../src/db.ts")).providerOf;
+  serverModelLabel = (await import("../src/pricing.ts")).modelLabel;
   const format = await import("../../web/src/lib/format.ts");
   webProviderOf = format.providerOf;
   webModelLabelOf = format.modelLabelOf;
@@ -59,5 +61,50 @@ describe("providerOf agrees between the server and the web copy", () => {
       expect(webProviderOf(model)).toBe("Moonshot");
       expect(webModelLabelOf(model)).toBe("K3");
     }
+  });
+});
+
+// The other half of the same class of bug, and the one that actually shipped.
+// providerOf was pinned here by #282; the display label was not, and it had
+// drifted: server modelLabel() returned the matched PRICE ROW's name, and a
+// price row buckets several ids on purpose. So "gpt-5" priced from the GPT-4.1
+// row was *called* "GPT-4.1" by the cost donut while the fleet card beside it
+// said "GPT-5" — one model, two names, two hash-derived colours, on one screen.
+//
+// Both sides now come from shared/models.ts. This is what stops the split
+// reopening the next time a rate row is made to cover one more id.
+describe("modelLabel agrees between the server and the web copy", () => {
+  const LABELLED = [
+    ...MODELS,
+    // The families where a rate row deliberately covers several models — the
+    // exact shape that used to collapse them all onto one name.
+    "gpt-5", "gpt-5-mini", "gpt-5-nano", "gpt-4.5",
+    "gpt-4.1-mini", "gpt-4.1-nano", "gpt-4-turbo",
+    "claude-opus-4-1", "claude-opus-4-5", "claude-3-5-sonnet-20241022",
+    "mythos-1", "k3[512k]",
+  ];
+  for (const m of LABELLED) {
+    test(`"${m}" is called the same thing on both sides`, () => {
+      expect(serverModelLabel(m)).toBe(webModelLabelOf(m));
+    });
+  }
+
+  test("null / undefined agree", () => {
+    expect(serverModelLabel(null)).toBe(webModelLabelOf(null));
+    expect(serverModelLabel(undefined)).toBe(webModelLabelOf(undefined));
+  });
+
+  // The regression that motivated all of this, stated as itself.
+  test("a GPT-5 id is not called GPT-4.1", () => {
+    expect(serverModelLabel("gpt-5")).toBe("GPT-5");
+    expect(serverModelLabel("gpt-5-mini")).toBe("GPT-5 mini");
+  });
+
+  // A price row may still bucket ids together — that is its job. What it may
+  // no longer do is decide what they are called.
+  test("a shared rate row does not merge two models' names", async () => {
+    const { priceFor } = await import("../src/pricing.ts");
+    expect(priceFor("gpt-5")?.input).toBe(priceFor("gpt-4.1")?.input);
+    expect(serverModelLabel("gpt-5")).not.toBe(serverModelLabel("gpt-4.1"));
   });
 });

--- a/server/test/stats-by-model-fold.test.ts
+++ b/server/test/stats-by-model-fold.test.ts
@@ -1,0 +1,96 @@
+// "Where the money goes" must have one row per model, not one per raw id (#248 F5).
+//
+// The SQL groups by `model_name` — the raw id the source reported — and the
+// display label is applied afterwards. Two ids that share a label therefore
+// arrived as two separate rows reading the same name: an Opus session split
+// across "claude-opus-4-1" and "claude-opus-4-5" rendered as two "Opus" slices,
+// each carrying part of the spend, in the same hash-derived colour, with no
+// single row stating what Opus actually cost. The donut's centre total was
+// right, which is what kept it hidden.
+//
+// `sessions` is the column that cannot simply be summed: it is a
+// COUNT(DISTINCT session_id) per raw id, so a session that switched model
+// version mid-run appears in both rows and would be counted twice by the fold.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-bymodel-"));
+const ROOT = join(dir, "proj");
+mkdirSync(ROOT, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "bymodel.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const event = (model: string, session: string, tokens: number) => ({
+  source_app: "proj",
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: model,
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: tokens, output_tokens: tokens, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: Date.now() - 60_000,
+  payload: { project_path: ROOT },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  // Two Opus point releases, and one session that used both — the case that
+  // makes summing `sessions` wrong.
+  db.insertEvent(event("claude-opus-4-1", "s-both", 1000) as any);
+  db.insertEvent(event("claude-opus-4-5", "s-both", 2000) as any);
+  db.insertEvent(event("claude-opus-4-5", "s-only-45", 3000) as any);
+  // A different model, so the fold has something to keep apart.
+  db.insertEvent(event("claude-haiku-4-5", "s-haiku", 500) as any);
+});
+
+const byLabel = (s: any, label: string) => s.by_model.filter((m: any) => m.model_name === label);
+
+describe("by_model folds raw ids into one row per label", () => {
+  test("two Opus point releases are one Opus row", () => {
+    const opus = byLabel(db.statsSummary(3_600_000), "Opus");
+    expect(opus.length).toBe(1);
+  });
+
+  test("that row carries the whole family's tokens, not a slice", () => {
+    const [opus] = byLabel(db.statsSummary(3_600_000), "Opus");
+    expect(opus.input_tokens).toBe(6000); // 1000 + 2000 + 3000
+    expect(opus.output_tokens).toBe(6000);
+  });
+
+  test("a session that used both versions counts once, not twice", () => {
+    const [opus] = byLabel(db.statsSummary(3_600_000), "Opus");
+    // s-both and s-only-45. Summing the per-id COUNT(DISTINCT) would give 3.
+    expect(opus.sessions).toBe(2);
+  });
+
+  test("a different model keeps its own row", () => {
+    const s = db.statsSummary(3_600_000);
+    expect(byLabel(s, "Haiku").length).toBe(1);
+    expect(byLabel(s, "Haiku")[0].input_tokens).toBe(500);
+  });
+
+  test("the fold preserves the total — the donut's centre still reconciles", () => {
+    const s = db.statsSummary(3_600_000);
+    const summed = s.by_model.reduce((n: number, m: any) => n + m.input_tokens + m.output_tokens, 0);
+    expect(summed).toBe(s.totals.input_tokens + s.totals.output_tokens);
+  });
+
+  // The panel renders the array in the order it arrives and the query has no
+  // ORDER BY, so without an explicit sort the slices reshuffle between refreshes.
+  test("rows arrive in a deterministic order, dearest first", () => {
+    const costs = db.statsSummary(3_600_000).by_model.map((m: any) => m.cost_usd);
+    expect([...costs].sort((a: number, b: number) => b - a)).toEqual(costs);
+  });
+});

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -1,0 +1,72 @@
+// What a model is called, and who makes it. One copy, both tiers.
+//
+// These two questions used to be answered three times: `providerOf` in
+// server/src/db.ts and again in web/src/lib/format.ts, and the display label
+// in web/src/lib/format.ts and — separately and differently — in
+// server/src/pricing.ts, where `modelLabel()` returned the matched price row's
+// name.
+//
+// That last one is the reason this file exists. A price row deliberately
+// buckets several model ids together, because several models can share a rate;
+// a label must not, because a name identifies one model. Welding them meant the
+// donut called a GPT-5 session "GPT-4.1" while the fleet card beside it called
+// the same session "GPT-5" — and, since modelColor() hashes the label string,
+// drew them in two different colours. Naming is now decided here and pricing in
+// pricing.ts, and neither can drift into the other.
+//
+// Kept deliberately dumb — substring matching, first hit wins, order specific
+// to general — because it runs per event on the ingest path.
+
+/** Raw fragment → display label. Order matters: specific before general. */
+const MODEL_LABELS: [string, string][] = [
+  ["kimi-code/k3", "K3"], ["kimi-k3", "K3"], ["moonshot/k3", "K3"],
+  ["opus", "Opus"], ["sonnet", "Sonnet"], ["haiku", "Haiku"], ["fable", "Fable"],
+  ["mythos", "Mythos"],
+  ["gpt-4o-mini", "GPT-4o mini"], ["gpt-4o", "GPT-4o"],
+  ["gpt-4.1-nano", "GPT-4.1 nano"], ["gpt-4.1-mini", "GPT-4.1 mini"], ["gpt-4.1", "GPT-4.1"],
+  ["gpt-5-nano", "GPT-5 nano"], ["gpt-5-mini", "GPT-5 mini"], ["gpt-5", "GPT-5"],
+  ["gpt-4.5", "GPT-4.5"],
+  ["gpt-4-turbo", "GPT-4 Turbo"], ["gpt-4", "GPT-4"], ["gpt-3.5", "GPT-3.5"],
+  ["o4-mini", "o4-mini"], ["o3-mini", "o3-mini"], ["o1-mini", "o1-mini"], ["o1", "o1"], ["o3", "o3"],
+  ["flash", "Gemini Flash"], ["gemini", "Gemini"],
+  ["deepseek", "DeepSeek"], ["grok", "Grok"], ["mixtral", "Mistral"], ["mistral", "Mistral"],
+  ["codestral", "Mistral"], ["llama", "Llama"], ["command", "Command"],
+];
+
+/** What the miss bucket is called. The server stores NULL for it; see
+ *  UNKNOWN_PROVIDER in server/src/db.ts for why the two must correspond. */
+export const UNKNOWN = "unknown";
+
+/**
+ * A raw model_name as a short display label.
+ *
+ * "claude-sonnet-5" → "Sonnet", "gpt-4o-2024-08-06" → "GPT-4o",
+ * "gemini-2.0-flash" → "Gemini Flash". An unrecognised name passes through
+ * unchanged rather than becoming "unknown": a model this table has not learned
+ * yet is still better identified by its own id than by a shrug.
+ */
+export function modelLabelOf(raw: string | null | undefined): string {
+  if (!raw) return UNKNOWN;
+  const m = raw.toLowerCase();
+  // K3 arrives bare or with a context suffix — `k3[512k]` is the same model.
+  if (m === "k3" || m.startsWith("k3[")) return "K3";
+  for (const [frag, label] of MODEL_LABELS) if (m.includes(frag)) return label;
+  return raw;
+}
+
+/** Coarse vendor for a model name — powers the provider filter and badge.
+ *  Works for Claude Code's `claude-opus-4-8` and for OpenTelemetry sources. */
+export function providerOf(raw: string | null | undefined): string {
+  if (!raw) return UNKNOWN;
+  const m = raw.toLowerCase();
+  if (/opus|sonnet|haiku|fable|claude|anthropic/.test(m)) return "Anthropic";
+  if (/gpt|davinci|openai|\bo1\b|\bo3\b|\bo4\b/.test(m)) return "OpenAI";
+  if (/gemini|palm|bison|flash|google|vertex/.test(m)) return "Google";
+  if (/kimi|moonshot/.test(m) || m === "k3" || m.startsWith("k3[")) return "Moonshot";
+  if (/deepseek/.test(m)) return "DeepSeek";
+  if (/grok|xai/.test(m)) return "xAI";
+  if (/mistral|mixtral|codestral/.test(m)) return "Mistral";
+  if (/llama|meta-/.test(m)) return "Meta";
+  if (/command|cohere/.test(m)) return "Cohere";
+  return UNKNOWN;
+}

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -97,43 +97,11 @@ export const TYPE_COLORS: Record<string, string> = {
 };
 export const typeColor = (t: string) => TYPE_COLORS[t] ?? "#64748b";
 
-// Map a raw model_name to a short label, across providers:
-// "claude-sonnet-5" → "Sonnet", "gpt-4o-2024-08-06" → "GPT-4o", "gemini-2.0-flash" → "Gemini Flash".
-// First substring hit wins, so order specific → general. Unknown names pass through.
-const MODEL_LABELS: [string, string][] = [
-  ["kimi-code/k3", "K3"], ["kimi-k3", "K3"], ["moonshot/k3", "K3"],
-  ["opus", "Opus"], ["sonnet", "Sonnet"], ["haiku", "Haiku"], ["fable", "Fable"],
-  ["gpt-4o-mini", "GPT-4o mini"], ["gpt-4o", "GPT-4o"], ["gpt-4.1", "GPT-4.1"],
-  ["gpt-4", "GPT-4"], ["gpt-3.5", "GPT-3.5"], ["gpt-5-mini", "GPT-5 mini"], ["gpt-5", "GPT-5"],
-  ["o4-mini", "o4-mini"], ["o3-mini", "o3-mini"], ["o1-mini", "o1-mini"], ["o1", "o1"], ["o3", "o3"],
-  ["flash", "Gemini Flash"], ["gemini", "Gemini"],
-  ["deepseek", "DeepSeek"], ["grok", "Grok"], ["mixtral", "Mistral"], ["mistral", "Mistral"],
-  ["codestral", "Mistral"], ["llama", "Llama"], ["command", "Command"],
-];
-export function modelLabelOf(raw: string | null | undefined): string {
-  if (!raw) return "unknown";
-  const m = raw.toLowerCase();
-  if (m === "k3" || m.startsWith("k3[")) return "K3";
-  for (const [frag, label] of MODEL_LABELS) if (m.includes(frag)) return label;
-  return raw;
-}
-
-// Coarse vendor for a model name — powers the provider filter/badge. Works for
-// both Claude Code (model_name like "claude-opus-4-8") and OpenTelemetry sources.
-export function providerOf(raw: string | null | undefined): string {
-  if (!raw) return "unknown";
-  const m = raw.toLowerCase();
-  if (/opus|sonnet|haiku|fable|claude|anthropic/.test(m)) return "Anthropic";
-  if (/gpt|davinci|openai|\bo1\b|\bo3\b|\bo4\b/.test(m)) return "OpenAI";
-  if (/gemini|palm|bison|flash|google|vertex/.test(m)) return "Google";
-  if (/kimi|moonshot/.test(m) || m === "k3" || m.startsWith("k3[")) return "Moonshot";
-  if (/deepseek/.test(m)) return "DeepSeek";
-  if (/grok|xai/.test(m)) return "xAI";
-  if (/mistral|mixtral|codestral/.test(m)) return "Mistral";
-  if (/llama|meta-/.test(m)) return "Meta";
-  if (/command|cohere/.test(m)) return "Cohere";
-  return "unknown";
-}
+// Both of these used to live here in full, with a second copy of providerOf in
+// server/src/db.ts and a rival label table in server/src/pricing.ts. They are
+// one implementation now — see shared/models.ts for why the label had to stop
+// coming from the price row it matched.
+export { modelLabelOf, providerOf } from "../../../shared/models.ts";
 
 export const MODEL_COLORS: Record<string, string> = {
   Opus: "#f472b6",


### PR DESCRIPTION
Part of #248. Fixes **F21** and **F5**, and removes the root cause behind **F10**.

## What was wrong

`modelLabel()` returned the matched **price row's** name:

```ts
export function modelLabel(modelName: string | null | undefined): string {
  const p = priceFor(modelName);
  return p?.label ?? (modelName ? modelName : "unknown");
}
```

A price row buckets several ids on purpose — several models can share a rate. A *name* identifies one model. Welding them meant the cost donut called a GPT-5 session **"GPT-4.1"** while the fleet card beside it called the same session **"GPT-5"**, and since `modelColor()` hashes the label string, drew one model in two different colours.

It was not one divergence. Pinning the two sides against each other turns up **fourteen**:

```
gpt-5           server="GPT-4.1"  ≠  web="GPT-5"
gpt-5-mini      server="GPT-4.1"  ≠  web="GPT-5 mini"
gpt-4.5         server="GPT-4.1"  ≠  web="GPT-4"
o3-mini         server="o-mini"   ≠  web="o3-mini"
…and ten more
```

## What changed

**Naming moved to `shared/models.ts`**, alongside `providerOf` — which was itself a second hand-kept copy of the server's. #282 pinned *those* two with a test after they drifted; this is the other half of the same class of bug, and the half that actually shipped. `ModelPrice.label` survives as the name of a rate row, which is what it always really was.

**`by_model` is folded by label (F5).** The SQL groups by the raw id and the label is applied after, so two ids sharing a label arrived as two rows reading the same name, each carrying part of that model's spend, in the same colour — an Opus session split across `claude-opus-4-1` and `claude-opus-4-5` rendered as two "Opus" slices and no single legend row said what Opus cost. The donut's centre total was right, which is what kept it hidden.

Two details in that fold:
- `sessions` is counted over distinct `(label, session_id)` pairs rather than summed — it is a `COUNT(DISTINCT session_id)` *per raw id*, so a session that switched version mid-run appears in both source rows and summing double-counts it.
- Rows now leave sorted by cost. The query has no `ORDER BY` and the panel renders arrival order, so the donut's slices were reshuffling between refreshes for no reason a viewer could see.

## What is deliberately NOT in this change

**The rates.** `gpt-5` is still priced from the GPT-4.1 row — it is now correctly *named* and still charged at $2/$8. That is on purpose:

- The file's own header makes verifying rates against the provider the contract, and every attempt to reach `openai.com/pricing`, `platform.openai.com/docs/pricing` and two independent trackers from this environment returned **403**. I am not writing numbers into a billing table on the strength of a search-result summary.
- Unwelding first is what makes the rate fix *safe* to do separately: after this, a rate row can cover one more id without renaming it.
- Separately worth your attention, and larger than F10 as filed: one search suggests **`gpt-5` and `gpt-5-mini` are no longer listed by OpenAI**, and the current lineup (GPT-5.6 Sol/Terra/Luna, GPT-5.5, GPT-5.4) has **no rows at all** — meaning current OpenAI models fall through to `DEFAULT_PRICE`, which is Sonnet-tier $3/$15. I could not corroborate that from a second source, so it is a flag, not a finding.

Note also that `cost_usd` is computed at insert, so any future rate change relabels history retroactively (labels are read-time) but does **not** recompute past cost. That discontinuity is its own decision and deserves its own PR.

## How was it tested?

Both guards were **run red before green** — a guard I have not seen fail is not a guard.

- `server/test/provider-parity.test.ts` extended to pin `modelLabel` the way #282 pinned `providerOf`. Reverting `modelLabel` to the old body fails **14 name tests** plus `a GPT-5 id is not called GPT-4.1` and `a shared rate row does not merge two models' names`. Restored: 89 pass.
- `server/test/stats-by-model-fold.test.ts` (new) — two Opus point releases plus a session that used both. Without the fold, **4 of 6 fail**: two rows instead of one, a sliced token count, `sessions` = 3 instead of 2, and non-deterministic order. It also asserts the fold preserves the total, so the donut centre still reconciles with its legend.
- Full suites: **807 server** / **419 web**, 0 failures. `bunx tsc --noEmit` clean in both tiers. `bunx vite build` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_