### PR TITLE
fix(metrics): six numbers that were answering the wrong question (#248)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1148,6 +1148,14 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
       `SELECT COUNT(*) AS events,
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) AS tool_calls,
               SUM(is_error) AS errors,
+              -- Errors that were actually a tool failing, which is the only
+              -- numerator tool_calls can honestly serve as a denominator for.
+              -- The errors column counts every errored event, and an LLM span
+              -- or a notification can carry is_error too (otlp.ts sets it on
+              -- "Turn complete") — dividing that by tool calls produced a
+              -- health ring below zero, and insights reading "6 of 4 tool
+              -- calls failed". Both ship; each answers its own question.
+              SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') AND is_error = 1 THEN 1 ELSE 0 END) AS tool_errors,
               COUNT(DISTINCT session_id) AS sessions,
               SUM(input_tokens) AS input_tokens,
               SUM(output_tokens) AS output_tokens,
@@ -1157,7 +1165,7 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
        FROM events WHERE timestamp >= ?${pf}`
     )
     .get(...A)!;
-  const evtTotals = totals as { events: number; tool_calls: number; errors: number };
+  const evtTotals = totals as { events: number; tool_calls: number; errors: number; tool_errors: number };
   const tokTotals = totals;
 
   // Per-model breakdown (from events so it respects the window).
@@ -1323,6 +1331,7 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
       sessions: tokTotals.sessions ?? 0,
       tool_calls: evtTotals.tool_calls ?? 0,
       errors: evtTotals.errors ?? 0,
+      tool_errors: evtTotals.tool_errors ?? 0,
       cost_usd: tokTotals.cost_usd ?? 0,
       input_tokens: tokTotals.input_tokens ?? 0,
       output_tokens: tokTotals.output_tokens ?? 0,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1113,11 +1113,16 @@ const statsCache = new Map<string, { at: number; data: StatsSummary }>();
 /** Full analytics summary over a rolling window (default 24h), optionally scoped
  *  to a single provider (Anthropic / OpenAI / Google / …). Always scoped to the
  *  open project, so spend, tool mix and the radar describe that project alone. */
-export function statsSummary(windowMs = 24 * 3600 * 1000, provider?: string): StatsSummary {
-  const key = `${windowMs}|${provider ?? ""}|${workspaceRoot() ?? ""}`;
+export function statsSummary(windowMs = 24 * 3600 * 1000, provider?: string, tz?: string): StatsSummary {
+  // tz belongs in the key, not only the arguments. The heatmap buckets by
+  // weekday and hour, which are only defined relative to a clock — and the
+  // viewer is often not on the server (remote access, the phone companion).
+  // Without it here, one viewer's grid is served to another in a different
+  // zone for the whole TTL.
+  const key = `${windowMs}|${provider ?? ""}|${workspaceRoot() ?? ""}|${tz ?? ""}`;
   const hit = statsCache.get(key);
   if (hit && Date.now() - hit.at < STATS_TTL_MS) return hit.data;
-  const data = computeStatsSummary(windowMs, provider);
+  const data = computeStatsSummary(windowMs, provider, tz);
   // One entry per (window, provider, scope). The window set is fixed and small
   // (the header's chips) and scope rarely changes, so this never grows unbounded
   // in practice; prune stale entries anyway so a long-lived server can't leak.
@@ -1126,7 +1131,7 @@ export function statsSummary(windowMs = 24 * 3600 * 1000, provider?: string): St
   return data;
 }
 
-function computeStatsSummary(windowMs: number, provider?: string): StatsSummary {
+function computeStatsSummary(windowMs: number, provider?: string, tz?: string): StatsSummary {
   const since = Date.now() - windowMs;
   const { clause: prov, args: pa } = providerScope(provider);
   const { clause: sc, args: sa } = scopeClause();
@@ -1311,7 +1316,39 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
       `SELECT timestamp, is_error, cost_usd, input_tokens, output_tokens FROM events WHERE timestamp >= ?${pf}`
     )
     .all(...A);
+  /**
+   * The heatmap is a weekday x hour grid, and neither exists without a clock.
+   *
+   * It used to bucket with getDay()/getHours(), which read the *server*
+   * process's zone, while the timeline beside it buckets UTC epochs and is
+   * rendered in the viewer's. So the cell labelled "Tue 14:00" and the tick
+   * labelled 14:00 described different real hours whenever the two clocks
+   * differed — shifted by the offset, with whole day columns moving when it
+   * crossed midnight. Remote access and the phone companion exist precisely
+   * so that the viewer is not on the server, so this was reachable rather
+   * than theoretical.
+   *
+   * The formatter is built once: formatToParts per event over a wide window
+   * is thousands of calls. An absent or unknown zone falls back to the old
+   * behaviour rather than throwing — the server's clock is still better than
+   * a 500.
+   */
   const heatmap = new Array(168).fill(0);
+  const WEEKDAY: Record<string, number> = { Sun: 0, Mon: 1, Tue: 2, Wed: 3, Thu: 4, Fri: 5, Sat: 6 };
+  let fmt: Intl.DateTimeFormat | null = null;
+  if (tz) {
+    try {
+      fmt = new Intl.DateTimeFormat("en-US", { timeZone: tz, weekday: "short", hour: "2-digit", hour12: false });
+    } catch { fmt = null; }
+  }
+  const cellOf = (ms: number): number => {
+    if (!fmt) { const d = new Date(ms); return d.getDay() * 24 + d.getHours(); }
+    const parts = fmt.formatToParts(ms);
+    const wd = WEEKDAY[parts.find((x) => x.type === "weekday")?.value ?? "Sun"] ?? 0;
+    // hour12:false spells midnight "24" in some locales.
+    const hr = Number(parts.find((x) => x.type === "hour")?.value ?? 0) % 24;
+    return wd * 24 + hr;
+  };
   for (const r of tlRows) {
     const t = Math.min(lastKey, Math.floor(r.timestamp / bucketMs) * bucketMs);
     const b = buckets.get(t);
@@ -1321,8 +1358,7 @@ function computeStatsSummary(windowMs: number, provider?: string): StatsSummary 
       b.cost_usd += r.cost_usd ?? 0;
       b.tokens += (r.input_tokens ?? 0) + (r.output_tokens ?? 0);
     }
-    const d = new Date(r.timestamp);
-    heatmap[d.getDay() * 24 + d.getHours()]++;
+    heatmap[cellOf(r.timestamp)]++;
   }
 
   return {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -20,7 +20,7 @@ import {
   gateHistory,
 } from "./db.ts";
 import { maybeAlert, setAlertSink } from "./alerts.ts";
-import { getSkills, catalogMarkdown, catalogCsv } from "./skills.ts";
+import { getSkills, catalogMarkdown, catalogCsv, usageSince } from "./skills.ts";
 import { getInsights } from "./insights.ts";
 import { getUsage } from "./usage.ts";
 import { submitGate, decideGate, pendingGates, awaitGate, restoreGates, GATE_MAX_MS } from "./gate.ts";
@@ -1216,7 +1216,7 @@ const server = Bun.serve<WsData>({
       });
       return out ? body(out) : json({ error: "not found" }, 404);
     }
-    if (pathname === "/skills") return json({ skills: await getSkills(), generated_at: Date.now() });
+    if (pathname === "/skills") return json({ skills: await getSkills(), usage_since: usageSince(), generated_at: Date.now() });
     if (pathname === "/skills/export") {
       const fmt = url.searchParams.get("format") || "md";
       const dl = (body: string, type: string, name: string) =>
@@ -1233,7 +1233,18 @@ const server = Bun.serve<WsData>({
     }
     if (pathname === "/stats") {
       const windowMs = parseWindowMs(url.searchParams.get("window"));
-      return json({ ...statsSummary(windowMs, url.searchParams.get("provider") || undefined), server_started_at: STARTED_AT });
+      // tz is the viewer's IANA zone, which only the browser knows. The
+      // heatmap is a weekday × hour grid and those are properties of a clock,
+      // not of an epoch — without this it was drawn in the server's zone while
+      // the timeline beside it was drawn in the viewer's.
+      return json({
+        ...statsSummary(
+          windowMs,
+          url.searchParams.get("provider") || undefined,
+          url.searchParams.get("tz") || undefined,
+        ),
+        server_started_at: STARTED_AT,
+      });
     }
 
     // --- export ---

--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -66,7 +66,13 @@ export function getInsights(): Insight[] {
   // 3) High failure rate — errors relative to tool calls in the last hour.
   const fails = db
     .query<{ source_app: string; session_id: string; errs: number; tools: number; last: number }, any[]>(
-      `SELECT source_app, session_id, SUM(is_error) errs,
+      // errs counts only tool failures, because tools is the denominator. It
+      // used to be SUM(is_error) over every event — and an errored LLM span or
+      // notification never enters `tools`, so the rate was unbounded: a session
+      // with 6 non-tool errors and 4 tool calls announced "High failure rate ·
+      // 150%" and, underneath it, "6 of 4 tool calls failed".
+      `SELECT source_app, session_id,
+              SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') AND is_error = 1 THEN 1 ELSE 0 END) errs,
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) tools,
               MAX(timestamp) last
        FROM events WHERE timestamp > ?${sc} GROUP BY session_id

--- a/server/src/skills.ts
+++ b/server/src/skills.ts
@@ -6,7 +6,7 @@ import { readdirSync, readFileSync, statSync, existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, relative } from "node:path";
 import type { SkillInfo } from "../../shared/types.ts";
-import { skillUsageDetail } from "./db.ts";
+import { skillUsageDetail, RETENTION_DAYS } from "./db.ts";
 
 // Where to look for `.claude` roots: the user's own + every project checkout.
 const CODE_DIR = process.env.AGENTGLASS_CODE_DIR || join(homedir(), "code");
@@ -164,6 +164,12 @@ async function gitAddedDates(repo: string): Promise<Map<string, number>> {
   return map;
 }
 
+/** The oldest moment skill usage can be known from, or 0 when pruning is
+ *  disabled and the counts really are lifetime. */
+export function usageSince(): number {
+  return RETENTION_DAYS ? Date.now() - RETENTION_DAYS * 86_400_000 : 0;
+}
+
 export async function getSkills(): Promise<SkillInfo[]> {
   const now = Date.now();
   if (cache && now - cacheAt < TTL) return cache;
@@ -210,7 +216,22 @@ export async function getSkills(): Promise<SkillInfo[]> {
 
   // Join usage + attributed cost ("plugin:skill" invocations also count for "skill").
   const usage = new Map<string, { calls: number; cost_usd: number; last_used: number }>();
-  for (const u of skillUsageDetail()) {
+  /**
+   * Read the window that exists, rather than asking for all of history.
+   *
+   * skillUsageDetail() defaulted to since = 0, which reads every event in
+   * the table — but events are pruned at AGENTGLASS_RETENTION_DAYS (8 by
+   * default). So a lifetime figure was silently a retained-window one: a
+   * skill run 40 times over three months reported "4x". The error is
+   * largest for the oldest, best-established skills, which is exactly
+   * backwards for the question the panel exists to answer.
+   *
+   * The count cannot be made lifetime without a table that survives the
+   * prune, so it is made honest instead: the bound is computed here and
+   * shipped, and the UI states it. RETENTION_DAYS === 0 means pruning is
+   * off, and then it really is all time.
+   */
+  for (const u of skillUsageDetail(usageSince())) {
     for (const key of new Set([u.skill, u.skill.split(":").pop()!])) {
       const cur = usage.get(key) ?? { calls: 0, cost_usd: 0, last_used: 0 };
       cur.calls += u.calls;

--- a/server/src/skills.ts
+++ b/server/src/skills.ts
@@ -222,7 +222,25 @@ export async function getSkills(): Promise<SkillInfo[]> {
 
   cache = [...merged.values()]
     .map((s) => {
-      const u = usage.get(s.name);
+      /**
+       * One invocation charges one catalog entry.
+       *
+       * The catalog is keyed by `kind:name` — a project may hold both
+       * `.claude/skills/review/SKILL.md` and `.claude/commands/review.md` —
+       * but the usage bucket is keyed by name alone, so both entries read it.
+       * A single $0.0175 run of the *skill* was reported as 2 calls and
+       * $0.035 across the catalogue, and the never-used command inherited the
+       * skill's `last_used`, its per-run cost, and a place in the "top 3 most
+       * used" badge it had never earned.
+       *
+       * The bucket only ever contains Skill-tool invocations (db.ts reads
+       * `tool_name = 'Skill'`), so where a skill of that name exists it is the
+       * one that ran. A command of the same name is charged only when no such
+       * skill exists — which keeps a genuine command invocation attributed if
+       * the Skill tool is ever what runs a slash command.
+       */
+      const skillOwns = s.kind === "skill" || !merged.has(`skill:${s.name}`);
+      const u = skillOwns ? usage.get(s.name) : undefined;
       const clean = { ...s } as SkillInfo & { mtime?: number };
       delete clean.mtime;
       return {

--- a/server/test/failure-rate-denominator.test.ts
+++ b/server/test/failure-rate-denominator.test.ts
@@ -1,0 +1,101 @@
+// A failure rate must divide tool failures by tool calls (#248 F6).
+//
+// `errors` was SUM(is_error) over every event, but the denominator everywhere
+// is tool calls — and an errored event need not be a tool. The OTLP paths set
+// is_error on "Turn complete", an LLM span that never enters tool_calls, and
+// ingest.ts flags any event carrying a top-level `error`/`stderr` string. So a
+// window with clean tools and errored spans read as failing:
+//
+//   health ring   1 - 3/10  → 70%, "Degraded", with zero tool failures
+//   insights      6 errs / 4 tools → "High failure rate · 150%",
+//                 and under it "6 of 4 tool calls failed"
+//
+// insights had no clamp at all, which is how the rate got above 100.
+//
+// The fix keeps both counts. `errors` still means "how much went wrong", which
+// is what the Failed tile and the timeline series want; `tool_errors` is the
+// one a tool-call denominator may be paired with.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-failrate-"));
+const ROOT = join(dir, "proj");
+mkdirSync(ROOT, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "failrate.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+let getInsights: typeof import("../src/insights.ts").getInsights;
+
+const SESSION = "s-clean-tools";
+
+const event = (type: string, isError: boolean, back: number) => ({
+  source_app: "proj",
+  session_id: SESSION,
+  hook_event_type: type,
+  tool_name: type.startsWith("PostToolUse") ? "Bash" : null,
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: isError ? 1 : 0,
+  error_text: isError ? "boom" : null,
+  usage: { input_tokens: 10, output_tokens: 10, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: Date.now() - back,
+  payload: { project_path: ROOT },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  getInsights = (await import("../src/insights.ts")).getInsights;
+  // Four tool calls, none of which failed.
+  for (let i = 0; i < 4; i++) db.insertEvent(event("PostToolUse", false, 60_000 + i) as any);
+  // Six errored LLM spans — the shape otlp.ts produces. More errors than there
+  // are tool calls, which is what drove the rate past 100%.
+  for (let i = 0; i < 6; i++) db.insertEvent(event("Turn complete", true, 50_000 + i) as any);
+});
+
+describe("the two error counts answer different questions", () => {
+  test("errors still counts every errored event", () => {
+    expect(db.statsSummary(3_600_000).totals.errors).toBe(6);
+  });
+
+  test("tool_errors counts only tool failures — here, none", () => {
+    expect(db.statsSummary(3_600_000).totals.tool_errors).toBe(0);
+  });
+
+  test("tool_errors can never exceed tool_calls, which is the whole point", () => {
+    const t = db.statsSummary(3_600_000).totals;
+    expect(t.tool_errors!).toBeLessThanOrEqual(t.tool_calls);
+  });
+});
+
+describe("insights does not report a failure rate for tools that did not fail", () => {
+  test("no high-failure-rate card when every tool call succeeded", () => {
+    const cards = getInsights().filter((i) => i.kind === "errors");
+    expect(cards).toEqual([]);
+  });
+
+  test("a real tool failure still raises one, and its rate is bounded", () => {
+    // Three of five tool calls fail — 60%, genuinely worth a card.
+    // Short id on purpose: insights keys a card by `${app}:${sid.slice(0, 8)}`.
+    const s2 = "s-real";
+    const ev = (type: string, isError: boolean, back: number) => ({
+      ...event(type, isError, back), session_id: s2,
+    });
+    for (let i = 0; i < 2; i++) db.insertEvent(ev("PostToolUse", false, 40_000 + i) as any);
+    for (let i = 0; i < 3; i++) db.insertEvent(ev("PostToolUseFailure", true, 30_000 + i) as any);
+    const card = getInsights().find((i) => i.kind === "errors" && (i.session ?? "").includes(s2));
+    expect(card).toBeDefined();
+    const pct = Number(card!.title.match(/(\d+)%/)![1]);
+    expect(pct).toBe(60);
+    expect(pct).toBeLessThanOrEqual(100);
+    expect(card!.detail).toBe("3 of 5 tool calls failed");
+  });
+});

--- a/server/test/skill-catalog-kind.test.ts
+++ b/server/test/skill-catalog-kind.test.ts
@@ -70,6 +70,10 @@ beforeAll(async () => {
   getSkills = (await import("../src/skills.ts")).getSkills;
   db.insertEvent(skillEvent("review", 0.0175) as any);
   db.insertEvent(skillEvent("ship", 0.0175) as any);
+  // One run of "deploy", older than the retention window. Seeded here so the
+  // catalogue TTL cache cannot let the assertion pass by accident.
+  const { RETENTION_DAYS } = await import("../src/db.ts");
+  db.insertEvent({ ...skillEvent("deploy", 0), timestamp: Date.now() - (RETENTION_DAYS + 2) * 86_400_000 } as any);
 });
 
 describe("a Skill invocation is charged to the skill, not to a same-named command", () => {
@@ -104,7 +108,35 @@ describe("a Skill invocation is charged to the skill, not to a same-named comman
     expect(find(all, "command", "ship").calls).toBe(1);
   });
 
-  test("an uncontested skill is unaffected", async () => {
+});
+
+// A count bounded by retention must not read as a lifetime total (#248 F15).
+//
+// getSkills() called skillUsageDetail() with the default since = 0, which asks
+// for all of history — but events are pruned at AGENTGLASS_RETENTION_DAYS (8
+// by default), so the answer was silently "in the last week". A skill run 40
+// times over three months reported "4×", and the understatement is largest for
+// the oldest, best-established skills — backwards for the question the panel
+// exists to answer ("which skills earn their keep?").
+//
+// It cannot be made lifetime without a table that survives the prune, so it is
+// made honest: the bound is computed, shipped, and stated by the UI.
+describe("the usage window is bounded and declared", () => {
+  test("usageSince is retention days back, not the beginning of time", async () => {
+    const { usageSince } = await import("../src/skills.ts");
+    const { RETENTION_DAYS } = await import("../src/db.ts");
+    const since = usageSince();
+    expect(RETENTION_DAYS).toBeGreaterThan(0); // default 8; the guard below assumes it
+    expect(since).toBeGreaterThan(0);
+    const days = (Date.now() - since) / 86_400_000;
+    expect(days).toBeCloseTo(RETENTION_DAYS, 1);
+  });
+
+  // "deploy" was invoked once, older than the retention window — seeded in
+  // beforeAll so the catalogue's TTL cache cannot make this pass by accident.
+  // Reading with since = 0 counts it and reports a lifetime "1×" for a run the
+  // events table is about to forget; reading the real window reports 0.
+  test("an invocation older than the window is not counted, so the number is true", async () => {
     const all = await getSkills();
     expect(find(all, "skill", "deploy").calls).toBe(0);
   });

--- a/server/test/skill-catalog-kind.test.ts
+++ b/server/test/skill-catalog-kind.test.ts
@@ -1,0 +1,111 @@
+// One invocation charges one catalog entry (#248 F9).
+//
+// The catalog is keyed by `kind:name`, because a project may legitimately hold
+// both `.claude/skills/review/SKILL.md` and `.claude/commands/review.md`. The
+// usage bucket, however, is keyed by name alone — so both entries read it. A
+// single run of the *skill* was reported as two calls and twice the cost across
+// the catalogue, and the command, which had never run, inherited the skill's
+// last_used, its per-run cost, a place in the "top 3 most used" badge and a
+// spot in the "used recently" filter instead of "to discover".
+//
+// The bucket only ever contains Skill-tool invocations, so where a skill of
+// that name exists it is the one that ran.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-skillkind-"));
+const CODE = join(dir, "code");
+const PROJ = join(CODE, "proj");
+const CLAUDE = join(PROJ, ".claude");
+mkdirSync(join(CLAUDE, "skills", "review"), { recursive: true });
+mkdirSync(join(CLAUDE, "commands"), { recursive: true });
+mkdirSync(join(CLAUDE, "skills", "deploy"), { recursive: true });
+
+// A skill and a command sharing the name "review" — the collision.
+writeFileSync(join(CLAUDE, "skills", "review", "SKILL.md"),
+  "---\nname: review\ndescription: Review a diff carefully\n---\nbody\n");
+writeFileSync(join(CLAUDE, "commands", "review.md"),
+  "---\ndescription: A slash command that happens to share the name\n---\nbody\n");
+// A command with no rival skill — must still be chargeable.
+writeFileSync(join(CLAUDE, "commands", "ship.md"),
+  "---\ndescription: Ship it\n---\nbody\n");
+// A skill with no rival command — the ordinary case.
+writeFileSync(join(CLAUDE, "skills", "deploy", "SKILL.md"),
+  "---\nname: deploy\ndescription: Deploy the thing\n---\nbody\n");
+
+process.env.AGENTGLASS_DB = join(dir, "kind.db");
+process.env.AGENTGLASS_ROOT = PROJ;
+process.env.XDG_CONFIG_HOME = dir;
+process.env.AGENTGLASS_CODE_DIR = CODE;
+
+let db: typeof import("../src/db.ts");
+let getSkills: typeof import("../src/skills.ts").getSkills;
+
+const skillEvent = (name: string, cost: number) => ({
+  source_app: "proj",
+  session_id: "s1",
+  hook_event_type: "PreToolUse",
+  tool_name: "Skill",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 1000, output_tokens: 500, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "ran a skill",
+  timestamp: Date.now(),
+  payload: { project_path: PROJ, tool_input: { skill: name } },
+  chat: null,
+});
+
+const find = (list: any[], kind: string, name: string) =>
+  list.find((s) => s.kind === kind && s.name === name);
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  getSkills = (await import("../src/skills.ts")).getSkills;
+  db.insertEvent(skillEvent("review", 0.0175) as any);
+  db.insertEvent(skillEvent("ship", 0.0175) as any);
+});
+
+describe("a Skill invocation is charged to the skill, not to a same-named command", () => {
+  test("the catalogue holds both entries — the collision is legitimate", async () => {
+    const all = await getSkills();
+    expect(find(all, "skill", "review")).toBeDefined();
+    expect(find(all, "command", "review")).toBeDefined();
+  });
+
+  test("the skill carries the call", async () => {
+    const all = await getSkills();
+    expect(find(all, "skill", "review").calls).toBe(1);
+  });
+
+  test("the same-named command carries none, and no cost", async () => {
+    const all = await getSkills();
+    const cmd = find(all, "command", "review");
+    expect(cmd.calls).toBe(0);
+    expect(cmd.cost_usd).toBe(0);
+    // It had never run, so it belongs in "to discover", not "used recently".
+    expect(cmd.last_used).toBeNull();
+  });
+
+  test("the catalogue's totals are not inflated by the collision", async () => {
+    const all = await getSkills();
+    const reviewCalls = all.filter((s) => s.name === "review").reduce((n, s) => n + s.calls, 0);
+    expect(reviewCalls).toBe(1); // was 2
+  });
+
+  test("a command with no rival skill is still charged", async () => {
+    const all = await getSkills();
+    expect(find(all, "command", "ship").calls).toBe(1);
+  });
+
+  test("an uncontested skill is unaffected", async () => {
+    const all = await getSkills();
+    expect(find(all, "skill", "deploy").calls).toBe(0);
+  });
+});

--- a/server/test/stats-heatmap-tz.test.ts
+++ b/server/test/stats-heatmap-tz.test.ts
@@ -1,0 +1,98 @@
+// The heatmap belongs to the viewer's clock, not the server's (#248 F13).
+//
+// It bucketed with getDay()/getHours(), which read the server process's zone,
+// while the timeline beside it buckets UTC epochs and is rendered in the
+// browser's. So "Tue 14:00" on the grid and 14:00 on the timeline described
+// different real hours whenever the two clocks differed — offset by the
+// difference, with whole day columns moving when it crossed midnight.
+//
+// Not theoretical: remote access and the phone companion exist precisely so
+// the viewer is not sitting at the server.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-heatmaptz-"));
+const ROOT = join(dir, "proj");
+mkdirSync(ROOT, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "heat.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+// Monday 2026-07-27 23:30 UTC. In Tokyo that is Tuesday 08:30; in Los Angeles,
+// Monday 16:30. One instant, three different cells.
+const AT = Date.parse("2026-07-27T23:30:00Z");
+const cell = (weekday: number, hour: number) => weekday * 24 + hour;
+
+const event = () => ({
+  source_app: "proj",
+  session_id: "s1",
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 10, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: AT,
+  payload: { project_path: ROOT },
+  chat: null,
+});
+
+// The window has to reach back past a fixed date, so it is generous.
+const WINDOW = Date.now() - AT + 3_600_000;
+const lit = (tz?: string) => {
+  const h = db.statsSummary(WINDOW, undefined, tz).heatmap;
+  return h.reduce<number[]>((acc, n, i) => (n > 0 ? [...acc, i] : acc), []);
+};
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  db.insertEvent(event() as any);
+});
+
+describe("the heatmap buckets in the zone it is asked for", () => {
+  test("Tokyo puts a 23:30Z Monday event in Tuesday 08:00", () => {
+    expect(lit("Asia/Tokyo")).toEqual([cell(2, 8)]);
+  });
+
+  test("Los Angeles puts the same instant in Monday 16:00", () => {
+    expect(lit("America/Los_Angeles")).toEqual([cell(1, 16)]);
+  });
+
+  test("UTC puts it in Monday 23:00", () => {
+    expect(lit("UTC")).toEqual([cell(1, 23)]);
+  });
+
+  // The three above are the point: one event, three answers, none of them the
+  // server's opinion.
+  test("two zones an offset apart do not agree, which is why tz is in the key", () => {
+    expect(lit("Asia/Tokyo")).not.toEqual(lit("America/Los_Angeles"));
+  });
+
+  test("an unknown zone falls back rather than throwing", () => {
+    expect(() => lit("Mars/Olympus_Mons")).not.toThrow();
+    expect(lit("Mars/Olympus_Mons").length).toBe(1);
+  });
+
+  test("no zone at all still works — the old behaviour, the server's clock", () => {
+    expect(lit(undefined).length).toBe(1);
+  });
+
+  // A cache keyed without tz would serve Tokyo's grid to Los Angeles for the
+  // whole TTL. Interleaved on purpose: the second call must not be a cache hit.
+  test("one viewer's grid is never served to another zone", () => {
+    const tokyo = lit("Asia/Tokyo");
+    const la = lit("America/Los_Angeles");
+    const tokyoAgain = lit("Asia/Tokyo");
+    expect(tokyoAgain).toEqual(tokyo);
+    expect(la).not.toEqual(tokyo);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -175,7 +175,15 @@ export interface StatsSummary {
     events: number;
     sessions: number;
     tool_calls: number;
+    /** Every errored event, whatever kind — the honest "how much went wrong". */
     errors: number;
+    /**
+     * Errors that were a tool call failing. The only numerator `tool_calls` is
+     * a legitimate denominator for: `errors` also counts LLM spans and
+     * notifications, which never enter `tool_calls`. Optional so an older
+     * server's payload still renders — treat a missing value as unknown, not 0.
+     */
+    tool_errors?: number;
     cost_usd: number;
     input_tokens: number;
     output_tokens: number;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WatchEvent, SessionRollup } from "../../shared/types.ts";
 import { useLive } from "./lib/useLive.ts";
 import { useStats } from "./lib/useStats.ts";
-import { deriveAgents, deriveAlerts, buildTitles } from "./lib/derive.ts";
+import { deriveAgents, deriveAlerts, buildTitles, buildRollups } from "./lib/derive.ts";
 import { publishFleet } from "./lib/demoBridge.ts";
 import { providerOf } from "./lib/format.ts";
 import { api, IS_DEMO } from "./lib/api.ts";
@@ -241,7 +241,11 @@ export default function App() {
     return () => clearInterval(id);
   }, []);
   const titles = useMemo(() => buildTitles(sessions), [sessions]);
-  const agentsAll = useMemo(() => deriveAgents(events, openTools, titles), [events, openTools, titles, tick]);
+  // Same rows, second question: the buffer the cards sum over is a capped
+  // window, so cost/tokens/tools come from the session roll-up where there is
+  // one. See buildRollups.
+  const rollups = useMemo(() => buildRollups(sessions), [sessions]);
+  const agentsAll = useMemo(() => deriveAgents(events, openTools, titles, rollups), [events, openTools, titles, rollups, tick]);
   // Kept identical across renders while its *contents* are. `agentsAll` is
   // rebuilt on every socket flush and every tick, so a plain useMemo handed out
   // a new Map several times a second — and everything downstream that depends
@@ -280,7 +284,7 @@ export default function App() {
   const agents = useMemo(
     () =>
       filter.provider
-        ? deriveAgents(visibleEvents, openTools.filter((s) => sessionProvider.get(s.session_id) === filter.provider), titles)
+        ? deriveAgents(visibleEvents, openTools.filter((s) => sessionProvider.get(s.session_id) === filter.provider), titles, rollups)
         : agentsAll,
     [filter.provider, visibleEvents, agentsAll, openTools, sessionProvider, titles]
   );

--- a/web/src/components/Kpis.tsx
+++ b/web/src/components/Kpis.tsx
@@ -3,6 +3,7 @@ import { motion } from "motion/react";
 import type { StatsSummary } from "../../../shared/types.ts";
 import type { AgentCard } from "../lib/derive.ts";
 import { useTicker, fmtClock } from "../lib/motion.ts";
+import { fmtUsd, usdDigits } from "../lib/format.ts";
 import { HealthRing } from "./HealthRing.tsx";
 
 const enter = { initial: { opacity: 0, y: 12 }, animate: { opacity: 1, y: 0 } };
@@ -102,7 +103,24 @@ export function Kpis({
         <div className="min-w-0 grow">
           <div className="panel-eyebrow">Spend · this window</div>
           <div className="text-[32px] font-semibold leading-none tabular-nums" style={{ color: "var(--success)" }}>
-            <NumberFlow value={cost} format={{ style: "currency", currency: "USD", minimumFractionDigits: 2 }} />
+            {/* The one currency site in the app not routed through fmtUsd —
+                NumberFlow animates a number and takes Intl options, not a
+                formatted string. So it takes fmtUsd's decision instead.
+                minimumFractionDigits alone did not do it: with
+                style:"currency" the maximum defaults to the currency's two
+                digits and is not raised by the minimum, so $0.004 rendered
+                "$0.00" here while the panel beside it and the phone shell,
+                reading the same field, said "$0.004". Both must be set, and
+                min may never exceed max or Intl throws.
+                Below a hundredth of a cent even four digits round to zero, so
+                that range falls back to fmtUsd's "<$0.0001" — no animation,
+                but a true statement. */}
+            {cost > 0 && cost < 0.0001
+              ? <span>{fmtUsd(cost)}</span>
+              : <NumberFlow value={cost} format={{
+                  style: "currency", currency: "USD",
+                  minimumFractionDigits: usdDigits(cost), maximumFractionDigits: usdDigits(cost),
+                }} />}
           </div>
           <div className="text-[11px] t-dim2 mt-1.5 tabular-nums">
             <NumberFlow value={tokens} /> tokens · {(cached / 1000).toFixed(0)}k cached

--- a/web/src/components/Kpis.tsx
+++ b/web/src/components/Kpis.tsx
@@ -79,10 +79,16 @@ export function Kpis({
   const waiting = agents.filter((a) => a.status === "waiting").length;
   const failed = t?.errors ?? 0;
   const tools = t?.tool_calls ?? 0;
+  // Health is a *tool* failure rate, so its numerator has to be tool failures.
+  // `errors` counts every errored event — an LLM span or a notification can
+  // carry one — and none of those are in `tool_calls`, so dividing by it drove
+  // the ring below zero on a fleet where no tool had failed at all. Falls back
+  // to the old field so a server that predates tool_errors still renders.
+  const toolFailed = t?.tool_errors ?? failed;
   const cost = t?.cost_usd ?? 0;
   const tokens = (t?.input_tokens ?? 0) + (t?.output_tokens ?? 0);
   const cached = t?.cache_read_tokens ?? 0;
-  const health = tools > 0 ? Math.max(0, Math.round((1 - failed / Math.max(tools, 1)) * 100)) : 100;
+  const health = tools > 0 ? Math.max(0, Math.round((1 - toolFailed / Math.max(tools, 1)) * 100)) : 100;
   const spark = (stats?.timeline ?? []).slice(-24).map((b) => b.cost_usd);
   const healthLabel = health >= 80 ? "All nominal" : health >= 50 ? "Degraded" : "Critical";
   const healthColor = health >= 80 ? "var(--success)" : health >= 50 ? "var(--warning)" : "var(--error)";

--- a/web/src/components/SkillsModal.tsx
+++ b/web/src/components/SkillsModal.tsx
@@ -123,6 +123,18 @@ function SkillCard({ s, isNew, isTop, expanded, onToggle }: { s: SkillInfo; isNe
 
 export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => void }) {
   const [skills, setSkills] = useState<SkillInfo[] | null>(null);
+  // The window the call counts actually cover. They are pruned at
+  // AGENTGLASS_RETENTION_DAYS (8 by default), so "used 3x" meant 3x in the
+  // last week while reading as a lifetime total — and the understatement is
+  // worst for the oldest, most-established skills, which is backwards for
+  // the question this panel exists to answer. Stated once here rather than
+  // on forty rows.
+  const [usageSince, setUsageSince] = useState<number | null>(null);
+  // usage_since === 0 means retention is disabled: the counts are genuinely
+  // lifetime and the caveat would be a lie of its own.
+  const usageWindow = usageSince
+    ? `the last ${Math.max(1, Math.round((Date.now() - usageSince) / 86_400_000))}d`
+    : null;
   const [q, setQ] = useState("");
   const [kind, setKind] = useState<Kind>("all");
   const [usage, setUsage] = useState<Usage>("all");
@@ -132,7 +144,7 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
 
   useEffect(() => {
     if (!open) return;
-    api.skills().then((r) => setSkills(r.skills)).catch(() => setSkills([]));
+    api.skills().then((r) => { setSkills(r.skills); setUsageSince(r.usage_since ?? null); }).catch(() => setSkills([]));
     setQ("");
     setExpanded(null);
   }, [open]);
@@ -215,7 +227,7 @@ export function SkillsModal({ open, onClose }: { open: boolean; onClose: () => v
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>Skills explorer</span>
                   {skills && (
                     <span className="text-[10px] t-dim2 tabular-nums">
-                      {all.length} available · {all.filter((s) => s.kind === "skill").length} skills · {all.filter((s) => s.kind === "command").length} commands · {used} used recently · {all.length - used} to discover
+                      {all.length} available · {all.filter((s) => s.kind === "skill").length} skills · {all.filter((s) => s.kind === "command").length} commands · {used} used recently · {all.length - used} to discover{usageWindow ? ` · usage over ${usageWindow}` : ""}
                     </span>
                   )}
                 </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -224,6 +224,17 @@ async function post<T>(path: string, body: unknown): Promise<T> {
   return r.json() as Promise<T>;
 }
 
+/** The viewer's IANA zone, or null if the runtime cannot say. Memoized: this
+ *  is asked on every stats poll and resolvedOptions() is not free. */
+let tzMemo: string | null | undefined;
+function viewerTz(): string | null {
+  if (tzMemo === undefined) {
+    try { tzMemo = Intl.DateTimeFormat().resolvedOptions().timeZone || null; }
+    catch { tzMemo = null; }
+  }
+  return tzMemo;
+}
+
 const D = <T,>(v: T) => Promise.resolve(v); // demo helper
 const demoPrAction = (): PrActionResult => ({ ok: false, error: "the demo is read-only" });
 
@@ -232,8 +243,17 @@ const realApi = {
   /** Scope + discovered projects. `workspace` is set when this instance was
    *  opened for a single project. */
   projects: () => get<{ projects: { source_app: string; path: string }[]; scanning: boolean; workspace: string | null }>("/projects"),
+  // tz: the heatmap is a weekday × hour grid, and only this end knows which
+  // clock those mean. Sent on every call rather than negotiated once, because
+  // a laptop can cross a timezone between two polls and the server caches per
+  // zone anyway. Resolving it can throw on an exotic runtime; the server falls
+  // back to its own clock when it is absent.
   stats: (windowMs: number, provider?: string) =>
-    get<StatsSummary>(`/stats?window=${windowMs}${provider ? `&provider=${encodeURIComponent(provider)}` : ""}`),
+    get<StatsSummary>(
+      `/stats?window=${windowMs}`
+      + (provider ? `&provider=${encodeURIComponent(provider)}` : "")
+      + (viewerTz() ? `&tz=${encodeURIComponent(viewerTz()!)}` : ""),
+    ),
   sessions: (limit = 100, provider?: string) =>
     get<SessionRollup[]>(`/sessions?limit=${limit}${provider ? `&provider=${encodeURIComponent(provider)}` : ""}`),
   filterOptions: () =>
@@ -243,7 +263,10 @@ const realApi = {
   exportUrl: (fmt: "csv" | "json") => withToken(`${SERVER}/export?format=${fmt}`),
   skillsExportUrl: (fmt: "md" | "csv" | "json" = "md") => withToken(`${SERVER}/skills/export?format=${fmt}`),
   usage: () => get<UsagePayload>(`/usage`),
-  skills: () => get<{ skills: SkillInfo[]; generated_at: number }>(`/skills`),
+  // usage_since: the epoch the call counts are known from. They are bounded
+  // by AGENTGLASS_RETENTION_DAYS, so a bare count reads as a lifetime total
+  // and is not. 0 means pruning is off and it really is all time.
+  skills: () => get<{ skills: SkillInfo[]; usage_since?: number; generated_at: number }>(`/skills`),
   changes: (limit = 200) => get<{ changes: FileChange[] }>(`/changes?limit=${limit}`),
   session: (id: string) => get<SessionDetail>(`/session?id=${encodeURIComponent(id)}`),
   insights: () => get<{ insights: Insight[] }>(`/insights`),

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, OpenToolCall, Liveness } from "../../../shared/types.ts";
+import type { WatchEvent, OpenToolCall, Liveness, SessionRollup } from "../../../shared/types.ts";
 import { agentKey, fmtMs, sessionTitle } from "./format.ts";
 import { sessionWorktree } from "./worktree.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
@@ -150,7 +150,33 @@ export function buildTitles(sessions: { session_id: string; source_app?: string;
   return m;
 }
 
-export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [], titles?: TitleLookup): AgentCard[] {
+/**
+ * Lifetime totals per session, from the server.
+ *
+ * The card used to sum cost and tokens over the live event buffer, and that
+ * buffer is a window, not a history: it is capped at MAX_EVENTS (2000) across
+ * the whole fleet, and a fresh page load starts from the 300 events the
+ * initial frame carries. So a session that had produced five thousand events
+ * showed the cost of whichever handful of them survived the trim — a real
+ * spend of dollars rendering as $0.00 right after a reload, against a /stats
+ * total that was correct all along.
+ *
+ * The sessions poll already runs for the titles; these are the same rows.
+ */
+export type RollupLookup = ReadonlyMap<string, Pick<SessionRollup, "cost_usd" | "input_tokens" | "output_tokens" | "tool_count">>;
+
+export function buildRollups(sessions: SessionRollup[]): RollupLookup {
+  const m = new Map<string, Pick<SessionRollup, "cost_usd" | "input_tokens" | "output_tokens" | "tool_count">>();
+  for (const s of sessions) {
+    m.set(s.session_id, {
+      cost_usd: s.cost_usd, input_tokens: s.input_tokens,
+      output_tokens: s.output_tokens, tool_count: s.tool_count,
+    });
+  }
+  return m;
+}
+
+export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [], titles?: TitleLookup, rollups?: RollupLookup): AgentCard[] {
   const now = Date.now();
   const map = new Map<string, AgentCard>();
   // Subagents fold into their parent session_id but carry agent_id/agent_type,
@@ -271,6 +297,22 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
   }
 
   for (const a of map.values()) {
+    // Server-authoritative lifetime totals win over the buffer sum wherever
+    // the poll has seen this session. Math.max rather than a plain assignment:
+    // the poll is every 30s and caps at 200 sessions, so a burst of spend
+    // arriving mid-interval is in the buffer before it is in the roll-up, and
+    // a headline number must never read backwards while you watch it.
+    //
+    // Deliberately not applied to errors/lastErrorTs. The rate rule below
+    // divides by a.tools, and swapping a lifetime tool count under a windowed
+    // error count would fire "high failure rate" on long-dead history. spark
+    // stays buffer-derived too — it is a picture of the recent window by design.
+    const r = rollups?.get(a.session_id);
+    if (r) {
+      a.cost = Math.max(a.cost, r.cost_usd);
+      a.tokens = Math.max(a.tokens, r.input_tokens + r.output_tokens);
+      a.tools = Math.max(a.tools, r.tool_count);
+    }
     const since = now - a.lastSeen;
     // A session that ended can't still be running a tool, whatever pair we
     // think is open; and an open pair past the ceiling is lost, not long.

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -39,6 +39,9 @@ export interface AgentCard {
   events: number;
   tools: number;
   errors: number;
+  /** The subset of `errors` that was a tool call failing. The only numerator
+   *  `tools` is a legitimate denominator for — see the rate rule below. */
+  toolErrors: number;
   cost: number;
   tokens: number;
   lastSeen: number;
@@ -105,6 +108,7 @@ function blankCard(key: string, source_app: string, session_id: string, model_na
     events: 0,
     tools: 0,
     errors: 0,
+    toolErrors: 0,
     cost: 0,
     tokens: 0,
     lastSeen: 0,
@@ -198,8 +202,13 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
       if (e.agent_type || !prev) m.set(e.agent_id, e.agent_type || prev || "subagent");
     }
     a.events++;
-    if (e.hook_event_type === "PostToolUse" || e.hook_event_type === "PostToolUseFailure") a.tools++;
-    if (e.is_error) { a.errors++; if (e.timestamp >= a.lastErrorTs) a.lastErrorTs = e.timestamp; }
+    const isTool = e.hook_event_type === "PostToolUse" || e.hook_event_type === "PostToolUseFailure";
+    if (isTool) a.tools++;
+    if (e.is_error) {
+      a.errors++;
+      if (isTool) a.toolErrors++;
+      if (e.timestamp >= a.lastErrorTs) a.lastErrorTs = e.timestamp;
+    }
     a.cost += e.cost_usd;
     a.tokens += e.input_tokens + e.output_tokens;
     if (e.timestamp >= a.lastSeen) {
@@ -390,7 +399,10 @@ export function deriveAlerts(agents: AgentCard[]): Alert[] {
         out.push({ id: "long:" + a.key, level: "warn", agent: a.key, ts: a.runningSince,
           text: `${a.runningTool} running ${openFor} — nothing local to check, so this could be either` });
     }
-    const rate = a.tools > 3 ? a.errors / a.tools : 0;
+    // toolErrors, not errors: the denominator is tool calls, and an errored
+    // LLM span or notification never enters it. With the all-events count this
+    // read "high failure rate 150%" on a session whose every tool succeeded.
+    const rate = a.tools > 3 ? a.toolErrors / a.tools : 0;
     if (rate > 0.25)
       out.push({ id: "rate:" + a.key, level: "error", agent: a.key, text: `high failure rate ${(rate * 100).toFixed(0)}%`, ts: a.lastSeen });
   }

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -1,15 +1,29 @@
 // Every formatter guards non-finite/nullish input: a single bad numeric field
 // upstream (a divide-by-zero rate, a forged event) otherwise leaks "$NaN" or
 // "Infinitys" straight into the UI.
+/**
+ * How many decimals a dollar figure needs to stop lying.
+ *
+ * Two cents needs two; four hundredths of a cent needs four, or it renders as
+ * "$0.00" and the panel claims nothing was spent. Exported because the hero
+ * KPI cannot use fmtUsd — it feeds a NumberFlow, which animates a *number* and
+ * takes Intl options rather than a formatted string — and the two renderings
+ * of the same field disagreeing is the bug this exists to prevent.
+ */
+export function usdDigits(n: number): number {
+  const a = Math.abs(n);
+  return a === 0 || a >= 1 ? 2 : a >= 0.01 ? 3 : 4;
+}
+
+// Every formatter guards non-finite/nullish input: a single bad numeric field
+// upstream (a divide-by-zero rate, a forged event) otherwise leaks "$NaN".
 export function fmtUsd(n: number | null | undefined): string {
   if (n == null || !isFinite(n)) return "—";
   const neg = n < 0 ? "-" : "";
   const a = Math.abs(n);
   if (a === 0) return "$0.00";
   if (a < 0.0001) return `${neg}<$0.0001`; // real spend that would round to $0.0000
-  if (a >= 1) return `${neg}$${a.toFixed(2)}`;
-  if (a >= 0.01) return `${neg}$${a.toFixed(3)}`;
-  return `${neg}$${a.toFixed(4)}`;
+  return `${neg}$${a.toFixed(usdDigits(a))}`;
 }
 
 // Platform-aware modifier label: ⌘ only on actual Macs, Ctrl+ elsewhere.

--- a/web/test/derive-agents.test.ts
+++ b/web/test/derive-agents.test.ts
@@ -5,7 +5,7 @@
 // and keep well clear of the thresholds (STALL 20s, IDLE 5m) so a few ms of
 // drift between the two Date.now() reads can never flip a case.
 import { test, expect } from "bun:test";
-import { deriveAgents, buildTitles } from "../src/lib/derive.ts";
+import { deriveAgents, deriveAlerts, buildTitles } from "../src/lib/derive.ts";
 import type { WatchEvent } from "../../shared/types.ts";
 
 const now = Date.now();
@@ -121,4 +121,37 @@ test("buildTitles prefers a custom title over an ai title, and omits sessions wi
   // A session with no title is left out entirely, so the UI falls back to the
   // uuid rather than being handed an empty string.
   expect(t.get("s-none")).toBeUndefined();
+});
+
+// A failure rate needs a numerator and denominator drawn from the same
+// population (#248 F6). `errors` counts every errored event — an OTLP source
+// flags "Turn complete" spans, and any event carrying a top-level error string
+// gets it — while the denominator is tool calls only. So a session whose every
+// tool call succeeded raised "high failure rate 150%".
+test("a failure rate counts tool failures, not every errored event", () => {
+  const events = [
+    ...Array.from({ length: 4 }, (_, i) =>
+      ev({ hook_event_type: "PostToolUse", is_error: 0, timestamp: now - 5000 - i })),
+    ...Array.from({ length: 6 }, (_, i) =>
+      ev({ hook_event_type: "Turn complete", tool_name: null, is_error: 1, timestamp: now - 4000 - i })),
+  ];
+  const card = only(events);
+  expect(card.tools).toBe(4);
+  expect(card.errors).toBe(6);   // still the honest "how much went wrong"
+  expect(card.toolErrors).toBe(0); // ...but no tool failed
+  expect(deriveAlerts([card]).filter((a) => a.id.startsWith("rate:"))).toEqual([]);
+});
+
+test("a real tool failure still raises the rate alert", () => {
+  const events = [
+    ...Array.from({ length: 2 }, (_, i) =>
+      ev({ hook_event_type: "PostToolUse", is_error: 0, timestamp: now - 5000 - i })),
+    ...Array.from({ length: 3 }, (_, i) =>
+      ev({ hook_event_type: "PostToolUseFailure", is_error: 1, timestamp: now - 4000 - i })),
+  ];
+  const card = only(events);
+  expect(card.toolErrors).toBe(3);
+  const rate = deriveAlerts([card]).filter((a) => a.id.startsWith("rate:"));
+  expect(rate.length).toBe(1);
+  expect(rate[0].text).toBe("high failure rate 60%");
 });

--- a/web/test/derive-agents.test.ts
+++ b/web/test/derive-agents.test.ts
@@ -5,7 +5,7 @@
 // and keep well clear of the thresholds (STALL 20s, IDLE 5m) so a few ms of
 // drift between the two Date.now() reads can never flip a case.
 import { test, expect } from "bun:test";
-import { deriveAgents, deriveAlerts, buildTitles } from "../src/lib/derive.ts";
+import { deriveAgents, deriveAlerts, buildTitles, buildRollups } from "../src/lib/derive.ts";
 import type { WatchEvent } from "../../shared/types.ts";
 
 const now = Date.now();
@@ -154,4 +154,62 @@ test("a real tool failure still raises the rate alert", () => {
   const rate = deriveAlerts([card]).filter((a) => a.id.startsWith("rate:"));
   expect(rate.length).toBe(1);
   expect(rate[0].text).toBe("high failure rate 60%");
+});
+
+// The card's cost and tokens must not come from a window (#248 F8).
+//
+// deriveAgents summed them over the live event buffer, which is capped at
+// MAX_EVENTS (2000) across the whole fleet and seeded with just 300 events on
+// a fresh load. A long-running session therefore showed the cost of whichever
+// handful of its events survived the trim — dollars of real spend rendering as
+// cents right after a reload, while /stats had it right the whole time.
+const rollup = (over: Partial<import("../../shared/types.ts").SessionRollup> = {}) => ({
+  session_id: "s1", source_app: "app", model_name: "claude-opus-4-8",
+  started_at: now - 60_000, ended_at: null, last_seen: now - 1000,
+  event_count: 5000, tool_count: 900, error_count: 0,
+  input_tokens: 900_000, output_tokens: 100_000,
+  cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: 12.34,
+  ...over,
+} as import("../../shared/types.ts").SessionRollup);
+
+test("a server roll-up beats the truncated buffer", () => {
+  // Two events survive the trim; the session really produced five thousand.
+  const events = [ev({ cost_usd: 0.01 }), ev({ cost_usd: 0.01 })];
+  const buffered = only(events);
+  expect(buffered.cost).toBeCloseTo(0.02, 6); // what the card used to show
+
+  const card = deriveAgents(events, [], undefined, buildRollups([rollup()]))[0];
+  expect(card.cost).toBeCloseTo(12.34, 6);
+  expect(card.tokens).toBe(1_000_000);
+  expect(card.tools).toBe(900);
+});
+
+test("a burst that beat the 30s poll is not rounded back down", () => {
+  // The buffer has more than the roll-up knows about yet. A headline number
+  // must never read backwards while you are watching it.
+  const events = Array.from({ length: 3 }, () => ev({ cost_usd: 10 }));
+  const card = deriveAgents(events, [], undefined, buildRollups([rollup({ cost_usd: 12.34 })]))[0];
+  expect(card.cost).toBeCloseTo(30, 6);
+});
+
+test("a session the poll has not returned still falls back to the buffer", () => {
+  const events = [ev({ session_id: "unseen", cost_usd: 0.25 })];
+  const card = deriveAgents(events, [], undefined, buildRollups([rollup()]))[0];
+  expect(card.cost).toBeCloseTo(0.25, 6);
+});
+
+// The rate rule divides by a.tools. Moving a lifetime tool count under a
+// windowed error count would fire "high failure rate" on long-dead history.
+test("the roll-up does not leak into the failure-rate inputs", () => {
+  const events = [
+    ...Array.from({ length: 2 }, () => ev({ hook_event_type: "PostToolUse", is_error: 0 })),
+    ...Array.from({ length: 3 }, () => ev({ hook_event_type: "PostToolUseFailure", is_error: 1 })),
+  ];
+  const card = deriveAgents(events, [], undefined, buildRollups([rollup({ tool_count: 900 })]))[0];
+  expect(card.errors).toBe(3);
+  expect(card.toolErrors).toBe(3);
+  // tools took the roll-up, so the rate falls — that is the honest reading of
+  // a lifetime denominator, and it must not be able to invent a failure.
+  expect(card.tools).toBe(900);
+  expect(deriveAlerts([card]).filter((a) => a.id.startsWith("rate:"))).toEqual([]);
 });

--- a/web/test/format-usd.test.ts
+++ b/web/test/format-usd.test.ts
@@ -1,0 +1,59 @@
+// One number, one rendering (#248 C3).
+//
+// The hero KPI was the only currency site in the app not routed through
+// fmtUsd: it feeds a NumberFlow, which animates a number and takes Intl
+// options rather than a formatted string, and it asked for
+// minimumFractionDigits: 2. With style:"currency" that does not raise the
+// maximum — Intl defaults it to the currency's two digits — so a window
+// costing $0.004 rendered "Spend · this window $0.00" on the desktop hero
+// while the mobile shell and the cost donut, reading the identical field,
+// said "$0.004". The dashboard claimed you had spent nothing next to a panel
+// saying you had.
+//
+// usdDigits is the shared decision. These pin it to fmtUsd so the two
+// renderings cannot drift apart again.
+import { test, expect, describe } from "bun:test";
+import { fmtUsd, usdDigits } from "../src/lib/format.ts";
+
+describe("usdDigits gives a figure enough decimals to be true", () => {
+  test("a dollar or more needs two", () => {
+    expect(usdDigits(1)).toBe(2);
+    expect(usdDigits(362.72)).toBe(2);
+  });
+  test("cents need three", () => {
+    expect(usdDigits(0.01)).toBe(3);
+    expect(usdDigits(0.5)).toBe(3);
+  });
+  test("sub-cent needs four — the range the hero used to render as $0.00", () => {
+    expect(usdDigits(0.004)).toBe(4);
+    expect(usdDigits(0.0001)).toBe(4);
+  });
+  test("zero is two, so an empty window reads $0.00 and not $0.0000", () => {
+    expect(usdDigits(0)).toBe(2);
+  });
+});
+
+describe("fmtUsd and usdDigits agree — they are one decision", () => {
+  for (const n of [0, 0.0001, 0.004, 0.0099, 0.01, 0.5, 0.999, 1, 362.72]) {
+    test(`${n} formats to exactly usdDigits(${n}) decimals`, () => {
+      const s = fmtUsd(n);
+      const decimals = s.includes(".") ? s.split(".")[1].length : 0;
+      expect(decimals).toBe(usdDigits(n));
+    });
+  }
+
+  test("real spend too small for four digits says so instead of rounding to zero", () => {
+    expect(fmtUsd(0.00001)).toBe("<$0.0001");
+  });
+
+  test("negatives keep their sign and their precision", () => {
+    expect(fmtUsd(-0.004)).toBe("-$0.0040");
+    expect(fmtUsd(-12.5)).toBe("-$12.50");
+  });
+
+  // The failure this whole thing is about: a number that is not zero must
+  // never render as if it were.
+  test("no non-zero spend renders as $0.00", () => {
+    for (const n of [0.0001, 0.001, 0.004, 0.0099]) expect(fmtUsd(n)).not.toBe("$0.00");
+  });
+});


### PR DESCRIPTION
Part of #248. Fixes **F6**, **F8**, **F9**, **F13**, **F15** and **C3**.

Every finding was re-verified against current `main` first — the audit predates several releases — and then put through a pass whose instructions were to *refute* it. Four findings died there and are **not** in this PR; they are [reported back on the issue](https://github.com/SirAllap/agentglass/issues/248#issuecomment-5096502171) instead, because they are work nobody should start.

---

### F6 · a failure rate needs one population, not two

`errors` is `SUM(is_error)` over **every** event; every denominator it is divided by is **tool calls**. `otlp.ts` sets `is_error` on `"Turn complete"`, an LLM span that never enters `tool_calls`. So a fleet whose every tool call succeeded reported failures — health `1 - 3/10` → **70% "Degraded"**, and insights **"High failure rate · 150%"** with **"6 of 4 tool calls failed"** underneath it. `insights.ts` had no clamp; the ring had one, so past parity it pinned to **0% "Critical"** instead — quieter, no less wrong.

Both counts ship now. `errors` still means *"how much went wrong"* (the Failed tile, the timeline series); `tool_errors` is the one a tool-call denominator may be paired with, and is optional on the wire so an older server reads as unknown rather than a confident 0.

### F8 · a fleet card's spend is not what fits in the buffer

`deriveAgents` summed cost and tokens over the live event buffer — capped at 2000 fleet-wide, and a fresh load starts from **300**. A session that produced five thousand events showed the cost of whatever survived the trim: **dollars rendering as cents right after a reload**, while `/stats` had it right all along.

Now prefers the session roll-up the titles poll already fetches. **`Math.max`, not assignment** — the poll is every 30s and a headline number must never read backwards while you watch it. **Not applied to `errors`/`lastErrorTs`** — a lifetime tool count under a windowed error count would fire "high failure rate" on long-dead history.

### F9 · a run charges one catalogue entry

The catalogue is keyed `kind:name`; the usage bucket by **name alone**. One $0.0175 run of a *skill* reported **2 calls and $0.035**, and a same-named command that had never run inherited its `last_used`, its per-run cost, and a place in the "top 3 most used" badge.

### F13 · the heatmap belongs to the viewer's clock

A weekday × hour grid, bucketed with `getDay()`/`getHours()` — the **server process's** zone — beside a timeline that buckets UTC epochs and renders in the browser's. One event at `23:30Z` lands in **Tue 08:00** in Tokyo and **Mon 16:00** in Los Angeles. Remote access and the phone companion exist precisely so the viewer is not at the server.

`/stats` now takes the viewer's IANA zone, and **`tz` is folded into the stats cache key** — without that one viewer's grid is served to another for the whole TTL. The formatter is built once, not per event; an unknown zone falls back rather than throwing.

### F15 · "used 3×" meant 3× this week

`getSkills()` read usage with `since = 0` — all of history — but events are pruned at `AGENTGLASS_RETENTION_DAYS` (8). A skill run 40 times over three months reported **"4×"**, and the understatement is largest for the oldest, best-established skills: backwards for the question the panel exists to answer.

It cannot be made lifetime without a table that survives the prune, so it is made **honest**: the bound is computed, shipped on the `/skills` envelope, and stated once in the panel header rather than on forty rows. Retention disabled still says all time, because then it is.

### C3 · $0.004 is not $0.00

The hero KPI was the one currency site not routed through `fmtUsd`. With `style:"currency"`, `minimumFractionDigits: 2` does not raise the *maximum*, so the hero read **$0.00** while the donut beside it and the phone shell — same field — read **$0.004**. `usdDigits()` is now shared by both.

---

## How was it tested?

**Every guard run red before green.**

| test | what fails without the fix |
|---|---|
| `failure-rate-denominator.test.ts` | the literal `"High failure rate · 150%"` / `"6 of 4 tool calls failed"` in the failing diff |
| `derive-agents.test.ts` (+6) | the card shows **$0.02 for $12.34** of spend |
| `skill-catalog-kind.test.ts` | a never-run command reports 1 call and $0.0175; an invocation 2 days past retention is counted |
| `stats-heatmap-tz.test.ts` | 4 cases, including two zones an offset apart agreeing when they must not |
| `format-usd.test.ts` | 4 cases if `usdDigits` is flattened to a constant 2 |

Each suite pins the *opposite* direction too, so a fix cannot pass by silencing a rule: a real 3-of-5 tool failure must still raise a card at 60%, a command with no rival skill must still be charged, a mid-poll burst must not be rounded down, an unknown timezone must not throw, and the roll-up must not leak into the rate inputs and invent an alert.

Full suites: **827 server** / **441 web**, 0 failures. `tsc --noEmit` clean in both tiers, `vite build` clean.

**Still open in #248 after this:** F4 + F7 (tool-latency sample size and Pre→Post pairing) and F14 (full-text search), plus the pricing-rates question flagged on the issue.