### PR TITLE
fix(traffic): give each half of the job the token it is entitled to

### DIFF
--- a/.github/workflows/traffic.yml
+++ b/.github/workflows/traffic.yml
@@ -15,8 +15,16 @@ on:
     - cron: "17 4 * * *"
   workflow_dispatch:
 
+# Two tokens doing two jobs, deliberately not one doing both.
+#
+# Reading traffic needs push access, which the Actions token does not carry, so
+# it needs a PAT. Writing the branch needs write access to contents, which the
+# Actions token has and a read-only PAT does not. Pointing both at the PAT
+# meant the API call succeeded and the push was refused; pointing both at the
+# Actions token meant the reverse. Each does the half it is entitled to, and
+# the PAT stays read-only, which is the whole reason to scope it that way.
 permissions:
-  contents: read
+  contents: write
 
 concurrency:
   group: traffic
@@ -35,7 +43,8 @@ jobs:
       # first run. Cloning separately keeps the checkout above untouched.
       - name: Check out the data branch, or start it
         env:
-          GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN || github.token }}
+          # The Actions token, not the PAT: this half is git, not the API.
+          GH_TOKEN: ${{ github.token }}
         run: |
           url="https://x-access-token:${GH_TOKEN}@github.com/${GITHUB_REPOSITORY}.git"
           if git clone --depth 1 --branch traffic-data --quiet "$url" data 2>/dev/null; then


### PR DESCRIPTION
## What does this PR do?

The first real run of the traffic job read the window fine and then failed to store it:

```
traffic: 14 days of views, 14 of clones, 10 referrers and 10 paths as of 2026-07-27
...
remote: Permission to SirAllap/agentglass.git denied to SirAllap.
fatal: ... The requested URL returned error: 403
```

The clone and push were pointed at the same token as the API call, so once `TRAFFIC_TOKEN` existed they ran as a PAT scoped to `Administration: read` and git refused.

The two halves want different rights and neither token has both. Reading traffic needs *push* access, which the Actions token does not carry — that is the 403 that made the PAT necessary in the first place. Writing the branch needs `contents: write`, which a read-only PAT does not have. So the git side takes `github.token` with `contents: write`, and the API side keeps the PAT.

That split is also the point rather than a workaround: the PAT stays read-only, which is the entire reason for scoping it that way, and nothing in this workflow can write to the repository with a credential the repository did not already grant its own Actions.

## How was it tested?

The failure is already reproduced by run #2 above, which is what identified it. YAML parses (`yaml.safe_load`), and the two token references are now confirmed distinct:

```
47:  GH_TOKEN: ${{ github.token }}                              # git
62:  TRAFFIC_TOKEN: ${{ secrets.TRAFFIC_TOKEN || github.token }} # API
```

Verification is the next dispatched run: success means the `traffic-data` branch appears carrying `views.csv`, `clones.csv`, `referrers.csv` and `paths.csv`, with 14 rows each in the first two.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185oPxEs6TkCphraS2MKn92

---
_Generated by [Claude Code](https://claude.ai/code/session_0185oPxEs6TkCphraS2MKn92)_