### PR TITLE
fix(landing): make the counter step say which way it went

### DIFF
--- a/scripts/landing-analytics.mjs
+++ b/scripts/landing-analytics.mjs
@@ -64,8 +64,21 @@ if (goat) {
   }
 }
 
+// Said as a workflow annotation, not just a log line. A deploy that quietly
+// ships no counter looks identical to one that ships a working counter nobody
+// is visiting, and telling those apart by reading the log means scrolling past
+// every asset the demo build lists. This puts the answer on the run itself.
+const say = (level, text) => console.log(`::${level}::${text}`);
+
 if (!snippet) {
-  console.log("analytics: no counter configured — the page ships without one");
+  say(
+    "warning",
+    "analytics: no counter configured, the page ships without one. " +
+      "Set GOATCOUNTER_CODE or CLOUDFLARE_ANALYTICS_TOKEN as a repository " +
+      "*variable* (Settings > Secrets and variables > Actions > Variables). " +
+      "A value set as a secret, or on the account rather than the repository, " +
+      "does not reach this step.",
+  );
   process.exit(0);
 }
 
@@ -79,4 +92,10 @@ if (from === -1 || to === -1 || to < from) {
 }
 
 writeFileSync(file, html.slice(0, from + START.length) + snippet + html.slice(to));
-console.log(`analytics: ${goat ? "goatcounter" : "cloudflare"} counter stamped into ${file}`);
+say(
+  "notice",
+  `analytics: ${goat ? `goatcounter (${goat})` : "cloudflare"} counter stamped into ${file}. ` +
+    "If the counter still reports nothing after this deploy, the page has the " +
+    "tag and something between the visitor and the counter is dropping it, " +
+    "which for these vendors is usually an ad blocker or a filtering resolver.",
+);


### PR DESCRIPTION
## What does this PR do?

A deploy that ships no counter and a deploy that ships a working counter nobody has visited yet look identical from outside. The step is green either way, deliberately, because an unconfigured repository must not fail the build. Telling the two apart meant reading one log line sitting behind the several hundred that the demo build's asset listing emits, which is not a thing anyone does twice, and in practice not a thing that can be done at all through a log viewer that truncates.

So both outcomes are workflow annotations now, and the answer is on the run rather than in it.

The unconfigured case names the exact place the value has to live. A repository **variable** is easy to confuse with a repository **secret**, and the account-level "Agents variables" page looks near enough identical to the right one to be worth naming as a trap. All three of those look the same from the workflow's side: absent.

The configured case names the code it stamped, and says what a still-empty counter means once the tag is definitely on the page. For these vendors that is nearly always an ad blocker or a filtering resolver between the visitor and the counter, not a missing tag, and knowing which of the two you are looking at is the whole point.

## How was it tested?

Both branches run locally against a real copy of `landing/index.html`:

```
$ bun scripts/landing-analytics.mjs p.html
::warning::analytics: no counter configured, the page ships without one. Set
GOATCOUNTER_CODE or CLOUDFLARE_ANALYTICS_TOKEN as a repository *variable* …

$ GOATCOUNTER_CODE=sirallap bun scripts/landing-analytics.mjs p.html
::notice::analytics: goatcounter (sirallap) counter stamped into p.html. …
```

and the stamped page carries the tag the vendor asks for, unchanged:

```html
<script data-goatcounter="https://sirallap.goatcounter.com/count" async src="//gc.zgo.at/count.js">
```

Behaviour is otherwise untouched: still exit 0 in both cases, still a no-op when the markers are missing, still refuses a value that is not the bare identifier its vendor issues.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185oPxEs6TkCphraS2MKn92

---
_Generated by [Claude Code](https://claude.ai/code/session_0185oPxEs6TkCphraS2MKn92)_