### PR TITLE
fix(ingest): read OpenInference token counts, and stop promising a metrics receiver (#366, #365)

### DIFF
--- a/server/src/otlp.ts
+++ b/server/src/otlp.ts
@@ -4,7 +4,15 @@
 // (the `gen_ai.*` semantic conventions) into agentglass ingest events. This is
 // what makes agentglass provider-agnostic: anything that emits OTel GenAI spans
 // — the OpenAI / Google / Bedrock SDK instrumentations, LangChain, LiteLLM,
-// OpenLLMetry, even Claude Code's own OTel export — can feed the dashboard.
+// OpenLLMetry, Arize Phoenix and the other OpenInference instrumentors — can
+// feed the dashboard.
+//
+// NOT Claude Code's own OTel export, which this used to claim. That export is
+// METRICS, and the only OTLP routes registered are /v1/traces and /v1/logs
+// (server/src/index.ts) — point OTEL_EXPORTER_OTLP_ENDPOINT here from Claude
+// Code and its metrics get a 404. Nothing breaks, because Claude Code is
+// already covered properly by the hooks, but the sentence sent anyone
+// extending this mapper looking for a metrics receiver that is not here.
 //
 // Mapping strategy:
 //   • a TOOL span (operation "execute_tool" or carrying gen_ai.tool.name) becomes
@@ -101,6 +109,13 @@ function tokenUsageFromAttributes(a: Record<string, unknown>) {
     "gen_ai.usage.cache_read_input_tokens",
     "gen_ai.usage.cache_read_tokens",
     "cached_token_count",
+    // OpenInference. `prompt_details` is a breakdown OF the prompt, so this
+    // is treated as a subset of it — the same contract every other alias in
+    // this list already has, and what the subtraction below assumes. If that
+    // turns out to be wrong for some instrumentor, the test named
+    // "cache reads are a subset of the prompt count" is the one to change,
+    // and it says so.
+    "llm.token_count.prompt_details.cache_read",
   ]);
   const cacheCreation = firstNum(a, [
     "gen_ai.usage.cache_creation.input_tokens",
@@ -115,6 +130,13 @@ function tokenUsageFromAttributes(a: Record<string, unknown>) {
     "input_tokens",
     "prompt_tokens",
     "llm.usage.prompt_tokens",
+    // OpenInference — the convention Arize Phoenix and its instrumentors
+    // emit. Missing this was silent rather than loud: the span is still
+    // recognised as GenAI (the check below accepts any `llm.` key), so the
+    // session landed, the model resolved and tool spans paired up — only the
+    // numbers were absent, which reads as "agentglass cannot price my
+    // provider" rather than "one attribute name is missing".
+    "llm.token_count.prompt",
   ]);
   return {
     input_tokens: Math.max(0, totalInput - cacheRead - cacheCreation),
@@ -125,6 +147,7 @@ function tokenUsageFromAttributes(a: Record<string, unknown>) {
       "output_tokens",
       "completion_tokens",
       "llm.usage.completion_tokens",
+      "llm.token_count.completion",
     ]),
     cache_read_tokens: cacheRead,
     cache_creation_tokens: cacheCreation,

--- a/server/test/otlp-openinference.test.ts
+++ b/server/test/otlp-openinference.test.ts
@@ -1,0 +1,124 @@
+// OpenInference reports usage under llm.token_count.* (#366).
+//
+// That is the convention Arize Phoenix and its instrumentors emit, and the
+// mapper never read it. The failure was silent rather than loud, which is what
+// made it worth fixing: the span is still recognised as a GenAI span, because
+// the check accepts any attribute key starting with `llm.` — so the session
+// lands, the model resolves, and tool spans pair up normally. Only the numbers
+// are missing. An Arize user sees every session appear and every one cost
+// $0.00, which reads as "agentglass can't price my provider" rather than "one
+// attribute name is missing".
+import { describe, expect, test } from "bun:test";
+import { otlpTracesToEvents } from "../src/otlp.ts";
+
+const kv = (key: string, value: string | number) => ({
+  key,
+  value: typeof value === "number" ? { intValue: value } : { stringValue: value },
+});
+
+const traces = (attributes: ReturnType<typeof kv>[], name = "ChatCompletion") => ({
+  resourceSpans: [{
+    resource: { attributes: [kv("service.name", "phoenix-app")] },
+    scopeSpans: [{
+      spans: [{
+        traceId: "trace-oi-1",
+        spanId: "span-oi-1",
+        name,
+        startTimeUnixNano: "1700000000000000000",
+        endTimeUnixNano: "1700000001000000000",
+        attributes,
+      }],
+    }],
+  }],
+});
+
+const BASE = [
+  kv("llm.model_name", "gpt-4o"),
+  kv("llm.system", "openai"),
+];
+
+describe("an OpenInference span carries its tokens", () => {
+  test("prompt and completion counts are read", () => {
+    const [event] = otlpTracesToEvents(traces([
+      ...BASE,
+      kv("llm.token_count.prompt", 1_200),
+      kv("llm.token_count.completion", 340),
+    ]));
+    expect(event).toBeDefined();
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 1_200,
+      output_tokens: 340,
+      cache_read_tokens: 0,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  test("the session still lands and the model still resolves", () => {
+    // This was already true — and is exactly why the bug was invisible.
+    const [event] = otlpTracesToEvents(traces([
+      ...BASE,
+      kv("llm.token_count.prompt", 10),
+      kv("llm.token_count.completion", 5),
+    ]));
+    expect(event.session_id).toBe("trace-oi-1");
+    expect(event.model_name).toBe("gpt-4o");
+  });
+
+  test("a span with no usage at all is still not charged something invented", () => {
+    const [event] = otlpTracesToEvents(traces(BASE));
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 0, output_tokens: 0, cache_read_tokens: 0, cache_creation_tokens: 0,
+    });
+  });
+
+  /**
+   * The one judgement call in this change, written down as a test so it is
+   * cheap to reverse.
+   *
+   * `llm.token_count.prompt_details.cache_read` is treated as a SUBSET of
+   * `llm.token_count.prompt`, so it is subtracted out — the same contract every
+   * other cache alias in that list already has, and what the mapper's
+   * `input_tokens = total - cacheRead - cacheCreation` has always assumed.
+   * `prompt_details` reads as a breakdown *of* the prompt, which is why.
+   *
+   * If some instrumentor turns out to report it additively, this is the test to
+   * change: the expected input_tokens becomes 1_200 and the subtraction of
+   * cacheRead has to stop for this alias.
+   */
+  test("cache reads are a subset of the prompt count", () => {
+    const [event] = otlpTracesToEvents(traces([
+      ...BASE,
+      kv("llm.token_count.prompt", 1_200),
+      kv("llm.token_count.completion", 340),
+      kv("llm.token_count.prompt_details.cache_read", 900),
+    ]));
+    expect(event.payload?.usage).toEqual({
+      input_tokens: 300, // 1200 - 900, not 1200
+      output_tokens: 340,
+      cache_read_tokens: 900,
+      cache_creation_tokens: 0,
+    });
+  });
+
+  test("input_tokens never goes negative if a source disagrees about that", () => {
+    const [event] = otlpTracesToEvents(traces([
+      ...BASE,
+      kv("llm.token_count.prompt", 100),
+      kv("llm.token_count.prompt_details.cache_read", 900),
+    ]));
+    expect((event.payload?.usage as any).input_tokens).toBe(0);
+  });
+});
+
+describe("the gen_ai.* conventions still win where both are present", () => {
+  // Order in the alias list is precedence, and llm.token_count.* is last, so a
+  // span emitting both shapes is unaffected by this change.
+  test("gen_ai.usage.input_tokens takes precedence", () => {
+    const [event] = otlpTracesToEvents(traces([
+      ...BASE,
+      kv("gen_ai.usage.input_tokens", 50),
+      kv("llm.token_count.prompt", 9_999),
+    ]));
+    expect((event.payload?.usage as any).input_tokens).toBe(50);
+  });
+});


### PR DESCRIPTION
Fixes #366 and #365. Both live in `server/src/otlp.ts`.

## #366 · every Arize session costs $0.00

OpenInference — the convention Arize Phoenix and its instrumentors emit — reports usage as `llm.token_count.prompt` and `llm.token_count.completion`. The mapper read `gen_ai.usage.*`, the bare `input_tokens`/`prompt_tokens` forms and `llm.usage.*`, and **none of those**.

The failure is **silent rather than loud**, which is what makes it worth fixing. The span is still recognised as a GenAI span — the check accepts any attribute key starting with `llm.` — so the session lands, the model resolves, and tool spans pair up normally. Only the numbers are missing.

So an Arize user watches every session appear and every one cost **$0.00**, and concludes *"agentglass can't price my provider"* rather than *"one attribute name is missing"*. Nothing in the UI can tell them apart.

The new aliases go **last** in each list, so precedence is unchanged: a span emitting both conventions still resolves through `gen_ai.*`. There is a test for that.

### The one judgement call, written down rather than buried

`llm.token_count.prompt_details.cache_read` is treated as a **subset** of the prompt count and subtracted out. That is the same contract every other cache alias in that list already has, and what `input_tokens = total - cacheRead - cacheCreation` has always assumed; `prompt_details` reads as a breakdown *of* the prompt.

I could not verify the spec from this environment (the same 403s that stopped me confirming pricing in #368), so rather than guess quietly, the assumption is a named test:

> `test("cache reads are a subset of the prompt count")`

with a comment stating exactly what to change if some instrumentor turns out to report it additively — the expected `input_tokens` becomes `1_200`, and this alias stops being subtracted. Cheap to reverse, and impossible to reverse by accident.

## #365 · a receiver that does not exist

The file header said anything emitting OTel GenAI spans can feed the dashboard — *"even Claude Code's own OTel export"*.

It cannot. That export is **metrics**, and the only OTLP routes registered are `/v1/traces` and `/v1/logs`. Point `OTEL_EXPORTER_OTLP_ENDPOINT` at agentglass from Claude Code and its metrics go to a 404.

Nothing breaks at runtime — Claude Code is already covered properly by the hooks — but that comment is the first thing anyone reads before extending this mapper, and it sent them looking for a metrics receiver that is not there, while implying one exists. It now says what is true, and names OpenInference among the conventions that *do* work.

## How was it tested?

`server/test/otlp-openinference.test.ts` (new), 6 cases. **Two fail without the aliases** — removed them to confirm:

```
(fail) prompt and completion counts are read
(fail) cache reads are a subset of the prompt count
```

The other four are the guards: the session still lands and the model still resolves (which was *already* true, and is exactly why the bug was invisible); a span with no usage is not charged something invented; `input_tokens` never goes negative if a source disagrees about the subset question; and `gen_ai.usage.*` still takes precedence when both conventions are present.

Full suite: **872 server** tests, 0 failures. `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_