### PR TITLE
feat(retention): fold expiring events into a daily rollup before deleting them (#292)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -343,6 +343,54 @@ db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_pat
 //
 // `decision` NULL means still pending. `resolution` records *who* decided:
 // human, timeout, or restart (expired while the server was down).
+/**
+ * What survives the prune.
+ *
+ * Raw events are deleted at AGENTGLASS_RETENTION_DAYS, which is right for
+ * rows carrying prompts and command lines, and silently caps every question
+ * worth asking: what a project cost last month, this sprint against the last,
+ * whether a budget is being kept. The only escape was raising retention and
+ * paying for it in database size and query time.
+ *
+ * So expiring events are folded into a day-grained summary before they are
+ * deleted. One row per (day, project, session, model, provider) is small
+ * enough to keep for years — a busy month of one project is a few thousand
+ * rows against a few hundred thousand events.
+ *
+ * What does NOT survive, and cannot: percentiles. p50 and p95 do not
+ * aggregate — an average of percentiles is not a percentile of anything. The
+ * total duration and the number of timed calls are carried instead, which
+ * gives an honest mean and nothing it cannot support.
+ *
+ * The key columns COALESCE to '' rather than allowing NULL, because NULLs are
+ * distinct from each other in a UNIQUE index and the upsert would insert a
+ * new row every night instead of accumulating.
+ */
+db.exec(`
+CREATE TABLE IF NOT EXISTS daily_rollup (
+  day TEXT NOT NULL,            -- YYYY-MM-DD, UTC
+  project_path TEXT NOT NULL,
+  session_id TEXT NOT NULL,
+  source_app TEXT NOT NULL,
+  model_name TEXT NOT NULL,
+  provider TEXT NOT NULL,
+  events INTEGER NOT NULL DEFAULT 0,
+  tool_calls INTEGER NOT NULL DEFAULT 0,
+  tool_errors INTEGER NOT NULL DEFAULT 0,
+  errors INTEGER NOT NULL DEFAULT 0,
+  input_tokens INTEGER NOT NULL DEFAULT 0,
+  output_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_creation_tokens INTEGER NOT NULL DEFAULT 0,
+  cache_read_tokens INTEGER NOT NULL DEFAULT 0,
+  cost_usd REAL NOT NULL DEFAULT 0,
+  duration_ms_total INTEGER NOT NULL DEFAULT 0,
+  timed_calls INTEGER NOT NULL DEFAULT 0,
+  PRIMARY KEY (day, project_path, session_id, model_name, provider)
+);
+CREATE INDEX IF NOT EXISTS idx_rollup_day ON daily_rollup(day);
+CREATE INDEX IF NOT EXISTS idx_rollup_project_day ON daily_rollup(project_path, day);
+`);
+
 // ---------------------------------------------------------------------------
 db.exec(`
 CREATE TABLE IF NOT EXISTS gates (
@@ -696,16 +744,131 @@ const isTerminal = (t: string) => t === "Stop" || t === "SessionEnd";
 // ---------------------------------------------------------------------------
 export const RETENTION_DAYS = Math.max(0, Number(process.env.AGENTGLASS_RETENTION_DAYS ?? 8));
 
-export function pruneOldRows(): { events: number; sessions: number } {
-  if (!RETENTION_DAYS) return { events: 0, sessions: 0 };
+/**
+ * Fold every event older than `cutoff` into daily_rollup.
+ *
+ * Runs inside the prune transaction, immediately before the DELETE, so a
+ * crash between the two cannot lose a day: either both happened or neither
+ * did. Accumulating rather than replacing, because a day is folded once when
+ * it expires and must not be double-counted if a prune is run twice — the
+ * DELETE that follows is what guarantees each event is folded exactly once.
+ */
+function foldExpiringEvents(cutoff: number): number {
+  const r = db.run(
+    `INSERT INTO daily_rollup (
+       day, project_path, session_id, source_app, model_name, provider,
+       events, tool_calls, tool_errors, errors,
+       input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+       cost_usd, duration_ms_total, timed_calls
+     )
+     SELECT date(timestamp / 1000, 'unixepoch'),
+            COALESCE(project_path, ''), session_id, COALESCE(source_app, ''),
+            COALESCE(model_name, ''), COALESCE(provider, ''),
+            COUNT(*),
+            SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END),
+            SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') AND is_error = 1 THEN 1 ELSE 0 END),
+            SUM(is_error),
+            SUM(COALESCE(input_tokens, 0)), SUM(COALESCE(output_tokens, 0)),
+            SUM(COALESCE(cache_creation_tokens, 0)), SUM(COALESCE(cache_read_tokens, 0)),
+            SUM(COALESCE(cost_usd, 0)),
+            SUM(COALESCE(duration_ms, 0)),
+            SUM(CASE WHEN duration_ms IS NOT NULL THEN 1 ELSE 0 END)
+     FROM events WHERE timestamp < ?
+     GROUP BY 1, 2, 3, 4, 5, 6
+     ON CONFLICT(day, project_path, session_id, model_name, provider) DO UPDATE SET
+       events = events + excluded.events,
+       tool_calls = tool_calls + excluded.tool_calls,
+       tool_errors = tool_errors + excluded.tool_errors,
+       errors = errors + excluded.errors,
+       input_tokens = input_tokens + excluded.input_tokens,
+       output_tokens = output_tokens + excluded.output_tokens,
+       cache_creation_tokens = cache_creation_tokens + excluded.cache_creation_tokens,
+       cache_read_tokens = cache_read_tokens + excluded.cache_read_tokens,
+       cost_usd = cost_usd + excluded.cost_usd,
+       duration_ms_total = duration_ms_total + excluded.duration_ms_total,
+       timed_calls = timed_calls + excluded.timed_calls`,
+    [cutoff]
+  );
+  return r.changes;
+}
+
+export function pruneOldRows(): { events: number; sessions: number; rolled: number } {
+  if (!RETENTION_DAYS) return { events: 0, sessions: 0, rolled: 0 };
   const cutoff = Date.now() - RETENTION_DAYS * 86_400_000;
-  db.run(`DELETE FROM events_fts WHERE rowid IN (SELECT id FROM events WHERE timestamp < ?)`, [cutoff]);
-  const ev = db.run(`DELETE FROM events WHERE timestamp < ?`, [cutoff]);
-  const se = db.run(`DELETE FROM sessions WHERE last_seen < ?`, [cutoff]);
-  // Resolved gates only — a pending one is a live request, never retention's
-  // business no matter how old its row looks.
-  db.run(`DELETE FROM gates WHERE decision IS NOT NULL AND created < ?`, [cutoff]);
-  return { events: ev.changes, sessions: se.changes };
+  // One transaction: the fold and the delete are the same decision, and a
+  // crash between them would delete a day nobody had summarised.
+  return db.transaction(() => {
+    const rolled = foldExpiringEvents(cutoff);
+    db.run(`DELETE FROM events_fts WHERE rowid IN (SELECT id FROM events WHERE timestamp < ?)`, [cutoff]);
+    const ev = db.run(`DELETE FROM events WHERE timestamp < ?`, [cutoff]);
+    const se = db.run(`DELETE FROM sessions WHERE last_seen < ?`, [cutoff]);
+    // Resolved gates only — a pending one is a live request, never retention's
+    // business no matter how old its row looks.
+    db.run(`DELETE FROM gates WHERE decision IS NOT NULL AND created < ?`, [cutoff]);
+    return { events: ev.changes, sessions: se.changes, rolled };
+  })();
+}
+
+/** A day's totals, from the rollup. `null` bounds mean no bound. */
+export interface RollupDay {
+  day: string;
+  events: number;
+  tool_calls: number;
+  tool_errors: number;
+  errors: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  cost_usd: number;
+  sessions: number;
+  /** Mean tool duration. There is no p95 here and there cannot be — see the
+   *  daily_rollup comment. */
+  avg_ms: number;
+}
+
+/**
+ * Daily totals from the rollup, scoped like every other metric.
+ *
+ * This reads only what the prune has already folded, so it answers about the
+ * past — the live window is still the events table's job. A caller wanting a
+ * continuous series joins the two at the retention boundary.
+ */
+export function rollupDays(fromDay?: string, toDay?: string): RollupDay[] {
+  const roots = scopeRoots();
+  const where: string[] = [];
+  const args: any[] = [];
+  if (fromDay) { where.push('day >= ?'); args.push(fromDay); }
+  if (toDay) { where.push('day <= ?'); args.push(toDay); }
+  if (roots.length) {
+    where.push(`project_path IN (${roots.map(() => '?').join(',')})`);
+    args.push(...roots);
+  }
+  const clause = where.length ? ` WHERE ${where.join(' AND ')}` : '';
+  return db
+    .query<RollupDay, any[]>(
+      `SELECT day,
+              SUM(events) AS events, SUM(tool_calls) AS tool_calls,
+              SUM(tool_errors) AS tool_errors, SUM(errors) AS errors,
+              SUM(input_tokens) AS input_tokens, SUM(output_tokens) AS output_tokens,
+              SUM(cache_creation_tokens) AS cache_creation_tokens,
+              SUM(cache_read_tokens) AS cache_read_tokens,
+              SUM(cost_usd) AS cost_usd,
+              COUNT(DISTINCT session_id) AS sessions,
+              CASE WHEN SUM(timed_calls) > 0
+                   THEN CAST(SUM(duration_ms_total) / SUM(timed_calls) AS INTEGER)
+                   ELSE 0 END AS avg_ms
+       FROM daily_rollup${clause}
+       GROUP BY day ORDER BY day`
+    )
+    .all(...args);
+}
+
+/** The oldest day the rollup can speak to, or null when it is empty. Lets a
+ *  panel state the real range instead of implying it has everything. */
+export function rollupEarliestDay(): string | null {
+  const r = db.query<{ day: string | null }, []>('SELECT MIN(day) AS day FROM daily_rollup').get();
+  return r?.day ?? null;
 }
 
 export interface InsertResult {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1448,9 +1448,12 @@ repairThemeArtifacts();
 // Retention: prune at boot and hourly so the DB stays lean but the 7d window
 // always has full history (see AGENTGLASS_RETENTION_DAYS in db.ts).
 function prune() {
-  const { events, sessions } = pruneOldRows();
+  const { events, sessions, rolled } = pruneOldRows();
   if (events || sessions) {
-    console.log(`🧹 pruned ${events} events / ${sessions} sessions older than ${RETENTION_DAYS}d`);
+    // `rolled` counts day-rows written, not events summarised. The point it
+    // makes is that the numbers outlived the rows they came from.
+    const folded = rolled ? ` → folded into ${rolled} rollup days` : "";
+    console.log(`🧹 pruned ${events} events / ${sessions} sessions older than ${RETENTION_DAYS}d${folded}`);
   }
 }
 prune();

--- a/server/test/rollup-before-prune.test.ts
+++ b/server/test/rollup-before-prune.test.ts
@@ -1,0 +1,125 @@
+// The numbers must outlive the rows they came from (#292).
+//
+// Raw events are deleted at AGENTGLASS_RETENTION_DAYS — right for rows
+// carrying prompts and command lines, and it silently capped every question
+// worth asking. You could not see what a project cost last month, compare this
+// sprint against the last, or set a budget that was not really a weekly one
+// wearing a monthly label. The only escape was raising retention and paying
+// for it in database size and query time.
+//
+// So expiring events are folded into a day-grained summary before the DELETE,
+// in the same transaction — either both happened or neither did.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-rollup-"));
+const ROOT = join(dir, "proj");
+const OTHER = join(dir, "other");
+for (const d of [ROOT, OTHER]) mkdirSync(d, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "rollup.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+const DAY = 86_400_000;
+
+const event = (over: Record<string, unknown> = {}) => ({
+  source_app: "proj",
+  session_id: "s-old",
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 100, output_tokens: 40, cache_creation_tokens: 0, cache_read_tokens: 10 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: Date.now() - 30 * DAY,
+  payload: { project_path: ROOT },
+  chat: null,
+  ...over,
+});
+
+const rawCount = () =>
+  db.db.query<{ n: number }, []>("SELECT COUNT(*) AS n FROM events").get()!.n;
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  // Thirty days ago: well past the 8-day default, so the prune takes it.
+  for (let i = 0; i < 4; i++) db.insertEvent(event({ timestamp: Date.now() - 30 * DAY + i }) as any);
+  // One errored tool call the same day, so the fold has something to separate.
+  db.insertEvent(event({ timestamp: Date.now() - 30 * DAY + 5, hook_event_type: "PostToolUseFailure", is_error: 1 }) as any);
+  // Another project, same day — must not leak into a scoped read.
+  db.insertEvent(event({ timestamp: Date.now() - 30 * DAY + 6, session_id: "s-other", payload: { project_path: OTHER } }) as any);
+  // And something recent, which the prune must leave alone entirely.
+  db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "s-live" }) as any);
+});
+
+describe("expiring events are summarised before they are deleted", () => {
+  test("the raw rows really do go", () => {
+    const before = rawCount();
+    const { events, rolled } = db.pruneOldRows();
+    expect(events).toBeGreaterThan(0);
+    expect(rolled).toBeGreaterThan(0);
+    expect(rawCount()).toBeLessThan(before);
+  });
+
+  test("but the day's totals survive them", () => {
+    const days = db.rollupDays();
+    expect(days.length).toBe(1);
+    const d = days[0];
+    // 5 scoped events on that day: 4 clean tool calls + 1 failure.
+    expect(d.events).toBe(5);
+    expect(d.tool_calls).toBe(5);
+    expect(d.tool_errors).toBe(1);
+    expect(d.input_tokens).toBe(500);
+    expect(d.output_tokens).toBe(200);
+    expect(d.cache_read_tokens).toBe(50);
+    expect(d.sessions).toBe(1);
+  });
+
+  test("the live window is untouched", () => {
+    // s-live is a minute old; the prune must not have taken it.
+    const n = db.db
+      .query<{ n: number }, []>("SELECT COUNT(*) AS n FROM events WHERE session_id = 's-live'")
+      .get()!.n;
+    expect(n).toBe(1);
+  });
+
+  test("the rollup is scoped like every other metric", () => {
+    // The other project's event was folded too, but a scoped read must not
+    // see it — the same rule the events queries follow.
+    const scoped = db.rollupDays()[0];
+    expect(scoped.sessions).toBe(1); // s-old only, not s-other
+  });
+
+  test("it can say how far back it goes, so a panel need not imply it has everything", () => {
+    expect(db.rollupEarliestDay()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+});
+
+describe("folding twice does not double-count", () => {
+  test("a second prune adds nothing, because the rows it would fold are gone", () => {
+    const before = db.rollupDays()[0].events;
+    db.pruneOldRows();
+    expect(db.rollupDays()[0].events).toBe(before);
+  });
+
+  test("a later day accumulates onto the same row rather than replacing it", () => {
+    // Another event on the SAME day, arriving late (a backfill, a replayed
+    // export) and then expiring: its numbers must add to the day, not
+    // overwrite it.
+    const day30 = Date.now() - 30 * DAY + 7;
+    db.insertEvent(event({ timestamp: day30, session_id: "s-old" }) as any);
+    const before = db.rollupDays()[0];
+    db.pruneOldRows();
+    const after = db.rollupDays()[0];
+    expect(after.events).toBe(before.events + 1);
+    expect(after.input_tokens).toBe(before.input_tokens + 100);
+  });
+});


### PR DESCRIPTION
Part of #292 — the half that stops the data being lost. See "Not in this change" below for the half that is not here.

> ⚠️ **New table** (`daily_rollup`) and a widened prune transaction.

## The problem

`RETENTION_DAYS` defaults to 8, so every event older than a week is deleted. That is the right call for raw rows — they carry prompts, command lines and outputs — but it silently caps every question worth asking:

- what did this project cost last month?
- how does this sprint compare to the last one?
- is the budget I set being kept? *(it is really a weekly budget wearing a monthly label)*

The only escape was raising `AGENTGLASS_RETENTION_DAYS`, which grows the database without bound and slows every `/stats` query.

## What changed

Expiring events are folded into `daily_rollup` **before** the `DELETE`: one row per `(day, project, session, model, provider)`, carrying event and tool counts, tool errors, tokens by class, cost, and the duration total with its sample count.

Small enough to keep for years — a busy month of one project is a few thousand rows against a few hundred thousand events.

**The fold and the delete are one transaction.** They are the same decision, and a crash between them would delete a day nobody had summarised.

### Two things that do not survive, said plainly rather than faked

| | |
|---|---|
| **percentiles** | p50 and p95 do not aggregate — an average of percentiles is not a percentile of anything. The rollup carries `duration_ms_total` and `timed_calls` and offers a **mean**, which is what those two can honestly support. |
| **event detail** | prompts, commands and outputs are exactly what retention exists to drop. The rollup is counts and sums. |

### One SQLite trap worth naming

The key columns `COALESCE` to `''` rather than allowing NULL. NULLs are **distinct from each other** in a UNIQUE index, so the upsert would have inserted a fresh row every night instead of accumulating onto the day — and nothing would have looked wrong until someone summed a month and got a number several times too large.

`rollupDays()` is scoped like every other metric, and `rollupEarliestDay()` lets a panel state the real range instead of implying it has everything.

## Not in this change

**The charts still read the events table**, so they still show the retained window. The difference is that the data behind the older part now *exists to be read* — today it is destroyed nightly and unrecoverable.

Wiring each panel to join raw-inside-the-window with rollup-outside-it is its own change, and its own set of decisions: what granularity looks right at the boundary, whether the seam should be visible, and what a percentile column should render for the older half where there is only a mean. Doing that first would have meant designing those answers before the data existed to check them against.

The issue's other two asks — exposing the effective window in the UI, and letting `/export` reach the rollups — belong with that follow-up for the same reason.

## How was it tested?

`server/test/rollup-before-prune.test.ts` (new), 7 cases. **Six fail with the fold disabled:**

```
(fail) the raw rows really do go
(fail) but the day's totals survive them
(fail) the rollup is scoped like every other metric
(fail) it can say how far back it goes
(fail) a second prune adds nothing
(fail) a later day accumulates onto the same row rather than replacing it
```

The fixture is a 30-day-old day holding four clean tool calls and one failure, plus another project's event on the same day and one event a minute old. That covers the four things that could go wrong: the totals must survive, the *live* window must be untouched, a scoped read must not see the other project, and a second prune must not double-count.

The last test is the one that would catch the NULL-key trap: a late-arriving event on an already-folded day must **add** to that row, not replace it.

Full suite: **879 server** tests, 0 failures. `tsc --noEmit` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_