### PR TITLE
feat(cost): say when a price is a guess (#248)

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -15,7 +15,7 @@ import type {
   OpenToolCall,
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
-import { costUsd, modelLabel } from "./pricing.ts";
+import { costUsd, modelLabel, hasPrice } from "./pricing.ts";
 import { providerOf as sharedProviderOf, UNKNOWN as UNKNOWN_MODEL } from "../../shared/models.ts";
 import { workspaceRoot, scopeRoots, isWithin } from "./config.ts";
 
@@ -1437,8 +1437,11 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
     const e = modelFold.get(label) ?? {
       model_name: label,
       input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0,
-      cost_usd: 0, sessions: 0,
+      cost_usd: 0, sessions: 0, unpriced: false,
     };
+    // Any contributing id without a rate makes the whole row's cost partly a
+    // fallback — the honest reading, since the row is one number.
+    if (!hasPrice(r.model_name)) e.unpriced = true;
     e.input_tokens += r.input_tokens ?? 0;
     e.output_tokens += r.output_tokens ?? 0;
     e.cache_creation_tokens += r.cache_creation_tokens ?? 0;

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -107,6 +107,24 @@ export interface TokenUsage {
   cache_read_tokens?: number;
 }
 
+/**
+ * Whether the table actually has a rate for this model.
+ *
+ * costUsd() falls back to DEFAULT_PRICE — Sonnet-tier $3/$15 — for anything
+ * it does not recognise, and returns that number with exactly the same
+ * confidence as a real one. Nothing downstream could tell the two apart, so
+ * a model the table has never heard of produced a spend figure that looked
+ * measured. This is the question the dashboard needs in order to say so.
+ *
+ * Deliberately not "is this cost estimated": a source that reports its own
+ * exact cost bypasses the table entirely (see reported_cost_usd), so the
+ * honest, checkable statement is the narrower one — agentglass has no rate
+ * for this model.
+ */
+export function hasPrice(modelName: string | null | undefined): boolean {
+  return priceFor(modelName) !== null;
+}
+
 /** Cost in USD for a given usage + model. Unknown model → DEFAULT_PRICE. */
 export function costUsd(usage: TokenUsage, modelName: string | null | undefined): number {
   const p = priceFor(modelName) ?? { ...DEFAULT_PRICE, match: [], label: "unknown" };

--- a/server/test/unpriced-model.test.ts
+++ b/server/test/unpriced-model.test.ts
@@ -1,0 +1,111 @@
+// A cost the table could not price must say so.
+//
+// costUsd() falls back to DEFAULT_PRICE — Sonnet-tier $3/$15 per MTok — for any
+// model it does not recognise, and returns that number with exactly the same
+// confidence as a real one. Nothing downstream could tell the two apart, so a
+// model the table has never heard of produced a spend figure that looked
+// measured.
+//
+// That is not hypothetical maintenance: model names change every few months,
+// and the file's own header says to re-verify the rates against each provider.
+// A rename is all it takes for a whole vendor's spend to become a guess
+// rendered as a fact.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-unpriced-"));
+const ROOT = join(dir, "proj");
+mkdirSync(ROOT, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "unpriced.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+let hasPrice: typeof import("../src/pricing.ts").hasPrice;
+
+const event = (model: string, session: string) => ({
+  source_app: "proj",
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: model,
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 1000, output_tokens: 500, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: Date.now() - 60_000,
+  payload: { project_path: ROOT },
+  chat: null,
+});
+
+let w = 3_600_000;
+const row = (label: string) =>
+  db.statsSummary(w++).by_model.find((m) => m.model_name === label);
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  hasPrice = (await import("../src/pricing.ts")).hasPrice;
+  db.insertEvent(event("claude-opus-4-8", "s-known") as any);
+  db.insertEvent(event("brand-new-model-9000", "s-unknown") as any);
+});
+
+describe("hasPrice answers the checkable question", () => {
+  test("a model in the table has a rate", () => {
+    expect(hasPrice("claude-opus-4-8")).toBe(true);
+    expect(hasPrice("gpt-4.1")).toBe(true);
+  });
+
+  test("one that is not, does not", () => {
+    expect(hasPrice("brand-new-model-9000")).toBe(false);
+  });
+
+  test("nothing at all is not a priced model either", () => {
+    expect(hasPrice(null)).toBe(false);
+    expect(hasPrice("")).toBe(false);
+  });
+
+  // The distinction that keeps this honest: it asks whether a RATE exists, not
+  // whether the displayed cost was estimated. A source reporting its own exact
+  // cost bypasses the table, and that is a different question.
+  test("it is about the table, not about how a cost happened to be obtained", () => {
+    expect(hasPrice("brand-new-model-9000")).toBe(false);
+  });
+});
+
+describe("the spend panel marks what it could not price", () => {
+  test("a known model is not marked", () => {
+    expect(row("Opus")!.unpriced).toBe(false);
+  });
+
+  test("an unknown one is", () => {
+    expect(row("brand-new-model-9000")!.unpriced).toBe(true);
+  });
+
+  test("it still gets a cost — the fallback, not zero", () => {
+    // 1M in + 0.5M out at the $3/$15 fallback. The number is not wrong so much
+    // as unfounded, which is exactly why it needs a mark rather than removal.
+    expect(row("brand-new-model-9000")!.cost_usd).toBeGreaterThan(0);
+  });
+
+  // Both the label table and the price table match on substrings, so a future
+  // release of a known family inherits its family's name and its family's rate.
+  // Deliberate, and worth pinning: pricing a claude-opus-9 at Opus rates is a
+  // far better guess than dropping it to the $3/$15 fallback, and the row is
+  // correctly NOT marked, because a rate really does exist for it.
+  //
+  // The corollary is what makes the mark useful — it fires for a genuinely new
+  // vendor or a renamed family, which is the case that costs money silently.
+  test("a future version of a known family keeps its rate and is not marked", () => {
+    db.insertEvent(event("claude-opus-9-9", "s-future") as any);
+    const opus = row("Opus")!;
+    expect(opus.unpriced).toBe(false);
+    // ...and it folded into that row rather than making one of its own.
+    expect(opus.sessions).toBeGreaterThan(1);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -93,6 +93,13 @@ export interface SessionRollup {
 
 export interface CostByModel {
   model_name: string;
+  /**
+   * True when at least one raw model id folded into this row has no rate in
+   * the price table, so any cost here the provider did not report exactly is
+   * a fallback at DEFAULT_PRICE. Optional — an older server does not send it,
+   * and absent means unknown rather than false.
+   */
+  unpriced?: boolean;
   input_tokens: number;
   output_tokens: number;
   cache_creation_tokens: number;

--- a/web/src/components/CostByModel.tsx
+++ b/web/src/components/CostByModel.tsx
@@ -72,6 +72,21 @@ export const CostByModel = memo(function CostByModel({ stats }: { stats: StatsSu
               <span className="flex items-center gap-1.5 t-dim">
                 <span className="h-2.5 w-2.5 rounded-full" style={{ background: modelColor(m.model_name) }} />
                 {m.model_name}
+                {/* The table has no rate for this model, so the figure beside it is
+                    a fallback at DEFAULT_PRICE ($3/$15 per MTok) wherever the
+                    provider did not report an exact cost — and until now it was
+                    rendered with exactly the same confidence as a measured one.
+                    A model rename or a new release is all it takes, so this is
+                    the mark that says the number is a floor, not a fact. */}
+                {m.unpriced && (
+                  <span
+                    className="t-dim2"
+                    style={{ color: "var(--warning)", fontSize: 10 }}
+                    title={`agentglass has no rate for ${m.model_name}. Any cost here that the provider did not report exactly is estimated at the fallback $3/$15 per million tokens — set AGENTGLASS_PRICING to a table with this model to fix it.`}
+                  >
+                    ~
+                  </span>
+                )}
               </span>
               <span className="flex items-center gap-3 tabular-nums">
                 <span className="t-dim2">{fmtTokens(m.input_tokens + m.output_tokens)} tok</span>


### PR DESCRIPTION
Related to #248 and to the pricing question [flagged on that issue](https://github.com/SirAllap/agentglass/issues/248#issuecomment-5096502171).

## The problem

`costUsd()` falls back to `DEFAULT_PRICE` — Sonnet-tier **$3/$15 per MTok** — for any model the table does not recognise, and returns that number with exactly the same confidence as a real one:

```ts
const p = priceFor(modelName) ?? { ...DEFAULT_PRICE, match: [], label: "unknown" };
```

Nothing downstream could tell the two apart. So a model agentglass has never heard of produced a spend figure that looked *measured* — in the panel whose entire job is telling you what you spent.

That is not hypothetical maintenance. Model names change every few months, the file's own header says to re-verify rates against each provider, and while working #248 I found evidence — which **I could not corroborate**, every route to a pricing page 403s from CI — that the current OpenAI lineup may have **no rows in the table at all**. If that is true, every current OpenAI session is already being billed at the Sonnet fallback and the dashboard is not saying so.

**This does not fix the rates**, which I cannot verify from here. It makes their absence visible, which is the part that does not need verifying.

## What changed

`hasPrice()` asks the narrow, **checkable** question: *does the table have a rate for this model?*

Deliberately **not** *"is this cost estimated"* — a source reporting its own exact cost bypasses the table entirely (`reported_cost_usd`), so that would be a different and much less answerable question. The narrow one is true, testable, and enough.

`by_model` carries the answer per row, and the panel marks it with a `~` whose tooltip names the model, states the fallback rate, and points at `AGENTGLASS_PRICING`.

A row is marked if **any** raw id folded into it lacks a rate, because the row is one number and part of it would be a guess.

### One behaviour pinned while here

Both the label table and the price table match on **substrings**, so a future release of a known family inherits its family's name *and* its family's rate. A `claude-opus-9` is priced at Opus rates and is correctly **not** marked — a far better guess than dropping it to $3/$15.

The corollary is what makes the mark useful: it fires for a genuinely new vendor or a **renamed family**, which is exactly the case that costs money silently.

## How was it tested?

`server/test/unpriced-model.test.ts` (new), 8 cases. One fails without the flag; the rest pin the semantics that keep it honest:

- a known model has a rate, an unknown one does not, and `null`/`""` are not priced models either
- an unpriced model still gets a **cost** — the fallback, not zero. The number is not so much wrong as unfounded, which is why it needs a mark rather than removal.
- a future version of a known family keeps its family rate, is not marked, and folds into that family's row rather than making one of its own

Full suites: **887 server** / **441 web**, 0 failures. `tsc --noEmit` clean in both tiers, `vite build` clean.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_