### PR TITLE
fix(ingest): an unrecognised OTel record is telemetry, not a request for a human

### DIFF
--- a/server/src/otlp.ts
+++ b/server/src/otlp.ts
@@ -326,12 +326,41 @@ function logRecordToEvent(rec: OtlpLogRecord, resAttrs: Record<string, unknown>)
       },
     };
   }
+  // Asked before the lifecycle patterns below, which match on loose words:
+  // "notification.idle_prompt" contains "prompt" and was read as a user
+  // prompt. Nothing in this set matches a genuine prompt or session name, so
+  // the stricter question is safe to ask first.
+  // An OTel source that really is asking for a human. Kept, because losing
+  // it would be the opposite failure — a genuine hold going unannounced.
+  if (/notification|permission|approval|awaiting|blocked|input.?required|needs.?(input|approval)/.test(eventName)) {
+    return { ...base, hook_event_type: "Notification", payload: { message: bodyText || eventName, event: eventName || undefined } };
+  }
+
   // Recognizable lifecycle events.
   if (/prompt|user.?message|user.?input/.test(eventName)) return { ...base, hook_event_type: "UserPromptSubmit", payload: { prompt: bodyText } };
   if (/session.?start|thread.?init|conversation.?start/.test(eventName)) return { ...base, hook_event_type: "SessionStart", payload: { message: bodyText } };
   if (/session.?end|thread.?end|turn.?complete|response.?complete/.test(eventName)) return { ...base, hook_event_type: "Turn complete", payload: { message: bodyText } };
-  // Any other GenAI-tagged record → a notification carrying its body.
-  if (bodyText || eventName) return { ...base, hook_event_type: "Notification", payload: { message: bodyText || eventName, event: eventName || undefined } };
+  /**
+   * Everything else GenAI-tagged: telemetry, not a request.
+   *
+   * This used to fall through to Notification, and Notification is not a
+   * neutral bucket — it is the vocabulary's word for "the agent wants you".
+   * Three consumers act on it:
+   *
+   *   web/lib/derive.ts:337  the fleet card turns to `waiting`
+   *   web/lib/derive.ts:399  the outcome ladder counts it `unanswered`
+   *   server/alerts.ts:119   a desktop notification fires, and the webhook
+   *
+   * So a Codex heartbeat, a rollout debug line, any vendor record this
+   * mapper had not learned yet, told the operator an agent was blocked on
+   * them — on their desk, on their phone, and in whatever Slack channel
+   * AGENTGLASS_WEBHOOK points at. A false "needs you" is the most expensive
+   * signal this product can emit, because the queue is the product.
+   *
+   * Telemetry is deliberately not in any of those three lists: it counts as
+   * an event and keeps its body, and claims nothing about a human.
+   */
+  if (bodyText || eventName) return { ...base, hook_event_type: "Telemetry", payload: { message: bodyText || eventName, event: eventName || undefined } };
   return null;
 }
 

--- a/server/test/otlp-not-a-notification.test.ts
+++ b/server/test/otlp-not-a-notification.test.ts
@@ -1,0 +1,100 @@
+// An unrecognised GenAI record is telemetry, not a request for a human.
+//
+// The mapper's catch-all turned ANY GenAI-tagged log record it had not learned
+// into `Notification`. That is not a neutral bucket — it is the vocabulary's
+// word for "the agent wants you", and three things act on it:
+//
+//   web/lib/derive.ts:337   the fleet card turns to `waiting`
+//   web/lib/derive.ts:399   the outcome ladder counts it `unanswered`
+//   server/alerts.ts:119    a desktop notification fires, and the webhook
+//
+// So a Codex heartbeat, a rollout debug line, or any vendor record newer than
+// this mapper told the operator an agent was blocked on them — on their desk,
+// on their phone, and in whatever Slack channel AGENTGLASS_WEBHOOK points at.
+// A false "needs you" is the most expensive signal this product can emit,
+// because the queue is the product. And it fired on the path agentglass
+// advertises as provider-agnostic, which is the path with the most unknown
+// record shapes by definition.
+import { describe, expect, test } from "bun:test";
+import { otlpLogsToEvents } from "../src/otlp.ts";
+
+const kv = (key: string, value: string | number) => ({
+  key,
+  value: typeof value === "number" ? { intValue: value } : { stringValue: value },
+});
+
+const record = (attrs: ReturnType<typeof kv>[], body?: string) => ({
+  resourceLogs: [{
+    resource: { attributes: [kv("service.name", "codex_cli_rs")] },
+    scopeLogs: [{
+      logRecords: [{
+        timeUnixNano: "1700000000000000000",
+        attributes: [kv("gen_ai.system", "openai"), kv("conversation.id", "c1"), ...attrs],
+        ...(body ? { body: { stringValue: body } } : {}),
+      }],
+    }],
+  }],
+});
+
+const typeOf = (attrs: ReturnType<typeof kv>[], body?: string) =>
+  otlpLogsToEvents(record(attrs, body))[0]?.hook_event_type;
+
+describe("records that do not ask for anything are not made to", () => {
+  for (const kind of [
+    "rollout.debug.heartbeat",
+    "stream.chunk",
+    "some.vendor.event.from.the.future",
+    "response.metadata",
+  ]) {
+    test(`"${kind}" is telemetry`, () => {
+      expect(typeOf([kv("event.kind", kind)], "…")).toBe("Telemetry");
+    });
+  }
+
+  test("a bare body with no event kind is telemetry too", () => {
+    expect(typeOf([], "some log line")).toBe("Telemetry");
+  });
+});
+
+describe("a record that IS asking for a human still says so", () => {
+  // Losing this would be the opposite failure, and a worse one: a genuine
+  // hold going unannounced.
+  for (const kind of [
+    "notification.idle_prompt",
+    "permission.request",
+    "approval.needed",
+    "agent.blocked",
+    "awaiting.user",
+    "input_required",
+  ]) {
+    test(`"${kind}" is a Notification`, () => {
+      expect(typeOf([kv("event.kind", kind)], "…")).toBe("Notification");
+    });
+  }
+});
+
+describe("the branches above the catch-all are untouched", () => {
+  test("a tool call is still a tool call", () => {
+    expect(typeOf([kv("event.kind", "tool.decision"), kv("gen_ai.tool.name", "bash")])).toBe("PreToolUse");
+  });
+
+  test("a tool result is still a tool result", () => {
+    expect(typeOf([kv("event.kind", "tool.result"), kv("gen_ai.tool.name", "bash")])).toBe("PostToolUse");
+  });
+
+  test("a token-bearing record is still a costed turn", () => {
+    expect(typeOf([kv("event.kind", "rollout.debug.heartbeat"), kv("input_token_count", 100)])).toBe("Turn complete");
+  });
+
+  test("a prompt is still a prompt", () => {
+    expect(typeOf([kv("event.kind", "user.message")], "hi")).toBe("UserPromptSubmit");
+  });
+
+  test("a session start is still a session start", () => {
+    expect(typeOf([kv("event.kind", "session.start")], "…")).toBe("SessionStart");
+  });
+
+  test("an empty record is still dropped rather than invented", () => {
+    expect(typeOf([])).toBeUndefined();
+  });
+});

--- a/web/src/lib/labels.ts
+++ b/web/src/lib/labels.ts
@@ -19,6 +19,11 @@ export function friendly(e: WatchEvent): Friendly {
       return { verb: "Needs your approval", color: "#fbbf24", dot: "warn" };
     case "Notification":
       return { verb: "Notification", color: "#fbbf24", dot: "warn" };
+    // A GenAI record from an OTel source that carries no lifecycle meaning —
+    // a heartbeat, a debug line, a vendor event the mapper has not learned.
+    // Rendered as the ambient thing it is, never as attention.
+    case "Telemetry":
+      return { verb: "Telemetry", color: "#94a3b8", dot: "idle" };
     case "UserPromptSubmit":
       return { verb: "New prompt", color: "#c4b5fd", dot: "run" };
     case "SessionStart":


### PR DESCRIPTION
## What was wrong

The OTLP log mapper's catch-all turned **any** GenAI-tagged record it had not learned into `Notification`:

```ts
// Any other GenAI-tagged record → a notification carrying its body.
if (bodyText || eventName) return { ...base, hook_event_type: "Notification", … };
```

`Notification` is not a neutral bucket. It is the vocabulary's word for *"the agent wants you"*, and three things act on it:

| | |
|---|---|
| `web/lib/derive.ts:337` | the fleet card turns to **`waiting`** |
| `web/lib/derive.ts:399` | the outcome ladder counts the session **`unanswered`** |
| `server/alerts.ts:119` | a **desktop notification** fires, and the **webhook** posts |

So a Codex heartbeat, a rollout debug line, or any vendor record newer than this mapper told the operator an agent was blocked on them — on their desk, on their phone, and in whatever Slack channel `AGENTGLASS_WEBHOOK` points at.

Reproduced end to end before touching anything:

```
mapped to:          [ "Notification" ]
fleet card status:  waiting
```

…from a record whose `event.kind` was `rollout.debug.heartbeat`.

**A false "needs you" is the most expensive signal this product can emit, because the queue is the product.** And it fired on the path advertised as provider-agnostic — which by definition sees the most unfamiliar record shapes.

## What changed

Unrecognised records become **`Telemetry`**, which is in none of those three lists: it counts as an event, keeps its body, and claims nothing about a human. The fleet card reads `working`, which is true — the session is alive and emitting.

Records that genuinely *are* asking are still recognised, because losing those would be the opposite and worse failure — a real hold going unannounced. `notification` / `permission` / `approval` / `awaiting` / `blocked` / `input-required` all still map through.

### An ordering detail found by the tests

That check is asked **before** the lifecycle patterns, which match on loose words: `notification.idle_prompt` contains `prompt` and was being read as a *user prompt submission*. Nothing in the attention set matches a genuine prompt or session name, so the stricter question is safe to ask first — and the tests pin both directions so it stays that way.

## How was it tested?

`server/test/otlp-not-a-notification.test.ts` (new), 17 cases. **Five fail** if the catch-all goes back to `Notification`.

The suite is deliberately split three ways, because "stop raising notifications" is trivially achievable by breaking the feature:

- **must not ask** — `rollout.debug.heartbeat`, `stream.chunk`, `some.vendor.event.from.the.future`, `response.metadata`, and a bare body with no event kind
- **must still ask** — six real attention shapes, including the `notification.idle_prompt` case that motivated the reorder
- **must be unchanged** — tool call, tool result, token-bearing turn, prompt, session start, and an empty record still being dropped rather than invented

Full suites: **904 server** / **441 web**, 0 failures. `tsc --noEmit` clean in both tiers, `vite build` clean.

Downstream safety was checked rather than assumed: `typeColor` falls back to a grey for an unknown type, `labels.ts` has a `default:` case (a `Telemetry` verb is added anyway so it reads as the ambient thing it is), and the type filter list is built from the database rather than hardcoded.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_