### PR TITLE
feat(gate): a denial the agent can act on

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,7 +686,10 @@ resolved by your configured policy and **says so** in "What needs you", because
 an outcome nobody chose is the one worth showing.
 
 Scope it with the `matcher` (e.g. `Bash` only, or a specific tool) so you're not
-gating every call. Denying returns a `PreToolUse` deny with your reason.
+gating every call. Denying returns a `PreToolUse` deny with your reason — and
+when you just press Deny without typing one, the agent is told a human stopped
+it, that retrying the same call is pointless, and to try another approach or ask
+you. That sentence is read by the model, not by you, so it is written for it.
 
 Want the opposite trade-off? Set `AGENTGLASS_GATE_FAILCLOSED=1` and a timeout or
 an unreachable control plane **denies** instead of allows — the fleet stops

--- a/hooks/gate_event.py
+++ b/hooks/gate_event.py
@@ -175,13 +175,13 @@ def main():
 
     if out is None:
         if FAIL_CLOSED:
-            emit("deny", "agentglass unreachable (fail-closed)")
+            emit("deny", "agentglass could not be reached and is configured fail-closed, so this call was blocked without a human seeing it. This is an infrastructure problem, not a judgement about the call — report it rather than working around it.")
         allow_silently()  # unreachable / error → never block (default)
 
     decision = out.get("decision", "allow")
     reason = out.get("reason", "")
     if decision == "deny":
-        emit("deny", reason or "denied from agentglass")
+        emit("deny", reason or "A human denied this call in agentglass. Do not retry the same call — take a different approach, or ask them what they would prefer.")
     if decision == "allow" and reason:
         emit("allow", reason)  # explicit approval (skips the normal prompt)
     allow_silently()

--- a/server/src/gate.ts
+++ b/server/src/gate.ts
@@ -42,7 +42,16 @@ export function onGateChange(fn: () => void) { onChange = fn; }
 
 /** What a timeout resolves to, under the configured policy. */
 function timeoutOutcome(): GateOutcome {
-  if (FAIL_CLOSED) return { decision: "deny", reason: "gate timeout — no decision (fail-closed)" };
+  // Same audience as defaultReason(): a model deciding what to do next. This
+  // one is emphatically NOT a judgement about the call — nobody looked at it —
+  // and an agent that treats it as one will start avoiding a perfectly fine
+  // approach for the rest of the session.
+  if (FAIL_CLOSED) {
+    return {
+      decision: "deny",
+      reason: "Nobody answered this request in time and agentglass is configured fail-closed, so it was blocked without a human seeing it. This is not a judgement about the call. Say that you were blocked waiting for approval rather than assuming the approach was wrong.",
+    };
+  }
   // Empty reason so the hook falls through to Claude Code's own permission
   // prompt instead of force-allowing — an auto-allow shouldn't silently
   // skip the human it was meant to ask.
@@ -127,12 +136,33 @@ export function awaitGate(id: string): Promise<GateOutcome> | GateOutcome | null
   return { decision: row.decision, reason: row.reason || "" };
 }
 
+/**
+ * What the agent is told when a human decides without typing anything.
+ *
+ * This string is not a log line. It travels to the hook, which hands it to
+ * Claude Code as `permissionDecisionReason` — so it is read by a model that
+ * has just been stopped and now has to choose what to do next.
+ *
+ * "denied from dashboard" told it nothing it could act on. The only moves it
+ * leaves are retrying the identical call, which will be denied again, or
+ * stalling — and both waste a turn and the human's next interruption. So the
+ * default says what happened, that retrying is pointless, and what to do
+ * instead.
+ *
+ * A reason typed by the human always wins; this is only the empty case.
+ */
+export function defaultReason(decision: GateDecision): string {
+  return decision === "deny"
+    ? "A human reviewed this call in agentglass and denied it. Do not retry the same call — it will be denied again. Take a different approach, or ask them what they would prefer."
+    : "A human reviewed this call in agentglass and approved it.";
+}
+
 export function decideGate(id: string, decision: GateDecision, reason: string): boolean {
   const row = getGate(id);
   // Decidable while pending, whether or not a connection is currently held: a
   // restored request has no waiter and must still take the operator's answer.
   if (!row || row.decision) return false;
-  finish(id, { decision, reason: reason || (decision === "deny" ? "denied from dashboard" : "approved from dashboard") }, "human");
+  finish(id, { decision, reason: reason || defaultReason(decision) }, "human");
   return true;
 }
 

--- a/server/test/gate-denial-reason.test.ts
+++ b/server/test/gate-denial-reason.test.ts
@@ -1,0 +1,177 @@
+// A gate decision is the one string in this codebase whose reader is a model.
+//
+// When you press Deny in the dashboard the UI sends no text — `gateDecide(id,
+// decision)` has no reason argument at the call site — so the server backfills
+// one, the hook puts it in `permissionDecisionReason`, and Claude Code hands it
+// straight to the agent it just stopped. The old backfill was "denied from
+// dashboard": true, and useless. It says nothing about *why*, so the only moves
+// it leaves the agent are retrying the identical call (denied again) or
+// stalling until the human comes back — and the human pressed Deny precisely to
+// avoid being needed again.
+//
+// So these tests are about content, not plumbing: the default has to say what
+// happened, that retrying is pointless, and what to do instead. The last two
+// pin the cases that must NOT gain a default, because a reason there changes
+// behaviour rather than wording.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { spawnSync } from "node:child_process";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-gate-reason-"));
+process.env.AGENTGLASS_DB = join(dir, "gate.db");
+process.env.XDG_CONFIG_HOME = dir;
+
+// Unique per run, deterministic per assertion — db.ts binds its file at import,
+// so in a full `bun test` this suite may land on a database another suite chose
+// and fixed ids would replay old rows. Same reasoning as gate-durability.
+let seq = 0;
+const newId = () => `${crypto.randomUUID().slice(0, 24)}${String(++seq).padStart(12, "0")}`;
+
+let gate: typeof import("../src/gate.ts");
+let db: typeof import("../src/db.ts");
+
+const req = (over: Record<string, unknown> = {}) => ({
+  source_app: "orbit",
+  session_id: "11111111-2222-3333-4444-555555555555",
+  tool_name: "Bash",
+  summary: "rm -rf /",
+  ...over,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  gate = await import("../src/gate.ts");
+});
+
+describe("what the agent is told when a human decides without typing", () => {
+  test("a denial tells it not to retry, and what to do instead", async () => {
+    const id = newId();
+    const held = gate.submitGate(req({ id }), 60_000);
+    gate.decideGate(id, "deny", ""); // the dashboard's Deny button: no text
+    const { reason } = await held;
+
+    // The regression itself.
+    expect(reason).not.toBe("denied from dashboard");
+    // A human looked at it — not a crash, not a timeout.
+    expect(reason).toMatch(/human/i);
+    // The two moves the old string left available are closed off, and an open
+    // one is named. Without this an agent burns its next turn on a retry that
+    // is guaranteed to be denied again.
+    expect(reason).toMatch(/do not retry|don't retry/i);
+    expect(reason).toMatch(/different approach|ask/i);
+    // Long enough to actually say those things.
+    expect(reason.length).toBeGreaterThan(60);
+  });
+
+  test("it is recorded with the request, not only handed to the waiter", () => {
+    const id = newId();
+    gate.submitGate(req({ id }), 60_000);
+    gate.decideGate(id, "deny", "");
+    // The hook re-attaching after a dropped connection reads the row, not the
+    // promise — it has to get the same sentence.
+    expect(db.getGate(id)!.reason).toBe(gate.defaultReason("deny"));
+  });
+
+  test("a reason the human typed wins, verbatim and unadorned", async () => {
+    const id = newId();
+    const held = gate.submitGate(req({ id }), 60_000);
+    gate.decideGate(id, "deny", "wrong repo — you're in the vendored copy");
+    await expect(held).resolves.toEqual({
+      decision: "deny",
+      reason: "wrong repo — you're in the vendored copy",
+    });
+  });
+
+  test("an approval keeps a non-empty reason, because empty means something else", async () => {
+    const id = newId();
+    const held = gate.submitGate(req({ id }), 60_000);
+    gate.decideGate(id, "allow", "");
+    const { reason } = await held;
+    // Not cosmetic: the hook only emits an explicit `allow` decision when the
+    // reason is non-empty, and an explicit allow is what skips Claude Code's
+    // own permission prompt. Blanking this would send the agent back to the
+    // prompt a human just answered.
+    expect(reason).not.toBe("");
+    expect(reason).toMatch(/human/i);
+  });
+});
+
+describe("the cases that must stay silent", () => {
+  test("a fail-open timeout says nothing at all", async () => {
+    const id = newId();
+    await gate.submitGate(req({ id }), 1); // floored to 1s, then auto-resolves
+    const row = db.getGate(id)!;
+    expect(row.decision).toBe("allow");
+    expect(row.resolution).toBe("timeout");
+    // The inverse of the test above. Nobody looked at this call, so the hook
+    // must fall through to Claude Code's normal prompt rather than force-allow;
+    // giving the timeout a friendly default silently removes that prompt.
+    expect(row.reason).toBe("");
+  });
+
+  test("the two human defaults stay distinct", () => {
+    // Guards the tempting simplification of one sentence for both: an agent
+    // that was allowed and one that was stopped need opposite next moves.
+    expect(gate.defaultReason("deny")).not.toBe(gate.defaultReason("allow"));
+  });
+});
+
+/*
+ * End to end, through the hook.
+ *
+ * gate.ts writing a good sentence is only half of it: the value the agent
+ * actually reads is whatever `gate_event.py` prints as
+ * `permissionDecisionReason`. These run the real hook against a stub server, so
+ * a change on either side that drops the reason on the floor fails here.
+ */
+const python = ["python3", "python", "py"].find(
+  (exe) => spawnSync(exe, ["--version"], { stdio: "ignore" }).status === 0,
+);
+
+async function runHook(reply: { decision: string; reason: string }): Promise<any> {
+  const server = Bun.serve({
+    hostname: "127.0.0.1",
+    port: 0,
+    fetch: () => Response.json(reply),
+  });
+  try {
+    const proc = Bun.spawn(
+      [python!, join(import.meta.dir, "..", "..", "hooks", "gate_event.py"), "--server", `http://127.0.0.1:${server.port}`],
+      { stdin: "pipe", stdout: "pipe", stderr: "pipe", env: { ...process.env, AGENTGLASS_INTERNAL: "" } },
+    );
+    proc.stdin.write(JSON.stringify({ session_id: "s1", tool_name: "Bash", tool_input: { command: "rm -rf /" } }));
+    proc.stdin.end();
+    const out = await new Response(proc.stdout).text();
+    await proc.exited;
+    return out.trim() ? JSON.parse(out) : null;
+  } finally {
+    server.stop(true);
+  }
+}
+
+describe("the hook hands the reason to Claude Code", () => {
+  test.if(!!python)("the server's sentence arrives intact", async () => {
+    // A sentinel rather than defaultReason(): what is under test here is that
+    // the hook forwards whatever the server decided, byte for byte — including
+    // the em dash — not that it agrees with gate.ts about the wording.
+    const sentinel = "A human reviewed this — do not retry, try X instead.";
+    const out = await runHook({ decision: "deny", reason: sentinel });
+    expect(out?.hookSpecificOutput).toMatchObject({
+      hookEventName: "PreToolUse",
+      permissionDecision: "deny",
+      permissionDecisionReason: sentinel,
+    });
+  });
+
+  test.if(!!python)("and its own fallback is actionable too, for a denial with no reason", async () => {
+    // An older server, or a decision recorded before this change, sends the
+    // decision with an empty reason. The hook is the last thing standing
+    // between that and the agent.
+    const reason = (await runHook({ decision: "deny", reason: "" }))?.hookSpecificOutput?.permissionDecisionReason;
+    expect(reason).not.toBe("denied from agentglass");
+    expect(reason).toMatch(/do not retry|don't retry/i);
+    expect(reason).toMatch(/different approach|ask/i);
+  });
+});

--- a/server/test/gate-durability.test.ts
+++ b/server/test/gate-durability.test.ts
@@ -96,8 +96,8 @@ describe("re-attaching after the connection drops", () => {
     gate.submitGate(req({ id }), 60_000); // the original connection, now "dropped"
     const again = gate.awaitGate(id) as Promise<{ decision: string; reason: string }>;
     expect(again).toBeInstanceOf(Promise);
-    gate.decideGate(id, "allow", "approved from dashboard");
-    await expect(again).resolves.toEqual({ decision: "allow", reason: "approved from dashboard" });
+    gate.decideGate(id, "allow", "go ahead, it's a scratch dir");
+    await expect(again).resolves.toEqual({ decision: "allow", reason: "go ahead, it's a scratch dir" });
   });
 
   test("a decision made while the hook was away is replayed, not lost", async () => {


### PR DESCRIPTION
## What does this PR do?

Replaces the string the gate hands an agent when a human denies a tool call without typing a reason. `"denied from dashboard"` becomes something the model can act on — what happened, that retrying is pointless, and what to do instead. Same for the two cases the hook has to answer alone.

## How was it tested?

`bun test` in `server/` — 922 pass, 0 fail, including 8 new ones in `server/test/gate-denial-reason.test.ts`. `bunx tsc --noEmit` in `server/`, `python3 -m py_compile hooks/gate_event.py`. Every new assertion was run **red first** by reverting the source: 5 fail without the change, and the 3 that pass are regression guards for behaviour that deliberately did not change. The last two tests drive the real `gate_event.py` against a stub server and read its stdout, so the whole chain is exercised, not just the server half.

---

## The problem

Pressing **Deny** in the dashboard sends no text. The UI calls `gateDecide(id, decision)` with no reason (`Alerts.tsx:71`, `mobile/MobileApp.tsx:168`), so the server backfilled one, the hook put it in `permissionDecisionReason`, and Claude Code handed it to the agent it had just stopped.

The backfill was `"denied from dashboard"`.

That is a log line, not a message to a model. It says nothing the agent can use, so the only moves it leaves are retrying the identical call — which will be denied again — or stalling until the human comes back. And the human pressed Deny precisely to avoid being needed a second time.

The gate is the one feature in this repo whose job is human oversight. The string it produces is the entire content of that oversight as far as the agent is concerned.

## The change

The defaults now say what happened, that retrying is pointless, and what to do instead:

> A human reviewed this call in agentglass and denied it. Do not retry the same call — it will be denied again. Take a different approach, or ask them what they would prefer.

Same treatment for the two cases the server never gets to speak:

- **`gate_event.py`, a denial arriving with no reason** — an older server, or a decision recorded before this change. The hook is the last thing standing between that and the agent.
- **`gate_event.py`, fail-closed + unreachable** — this one additionally says it is an infrastructure problem, not a judgement about the call. An agent that reads a timeout as disapproval starts avoiding a perfectly good approach for the rest of the session.
- **`timeoutOutcome()`, fail-closed** — same audience, same distinction.

None of this is rendered in the UI. `Alerts.tsx` shows the tool name and the resolution, never `reason` — so there is no length or layout cost, and the string is free to be written for its actual reader.

## What deliberately did not change

Three behaviours that a "let's default the reason everywhere" refactor would quietly break. Each now has a test:

| Case | Reason | Why it matters |
|---|---|---|
| Human typed a reason | theirs, verbatim | the default is only the empty case |
| Fail-**open** timeout | stays **empty** | a non-empty reason makes the hook force-allow; empty lets it fall through to Claude Code's own permission prompt, which nobody has answered yet |
| Human approval, no text | stays **non-empty** | the hook only emits an explicit `allow` when the reason is non-empty, and that explicit allow is what skips the prompt the human just answered |

One drive-by in `gate-durability.test.ts`: a test passed `"approved from dashboard"` as a human-typed reason. Still correct, but it now reads like the removed default. Renamed to something obviously typed by a person.
