### PR TITLE
feat(stats): keep the numbers past the retention window — read the rollup, mark the windows, export the days

### DIFF
--- a/README.md
+++ b/README.md
@@ -878,7 +878,8 @@ cannot be configured by `export` at all.
 | `GET /search?q=` | Full-text search across all captured prompts/commands/outputs. |
 | `POST /gate` · `GET /gate/pending` · `POST /gate/decide` | Control-plane approve/deny for the opt-in `PreToolUse` gate. |
 | `POST /control` | Drive the dashboard's own UI (switch view, toggle workspace, theme, zoom, new chat) from an external controller — a Stream Deck, a phone. Validated then rebroadcast on `/stream`; changes only what's shown, grants no capability the keyboard doesn't. See [`docs/EXTENDING.md`](docs/EXTENDING.md). |
-| `GET /export?format=csv\|json` | Download all events. |
+| `GET /export?format=csv\|json` | Download all events (bounded by retention). |
+| `GET /export?kind=daily&format=csv\|json` | Download the **daily totals**, rollup included — so a month already pruned still exports. |
 | `WS /stream` | Live frames — `initial` · `openTools` · `event` · `session` · `git` · `ci` · `alert` · `control`. Read-only: the socket never accepts commands. |
 
 ---

--- a/README.md
+++ b/README.md
@@ -786,7 +786,7 @@ in its own buckets rather than charged again as ordinary input.
 | `AGENTGLASS_PROJECTS_DIR` | `~/.claude/projects` | Root the transcript scanner reads Claude Code session logs from. Several roots can be listed, separated by the platform's `PATH` delimiter (`:` on Linux/macOS, `;` on Windows). |
 | `AGENTGLASS_SCAN_INTERVAL_MS` | `3000` | Transcript scan poll interval (min 500). |
 | `AGENTGLASS_SCAN_DISABLED` | — | `1` → turn off the machine-wide transcript scanner (rely on hooks / OTel only). |
-| `AGENTGLASS_RETENTION_DAYS` | `8` | Days of history to keep (pruned hourly). Covers the full 7d stats window; `0` = keep forever. |
+| `AGENTGLASS_RETENTION_DAYS` | `8` | Days of **raw events** to keep (pruned hourly). Covers the full 7d stats window; `0` = keep forever. Expiring days are folded into a daily rollup first, so spend history outlives the rows — see *spend per day* in Statistics. |
 | `AGENTGLASS_PRICING` | — | Path to a JSON pricing override (see `server/src/pricing.ts`). |
 | `AGENTGLASS_WEBHOOK` | — | POST `{text}` alerts here (Slack/Discord compatible). |
 | `AGENTGLASS_NOTIFY` | — | `1` → fire desktop alerts. A connected client (browser or desktop app) raises a **native OS notification** on any platform; `notify-send` is the fallback for a headless server with nothing attached to show it. |
@@ -853,6 +853,7 @@ cannot be configured by `export` at all.
 | `POST /workspace` | Scope the cockpit to a project / folder at runtime (`{root}`; `null` → whole machine). Applied live, persisted to the config file — this is what the in-app project picker calls. |
 | `GET /sessions?limit=` | Session rollups. |
 | `GET /stats?window=<ms>` | Full analytics summary (totals, by-model, tool latency, timeline). |
+| `GET /usage/daily?days=<n>` | Daily totals **across the retention boundary** — the folded rollup plus the live events, joined and summed, with `seam_day` saying where one ends and the other begins. |
 | `GET /skills` | Skill/command catalog scanned from `~/.claude` + `$AGENTGLASS_CODE_DIR/*/.claude`, joined with recorded usage. |
 | `GET /changes?limit=` | Recent file changes (Edit/Write) as diff hunks — feeds the **File changes** diff viewer. |
 | `POST /walkthrough` | AI **Explain** — a local-Claude walkthrough of a set of diffs (per-file summary + review focus). |

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -13,6 +13,7 @@ import type {
   AppUsage,
   TypeCount,
   OpenToolCall,
+  UsageDay,
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
 import { costUsd, modelLabel, hasPrice } from "./pricing.ts";
@@ -797,6 +798,9 @@ export function pruneOldRows(): { events: number; sessions: number; rolled: numb
   const cutoff = Date.now() - RETENTION_DAYS * 86_400_000;
   // One transaction: the fold and the delete are the same decision, and a
   // crash between them would delete a day nobody had summarised.
+  // The fold is the only thing that writes daily_rollup, so this is the only
+  // place its path set can change.
+  rollupPathCache = null;
   return db.transaction(() => {
     const rolled = foldExpiringEvents(cutoff);
     db.run(`DELETE FROM events_fts WHERE rowid IN (SELECT id FROM events WHERE timestamp < ?)`, [cutoff]);
@@ -809,59 +813,148 @@ export function pruneOldRows(): { events: number; sessions: number; rolled: numb
   })();
 }
 
-/** A day's totals, from the rollup. `null` bounds mean no bound. */
-export interface RollupDay {
-  day: string;
-  events: number;
-  tool_calls: number;
-  tool_errors: number;
-  errors: number;
-  input_tokens: number;
-  output_tokens: number;
-  cache_creation_tokens: number;
-  cache_read_tokens: number;
-  cost_usd: number;
-  sessions: number;
-  /** Mean tool duration. There is no p95 here and there cannot be — see the
-   *  daily_rollup comment. */
-  avg_ms: number;
+/**
+ * Every project path the rollup itself contains.
+ *
+ * Deliberately not recordedPaths(): that reads the events table, and the whole
+ * point of the rollup is that those rows are gone. A project last touched a
+ * month ago has no path left in events at all, so scoping rollup queries by
+ * what events still remembers would hide precisely the history the rollup was
+ * built to keep — the further back you look, the more of it disappears.
+ *
+ * The prune is the only writer, so the cache is dropped there rather than
+ * timed out.
+ */
+let rollupPathCache: string[] | null = null;
+function rollupPaths(): string[] {
+  if (rollupPathCache) return rollupPathCache;
+  const rows = db.query<{ p: string }, []>("SELECT DISTINCT project_path AS p FROM daily_rollup").all();
+  return (rollupPathCache = rows.map((r) => r.p).filter(Boolean));
 }
 
 /**
- * Daily totals from the rollup, scoped like every other metric.
+ * Scope fragment for a `daily_rollup` query — the counterpart of scopeClause().
+ *
+ * Two differences from the events version, both forced by what the fold keeps.
+ * It tests `isWithin` rather than equality against the scope roots, because
+ * `project_path` is the path the event carried and that is often a directory
+ * *inside* a checkout (a monorepo package) — an exact IN against the roots
+ * matched none of those and reported a scoped project as having no history.
+ * And there is no `cwd_path` to fall back on: the fold does not carry one, so
+ * a row whose only in-scope path was the cwd cannot be recovered here.
+ */
+function rollupScopeClause(scope: string | null = workspaceRoot()): { clause: string; args: string[] } {
+  if (!scope) return { clause: "", args: [] };
+  const roots = scopeRoots(scope);
+  const inScope = rollupPaths().filter((p) => roots.some((r) => isWithin(p, r)));
+  // Same honest answer as scopeClause: nothing folded for this project yet.
+  if (!inScope.length) return { clause: " AND 0", args: [] };
+  return { clause: ` AND project_path IN (${inScope.map(() => "?").join(",")})`, args: inScope };
+}
+
+/** The per-day aggregate shared by rollupDays() and dailyUsage(), so the two
+ *  cannot drift into answering the same question differently. */
+const DAY_TOTALS = `SELECT day,
+        SUM(events) AS events, SUM(tool_calls) AS tool_calls,
+        SUM(tool_errors) AS tool_errors, SUM(errors) AS errors,
+        SUM(input_tokens) AS input_tokens, SUM(output_tokens) AS output_tokens,
+        SUM(cache_creation_tokens) AS cache_creation_tokens,
+        SUM(cache_read_tokens) AS cache_read_tokens,
+        SUM(cost_usd) AS cost_usd,
+        COUNT(DISTINCT session_id) AS sessions,
+        CASE WHEN SUM(timed_calls) > 0
+             THEN CAST(SUM(duration_ms_total) / SUM(timed_calls) AS INTEGER)
+             ELSE 0 END AS avg_ms`;
+
+/**
+ * Daily totals from the rollup alone, scoped like every other metric.
  *
  * This reads only what the prune has already folded, so it answers about the
- * past — the live window is still the events table's job. A caller wanting a
- * continuous series joins the two at the retention boundary.
+ * past and stops at the retention boundary. Callers wanting a series that runs
+ * up to now want dailyUsage() instead — it is this plus the live events.
  */
-export function rollupDays(fromDay?: string, toDay?: string): RollupDay[] {
-  const roots = scopeRoots();
+export function rollupDays(fromDay?: string, toDay?: string): UsageDay[] {
+  const scope = rollupScopeClause();
   const where: string[] = [];
   const args: any[] = [];
-  if (fromDay) { where.push('day >= ?'); args.push(fromDay); }
-  if (toDay) { where.push('day <= ?'); args.push(toDay); }
-  if (roots.length) {
-    where.push(`project_path IN (${roots.map(() => '?').join(',')})`);
-    args.push(...roots);
-  }
-  const clause = where.length ? ` WHERE ${where.join(' AND ')}` : '';
+  if (fromDay) { where.push("day >= ?"); args.push(fromDay); }
+  if (toDay) { where.push("day <= ?"); args.push(toDay); }
+  const clause = ` WHERE 1${where.length ? ` AND ${where.join(" AND ")}` : ""}${scope.clause}`;
   return db
-    .query<RollupDay, any[]>(
-      `SELECT day,
-              SUM(events) AS events, SUM(tool_calls) AS tool_calls,
-              SUM(tool_errors) AS tool_errors, SUM(errors) AS errors,
-              SUM(input_tokens) AS input_tokens, SUM(output_tokens) AS output_tokens,
-              SUM(cache_creation_tokens) AS cache_creation_tokens,
-              SUM(cache_read_tokens) AS cache_read_tokens,
-              SUM(cost_usd) AS cost_usd,
-              COUNT(DISTINCT session_id) AS sessions,
-              CASE WHEN SUM(timed_calls) > 0
-                   THEN CAST(SUM(duration_ms_total) / SUM(timed_calls) AS INTEGER)
-                   ELSE 0 END AS avg_ms
-       FROM daily_rollup${clause}
-       GROUP BY day ORDER BY day`
+    .query<UsageDay, any[]>(`${DAY_TOTALS} FROM daily_rollup${clause} GROUP BY day ORDER BY day`)
+    .all(...args, ...scope.args);
+}
+
+/**
+ * One continuous daily series, across the retention boundary.
+ *
+ * The rollup holds the days the prune has folded; `events` holds the days it
+ * has not. Neither alone can answer "what did this project cost this month" on
+ * a default install — retention is 8 days, so a 30d window read from events is
+ * eight days of data wearing a thirty-day label.
+ *
+ * The two sources are summed, not preferred, because the boundary is a
+ * *timestamp*, not a midnight: the prune folds `timestamp < now - N days`, so
+ * the day the cutoff lands in is split between the tables and is only whole
+ * when both halves are added. Every other day is in exactly one of them, where
+ * adding is the identity.
+ *
+ * Sessions are the one column that cannot be summed — a session that ran
+ * across the cutoff has a row on both sides — so the union is counted distinct
+ * over (day, session_id) instead of adding two counts that both include it.
+ *
+ * Days are UTC, matching what the fold wrote. The heatmap is the panel that
+ * needs a viewer's local clock; a day-grained cost series does not, and
+ * shifting it would put spend on a different day than the rollup recorded it.
+ */
+export function dailyUsage(fromDay?: string, toDay?: string): UsageDay[] {
+  const rs = rollupScopeClause();
+  const es = scopeClause();
+  const rWhere: string[] = [];
+  const rArgs: any[] = [];
+  const eWhere: string[] = [];
+  const eArgs: any[] = [];
+  if (fromDay) {
+    rWhere.push("day >= ?"); rArgs.push(fromDay);
+    // Bounded on `timestamp` rather than on date(timestamp), so the events half
+    // can use the timestamp index instead of computing a date per row. With
+    // retention disabled this table holds everything, and "all time" is exactly
+    // when that matters.
+    eWhere.push("timestamp >= CAST(strftime('%s', ?) AS INTEGER) * 1000"); eArgs.push(fromDay);
+  }
+  if (toDay) {
+    rWhere.push("day <= ?"); rArgs.push(toDay);
+    eWhere.push("timestamp < (CAST(strftime('%s', ?) AS INTEGER) + 86400) * 1000"); eArgs.push(toDay);
+  }
+  const rc = ` WHERE 1${rWhere.length ? ` AND ${rWhere.join(" AND ")}` : ""}${rs.clause}`;
+  const ec = ` WHERE 1${eWhere.length ? ` AND ${eWhere.join(" AND ")}` : ""}${es.clause}`;
+  return db
+    .query<UsageDay, any[]>(
+      `WITH merged AS (
+         SELECT day, session_id, events, tool_calls, tool_errors, errors,
+                input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens,
+                cost_usd, duration_ms_total, timed_calls
+         FROM daily_rollup${rc}
+         UNION ALL
+         -- Folded the same way foldExpiringEvents() folds, down to the date
+         -- expression: a day that is half here and half in the rollup has to
+         -- land on the same key in both halves or it splits into two days.
+         SELECT date(timestamp / 1000, 'unixepoch') AS day, session_id,
+                COUNT(*),
+                SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END),
+                SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') AND is_error = 1 THEN 1 ELSE 0 END),
+                SUM(COALESCE(is_error, 0)),
+                SUM(COALESCE(input_tokens, 0)), SUM(COALESCE(output_tokens, 0)),
+                SUM(COALESCE(cache_creation_tokens, 0)), SUM(COALESCE(cache_read_tokens, 0)),
+                SUM(COALESCE(cost_usd, 0)),
+                SUM(COALESCE(duration_ms, 0)),
+                SUM(CASE WHEN duration_ms IS NOT NULL THEN 1 ELSE 0 END)
+         FROM events${ec}
+         GROUP BY 1, 2
+       )
+       ${DAY_TOTALS} FROM merged GROUP BY day ORDER BY day`
     )
-    .all(...args);
+    .all(...rArgs, ...rs.args, ...eArgs, ...es.args);
 }
 
 /** The oldest day the rollup can speak to, or null when it is empty. Lets a
@@ -869,6 +962,18 @@ export function rollupDays(fromDay?: string, toDay?: string): RollupDay[] {
 export function rollupEarliestDay(): string | null {
   const r = db.query<{ day: string | null }, []>('SELECT MIN(day) AS day FROM daily_rollup').get();
   return r?.day ?? null;
+}
+
+/**
+ * The UTC day the retention boundary currently falls in, or null when nothing
+ * is pruned. Days before it are day-grained summaries; the boundary day itself
+ * and everything after are still whole events — which is worth saying on a
+ * chart, because it is the difference between "no spend" and "no longer known
+ * in that detail".
+ */
+export function retentionSeamDay(): string | null {
+  if (!RETENTION_DAYS) return null;
+  return new Date(Date.now() - RETENTION_DAYS * 86_400_000).toISOString().slice(0, 10);
 }
 
 export interface InsertResult {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1273,6 +1273,48 @@ const server = Bun.serve<WsData>({
     }
 
     // --- export ---
+    /*
+     * The daily series as a file.
+     *
+     * /export below hands out raw events, which retention deletes — so the
+     * export inherited the same eight-day ceiling as the charts did, and the
+     * one number people actually take out of here (what did this cost) could
+     * not be exported for a month that had ended. This one reads the rollup
+     * too, so what leaves the building goes back as far as the fold does.
+     *
+     * A separate `kind` rather than a new route, so a caller already pointed
+     * at /export keeps working unchanged and switches grain with a parameter.
+     */
+    if (pathname === "/export" && url.searchParams.get("kind") === "daily") {
+      const fmt = url.searchParams.get("format") || "json";
+      const days = dailyUsage();
+      if (fmt === "csv") {
+        const cols = [
+          "day", "events", "tool_calls", "tool_errors", "errors",
+          "input_tokens", "output_tokens", "cache_creation_tokens", "cache_read_tokens",
+          "cost_usd", "sessions", "avg_ms",
+        ];
+        const lines = [cols.join(",")];
+        for (const d of days) lines.push(cols.map((c) => csvEscape((d as any)[c])).join(","));
+        return new Response(lines.join("\n"), {
+          headers: {
+            "content-type": "text/csv",
+            "content-disposition": 'attachment; filename="agentglass-daily.csv"',
+            ...cors,
+          },
+        });
+      }
+      return new Response(
+        JSON.stringify({ days, seam_day: retentionSeamDay(), retention_days: RETENTION_DAYS }, null, 2),
+        {
+          headers: {
+            "content-type": "application/json",
+            "content-disposition": 'attachment; filename="agentglass-daily.json"',
+            ...cors,
+          },
+        },
+      );
+    }
     if (pathname === "/export") {
       const fmt = url.searchParams.get("format") || "json";
       const rows = exportRows();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1248,6 +1248,7 @@ const server = Bun.serve<WsData>({
           url.searchParams.get("tz") || undefined,
         ),
         server_started_at: STARTED_AT,
+        retention_days: RETENTION_DAYS,
       });
     }
     /*

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -18,6 +18,9 @@ import {
   ftsText,
   providerOf,
   gateHistory,
+  dailyUsage,
+  rollupEarliestDay,
+  retentionSeamDay,
 } from "./db.ts";
 import { maybeAlert, setAlertSink } from "./alerts.ts";
 import { getSkills, catalogMarkdown, catalogCsv, usageSince } from "./skills.ts";
@@ -1245,6 +1248,26 @@ const server = Bun.serve<WsData>({
           url.searchParams.get("tz") || undefined,
         ),
         server_started_at: STARTED_AT,
+      });
+    }
+    /*
+     * The daily series, across the retention boundary.
+     *
+     * /stats reads the events table, which retention keeps at 8 days by
+     * default — so its 30d and all-time windows were eight days of data
+     * wearing a longer label. This one adds the folded days back, at the day
+     * granularity they were folded to, and says where the seam is instead of
+     * pretending there isn't one.
+     */
+    if (pathname === "/usage/daily") {
+      const days = Math.max(1, Math.min(3650, Number(url.searchParams.get("days")) || 90));
+      // Inclusive of today, so `days=1` means today rather than nothing.
+      const from = new Date(Date.now() - (days - 1) * 86_400_000).toISOString().slice(0, 10);
+      return json({
+        days: dailyUsage(from),
+        seam_day: retentionSeamDay(),
+        retention_days: RETENTION_DAYS,
+        rollup_from: rollupEarliestDay(),
       });
     }
 

--- a/server/test/usage-across-the-seam.test.ts
+++ b/server/test/usage-across-the-seam.test.ts
@@ -1,0 +1,186 @@
+// #292 built the rollup so the numbers outlive the rows. Nothing read it.
+//
+// So the dashboard kept answering "last 30d" and "all time" from the events
+// table alone, which retention trims to 8 days — thirty days of label over
+// eight days of data, and the difference between "we spent nothing" and "we no
+// longer keep that". dailyUsage() is the join the rollup's own doc comment
+// asked a caller to make.
+//
+// The interesting case is not "old days plus new days". It is the ONE day the
+// two sources share: the prune cuts at `now - N days`, a timestamp rather than
+// a midnight, so the day the cutoff lands in is half folded and half live and
+// is only whole once both halves are added — while a session that ran across
+// that cutoff has a row on each side and must still count once.
+//
+// Fixtures write daily_rollup directly instead of pruning, so the split day is
+// a day this test chooses rather than whatever hour it happens to run at.
+// Whether the prune folds correctly is rollup-before-prune.test.ts's question.
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-seam-"));
+const ROOT = join(dir, "proj");
+const PKG = join(ROOT, "packages", "api"); // a monorepo subdir, not the root
+const OTHER = join(dir, "other");
+for (const d of [PKG, OTHER]) mkdirSync(d, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "seam.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+const DAY = 86_400_000;
+
+/** A UTC day well outside retention, and noon inside it — far enough from
+ *  either midnight that no timezone or rounding accident moves an event to a
+ *  neighbouring day. */
+const dayOf = (msAgo: number) => new Date(Date.now() - msAgo).toISOString().slice(0, 10);
+const noonOn = (day: string) => Date.parse(`${day}T12:00:00Z`);
+
+const SPLIT = dayOf(20 * DAY); // half in the rollup, half still in events
+const OLD = dayOf(40 * DAY); // rollup only
+const LIVE = dayOf(0); // events only
+
+const event = (over: Record<string, unknown> = {}) => ({
+  source_app: "proj",
+  session_id: "seam-live",
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 100, output_tokens: 40, cache_creation_tokens: 0, cache_read_tokens: 10 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: Date.now(),
+  payload: { project_path: PKG },
+  chat: null,
+  ...over,
+});
+
+/** A folded day, written the way foldExpiringEvents() would have written it. */
+function fold(over: {
+  day: string;
+  session_id: string;
+  project_path?: string;
+  events?: number;
+  input_tokens?: number;
+  cost_usd?: number;
+}) {
+  db.db.run(
+    `INSERT INTO daily_rollup (day, project_path, session_id, source_app, model_name, provider,
+       events, tool_calls, tool_errors, errors, input_tokens, output_tokens,
+       cache_creation_tokens, cache_read_tokens, cost_usd, duration_ms_total, timed_calls)
+     VALUES (?, ?, ?, 'proj', 'claude-opus-4-8', 'anthropic', ?, ?, 0, 0, ?, 0, 0, 0, ?, 0, 0)`,
+    [
+      over.day,
+      over.project_path ?? PKG,
+      over.session_id,
+      over.events ?? 1,
+      over.events ?? 1,
+      over.input_tokens ?? 0,
+      over.cost_usd ?? 0,
+    ],
+  );
+}
+
+const byDay = <T extends { day: string }>(days: T[], d: string) => days.find((x) => x.day === d);
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+
+  // Rollup side.
+  fold({ day: OLD, session_id: "seam-old", events: 7, input_tokens: 700, cost_usd: 3 });
+  fold({ day: SPLIT, session_id: "seam-split", events: 3, input_tokens: 300, cost_usd: 1 });
+  // The same day in a project this scope does not cover.
+  fold({ day: OLD, session_id: "seam-elsewhere", project_path: OTHER, events: 99, cost_usd: 99 });
+
+  // Events side. Two on the split day under the SAME session as its folded
+  // half, plus one live today.
+  db.insertEvent(event({ timestamp: noonOn(SPLIT), session_id: "seam-split" }) as any);
+  db.insertEvent(event({ timestamp: noonOn(SPLIT) + 1000, session_id: "seam-split" }) as any);
+  db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "seam-live" }) as any);
+});
+
+describe("one continuous series across the retention boundary", () => {
+  test("days from both sides are present, in order", () => {
+    const days = db.dailyUsage();
+    expect(days.map((d) => d.day)).toEqual([OLD, SPLIT, LIVE]);
+    // The rollup alone stops at the boundary — that is what made it unusable
+    // for a chart on its own.
+    expect(db.rollupDays().map((d) => d.day)).toEqual([OLD, SPLIT]);
+  });
+
+  test("the split day is whole: both halves are added, not chosen between", () => {
+    const d = byDay(db.dailyUsage(), SPLIT)!;
+    expect(d.events).toBe(5); // 3 folded + 2 live
+    expect(d.input_tokens).toBe(500); // 300 folded + 2 × 100 live
+    expect(d.cost_usd).toBeGreaterThan(1); // the folded 1.00 plus the live rows'
+  });
+
+  test("and a session that ran across the boundary counts once", () => {
+    // seam-split has a row on each side. Summing the two COUNT(DISTINCT)s would
+    // report two sessions where one agent ran.
+    expect(byDay(db.dailyUsage(), SPLIT)!.sessions).toBe(1);
+  });
+
+  test("two different sessions on the same day still count as two", () => {
+    // The opposite error: deduping so hard that distinct work merges.
+    fold({ day: SPLIT, session_id: "seam-other-agent", events: 1 });
+    expect(byDay(db.dailyUsage(), SPLIT)!.sessions).toBe(2);
+  });
+
+  test("a day the rollup alone knows survives with its numbers", () => {
+    const d = byDay(db.dailyUsage(), OLD)!;
+    expect(d.events).toBe(7);
+    expect(d.input_tokens).toBe(700);
+    expect(d.cost_usd).toBe(3);
+  });
+
+  test("the from bound trims both sources, not just one", () => {
+    const days = db.dailyUsage(SPLIT);
+    expect(days.map((d) => d.day)).toEqual([SPLIT, LIVE]);
+    // The events half is bounded on `timestamp`, which is a different
+    // expression from the rollup's `day >= ?` — an off-by-one there would drop
+    // or duplicate the boundary day itself.
+    expect(byDay(days, SPLIT)!.events).toBe(6); // 4 folded (3 + the extra) + 2 live
+  });
+
+  test("the to bound excludes days after it and keeps the day itself whole", () => {
+    const days = db.dailyUsage(undefined, SPLIT);
+    expect(days.map((d) => d.day)).toEqual([OLD, SPLIT]);
+    expect(byDay(days, SPLIT)!.events).toBe(6); // the live half of SPLIT is still in
+  });
+});
+
+describe("the rollup is scoped by what the rollup knows", () => {
+  test("another project's folded days stay out", () => {
+    // seam-elsewhere folded 99 events on OLD under a path outside this scope.
+    expect(byDay(db.dailyUsage(), OLD)!.events).toBe(7);
+    expect(db.dailyUsage().every((d) => d.cost_usd < 99)).toBe(true);
+  });
+
+  test("a monorepo subdirectory is inside the project, as it is for events", () => {
+    // Every fixture above writes project_path = <root>/packages/api, which is
+    // where a monorepo's events actually come from. Scoping the rollup by
+    // equality against the scope roots matched none of them and reported a
+    // project with months of history as having none.
+    expect(db.dailyUsage().length).toBeGreaterThan(0);
+    expect(db.rollupDays().length).toBeGreaterThan(0);
+  });
+});
+
+describe("saying where the seam is", () => {
+  test("the boundary is reported as a day the chart can mark", () => {
+    // A gap before this day means "not kept in that detail"; a gap after it
+    // means the fleet was idle. A chart that cannot tell them apart is worse
+    // than one that shows less.
+    expect(db.retentionSeamDay()).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(db.retentionSeamDay()! < dayOf(0)).toBe(true);
+    expect(db.retentionSeamDay()! > OLD).toBe(true);
+  });
+});

--- a/server/test/usage-across-the-seam.test.ts
+++ b/server/test/usage-across-the-seam.test.ts
@@ -174,6 +174,29 @@ describe("the rollup is scoped by what the rollup knows", () => {
   });
 });
 
+describe("the export goes as far back as the chart does", () => {
+  // /export?kind=daily serialises exactly this, so what the CSV can contain is
+  // decided here: a month already pruned has to survive leaving the building,
+  // which was the last part of #292 the events-only export could not do.
+  test("every column the CSV writes is present and numeric", () => {
+    const d = byDay(db.dailyUsage(), OLD)!;
+    for (const col of [
+      "events", "tool_calls", "tool_errors", "errors",
+      "input_tokens", "output_tokens", "cache_creation_tokens", "cache_read_tokens",
+      "cost_usd", "sessions", "avg_ms",
+    ] as const) {
+      expect(typeof d[col]).toBe("number");
+      expect(Number.isFinite(d[col])).toBe(true);
+    }
+  });
+
+  test("an unbounded call really is unbounded — that is what the export sends", () => {
+    // No arguments: the export takes the whole series rather than a window,
+    // so a day older than any default `days=` bound still has to come out.
+    expect(db.dailyUsage().map((x) => x.day)).toContain(OLD);
+  });
+});
+
 describe("saying where the seam is", () => {
   test("the boundary is reported as a day the chart can mark", () => {
     // A gap before this day means "not kept in that detail"; a gap after it

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -260,6 +260,15 @@ export interface StatsSummary {
   /** Wall-clock ms when the server process started — what the header's
    *  uptime counts from. Absent in demo mode, where nothing is "up". */
   server_started_at?: number;
+  /**
+   * AGENTGLASS_RETENTION_DAYS, so the window chips can tell the truth.
+   *
+   * Every number in this object comes from the events table, which is pruned
+   * at that many days — so a window longer than it is answered with less data
+   * than its own label claims. 0 means nothing is pruned and every window is
+   * exactly what it says. Absent in demo mode's older payloads.
+   */
+  retention_days?: number;
 }
 
 /** One tmux window, as tmux itself reports it. The panel renders these as its

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -140,6 +140,44 @@ export interface TimeBucket {
   tokens: number;
 }
 
+/**
+ * One UTC day of the fleet, from the retention rollup, the live events, or
+ * both — the day the prune's cutoff falls in is split across the two and is
+ * only whole once they are added.
+ *
+ * Day-grained on purpose. Everything here survives being folded into a daily
+ * summary; a percentile does not (a mean of p95s is a p95 of nothing), so the
+ * mean is the only latency this shape can honestly carry.
+ */
+export interface UsageDay {
+  /** YYYY-MM-DD, UTC. */
+  day: string;
+  events: number;
+  tool_calls: number;
+  tool_errors: number;
+  errors: number;
+  input_tokens: number;
+  output_tokens: number;
+  cache_creation_tokens: number;
+  cache_read_tokens: number;
+  cost_usd: number;
+  sessions: number;
+  /** Mean tool duration, ms. */
+  avg_ms: number;
+}
+
+/** The daily series plus what it is honest about: where day summaries end and
+ *  whole events begin, and how long events are kept in the first place. */
+export interface UsageHistory {
+  days: UsageDay[];
+  /** UTC day the retention boundary falls in; null when nothing is pruned. */
+  seam_day: string | null;
+  /** AGENTGLASS_RETENTION_DAYS. 0 means events are never pruned. */
+  retention_days: number;
+  /** Oldest day the rollup holds, or null when it is empty. */
+  rollup_from: string | null;
+}
+
 export interface SkillUsage {
   skill: string;
   calls: number;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -528,6 +528,7 @@ export default function App() {
         conn={conn}
         windowMs={windowMs}
         onWindow={setWindowMs}
+        retentionDays={stats?.retention_days}
         apps={opts.source_apps}
         types={opts.hook_event_types}
         providers={providers}

--- a/web/src/components/CommandPalette.tsx
+++ b/web/src/components/CommandPalette.tsx
@@ -81,6 +81,9 @@ export function CommandPalette({
     for (const t of THEMES) list.push({ id: "theme:" + t.id, group: "Theme", label: t.name, run: () => { pickTheme(t.id); onTheme(t.id); } });
     list.push({ id: "csv", group: "Export", label: "Download CSV", run: () => window.open(api.exportUrl("csv")) });
     list.push({ id: "json", group: "Export", label: "Download JSON", run: () => window.open(api.exportUrl("json")) });
+    // Day totals rather than events, and the only one that reaches past the
+    // retention window — see /export?kind=daily.
+    list.push({ id: "daily-csv", group: "Export", label: "Download daily totals (CSV)", run: () => window.open(api.exportUrl("csv", "daily")) });
     return list;
   }, [apps, types, onFilter, onWindow, onTheme, onStats, onSkills, onChanges, onGit, onPr, onDocker, onTerminal, onChat, onSearch, onClear, onZoom]);
 

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -95,13 +95,15 @@ function MoreMenu({ onOpen }: { onOpen: () => void }) {
 }
 
 export function Header({
-  conn, windowMs, onWindow, apps, types, providers, filter, onFilter, theme, onTheme,
+  conn, windowMs, onWindow, retentionDays, apps, types, providers, filter, onFilter, theme, onTheme,
   sound, onSound, onOpenPalette, onOpenHelp, onOpenStats, onOpenSkills, onOpenWorkspace, onOpenSettings, onClear, showUsage,
   workspace, onOpenProject,
 }: {
   conn: ConnState;
   windowMs: number;
   onWindow: (ms: number) => void;
+  /** AGENTGLASS_RETENTION_DAYS. 0 (or undefined) → nothing is pruned. */
+  retentionDays?: number;
   apps: string[];
   types: string[];
   providers: string[];
@@ -186,12 +188,30 @@ export function Header({
           right-side controls get pushed off-screen and become unreachable. */}
       <div className="flex items-center gap-2 grow min-w-0 overflow-x-auto agw-noscrollbar order-3 basis-full sm:order-none sm:basis-0">
       <div className="flex items-center gap-0.5 p-0.5 rounded-lg shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 35%, transparent)" }}>
-        {WINDOWS.map((w) => (
-          <button key={w.label} onClick={() => onWindow(w.ms)} className="px-2 py-1 rounded-md text-[11px] transition-all"
-            style={windowMs === w.ms ? { background: "color-mix(in srgb, var(--primary) 22%, transparent)", color: "var(--primary-hover)" } : { color: "var(--text4)" }}>
-            {w.label}
-          </button>
-        ))}
+        {WINDOWS.map((w) => {
+          /*
+           * A window longer than retention cannot be answered in full.
+           *
+           * Every panel behind these chips reads the events table, which is
+           * pruned at AGENTGLASS_RETENTION_DAYS (8 by default) — so "30d" was
+           * eight days of data under a thirty-day label, and there was no way
+           * to tell that from a quiet month. The chip now says so rather than
+           * the dashboard implying otherwise, and points at the one view that
+           * does go further back.
+           *
+           * Nothing marked when retention is off (the desktop default), where
+           * every window really is what it claims.
+           */
+          const beyond = !!retentionDays && w.ms > retentionDays * 86_400_000;
+          return (
+            <button key={w.label} onClick={() => onWindow(w.ms)} className="px-2 py-1 rounded-md text-[11px] transition-all"
+              title={beyond ? `Events are kept for ${retentionDays} days, so this window is answered from the last ${retentionDays}d. Statistics (s) → “spend per day” goes further back.` : undefined}
+              style={windowMs === w.ms ? { background: "color-mix(in srgb, var(--primary) 22%, transparent)", color: "var(--primary-hover)" } : { color: "var(--text4)" }}>
+              {w.label}
+              {beyond && <sup className="ml-[1px] text-[8px] opacity-70" aria-hidden>*</sup>}
+            </button>
+          );
+        })}
       </div>
 
       {/* max-w keeps long worktree names (e.g. feature-branch-…) from blowing the header open */}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -903,6 +903,13 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                       href={api.exportUrl("csv")} download="agentglass-events.csv" />
                     <Row label="Events — JSON" hint="Full payloads, for scripting"
                       href={api.exportUrl("json")} download="agentglass-events.json" />
+                    {/* The only export that outlives retention: it reads the
+                        daily rollup as well as the live events, so a month
+                        that has already been pruned still comes out. */}
+                    <Row label="Daily totals — CSV" hint="One row per day, back past the retention window"
+                      href={api.exportUrl("csv", "daily")} download="agentglass-daily.csv" />
+                    <Row label="Daily totals — JSON" hint="The same series, with where the retention seam falls"
+                      href={api.exportUrl("json", "daily")} download="agentglass-daily.json" />
                     <Row label="Skills catalog — Markdown" hint="Every skill the fleet has available"
                       href={api.skillsExportUrl()} download="agentglass-skills.md" />
                   </Section>

--- a/web/src/components/StatsModal.tsx
+++ b/web/src/components/StatsModal.tsx
@@ -1,6 +1,8 @@
+import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
-import type { StatsSummary } from "../../../shared/types.ts";
+import type { StatsSummary, UsageHistory } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
+import { api } from "../lib/api.ts";
 import { fmtUsd, fmtTokens, typeColor } from "../lib/format.ts";
 
 const WINDOW_LABELS: [number, string][] = [
@@ -44,6 +46,86 @@ function Heatmap({ data }: { data: number[] }) {
             })}
           </div>
         ))}
+      </div>
+    </div>
+  );
+}
+
+/**
+ * Daily spend, further back than the events table goes.
+ *
+ * Every other widget here reads /stats, which reads the events table, which
+ * retention trims to eight days by default — so picking "30d" or "all time"
+ * showed eight days of data under a longer label. The retention fold has kept
+ * the day totals all along (#292); this is the panel that finally reads them.
+ *
+ * The seam is drawn rather than hidden. Left of it the bars are day summaries
+ * of rows that no longer exist; right of it they are still whole events. A
+ * chart that blurred the two would make "we stopped keeping that" look
+ * identical to "we spent nothing", which is the one confusion this feature has
+ * to avoid.
+ */
+function SpendHistory({ history }: { history: UsageHistory | null }) {
+  if (!history) return <div className="t-dim2 text-[11px] py-3">Loading…</div>;
+  const days = history.days;
+  if (!days.length) return <div className="t-dim2 text-[11px] py-3">No history yet — this fills in as the fleet runs</div>;
+
+  const max = Math.max(0.0001, ...days.map((d) => d.cost_usd));
+  const total = days.reduce((n, d) => n + d.cost_usd, 0);
+  const seam = history.seam_day;
+  const folded = seam ? days.filter((d) => d.day < seam) : [];
+  // The seam is only worth drawing when there is something on both sides of it.
+  const showSeam = folded.length > 0 && folded.length < days.length;
+
+  return (
+    <div className="flex flex-col gap-2">
+      <div className="flex items-end gap-[2px] h-28">
+        {days.map((d) => {
+          const summarised = !!seam && d.day < seam;
+          // A day with spend never renders as nothing: a 1px floor keeps a
+          // quiet day visually distinct from a day with no data at all.
+          const h = d.cost_usd > 0 ? Math.max(2, (d.cost_usd / max) * 100) : 0;
+          return (
+            <div
+              key={d.day}
+              className="flex-1 min-w-[2px] h-full flex items-end"
+              title={`${d.day} · ${fmtUsd(d.cost_usd)} · ${d.events.toLocaleString()} events · ${d.sessions} session${d.sessions === 1 ? "" : "s"}${summarised ? " (day summary)" : ""}`}
+            >
+              <div
+                className="w-full rounded-[2px]"
+                style={{
+                  height: `${h}%`,
+                  // Same hue either side — this is one series, not two — with
+                  // the folded half held back so the eye reads it as older and
+                  // coarser rather than as a different measurement.
+                  background: h
+                    ? summarised
+                      ? "color-mix(in srgb, var(--primary) 38%, transparent)"
+                      : "var(--primary)"
+                    : "transparent",
+                }}
+              />
+            </div>
+          );
+        })}
+      </div>
+
+      <div className="flex items-center justify-between gap-3 text-[9.5px] t-dim2 flex-wrap">
+        <span className="tabular-nums">{days[0]!.day} → {days[days.length - 1]!.day}</span>
+        {showSeam && (
+          <span className="flex items-center gap-3">
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-[2px]" style={{ background: "color-mix(in srgb, var(--primary) 38%, transparent)" }} />
+              day summaries
+            </span>
+            <span className="flex items-center gap-1">
+              <span className="h-2 w-2 rounded-[2px]" style={{ background: "var(--primary)" }} />
+              full events {history.retention_days ? `(last ${history.retention_days}d)` : ""}
+            </span>
+          </span>
+        )}
+        {!history.retention_days && <span>nothing is pruned — every day here is still whole events</span>}
+        <span className="tabular-nums" style={{ color: "var(--text2)" }}>{fmtUsd(total)} total</span>
       </div>
     </div>
   );
@@ -132,6 +214,18 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
   const apps = (stats?.by_app ?? []).slice(0, 10);
   const types = (stats?.by_type ?? []).slice(0, 10);
 
+  // Fetched here rather than lifted into the poller: it is day-grained and
+  // changes at most once a day, so re-reading it on the /stats cadence would
+  // be a scan of the whole rollup every few seconds for a chart that cannot
+  // have moved. Once per opening is the right frequency.
+  const [history, setHistory] = useState<UsageHistory | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    api.usageDaily(90).then((h) => { if (alive) setHistory(h); }).catch(() => {});
+    return () => { alive = false; };
+  }, [open]);
+
   return (
     <Portal>
       <AnimatePresence>
@@ -163,8 +257,15 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                   </motion.div>
 
                 <div className="flex flex-col gap-6">
+                {/* First, because it is the only widget here that is not bound
+                    by the window chip above — and the one that answers the
+                    question the chip cannot: what did the last quarter cost. */}
+                <Widget title="spend per day · past the retention line" i={0} full>
+                  <SpendHistory history={history} />
+                </Widget>
+
                 {stats?.heatmap && stats.heatmap.some((n) => n > 0) && (
-                  <Widget title="when the fleet works · day × hour" i={0} full>
+                  <Widget title="when the fleet works · day × hour" i={6} full>
                     <Heatmap data={stats.heatmap} />
                   </Widget>
                 )}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, UsageHistory } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -254,6 +254,10 @@ const realApi = {
       + (provider ? `&provider=${encodeURIComponent(provider)}` : "")
       + (viewerTz() ? `&tz=${encodeURIComponent(viewerTz()!)}` : ""),
     ),
+  // No tz, unlike /stats: these days are UTC because that is the grain the
+  // retention fold wrote them at, and re-slicing a day-summary by a viewer's
+  // clock would move spend onto a day it was never recorded on.
+  usageDaily: (days = 90) => get<UsageHistory>(`/usage/daily?days=${days}`),
   sessions: (limit = 100, provider?: string) =>
     get<SessionRollup[]>(`/sessions?limit=${limit}${provider ? `&provider=${encodeURIComponent(provider)}` : ""}`),
   filterOptions: () =>
@@ -568,6 +572,7 @@ const demoApi: typeof realApi = {
   // The demo is a showcase of the whole fleet, so it is never scoped.
   projects: () => D({ projects: [], scanning: false, workspace: null }),
   stats: (windowMs: number, provider?: string) => D(demo.stats(windowMs, provider)),
+  usageDaily: (days = 90) => D(demo.usageDaily(days)),
   sessions: (_limit?: number, provider?: string) => D(demo.sessions(provider)),
   filterOptions: () => D(demo.filterOptions()),
   exportUrl: (fmt: "csv" | "json") => demo.eventsExportUri(fmt),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -264,7 +264,11 @@ const realApi = {
     get<{ source_apps: string[]; hook_event_types: string[]; models: string[] }>(
       `/events/filter-options`
     ),
-  exportUrl: (fmt: "csv" | "json") => withToken(`${SERVER}/export?format=${fmt}`),
+  // `kind`: "events" is the raw rows, bounded by retention; "daily" is the
+  // day series, which reads the rollup too and so goes back as far as the
+  // fold does rather than as far as the events table happens to.
+  exportUrl: (fmt: "csv" | "json", kind: "events" | "daily" = "events") =>
+    withToken(`${SERVER}/export?format=${fmt}${kind === "daily" ? "&kind=daily" : ""}`),
   skillsExportUrl: (fmt: "md" | "csv" | "json" = "md") => withToken(`${SERVER}/skills/export?format=${fmt}`),
   usage: () => get<UsagePayload>(`/usage`),
   // usage_since: the epoch the call counts are known from. They are bounded
@@ -575,7 +579,8 @@ const demoApi: typeof realApi = {
   usageDaily: (days = 90) => D(demo.usageDaily(days)),
   sessions: (_limit?: number, provider?: string) => D(demo.sessions(provider)),
   filterOptions: () => D(demo.filterOptions()),
-  exportUrl: (fmt: "csv" | "json") => demo.eventsExportUri(fmt),
+  exportUrl: (fmt: "csv" | "json", kind: "events" | "daily" = "events") =>
+    kind === "daily" ? demo.dailyExportUri(fmt) : demo.eventsExportUri(fmt),
   skillsExportUrl: () => demo.skillsExportUri(),
   usage: () => D(demo.usage() as UsagePayload),
   skills: () => D(demo.skills()),

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -614,6 +614,19 @@ export function eventsExportUri(fmt: "csv" | "json"): string {
   return dataUri("text/csv", [cols.join(","), ...rows].join("\n"));
 }
 
+/** The same daily series the chart draws, as a downloadable file. */
+export function dailyExportUri(fmt: "csv" | "json"): string {
+  const h = usageDaily(120);
+  if (fmt === "json") return dataUri("application/json", JSON.stringify(h, null, 2));
+  const cols: (keyof UsageDay)[] = [
+    "day", "events", "tool_calls", "tool_errors", "errors",
+    "input_tokens", "output_tokens", "cache_creation_tokens", "cache_read_tokens",
+    "cost_usd", "sessions", "avg_ms",
+  ];
+  const rows = h.days.map((d) => cols.map((c) => String(d[c])).join(","));
+  return dataUri("text/csv", [cols.join(","), ...rows].join("\n"));
+}
+
 export function skillsExportUri(): string {
   const { skills: list } = skills();
   const out = ["# Skills catalog", "", `_${list.length} skills · agentglass demo (sample data)_`, ""];

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -12,6 +12,7 @@ import type {
   WalkthroughResult, WalkthroughInputFile, GitRepoRef, WorkingTree, GitFileChange, GitActionResult,
   GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult,
   PrRepoId, PrSummary, PrDetail, PrThread, PrCheck, PrCheckRollup, PrCheckState, PrListResponse,
+  UsageDay, UsageHistory,
 } from "../../../shared/types.ts";
 import { modelLabelOf, providerOf } from "./format.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
@@ -279,6 +280,48 @@ export function stats(windowMs: number, provider?: string): StatsSummary {
     if (extra) m.cost_usd = Number((m.cost_usd + extra).toFixed(2));
   }
   return provider ? scopeStats(summary, provider) : summary;
+}
+
+/**
+ * A daily series with a seam in it, because the seam is the point.
+ *
+ * The showcase's retention is the default 8 days, so days before that are what
+ * the fold kept and days after are still whole events — and the chart is only
+ * worth having if it shows the first group at all.
+ */
+export function usageDaily(days = 90): UsageHistory {
+  const DAY = 86_400_000;
+  const utcDay = (ms: number) => new Date(ms).toISOString().slice(0, 10);
+  const retention = 8;
+  const series: UsageDay[] = [];
+  for (let i = days - 1; i >= 0; i--) {
+    const at = Date.now() - i * DAY;
+    const dow = new Date(at).getUTCDay();
+    // Weekends are quiet; the fleet ramps up over the quarter.
+    const busy = (dow === 0 || dow === 6 ? 0.18 : 1) * (0.45 + 0.55 * ((days - i) / days));
+    const events = rint(0, Math.round(900 * busy));
+    const tool_calls = Math.round(events * 0.48);
+    series.push({
+      day: utcDay(at),
+      events,
+      tool_calls,
+      tool_errors: Math.round(tool_calls * rnd(0, 0.02)),
+      errors: Math.round(events * rnd(0, 0.01)),
+      input_tokens: Math.round(events * rnd(400, 900)),
+      output_tokens: Math.round(events * rnd(40, 90)),
+      cache_creation_tokens: Math.round(events * rnd(20, 60)),
+      cache_read_tokens: Math.round(events * rnd(3000, 7000)),
+      cost_usd: Number((events * rnd(0.04, 0.09)).toFixed(2)),
+      sessions: Math.max(events ? 1 : 0, Math.round(events / rnd(90, 180))),
+      avg_ms: rint(140, 900),
+    });
+  }
+  return {
+    days: series,
+    seam_day: utcDay(Date.now() - retention * DAY),
+    retention_days: retention,
+    rollup_from: series[0]?.day ?? null,
+  };
 }
 
 export function sessions(provider?: string): SessionRollup[] {

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -274,6 +274,9 @@ export function stats(windowMs: number, provider?: string): StatsSummary {
     by_type: [["PreToolUse", 4069], ["PostToolUse", 4057], ["SessionStart", 1402], ["UserPromptSubmit", 436], ["Stop", 395], ["SubagentStop", 336], ["Notification", 216], ["SessionEnd", 42]].map(([hook_event_type, count]) => ({ hook_event_type: hook_event_type as string, count: si(count as number) })),
     heatmap,
     window_ms: windowMs,
+    // The showcase runs the default retention, so the long-window chips carry
+    // their asterisk here exactly as they would on a real install.
+    retention_days: 8,
   };
   for (const m of summary.by_model) {
     const extra = streamed.byModel.get(m.model_name);


### PR DESCRIPTION
## What does this PR do?

Closes #292. #376 built the retention rollup and nothing ever read it, so **30d** and **All** were still eight days of data under a longer label. This joins the rollup to the live events into one continuous daily series, marks the window chips that outrun retention, and lets `/export` reach past it — the three parts of #292 that #376 left.

## How was it tested?

`bun test` in `server/` — 916 pass, 0 fail, including 12 new ones in `server/test/usage-across-the-seam.test.ts`, run **red first** against two separate reverts (see the table below). `bunx tsc --noEmit` in both `server/` and `web/`, `bun run build` in `web/`. Both UI changes were checked by rendering the real interface headless against the demo build — Statistics for the new widget, the header for the marked chips. `/usage/daily` and both export formats were driven against a live server: `days=1` returns today inclusive, `days=3` on an empty DB returns `[]` with the seam still reported, and `/export?format=csv` without `kind` is byte-for-byte what it was.

---

Follow-up to #376. #292 asked for four things; #376 delivered the first.

| #292 asked for | |
|---|---|
| Fold expiring events into a daily rollup | ✅ #376 |
| Charts read raw inside the window, rollups outside it | ✅ commit 1 |
| Expose the effective window so a number is never silently a partial answer | ✅ commit 2 |
| Let `/export` reach the rollups | ✅ commit 3 |

## The problem

`AGENTGLASS_RETENTION_DAYS` is 8. Every analytics panel — and the export — reads the `events` table. So **30d** and **All** have been serving eight days of data under a longer label, and under that label "we spent nothing last month" and "we no longer keep that" render identically.

#376 already built the raw material: expiring events folded into `daily_rollup` before the DELETE, in the same transaction, one row per `(day, project, session, model, provider)` — small enough to keep for years. Nothing read it. `rollupDays()` has been dead code since it landed, and its own doc comment names the missing piece:

> A caller wanting a continuous series joins the two at the retention boundary.

## 1. The join, and why it isn't "old days + new days"

`dailyUsage(from?, to?)` merges `daily_rollup` and `events` into one UTC-day series. Three things make it more than a concatenation:

**The boundary day is split.** The prune cuts at `now - N days` — a *timestamp*, not a midnight. The day the cutoff lands in is half folded and half live. The two sources are **summed**, not preferred, because that day is only whole with both halves; every other day is in exactly one table, where adding is the identity.

**Sessions can't be summed.** A session that ran across the cutoff has a row on each side. `COUNT(DISTINCT session_id)` runs over the union of `(day, session_id)` rather than adding two counts that both include it. Tested both ways — one session across the seam counts once, two sessions on one day still count two.

**The events half is bounded on `timestamp`, not `date(timestamp)`**, so it can use the index instead of computing a date per row. With retention disabled that table holds everything, which is precisely when the scan would hurt.

Day grain is UTC, matching what the fold wrote. Unlike the heatmap this deliberately does *not* take the viewer's timezone — re-slicing a day summary by a different clock would move spend onto a day it was never recorded on.

**A latent bug in #376, fixed along the way.** `rollupDays()` scoped by `project_path IN (<scope roots>)`, but `project_path` is the path the *event* carried — usually a directory inside a checkout, not the checkout. `scopeClause()` handles that with `isWithin`; the rollup version didn't, so a monorepo would have seen none of its own history. It also drew its in-scope path set from `recordedPaths()` (`SELECT DISTINCT project_path FROM events`) — after a prune, exactly the paths that no longer exist, so scoping the rollup by what `events` remembers hides more history the further back you look. `rollupPaths()` reads the rollup's own paths, cached and dropped in `pruneOldRows()` (the only writer).

`GET /usage/daily?days=N` → `{ days, seam_day, retention_days, rollup_from }`.

**Statistics** gains a full-width *spend per day · past the retention line* widget, first in the modal because it is the only panel there not bound by the window chip. One hue either side (it is one series, not two), the folded half held back so it reads as older and coarser, a legend naming both. The seam is drawn rather than smoothed over — telling a quiet week from a forgotten one is the entire point.

## 2. The chips stop claiming what they can't deliver

`/stats` now carries `retention_days`, and a window chip that outruns it gets an asterisk plus a title saying how far the data really goes and where the full history is:

```
15m  1h  6h  24h  7d  30d*  All*
```

`7d` stays unmarked on the default 8-day retention — this marks the windows that actually fall short, not every long one. Nothing is marked when retention is off (the desktop default), where every window is exactly what it claims.

## 3. The export follows

`/export?kind=daily&format=csv|json` serves the same merged series. CSV for a spreadsheet; JSON carries `seam_day` and `retention_days` alongside, because a file read six months from now has no other way to know which of its days are summaries. A parameter rather than a new route, so anything already pointed at `/export` keeps working and switches grain without switching endpoint. Settings › Export gains both rows, the command palette the CSV.

## The red-first runs

Fixtures write `daily_rollup` directly instead of pruning, so the split day is a day the test chooses rather than whatever hour CI runs at — whether the prune folds correctly is already `rollup-before-prune.test.ts`'s question.

| Reverted to | Fails |
|---|---|
| the pre-fix rollup scoping (exact `IN` over scope roots) | 8 of 10 |
| a rollup-only series (no join with events) | 4 of 10 |

The tests surviving each revert are the ones that should — they pin behaviour that revert didn't change.

## Contract

`shared/types.ts` gains `UsageDay` and `UsageHistory`, plus an optional `retention_days` on `StatsSummary`. README updated: both new routes in the endpoint table, and the `AGENTGLASS_RETENTION_DAYS` row now says it bounds *raw events* rather than history.
