### PR TITLE
fix(mobile): ask before the four taps that cannot be undone

### DIFF
--- a/server/test/mobile-confirms.test.ts
+++ b/server/test/mobile-confirms.test.ts
@@ -1,0 +1,103 @@
+/*
+ * A thumb must not be able to do something irreversible in one tap.
+ *
+ * The phone companion inherited the desktop's action set, where every one of
+ * these lives behind a pointer, a hover title and a screen wide enough to show
+ * what is selected. On a phone none of that holds: the button is under the
+ * thumb that is already scrolling, and the thing it acts on is usually off
+ * screen — the file is behind a diff, the container behind a stats card, the
+ * branch not rendered at all. `api.gitDiscard` fired on touch-down with no
+ * question and nothing named.
+ *
+ * These are asserted against the source rather than driven through the UI on
+ * purpose. A click-through test would have to reach each screen through the
+ * demo fixture, which does not contain a mergeable pull request — so the merge
+ * confirm, the most expensive of the four, is the one a UI test would silently
+ * skip. Reading the call site cannot skip it.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const WEB = join(import.meta.dir, "..", "..", "web", "src", "mobile");
+const read = (f: string) => readFileSync(join(WEB, f), "utf8");
+
+/**
+ * The four calls that cannot be taken back, and the file each lives in.
+ *
+ * Not an exhaustive list of mobile writes — stage, restart, stop, approve and
+ * re-run are all one tap on purpose, because each of them is undone by another
+ * tap. The line is reversibility, not danger.
+ */
+const IRREVERSIBLE: { file: string; call: string; what: string }[] = [
+  { file: "MobileRepo.tsx", call: "api.gitDiscard(", what: "discarding a file's changes" },
+  { file: "MobileRepo.tsx", call: "api.dockerRm(", what: "removing a container" },
+  { file: "MobilePr.tsx", call: "api.prClose(", what: "closing a pull request" },
+  { file: "MobilePr.tsx", call: "api.prMerge(", what: "squash-merging and deleting the branch" },
+  { file: "MobileApp.tsx", call: "api.prMerge(", what: "squash-merging from the Now queue" },
+];
+
+/** The `confirm({...})` call this one sits inside, if any. Walks back from the
+ *  call to the nearest enclosing `confirm(` — a `run:` property inside a spec
+ *  is confirmed; the same call in a bare `onAct` is not. */
+function confirmedSpec(src: string, at: number): string | null {
+  const open = src.lastIndexOf("confirm({", at);
+  if (open === -1) return null;
+  // Balance braces from the spec's `{` to make sure `at` is really inside it
+  // and not after a spec that closed earlier in the same handler.
+  let depth = 0;
+  for (let i = src.indexOf("{", open); i < src.length; i++) {
+    if (src[i] === "{") depth++;
+    else if (src[i] === "}") {
+      depth--;
+      if (depth === 0) return i > at ? src.slice(open, i + 1) : null;
+    }
+  }
+  return null;
+}
+
+describe("the phone asks before it does something irreversible", () => {
+  for (const { file, call, what } of IRREVERSIBLE) {
+    test(`${what} goes through a confirm`, () => {
+      const src = read(file);
+      const at = src.indexOf(call);
+      expect(at, `${call} not found in ${file} — the call moved, so this guard is now watching nothing`).toBeGreaterThan(-1);
+
+      const spec = confirmedSpec(src, at);
+      expect(spec, `${file}: ${call} is reachable in one tap`).not.toBeNull();
+
+      // A confirm that says only "Are you sure?" is worse than none — it
+      // trains the thumb to dismiss it. The spec has to name what it is about
+      // to touch and say what does not come back.
+      expect(spec).toContain("verb:");
+      expect(spec).toContain("subject:");
+      expect(spec).toContain("warn:");
+    });
+  }
+
+  test("the subject is read from scope, never a fixed string", () => {
+    // "Discard the file?" is the failure this catches. The whole reason the
+    // sheet exists is that the person cannot see which file, container or PR
+    // is selected — so a hardcoded noun confirms nothing. Anything evaluated
+    // counts: a template literal, a variable, `rel(paths[diffAt]!)`. What does
+    // not count is a quoted constant.
+    const LITERAL = /^\s*(["'])(?:(?!\1).)*\1\s*$/;
+    for (const { file, call } of IRREVERSIBLE) {
+      const src = read(file);
+      const spec = confirmedSpec(src, src.indexOf(call))!;
+      const subject = spec.match(/subject:\s*([^,\n]+)/)?.[1] ?? "";
+      expect(subject.trim(), `${file}: ${call} has no subject at all`).not.toBe("");
+      expect(LITERAL.test(subject), `${file}: ${call} names a fixed subject — ${subject}`).toBe(false);
+    }
+  });
+
+  test("reversible actions are left alone", () => {
+    // The guard above is only meaningful if it is not applied to everything.
+    // Staging and restarting are one tap by design; a confirm on them would
+    // make the confirms themselves noise.
+    const repo = read("MobileRepo.tsx");
+    for (const call of ["api.gitStage(", "api.dockerRestart(", "api.dockerStop("]) {
+      expect(confirmedSpec(repo, repo.indexOf(call)), `${call} should stay one tap`).toBeNull();
+    }
+  });
+});

--- a/server/test/mobile-confirms.test.ts
+++ b/server/test/mobile-confirms.test.ts
@@ -9,11 +9,12 @@
  * branch not rendered at all. `api.gitDiscard` fired on touch-down with no
  * question and nothing named.
  *
- * These are asserted against the source rather than driven through the UI on
- * purpose. A click-through test would have to reach each screen through the
- * demo fixture, which does not contain a mergeable pull request — so the merge
- * confirm, the most expensive of the four, is the one a UI test would silently
- * skip. Reading the call site cannot skip it.
+ * Asserted against the source rather than driven through the UI on purpose.
+ * A click-through test has to reach each screen through the demo fixture,
+ * which contains no mergeable pull request and no containers — so it would
+ * have driven two of the five and passed silently on the rest, including
+ * squash-merge-and-delete-branch, the most expensive of the set. Reading the
+ * call site cannot skip one.
  */
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
@@ -23,11 +24,11 @@ const WEB = join(import.meta.dir, "..", "..", "web", "src", "mobile");
 const read = (f: string) => readFileSync(join(WEB, f), "utf8");
 
 /**
- * The four calls that cannot be taken back, and the file each lives in.
+ * The calls that cannot be taken back, and the file each lives in.
  *
  * Not an exhaustive list of mobile writes — stage, restart, stop, approve and
- * re-run are all one tap on purpose, because each of them is undone by another
- * tap. The line is reversibility, not danger.
+ * re-run are all one tap on purpose, because each is undone by another tap.
+ * The line is reversibility, not danger.
  */
 const IRREVERSIBLE: { file: string; call: string; what: string }[] = [
   { file: "MobileRepo.tsx", call: "api.gitDiscard(", what: "discarding a file's changes" },
@@ -37,20 +38,29 @@ const IRREVERSIBLE: { file: string; call: string; what: string }[] = [
   { file: "MobileApp.tsx", call: "api.prMerge(", what: "squash-merging from the Now queue" },
 ];
 
-/** The `confirm({...})` call this one sits inside, if any. Walks back from the
- *  call to the nearest enclosing `confirm(` — a `run:` property inside a spec
- *  is confirmed; the same call in a bare `onAct` is not. */
-function confirmedSpec(src: string, at: number): string | null {
-  const open = src.lastIndexOf("confirm({", at);
+/**
+ * The `ask({…})` spec guarding this call, if there is one.
+ *
+ * The shape under test is the same one the desktop panels use:
+ *
+ *   if (!(await ask({ … }))) return;
+ *   await api.whatever(…)
+ *
+ * so the guard is the nearest preceding `await ask({`, and the call has to
+ * come after that spec closes. Moving the write into a *different* handler
+ * after the guard breaks the pairing, which is why the span between them is
+ * checked for another handler opening.
+ */
+function askedFirst(src: string, at: number): string | null {
+  const open = src.lastIndexOf("await ask({", at);
   if (open === -1) return null;
-  // Balance braces from the spec's `{` to make sure `at` is really inside it
-  // and not after a spec that closed earlier in the same handler.
   let depth = 0;
   for (let i = src.indexOf("{", open); i < src.length; i++) {
     if (src[i] === "{") depth++;
-    else if (src[i] === "}") {
-      depth--;
-      if (depth === 0) return i > at ? src.slice(open, i + 1) : null;
+    else if (src[i] === "}" && --depth === 0) {
+      if (i > at) return null; // the call is inside the spec, not after it
+      const between = src.slice(i, at);
+      return /onAct=|run:\s*(async\s*)?\(/.test(between) ? null : src.slice(open, i + 1);
     }
   }
   return null;
@@ -58,24 +68,24 @@ function confirmedSpec(src: string, at: number): string | null {
 
 describe("the phone asks before it does something irreversible", () => {
   for (const { file, call, what } of IRREVERSIBLE) {
-    test(`${what} goes through a confirm`, () => {
+    test(`${what} goes through ask()`, () => {
       const src = read(file);
       const at = src.indexOf(call);
-      expect(at, `${call} not found in ${file} — the call moved, so this guard is now watching nothing`).toBeGreaterThan(-1);
+      expect(at, `${call} is not in ${file} — the call moved, so this guard now watches nothing`).toBeGreaterThan(-1);
 
-      const spec = confirmedSpec(src, at);
+      const spec = askedFirst(src, at);
       expect(spec, `${file}: ${call} is reachable in one tap`).not.toBeNull();
 
-      // A confirm that says only "Are you sure?" is worse than none — it
-      // trains the thumb to dismiss it. The spec has to name what it is about
-      // to touch and say what does not come back.
-      expect(spec).toContain("verb:");
-      expect(spec).toContain("subject:");
-      expect(spec).toContain("warn:");
+      // A question that says only "Are you sure?" is worse than none — it
+      // trains the thumb to dismiss it. The spec has to carry the sentence
+      // about what does not come back, and paint the button red.
+      expect(spec).toContain("title:");
+      expect(spec).toContain("body:");
+      expect(spec).toContain("danger: true");
     });
   }
 
-  test("the subject is read from scope, never a fixed string", () => {
+  test("the title names the actual subject, read from scope", () => {
     // "Discard the file?" is the failure this catches. The whole reason the
     // sheet exists is that the person cannot see which file, container or PR
     // is selected — so a hardcoded noun confirms nothing. Anything evaluated
@@ -84,20 +94,30 @@ describe("the phone asks before it does something irreversible", () => {
     const LITERAL = /^\s*(["'])(?:(?!\1).)*\1\s*$/;
     for (const { file, call } of IRREVERSIBLE) {
       const src = read(file);
-      const spec = confirmedSpec(src, src.indexOf(call))!;
-      const subject = spec.match(/subject:\s*([^,\n]+)/)?.[1] ?? "";
-      expect(subject.trim(), `${file}: ${call} has no subject at all`).not.toBe("");
-      expect(LITERAL.test(subject), `${file}: ${call} names a fixed subject — ${subject}`).toBe(false);
+      const spec = askedFirst(src, src.indexOf(call))!;
+      const title = spec.match(/title:\s*([^,\n]+)/)?.[1] ?? "";
+      expect(title.trim(), `${file}: ${call} has no title at all`).not.toBe("");
+      expect(LITERAL.test(title), `${file}: ${call} asks a fixed question — ${title}`).toBe(false);
     }
   });
 
   test("reversible actions are left alone", () => {
     // The guard above is only meaningful if it is not applied to everything.
-    // Staging and restarting are one tap by design; a confirm on them would
-    // make the confirms themselves noise.
+    // Staging and restarting are one tap by design; a question on those would
+    // turn every question on this screen into noise.
     const repo = read("MobileRepo.tsx");
     for (const call of ["api.gitStage(", "api.dockerRestart(", "api.dockerStop("]) {
-      expect(confirmedSpec(repo, repo.indexOf(call)), `${call} should stay one tap`).toBeNull();
+      expect(askedFirst(repo, repo.indexOf(call)), `${call} should stay one tap`).toBeNull();
     }
+  });
+
+  test("the phone uses the app's own dialog contract, not a second one", () => {
+    // web/test/no-native-dialogs.test.ts bans window.confirm across web/src.
+    // A phone-shaped confirm is still legitimate — a centred modal ignores the
+    // back gesture and lands nowhere near the thumb — but it has to BE the
+    // desktop's contract in a different surface, not a rival vocabulary.
+    const ui = readFileSync(join(WEB, "mobileUi.tsx"), "utf8");
+    expect(ui).toContain('import type { ConfirmSpec } from "../components/ConfirmDialog.tsx"');
+    expect(ui).toContain("Promise<boolean>");
   });
 });

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -3,7 +3,7 @@ import { api } from "../lib/api.ts";
 import { useStats } from "../lib/useStats.ts";
 import { fmtUsd, fmtTokens } from "../lib/format.ts";
 import { MobileChats } from "./MobileChats.tsx";
-import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useConfirm } from "./mobileUi.tsx";
+import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobileUi.tsx";
 import { DIFF_CSS } from "./MobileDiff.tsx";
 import { NOW_CSS, NowHero, NowStream, type NowAction } from "./MobileNow.tsx";
 import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
@@ -49,7 +49,7 @@ const PR_MS = 60_000;
 export function MobileApp() {
   const [tab, setTab] = useState<Tab>("now");
   const { toasts, toast } = useToasts();
-  const { confirm, sheet: confirmSheet } = useConfirm();
+  const { ask, dialog: askDialog } = useAsk();
   const { stats } = useStats(86_400_000);
 
   const [gates, setGates] = useState<PendingGate[]>([]);
@@ -212,11 +212,13 @@ export function MobileApp() {
             // re-runs, snoozes or opens something; this rewrites history and
             // deletes a branch, from a card the thumb is already scrolling past.
             label: "Squash & merge", kind: "ok",
-            run: () => confirm({
-              verb: "Squash & merge", subject: `#${o.pr.number}`,
-              warn: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
-              run: () => settle(`Merged #${o.pr.number}`, () => api.prMerge(o.root, o.pr.number, "squash", { deleteBranch: true }), it.id),
-            }),
+            run: async () => {
+              if (!(await ask({
+                title: `Squash & merge #${o.pr.number}?`, danger: true, confirmLabel: "Squash & merge",
+                body: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
+              }))) return;
+              await settle(`Merged #${o.pr.number}`, () => api.prMerge(o.root, o.pr.number, "squash", { deleteBranch: true }), it.id);
+            },
           },
           { label: "Review", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
         ];
@@ -243,7 +245,7 @@ export function MobileApp() {
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
       <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}</style>
-      {confirmSheet}
+      {askDialog}
       <div className="mb-sky" />
 
       <header className="sticky top-0 z-40 flex items-center gap-2 px-4"

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -3,7 +3,7 @@ import { api } from "../lib/api.ts";
 import { useStats } from "../lib/useStats.ts";
 import { fmtUsd, fmtTokens } from "../lib/format.ts";
 import { MobileChats } from "./MobileChats.tsx";
-import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act } from "./mobileUi.tsx";
+import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useConfirm } from "./mobileUi.tsx";
 import { DIFF_CSS } from "./MobileDiff.tsx";
 import { NOW_CSS, NowHero, NowStream, type NowAction } from "./MobileNow.tsx";
 import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
@@ -49,6 +49,7 @@ const PR_MS = 60_000;
 export function MobileApp() {
   const [tab, setTab] = useState<Tab>("now");
   const { toasts, toast } = useToasts();
+  const { confirm, sheet: confirmSheet } = useConfirm();
   const { stats } = useStats(86_400_000);
 
   const [gates, setGates] = useState<PendingGate[]>([]);
@@ -207,8 +208,15 @@ export function MobileApp() {
       case "pr-ready":
         return [
           {
+            // The one queue action that cannot be undone. Everything else here
+            // re-runs, snoozes or opens something; this rewrites history and
+            // deletes a branch, from a card the thumb is already scrolling past.
             label: "Squash & merge", kind: "ok",
-            run: () => settle(`Merged #${o.pr.number}`, () => api.prMerge(o.root, o.pr.number, "squash", { deleteBranch: true }), it.id),
+            run: () => confirm({
+              verb: "Squash & merge", subject: `#${o.pr.number}`,
+              warn: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
+              run: () => settle(`Merged #${o.pr.number}`, () => api.prMerge(o.root, o.pr.number, "squash", { deleteBranch: true }), it.id),
+            }),
           },
           { label: "Review", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
         ];
@@ -235,6 +243,7 @@ export function MobileApp() {
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
       <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}</style>
+      {confirmSheet}
       <div className="mb-sky" />
 
       <header className="sticky top-0 z-40 flex items-center gap-2 px-4"

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
 import { parseUnifiedDiff } from "../lib/prBody.ts";
-import { Screen, Sheet, Seg, Empty, Act } from "./mobileUi.tsx";
+import { Screen, Sheet, Seg, Empty, Act, useConfirm } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { fmtAgo } from "../lib/format.ts";
 import type { PrDetail, PrCheck } from "../../../shared/types.ts";
@@ -73,12 +73,14 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
       if (r.ok) reload();
     } catch (e) { toast(String(e), true); }
   };
+  const { confirm, sheet: confirmSheet } = useConfirm();
 
   const canMerge = d?.mergeState === "CLEAN";
   const openThreads = d?.threads.filter((t) => !t.isResolved).length ?? 0;
 
   return (
     <>
+      {confirmSheet}
       <Screen
         open={open && diffAt == null}
         title={d ? `#${d.number} · ${d.author}` : number != null ? `#${number}` : ""}
@@ -100,7 +102,11 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
             </Act>
             <Act kind="acc" full disabled={!canMerge}
               title={canMerge ? undefined : MERGE_WHY[d.mergeState]}
-              onAct={() => act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true }))}>
+              onAct={() => confirm({
+                verb: "Squash & merge", subject: `#${d.number}`,
+                warn: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
+                run: () => act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true })),
+              })}>
               {canMerge ? "Squash & merge" : "Blocked"}
             </Act>
           </>
@@ -243,8 +249,12 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
                 () => api.prDraft(root, d.number, !d.isDraft)).then(() => setMore(false))}>
                 {d.isDraft ? "Mark ready for review" : "Convert to draft"}
               </Act>
-              <Act full small kind="dang" onAct={() => act("Pull request closed",
-                () => api.prClose(root, d.number)).then(() => { setMore(false); onBack(); })}>
+              <Act full small kind="dang" onAct={() => confirm({
+                verb: "Close", subject: `#${d.number}`,
+                warn: "It stops being reviewable and drops off the queue. Reopening it means going to GitHub.",
+                run: () => act("Pull request closed", () => api.prClose(root, d.number))
+                  .then(() => { setMore(false); onBack(); }),
+              })}>
                 Close pull request
               </Act>
             </>

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
 import { parseUnifiedDiff } from "../lib/prBody.ts";
-import { Screen, Sheet, Seg, Empty, Act, useConfirm } from "./mobileUi.tsx";
+import { Screen, Sheet, Seg, Empty, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { fmtAgo } from "../lib/format.ts";
 import type { PrDetail, PrCheck } from "../../../shared/types.ts";
@@ -73,14 +73,14 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
       if (r.ok) reload();
     } catch (e) { toast(String(e), true); }
   };
-  const { confirm, sheet: confirmSheet } = useConfirm();
+  const { ask, dialog: askDialog } = useAsk();
 
   const canMerge = d?.mergeState === "CLEAN";
   const openThreads = d?.threads.filter((t) => !t.isResolved).length ?? 0;
 
   return (
     <>
-      {confirmSheet}
+      {askDialog}
       <Screen
         open={open && diffAt == null}
         title={d ? `#${d.number} · ${d.author}` : number != null ? `#${number}` : ""}
@@ -102,11 +102,13 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
             </Act>
             <Act kind="acc" full disabled={!canMerge}
               title={canMerge ? undefined : MERGE_WHY[d.mergeState]}
-              onAct={() => confirm({
-                verb: "Squash & merge", subject: `#${d.number}`,
-                warn: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
-                run: () => act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true })),
-              })}>
+              onAct={async () => {
+                if (!(await ask({
+                  title: `Squash & merge #${d.number}?`, danger: true, confirmLabel: "Squash & merge",
+                  body: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
+                }))) return;
+                await act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true }));
+              }}>
               {canMerge ? "Squash & merge" : "Blocked"}
             </Act>
           </>
@@ -249,12 +251,14 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
                 () => api.prDraft(root, d.number, !d.isDraft)).then(() => setMore(false))}>
                 {d.isDraft ? "Mark ready for review" : "Convert to draft"}
               </Act>
-              <Act full small kind="dang" onAct={() => confirm({
-                verb: "Close", subject: `#${d.number}`,
-                warn: "It stops being reviewable and drops off the queue. Reopening it means going to GitHub.",
-                run: () => act("Pull request closed", () => api.prClose(root, d.number))
-                  .then(() => { setMore(false); onBack(); }),
-              })}>
+              <Act full small kind="dang" onAct={async () => {
+                if (!(await ask({
+                  title: `Close #${d.number}?`, danger: true, confirmLabel: "Close it",
+                  body: "It stops being reviewable and drops off the queue. Reopening it means going to GitHub.",
+                }))) return;
+                await act("Pull request closed", () => api.prClose(root, d.number));
+                setMore(false); onBack();
+              }}>
                 Close pull request
               </Act>
             </>

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
-import { Screen, Sheet, Seg, Empty, Row, Act, useConfirm } from "./mobileUi.tsx";
+import { Screen, Sheet, Seg, Empty, Row, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { MobilePr } from "./MobilePr.tsx";
 import type {
@@ -122,11 +122,11 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
       if (r.ok) { loadTree(); onRefresh(); }
     } catch (e) { toast(String(e), true); }
   };
-  const { confirm, sheet: confirmSheet } = useConfirm();
+  const { ask, dialog: askDialog } = useAsk();
 
   return (
     <>
-      {confirmSheet}
+      {askDialog}
       <Screen open={open && !openPr && !ctr && diffAt == null} title={repo?.name ?? ""} sub={repo?.branch} onBack={onBack}>
         <Seg sticky value={facet} onPick={setFacet} options={[
           { id: "changes", label: "Changes", n: repo?.dirty || null },
@@ -246,11 +246,13 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
         extra={diffAt != null && (
           <>
             <Act small onAct={() => act("Staged", () => api.gitStage(root, [paths[diffAt]!]))}>Stage this file</Act>
-            <Act small kind="dang" onAct={() => confirm({
-              verb: "Discard", subject: rel(paths[diffAt]!),
-              warn: "Every change in this file goes back to HEAD. There is no undo, and it is not in git anywhere.",
-              run: () => act("Discarded — back to HEAD", () => api.gitDiscard(root, [paths[diffAt]!])),
-            })}>Discard</Act>
+            <Act small kind="dang" onAct={async () => {
+              if (!(await ask({
+                title: `Discard ${rel(paths[diffAt]!)}?`, danger: true, confirmLabel: "Discard",
+                body: "Every change in this file goes back to HEAD. There is no undo, and it is not in git anywhere.",
+              }))) return;
+              await act("Discarded — back to HEAD", () => api.gitDiscard(root, [paths[diffAt]!]));
+            }}>Discard</Act>
           </>
         )}
       />
@@ -305,11 +307,11 @@ function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
     if (r.ok) onRefresh();
   };
   const up = c?.state === "running";
-  const { confirm, sheet: confirmSheet } = useConfirm();
+  const { ask, dialog: askDialog } = useAsk();
 
   return (
     <>
-      {confirmSheet}
+      {askDialog}
     <Screen open={open} title={c?.name ?? ""} sub={c ? `${c.image} · ${c.status}` : undefined} onBack={onBack}
       foot={c ? (up ? (
         <>
@@ -319,11 +321,13 @@ function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
       ) : (
         <>
           <Act small full kind="ok" onAct={() => run(`Started ${c.name}`, () => api.dockerStart(c.id))}>Start</Act>
-          <Act small full kind="dang" onAct={() => confirm({
-            verb: "Remove", subject: c.name,
-            warn: "The container and anything written inside it that is not on a volume are gone.",
-            run: () => run(`Removed ${c.name}`, () => api.dockerRm(c.id)),
-          })}>Remove</Act>
+          <Act small full kind="dang" onAct={async () => {
+            if (!(await ask({
+              title: `Remove ${c.name}?`, danger: true, confirmLabel: "Remove",
+              body: "The container and anything written inside it that is not on a volume are gone.",
+            }))) return;
+            await run(`Removed ${c.name}`, () => api.dockerRm(c.id));
+          }}>Remove</Act>
         </>
       )) : undefined}>
       <div className="grid grid-cols-2 gap-2.5 mb-3">

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
-import { Screen, Sheet, Seg, Empty, Row, Act } from "./mobileUi.tsx";
+import { Screen, Sheet, Seg, Empty, Row, Act, useConfirm } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { MobilePr } from "./MobilePr.tsx";
 import type {
@@ -122,9 +122,11 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
       if (r.ok) { loadTree(); onRefresh(); }
     } catch (e) { toast(String(e), true); }
   };
+  const { confirm, sheet: confirmSheet } = useConfirm();
 
   return (
     <>
+      {confirmSheet}
       <Screen open={open && !openPr && !ctr && diffAt == null} title={repo?.name ?? ""} sub={repo?.branch} onBack={onBack}>
         <Seg sticky value={facet} onPick={setFacet} options={[
           { id: "changes", label: "Changes", n: repo?.dirty || null },
@@ -244,7 +246,11 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
         extra={diffAt != null && (
           <>
             <Act small onAct={() => act("Staged", () => api.gitStage(root, [paths[diffAt]!]))}>Stage this file</Act>
-            <Act small kind="dang" onAct={() => act("Discarded — back to HEAD", () => api.gitDiscard(root, [paths[diffAt]!]))}>Discard</Act>
+            <Act small kind="dang" onAct={() => confirm({
+              verb: "Discard", subject: rel(paths[diffAt]!),
+              warn: "Every change in this file goes back to HEAD. There is no undo, and it is not in git anywhere.",
+              run: () => act("Discarded — back to HEAD", () => api.gitDiscard(root, [paths[diffAt]!])),
+            })}>Discard</Act>
           </>
         )}
       />
@@ -299,8 +305,11 @@ function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
     if (r.ok) onRefresh();
   };
   const up = c?.state === "running";
+  const { confirm, sheet: confirmSheet } = useConfirm();
 
   return (
+    <>
+      {confirmSheet}
     <Screen open={open} title={c?.name ?? ""} sub={c ? `${c.image} · ${c.status}` : undefined} onBack={onBack}
       foot={c ? (up ? (
         <>
@@ -310,7 +319,11 @@ function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
       ) : (
         <>
           <Act small full kind="ok" onAct={() => run(`Started ${c.name}`, () => api.dockerStart(c.id))}>Start</Act>
-          <Act small full kind="dang" onAct={() => run(`Removed ${c.name}`, () => api.dockerRm(c.id))}>Remove</Act>
+          <Act small full kind="dang" onAct={() => confirm({
+            verb: "Remove", subject: c.name,
+            warn: "The container and anything written inside it that is not on a volume are gone.",
+            run: () => run(`Removed ${c.name}`, () => api.dockerRm(c.id)),
+          })}>Remove</Act>
         </>
       )) : undefined}>
       <div className="grid grid-cols-2 gap-2.5 mb-3">
@@ -330,5 +343,6 @@ function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
         {loading ? "Reading the log…" : logs || "Nothing logged."}
       </pre>
     </Screen>
+    </>
   );
 }

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useRef, useState } from "react";
+import type { ConfirmSpec } from "../components/ConfirmDialog.tsx";
 
 /**
  * The phone's own visual language, and the few primitives every screen needs.
@@ -291,57 +292,50 @@ export function Act({ children, onAct, kind, small, disabled, title, full }: {
 }
 
 /**
- * What a destructive action has to say before a thumb can do it.
+ * The phone's answer to `useDialogs()`.
  *
- * `subject` is the part that matters and the part a desktop dialog can get
- * away with omitting. On a phone the thing being acted on is usually not on
- * screen when the button is — the file is behind a diff, the container behind
- * a stats card, the branch not shown at all — so "Discard?" asks a question
- * the person cannot answer. Naming it is the confirmation.
+ * Same contract as the desktop's — `ConfirmSpec` in, `Promise<boolean>` out,
+ * render the node it hands back — so a call site reads identically on both:
+ *
+ *   if (!(await ask({ title: "Discard src/cart.ts?", danger: true }))) return;
+ *
+ * Different surface, because a centred modal on a phone is the same foreignness
+ * `ConfirmDialog` was written to avoid, one layer up: it ignores the back
+ * gesture, puts its buttons where nothing else on the screen puts them, and
+ * lands nowhere near the thumb. This is the sheet every other question on the
+ * phone already arrives in.
+ *
+ * The title is where the work is. On a phone the thing being acted on is
+ * usually not on screen when the button is — the file is behind a diff, the
+ * container behind a stats card, the branch not rendered at all — so "Discard?"
+ * asks a question the person cannot answer. Naming it is the confirmation.
  */
-export type ConfirmSpec = {
-  /** The verb, worded the way the button will repeat it. */
-  verb: string;
-  /** What it happens to, named: a path, a container, `#381`. */
-  subject: string;
-  /** The one sentence about what does not come back. */
-  warn: string;
-  run: () => Promise<string | void> | string | void;
-};
+export function useAsk(): { ask: (spec: ConfirmSpec) => Promise<boolean>; dialog: React.ReactNode } {
+  const [pending, setPending] = useState<(ConfirmSpec & { resolve: (v: boolean) => void }) | null>(null);
+  const settle = useCallback((v: boolean) => {
+    setPending((p) => { p?.resolve(v); return null; });
+  }, []);
 
-/**
- * A confirm step for the actions that cannot be undone.
- *
- * Deliberately not a `window.confirm`: that is a desktop dialog on a phone —
- * it lands under the thumb with its buttons in the platform's order, not the
- * app's, and its "OK" cannot say what it is about to do. This reuses the same
- * bottom sheet the rest of the phone uses, so the destructive button sits
- * where every other primary action on this screen sits.
- */
-export function useConfirm(): { confirm: (spec: ConfirmSpec) => void; sheet: React.ReactNode } {
-  const [spec, setSpec] = useState<ConfirmSpec | null>(null);
-  const close = useCallback(() => setSpec(null), []);
-  const sheet = (
-    <Sheet
-      open={!!spec}
-      title={spec ? `${spec.verb} ${spec.subject}?` : ""}
-      sub={spec?.warn}
-      onClose={close}
-    >
-      {spec && (
+  const ask = useCallback(
+    (spec: ConfirmSpec) => new Promise<boolean>((resolve) => setPending({ ...spec, resolve })),
+    [],
+  );
+
+  const dialog = (
+    // Dismissing by the scrim or the back gesture resolves false, exactly as
+    // the desktop's does — a question the person walked away from is a no.
+    <Sheet open={!!pending} title={pending?.title ?? ""} sub={pending?.body} onClose={() => settle(false)}>
+      {pending && (
         <div className="flex flex-col gap-2">
-          {/* Destructive first, because it is the one being asked about — and
-              the sheet is dismissed by the scrim, the back gesture and Cancel,
-              so the safe way out is never more than the nearest edge. */}
-          <Act full kind="dang" onAct={async () => { await spec.run(); close(); }}>
-            {spec.verb} {spec.subject}
+          <Act full kind={pending.danger ? "dang" : "acc"} onAct={() => settle(true)}>
+            {pending.confirmLabel ?? "Confirm"}
           </Act>
-          <Act full onAct={close}>Cancel</Act>
+          <Act full onAct={() => settle(false)}>{pending.cancelLabel ?? "Cancel"}</Act>
         </div>
       )}
     </Sheet>
   );
-  return { confirm: setSpec, sheet };
+  return { ask, dialog };
 }
 
 export function Switch({ on, onToggle, label }: { on: boolean; onToggle: () => void; label: string }) {

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -290,6 +290,60 @@ export function Act({ children, onAct, kind, small, disabled, title, full }: {
   );
 }
 
+/**
+ * What a destructive action has to say before a thumb can do it.
+ *
+ * `subject` is the part that matters and the part a desktop dialog can get
+ * away with omitting. On a phone the thing being acted on is usually not on
+ * screen when the button is — the file is behind a diff, the container behind
+ * a stats card, the branch not shown at all — so "Discard?" asks a question
+ * the person cannot answer. Naming it is the confirmation.
+ */
+export type ConfirmSpec = {
+  /** The verb, worded the way the button will repeat it. */
+  verb: string;
+  /** What it happens to, named: a path, a container, `#381`. */
+  subject: string;
+  /** The one sentence about what does not come back. */
+  warn: string;
+  run: () => Promise<string | void> | string | void;
+};
+
+/**
+ * A confirm step for the actions that cannot be undone.
+ *
+ * Deliberately not a `window.confirm`: that is a desktop dialog on a phone —
+ * it lands under the thumb with its buttons in the platform's order, not the
+ * app's, and its "OK" cannot say what it is about to do. This reuses the same
+ * bottom sheet the rest of the phone uses, so the destructive button sits
+ * where every other primary action on this screen sits.
+ */
+export function useConfirm(): { confirm: (spec: ConfirmSpec) => void; sheet: React.ReactNode } {
+  const [spec, setSpec] = useState<ConfirmSpec | null>(null);
+  const close = useCallback(() => setSpec(null), []);
+  const sheet = (
+    <Sheet
+      open={!!spec}
+      title={spec ? `${spec.verb} ${spec.subject}?` : ""}
+      sub={spec?.warn}
+      onClose={close}
+    >
+      {spec && (
+        <div className="flex flex-col gap-2">
+          {/* Destructive first, because it is the one being asked about — and
+              the sheet is dismissed by the scrim, the back gesture and Cancel,
+              so the safe way out is never more than the nearest edge. */}
+          <Act full kind="dang" onAct={async () => { await spec.run(); close(); }}>
+            {spec.verb} {spec.subject}
+          </Act>
+          <Act full onAct={close}>Cancel</Act>
+        </div>
+      )}
+    </Sheet>
+  );
+  return { confirm: setSpec, sheet };
+}
+
 export function Switch({ on, onToggle, label }: { on: boolean; onToggle: () => void; label: string }) {
   return (
     <button className="mb-sw mb-press" data-on={on ? "1" : "0"}


### PR DESCRIPTION
## What does this PR do?

Five actions on the phone fired on touch-down with no question and nothing named: discarding a file's changes, removing a container, closing a pull request, and squash-merging-and-deleting-a-branch (from the PR screen and from the Now queue). Each now goes through the app's own `ask()` — the same contract `useDialogs()` gives the desktop panels — rendered in the phone's bottom sheet.

## How was it tested?

`bun test` in **both** `server/` (937 pass) and `web/` (441 pass), 0 fail, including 8 new ones in `server/test/mobile-confirms.test.ts` run **red first**: 6 of the 8 fail against the unwired version. `bunx tsc --noEmit` in both, `bun run build` clean. See *On verification* for what I could and could not drive through the demo build.

---

## The problem

The phone companion inherited the desktop's action set. On the desktop each of these lives behind a pointer, a hover title, and a screen wide enough to show what is selected. On a phone none of that holds:

- The button is under the thumb that is already scrolling.
- **The subject is usually off screen.** The file is behind a diff, the container behind a stats card, the branch not rendered at all.

`api.gitDiscard(root, [paths[diffAt]!])` fired on touch-down. So did `api.prMerge(..., "squash", { deleteBranch: true })` — from a Now-queue card, mid-scroll.

## One contract, two surfaces

The first commit here got this wrong and CI caught it, which is worth writing down rather than squashing away.

`web/test/no-native-dialogs.test.ts` bans a bare `confirm()` across `web/src`, and it was right to: the repo **already has this primitive** — `useDialogs()` in `components/ConfirmDialog.tsx`, promise-based, four desktop call sites — and I had written a rival vocabulary beside it with a spec shape of its own. The guard failed on a duplicate, not on a native dialog, and that is exactly the drift it exists to stop.

`useAsk()` is now the same contract in a different surface: same `ConfirmSpec` in, same `Promise<boolean>` out, so a call site reads identically on both —

```ts
if (!(await ask({ title: `Discard ${rel(path)}?`, danger: true }))) return;
```

— and only the presentation differs. That difference still earns its place: a centred modal on a phone ignores the back gesture, puts its buttons where nothing else on the screen puts them, and lands nowhere near the thumb. It is the same foreignness `ConfirmDialog` was written to avoid, one layer up. So the phone renders the question in the sheet every other question already arrives in, and dismissing by scrim or back gesture resolves `false`, exactly as the desktop's does.

## What it says

The title is where the work is. "Discard?" asks a question the person cannot answer.

| Action | Sheet says |
|---|---|
| discard | **Discard src/cart.ts?** — Every change in this file goes back to HEAD. There is no undo, and it is not in git anywhere. |
| docker rm | **Remove shop-api?** — The container and anything written inside it that is not on a volume are gone. |
| squash & merge | **Squash & merge #482?** — Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here. |
| close PR | **Close #482?** — It stops being reviewable and drops off the queue. Reopening it means going to GitHub. |

## What deliberately stays one tap

Stage, restart, stop, approve, re-run. **Each is undone by another tap.** The line is reversibility, not danger — a question on those would turn every question on the screen into noise, and a sheet the thumb learns to dismiss is worse than no sheet. A test asserts these three did *not* gain one.

## On verification

The guard reads the call sites instead of clicking through them, and that is the interesting choice here.

I tried the click-through first. The demo fixture has **no mergeable pull request** (the merge button renders as `Blocked`) and **no containers under a repo** — so a UI test would have driven two of the five paths and passed silently on the other three, including squash-merge-and-delete-branch. That is the failure mode where a green test is worse than none.

Reading the call site cannot skip a path. The parser walks back from each `api.*` call to the nearest `await ask({`, balances braces, and checks the write comes *after* the spec closes with no other handler opening in between — so moving the write out of the guarded path fails, not just deleting the word `ask`.

The red-first split is the shape you want: 6 of 8 fail unwired. The two that pass are *"reversible actions are left alone"* and the contract check, both of which are there so the guard cannot be satisfied by confirming everything or by inventing a third dialog.

## Provenance

From reading [kube-coder](https://github.com/imran31415/kube-coder), which wraps destructive operations in a permission layer. The permission layer itself is wrong here — agentglass already has one, and it is the gate — but the observation that a one-tap irreversible action must name its subject transfers directly.
