### PR TITLE
docs(security): say what is kept, how to remove it, and what is not a bug

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -72,6 +72,65 @@ complement, rather than replace, the private reporting path below.
   agents. Set `AGENTGLASS_GATE_FAILCLOSED=1` if you would rather a timeout or an
   unreachable control plane denied the call.
 
+## What agentglass stores, and how to get rid of it
+
+Everything below is on your machine and nowhere else. There is no account, no
+sync, and no upload — the hooks refuse to post anywhere but this host (see
+`AGENTGLASS_ALLOW_REMOTE` above). But it is worth saying plainly what lands on
+disk, because **nothing in the app deletes it**: there is no route, no button
+and no menu item that removes recorded data. The `Clear ✕` in the header clears
+*filters*, not history.
+
+| Where | What is in it |
+|---|---|
+| `~/.local/share/agentglass/agentglass.db`<br><sub>or `$XDG_DATA_HOME/agentglass/`, or `./agentglass.db` if one is already there</sub> | Every event, with its `summary`, its `error_text` and the **raw hook payload** — which for a tool call is the command line, the file path, and the prompt. Plus session totals, the full-text search index, gate decisions, and the daily rollup. |
+| `~/.config/agentglass/token` | The shared secret, `0600`, when one has been minted. |
+| `~/.config/agentglass/config.json` | The active project scope and the UI switches. |
+
+Two things about retention are easy to get wrong:
+
+- **`AGENTGLASS_RETENTION_DAYS` bounds the raw events, not the history.** Expiring
+  events are folded into a daily rollup *before* they are deleted, so per-day
+  totals — cost, tokens, error counts, session counts — survive the prune and
+  keep accumulating. That is the point of the feature, and it means the default
+  8 days is not how long agentglass remembers you.
+- **The rollup has no expiry at all.** Nothing prunes it, and there is no path
+  in the product that removes a row from it. It is designed to be kept for
+  years.
+
+To get rid of any of it, delete the files. Stop the server first — SQLite is
+open while it runs:
+
+```sh
+rm -rf ~/.local/share/agentglass ~/.config/agentglass
+```
+
+Removing only the history and keeping your settings means deleting the `.db`
+alone. Nothing else in the app depends on it; the next event starts a new one.
+
+## Out of scope
+
+agentglass is a tool you point at your own machine, so the boundary is
+provenance, not symptom. **A surface you deliberately opened, doing something
+to the machine you opened it on, is the tool working.** In particular:
+
+- The terminal, the chat panes and the Docker controls run **as you**, with your
+  permissions. Filling the disk, killing a process, removing your own container
+  or running a destructive command through them is not a vulnerability — it is
+  the capability, and each one has a switch in the table below.
+- The gate is **fail-open by default and by design**. An agent proceeding
+  because nobody answered in time, or because agentglass was not running, is
+  documented behaviour; `AGENTGLASS_GATE_FAILCLOSED=1` inverts it.
+- Recorded data staying recorded (above) is a retention decision, not a leak.
+- Findings that require an attacker to already have a shell on the machine, or
+  to already hold the token, are not separate issues — at that point they have
+  what the token protects.
+
+What **is** in scope is anything that crosses a boundary without you: a webpage
+reaching the server, another machine reaching it without the token, a repository
+you cloned redirecting your transcripts, one project's scope reading another's
+data, or a path that escapes the active scope.
+
 ## Reporting a vulnerability
 
 Please **do not open a public issue** for security problems.

--- a/server/test/retention-promises.test.ts
+++ b/server/test/retention-promises.test.ts
@@ -1,0 +1,71 @@
+/*
+ * SECURITY.md makes three factual claims about what is kept. These pin them.
+ *
+ * A security policy that has drifted from the code is worse than none: someone
+ * reads "nothing in the app deletes it", plans around that, and is wrong. But
+ * the claims are exactly the kind that stop being true as a side effect —
+ * somebody adds a "clear history" button, or gives the rollup an expiry, and
+ * the document says otherwise for as long as nobody rereads it.
+ *
+ * So this is a tripwire on the prose, not a ban on the feature. If one of these
+ * fails because the product genuinely changed, the fix is to update SECURITY.md
+ * in the same commit — which is the whole point.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
+
+describe("the promises SECURITY.md makes about retention", () => {
+  test("the only rows anything deletes are the ones retention prunes", () => {
+    // "there is no route, no button and no menu item that removes recorded
+    // data". Every DELETE in the server, and each one has to be the prune.
+    const src = read("server/src/db.ts");
+    const all: string[] = [];
+    for (const f of ["db.ts", "gate.ts", "index.ts", "transcripts.ts", "skills.ts", "insights.ts"]) {
+      for (const m of read(`server/src/${f}`).matchAll(/DELETE\s+FROM\s+(\w+)/gi)) all.push(`${f}:${m[1]}`);
+    }
+    expect(all.sort()).toEqual([
+      "db.ts:events",
+      "db.ts:events_fts",
+      "db.ts:gates",
+      "db.ts:sessions",
+    ]);
+    // …and all four are inside pruneOldRows, bounded by the cutoff.
+    const prune = src.slice(src.indexOf("export function pruneOldRows"));
+    const body = prune.slice(0, prune.indexOf("\n}\n"));
+    for (const t of ["events_fts", "events", "sessions", "gates"]) {
+      expect(body, `DELETE FROM ${t} escaped pruneOldRows`).toContain(`DELETE FROM ${t}`);
+    }
+  });
+
+  test("the rollup has no expiry and no removal path", () => {
+    // "The rollup has no expiry at all." It is the one table designed to be
+    // kept for years, and the one whose contents outlive the rows they came
+    // from — so a DELETE against it would silently shorten every long-window
+    // number in the product.
+    for (const f of ["db.ts", "index.ts"]) {
+      expect(read(`server/src/${f}`)).not.toMatch(/DELETE\s+FROM\s+daily_rollup/i);
+    }
+  });
+
+  test("no route removes recorded data", () => {
+    // A DELETE-verb route, or a path that reads like one, would make the
+    // "no route" half of the claim false.
+    const idx = read("server/src/index.ts");
+    const routes = [...idx.matchAll(/pathname === "(\/[^"]*)"/g)].map((m) => m[1]!);
+    const suspicious = routes.filter((r) => /delete|purge|clear|wipe|forget|reset/i.test(r));
+    expect(suspicious, "a route now removes data — say so in SECURITY.md").toEqual([]);
+  });
+
+  test("SECURITY.md still says all three, so the tripwire is wired to something", () => {
+    // Guards against the other failure: the claims quietly leaving the
+    // document while these tests carry on passing about nothing.
+    const doc = read("SECURITY.md");
+    expect(doc).toContain("nothing in the app deletes it");
+    expect(doc).toContain("The rollup has no expiry at all");
+    expect(doc).toContain("bounds the raw events, not the history");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds two sections to `SECURITY.md` — *What agentglass stores, and how to get rid of it* and *Out of scope* — and pins the three factual claims the first one makes with tests, so the policy cannot drift from the code in silence.

## How was it tested?

`bun test` in both `server/` (941 pass) and `web/` (441 pass), 0 fail, including 4 new ones in `server/test/retention-promises.test.ts`. Each was run **red first** against a plausible way of quietly breaking it: a `forgetRollup()` helper, a `/history/clear` route, and a `DELETE FROM daily_rollup`. 3 of the 4 fail against those; the 4th is the one that checks the sentences are still in the document.

---

## What is kept

The policy described every boundary around the data and never the data itself.

**Nothing in the product deletes recorded events.** No route, no button, no menu item — and the header's `Clear ✕` clears *filters*, not history. That was written down nowhere.

It matters more since #381. Expiring events are folded into a daily rollup *before* the DELETE, so `AGENTGLASS_RETENTION_DAYS` bounds the raw rows and not the history — and the rollup has **no expiry at all**. Read quickly, "retention: 8 days" says agentglass forgets you after a week. It does not, deliberately, and someone deciding what to point it at deserves to know which.

So the section says where the three files are, what is actually in them (the raw hook payload is the command line, the file path and the prompt — not a summary), and the `rm` that removes them.

## What is not a bug

Scoped by **provenance**, not by symptom — a symptom list would be endless and wrong. A surface you deliberately opened, acting on the machine you opened it on, is the tool working:

- The terminal, chat panes and Docker controls run **as you**, with your permissions. Each already has a switch in the hardening table.
- The gate is fail-open **by construction**, and says so three times in the codebase already.
- A finding that needs a shell on the box, or the token, already has what the token protects.

What stays in scope is anything crossing a boundary *without* you — a webpage reaching the server, another machine reaching it untokened, a cloned repo redirecting transcripts, one scope reading another's data. That list was already implicit in the trust model; this makes it the explicit complement.

## Why the tests

A security policy that has drifted from the code is worse than none: someone reads *"nothing in the app deletes it"*, plans around it, and is wrong. These claims are exactly the kind that stop being true as a side effect — somebody adds a "clear history" button, or gives the rollup an expiry, and the document says otherwise for as long as nobody rereads it.

| Test | Fails when |
|---|---|
| every `DELETE FROM` in the server is one of the prune's four, and all four are inside `pruneOldRows` | a delete appears anywhere else, or one escapes the prune |
| `daily_rollup` has no `DELETE` | the rollup gains an expiry |
| no route path reads as removing data | a `/history/clear` shows up |
| the three sentences are still in `SECURITY.md` | the claims leave the document and the tripwire ends up wired to nothing |

This is a tripwire on the prose, **not a ban on the feature**. If one fails because the product genuinely gained a delete, the fix is to update `SECURITY.md` in the same commit — which is exactly what it is for.

## Provenance

Two findings from reading [relay-mcp](https://github.com/blak0p/relay-mcp) and [kube-coder](https://github.com/imran31415/kube-coder): both write an explicit out-of-scope section, and both say what their store keeps. Neither mechanism transfers — the boundary here is different and the store is different — but the two omissions were real, and the rollup had just widened one of them.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_