### PR TITLE
fix(diff): tokenize the first line of a file as well as the rest

### DIFF
--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -38,7 +38,7 @@ import { stepFileIndex } from "../lib/prNav.ts";
 import { PrFilterBar } from "./PrFilterBar.tsx";
 import { Avatar } from "./Avatar.tsx";
 import { parseQuery, sortRows, buildFacets, activeCount, type RepoFacets } from "../lib/prFilter.ts";
-import { getHighlighter, shikiTheme } from "../lib/highlight.ts";
+import { getHighlighter, shikiTheme, ensureLanguage } from "../lib/highlight.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 
 type Filter = "mine" | "review" | "all";
@@ -366,7 +366,9 @@ function CodeBlock({ text, lang }: { text: string; lang?: string }) {
     (async () => {
       try {
         const hl = await getHighlighter();
-        await hl.loadLanguage(id as never).catch(() => {});
+        // ensureLanguage, not loadLanguage: the grammar is warmed so the first
+        // line of the first file of this language is tokenized properly.
+        await ensureLanguage(hl, id).catch(() => {});
         if (!hl.getLoadedLanguages().includes(id)) return;
         const out = hl.codeToHtml(text, { lang: id as never, theme: shikiTheme() });
         if (live) setHtml(out);

--- a/web/src/lib/diffHighlight.ts
+++ b/web/src/lib/diffHighlight.ts
@@ -4,7 +4,7 @@
 // value to drop into <HiliteCtx.Provider>.
 import { createContext, useEffect, useMemo, useState } from "react";
 import type { Highlighter } from "shiki";
-import { getHighlighter, langFromPath, shikiTheme, ensureTheme, themeLabel } from "./highlight.ts";
+import { getHighlighter, langFromPath, shikiTheme, ensureTheme, ensureLanguage, themeLabel } from "./highlight.ts";
 
 export type Hilite = { hl: Highlighter | null; lang: string | null; theme: string | null };
 export const HiliteCtx = createContext<Hilite>({ hl: null, lang: null, theme: null });
@@ -37,7 +37,7 @@ export function useDiffHighlight(filePath?: string) {
   useEffect(() => {
     if (!hl || !lang || loadedLangs.has(lang)) return;
     let alive = true;
-    hl.loadLanguage(lang as never)
+    ensureLanguage(hl, lang)
       .then(() => { if (alive) { setLoadedLangs((s) => new Set(s).add(lang)); setLangError(null); } })
       .catch(() => { if (alive) setLangError(`The ${lang} grammar couldn't be loaded — this file is shown as plain text.`); });
     return () => { alive = false; };

--- a/web/src/lib/highlight.ts
+++ b/web/src/lib/highlight.ts
@@ -105,6 +105,49 @@ async function loadInto(hl: Highlighter, id: string, bold: boolean): Promise<str
   return name;
 }
 
+const loadedLangs = new Set<string>();
+
+/**
+ * Load a grammar and make it ready to tokenize *correctly on the first call*.
+ *
+ * The JavaScript engine above initialises a grammar lazily, on the first
+ * `codeToTokens` for that language — and the first call's OUTPUT is what pays
+ * for it. Measured on a fresh process: `const greeting = "hello"; // note`
+ * comes back as ONE token, then eight, then ten, converging only after several
+ * calls. The Oniguruma engine is right the first time; this is the price of not
+ * needing wasm, and it is not a price anyone chose to pay because nobody knew
+ * it was there.
+ *
+ * A diff tokenizes line by line, so what a user actually saw was the first line
+ * of the first file of that language they opened all session rendering
+ * under-highlighted, and every line after it fine. Nothing logged, nothing to
+ * report, and it looked like the file simply had a dull first line. Three of
+ * seventeen sampled languages were affected — typescript, css, haskell — and
+ * which three moves.
+ *
+ * So the initialisation is paid here, with a throwaway single character, before
+ * anything the user will look at goes through. It warms the grammar rather than
+ * the theme pairing: warming with one theme and rendering with another is fine,
+ * verified. The state lives in the engine for the life of the process, which is
+ * also why this only ever bites once.
+ */
+export async function ensureLanguage(hl: Highlighter, lang: string): Promise<void> {
+  if (loadedLangs.has(lang)) return;
+  await hl.loadLanguage(lang as never);
+  try {
+    // Any registered theme will do; register the dark fallback if the theme
+    // step has not run yet, which it may not have — the two load in parallel.
+    let theme = hl.getLoadedThemes()[0];
+    if (!theme) { await hl.loadTheme(FALLBACK.dark as never); theme = FALLBACK.dark; }
+    hl.codeToTokens("a", { lang: lang as never, theme });
+  } catch {
+    // A grammar that loaded but will not tokenize is the renderer's problem to
+    // report, not this one's. Never let warming turn a working load into a
+    // failed one.
+  }
+  loadedLangs.add(lang);
+}
+
 /** Whichever theme a diff surface should actually tokenize with. `name` is
  *  always a theme that is registered on the highlighter, or null when nothing
  *  could be registered at all; `failed` carries the id we were asked for when

--- a/web/test/diff-theme.test.ts
+++ b/web/test/diff-theme.test.ts
@@ -8,7 +8,7 @@
 // was to compare two themes side by side.
 import { expect, test } from "bun:test";
 import { bundledThemes } from "shiki";
-import { getHighlighter, ensureTheme, langFromPath, THEMES, themeLabel } from "../src/lib/highlight.ts";
+import { getHighlighter, ensureTheme, ensureLanguage, langFromPath, THEMES, themeLabel } from "../src/lib/highlight.ts";
 
 const CODE = 'const greeting = "hello"; // note';
 
@@ -36,6 +36,44 @@ for (const k of ["Instance", "Module"] as const) {
   };
 }
 
+/**
+ * The first render of a language is as good as the tenth.
+ *
+ * shiki's JavaScript engine — the one this module uses on purpose, because
+ * Oniguruma is wasm and the desktop CSP forbids it — initialises a grammar
+ * lazily on the first `codeToTokens`, and the first call's OUTPUT is what pays
+ * for it. On a cold process this very line came back as ONE token, then eight,
+ * then ten. A diff tokenizes line by line, so the visible symptom was the first
+ * line of the first file of that language rendering under-highlighted, all
+ * session, with nothing logged.
+ *
+ * This is also why this file used to fail intermittently: the warm state lives
+ * in the engine for the life of the process, so whichever test file tokenized
+ * first paid it, and bun does not fix the order.
+ *
+ * Deliberately NOT typescript, and deliberately the first test in the file:
+ * three tests below tokenize typescript, so by the time any of them has run the
+ * grammar is warm and a guard written against it would pass about nothing. This
+ * has to be the call that finds the grammar cold.
+ */
+const HS = 'main = putStrLn "hi" -- note';
+test("a grammar tokenizes correctly on its very first call, not its third", async () => {
+  const hl = await getHighlighter();
+  await ensureLanguage(hl, "haskell");
+  const { name } = await ensureTheme(hl, "github-dark", false);
+  const run = () => hl.codeToTokens(HS, { lang: "haskell" as never, theme: name! }).tokens.flat().length;
+
+  const first = run();
+  // Let it converge the way the old code only did after several renders.
+  let settled = first;
+  for (let i = 0; i < 5; i++) settled = run();
+
+  expect(`first=${first} settled=${settled}`).toBe(`first=${settled} settled=${settled}`);
+  // And the settled answer is a real tokenization, not one dull token that
+  // happens to be stable.
+  expect(settled).toBeGreaterThan(5);
+});
+
 test("every theme the picker offers is a real shiki bundled id", () => {
   // A typo, or an id shiki renames or drops in a future major, would otherwise
   // only ever show up as one entry in the menu quietly doing nothing.
@@ -54,7 +92,7 @@ test("the picker's light/dark grouping matches the theme's own type", async () =
 
 test("every offered theme tokenizes, in both plain and bold mode", async () => {
   const hl = await getHighlighter();
-  await hl.loadLanguage("typescript" as never);
+  await ensureLanguage(hl, "typescript");
   for (const bold of [false, true]) {
     for (const t of THEMES) {
       const { name, failed } = await ensureTheme(hl, t.id, bold);
@@ -63,14 +101,18 @@ test("every offered theme tokenizes, in both plain and bold mode", async () => {
       // does not throw and every token comes out with a colour.
       const tokens = hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! }).tokens.flat();
       expect(tokens.every((x) => !!x.color)).toBe(true);
-      expect(new Set(tokens.map((x) => x.color)).size).toBeGreaterThan(1);
+      // Named, because "Expected > 1, Received 1" over a 44-iteration loop says
+      // nothing about which theme produced it — that cost an afternoon once.
+      const colours = new Set(tokens.map((x) => x.color)).size;
+      expect(`${t.id} bold=${bold} colours=${colours > 1 ? "many" : "one"} tokens=${tokens.length}`)
+        .toBe(`${t.id} bold=${bold} colours=many tokens=${tokens.length}`);
     }
   }
 });
 
 test("bold mode bolds keywords the theme itself leaves plain", async () => {
   const hl = await getHighlighter();
-  await hl.loadLanguage("typescript" as never);
+  await ensureLanguage(hl, "typescript");
   const count = async (bold: boolean) => {
     const { name } = await ensureTheme(hl, "github-dark", bold);
     return hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! })
@@ -81,7 +123,7 @@ test("bold mode bolds keywords the theme itself leaves plain", async () => {
 
 test("a theme that cannot load falls back to one that is actually registered", async () => {
   const hl = await getHighlighter();
-  await hl.loadLanguage("typescript" as never);
+  await ensureLanguage(hl, "typescript");
   // An id shiki does not bundle stands in for the runtime failure we cannot
   // stage here — a theme chunk that 404s or never arrives.
   const { name, failed } = await ensureTheme(hl, "no-such-theme", true);
@@ -92,7 +134,7 @@ test("a theme that cannot load falls back to one that is actually registered", a
 
 test("the highlighter tokenizes without instantiating any WebAssembly", async () => {
   const hl = await getHighlighter();
-  await hl.loadLanguage("typescript" as never);
+  await ensureLanguage(hl, "typescript");
   const { name, failed } = await ensureTheme(hl, "gruvbox-dark-medium", true);
   expect(failed).toBeUndefined();
   const tokens = hl.codeToTokens(CODE, { lang: "typescript" as never, theme: name! }).tokens.flat();


### PR DESCRIPTION
## What does this PR do?

shiki's JavaScript regex engine initialises a grammar lazily on the first `codeToTokens` for that language, and **the first call's output is what pays for it** — the line comes back barely tokenized. A diff tokenizes line by line, so the first line of the first file of a given language you opened all session rendered under-highlighted. `ensureLanguage()` pays that initialisation with a throwaway character first.

## How was it tested?

`bun test` in `web/` — **five consecutive full-suite runs, 446 pass / 0 fail** (this fixes an intermittent, so one green run proves nothing). `server/` 974 pass, 0 fail. `bunx tsc --noEmit` and `bun run build` clean. New guard runs red at `first=2 settled=7` against the unwarmed version.

---

## What a user saw

```
cold:   1 token   ["const greeting = \"hello\"; // note"]
then:   8 tokens  ["const"," ","greeting"," ","="," ","\"hello\"","; // note"]
then:  10 tokens  ["const"," ","greeting"," ","="," ","\"hello\"","; ","//"," note"]
```

It converges after several calls. The first line of a diff is the one that pays, every other line is fine — so it looked like a file that happened to open on a dull line. Nothing logged, nothing to report.

Three of seventeen sampled languages were affected — **typescript, css, haskell** — and *which* three moves between runs.

## Why we can't just use the other engine

We use the JS engine on purpose: Oniguruma is WebAssembly, and the packaged desktop shell serves under `script-src 'self'` with no `'wasm-unsafe-eval'`, which is already documented at the top of `highlight.ts`. Measured side by side on a fresh process per engine:

| engine | languages wrong on first render |
|---|---|
| oniguruma (wasm) | **0/17** |
| javascript | 2–3/17 |
| javascript + `forgiving: true` | 2–3/17 |

So this is a cost of not needing wasm that nobody chose, because nobody knew it was there. `forgiving` is not the lever.

## The fix

One throwaway `codeToTokens("a", …)` after `loadLanguage`, memoized per language. It warms the **grammar**, not the theme pairing — warming with one theme and rendering with another is fine, verified in isolation, which matters because the language and theme steps load in parallel and either can win.

**0.2–1.4 ms, once per language**, against a grammar load that already costs 19–870 ms.

## Two measurement traps worth writing down

I got the wrong answer twice before getting the right one, both the same way.

**The warm state is per *process*, not per highlighter.** `hl.dispose()` does not reset it. So a probe that constructs three highlighters in one process and compares them measures nothing after the first — the first one warms the engine for the rest. My first conclusion was *"`forgiving: true` fixes it"*, which was only true because the run before it had already paid the cost. One mode per process shows they are identical.

**"Monochrome" is the wrong metric.** My first sweep counted themes producing a single colour and found 0/68 — because a cold call can return 2–3 tokens in 2 colours and still be badly wrong. Comparing first render against settled render is the property that actually matters.

## The guard, and why it is placed where it is

`a grammar tokenizes correctly on its very first call, not its third` is **deliberately the first test in its file, and deliberately uses haskell rather than typescript.** Three later tests in that file tokenize typescript, so by the time any of them has run the grammar is warm — a guard written against typescript would have passed about nothing. This has to be the call that finds a grammar cold.

That is also the whole explanation for the intermittency: the warm state lives in the engine for the life of the process, so whichever *test file* tokenized first paid for it, and bun does not fix the order between files. Same class of bug as the test, same class of cause.

## One more thing

The theme loop's diversity assertion now names the theme it is talking about. `Expected: > 1, Received: 1` over a 44-iteration loop identifies nothing, and that is most of why this took as long to find as it did.

## Related

Second and last of the two intermittent failures in the `web/` suite. The other was #386, a different root cause (a quadratic in `saveChats` crossing bun's 5s timeout). The suite has no known flakes left — five clean full runs above.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_