### PR TITLE
fix(mobile): stop polling a phone nobody is looking at

### DIFF
--- a/web/src/lib/gateStore.ts
+++ b/web/src/lib/gateStore.ts
@@ -32,6 +32,7 @@ let snapshot: PendingGate[] = [];
 export const listGates = (): PendingGate[] => snapshot;
 
 export function subscribeGates(fn: () => void): () => void {
+  startPolling();
   subs.add(fn);
   return () => subs.delete(fn);
 }
@@ -51,6 +52,7 @@ function changed() {
 const arrivals = new Set<(g: PendingGate) => void>();
 
 export function subscribeNewGates(fn: (g: PendingGate) => void): () => void {
+  startPolling();
   arrivals.add(fn);
   return () => arrivals.delete(fn);
 }
@@ -208,7 +210,28 @@ async function tick() {
   timer = setTimeout(tick, POLL_MS);
 }
 
-if (typeof window !== "undefined") {
+let started = false;
+
+/**
+ * Begin polling. Idempotent, and once begun it never stops.
+ *
+ * Called from the two subscribe functions rather than at import, which is the
+ * whole point: `main.tsx` imports the desktop tree unconditionally so it can
+ * choose between it and the phone one, so on a phone this module was loaded,
+ * this poll was started, and `/gate/pending` was fetched every two seconds
+ * *for a store nothing on that device ever reads*. The phone keeps its own
+ * gate list in MobileApp and polls it separately, so the whole loop was waste
+ * — on the one device where it costs a battery.
+ *
+ * Never stopping is deliberate and is the property the module comment is about:
+ * tying the poll to a panel's lifetime meant agentglass stopped noticing new
+ * holds the moment you opened the workspace. Starting on the first subscriber
+ * and never stopping keeps that guarantee exactly — on the desktop the alerts
+ * panel mounts on the first paint, so the poll begins when it always did.
+ */
+function startPolling() {
+  if (started || typeof window === "undefined") return;
+  started = true;
   void tick();
   // Coming back to a hidden tab should not wait out the remaining interval:
   // a gate raised while you were away is exactly what you returned to answer.

--- a/web/src/lib/poll.ts
+++ b/web/src/lib/poll.ts
@@ -1,0 +1,59 @@
+/**
+ * Polling that stops costing anything while nobody is looking.
+ *
+ * The phone runs five of these — gates and sessions every 4s, docker every 15s,
+ * working trees every 30s, pull requests every 60s, and a transcript every 5s
+ * while a chat is open — and every one of them ran flat out with the tab
+ * hidden. On a desk that is a few wasted requests; on a phone it is a radio
+ * wake per tick, which is the part that shows up in a battery graph.
+ *
+ * Skipping the work rather than clearing the timer is deliberate: browsers
+ * already throttle background timers to near-nothing, so the timer itself is
+ * free, and keeping it means coming back needs no re-arming.
+ *
+ * The catch-up is the half that makes it safe to skip at all. Returning to a
+ * view showing data from before you left is worse than the requests saved, so
+ * a poll that missed a tick runs immediately when the page becomes visible —
+ * and one that missed nothing does not, so tabbing away and straight back does
+ * not fire a burst.
+ */
+
+/** The document surface this needs, so the rule can be tested without a DOM. */
+export interface PollDoc {
+  hidden: boolean;
+  addEventListener(type: "visibilitychange", fn: () => void): void;
+  removeEventListener(type: "visibilitychange", fn: () => void): void;
+}
+
+/**
+ * Run `fn` every `ms`, but only while the page is visible — and once on the
+ * way back if a tick was missed. Returns the stop function to hand to a React
+ * effect's cleanup.
+ */
+export function pollWhileVisible(fn: () => void, ms: number, doc?: PollDoc): () => void {
+  const d = doc ?? (typeof document === "undefined" ? null : (document as unknown as PollDoc));
+  // No document at all (a test, SSR): behave like a plain interval rather than
+  // silently never running.
+  if (!d) {
+    const plain = setInterval(fn, ms);
+    return () => clearInterval(plain);
+  }
+
+  let missed = false;
+  const timer = setInterval(() => {
+    if (d.hidden) { missed = true; return; }
+    fn();
+  }, ms);
+
+  const wake = () => {
+    if (d.hidden || !missed) return;
+    missed = false;
+    fn();
+  };
+  d.addEventListener("visibilitychange", wake);
+
+  return () => {
+    clearInterval(timer);
+    d.removeEventListener("visibilitychange", wake);
+  };
+}

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -4,6 +4,7 @@ import { useStats } from "../lib/useStats.ts";
 import { fmtUsd, fmtTokens } from "../lib/format.ts";
 import { MobileChats } from "./MobileChats.tsx";
 import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobileUi.tsx";
+import { pollWhileVisible } from "../lib/poll.ts";
 import { DIFF_CSS } from "./MobileDiff.tsx";
 import { NOW_CSS, NowHero, NowStream, type NowAction } from "./MobileNow.tsx";
 import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
@@ -107,13 +108,10 @@ export function MobileApp() {
 
   useEffect(() => {
     loadFast();
-    const t = setInterval(loadFast, GATE_MS);
-    // Catching up the moment the screen comes back is what makes a poll feel
-    // live: a phone returning from sleep would otherwise show the last frame it
-    // managed to paint before it slept.
-    const wake = () => { if (document.visibilityState === "visible") loadFast(); };
-    document.addEventListener("visibilitychange", wake);
-    return () => { clearInterval(t); document.removeEventListener("visibilitychange", wake); };
+    // Skipped while the tab is hidden and caught up on the way back — see
+    // pollWhileVisible. Nobody answers a gate they cannot see, and on a phone
+    // each tick costs a radio wake as well as a round trip.
+    return pollWhileVisible(loadFast, GATE_MS);
   }, [loadFast]);
 
   useEffect(() => {
@@ -124,10 +122,12 @@ export function MobileApp() {
 
   useEffect(() => {
     if (!repos.length) return;
-    const a = setInterval(() => loadTrees(repos), TREE_MS);
-    const b = setInterval(() => loadPrs(repos), PR_MS);
-    const c = setInterval(loadDocker, DOCKER_MS);
-    return () => { clearInterval(a); clearInterval(b); clearInterval(c); };
+    const stop = [
+      pollWhileVisible(() => loadTrees(repos), TREE_MS),
+      pollWhileVisible(() => loadPrs(repos), PR_MS),
+      pollWhileVisible(loadDocker, DOCKER_MS),
+    ];
+    return () => { for (const s of stop) s(); };
   }, [repos, loadTrees, loadPrs, loadDocker]);
 
   const refreshAll = useCallback(() => {

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -1,6 +1,7 @@
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api, ChatStreamError } from "../lib/api.ts";
 import { toolTarget } from "../lib/chatStore.ts";
+import { pollWhileVisible } from "../lib/poll.ts";
 import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
@@ -116,7 +117,7 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
 
   useEffect(() => {
     load();
-    const t = setInterval(() => {
+    return pollWhileVisible(() => {
       // While our own turn is streaming the transcript is a scan behind, so
       // polling would paint a stale copy of what is already on screen. Once it
       // has gone quiet past the threshold that stops being true.
@@ -124,7 +125,6 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
       if (!streaming.current || quiet) load();
       if (streaming.current) setStalled(quiet);
     }, 5000);
-    return () => clearInterval(t);
   }, [load]);
 
   useEffect(() => { foot.current?.scrollIntoView({ block: "end" }); }, [detail?.conversation.length, live?.text, sent]);

--- a/web/test/gate-store.test.ts
+++ b/web/test/gate-store.test.ts
@@ -117,3 +117,56 @@ test("a gate that resolves and is later reissued is announced again", () => {
   expect(gateNotes()).toHaveLength(2);
   unsub?.();
 });
+
+/**
+ * The poll is started by someone listening, not by the module being imported.
+ *
+ * `main.tsx` imports the desktop tree unconditionally so it can pick between it
+ * and the phone one. That meant loading this module on a phone — and starting
+ * a two-second `/gate/pending` poll there, feeding a store nothing on that
+ * device ever reads, since MobileApp keeps its own gate list. A whole loop of
+ * waste on the one device where it costs a battery.
+ *
+ * Driven through `fetch` rather than by mocking the api module: what matters is
+ * that no request leaves, and the request is the thing to count.
+ */
+test("importing the store does not start a poll; subscribing does", async () => {
+  const realFetch = globalThis.fetch;
+  const realWindow = (globalThis as any).window;
+  const realDocument = (globalThis as any).document;
+  let calls = 0;
+  (globalThis as any).fetch = (...args: unknown[]) => {
+    calls++;
+    void args;
+    return Promise.resolve(new Response(JSON.stringify({ gates: [] }), { headers: { "content-type": "application/json" } }));
+  };
+  // A window, so the poll is allowed to start at all — its absence is why the
+  // rest of this file can import the store without one running.
+  (globalThis as any).window = {};
+  (globalThis as any).document = { hidden: false, addEventListener() {} };
+
+  try {
+    // A second module instance: this file's own import happened without a
+    // window and can never start, so it cannot answer the question.
+    const fresh = "../src/lib/gateStore.ts?lazy=1";
+    const s = (await import(fresh)) as typeof import("../src/lib/gateStore.ts");
+    await new Promise((r) => setTimeout(r, 30));
+    expect(calls, "the module polled merely because it was imported").toBe(0);
+
+    const off = s.subscribeGates(() => {});
+    await new Promise((r) => setTimeout(r, 30));
+    expect(calls, "nobody polled after a subscriber arrived").toBeGreaterThan(0);
+
+    // Unsubscribing does not stop it, and that is the point: tying the poll to
+    // a panel's lifetime is what made agentglass stop noticing new holds the
+    // moment you opened the workspace.
+    const afterOff = calls;
+    off();
+    await new Promise((r) => setTimeout(r, 2_100));
+    expect(calls, "the poll stopped when the last subscriber left").toBeGreaterThan(afterOff);
+  } finally {
+    globalThis.fetch = realFetch;
+    (globalThis as any).window = realWindow;
+    (globalThis as any).document = realDocument;
+  }
+}, 10_000);

--- a/web/test/poll-visible.test.ts
+++ b/web/test/poll-visible.test.ts
@@ -1,0 +1,124 @@
+/*
+ * The phone polls five things, and every one of them used to run flat out with
+ * the tab hidden: gates and sessions every 4s, docker every 15s, working trees
+ * every 30s, pull requests every 60s, and a transcript every 5s while a chat is
+ * open. On a desk that is a handful of wasted requests. On a phone each tick is
+ * a radio wake, which is the part that reaches a battery graph.
+ *
+ * Two properties, and the second is what makes the first safe: skip while
+ * hidden, and catch up on the way back — but only if a tick was actually
+ * missed, so tabbing away and straight back does not fire a burst.
+ *
+ * The last test is the one that matters over time. Fixing the five polls that
+ * exist is worth little if the sixth is written the old way, so the rule is
+ * asserted over the tree rather than over the five.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { pollWhileVisible, type PollDoc } from "../src/lib/poll.ts";
+
+/** A document whose visibility the test drives. */
+function fakeDoc() {
+  const listeners = new Set<() => void>();
+  const d = {
+    hidden: false,
+    addEventListener: (_t: "visibilitychange", fn: () => void) => { listeners.add(fn); },
+    removeEventListener: (_t: "visibilitychange", fn: () => void) => { listeners.delete(fn); },
+  } satisfies PollDoc;
+  return {
+    doc: d as PollDoc,
+    hide: () => { d.hidden = true; for (const fn of listeners) fn(); },
+    show: () => { d.hidden = false; for (const fn of listeners) fn(); },
+    listeners,
+  };
+}
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("pollWhileVisible", () => {
+  test("runs while visible", async () => {
+    const { doc } = fakeDoc();
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 20, doc);
+    await wait(90);
+    stop();
+    expect(n).toBeGreaterThan(1);
+  });
+
+  test("stops running while hidden", async () => {
+    const { doc, hide } = fakeDoc();
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 20, doc);
+    await wait(70);
+    const before = n;
+    hide();
+    await wait(120);
+    stop();
+    // Not "no more than before" — exactly before. A tick that fires while
+    // hidden is the whole cost being removed.
+    expect(n).toBe(before);
+  });
+
+  test("catches up once on the way back, having missed a tick", async () => {
+    const { doc, hide, show } = fakeDoc();
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 20, doc);
+    await wait(50);
+    hide();
+    await wait(80); // several ticks skipped
+    const hidden = n;
+    show();
+    stop();
+    // Exactly one catch-up, not one per skipped tick: coming back from an hour
+    // away must not fire an hour of requests.
+    expect(n).toBe(hidden + 1);
+  });
+
+  test("does not catch up when nothing was missed", async () => {
+    const { doc, hide, show } = fakeDoc();
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 10_000, doc);
+    hide();
+    show(); // away and back inside one interval
+    stop();
+    expect(n).toBe(0);
+  });
+
+  test("stopping removes the listener as well as the timer", async () => {
+    const { doc, listeners } = fakeDoc();
+    const stop = pollWhileVisible(() => {}, 20, doc);
+    expect(listeners.size).toBe(1);
+    stop();
+    expect(listeners.size).toBe(0);
+  });
+
+  test("with no document at all it still runs, rather than silently never", async () => {
+    // A test environment or SSR. Failing closed here would turn "no DOM" into
+    // "no polling", which is a much worse bug than a few extra requests.
+    let n = 0;
+    const stop = pollWhileVisible(() => n++, 20, null as unknown as PollDoc | undefined);
+    await wait(70);
+    stop();
+    expect(n).toBeGreaterThan(1);
+  });
+});
+
+describe("every poll on the phone goes through it", () => {
+  // Fixing five polls is worth little if the sixth is written the old way.
+  const MOBILE = join(import.meta.dir, "..", "src", "mobile");
+  const files = (dir: string): string[] =>
+    readdirSync(dir).flatMap((n) => {
+      const p = join(dir, n);
+      return statSync(p).isDirectory() ? files(p) : p.endsWith(".tsx") || p.endsWith(".ts") ? [p] : [];
+    });
+
+  test("no raw setInterval survives in the phone tree", () => {
+    const offenders = files(MOBILE)
+      .filter((f) => /\bsetInterval\s*\(/.test(readFileSync(f, "utf8")))
+      .map((f) => f.slice(MOBILE.length + 1));
+    // The message names the fix, because the person who trips this will be
+    // adding a poll and will not know this rule exists.
+    expect(offenders, "use pollWhileVisible() — a raw setInterval polls a phone that nobody is looking at").toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Six polls ran flat out on a backgrounded phone — and one of them ran for a store that device never reads. `gateStore` now starts on its first subscriber instead of at import, and every poll in the phone tree goes through a `pollWhileVisible()` that skips while hidden and catches up on the way back.

## How was it tested?

`bun test` in `web/` — three consecutive full-suite runs, **454 pass / 0 fail**. `server/` 974 pass, 0 fail. `bunx tsc --noEmit` and `bun run build` clean. Two new test files, both run red first.

---

## The one nobody reads

`gateStore.ts` starts its **2-second** `/gate/pending` loop at module import:

```ts
if (typeof window !== "undefined") { void tick(); … }
```

It is imported by exactly two components — `Alerts.tsx` and `DynamicIsland.tsx`, both desktop. But `main.tsx` imports the desktop tree **unconditionally**, because it has to have both trees available to choose between them:

```ts
import App from "./App.tsx";               // ← evaluates gateStore, starts the poll
import { MobileApp } from "./mobile/MobileApp.tsx";
const Root = phone ? MobileApp : App;
```

So on a phone the module loaded, the loop started, and the results went nowhere: `MobileApp` keeps its own `gates` state and polls `/gate/pending` separately every 4s. **Thirty requests a minute, forever, discarded**, on the one device where each one is a radio wake.

(Gating on `document.documentElement.dataset.layout` would not have worked, incidentally — ES imports are evaluated before any statement in `main.tsx`, so the poll starts before that attribute is set.)

**The fix is to start on the first subscriber and never stop.** Never stopping is the point rather than an oversight — the module's own comment explains why the poll is at module level:

> Polling from that panel meant agentglass stopped noticing new holds the moment you opened the workspace

That guarantee is kept exactly. On the desktop `Alerts` is unconditionally mounted in the dashboard, so the poll begins on the first paint, when it always did. On a phone nobody ever subscribes, so it never begins. A test asserts the never-stopping half too, since "stop on last unsubscribe" is the tempting symmetry that would reintroduce the original bug.

## The five that ran hidden

| poll | every | guarded before |
|---|---|---|
| gates + sessions | 4s | ✗ |
| docker overview + stats | 15s | ✗ |
| working trees (per repo) | 30s | ✗ |
| pull requests (2 per repo) | 60s | ✗ |
| chat transcript | 5s | ✗ |
| `gateStore` | 2s | ✓ since it was written |

`pollWhileVisible()` skips the work while hidden and runs once on the way back **if a tick was missed**. The catch-up is what makes the skipping safe: returning to a view showing data from before you left is worse than the requests saved. *Only if missed*, so tabbing away and straight back does not fire a burst; *only once*, so an hour away does not fire an hour of them.

Skipping the work rather than clearing the timer is deliberate — browsers already throttle background timers to near-nothing, so the timer is free, and keeping it means coming back needs no re-arming.

## How the other four were found

The first pass here fixed `loadFast` alone — the one the original note pointed at. I then wrote the guard as a rule over the tree rather than an assertion about that one call site, and it immediately turned up **four more**: trees, PRs, docker and the transcript, three of which are heavier than the one I had just fixed.

That guard names the fix in its failure message, because whoever trips it will be adding a sixth poll and will not know this rule exists:

```
use pollWhileVisible() — a raw setInterval polls a phone that nobody is looking at
```

## Red first

| test | fails as |
|---|---|
| importing the store does not start a poll; subscribing does | `the module polled merely because it was imported` |
| no raw setInterval survives in the phone tree | names the offending files |

The `pollWhileVisible` unit tests drive an injected fake document rather than a real one, so the visibility rule is testable without a DOM — including the two negative cases that a naive implementation gets wrong: no catch-up when nothing was missed, and exactly one catch-up rather than one per skipped tick.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_