### PR TITLE
feat(audit): keep a record of who did what

### DIFF
--- a/README.md
+++ b/README.md
@@ -880,6 +880,7 @@ cannot be configured by `export` at all.
 | `GET /insights` | Derived warnings — loops, fast burn, high failure rate, spend velocity. |
 | `GET /search?q=` | Full-text search across all captured prompts/commands/outputs. |
 | `POST /gate` · `GET /gate/pending` · `POST /gate/decide` | Control-plane approve/deny for the opt-in `PreToolUse` gate. |
+| `GET /actions?limit=&before=` | Every write the cockpit performed — git, docker, pull requests, gate decisions — with the address it came from. Append-only; unscoped on purpose. |
 | `POST /control` | Drive the dashboard's own UI (switch view, toggle workspace, theme, zoom, new chat) from an external controller — a Stream Deck, a phone. Validated then rebroadcast on `/stream`; changes only what's shown, grants no capability the keyboard doesn't. See [`docs/EXTENDING.md`](docs/EXTENDING.md). |
 | `GET /export?format=csv\|json` | Download all events (bounded by retention). |
 | `GET /export?kind=daily&format=csv\|json` | Download the **daily totals**, rollup included — so a month already pruned still exports. |

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -83,7 +83,7 @@ and no menu item that removes recorded data. The `Clear ✕` in the header clear
 
 | Where | What is in it |
 |---|---|
-| `~/.local/share/agentglass/agentglass.db`<br><sub>or `$XDG_DATA_HOME/agentglass/`, or `./agentglass.db` if one is already there</sub> | Every event, with its `summary`, its `error_text` and the **raw hook payload** — which for a tool call is the command line, the file path, and the prompt. Plus session totals, the full-text search index, gate decisions, and the daily rollup. |
+| `~/.local/share/agentglass/agentglass.db`<br><sub>or `$XDG_DATA_HOME/agentglass/`, or `./agentglass.db` if one is already there</sub> | Every event, with its `summary`, its `error_text` and the **raw hook payload** — which for a tool call is the command line, the file path, and the prompt. Plus session totals, the full-text search index, gate decisions, the daily rollup, and the **activity log** — every write the dashboard performed, with the address it came from. |
 | `~/.config/agentglass/token` | The shared secret, `0600`, when one has been minted. |
 | `~/.config/agentglass/config.json` | The active project scope and the UI switches. |
 
@@ -97,6 +97,12 @@ Two things about retention are easy to get wrong:
 - **The rollup has no expiry at all.** Nothing prunes it, and there is no path
   in the product that removes a row from it. It is designed to be kept for
   years.
+- **Neither does the activity log.** Settings › Activity is an audit trail, so
+  it is append-only by design: every git write, container action, pull-request
+  action and gate decision, with what it touched and the address it came from
+  (`local` for this machine, otherwise the IP — there are no accounts here, so
+  a name would be invented). One row per thing a person pressed, which is tens
+  a day rather than the thousands an hour the events table takes.
 
 To get rid of any of it, delete the files. Stop the server first — SQLite is
 open while it runs:

--- a/server/src/actions.ts
+++ b/server/src/actions.ts
@@ -1,0 +1,99 @@
+// What the cockpit did, and where the request came from.
+//
+// The dashboard performs real writes: it stages and discards, pushes, merges
+// pull requests, removes containers, and answers the gate that has an agent
+// stopped at the other end of it. Until now the only record was a ring buffer
+// that says of itself it is "a live view of the current session, not an audit
+// trail" (gitlog.ts:11) — so "who approved that", and "what happened to my
+// branch while I was at lunch", had no answer at all.
+//
+// This module owns two decisions and nothing else: who the actor is, and what
+// the target of a route was. The writing itself is db.recordAction.
+
+import { isLoopback } from "./remote.ts";
+import { recordAction } from "./db.ts";
+import { basename } from "node:path";
+
+/**
+ * Who did it, as far as the server can honestly tell.
+ *
+ * There are no accounts here, and the token is shared rather than personal, so
+ * a name would be a fiction. What is true is where the request arrived from:
+ * `local` for a loopback caller — the dashboard on this machine — and the
+ * address for anything else, which is what makes "I approved that from my
+ * phone" a question with an answer.
+ */
+export function actorOf(ip: string | null | undefined): string {
+  if (!ip) return "local";
+  return isLoopback(ip) ? "local" : ip.replace(/^::ffff:/, "");
+}
+
+/** Longest a target may be. A commit message or a review body belongs in the
+ *  thing it was written on, not in a log line about it. */
+const MAX_TARGET = 120;
+const clip = (s: string) => (s.length > MAX_TARGET ? s.slice(0, MAX_TARGET - 1) + "…" : s);
+
+/**
+ * The subject of a write, short enough to read in a list.
+ *
+ * `root` is an absolute path and would be the same prefix on every line, so it
+ * is reduced to the checkout's own name — which is what the rest of the UI
+ * shows too. What varies is what follows it, and that is the part worth
+ * keeping: which files were discarded, which branch was deleted, which
+ * container was removed.
+ */
+export function targetOf(pathname: string, b: Record<string, unknown>): string {
+  const repo = typeof b.root === "string" && b.root ? basename(b.root) : "";
+  const paths = Array.isArray(b.paths) ? (b.paths as unknown[]).filter((p) => typeof p === "string") as string[] : [];
+  const named = (n: unknown) => (typeof n === "string" || typeof n === "number" ? String(n) : "");
+
+  // A gate: what was held, not the uuid it was held under.
+  if (pathname.startsWith("/gate/")) return clip([named(b.tool), named(b.summary)].filter(Boolean).join(" · "));
+  if (pathname.startsWith("/docker/")) return named(b.id);
+  // A chat launch: where it runs and on what. Never the prompt — see index.ts.
+  if (pathname === "/chat/send") return clip([repo, named(b.name)].filter(Boolean).join(" · "));
+  if (pathname.startsWith("/prs/")) {
+    const num = named(b.number);
+    return clip([repo, num && `#${num}`].filter(Boolean).join(" "));
+  }
+  if (pathname.startsWith("/git/")) {
+    // The argument that identifies what was touched. Which one that is depends
+    // on the verb, and getting it wrong turns "deleted branch release-4" into
+    // an unhelpful bare repo name.
+    const what =
+      paths.length ? paths.map((p) => (repo && p.includes("/") ? p.split("/").slice(-2).join("/") : p)).join(" ")
+      : named(b.name) || named(b.message) || named(b.title) || named(b.ref) || named(b.to)
+      || (b.index !== undefined ? `#${named(b.index)}` : "");
+    return clip([repo, what].filter(Boolean).join(" "));
+  }
+  return clip(repo);
+}
+
+/**
+ * Record one write.
+ *
+ * Everything that goes through a write route is kept, including the small
+ * things — a resolved review thread, an emoji reaction. A recorder that decides
+ * what is worth recording is a log nobody can trust, and the filtering belongs
+ * to whoever reads it. The volume allows for that: every row here is a person
+ * pressing something, which is tens a day, not the thousands an hour the events
+ * table takes.
+ *
+ * `/control` is not routed through here and is not meant to be: it moves the
+ * UI's own focus and grants nothing the keyboard does not already have, so
+ * logging it would bury the merges under navigation.
+ */
+export function noteAction(
+  ip: string | null | undefined,
+  pathname: string,
+  body: Record<string, unknown>,
+  res: { ok?: boolean; error?: string } | null,
+): void {
+  recordAction({
+    actor: actorOf(ip),
+    action: pathname,
+    target: targetOf(pathname, body),
+    ok: !!res?.ok,
+    detail: res?.error ? clip(String(res.error)) : null,
+  });
+}

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -333,6 +333,84 @@ for (const col of ["project_path", "cwd_path"]) {
 db.exec("CREATE INDEX IF NOT EXISTS idx_sessions_project ON sessions(project_path)");
 
 // ---------------------------------------------------------------------------
+/**
+ * Who did what, kept.
+ *
+ * The cockpit performs real writes — it stages and discards, force-pushes,
+ * merges pull requests, removes containers, and answers the gate that has an
+ * agent stopped at the other end of it. Every one of those was recorded only in
+ * a ring buffer that says of itself, at gitlog.ts:11, that it is "a live view of
+ * the current session, not an audit trail". So the moment more than one person
+ * can reach a cockpit — or one person can reach it from two devices — "who
+ * approved that" has no answer, and neither does "what happened to my branch
+ * while I was at lunch".
+ *
+ * Append-only, and small enough to stay that way: every row here is a human
+ * pressing something, which is tens of rows a day, not the thousands an hour
+ * the events table takes. Nothing prunes it and nothing needs to.
+ *
+ * `actor` is what the server can honestly assert, which is where the request
+ * came from and nothing more. There are no accounts here — a token is shared,
+ * not personal — so claiming a name would be a fiction. `local` means the
+ * loopback caller, which is the dashboard on this machine; anything else is the
+ * address it came from, which is how "I approved that from my phone" gets an
+ * answer.
+ */
+db.exec(`
+CREATE TABLE IF NOT EXISTS actions (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  at INTEGER NOT NULL,
+  actor TEXT NOT NULL,
+  action TEXT NOT NULL,
+  target TEXT NOT NULL DEFAULT '',
+  ok INTEGER NOT NULL,
+  detail TEXT
+);
+CREATE INDEX IF NOT EXISTS idx_actions_at ON actions(at);
+`);
+
+export interface ActionRow {
+  id: number;
+  at: number;
+  actor: string;
+  action: string;
+  target: string;
+  ok: number;
+  detail: string | null;
+}
+
+const actionInsert = db.query(
+  `INSERT INTO actions (at, actor, action, target, ok, detail) VALUES ($at, $actor, $action, $target, $ok, $detail)`
+);
+
+/** Write one row. Never throws: a failed audit write must not fail the action
+ *  it was recording, which would be a worse outcome than a missing line. */
+export function recordAction(a: {
+  actor: string; action: string; target?: string; ok: boolean; detail?: string | null; at?: number;
+}): void {
+  try {
+    actionInsert.run({
+      $at: a.at ?? Date.now(),
+      $actor: a.actor,
+      $action: a.action,
+      $target: a.target ?? "",
+      $ok: a.ok ? 1 : 0,
+      $detail: a.detail ?? null,
+    } as any);
+  } catch { /* the action already happened; losing its record is the lesser harm */ }
+}
+
+/** Newest first. Unscoped on purpose: the question this answers is "what has
+ *  been done through this cockpit", and narrowing it by the project that
+ *  happens to be open would hide exactly the answer somebody is looking for. */
+export function actionLog(limit = 200, before?: number): ActionRow[] {
+  const n = Math.max(1, Math.min(1000, limit));
+  return before
+    ? db.query<ActionRow, [number, number]>(`SELECT * FROM actions WHERE at < ? ORDER BY at DESC, id DESC LIMIT ?`).all(before, n)
+    : db.query<ActionRow, [number]>(`SELECT * FROM actions ORDER BY at DESC, id DESC LIMIT ?`).all(n);
+}
+
+// ---------------------------------------------------------------------------
 // Control plane: gate requests.
 //
 // The gate used to live only in memory, which made the one feature whose job is

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -21,8 +21,11 @@ import {
   dailyUsage,
   rollupEarliestDay,
   retentionSeamDay,
+  getGate,
+  actionLog,
 } from "./db.ts";
 import { maybeAlert, setAlertSink } from "./alerts.ts";
+import { noteAction } from "./actions.ts";
 import { getSkills, catalogMarkdown, catalogCsv, usageSince } from "./skills.ts";
 import { getInsights } from "./insights.ts";
 import { getUsage } from "./usage.ts";
@@ -694,7 +697,16 @@ const server = Bun.serve<WsData>({
       if (!localOrigin(req)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false }); }
-      const ok = decideGate(String(b.id), b.decision === "deny" ? "deny" : "allow", String(b.reason || ""));
+      const decision = b.decision === "deny" ? "deny" : "allow";
+      // Read the row BEFORE deciding: afterwards it is resolved, and what makes
+      // the line worth keeping is what was held, not the uuid it was held
+      // under. "denied Bash · rm -rf build" is an audit line; a uuid is not.
+      const held = getGate(String(b.id));
+      const ok = decideGate(String(b.id), decision, String(b.reason || ""));
+      // "Who approved that" is the question #299 opens with, and a gate is the
+      // one write with a stopped agent on the other end of it.
+      noteAction(srv.requestIP(req)?.address, `/gate/${decision}`,
+        { tool: held?.tool_name, summary: held?.summary }, { ok });
       return json({ ok });
     }
     // Drive the dashboard's own UI from outside — a Stream Deck, a phone. Unlike
@@ -960,7 +972,9 @@ const server = Bun.serve<WsData>({
         case "/git/undo-merge": res = await undoMerge(root); break;
         default: res = null;
       }
-      if (res) return json(res, res.ok ? 200 : 400);
+      // Every write through this switch is recorded — see actions.ts for why
+      // it keeps the small ones too.
+      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res); return json(res, res.ok ? 200 : 400); }
     }
 
     // --- live docker panel (lazydocker-style) ---
@@ -1013,7 +1027,9 @@ const server = Bun.serve<WsData>({
         case "/docker/rm": res = await removeContainer(id); break;
         default: res = null;
       }
-      if (res) return json(res, res.ok ? 200 : 400);
+      // Every write through this switch is recorded — see actions.ts for why
+      // it keeps the small ones too.
+      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res); return json(res, res.ok ? 200 : 400); }
     }
 
     // --- pull requests (gh-backed) ---
@@ -1111,7 +1127,9 @@ const server = Bun.serve<WsData>({
         case "/prs/review-prompt": res = await prepareReviewPrompt(root, n); break;
         default: res = null;
       }
-      if (res) return json(res, res.ok ? 200 : 400);
+      // Every write through this switch is recorded — see actions.ts for why
+      // it keeps the small ones too.
+      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res); return json(res, res.ok ? 200 : 400); }
     }
 
     // --- in-browser terminal: ready-to-run project commands (make + scripts) ---
@@ -1144,6 +1162,16 @@ const server = Bun.serve<WsData>({
       if (!localOrigin(req)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
+      // The launch, not the turn. chatSend returns a stream rather than an
+      // outcome, and the auditable fact is that somebody started an agent in a
+      // checkout through this cockpit — what it then does is gated and lands in
+      // the events table on its own.
+      //
+      // The prompt is deliberately not kept here. It is already in the
+      // transcript and in `events`, and a second copy in an append-only table
+      // that nothing prunes is a copy nobody asked for.
+      noteAction(srv.requestIP(req)?.address, "/chat/send",
+        { root: b.cwd, name: b.model }, { ok: true });
       return chatSend(b);
     }
     // The command that hands a chat to the user's own terminal. Server-side
@@ -1270,6 +1298,20 @@ const server = Bun.serve<WsData>({
         retention_days: RETENTION_DAYS,
         rollup_from: rollupEarliestDay(),
       });
+    }
+
+    /*
+     * What has been done through this cockpit.
+     *
+     * Unscoped on purpose. Every other metric narrows to the open project, but
+     * the question this answers — "who merged that", "what happened while I was
+     * at lunch" — is at its most useful precisely when the answer is somewhere
+     * you were not looking.
+     */
+    if (pathname === "/actions") {
+      const limit = Number(url.searchParams.get("limit") || 200);
+      const before = Number(url.searchParams.get("before")) || undefined;
+      return json({ actions: actionLog(limit, before).map((a) => ({ ...a, ok: !!a.ok })) });
     }
 
     // --- export ---

--- a/server/test/action-log.test.ts
+++ b/server/test/action-log.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Who did what, kept — #299.
+ *
+ * The cockpit performs real writes: it discards, force-pushes, merges pull
+ * requests, removes containers, and answers the gate that has an agent stopped
+ * at the other end of it. The only record was a ring buffer that says of itself
+ * it is "a live view of the current session, not an audit trail"
+ * (gitlog.ts:11), so "who approved that" had no answer at all.
+ *
+ * The last test is the one with a future: an audit trail with a hole in it is
+ * worse than none, because you stop looking for the missing line. So the rule
+ * is asserted over the routing table rather than over the four sites that
+ * exist today.
+ */
+import { describe, expect, test, beforeAll } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { actorOf, targetOf } from "../src/actions.ts";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-actions-"));
+process.env.AGENTGLASS_DB = join(dir, "actions.db");
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+beforeAll(async () => { db = await import("../src/db.ts"); });
+
+describe("who", () => {
+  test("a loopback caller is this machine, not an address", () => {
+    // The dashboard fetches itself thousands of times; "127.0.0.1" on every
+    // line would be noise standing in for the only case that needs no name.
+    for (const ip of ["127.0.0.1", "127.0.1.1", "::1", "::ffff:127.0.0.1"]) {
+      expect(actorOf(ip), ip).toBe("local");
+    }
+    expect(actorOf(null)).toBe("local");
+    expect(actorOf(undefined)).toBe("local");
+  });
+
+  test("anything else is the address it came from", () => {
+    // The whole point: "I approved that from my phone" becomes answerable.
+    expect(actorOf("192.168.1.42")).toBe("192.168.1.42");
+    // Bun hands back v4-mapped v6 on a dual-stack listener; the log should not
+    // show two different actors for one phone.
+    expect(actorOf("::ffff:192.168.1.42")).toBe("192.168.1.42");
+  });
+});
+
+describe("what it was done to", () => {
+  test("a git write names the files, not just the repo", () => {
+    // "discarded shop-api" tells you nothing you needed; the path is the whole
+    // reason to read the line.
+    expect(targetOf("/git/discard", { root: "/home/you/code/shop-api", paths: ["src/pay.ts"] }))
+      .toBe("shop-api src/pay.ts");
+  });
+
+  test("a git write with no paths names whatever else identifies it", () => {
+    expect(targetOf("/git/branch-delete", { root: "/home/you/code/shop-api", name: "feat/coupon" }))
+      .toBe("shop-api feat/coupon");
+    expect(targetOf("/git/stash-drop", { root: "/home/you/code/shop-api", index: 2 }))
+      .toBe("shop-api #2");
+  });
+
+  test("a gate names what was held, not the uuid it was held under", () => {
+    expect(targetOf("/gate/deny", { tool: "Bash", summary: "rm -rf build" }))
+      .toBe("Bash · rm -rf build");
+  });
+
+  test("a pull request names the repo and the number", () => {
+    expect(targetOf("/prs/merge", { root: "/home/you/code/shop-api", number: 482 })).toBe("shop-api #482");
+  });
+
+  test("a commit message is clipped rather than kept whole", () => {
+    // A body belongs in the commit, not in a log line about it — and an
+    // unbounded field here is an unbounded row for every future write.
+    const t = targetOf("/git/commit-staged", { root: "/r", title: "x".repeat(500) });
+    expect(t.length).toBeLessThanOrEqual(120);
+    expect(t.endsWith("…")).toBe(true);
+  });
+});
+
+describe("the record", () => {
+  test("a write is kept, with its outcome", () => {
+    db.recordAction({ actor: "local", action: "/git/push", target: "agentglass", ok: false, detail: "rejected" });
+    const [row] = db.actionLog(1);
+    expect(row!.action).toBe("/git/push");
+    expect(row!.ok).toBe(0);
+    expect(row!.detail).toBe("rejected");
+  });
+
+  test("newest first, and pageable past the newest", () => {
+    const base = Date.now();
+    for (let i = 0; i < 5; i++) {
+      db.recordAction({ actor: "local", action: `/git/stage`, target: `f${i}`, ok: true, at: base + i });
+    }
+    const page = db.actionLog(3);
+    expect(page.map((a) => a.target)).toEqual(["f4", "f3", "f2"]);
+    // `before` is what a "load more" needs, and an off-by-one here would either
+    // repeat a row or skip one.
+    expect(db.actionLog(2, page[2]!.at).map((a) => a.target)).toEqual(["f1", "f0"]);
+  });
+
+  test("a failed write to the log does not fail the action it was recording", () => {
+    // The action already happened. Losing its line is bad; throwing after the
+    // branch is already deleted is worse.
+    expect(() => db.recordAction({
+      actor: "local", action: "/git/push", ok: true,
+      detail: { toString() { throw new Error("nope"); } } as unknown as string,
+    })).not.toThrow();
+  });
+});
+
+describe("nothing writes without being recorded", () => {
+  /*
+   * The three families each route through one switch, and the gate through its
+   * own handler. That is four places to instrument today — and exactly four
+   * places for a fifth to be added without one.
+   */
+  const index = readFileSync(join(import.meta.dir, "..", "src", "index.ts"), "utf8");
+
+  test("every write chokepoint records before it answers", () => {
+    // Each family ends in a single `if (res) return json(res, …)`. Find them
+    // all and require noteAction on the same line.
+    const returns = index.split("\n").filter((l) => /if \(res\) .*return json\(res/.test(l));
+    expect(returns.length, "the write switches were restructured — re-check this guard").toBe(3);
+    for (const line of returns) {
+      expect(line, "a write family answers without recording").toContain("noteAction(");
+    }
+  });
+
+  test("the gate decision records too", () => {
+    const at = index.indexOf('pathname === "/gate/decide"');
+    expect(at).toBeGreaterThan(-1);
+    const handler = index.slice(at, index.indexOf("\n    }", at));
+    expect(handler).toContain("noteAction(");
+    // Read before deciding, or the row is already resolved and the line loses
+    // the only part worth keeping.
+    expect(handler.indexOf("getGate(")).toBeLessThan(handler.indexOf("decideGate("));
+  });
+
+  test("a chat launch is recorded, and its prompt is not", () => {
+    // #299 names chat-initiated runs. What is auditable is that somebody
+    // started an agent in a checkout; the prompt is already in the transcript
+    // and in `events`, and a second copy in a table nothing prunes is a copy
+    // nobody asked for.
+    const at = index.indexOf('pathname === "/chat/send"');
+    expect(at).toBeGreaterThan(-1);
+    const handler = index.slice(at, index.indexOf("\n    }", at));
+    expect(handler).toContain("noteAction(");
+    expect(handler, "the prompt must not reach the audit log").not.toMatch(/noteAction\([^)]*b\.message/s);
+    expect(targetOf("/chat/send", { root: "/home/you/code/shop-api", name: "opus" })).toBe("shop-api · opus");
+  });
+
+  test("/control is left out, and that is a decision rather than an oversight", () => {
+    // It moves the UI's own focus and grants nothing the keyboard does not
+    // already have, so logging it would bury the merges under navigation.
+    const at = index.indexOf('pathname === "/control"');
+    expect(at).toBeGreaterThan(-1);
+    expect(index.slice(at, at + 600)).not.toContain("noteAction(");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -308,6 +308,27 @@ export interface GateRecord extends PendingGate {
   decided_at: number | null;
 }
 
+/**
+ * One write the cockpit performed, kept.
+ *
+ * `actor` is where the request came from, not who someone is: there are no
+ * accounts and the token is shared, so `local` means the loopback caller — this
+ * machine's dashboard — and anything else is the address it arrived from.
+ */
+export interface ActionRecord {
+  id: number;
+  at: number;
+  actor: string;
+  /** The route, which is the verb: `/git/discard`, `/docker/rm`, `/gate/deny`. */
+  action: string;
+  /** What it was done to, already shortened for a list. Empty when there is
+   *  nothing more specific than the route itself. */
+  target: string;
+  ok: boolean;
+  /** The server's error text when it failed. */
+  detail: string | null;
+}
+
 export interface SearchHit {
   id: number;
   timestamp: number;

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -12,6 +12,8 @@ import { useEffect, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
+import { fmtAgo } from "../lib/format.ts";
+import type { ActionRecord } from "../../../shared/types.ts";
 import { ingestUpdate } from "../lib/updateStore.ts";
 import { ReleaseNotesModal } from "./ReleaseNotesModal.tsx";
 import { installedNotes, type NotesTarget } from "../lib/whatsNew.ts";
@@ -125,12 +127,13 @@ function Row({ label, hint, kbd, href, download, onClick }: { label: string; hin
     : <button onClick={onClick} className={cls}>{body}</button>;
 }
 
-type Pane = "prefs" | "keys" | "open" | "export" | "hooks" | "reqs" | "remote" | "about";
+type Pane = "prefs" | "keys" | "open" | "export" | "log" | "hooks" | "reqs" | "remote" | "about";
 const TABS: { id: Pane; label: string }[] = [
   { id: "prefs", label: "Preferences" },
   { id: "keys", label: "Shortcuts" },
   { id: "open", label: "Open" },
   { id: "export", label: "Export" },
+  { id: "log", label: "Activity" },
   { id: "hooks", label: "Hooks" },
   { id: "reqs", label: "Requirements" },
   { id: "remote", label: "Remote" },
@@ -217,6 +220,111 @@ function KeyRow({ id, keyName, capturing, onCapture, error, chord }: {
  * it cannot run — a dirty checkout, a diverged branch — it says which, because
  * "update unavailable" sends people looking in the wrong place.
  */
+/**
+ * What has been done through this cockpit.
+ *
+ * The dashboard makes real changes — it discards, force-pushes, merges pull
+ * requests, removes containers, answers the gate an agent is stopped at — and
+ * every one of those was recorded only in a ring buffer that says of itself it
+ * is a live view of the session rather than an audit trail. So "who approved
+ * that" and "what happened to my branch while I was at lunch" had no answer.
+ *
+ * `actor` is deliberately an address rather than a name. There are no accounts
+ * here and the token is shared, so a name would be invented; where the request
+ * came from is a fact. `local` is this machine's dashboard, and anything else
+ * is the device that reached it — which is what makes "I approved that from my
+ * phone" answerable.
+ */
+function ActivityPane({ open }: { open: boolean }) {
+  const [rows, setRows] = useState<ActionRecord[] | null>(null);
+  useEffect(() => {
+    if (!open) return;
+    let alive = true;
+    api.actions(200).then((r) => { if (alive) setRows(r.actions); }).catch(() => { if (alive) setRows([]); });
+    return () => { alive = false; };
+  }, [open]);
+
+  if (!rows) return <Section title="Activity"><div className="px-3 py-3 text-[11.5px] t-dim2">Loading…</div></Section>;
+  if (!rows.length) {
+    return (
+      <Section title="Activity">
+        <div className="px-3 py-3 text-[11.5px] t-dim2">
+          Nothing yet. Every write this dashboard performs — staging, discarding, pushing,
+          merging, container actions, gate decisions — is recorded here as it happens.
+        </div>
+      </Section>
+    );
+  }
+
+  return (
+    <Section title="Activity">
+      <div className="px-3 pb-2 text-[10.5px] t-dim2">
+        Newest first. Kept indefinitely — these are the changes you made, not telemetry.
+      </div>
+      <div className="flex flex-col">
+        {rows.map((a) => (
+          <div key={a.id} className="grid grid-cols-[auto_minmax(0,1fr)_auto] gap-x-3 items-baseline px-3 py-1.5 rounded-lg hover:bg-white/5">
+            <span
+              className="text-[9.5px] font-semibold tabular-nums shrink-0"
+              style={{ color: a.ok ? "var(--text4)" : "var(--error)" }}
+              title={a.ok ? "succeeded" : a.detail || "failed"}
+            >
+              {a.ok ? "·" : "✕"}
+            </span>
+            <span className="min-w-0">
+              <span className="text-[11.5px]" style={{ color: "var(--text)" }}>{verb(a.action)}</span>
+              {a.target && <span className="text-[11.5px] t-dim"> {a.target}</span>}
+              {!a.ok && a.detail && <span className="block text-[10px] mt-0.5" style={{ color: "var(--error)" }}>{a.detail}</span>}
+            </span>
+            <span className="text-[9.5px] t-dim2 tabular-nums shrink-0 text-right">
+              {a.actor === "local" ? "" : `${a.actor} · `}{fmtAgo(a.at)}
+            </span>
+          </div>
+        ))}
+      </div>
+    </Section>
+  );
+}
+
+/**
+ * `/git/branch-delete` reads as a route. "deleted branch" reads as something a
+ * person did, which is what a log is for — and past tense, because every line
+ * here is already over.
+ *
+ * Named where naming helps and derived where it does not, so a route added
+ * later still produces a readable line instead of nothing.
+ */
+const VERBS: Record<string, string> = {
+  "/gate/allow": "approved", "/gate/deny": "denied",
+  "/git/stage": "staged", "/git/unstage": "unstaged",
+  "/git/stage-all": "staged everything", "/git/unstage-all": "unstaged everything",
+  "/git/discard": "discarded", "/git/commit-staged": "committed",
+  "/git/push": "pushed", "/git/pull": "pulled", "/git/fetch": "fetched",
+  "/git/checkout": "checked out", "/git/branch-create": "created branch",
+  "/git/branch-delete": "deleted branch", "/git/branch-rename": "renamed branch",
+  "/git/merge": "merged", "/git/rebase": "rebased", "/git/reset": "reset",
+  "/git/stash-push": "stashed", "/git/stash-apply": "applied stash",
+  "/git/stash-pop": "popped stash", "/git/stash-drop": "dropped stash",
+  "/git/apply-hunk": "staged a hunk", "/git/undo-merge": "undid the merge",
+  "/git/worktree-add": "added worktree", "/git/worktree-remove": "removed worktree",
+  "/docker/start": "started container", "/docker/stop": "stopped container",
+  "/docker/restart": "restarted container", "/docker/rm": "removed container",
+  "/prs/merge": "merged pull request", "/prs/close": "closed pull request",
+  "/prs/review": "reviewed", "/prs/comment": "commented on",
+  "/prs/rerun": "re-ran the checks on", "/prs/draft": "changed draft state of",
+  "/chat/send": "started a chat in",
+};
+
+function verb(action: string): string {
+  const known = VERBS[action];
+  if (known) return known;
+  const [, family, ...rest] = action.split("/");
+  const what = rest.join("/").replace(/-/g, " ");
+  if (family === "docker") return `${what} container`;
+  if (family === "prs") return `${what} pull request`;
+  return what || action;
+}
+
 function AboutPane({ open }: { open: boolean }) {
   const [st, setSt] = useState<UpdateStatus | null>(null);
   const [busy, setBusy] = useState(false);
@@ -921,6 +1029,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
 
                   {pane === "remote" && <RemoteAccessPane open={open} />}
 
+                  {pane === "log" && <ActivityPane open={open} />}
                   {pane === "about" && <AboutPane open={open} />}
                   </div>
                 </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, UsageHistory } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -281,6 +281,10 @@ const realApi = {
   search: (q: string) => get<{ hits: SearchHit[] }>(`/search?q=${encodeURIComponent(q)}`),
   gatePending: () => get<{ gates: PendingGate[] }>(`/gate/pending`),
   gateHistory: (limit = 25) => get<{ gates: GateRecord[] }>(`/gate/history?limit=${limit}`),
+  // Unscoped, unlike every other metric call: "who merged that" is at its most
+  // useful when the answer is somewhere you were not looking.
+  actions: (limit = 200, before?: number) =>
+    get<{ actions: ActionRecord[] }>(`/actions?limit=${limit}${before ? `&before=${before}` : ""}`),
   gateDecide: (id: string, decision: "allow" | "deny", reason = "") =>
     fetch(SERVER + "/gate/decide", {
       method: "POST",
@@ -590,6 +594,7 @@ const demoApi: typeof realApi = {
   search: (q: string) => D(demo.search(q)),
   gatePending: () => D(demo.gatePending()),
   gateHistory: () => D({ gates: [] as GateRecord[] }),
+  actions: () => D(demo.actions()),
   gateDecide: (id: string) => D(demo.gateDecide(id)),
   gitStatus: (_paths: string[]) => D(demo.gitStatus()),
   gitCommit: (_payload: { root: string; files: string[]; title: string; body: string }) => D(demo.gitCommit()),

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -12,7 +12,7 @@ import type {
   WalkthroughResult, WalkthroughInputFile, GitRepoRef, WorkingTree, GitFileChange, GitActionResult,
   GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, DockerOverview, DockerStat, DockerActionResult,
   PrRepoId, PrSummary, PrDetail, PrThread, PrCheck, PrCheckRollup, PrCheckState, PrListResponse,
-  UsageDay, UsageHistory,
+  UsageDay, UsageHistory, ActionRecord,
 } from "../../../shared/types.ts";
 import { modelLabelOf, providerOf } from "./format.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
@@ -625,6 +625,27 @@ export function dailyExportUri(fmt: "csv" | "json"): string {
   ];
   const rows = h.days.map((d) => cols.map((c) => String(d[c])).join(","));
   return dataUri("text/csv", [cols.join(","), ...rows].join("\n"));
+}
+
+/** A plausible afternoon of writes, for the showcase. */
+export function actions(): { actions: ActionRecord[] } {
+  const now = Date.now();
+  const rows: [string, string, string, boolean, string | null][] = [
+    ["local", "/gate/deny", "Bash · rm -rf ./dist ./node_modules", true, null],
+    ["192.168.1.42", "/prs/merge", "shop-api #482", true, null],
+    ["192.168.1.42", "/gate/allow", "Write · src/checkout/index.ts", true, null],
+    ["local", "/git/discard", "shop-api src/pay.ts", true, null],
+    ["local", "/docker/rm", "shop-api-redis-1", true, null],
+    ["local", "/git/branch-delete", "shop-api feat/coupon-table", true, null],
+    ["local", "/git/push", "agentglass", false, "rejected — remote has commits you do not"],
+    ["local", "/prs/review", "shop-api #468", true, null],
+    ["local", "/git/commit-staged", "agentglass round prices at the cart boundary", true, null],
+  ];
+  return {
+    actions: rows.map(([actor, action, target, ok, detail], i) => ({
+      id: rows.length - i, at: now - i * rnd(4, 40) * 60_000, actor, action, target, ok, detail,
+    })),
+  };
 }
 
 export function skillsExportUri(): string {


### PR DESCRIPTION
Addresses #299. **One deliberate divergence from what the issue asks for — see *On `decided_by`* below.** Not marked as closing it; that call is yours.

## What does this PR do?

An append-only `actions` table records every write the cockpit performs — git, docker, pull requests, gate decisions, chat launches — with what it touched, whether it worked, and where the request came from. Settings gains an **Activity** pane that reads it back.

## How was it tested?

`bun test` — `server/` 988 pass, `web/` 454 pass, 0 fail. 14 new tests in `server/test/action-log.test.ts`, run **red first**. `bunx tsc --noEmit` and `bun run build` clean. The pane was rendered headless against the demo build; the route was driven against a live server with a real failed `git discard`, which came back as `{"actor":"local","action":"/git/discard","target":"nope src/pay.ts","ok":false,"detail":"not a git repository root"}`.

---

## The gap

`gitlog.ts:11` says it out loud:

> a live view of the current session, not an audit trail

That was the only record of anything the dashboard did. So the moment more than one person can reach a cockpit — or one person can reach it from two devices — *"who approved that"* had no answer, and neither did *"what happened to my branch while I was at lunch"*.

## What it looks like

```
ACTIVITY
Newest first. Kept indefinitely — these are the changes you made, not telemetry.

 ·  denied Bash · rm -rf ./dist ./node_modules                              now
 ·  merged pull request shop-api #482                    192.168.1.42 · 28m
 ·  approved Write · src/checkout/index.ts               192.168.1.42 · 22m
 ·  discarded shop-api src/pay.ts                                          30m
 ·  removed container shop-api-redis-1                                      1h
 ✕  pushed agentglass                                                       2h
    rejected — remote has commits you do not
```

The address only appears when it is not `local`, so a desk-only install reads as a plain list and the one line you answered from the bus stands out.

## Three decisions worth arguing with

**`actor` is an address, not a name.** There are no accounts here and the token is shared rather than personal, so a name would be a fiction the log then carries forever. Where a request arrived from is a fact. `local` is the loopback caller — this machine's dashboard — and anything else is the device that reached it. v4-mapped v6 is unwrapped so one phone is one actor.

**Everything is kept, including the small things.** A resolved review thread and an emoji reaction go in beside the merges. A recorder that decides what is worth recording is a log nobody can trust, and filtering belongs to whoever reads it. The volume allows it: every row is a person pressing something — tens a day, not the thousands an hour `events` takes — so nothing prunes it and nothing needs to.

**Two things are left out on purpose.** `/control` moves the UI's own focus and grants nothing the keyboard does not already have, so logging it would bury the merges under navigation. And a chat launch records the checkout and the model but **never the prompt** — that is already in the transcript and in `events`, and a second copy in a table nothing prunes is a copy nobody asked for. Both have tests asserting the absence, so neither can be quietly "fixed" later.

## On `decided_by`

The issue asks for a `decided_by` column on the gate record. **I did not add one**, and the reasoning is worth your judgement rather than mine alone:

`gates` has no viewer. The Alerts panel's history strip filters to `resolution !== "human"` — it exists to surface outcomes *nobody chose* — so a column recording who chose one would have had nowhere to render. Adding a stored column with no reader is exactly what #376 did with the retention rollup, which #381 then had to go back and finish.

A gate decision is a write like the others, so it is one row type in the log, and the question the issue opens with — *"who approved that"* — is answered in the pane. If you would rather also have the column on `gates` for a future gate-history view, say so and it is a small follow-up.

## The guard that matters

An audit trail with a hole in it is worse than none, because you stop looking for the missing line. So the rule is asserted over the **routing table**, not over the five sites that exist today:

| test | fails when |
|---|---|
| every write chokepoint records before it answers | a family answers without `noteAction` — and separately if the three switches are restructured, so the guard cannot silently stop watching |
| the gate decision records too | …and that it calls `getGate` **before** `decideGate`, since afterwards the row is resolved and the line loses the only part worth keeping |
| a chat launch is recorded, and its prompt is not | either half changes |
| `/control` is left out | it gains a `noteAction`, which should be a conscious decision |

Removing the recording from one family and from the gate fails two of them.

The three write families each route through a single `switch` with one `return json(res, …)`, which is why this is four instrumentation points rather than forty — that was the finding that made the whole issue tractable.

## Docs

`SECURITY.md` updated **in the same commit**, which its own tripwire from #384 required: the storage table names this log, and the retention section says it is append-only by design. `README.md` gains the `/actions` row.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_