### PR TITLE
fix(explain): stop sending your .env to a model

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -87,6 +87,18 @@ and no menu item that removes recorded data. The `Clear ✕` in the header clear
 | `~/.config/agentglass/token` | The shared secret, `0600`, when one has been minted. |
 | `~/.config/agentglass/config.json` | The active project scope and the UI switches. |
 
+**One feature does send data off this machine, and it is the only one.** The AI
+**Explain** walkthrough hands your changed lines to a model — the local `claude`
+CLI, or the Anthropic API if you have set a key — so it can describe them. That
+is what the button is for, and it runs only when you press it.
+
+What it will not send: files whose contents are a credential by design (`.env*`,
+`*.pem`, `*.key`, `id_rsa`, `credentials.json`, `.npmrc`, and their neighbours)
+are held back, and the patches that do go are run through the same secret
+scrubber the crash reporter uses, for a key pasted into an ordinary source file.
+Anything withheld is **named on screen** rather than quietly missing — a summary
+of a different changeset than the one you are looking at is worse than none.
+
 Two things about retention are easy to get wrong:
 
 - **`AGENTGLASS_RETENTION_DAYS` bounds the raw events, not the history.** Expiring

--- a/server/src/walkthrough.ts
+++ b/server/src/walkthrough.ts
@@ -11,6 +11,7 @@
 
 import Anthropic from "@anthropic-ai/sdk";
 import type { WalkthroughResult, WalkthroughInputFile } from "../../shared/types.ts";
+import { stripSecrets } from "../../shared/scrub.ts";
 
 // Haiku by default: the task is a one-liner per file, so a small fast model is
 // plenty and keeps latency + token cost low. Override with the env var to trade
@@ -67,6 +68,37 @@ const SCHEMA = {
 // Human-readable shape for the CLI path (no structured-output enforcement).
 const SCHEMA_HINT = '{"reviewFocus": string, "files": [{"path": string, "description": string, "tag": "feature"|"fix"|"refactor"|"test"|"docs"|"config"|"style"|"chore"}]}';
 
+/**
+ * Files whose whole purpose is a credential.
+ *
+ * Explain sends real changed lines to a model — the local `claude` CLI or the
+ * API, both of which leave this machine. That is the feature working, and it is
+ * fine for source. It is not fine for the file you keep your keys in, and
+ * nothing was stopping it: `git diff` on a modified `.env` produced `+` lines,
+ * and every `+` line went into the prompt.
+ *
+ * Matched on the basename so a path anywhere in the tree is caught, and kept
+ * deliberately blunt. A false positive costs one file's summary; a false
+ * negative sends somebody's production credentials to a model.
+ */
+const SECRET_FILES: RegExp[] = [
+  /^\.env(\.|$)/i, // .env, .env.local, .env.production
+  /^\.?(npmrc|netrc|pgpass|htpasswd)$/i,
+  /^id_(rsa|dsa|ecdsa|ed25519)(\.pub)?$/i,
+  /\.(pem|key|p12|pfx|jks|keystore|ppk)$/i,
+  // Any extension, not a list of them: `secrets.tfvars.json` and
+  // `credentials.enc.yaml` are exactly the shapes an extension allowlist
+  // misses. Anchored on a dot so `secrets-policy.md` is still prose.
+  /^(credentials?|secrets?|service-account[^/]*)\./i,
+  /^(secring|master\.key)$/i,
+];
+
+/** Whether a changed file is one whose contents are a credential by design. */
+export function isSecretFile(path: string): boolean {
+  const base = (path || "").replace(/\\/g, "/").split("/").pop() || "";
+  return SECRET_FILES.some((re) => re.test(base));
+}
+
 // Keep only what the model needs to summarize: hunk headers + added/removed
 // lines. Dropping context lines (the usual majority) roughly halves the input
 // tokens with no loss for a one-line-per-file summary.
@@ -79,14 +111,36 @@ function compressPatch(patch: string): string {
   return out.slice(0, MAX_PATCH_LINES).join("\n");
 }
 
-function trimFiles(files: WalkthroughInputFile[]) {
-  return (files ?? []).slice(0, MAX_FILES).map((f) => ({
-    path: f.path,
-    tool: f.tool,
-    additions: f.additions,
-    deletions: f.deletions,
-    patch: compressPatch(f.patch || ""),
-  }));
+/**
+ * What actually goes to the model, and what was held back.
+ *
+ * Withheld files are *reported*, never silently dropped: a summary that
+ * describes a different changeset from the one on screen is worse than no
+ * summary, because it is trusted. The name still goes — the model can say "a
+ * config file changed" — and only the contents stay behind.
+ *
+ * The patches that do go through `stripSecrets` as well, using the same
+ * definition of a credential the crash reporter already uses (#207): a key
+ * pasted into an ordinary source file is not caught by any filename rule.
+ */
+type SentFile = { path: string; tool?: string; additions?: number; deletions?: number; patch: string };
+
+export function trimFiles(files: WalkthroughInputFile[]): { sent: SentFile[]; withheld: string[] } {
+  const withheld: string[] = [];
+  const sent = (files ?? []).slice(0, MAX_FILES).map((f) => {
+    if (isSecretFile(f.path)) {
+      withheld.push(f.path);
+      return { path: f.path, tool: f.tool, additions: f.additions, deletions: f.deletions, patch: "" };
+    }
+    return {
+      path: f.path,
+      tool: f.tool,
+      additions: f.additions,
+      deletions: f.deletions,
+      patch: stripSecrets(compressPatch(f.patch || "")),
+    };
+  });
+  return { sent, withheld };
 }
 
 function extractJson(text: string): { reviewFocus?: unknown; files?: unknown } {
@@ -107,7 +161,7 @@ function shape(parsed: { reviewFocus?: unknown; files?: unknown }): WalkthroughR
 }
 
 /** Primary path: drive the local `claude` CLI headlessly, reusing its login. */
-async function viaClaudeCli(files: WalkthroughInputFile[]): Promise<WalkthroughResult> {
+async function viaClaudeCli(sent: SentFile[]): Promise<WalkthroughResult> {
   const bin = claudeBin();
   if (!bin) throw new Error("claude CLI not found");
   const prompt = [
@@ -117,7 +171,7 @@ async function viaClaudeCli(files: WalkthroughInputFile[]): Promise<WalkthroughR
     SCHEMA_HINT,
     "",
     "Files changed (unified diffs):",
-    JSON.stringify(trimFiles(files), null, 2),
+    JSON.stringify(sent, null, 2),
   ].join("\n");
 
   const proc = Bun.spawn([bin, "-p", "--output-format", "json", "--max-turns", "1", "--model", MODEL], {
@@ -154,7 +208,7 @@ async function viaClaudeCli(files: WalkthroughInputFile[]): Promise<WalkthroughR
 }
 
 /** Fallback path: Anthropic SDK with structured outputs (needs an API key). */
-async function viaApi(files: WalkthroughInputFile[]): Promise<WalkthroughResult> {
+async function viaApi(sent: SentFile[]): Promise<WalkthroughResult> {
   const client = new Anthropic();
   const res = await client.messages.create({
     model: MODEL,
@@ -162,7 +216,7 @@ async function viaApi(files: WalkthroughInputFile[]): Promise<WalkthroughResult>
     thinking: { type: "adaptive" },
     output_config: { format: { type: "json_schema", schema: SCHEMA as unknown as Record<string, unknown> }, effort: "low" },
     system: SYSTEM,
-    messages: [{ role: "user", content: "Files changed (unified diffs):\n\n" + JSON.stringify(trimFiles(files), null, 2) }],
+    messages: [{ role: "user", content: "Files changed (unified diffs):\n\n" + JSON.stringify(sent, null, 2) }],
   });
   const block = res.content.find((b) => b.type === "text");
   return shape(block && block.type === "text" ? JSON.parse(block.text) : {});
@@ -177,13 +231,16 @@ export async function generateWalkthrough(files: WalkthroughInputFile[]): Promis
       error: "no local `claude` CLI and no ANTHROPIC_API_KEY — install Claude Code or set a key to enable walkthroughs",
     };
   }
+  // Filtered once, before either path can see it: the two transports are
+  // different ways off this machine, not different trust levels.
+  const { sent, withheld } = trimFiles(files);
   if (claudeBin()) {
     try {
-      return await viaClaudeCli(files);
+      return { ...(await viaClaudeCli(sent)), withheld };
     } catch (e) {
       if (!hasApiKey()) throw e; // no fallback available — surface the error
       // otherwise fall through to the API path
     }
   }
-  return await viaApi(files);
+  return { ...(await viaApi(sent)), withheld };
 }

--- a/server/test/walkthrough-egress.test.ts
+++ b/server/test/walkthrough-egress.test.ts
@@ -1,0 +1,167 @@
+/*
+ * Explain is the one feature that sends your working tree off this machine.
+ *
+ * It takes the changed files, keeps every `+`/`-` line, and hands them to a
+ * model — the local `claude` CLI or the Anthropic API, both of which leave the
+ * box. That is the feature working, and it is fine for source. It was not fine
+ * for the file you keep your keys in: a modified `.env` produced `+` lines like
+ * any other file, and every one of them went into the prompt.
+ *
+ * Two rules now, and the second matters because the first cannot catch
+ * everything: a credential file never has its contents sent, and the patches
+ * that do go are run through the same secret scrubber the crash reporter uses,
+ * for the key somebody pasted into an ordinary source file.
+ *
+ * Withheld files are named rather than dropped. A summary describing a
+ * different changeset from the one on screen is worse than no summary, because
+ * it is the one people trust.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { isSecretFile, trimFiles } from "../src/walkthrough.ts";
+import { stripSecrets } from "../../shared/scrub.ts";
+
+describe("files whose contents are a credential", () => {
+  const SECRET = [
+    ".env", ".env.local", ".env.production", ".ENV",
+    "id_rsa", "id_ed25519", "id_rsa.pub",
+    "deploy-key.pem", "server.key", "cert.p12", "keystore.jks", "aws.ppk",
+    "credentials.json", "secrets.yaml", "secret.yml", "service-account-prod.json",
+    // The shapes an extension allowlist misses, which is how the first version
+    // of this rule let a terraform secrets file through.
+    "secrets.tfvars.json", "credentials.enc.yaml", "secret.auto.tfvars",
+    // Blunt on purpose: a file called credentials.* is withheld even when it is
+    // a test. One missing file summary against a real credential is not a close
+    // call — the rule's own comment says so, and this is it being applied.
+    "test/credentials.test.ts",
+    ".npmrc", ".netrc", ".pgpass",
+    // Anywhere in the tree, not just at the root.
+    "config/.env.staging", "infra/terraform/secrets.tfvars.json", "deploy/id_ed25519",
+  ];
+  for (const p of SECRET) {
+    test(`withholds ${p}`, () => expect(isSecretFile(p)).toBe(true));
+  }
+
+  const ORDINARY = [
+    "src/env.ts", "src/environment.tsx", "README.md", "package.json",
+    // The near-misses that a lazy rule would swallow along with the real ones.
+    "src/keyboard.ts", "docs/secrets-policy.md",
+    "src/lib/keys.ts", "envoy.yaml", "src/pemberton.ts",
+  ];
+  for (const p of ORDINARY) {
+    test(`sends ${p}`, () => expect(isSecretFile(p)).toBe(false));
+  }
+
+  test("a windows path is split on the right separator", () => {
+    expect(isSecretFile("config\\\\.env")).toBe(true);
+    expect(isSecretFile("src\\\\envoy.ts")).toBe(false);
+  });
+});
+
+describe("the patches that do go", () => {
+  test("a key pasted into ordinary source is redacted", () => {
+    // No filename rule can catch this one, which is why the scrubber runs over
+    // everything that survives the path filter.
+    const patch = [
+      "@@ -1,3 +1,4 @@",
+      '+const client = new S3({ accessKeyId: "AKIAIOSFODNN7EXAMPLE" });',
+      '+const gh = "ghp_" + "AbCdEf0123456789AbCdEfGh";',
+    ].join("\n");
+    const out = stripSecrets(patch);
+    expect(out).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    expect(out).not.toContain("ghp_" + "AbCdEf0123456789AbCdEfGh");
+    // …and the diff is still a diff. A scrubber that eats the hunk headers or
+    // the paths makes the summary useless, which is why redactText (which drops
+    // every path) is deliberately not what runs here.
+    expect(out).toContain("@@ -1,3 +1,4 @@");
+    expect(out).toContain("const client = new S3");
+  });
+
+  test("ordinary code survives intact", () => {
+    const patch = '@@ -1 +1 @@\n+export const timeoutMs = 5000; // was 3000\n-import { readFileSync } from "node:fs";';
+    expect(stripSecrets(patch)).toBe(patch);
+  });
+});
+
+describe("what trimFiles actually hands over", () => {
+  // The tests above check the two rules in isolation, which is not the same as
+  // checking they are wired in — the first version of this file passed
+  // unchanged against a trimFiles with both of them disabled. These call it.
+  const file = (path: string, patch: string) => ({ path, tool: "git", additions: 1, deletions: 0, patch });
+
+  // Assembled rather than written out, because a literal of this shape is a
+  // live-key pattern and the repository's own secret scanner blocks the push —
+  // which is the same instinct this whole file is about, applied to itself.
+  const STRIPE_KEY = "sk_" + "live_51H8xQ2eZvKYlo2C";
+
+  test("a credential file's contents never reach the prompt", () => {
+    const { sent, withheld } = trimFiles([
+      file(".env", `@@ -1 +1 @@\n+STRIPE_SECRET_KEY=${STRIPE_KEY}\n`),
+      file("src/pay.ts", "@@ -1 +1 @@\n+export const currency = \"EUR\";\n"),
+    ]);
+    const wire = JSON.stringify(sent);
+    expect(wire).not.toContain("STRIPE_SECRET_KEY");
+    expect(wire).not.toContain(STRIPE_KEY);
+    // The name still goes, so the summary can say a config file changed.
+    expect(wire).toContain(".env");
+    expect(withheld).toEqual([".env"]);
+    // …and the ordinary file is untouched.
+    expect(wire).toContain("export const currency");
+  });
+
+  test("a key in an ordinary file is redacted on the way out", () => {
+    const { sent, withheld } = trimFiles([
+      file("src/s3.ts", '@@ -1 +1 @@\n+const id = "AKIAIOSFODNN7EXAMPLE";\n'),
+    ]);
+    expect(JSON.stringify(sent)).not.toContain("AKIAIOSFODNN7EXAMPLE");
+    // Not withheld — the file is ordinary, only the value was scrubbed.
+    expect(withheld).toEqual([]);
+    expect(JSON.stringify(sent)).toContain("const id");
+  });
+
+  test("nothing is withheld when nothing needs to be", () => {
+    const { sent, withheld } = trimFiles([file("README.md", "@@ -1 +1 @@\n+# Title\n")]);
+    expect(withheld).toEqual([]);
+    expect(sent[0]!.patch).toContain("# Title");
+  });
+});
+
+describe("the filter runs before either transport can see the files", () => {
+  const src = readFileSync(join(import.meta.dir, "..", "src", "walkthrough.ts"), "utf8");
+
+  test("both prompt paths are handed the already-filtered list", () => {
+    // The CLI and the API are two ways off this machine, not two trust levels.
+    // Filtering inside one of them would leave the other open.
+    expect(src).toContain("async function viaClaudeCli(sent: SentFile[])");
+    expect(src).toContain("async function viaApi(sent: SentFile[])");
+    // Neither transport may reach for the raw input again — only
+    // generateWalkthrough calls trimFiles, exactly once, above both of them.
+    const body = (name: string) => {
+      const start = src.indexOf(`async function ${name}(`);
+      return src.slice(start, src.indexOf("\n}\n", start));
+    };
+    expect(body("viaClaudeCli")).not.toContain("trimFiles");
+    expect(body("viaApi")).not.toContain("trimFiles");
+    // Its definition plus exactly one call site, and that call site is in
+    // generateWalkthrough: two occurrences, not three.
+    expect(src.split("trimFiles(").length - 1, "trimFiles gained a second call site").toBe(2);
+  });
+
+  test("withheld files are reported, not dropped", () => {
+    expect(src).toContain("withheld");
+    // The name still goes, so the model can say "a config file changed"; only
+    // the contents stay behind.
+    const trim = src.slice(src.indexOf("function trimFiles"), src.indexOf("function extractJson"));
+    expect(trim).toContain("path: f.path");
+    expect(trim).toContain('patch: ""');
+  });
+
+  test("SECURITY.md says Explain sends diffs off the machine", () => {
+    // The storage section says everything is local, which is true of what is
+    // stored and not of this. Somebody reading only that would be wrong about
+    // the one feature that uploads.
+    const doc = readFileSync(join(import.meta.dir, "..", "..", "SECURITY.md"), "utf8");
+    expect(doc).toContain("Explain");
+  });
+});

--- a/shared/scrub.ts
+++ b/shared/scrub.ts
@@ -63,7 +63,15 @@ const SECRET_PATTERNS: RegExp[] = [
   /\b[A-Za-z0-9+]{40,}={0,2}\b/g, // long high-entropy blob (raw base64/hex secrets); no "/" so it never eats a path
 ];
 
-function stripSecrets(s: string): string {
+/**
+ * Redact credential-shaped text, leaving everything else alone.
+ *
+ * Exported separately from `redactText` because one caller needs exactly this
+ * half: the AI walkthrough sends real diffs to a model, so paths have to
+ * survive — a patch whose every path became `<path>` describes nothing — while
+ * a key on a changed line must not.
+ */
+export function stripSecrets(s: string): string {
   let out = s;
   for (const re of SECRET_PATTERNS) out = out.replace(re, "<redacted-secret>");
   return out;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -981,6 +981,13 @@ export interface WalkthroughResult {
   reviewFocus: string;
   files: WalkthroughFile[];
   error?: string;
+  /**
+   * Files whose contents were deliberately not sent — `.env`, keys, credential
+   * files. Named rather than dropped: a summary that describes a different
+   * changeset from the one on screen is worse than no summary, because it is
+   * the one people trust.
+   */
+  withheld?: string[];
 }
 
 // --- chat attachments (images pasted into the composer) ----------------------

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -952,6 +952,12 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                     ) : (
                       <span style={{ color: "var(--warning)" }}>{walk?.error}</span>
                     )}
+                    {/* Named, not silently missing — see GitPanel. */}
+                    {!!walk?.withheld?.length && (
+                      <div className="mt-1 text-[10px] t-dim2">
+                        Not sent: {walk.withheld.join(", ")} — credential files are kept out of the prompt.
+                      </div>
+                    )}
                   </div>
                 )}
 

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1800,6 +1800,14 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                               {walk?.reviewFocus ? <><span className="t-dim2 uppercase tracking-wide text-[8.5px] mr-1">focus</span>{walk.reviewFocus}</> : walk?.error}
                             </div>
                           )}
+                          {/* Named, not silently missing: a summary that covers
+                              a different changeset than the one on screen is
+                              worse than none, because it is the one you trust. */}
+                          {!!walk?.withheld?.length && (
+                            <div className="mt-1 text-[9.5px] leading-snug t-dim2">
+                              Not sent: {walk.withheld.join(", ")} — credential files are kept out of the prompt.
+                            </div>
+                          )}
                         </div>
                       )}
                       {!tree?.clean && (


### PR DESCRIPTION
## What does this PR do?

Explain is the one feature in agentglass that sends your working tree off the machine. `GitPanel.tsx` hands `generateWalkthrough` every changed file with its full unified patch, `compressPatch` keeps every `+`/`-` line, and both transports — the local `claude` CLI and the Anthropic API — leave the box. That is the feature working, and it is fine for source. It was not fine for the file you keep your keys in: a modified `.env` produced `+` lines like any other file, and every one of them went into the prompt.

Two rules now, applied in `trimFiles` before either transport can see the list:

1. **A credential file never has its contents sent.** `isSecretFile` matches on path — `.env*`, `id_rsa`/`id_ed25519`, `*.pem|key|p12|pfx|jks|keystore|ppk`, `.npmrc`/`.netrc`/`.pgpass`, and anything named `credentials.*` / `secrets.*` / `service-account*.*`.
2. **The patches that do go are scrubbed.** No filename rule catches a key somebody pasted into ordinary source, so surviving patches run through the same secret matcher the crash reporter uses.

`stripSecrets` is a new export from `shared/scrub.ts` — the secret half of `redactText` without the path half. Explain needs paths to survive; a patch whose every path was replaced by a placeholder describes nothing.

Withheld files are **named, not dropped**. `WalkthroughResult.withheld` carries them, and `GitPanel` / `ChangesModal` render "Not sent: … — credential files are kept out of the prompt." A summary silently describing a different changeset than the one on screen is worse than no summary, because it is the one people trust. The filename still reaches the model, so it can say "a config file changed".

`SECURITY.md` said storage is local, which is true of what is stored and not of this. It now says which feature uploads, and what it withholds.

Two things my own tests surfaced, both worth stating because they are the failure modes this kind of rule has:

- The first version of the rule required a known extension directly after the name, so `secrets.tfvars.json` — a terraform secrets file — sailed straight through. The rule is now anchored on a dot with any extension after it, so `secrets-policy.md` is still prose but `credentials.enc.yaml` is not.
- The first version of the test suite passed unchanged against a `trimFiles` with both rules disabled, because it only ever exercised the two helpers in isolation. `trimFiles` is exported and called directly now.

## How was it tested?

`server/test/walkthrough-egress.test.ts`, 44 tests:

- Every secret shape above, at the root and nested, on both path separators — and the near-misses a lazy rule would swallow with them (`src/keyboard.ts`, `docs/secrets-policy.md`, `src/lib/keys.ts`, `envoy.yaml`, `src/pemberton.ts`).
- `trimFiles` called directly: an `.env` alongside an ordinary file, asserted against `JSON.stringify(sent)` — the value is gone, the name is in `withheld`, the ordinary file is untouched. A key in ordinary source is scrubbed without the file being withheld.
- Structural guards over `walkthrough.ts` itself rather than over today's call sites: both transports take `SentFile[]`, neither body mentions `trimFiles`, and `trimFiles(` appears exactly twice in the file — its definition and one call. A second call site fails the suite.

Red before green confirmed: disabling both rules inside `trimFiles` fails `a credential file's contents never reach the prompt` and `a key in an ordinary file is redacted on the way out`.

Full suites: `server/` 1032 pass / 0 fail, `web/` 454 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.