### PR TITLE
fix(mobile): make the phone companion work — one writer per session, a chat that reads like a chat, and a diff that opens

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -197,7 +197,11 @@ async function main() {
     await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 5 });
     await cdp.send("Page.addScriptToEvaluateOnNewDocument", { source: COLLECTOR });
 
-    await cdp.send("Page.navigate", { url: ORIGIN + "/" });
+    // A token is only needed against a server that is exposed — the desktop
+    // app's own sidecar mints one. The bundle takes it off the URL on first
+    // load and keeps it, exactly as the QR link does.
+    const token = process.env.AUDIT_TOKEN?.trim();
+    await cdp.send("Page.navigate", { url: ORIGIN + "/" + (token ? `?token=${encodeURIComponent(token)}` : "") });
     await until(cdp, `document.querySelector(".mb")`, "the phone shell", 25_000);
     await Bun.sleep(1200);
 

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -235,6 +235,12 @@ async function main() {
     if (await tap(cdp, "main .mb-row, main button.w-full", repo || undefined)) {
       await until(cdp, `document.querySelector(".mb-screen.on")`, "the repo screen", 12_000);
       await Bun.sleep(1200);
+      // A project can have several checkouts. Pick one with uncommitted work,
+      // or the changes list below is legitimately empty and proves nothing.
+      const switched = await cdp.ev(`(()=>{const s=${TOP}; if(!s) return "";
+        const chip=[...s.querySelectorAll("button")].find(b=>/·\\s*\\d+$/.test(b.textContent.trim()));
+        if(!chip) return ""; chip.click(); return chip.textContent.trim();})()`);
+      if (switched) { note("repos", "worktrees are offered inside the project", true, switched); await Bun.sleep(1600); }
       // The screen opens on whatever is wrong, which for a clean checkout is
       // the pull request list. Ask for Changes explicitly rather than reading
       // whichever facet happened to win.

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -1,0 +1,300 @@
+#!/usr/bin/env bun
+/**
+ * Drive the phone companion in a real browser, at a real phone viewport, and
+ * report what breaks.
+ *
+ * The companion shipped with faults that no unit test could have caught and no
+ * amount of reading did catch: a header pinned under another header, a composer
+ * hidden behind the browser's own URL bar, file paths that came back with a
+ * `w/` on the front and could not be staged. Every one of them needed the thing
+ * to actually be opened and poked. This is that, written down and repeatable.
+ *
+ * It is deliberately READ-ONLY. It opens screens, reads what rendered, and
+ * checks invariants; it never sends a message, stages a file, restarts a
+ * container or touches a pull request, because it runs against the real server
+ * on this machine with the real fleet in it.
+ *
+ *   bun scripts/phone-audit.ts                  # against a server on :4055
+ *   AUDIT_ORIGIN=http://127.0.0.1:4001 bun scripts/phone-audit.ts
+ *
+ * Exit code is the number of failed checks, so it can gate a commit.
+ */
+
+import { spawn } from "bun";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { connect, findChrome, until, type CDP } from "./cdp.ts";
+
+const ORIGIN = process.env.AUDIT_ORIGIN || "http://127.0.0.1:4055";
+const SHOTS = process.env.AUDIT_SHOTS || join(tmpdir(), "agentglass-phone-audit");
+/** A Pixel-ish viewport: the layout switches itself below 768px. */
+const PHONE = { w: 412, h: 915, scale: 2 };
+
+type Check = { screen: string; what: string; ok: boolean; detail?: string };
+const checks: Check[] = [];
+const note = (screen: string, what: string, ok: boolean, detail?: string) => {
+  checks.push({ screen, what, ok, detail });
+  console.log(`${ok ? "  ok  " : "  FAIL"} ${screen} · ${what}${ok || !detail ? "" : `\n        ${detail}`}`);
+};
+
+/** Injected before any app code: the page's own error channels, collected. */
+const COLLECTOR = `
+window.__audit = { errors: [], net: [] };
+addEventListener("error", (e) => window.__audit.errors.push(String(e.message || e.error)));
+addEventListener("unhandledrejection", (e) => window.__audit.errors.push("unhandled: " + String(e.reason)));
+(() => {
+  const ce = console.error;
+  console.error = (...a) => { try { window.__audit.errors.push(a.map(String).join(" ")); } catch {} ce(...a); };
+  const of = window.fetch;
+  window.fetch = async (...a) => {
+    const r = await of(...a);
+    if (!r.ok) window.__audit.net.push(r.status + " " + (typeof a[0] === "string" ? a[0] : a[0].url));
+    return r;
+  };
+})();
+`;
+
+const drain = async (cdp: CDP, screen: string) => {
+  const a = await cdp.ev("JSON.stringify(window.__audit || {errors:[],net:[]})");
+  const { errors, net } = JSON.parse(a || '{"errors":[],"net":[]}');
+  note(screen, "no page errors", errors.length === 0, errors.slice(0, 3).join(" | "));
+  note(screen, "no failed requests", net.length === 0, net.slice(0, 3).join(" | "));
+  await cdp.ev("window.__audit = { errors: [], net: [] }");
+};
+
+const shot = async (cdp: CDP, name: string) => {
+  const png = await cdp.shot();
+  writeFileSync(join(SHOTS, `${name}.png`), png);
+};
+
+/** Text of everything matching a selector, for eyeballing a list in one read. */
+const texts = (cdp: CDP, sel: string) =>
+  cdp.ev(`JSON.stringify([...document.querySelectorAll(${JSON.stringify(sel)})].map(e=>e.textContent.trim()).slice(0,40))`)
+    .then((s: string) => JSON.parse(s || "[]") as string[]);
+
+const tap = async (cdp: CDP, sel: string, needle?: string) => {
+  const hit = await cdp.ev(`(()=>{const els=[...document.querySelectorAll(${JSON.stringify(sel)})];
+    const el = ${needle ? `els.find(e=>e.textContent.includes(${JSON.stringify(needle)}))` : "els[0]"};
+    if(!el) return false; el.click(); return true;})()`);
+  await Bun.sleep(700);
+  return !!hit;
+};
+
+async function main() {
+  mkdirSync(SHOTS, { recursive: true });
+  const profile = mkdtempSync(join(tmpdir(), "agx-audit-"));
+  const port = 9333;
+  const chrome = spawn([
+    findChrome(),
+    `--remote-debugging-port=${port}`,
+    `--user-data-dir=${profile}`,
+    "--headless=new",
+    "--hide-scrollbars",
+    "--no-first-run",
+    `--window-size=${PHONE.w},${PHONE.h}`,
+    "about:blank",
+  ], { stdout: "ignore", stderr: "ignore" });
+
+  const cdp = await connect(port);
+  try {
+    // A phone, not a narrow desktop: touch, coarse pointer, device pixels.
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: PHONE.w, height: PHONE.h, deviceScaleFactor: PHONE.scale, mobile: true,
+    });
+    await cdp.send("Emulation.setTouchEmulationEnabled", { enabled: true, maxTouchPoints: 5 });
+    await cdp.send("Page.addScriptToEvaluateOnNewDocument", { source: COLLECTOR });
+
+    await cdp.send("Page.navigate", { url: ORIGIN + "/" });
+    await until(cdp, `document.querySelector(".mb")`, "the phone shell", 25_000);
+    await Bun.sleep(1200);
+
+    // ---- shell -------------------------------------------------------
+    note("shell", "phone layout chosen",
+      (await cdp.ev(`document.documentElement.dataset.layout`)) === "phone");
+    note("shell", "tab bar is on screen",
+      await cdp.ev(`(()=>{const n=document.querySelector("nav");if(!n)return false;
+        const r=n.getBoundingClientRect();return r.bottom<=innerHeight+1&&r.top<innerHeight;})()`));
+    await shot(cdp, "01-now");
+    await drain(cdp, "shell");
+
+    // ---- Now ---------------------------------------------------------
+    const nowText = await cdp.ev(`document.querySelector("main")?.textContent?.trim()?.length || 0`);
+    note("now", "renders something", nowText > 20, `main had ${nowText} chars`);
+
+    // ---- Chats -------------------------------------------------------
+    note("chats", "tab opens", await tap(cdp, "nav button", "Chats"));
+    await Bun.sleep(900);
+    const scopes = await texts(cdp, "main button");
+    note("chats", "scope chips present",
+      scopes.some((t) => t.startsWith("Working")) && scopes.includes("Today") && scopes.includes("All"),
+      scopes.slice(0, 6).join(" / "));
+    const rows = await cdp.ev(`document.querySelectorAll("main button.w-full").length`);
+    note("chats", "list is not the whole archive", rows < 40, `${rows} rows on the opening scope`);
+    await shot(cdp, "02-chats");
+    await drain(cdp, "chats");
+
+    // ---- a conversation ---------------------------------------------
+    if (rows > 0) {
+      await tap(cdp, "main button.w-full");
+      await until(cdp, `document.querySelector(".mb-chat")`, "the conversation screen", 12_000);
+      await Bun.sleep(1400);
+
+      note("conversation", "one bar, no app header above it",
+        await cdp.ev(`(()=>{const s=document.querySelector(".mb-chat");if(!s)return false;
+          const hd=s.querySelector(".hd").getBoundingClientRect();
+          const app=document.querySelector("header")?.getBoundingClientRect();
+          return !app || app.bottom<=hd.top+1 || getComputedStyle(document.querySelector("header")).display==="none"
+            || hd.top>=0 && s.getBoundingClientRect().top<=0;})()`));
+      note("conversation", "composer is inside the viewport",
+        await cdp.ev(`(()=>{const f=document.querySelector(".mb-chat .ft");if(!f)return false;
+          const r=f.getBoundingClientRect();return r.bottom<=innerHeight+1&&r.top>0;})()`));
+      note("conversation", "the thread is the scroller",
+        await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");if(!b)return false;
+          return getComputedStyle(b).overflowY==="auto";})()`));
+      note("conversation", "no tab bar over the chat",
+        await cdp.ev(`(()=>{const n=document.querySelector("nav");if(!n)return true;
+          const s=document.querySelector(".mb-chat").getBoundingClientRect();
+          const r=n.getBoundingClientRect();return r.top>=s.bottom-1;})()`));
+      // Scoped to the composer: the phrase can legitimately appear inside a
+      // transcript that happens to be discussing it, which is exactly what a
+      // body-wide search reported the first time this ran.
+      note("conversation", "composer offers a way to reply",
+        await cdp.ev(`(()=>{const f=document.querySelector(".mb-chat .ft");if(!f)return false;
+          return !!f.querySelector("textarea") && !f.textContent.includes("did not record where it ran");})()`));
+      note("conversation", "thread is scrolled to the newest turn",
+        await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");if(!b)return false;
+          return b.scrollHeight - b.scrollTop - b.clientHeight < 80;})()`));
+      await shot(cdp, "03-conversation");
+      await drain(cdp, "conversation");
+      await tap(cdp, ".mb-chat .hd .back");
+      await Bun.sleep(700);
+    }
+
+    // ---- Repos, changes, and a diff ----------------------------------
+    note("repos", "tab opens", await tap(cdp, "nav button", "Repos"));
+    await Bun.sleep(1100);
+    const repoRows = await cdp.ev(`document.querySelectorAll("main .mb-row, main button").length`);
+    note("repos", "lists repositories", repoRows > 0, `${repoRows} rows`);
+    await shot(cdp, "04-repos");
+
+    // A repository with uncommitted work, so the changes list is not empty by
+    // accident and the diff has something to draw. AUDIT_REPO names it.
+    const repo = process.env.AUDIT_REPO || "";
+    if (await tap(cdp, "main .mb-row, main button.w-full", repo || undefined)) {
+      await until(cdp, `document.querySelector(".mb-screen.on")`, "the repo screen", 12_000);
+      await Bun.sleep(1200);
+      // The screen opens on whatever is wrong, which for a clean checkout is
+      // the pull request list. Ask for Changes explicitly rather than reading
+      // whichever facet happened to win.
+      await tap(cdp, ".mb-screen.on button", "Changes");
+      await Bun.sleep(1600);
+      const files = await texts(cdp, ".mb-screen .mb-row b");
+      note("changes", "lists the changed files", files.length > 0, `${files.length} rows`);
+      note("changes", "file paths carry no diff prefix",
+        files.length > 0 && !files.some((f) => /^[abciwo]\//.test(f)),
+        files.filter((f) => /^[abciwo]\//.test(f)).join(", ") || "(list was empty)");
+      await shot(cdp, "05-changes");
+      await drain(cdp, "changes");
+
+      // Open the first file's diff — the "it just won't load" report.
+      // Scoped to the screen that is actually on: every other screen is still
+      // in the DOM, parked off to the right, and clicking into one of those
+      // looks exactly like a click that did nothing.
+      if (files.length && await tap(cdp, ".mb-screen.on .mb-row button")) {
+        await Bun.sleep(2200);
+        note("diff", "the diff screen opens",
+          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .hd .t b")]
+            .some(b=>b.textContent.includes("."))`));
+        const lines = await cdp.ev(`document.querySelectorAll(".mb-dl, .mb-diff-line, .mb-hunk").length`);
+        const said = await cdp.ev(`(document.querySelector(".mb-screen.on")?.textContent || "")
+          .includes("Nothing to show") ? "empty" : ""`);
+        note("diff", "the diff renders lines", lines > 0 && !said, `${lines} line nodes ${said}`);
+        await shot(cdp, "06-diff");
+        await drain(cdp, "diff");
+
+        // The phone's own back gesture, which is what the screen stack exists
+        // for: it must close the diff and land back on the repo, not leave.
+        await cdp.ev("history.back()");
+        await Bun.sleep(900);
+        note("back gesture", "closes the diff and keeps the repo",
+          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .hd .t b")]
+            .some(b=>b.textContent.trim() === ${JSON.stringify(process.env.AUDIT_REPO || "")} || !b.textContent.includes("."))`));
+        await drain(cdp, "back gesture");
+      }
+
+      // Staging, the round trip. Off by default because it writes to the
+      // repository under test; AUDIT_WRITE=1 opts in, and it puts the file
+      // back the way it found it.
+      if (process.env.AUDIT_WRITE === "1") {
+        const before = await cdp.ev(`(document.querySelector(".mb-screen.on .bd")?.textContent||"").match(/(\\d+) of (\\d+) staged/)?.[1]`);
+        await tap(cdp, ".mb-screen.on .mb-row .mb-sw");
+        await Bun.sleep(1600);
+        const after = await cdp.ev(`(document.querySelector(".mb-screen.on .bd")?.textContent||"").match(/(\\d+) of (\\d+) staged/)?.[1]`);
+        note("staging", "staging a file counts it as staged",
+          Number(after) === Number(before) + 1, `${before} → ${after}`);
+        note("staging", "no error surfaced",
+          !(await cdp.ev(`document.body.textContent.includes("did not match any files")`)));
+        await shot(cdp, "10-staged");
+
+        await tap(cdp, ".mb-screen.on .mb-row .mb-sw");
+        await Bun.sleep(1600);
+        const back = await cdp.ev(`(document.querySelector(".mb-screen.on .bd")?.textContent||"").match(/(\\d+) of (\\d+) staged/)?.[1]`);
+        note("staging", "unstaging puts it back", Number(back) === Number(before), `${after} → ${back}`);
+        await drain(cdp, "staging");
+      }
+
+      // Pull requests and containers, the other two facets of the same screen.
+      for (const facet of ["Pull requests", "Containers"]) {
+        if (await tap(cdp, ".mb-screen.on button", facet)) {
+          await Bun.sleep(2000);
+          const body = await cdp.ev(`(document.querySelector(".mb-screen.on .bd")?.textContent || "").trim().length`);
+          note(facet.toLowerCase(), "renders", body > 0, `${body} chars`);
+          await shot(cdp, `07-${facet.split(" ")[0]!.toLowerCase()}`);
+          await drain(cdp, facet.toLowerCase());
+        }
+      }
+      await tap(cdp, ".mb-screen.on .hd .back");
+      await Bun.sleep(600);
+    }
+
+    // ---- settings ----------------------------------------------------
+    if (await tap(cdp, "header button[aria-label='Settings']")) {
+      await Bun.sleep(900);
+      note("settings", "sheet opens", await cdp.ev(`!!document.querySelector(".mb-sheet.on")`));
+      note("settings", "reports what this machine spent",
+        await cdp.ev(`(document.querySelector(".mb-sheet.on")?.textContent || "").includes("Spend today")`));
+      await shot(cdp, "08-settings");
+      await drain(cdp, "settings");
+      await cdp.ev(`document.querySelector(".mb-scrim")?.click()`);
+      await Bun.sleep(600);
+    }
+
+    // ---- new chat form (opened, never sent) --------------------------
+    await tap(cdp, "nav button", "Chats");
+    await Bun.sleep(800);
+    if (await tap(cdp, "main button", "New chat")) {
+      await Bun.sleep(1500);
+      const repos = await cdp.ev(`document.querySelectorAll("main select option").length`);
+      note("new chat", "offers somewhere to run", repos > 0, `${repos} options`);
+      note("new chat", "offers a model", await cdp.ev(`document.querySelectorAll("main button").length > 3`));
+      await shot(cdp, "09-newchat");
+      await drain(cdp, "new chat");
+      await tap(cdp, "main button", "← Chats");
+      await Bun.sleep(500);
+    }
+
+    console.log(`\nscreenshots → ${SHOTS}`);
+  } finally {
+    cdp.close();
+    chrome.kill();
+    rmSync(profile, { recursive: true, force: true });
+  }
+
+  const failed = checks.filter((c) => !c.ok);
+  console.log(`\n${checks.length - failed.length}/${checks.length} checks passed`);
+  for (const f of failed) console.log(`  FAIL ${f.screen} · ${f.what}${f.detail ? ` — ${f.detail}` : ""}`);
+  process.exit(failed.length);
+}
+
+main().catch((e) => { console.error(e); process.exit(99); });

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -284,6 +284,31 @@ async function main() {
       await Bun.sleep(500);
     }
 
+    // ---- the Now tab, and what it offers to do -----------------------
+    await tap(cdp, "nav button", "Now");
+    await Bun.sleep(1400);
+    note("now", "the queue lists something or says it is empty",
+      await cdp.ev(`(document.querySelector("main")?.textContent || "").trim().length > 40`));
+    const actions = await texts(cdp, "main button");
+    note("now", "offers an action per item, or none at all",
+      !actions.some((a) => a === ""), `${actions.length} buttons`);
+    await shot(cdp, "11-now-queue");
+    await drain(cdp, "now");
+
+    // ---- the server going away ---------------------------------------
+    // A companion that silently shows stale numbers when the machine it is
+    // watching has gone is worse than one that says so.
+    await cdp.ev(`window.__origFetch = window.fetch; window.fetch = () => Promise.reject(new Error("offline"))`);
+    await Bun.sleep(6000);
+    note("offline", "says the connection is gone",
+      await cdp.ev(`(document.querySelector("header")?.textContent || "").includes("Offline")`));
+    await shot(cdp, "12-offline");
+    await cdp.ev(`window.fetch = window.__origFetch; window.__audit = { errors: [], net: [] }`);
+    await Bun.sleep(5000);
+    note("offline", "comes back on its own",
+      await cdp.ev(`(document.querySelector("header")?.textContent || "").includes("Live")`));
+    await drain(cdp, "offline");
+
     console.log(`\nscreenshots → ${SHOTS}`);
   } finally {
     cdp.close();

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -63,6 +63,75 @@ const drain = async (cdp: CDP, screen: string) => {
   await cdp.ev("window.__audit = { errors: [], net: [] }");
 };
 
+/**
+ * The defects that are invisible in code and obvious on a phone.
+ *
+ * Every one of these was reported by hand at least once: a switch clipped by
+ * its own hit area, a header sitting under another header, a control too small
+ * to hit, a row wider than the screen. They are cheap to check and they are the
+ * difference between "works" and "polished", so every screen gets swept rather
+ * than only the ones someone thought to look at.
+ */
+const HYGIENE = `(() => {
+  const bad = { overflow: [], tiny: [], clipped: [], covered: [] };
+  const vw = innerWidth, vh = innerHeight;
+  // A screen that is closed is still mounted, parked one viewport to the right.
+  // Everything inside it "overflows" by exactly that much and none of it is on
+  // screen, so the whole subtree is out of scope.
+  const parked = (el) => !!el.closest('.mb-screen:not(.on), [aria-hidden="true"]');
+  // Content inside a horizontal scroller is reachable by definition — a long
+  // diff line in Scroll mode is the feature, not a defect.
+  const scrollable = (el) => {
+    for (let p = el.parentElement; p && p !== document.body; p = p.parentElement) {
+      const o = getComputedStyle(p).overflowX;
+      if (o === "auto" || o === "scroll") return true;
+    }
+    return false;
+  };
+  const visible = (el) => {
+    if (parked(el)) return false;
+    const s = getComputedStyle(el);
+    if (s.display === "none" || s.visibility === "hidden" || Number(s.opacity) === 0) return false;
+    const r = el.getBoundingClientRect();
+    return r.width > 0 && r.height > 0 && r.bottom > 0 && r.top < vh;
+  };
+  const name = (el) => (el.tagName.toLowerCase() + (el.className && typeof el.className === "string"
+    ? "." + el.className.trim().split(/\\s+/).slice(0, 2).join(".") : "")
+    + (el.textContent ? " «" + el.textContent.trim().slice(0, 24) + "»" : "")).slice(0, 80);
+
+  for (const el of document.querySelectorAll("body *")) {
+    if (!visible(el)) continue;
+    const r = el.getBoundingClientRect();
+
+    // Something reaching past the right edge: the page cannot scroll sideways,
+    // so whatever is out there is simply gone.
+    if (r.right > vw + 1.5 && getComputedStyle(el).position !== "fixed" && !scrollable(el)) {
+      bad.overflow.push(name(el) + " right=" + Math.round(r.right));
+    }
+
+    // A tap target you have to aim at. 40px is the floor everyone agrees on.
+    const tappable = el.tagName === "BUTTON" || el.getAttribute("role") === "switch"
+      || el.getAttribute("role") === "tab" || el.tagName === "A";
+    if (tappable && (r.height < 36 || r.width < 24)) bad.tiny.push(name(el) + " " + Math.round(r.width) + "x" + Math.round(r.height));
+
+    // Text cut off with no ellipsis and no way to scroll to it.
+    const s = getComputedStyle(el);
+    if (el.children.length === 0 && el.textContent && el.textContent.trim()
+        && el.scrollWidth > el.clientWidth + 2 && s.textOverflow !== "ellipsis" && s.overflowX === "hidden") {
+      bad.clipped.push(name(el));
+    }
+  }
+  return JSON.stringify(bad);
+})()`;
+
+const hygiene = async (cdp: CDP, screen: string) => {
+  const raw = await cdp.ev(HYGIENE);
+  const b = JSON.parse(raw || "{}") as Record<string, string[]>;
+  note(screen, "nothing reaches past the right edge", !b.overflow?.length, b.overflow?.slice(0, 3).join(" | "));
+  note(screen, "every control is big enough to hit", !b.tiny?.length, b.tiny?.slice(0, 3).join(" | "));
+  note(screen, "no text is cut off without an ellipsis", !b.clipped?.length, b.clipped?.slice(0, 3).join(" | "));
+};
+
 const shot = async (cdp: CDP, name: string) => {
   const png = await cdp.shot();
   writeFileSync(join(SHOTS, `${name}.png`), png);
@@ -140,6 +209,7 @@ async function main() {
         const r=n.getBoundingClientRect();return r.bottom<=innerHeight+1&&r.top<innerHeight;})()`));
     await shot(cdp, "01-now");
     await drain(cdp, "shell");
+    await hygiene(cdp, "now");
 
     // ---- Now ---------------------------------------------------------
     const nowText = await cdp.ev(`document.querySelector("main")?.textContent?.trim()?.length || 0`);
@@ -170,6 +240,7 @@ async function main() {
     await tap(cdp, "main button", "Today");
     await Bun.sleep(900);
     await drain(cdp, "chats");
+    await hygiene(cdp, "chats");
 
     // ---- a conversation ---------------------------------------------
     if (rows > 0) {
@@ -218,6 +289,7 @@ async function main() {
           return b.scrollHeight - b.scrollTop - b.clientHeight < 80;})()`));
       await shot(cdp, "03-conversation");
       await drain(cdp, "conversation");
+      await hygiene(cdp, "conversation");
       await tap(cdp, ".mb-chat .hd .back");
       await Bun.sleep(700);
     }
@@ -253,6 +325,7 @@ async function main() {
         files.filter((f) => /^[abciwo]\//.test(f)).join(", ") || "(list was empty)");
       await shot(cdp, "05-changes");
       await drain(cdp, "changes");
+      await hygiene(cdp, "changes");
 
       // Open the first file's diff — the "it just won't load" report.
       // Scoped to the screen that is actually on: every other screen is still
@@ -290,6 +363,7 @@ async function main() {
         await Bun.sleep(1200);
         await shot(cdp, "06-diff");
         await drain(cdp, "diff");
+      await hygiene(cdp, "diff");
 
         // The phone's own back gesture, which is what the screen stack exists
         // for: it must close the diff and land back on the repo, not leave.
@@ -347,6 +421,7 @@ async function main() {
           return r.bottom<=innerHeight+1 && r.top>=-1;})()`));
       await shot(cdp, "08-settings");
       await drain(cdp, "settings");
+      await hygiene(cdp, "settings");
       // The scrim that is actually up: every sheet keeps one mounted, and the
       // first in the document belongs to a sheet that is closed.
       await cdp.ev(`document.querySelector(".mb-scrim.on")?.click()`);
@@ -365,6 +440,7 @@ async function main() {
       note("new chat", "offers a model", await cdp.ev(`document.querySelectorAll("main button").length > 3`));
       await shot(cdp, "09-newchat");
       await drain(cdp, "new chat");
+      await hygiene(cdp, "new chat");
       await tap(cdp, "main button", "← Chats");
       await Bun.sleep(500);
     }

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -73,6 +73,29 @@ const texts = (cdp: CDP, sel: string) =>
   cdp.ev(`JSON.stringify([...document.querySelectorAll(${JSON.stringify(sel)})].map(e=>e.textContent.trim()).slice(0,40))`)
     .then((s: string) => JSON.parse(s || "[]") as string[]);
 
+/**
+ * The screen the user is looking at.
+ *
+ * Parent screens stay mounted and open underneath their children (that is what
+ * stopped the diff closing itself), so "the screen that is on" is the LAST one
+ * in the document, not the first. Reading the first is how this harness came to
+ * compare a diff's title with the repository's and report a working Next button
+ * as broken.
+ */
+const TOP = `[...document.querySelectorAll(".mb-screen.on")].pop()`;
+
+/** Click inside the topmost screen only. */
+const tapTop = async (cdp: CDP, sel: string, needle?: string) => {
+  const hit = await cdp.ev(`(()=>{const s=${TOP}; if(!s) return false;
+    const els=[...s.querySelectorAll(${JSON.stringify(sel)})];
+    const el = ${needle ? `els.find(e=>e.textContent.includes(${JSON.stringify(needle)}))` : "els[0]"};
+    if(!el) return false; el.click(); return true;})()`);
+  await Bun.sleep(700);
+  return !!hit;
+};
+
+const topTitle = (cdp: CDP) => cdp.ev(`(${TOP})?.querySelector(".hd .t b")?.textContent || ""`);
+
 const tap = async (cdp: CDP, sel: string, needle?: string) => {
   const hit = await cdp.ev(`(()=>{const els=[...document.querySelectorAll(${JSON.stringify(sel)})];
     const el = ${needle ? `els.find(e=>e.textContent.includes(${JSON.stringify(needle)}))` : "els[0]"};
@@ -132,6 +155,20 @@ async function main() {
     const rows = await cdp.ev(`document.querySelectorAll("main button.w-full").length`);
     note("chats", "list is not the whole archive", rows < 40, `${rows} rows on the opening scope`);
     await shot(cdp, "02-chats");
+
+    // Each scope has to actually change the list, and All has to be the widest.
+    await tap(cdp, "main button", "All");
+    await Bun.sleep(900);
+    const allRows = await cdp.ev(`document.querySelectorAll("main button.w-full").length`);
+    note("chats", "All widens the list", allRows >= rows, `${rows} → ${allRows}`);
+    await tap(cdp, "main button", "Working");
+    await Bun.sleep(900);
+    const liveRows = await cdp.ev(`document.querySelectorAll("main button.w-full").length`);
+    note("chats", "Working narrows it", liveRows <= allRows, `${allRows} → ${liveRows}`);
+    note("chats", "an empty scope explains itself",
+      liveRows > 0 || await cdp.ev(`document.body.textContent.includes("Try a wider range")`));
+    await tap(cdp, "main button", "Today");
+    await Bun.sleep(900);
     await drain(cdp, "chats");
 
     // ---- a conversation ---------------------------------------------
@@ -162,6 +199,20 @@ async function main() {
       note("conversation", "composer offers a way to reply",
         await cdp.ev(`(()=>{const f=document.querySelector(".mb-chat .ft");if(!f)return false;
           return !!f.querySelector("textarea") && !f.textContent.includes("did not record where it ran");})()`));
+      // Reading history must not be interrupted by a poll landing, and there
+      // has to be a way back down again.
+      await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");if(b) b.scrollTop = 0;})()`);
+      await Bun.sleep(400);
+      note("conversation", "scrolling up stays where you put it",
+        await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");
+          return !!b && b.scrollTop < 40;})()`));
+      await Bun.sleep(6000);
+      note("conversation", "a poll does not yank you back down",
+        await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");
+          return !!b && b.scrollTop < 200;})()`));
+      await shot(cdp, "03b-scrolled-up");
+      await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");if(b) b.scrollTop = b.scrollHeight;})()`);
+      await Bun.sleep(500);
       note("conversation", "thread is scrolled to the newest turn",
         await cdp.ev(`(()=>{const b=document.querySelector(".mb-chat .bd");if(!b)return false;
           return b.scrollHeight - b.scrollTop - b.clientHeight < 80;})()`));
@@ -203,13 +254,34 @@ async function main() {
       // looks exactly like a click that did nothing.
       if (files.length && await tap(cdp, ".mb-screen.on .mb-row button")) {
         await Bun.sleep(2200);
-        note("diff", "the diff screen opens",
-          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .hd .t b")]
-            .some(b=>b.textContent.includes("."))`));
+        note("diff", "the diff screen opens", (await topTitle(cdp)).includes("."), await topTitle(cdp));
         const lines = await cdp.ev(`document.querySelectorAll(".mb-dl, .mb-diff-line, .mb-hunk").length`);
         const said = await cdp.ev(`(document.querySelector(".mb-screen.on")?.textContent || "")
           .includes("Nothing to show") ? "empty" : ""`);
         note("diff", "the diff renders lines", lines > 0 && !said, `${lines} line nodes ${said}`);
+        // Walking files from inside the diff, when there is more than one to
+        // walk — with a single changed file the footer correctly has no
+        // Prev/Next to press.
+        if (files.length > 1) {
+          const firstTitle = await topTitle(cdp);
+          await tapTop(cdp, ".ft button", "Next");
+          await Bun.sleep(1400);
+          const secondTitle = await topTitle(cdp);
+          note("diff", "Next moves to another file", !!secondTitle && secondTitle !== firstTitle,
+            `${firstTitle} → ${secondTitle}`);
+          note("diff", "the new file has content",
+            await cdp.ev(`(${TOP})?.querySelectorAll(".bd *").length > 5`));
+        } else {
+          note("diff", "a single changed file offers no Prev/Next",
+            await cdp.ev(`!(${TOP})?.querySelector(".ft")`), `${files.length} file`);
+        }
+        await tapTop(cdp, ".hd button", "Wrap");
+        await Bun.sleep(600);
+        note("diff", "the wrap toggle answers",
+          await cdp.ev(`[...(${TOP})?.querySelectorAll(".hd button")]
+            .some(b=>b.textContent.trim() === "Scroll")`));
+        await tapTop(cdp, ".ft button", "Prev");
+        await Bun.sleep(1200);
         await shot(cdp, "06-diff");
         await drain(cdp, "diff");
 
@@ -218,8 +290,7 @@ async function main() {
         await cdp.ev("history.back()");
         await Bun.sleep(900);
         note("back gesture", "closes the diff and keeps the repo",
-          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .hd .t b")]
-            .some(b=>b.textContent.trim() === ${JSON.stringify(process.env.AUDIT_REPO || "")} || !b.textContent.includes("."))`));
+          !(await topTitle(cdp)).includes("."), await topTitle(cdp));
         await drain(cdp, "back gesture");
       }
 
@@ -264,10 +335,18 @@ async function main() {
       note("settings", "sheet opens", await cdp.ev(`!!document.querySelector(".mb-sheet.on")`));
       note("settings", "reports what this machine spent",
         await cdp.ev(`(document.querySelector(".mb-sheet.on")?.textContent || "").includes("Spend today")`));
+      note("settings", "the sheet scrolls rather than running off the screen",
+        await cdp.ev(`(()=>{const s=document.querySelector(".mb-sheet.on");if(!s)return false;
+          const r=s.getBoundingClientRect();
+          return r.bottom<=innerHeight+1 && r.top>=-1;})()`));
       await shot(cdp, "08-settings");
       await drain(cdp, "settings");
-      await cdp.ev(`document.querySelector(".mb-scrim")?.click()`);
-      await Bun.sleep(600);
+      // The scrim that is actually up: every sheet keeps one mounted, and the
+      // first in the document belongs to a sheet that is closed.
+      await cdp.ev(`document.querySelector(".mb-scrim.on")?.click()`);
+      await Bun.sleep(700);
+      note("settings", "tapping outside closes it",
+        !(await cdp.ev(`!!document.querySelector(".mb-sheet.on")`)));
     }
 
     // ---- new chat form (opened, never sent) --------------------------
@@ -308,6 +387,35 @@ async function main() {
     note("offline", "comes back on its own",
       await cdp.ev(`(document.querySelector("header")?.textContent || "").includes("Live")`));
     await drain(cdp, "offline");
+
+    // ---- landscape ----------------------------------------------------
+    // A phone turned sideways is 915x412: the same app, half the height, and
+    // the composer still has to be reachable.
+    await tap(cdp, "nav button", "Chats");
+    await Bun.sleep(800);
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: 915, height: 412, deviceScaleFactor: PHONE.scale, mobile: true,
+    });
+    await Bun.sleep(900);
+    note("landscape", "still the phone application",
+      (await cdp.ev(`document.documentElement.dataset.layout`)) === "phone");
+    note("landscape", "nothing spills off the side",
+      await cdp.ev(`document.documentElement.scrollWidth <= innerWidth + 2`));
+    await shot(cdp, "13-landscape");
+    if (await tap(cdp, "main button.w-full")) {
+      await Bun.sleep(1400);
+      note("landscape", "the composer is still on screen",
+        await cdp.ev(`(()=>{const f=document.querySelector(".mb-chat .ft");if(!f)return false;
+          const r=f.getBoundingClientRect();return r.bottom<=innerHeight+1&&r.top>0;})()`));
+      await shot(cdp, "14-landscape-chat");
+      await cdp.ev("history.back()");
+      await Bun.sleep(700);
+    }
+    await drain(cdp, "landscape");
+    await cdp.send("Emulation.setDeviceMetricsOverride", {
+      width: PHONE.w, height: PHONE.h, deviceScaleFactor: PHONE.scale, mobile: true,
+    });
+    await Bun.sleep(700);
 
     console.log(`\nscreenshots → ${SHOTS}`);
   } finally {

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -299,9 +299,60 @@ export function chatStream(cwd: unknown, message: unknown, model: unknown, resum
   return chatStreamPlanned(plan);
 }
 
+/**
+ * Sessions with a turn running right now, and how many runs are on each.
+ *
+ * A session has exactly one writer, and nothing a client can read tells it
+ * whether that writer is busy. The transcript is written by the scanner and
+ * arrives late; "last seen recently" is true of a session that finished ten
+ * seconds ago as well as one that is mid-thought. Guessing from that is how the
+ * phone came to send a second `claude -p --resume` into a session that was
+ * already answering, which interrupts the running turn and loses the reply.
+ *
+ * We spawned the process, so we simply know. Counted rather than flagged
+ * because the desktop and the phone can both be talking to the same session,
+ * and the first one to finish must not clear the flag for the other.
+ */
+const ACTIVE = new Map<string, number>();
+
+function markActive(id: string, on: boolean): void {
+  if (!id) return;
+  const n = (ACTIVE.get(id) ?? 0) + (on ? 1 : -1);
+  if (n > 0) ACTIVE.set(id, n);
+  else ACTIVE.delete(id);
+}
+
+/** Is a turn in flight for this session? */
+export const turnActive = (id: string): boolean => ACTIVE.has(id);
+
+/** Every session with a turn in flight. */
+export const activeTurns = (): string[] => [...ACTIVE.keys()];
+
+/** The session id `claude` reports in its opening frame, if this chunk carries
+ *  one. A new chat has no id until then — and it is the id the client will use
+ *  to resume, so it is the one that has to be marked busy. */
+export function sessionIdIn(chunk: string): string | null {
+  const at = chunk.indexOf('"session_id"');
+  if (at < 0) return null;
+  const m = /"session_id"\s*:\s*"([0-9a-fA-F-]{8,})"/.exec(chunk);
+  return m ? m[1]! : null;
+}
+
 function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
   const bin = claudeBin()!;
   const { dir, text: msgText, model: m, mode: pm, resumeId: rid, images: imgs } = plan;
+
+  // The guard itself, not just the advice. A client that asks anyway — an old
+  // build, a stale tab, a retry — would otherwise put a second `claude` on a
+  // transcript that is being written, and the visible result is the running
+  // turn interrupted and both answers lost. Refusing costs one message that
+  // has to be sent again; allowing it costs the conversation.
+  if (rid && turnActive(rid)) {
+    return new Response(JSON.stringify({
+      error: "that session is mid-turn — wait for it to finish, or your message will interrupt it",
+      code: "turn_in_flight",
+    }), { status: 409, headers: { "content-type": "application/json", ...CORS } });
+  }
 
   const args = [bin, "-p", "--output-format", "stream-json", "--verbose", "--model", m];
   // Same flag both engines use. Verified it applies to `-p` as well as to an
@@ -341,6 +392,14 @@ function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
 
   const enc = new TextEncoder();
   let cancelled = false;
+  // A resumed turn is busy on a known session from this moment; a new chat
+  // becomes busy on the id its first frame announces. `released` keeps the
+  // bookkeeping balanced however the stream ends — finished, errored, or
+  // cancelled from the browser.
+  let busyId = rid;
+  let released = false;
+  const release = () => { if (!released) { released = true; markActive(busyId, false); } };
+  if (busyId) markActive(busyId, true);
   const stream = new ReadableStream<Uint8Array>({
     async start(controller) {
       const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
@@ -377,16 +436,29 @@ function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
           else proc.kill();
         } catch { /* gone */ }
       }, STARTUP_TIMEOUT_MS);
+      const dec = new TextDecoder();
       try {
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
-          if (value) { firstByte = true; clearTimeout(watchdog); controller.enqueue(value); }
+          if (value) {
+            firstByte = true;
+            clearTimeout(watchdog);
+            // A chat with no resume id learns its session from the first frame.
+            // Until that lands nobody can address this session, so there is
+            // nothing to collide with; from here on there is.
+            if (!busyId) {
+              const found = sessionIdIn(dec.decode(value, { stream: true }));
+              if (found) { busyId = found; markActive(busyId, true); }
+            }
+            controller.enqueue(value);
+          }
         }
       } catch { /* closed */ }
       clearTimeout(watchdog);
       stopKeepalive();
       const code = await proc.exited;
+      release();
       // The reader loop ends on cancel too, and a cancelled controller throws
       // on enqueue/close — which would surface as an unhandled rejection on
       // every "stop" the user presses.
@@ -399,6 +471,7 @@ function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
     },
     cancel() {
       cancelled = true;
+      release();
       try {
         if (setsid) process.kill(-proc.pid, "SIGTERM"); // the group, not just claude
         else proc.kill();

--- a/server/src/git.ts
+++ b/server/src/git.ts
@@ -23,12 +23,38 @@ export const COMMIT_ENABLED = process.env.AGENTGLASS_COMMIT_DISABLED !== "1";
 
 type GitResult = { code: number; stdout: string; stderr: string };
 
+/**
+ * Configuration this server sets on every git call, because it parses the
+ * output and the user's own config can change it.
+ *
+ * `diff.mnemonicPrefix` is the one that bit: with it on — and plenty of people
+ * have it on — git labels a diff `i/file` and `w/file` (index and worktree)
+ * instead of `a/file` and `b/file`. Our diff parser stripped `a/`/`b/` only, so
+ * every path came out as `w/web/src/…`. The panel then asked for a diff of a
+ * file by that name and got nothing, and staging one ran
+ * `git add -- w/web/src/…`, which fails with "did not match any files". A
+ * working repo looked like a broken app, and only for people with that setting.
+ *
+ * `diff.noprefix` is the same trap from the other side (no prefix at all),
+ * `core.quotepath` escapes non-ASCII names into `\303\251` octal, and
+ * `color.ui=always` would wrap everything we read in ANSI escapes.
+ *
+ * Passed as `-c` overrides rather than environment variables so they apply to
+ * exactly these calls and nothing the user runs themselves.
+ */
+const PINNED: string[] = [
+  "-c", "diff.mnemonicPrefix=false",
+  "-c", "diff.noprefix=false",
+  "-c", "core.quotepath=false",
+  "-c", "color.ui=false",
+];
+
 export function git(cwd: string, args: string[]): GitResult {
   const t0 = performance.now();
   try {
     // A hung git call (index.lock contention, a repo on a stalled mount) would
     // otherwise freeze the whole single-threaded server indefinitely.
-    const proc = Bun.spawnSync(["git", "-C", cwd, ...args], { stdout: "pipe", stderr: "pipe", timeout: 15_000 });
+    const proc = Bun.spawnSync(["git", ...PINNED, "-C", cwd, ...args], { stdout: "pipe", stderr: "pipe", timeout: 15_000 });
     const r = {
       code: proc.exitCode ?? 1,
       stdout: proc.stdout?.toString() ?? "",
@@ -126,7 +152,7 @@ async function runGit(cwd: string, args: string[]): Promise<GitResult> {
   // arrive in the meantime. See loopwatch.
   const owner = currentLabel();
   try {
-    const proc = Bun.spawn(["git", "-C", cwd, ...args], {
+    const proc = Bun.spawn(["git", ...PINNED, "-C", cwd, ...args], {
       stdout: "pipe",
       stderr: "pipe",
       // A git that never returns used to cost one hung request: bad, bounded,

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -54,12 +54,19 @@ function inRepo(root: string, rel: string): string | null {
   return abs;
 }
 
-// Strip a/ b/ prefixes, /dev/null, and C-style git quoting from a diff path.
+// Strip the diff prefix, /dev/null, and C-style git quoting from a diff path.
+//
+// The prefix is normally `a/` and `b/`, and git.ts pins the config that decides
+// so on every call. This also accepts the mnemonic set — `c/` commit, `i/`
+// index, `w/` worktree, `o/` object — because that is what a repo with
+// `diff.mnemonicPrefix` emits, and a path that keeps its prefix does not merely
+// look wrong: it is passed back to `git add`, which then fails with "did not
+// match any files" on a file that is sitting right there.
 function pathFrom(s: string): string {
   s = s.trim().replace(/\t.*$/, "");
   if (s === "/dev/null") return "/dev/null";
   if (s.startsWith('"') && s.endsWith('"')) { try { s = JSON.parse(s); } catch { /* keep raw */ } }
-  if (s.startsWith("a/") || s.startsWith("b/")) s = s.slice(2);
+  if (/^[abciwo]\//.test(s)) s = s.slice(2);
   return s;
 }
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -66,7 +66,7 @@ import {
 } from "./prs.ts";
 import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
-import { chatSend, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
+import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
@@ -1237,6 +1237,13 @@ const server = Bun.serve<WsData>({
         return json({ available: true, reviewFocus: "", files: [], error: String(e?.message || e) });
       }
     }
+    // Which sessions have a turn running right now. Read by any surface before
+    // it sends: a message into a session that is mid-turn interrupts it and is
+    // lost, and nothing else a client can poll answers this — the transcript
+    // arrives late and "seen recently" is equally true of a session that
+    // finished ten seconds ago. Deliberately outside the session cache: it
+    // changes on process lifetimes, not on events.
+    if (pathname === "/chat/active") return json({ ids: activeTurns() });
     if (pathname === "/session") {
       const id = url.searchParams.get("id") || "";
       if (!id) return json({ error: "not found" }, 404);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -450,7 +450,13 @@ const server = Bun.serve<WsData>({
     // Proof of reachability for the remote-access panel: which off-box devices
     // have actually arrived. Loopback is ignored — it is every call the app
     // makes of itself and says nothing about whether a phone can get in.
-    noteClient(srv.requestIP(req)?.address);
+    const clientIp = srv.requestIP(req)?.address;
+    noteClient(clientIp);
+    // Same fact, put to a second use: a page served off-box gets the phone
+    // application, not the cockpit (see webui.ts). An address we cannot read is
+    // treated as local — it means the socket had no peer to report, which on
+    // this server is the app talking to itself.
+    const fromRemote = clientIp ? !isLoopback(clientIp) : false;
 
     // Per-request response helpers: `cors` reflects this caller's Origin, so it
     // has to be built here rather than shared as a module constant.
@@ -484,7 +490,7 @@ const server = Bun.serve<WsData>({
     // never collide here: none of them maps to a real file under web/dist, so
     // for them this falls straight through to the routes.
     if (req.method === "GET" || req.method === "HEAD") {
-      const asset = serveWeb(pathname, cors);
+      const asset = serveWeb(pathname, cors, fromRemote);
       if (asset) return asset;
     }
 
@@ -1392,7 +1398,7 @@ const server = Bun.serve<WsData>({
     // index.html and let the bundle take it from there. Anything else — curl,
     // fetch, an exporter probing a bad path — still gets the JSON 404.
     if (req.method === "GET" && (req.headers.get("accept") || "").includes("text/html")) {
-      const page = serveIndex(cors);
+      const page = serveIndex(cors, fromRemote);
       if (page) return page;
     }
 

--- a/server/src/webui.ts
+++ b/server/src/webui.ts
@@ -67,12 +67,29 @@ export const WEB_UI_ENABLED = DIST !== null;
  *  conventional :4000 — see SERVER in web/src/lib/api.ts. */
 const MARKER = "<script>window.__AGENTGLASS_SAME_ORIGIN__=true</script>";
 
-/** Plant the marker in index.html on its way out. Injected at serve time, not
+/**
+ * The off-box marker: this page is leaving the machine.
+ *
+ * Which application a device gets used to be decided in the browser, from
+ * viewport width and pointer type (web/src/lib/viewport.ts). That reads the
+ * wrong thing. A phone asking for the desktop site, a saved layout override, a
+ * tablet-width window — any of them widens the measurement, and the cockpit
+ * mounts on a device that reached us over the network: a terminal, git write
+ * access and docker control, behind a link that was scanned off a screen.
+ *
+ * The connection knows what the viewport cannot. A request that did not come
+ * from loopback is remote, whatever the browser says about itself, and the
+ * bundle cannot argue with a marker that was never sent.
+ */
+const REMOTE_MARKER = "<script>window.__AGENTGLASS_REMOTE__=true</script>";
+
+/** Plant the markers in index.html on its way out. Injected at serve time, not
  *  build time, so the SAME build still works under vite preview or the desktop
  *  shell's static server — pages those serve never carry the marker. */
-export function injectSameOrigin(html: string): string {
+export function injectSameOrigin(html: string, remote = false): string {
+  const planted = MARKER + (remote ? REMOTE_MARKER : "");
   const head = html.indexOf("</head>");
-  return head >= 0 ? html.slice(0, head) + MARKER + html.slice(head) : MARKER + html;
+  return head >= 0 ? html.slice(0, head) + planted + html.slice(head) : planted + html;
 }
 
 /** Map a request path to a real file under dist, or null. Clamped the same way
@@ -99,20 +116,21 @@ export function resolveAsset(pathname: string, dist: string | null = DIST): stri
 
 /** index.html, marker planted. Never cached: it's the one file whose content
  *  names the (hashed) assets, so a stale copy pins a whole stale UI. */
-function indexResponse(dist: string, cors: Record<string, string>): Response {
-  const html = injectSameOrigin(readFileSync(resolve(dist, "index.html"), "utf8"));
+function indexResponse(dist: string, cors: Record<string, string>, remote: boolean): Response {
+  const html = injectSameOrigin(readFileSync(resolve(dist, "index.html"), "utf8"), remote);
   return new Response(html, {
     headers: { "content-type": "text/html; charset=utf-8", "cache-control": "no-cache", ...cors },
   });
 }
 
 /** Serve `pathname` as a static UI file, or null when it maps to none (an API
- *  route, a WS upgrade — anything that isn't a real file under web/dist). */
-export function serveWeb(pathname: string, cors: Record<string, string>): Response | null {
+ *  route, a WS upgrade — anything that isn't a real file under web/dist).
+ *  `remote` says the request came from off-box; only index.html cares. */
+export function serveWeb(pathname: string, cors: Record<string, string>, remote = false): Response | null {
   if (!DIST) return null;
   const abs = resolveAsset(pathname);
   if (!abs) return null;
-  if (abs === resolve(DIST, "index.html")) return indexResponse(DIST, cors);
+  if (abs === resolve(DIST, "index.html")) return indexResponse(DIST, cors, remote);
   // Bun.file knows the MIME from the extension. Vite content-hashes everything
   // under assets/, which is what makes the far-future cache safe; the rest
   // (favicon and friends) revalidates.
@@ -124,7 +142,7 @@ export function serveWeb(pathname: string, cors: Record<string, string>): Respon
 
 /** The SPA fallback: index.html for a UI deep-link. The caller has already let
  *  every API route decline, and only calls this for a GET that accepts html. */
-export function serveIndex(cors: Record<string, string>): Response | null {
+export function serveIndex(cors: Record<string, string>, remote = false): Response | null {
   if (!DIST) return null;
-  return indexResponse(DIST, cors);
+  return indexResponse(DIST, cors, remote);
 }

--- a/server/test/turn-in-flight.test.ts
+++ b/server/test/turn-in-flight.test.ts
@@ -1,0 +1,44 @@
+// Knowing which sessions are mid-turn is what stops a second `claude` being
+// put on a transcript that is already being written — the failure that cut
+// replies off halfway and lost the message that caused it.
+import { describe, expect, test } from "bun:test";
+import { sessionIdIn, activeTurns, turnActive } from "../src/chat.ts";
+
+describe("sessionIdIn", () => {
+  test("reads the id out of the opening frame", () => {
+    const frame = JSON.stringify({
+      type: "system", subtype: "init", session_id: "e3276954-da78-4890-b206-97239111dc5b", model: "claude-haiku-4-5",
+    });
+    expect(sessionIdIn(frame)).toBe("e3276954-da78-4890-b206-97239111dc5b");
+  });
+
+  test("finds it wherever in the chunk it lands", () => {
+    expect(sessionIdIn(`{"a":1}\n{"type":"system","session_id":"abcdef12-0000-4000-8000-000000000000"}\n`))
+      .toBe("abcdef12-0000-4000-8000-000000000000");
+  });
+
+  test("no id in an ordinary assistant frame", () => {
+    expect(sessionIdIn(JSON.stringify({ type: "assistant", message: { content: [{ type: "text", text: "hi" }] } })))
+      .toBe(null);
+  });
+
+  test("a truncated or malformed id is not an id", () => {
+    expect(sessionIdIn(`{"session_id":"short"}`)).toBe(null);
+    expect(sessionIdIn(`{"session_id":}`)).toBe(null);
+    expect(sessionIdIn("")).toBe(null);
+  });
+
+  test("does not mistake a similarly named field", () => {
+    expect(sessionIdIn(`{"parent_session_ids":["aaaaaaaa-0000-4000-8000-000000000000"]}`)).toBe(null);
+  });
+});
+
+describe("the in-flight register", () => {
+  test("starts empty and answers for an unknown session", () => {
+    // No turn has been spawned in this process, so nothing may claim to be one:
+    // a false positive here freezes a composer that should be usable.
+    expect(activeTurns()).toEqual([]);
+    expect(turnActive("e3276954-da78-4890-b206-97239111dc5b")).toBe(false);
+    expect(turnActive("")).toBe(false);
+  });
+});

--- a/server/test/webui.test.ts
+++ b/server/test/webui.test.ts
@@ -74,6 +74,24 @@ describe("injectSameOrigin", () => {
   test("headless html still gets the marker (prepended)", () => {
     expect(injectSameOrigin("<div/>").startsWith("<script>")).toBe(true);
   });
+
+  // The off-box mark. It decides which application the device gets, so the one
+  // thing that must never happen is planting it by default: that would put the
+  // phone companion on the desk.
+  test("the remote mark is planted only when asked for", () => {
+    const local = injectSameOrigin("<html><head></head><body></body></html>");
+    expect(local).not.toContain("__AGENTGLASS_REMOTE__");
+
+    const remote = injectSameOrigin("<html><head></head><body></body></html>", true);
+    expect(remote).toContain("window.__AGENTGLASS_REMOTE__=true");
+    expect(remote.indexOf("__AGENTGLASS_REMOTE__")).toBeLessThan(remote.indexOf("</head>"));
+    // Both marks, and the same-origin one still first.
+    expect(remote.indexOf("__AGENTGLASS_SAME_ORIGIN__")).toBeLessThan(remote.indexOf("__AGENTGLASS_REMOTE__"));
+  });
+
+  test("headless html carries the remote mark too", () => {
+    expect(injectSameOrigin("<div/>", true)).toContain("__AGENTGLASS_REMOTE__");
+  });
 });
 
 // AGENTGLASS_WEB_DIR: the override that lets the packaged desktop sidecar find

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -20,6 +20,7 @@ import { ToolFeed } from "./ToolFeed.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
 import { buildRows } from "../lib/toolTree.ts";
 import { chatToMarkdown } from "../lib/chatTranscript.ts";
+import { busyElsewhere, setActiveTurns } from "../lib/chatStore.ts";
 import { tidyPaneScreen } from "../lib/paneScreen.ts";
 import { quickSkills, pinnedSkills, togglePinnedSkill } from "../lib/quickSkills.ts";
 import { fmtTime } from "../lib/format.ts";
@@ -404,12 +405,15 @@ function CopyButton({ label, title, text, disabled }: { label: string; title: st
 
 /** Why a session can't be picked up, or `null` if it can.
  *
- *  Three different refusals with three different remedies — "wait for it to
- *  finish", "nothing we can do", "it's already open over there" — so the row
- *  has to say which one applies rather than just going grey. */
-type Blocked = "live" | "no-dir" | null;
-const blockedReason = (s: SessionRollup): Blocked =>
-  sessionIsLive(s) ? "live" : sessionCwd(s) ? null : "no-dir";
+ *  Only one refusal is absolute now: a session that never recorded a directory
+ *  has nowhere to resume into. "Still running" used to be the other, which made
+ *  the sessions you most wanted — the one you just started on your phone, the
+ *  one working in a terminal — the only ones you could not open. They can be
+ *  opened and read; what protects the transcript is that a turn is queued
+ *  rather than sent while someone else is writing (see chatStore.busyElsewhere,
+ *  and the server's own 409 behind it). */
+type Blocked = "no-dir" | null;
+const blockedReason = (s: SessionRollup): Blocked => (sessionCwd(s) ? null : "no-dir");
 
 /** One resumable session in the picker. */
 function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: string; onPick: () => void }) {
@@ -419,12 +423,13 @@ function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: s
   // itself — resuming lands back in that checkout, so it has to say which.
   const wt = sessionWorktree(s);
   const label = (s.project_path ? repoName(s.project_path) : s.source_app) + (wt ? ` └ ${wt}` : "");
-  const note = why === "live"
-    ? "This session is still running. A claude session has a single owner — a second one writing to the same transcript would corrupt its history. Resume it once it stops."
-    : why === "no-dir"
+  const live = sessionIsLive(s);
+  const note = why === "no-dir"
     ? "No directory was recorded for this session, so there's nowhere to run the resumed conversation."
     : openChatId
     ? "Already open in this panel — picking it focuses that tab."
+    : live
+    ? `Running now. Opening it shows the conversation; anything you send waits until this turn ends, because a session has one writer.`
     : `Continue this conversation in ${sessionCwd(s)}`;
 
   return (
@@ -448,7 +453,7 @@ function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: s
           <span>· {fmtUsd(s.cost_usd)}</span>
         </div>
       </div>
-      {why === "live"
+      {live
         ? <span className="text-[9.5px] shrink-0" style={{ color: "var(--success)" }}>● Running</span>
         : why === "no-dir"
         ? <span className="text-[9.5px] shrink-0 t-dim2">No dir</span>
@@ -604,6 +609,27 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   useEffect(() => { try { localStorage.setItem(ALLOW_KEY, allowed); } catch { /* private mode */ } }, [allowed]);
   const [query, setQuery] = useState("");
   const [resumeOpen, setResumeOpen] = useState(false);
+
+  /**
+   * Which sessions are mid-turn, from the server.
+   *
+   * The panel knows about its own turns and nothing about a turn started on the
+   * phone or in a terminal — and sending into one of those interrupts it and
+   * loses both answers. Polled rather than pushed because it is two words of
+   * JSON and it must be right within a couple of seconds of a turn ending, when
+   * a queued message is waiting to go out.
+   */
+  useEffect(() => {
+    let stop = false;
+    const read = () => {
+      api.chatActive()
+        .then((r) => { if (!stop) setActiveTurns(r.ids); })
+        .catch(() => { /* keep the last answer; guessing a new one is the bug */ });
+    };
+    read();
+    const t = setInterval(read, 3000);
+    return () => { stop = true; clearInterval(t); };
+  }, []);
   const [defaultCwd, setDefaultCwd] = useState<string>(() => { try { return localStorage.getItem(CWD_KEY) || ""; } catch { return ""; } });
   const inputRef = useRef<HTMLTextAreaElement>(null);
   const fileRef = useRef<HTMLInputElement>(null);
@@ -768,7 +794,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     setResumeOpen(false);
     // Resume in the checkout it ran in, not the repo it rolls up to.
     const cwd = sessionCwd(s);
-    if (!cwd || sessionIsLive(s)) return;
+    if (!cwd) return;
     const chat = chatResuming(s.session_id)
       ?? newChat(cwd, s.model_name || undefined, active?.mode ?? DEFAULT_MODE, {
         sessionId: s.session_id,
@@ -811,7 +837,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // Mid-turn, Enter queues instead of sending. The composer used to go dead
     // for the length of a reply, so a long tool-running turn meant watching it
     // work with an answer already typed and no way to hand it over.
-    if (active.sending) { enqueue(active.id, text); return; }
+    //
+    // The same applies when the turn belongs to someone else — a chat you
+    // started on the phone, an agent running in a terminal. `send` would queue
+    // it anyway; doing it here keeps the composer honest about what pressing
+    // Enter just did.
+    if (active.sending || busyElsewhere(active)) { enqueue(active.id, text); return; }
     send(active.id, text, () => openRef.current && activeIdRef.current === active.id, allowed.split(/\s+/).filter(Boolean));
   };
   const [hint, setHint] = useState("");

--- a/web/src/components/RemoteAccessPane.tsx
+++ b/web/src/components/RemoteAccessPane.tsx
@@ -91,8 +91,9 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
     <Wrap>
       <div className="px-3 py-2 flex flex-col gap-3">
         <div className="text-[11.5px]" style={{ color: "var(--text2)" }}>
-          Open this dashboard on a phone or tablet on the same network. Monitoring, sessions and gate
-          approvals, from the sofa.
+          Open agentglass on a phone or tablet on the same network. Monitoring, sessions and gate
+          approvals, from the sofa. A device that connects from off this machine always gets the
+          phone companion, never this dashboard.
         </div>
 
         {enabled === null ? (

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -277,6 +277,9 @@ const realApi = {
   skills: () => get<{ skills: SkillInfo[]; usage_since?: number; generated_at: number }>(`/skills`),
   changes: (limit = 200) => get<{ changes: FileChange[] }>(`/changes?limit=${limit}`),
   session: (id: string) => get<SessionDetail>(`/session?id=${encodeURIComponent(id)}`),
+  /** Sessions with a turn running right now. The only honest answer to "can I
+   *  send to this without interrupting it" — see server/src/chat.ts. */
+  chatActive: () => get<{ ids: string[] }>(`/chat/active`),
   insights: () => get<{ insights: Insight[] }>(`/insights`),
   search: (q: string) => get<{ hits: SearchHit[] }>(`/search?q=${encodeURIComponent(q)}`),
   gatePending: () => get<{ gates: PendingGate[] }>(`/gate/pending`),
@@ -590,6 +593,8 @@ const demoApi: typeof realApi = {
   skills: () => D(demo.skills()),
   changes: () => D(demo.changes()),
   session: (id: string) => D(demo.session(id)),
+  // Nothing spawns anything in the demo, so nothing is ever mid-turn.
+  chatActive: () => D({ ids: [] as string[] }),
   insights: () => D(demo.insights()),
   search: (q: string) => D(demo.search(q)),
   gatePending: () => D(demo.gatePending()),

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -644,6 +644,41 @@ const titleOf = (s: string) => {
  * `activeId` decides whether the reply counts as unread — a chat answering in
  * the background should say so, and the one on screen shouldn't.
  */
+/**
+ * Sessions the server says are mid-turn, refreshed by the panel.
+ *
+ * A session has exactly one writer. This browser knows about its own turns
+ * (`chat.sending`) and nothing about a turn started from the phone or from a
+ * terminal — and sending into one of those interrupts it and loses both
+ * answers. The server spawned the process, so it is the one that knows; see
+ * server/src/chat.ts and GET /chat/active.
+ */
+let activeElsewhere = new Set<string>();
+
+export function setActiveTurns(ids: string[]): void {
+  const next = new Set(ids);
+  // Only wake the UI when the answer actually changed: this is polled.
+  if (next.size === activeElsewhere.size && [...next].every((i) => activeElsewhere.has(i))) return;
+  const freed = [...activeElsewhere].filter((i) => !next.has(i));
+  activeElsewhere = next;
+  emit();
+  // Somebody else's turn just ended. Anything held for that session goes now —
+  // without this the queue would wait for a turn of ours that never comes.
+  for (const sid of freed) {
+    for (const c of chats.values()) {
+      if (c.sessionId !== sid || c.sending || !c.queued.length) continue;
+      const q = c.queued[0]!;
+      update(c.id, (x) => { x.queued = x.queued.filter((t) => t.id !== q.id); });
+      void send(c.id, q.text, () => activeChatId === c.id, [], q.images);
+    }
+  }
+}
+
+/** Is this chat's session being written by someone other than this tab? */
+export function busyElsewhere(chat: Pick<Chat, "sessionId" | "sending">): boolean {
+  return !!chat.sessionId && !chat.sending && activeElsewhere.has(chat.sessionId);
+}
+
 export async function send(id: string, text: string, isActive: () => boolean, allowedTools: string[] = [], queuedImages?: ChatImage[]) {
   const chat = chats.get(id);
   const msg = text.trim();
@@ -655,6 +690,16 @@ export async function send(id: string, text: string, isActive: () => boolean, al
   // is being written next.
   const images: ChatImage[] = queuedImages ?? (chat ? chat.attachments.map((a) => ({ mediaType: a.mediaType, data: a.data })) : []);
   if (!chat || (!msg && !images.length) || chat.sending || !chat.cwd) return;
+
+  // Someone else is mid-turn on this session — the phone, a terminal, another
+  // tab. Sending now interrupts their turn and loses this message with it, so
+  // it goes in the queue and leaves when the session is free. The server would
+  // refuse it anyway (409 turn_in_flight); this is the same answer without the
+  // round trip and without a message disappearing on the way.
+  if (busyElsewhere(chat)) {
+    enqueue(id, msg);
+    return;
+  }
 
   update(id, (c) => {
     // A name you chose outranks one derived from the first message.
@@ -866,8 +911,11 @@ export async function send(id: string, text: string, isActive: () => boolean, al
       });
     }
   } finally {
-    // Read before the update, because draining pops it.
-    const next = broke ? undefined : chats.get(id)?.queued[0];
+    // Read before the update, because draining pops it. A session that is now
+    // being written from somewhere else keeps its queue: the next turn goes out
+    // when that writer is done, not on top of it.
+    const nowBusy = (() => { const c = chats.get(id); return !!c && busyElsewhere({ sessionId: c.sessionId, sending: false }); })();
+    const next = broke || nowBusy ? undefined : chats.get(id)?.queued[0];
     update(id, (c) => {
       c.sending = false;
       c.abort = null;

--- a/web/src/lib/viewport.ts
+++ b/web/src/lib/viewport.ts
@@ -10,6 +10,15 @@
 // when it is widened, and a tablet in landscape is a perfectly good desk. The
 // coarse-pointer rule catches the phone held sideways, where the width alone
 // would say "small laptop": 900px of touch screen still has no keyboard.
+//
+// One case is not a measurement at all. A device that reached this page over
+// the network — the QR link from Settings > Remote — gets the phone
+// application and nothing else, because the cockpit it would otherwise mount
+// carries a terminal, git write access and docker control. Width cannot decide
+// that: Chrome's "Desktop site" reports 980px from a phone, a saved override
+// outlives the reason it was set, and a tablet is wide by definition. The
+// server marks the page instead, from the address the request came from, and
+// that mark wins over everything below.
 
 /** localStorage key holding an explicit choice, which always wins. */
 export const LAYOUT_KEY = "agentglass_layout";
@@ -24,8 +33,14 @@ export type LayoutOverride = "mobile" | "desktop" | null;
 export function wantsPhoneLayout(
   width: number,
   coarsePointer: boolean,
-  override: LayoutOverride = null
+  override: LayoutOverride = null,
+  remote = false
 ): boolean {
+  // Ahead of the override on purpose: the choice a person made about the
+  // laptop on their desk is not consent for the cockpit to open on a device
+  // that scanned a QR code, and the override is remembered per browser, so it
+  // would otherwise be the one input the phone can set for itself.
+  if (remote) return true;
   if (override === "mobile") return true;
   if (override === "desktop") return false;
   if (width < 768) return true;
@@ -64,9 +79,24 @@ function safeStorage(): Storage | null {
   }
 }
 
+/**
+ * Was this page served to a device off this machine?
+ *
+ * Planted by the server into index.html, per connection, from the peer address
+ * of the socket (server/src/webui.ts). Absent for the desktop shell, which
+ * loads the renderer from its own `agentglass://` scheme, and for vite dev and
+ * the demo build, which are not served by the server at all.
+ */
+export function servedToRemoteDevice(): boolean {
+  return (
+    typeof window !== "undefined" &&
+    (window as unknown as { __AGENTGLASS_REMOTE__?: boolean }).__AGENTGLASS_REMOTE__ === true
+  );
+}
+
 /** The live answer for this browser, right now. */
 export function phoneLayoutNow(): boolean {
   if (typeof window === "undefined") return false;
   const coarse = typeof window.matchMedia === "function" && window.matchMedia("(pointer: coarse)").matches;
-  return wantsPhoneLayout(window.innerWidth, coarse, readOverride());
+  return wantsPhoneLayout(window.innerWidth, coarse, readOverride(), servedToRemoteDevice());
 }

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -66,6 +66,8 @@ export function MobileApp() {
   const [openRepo, setOpenRepo] = useState<RepoSummary | null>(null);
   const [openPr, setOpenPr] = useState<{ root: string; number: number } | null>(null);
   const [settings, setSettings] = useState(false);
+  /** A conversation is open and owns the whole screen: no app header, no tabs. */
+  const [immersive, setImmersive] = useState(false);
   const [dismissed, setDismissed] = useState<string[]>([]);
 
   // ── polling ──────────────────────────────────────────────────────────
@@ -248,7 +250,7 @@ export function MobileApp() {
       {askDialog}
       <div className="mb-sky" />
 
-      <header className="sticky top-0 z-40 flex items-center gap-2 px-4"
+      {!immersive && <header className="sticky top-0 z-40 flex items-center gap-2 px-4"
         style={{
           paddingTop: "calc(env(safe-area-inset-top) + 11px)", paddingBottom: 10,
           background: "color-mix(in srgb, var(--bg) 80%, transparent)", backdropFilter: "blur(16px) saturate(1.4)",
@@ -265,9 +267,13 @@ export function MobileApp() {
         <button className="mb-press grid place-items-center" aria-label="Settings"
           style={{ minHeight: 40, minWidth: 40, borderRadius: 11, fontSize: 15, color: "var(--text3)", background: "transparent" }}
           onClick={() => setSettings(true)}>⚙</button>
-      </header>
+      </header>}
 
-      <main className="flex-1 relative" style={{ zIndex: 1, padding: "14px 15px calc(var(--nav) + env(safe-area-inset-bottom) + 22px)" }}>
+      {/* No padding while a conversation owns the screen: it is a fixed
+          full-height surface of its own, and the reserve for a tab bar that is
+          not being drawn would only push its composer off the bottom. */}
+      <main className="flex-1 relative"
+        style={{ zIndex: 1, padding: immersive ? 0 : "14px 15px calc(var(--nav) + env(safe-area-inset-bottom) + 22px)" }}>
         {tab === "now" && (
           <>
             <NowHero
@@ -282,11 +288,11 @@ export function MobileApp() {
             <NowStream items={queue} actionsFor={actionsFor} onOpen={openItem} />
           </>
         )}
-        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} />}
+        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} onImmersive={setImmersive} />}
         {tab === "repos" && <RepoList repos={repoSummaries} onOpen={setOpenRepo} />}
       </main>
 
-      <nav className="fixed left-0 right-0 bottom-0 z-40 flex"
+      {!immersive && <nav className="fixed left-0 right-0 bottom-0 z-40 flex"
         style={{
           background: "color-mix(in srgb, var(--bg2) 84%, transparent)", backdropFilter: "blur(20px) saturate(1.5)",
           borderTop: "1px solid color-mix(in srgb, var(--border) 48%, transparent)",
@@ -295,7 +301,7 @@ export function MobileApp() {
         <TabBtn id="now" tab={tab} onPick={setTab} glyph="◎" label="Now" badge={queue.length} />
         <TabBtn id="chats" tab={tab} onPick={setTab} glyph="▤" label="Chats" />
         <TabBtn id="repos" tab={tab} onPick={setTab} glyph="◇" label="Repos" />
-      </nav>
+      </nav>}
 
       <RepoScreen open={!!openRepo && !openPr} repo={openRepo} containers={containers} stats={dstats}
         onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll} />

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -8,6 +8,7 @@ import { pollWhileVisible } from "../lib/poll.ts";
 import { DIFF_CSS } from "./MobileDiff.tsx";
 import { NOW_CSS, NowHero, NowStream, type NowAction } from "./MobileNow.tsx";
 import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
+import { projectRows } from "./projects.ts";
 import { MobilePr } from "./MobilePr.tsx";
 import { buildQueue, type NowItem } from "./nowQueue.ts";
 import type {
@@ -188,9 +189,18 @@ export function MobileApp() {
   };
   /** A container belongs to a repo, so open its repo rather than inventing a
    *  second route to the same screen. */
+  /** Open a project's screen with all of its checkouts, however you got there —
+   *  the list, a container, a queue item. Opening it without them would leave
+   *  the picker showing whichever project was opened last. */
+  const openProject = useCallback((r: RepoSummary) => {
+    const group = projectRows(repoSummaries).find((g) => g.checkouts.some((c) => c.ref.root === r.ref.root));
+    setOpenCheckouts(group?.checkouts ?? [r]);
+    setOpenRepo(r);
+  }, [repoSummaries]);
+
   const openContainerRepo = (c: DockerContainer) => {
     const r = repoSummaries.find((x) => x.name === (c.project ?? ""));
-    if (r) setOpenRepo(r); else toast("That container is not in a repo agentglass knows", true);
+    if (r) openProject(r); else toast("That container is not in a repo agentglass knows", true);
   };
 
   const actionsFor = (it: NowItem): NowAction[] => {
@@ -293,8 +303,7 @@ export function MobileApp() {
           </>
         )}
         {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} onImmersive={setImmersive} />}
-        {tab === "repos" && <RepoList repos={repoSummaries}
-          onOpen={(r, siblings) => { setOpenCheckouts(siblings); setOpenRepo(r); }} />}
+        {tab === "repos" && <RepoList repos={repoSummaries} onOpen={(r, siblings) => { setOpenCheckouts(siblings); setOpenRepo(r); }} />}
       </main>
 
       {!immersive && <nav className="fixed left-0 right-0 bottom-0 z-40 flex"

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -64,6 +64,10 @@ export function MobileApp() {
   const [me, setMe] = useState("");
 
   const [openRepo, setOpenRepo] = useState<RepoSummary | null>(null);
+  /** Every checkout of the open project — the repo and its linked worktrees —
+   *  so the screen can offer them instead of the list pretending they are
+   *  separate projects. */
+  const [openCheckouts, setOpenCheckouts] = useState<RepoSummary[]>([]);
   const [openPr, setOpenPr] = useState<{ root: string; number: number } | null>(null);
   const [settings, setSettings] = useState(false);
   /** A conversation is open and owns the whole screen: no app header, no tabs. */
@@ -289,7 +293,8 @@ export function MobileApp() {
           </>
         )}
         {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} onImmersive={setImmersive} />}
-        {tab === "repos" && <RepoList repos={repoSummaries} onOpen={setOpenRepo} />}
+        {tab === "repos" && <RepoList repos={repoSummaries}
+          onOpen={(r, siblings) => { setOpenCheckouts(siblings); setOpenRepo(r); }} />}
       </main>
 
       {!immersive && <nav className="fixed left-0 right-0 bottom-0 z-40 flex"
@@ -303,7 +308,9 @@ export function MobileApp() {
         <TabBtn id="repos" tab={tab} onPick={setTab} glyph="◇" label="Repos" />
       </nav>}
 
-      <RepoScreen open={!!openRepo && !openPr} repo={openRepo} containers={containers} stats={dstats}
+      <RepoScreen open={!!openRepo && !openPr} repo={openRepo}
+        checkouts={openCheckouts} onPickCheckout={setOpenRepo}
+        containers={containers} stats={dstats}
         onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll} />
 
       <MobilePr open={!!openPr} root={openPr?.root ?? ""} number={openPr?.number ?? null}

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -37,7 +37,21 @@ const SCOPES: [ChatScope, string][] = [["live", "Working"], ["today", "Today"], 
 /** A turn being streamed right now, before the transcript catches up. */
 type Live = { text: string; tools: string[]; error: string | null };
 
-export function MobileChats({ sessions, onRefresh }: { sessions: SessionRollup[]; onRefresh: () => void }) {
+export function MobileChats({ sessions, onRefresh, onImmersive }: {
+  sessions: SessionRollup[];
+  onRefresh: () => void;
+  /**
+   * Tell the shell a conversation has the screen.
+   *
+   * Not decoration: `main` carries `z-index: 1`, which makes it a stacking
+   * context, and a conversation rendered inside it cannot rise above the app
+   * header however high its own z-index goes. The header painted straight over
+   * the chat's bar, and the tab bar sat on top of the composer. A chat takes
+   * the whole screen, so the shell puts its own chrome away rather than
+   * fighting it.
+   */
+  onImmersive?: (on: boolean) => void;
+}) {
   const [openId, setOpenId] = useState<string | null>(null);
   const [composing, setComposing] = useState(false);
   /**
@@ -60,6 +74,12 @@ export function MobileChats({ sessions, onRefresh }: { sessions: SessionRollup[]
   const liveCount = useMemo(() => scopeSessions(sessions, "live").length, [sessions]);
 
   const open = (id: string, cwd: string) => { setOpenCwd(cwd); setOpenId(id); };
+
+  // Leaving the tab, or the app, must give the chrome back.
+  useEffect(() => {
+    onImmersive?.(!!openId);
+    return () => onImmersive?.(false);
+  }, [openId, onImmersive]);
 
   if (composing) return <NewChat onCancel={() => setComposing(false)} onStarted={(id, cwd) => { setComposing(false); open(id, cwd); onRefresh(); }} />;
   if (openId) return <Conversation id={openId} knownCwd={openCwd} onBack={() => { setOpenId(null); onRefresh(); }} />;

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -4,6 +4,7 @@ import { toolTarget } from "../lib/chatStore.ts";
 import { pollWhileVisible } from "../lib/poll.ts";
 import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
+import { recentTurns } from "./transcript.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
 
 /**
@@ -127,7 +128,21 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
     }, 5000);
   }, [load]);
 
-  useEffect(() => { foot.current?.scrollIntoView({ block: "end" }); }, [detail?.conversation.length, live?.text, sent]);
+  /** The newest turns, oldest at the top and the latest one last — see
+   *  transcript.ts for why the server's order is the other way round. */
+  const turns = useMemo(() => recentTurns(detail?.conversation), [detail?.conversation]);
+
+  /**
+   * Land on the newest turn, every time one arrives.
+   *
+   * Keyed on the newest timestamp rather than the count: the transcript is
+   * capped by a size budget on the server, so a long session can gain a turn
+   * and lose its oldest in the same poll and never change length. That is
+   * exactly the case where a message arrived and the view would have stayed
+   * where it was.
+   */
+  const newestTs = turns.length ? turns[turns.length - 1]!.ts : 0;
+  useEffect(() => { foot.current?.scrollIntoView({ block: "end" }); }, [newestTs, turns.length, live?.text, sent]);
 
   const cwd = detail?.cwd_path || detail?.project_path || "";
   const running = !!detail && !detail.ended_at && Date.now() - detail.last_seen < 120_000;
@@ -191,7 +206,7 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
       )}
 
       <div className="flex flex-col gap-2.5 pb-2">
-        {detail?.conversation.slice(-40).map((m, i) => <Bubble key={`${m.ts}-${i}`} role={m.role} text={m.text} ts={m.ts} />)}
+        {turns.map((m, i) => <Bubble key={`${m.ts}-${i}`} role={m.role} text={m.text} ts={m.ts} />)}
         {sent && <Bubble role="user" text={sent} />}
         {live && (
           <Bubble role="assistant" text={live.text || "…"} streaming tools={live.tools} error={live.error} />

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -6,7 +6,7 @@ import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
 import { sessionIsLive } from "../lib/derive.ts";
 import { scopeSessions, openingScope, type ChatScope } from "./chatList.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
-import { recentTurns } from "./transcript.ts";
+import { recentTurns, buildFeed, summariseRuns, shortTarget, type FeedEntry, type FeedItem, type FeedTool } from "./transcript.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
 
 /**
@@ -247,9 +247,24 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
     }, 5000);
   }, [load]);
 
-  /** The newest turns, oldest at the top and the latest one last — see
-   *  transcript.ts for why the server's order is the other way round. */
-  const turns = useMemo(() => recentTurns(detail?.conversation), [detail?.conversation]);
+  /**
+   * What this agent said AND what it did, oldest first.
+   *
+   * The phone used to draw messages only, so a session that spent twenty
+   * minutes reading files, running tests and editing code looked like three
+   * sentences of commentary. The desktop has always shown the work; the
+   * companion has to show the same thing or the two are not the same product.
+   *
+   * `timeline` carries both. `conversation` is the fallback for a server older
+   * than that field.
+   */
+  const feed = useMemo(() => {
+    const built = buildFeed(detail?.timeline as FeedEntry[] | undefined);
+    if (built.length) return built;
+    return recentTurns(detail?.conversation).map((m): FeedItem =>
+      ({ kind: "message", ts: m.ts, role: m.role, text: m.text }));
+  }, [detail?.timeline, detail?.conversation]);
+  const turns = feed;
 
   /** Jump the thread to the newest turn. */
   const toBottom = useCallback((smooth = false) => {
@@ -422,7 +437,9 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
           </div>
         )}
 
-        {turns.map((m, i) => <Bubble key={`${m.ts}-${i}`} role={m.role} text={m.text} ts={m.ts} />)}
+        {turns.map((item, i) => item.kind === "message"
+          ? <Bubble key={`${item.ts}-${i}`} role={item.role} text={item.text} ts={item.ts} />
+          : <ToolBlock key={`${item.ts}-${i}`} runs={item.runs} errors={item.errors} />)}
         {sent && <Bubble role="user" text={sent} />}
         {live && (
           <Bubble role="assistant" text={live.text || "…"} streaming tools={live.tools} error={live.error} />
@@ -482,6 +499,45 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
           </div>
         )}
       </div>
+    </div>
+  );
+}
+
+/**
+ * The work between two things the agent said.
+ *
+ * Collapsed by default and one line high: a turn is routinely twenty tool runs,
+ * and twenty rows of "Read" on a 412px screen buries the sentence they belong
+ * to. Open it and every run is there with what it acted on — the same trade the
+ * terminal makes, and the same one the desktop panel makes.
+ */
+function ToolBlock({ runs, errors }: { runs: FeedTool[]; errors: number }) {
+  const [open, setOpen] = useState(false);
+  return (
+    <div className="self-stretch">
+      <button onClick={() => setOpen((o) => !o)}
+        className="w-full text-left flex items-center gap-2 px-2.5 py-2 rounded-xl"
+        style={{
+          minHeight: 40,
+          background: "color-mix(in srgb, var(--bg2) 45%, transparent)",
+          border: `1px solid color-mix(in srgb, ${errors ? "var(--error)" : "var(--border)"} 30%, transparent)`,
+          color: "var(--text3)",
+        }}>
+        <span className="text-[10px] shrink-0" style={{ opacity: 0.8 }}>{open ? "▾" : "▸"}</span>
+        <span className="text-[11px] truncate flex-1">{summariseRuns(runs)}</span>
+        {!!errors && <span className="text-[10px] shrink-0" style={{ color: "var(--error)" }}>{errors} failed</span>}
+        <span className="text-[10px] shrink-0 tabular-nums" style={{ opacity: 0.7 }}>{runs.length}</span>
+      </button>
+      {open && (
+        <div className="flex flex-col gap-1 px-2.5 pt-1.5">
+          {runs.map((r, i) => (
+            <div key={i} className="flex items-baseline gap-2 text-[10.5px]" style={{ color: "var(--text3)" }}>
+              <span className="shrink-0" style={{ color: r.is_error ? "var(--error)" : "var(--text4)" }}>{r.tool || "tool"}</span>
+              <span className="truncate" style={{ opacity: 0.85 }}>{shortTarget(r.note || r.target)}</span>
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -31,6 +31,17 @@ import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/t
  *  a connection that died quietly does not leave you watching a dead screen. */
 const STALL_MS = 45_000;
 
+/**
+ * How long a session must be silent before its turn counts as finished.
+ *
+ * An agent mid-turn writes hook events all the way through — a tool starting,
+ * a tool finishing, a message. Thirty seconds of nothing is a turn that ended
+ * or a session waiting on a person, and in both cases the next message is ours
+ * to send. Short enough not to strand you behind your own last reply, long
+ * enough to sit through a slow build without deciding the agent has stopped.
+ */
+const IDLE_MS = 30_000;
+
 /** The three ranges the list offers, narrowest first. */
 const SCOPES: [ChatScope, string][] = [["live", "Working"], ["today", "Today"], ["all", "All"]];
 
@@ -203,6 +214,27 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
   const lastEvent = useRef(0);
   const [stalled, setStalled] = useState(false);
 
+  /**
+   * Whether the server has a turn running for this session.
+   *
+   * Asked rather than inferred. The transcript cannot answer it — it is written
+   * by the scanner and arrives a poll late, and a session that finished ten
+   * seconds ago looks exactly like one that is still thinking. The server
+   * spawned the process, so it knows, and this is the difference between
+   * queueing a message and interrupting a turn with it.
+   */
+  const [turnRunning, setTurnRunning] = useState(false);
+  const readActive = useCallback(() => {
+    api.chatActive()
+      .then((r) => setTurnRunning(r.ids.includes(id)))
+      .catch(() => { /* keep the last answer rather than guessing a new one */ });
+  }, [id]);
+
+  useEffect(() => {
+    readActive();
+    return pollWhileVisible(readActive, 3000);
+  }, [readActive]);
+
   useEffect(() => {
     load();
     return pollWhileVisible(() => {
@@ -273,21 +305,20 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
   const running = !!detail && sessionIsLive(detail);
 
   /**
-   * Whether this agent has a writer other than us right now.
+   * Whether a turn is in flight, and therefore whether sending would collide.
    *
-   * A session has exactly one writer. Sending into one that is already running
-   * — in a terminal, or from the desktop app — puts a second `claude` on the
-   * same transcript, and what comes back is the turn being interrupted: the
-   * reply is cut off and the message is lost. The desktop has refused to resume
-   * a live session since it learned this; the phone was still doing it.
+   * A session has exactly one writer. Sending into one that is mid-turn — from
+   * a terminal, from the desktop, or from this phone a moment ago — puts a
+   * second `claude` on the same transcript, and what comes back is the running
+   * turn interrupted: the reply cut off, the message lost.
    *
-   * `owned` is what keeps that from freezing the composer for two minutes after
-   * every reply: once a turn of ours has completed, the session is only "live"
-   * because of the events we just caused, and the next turn is ours to send.
+   * `turnRunning` is the server's own answer and the one that decides. Recent
+   * activity is kept as a second opinion for the seconds before the first
+   * answer arrives, and for a writer the server did not spawn — a session being
+   * driven from a terminal, which is exactly the case that used to eat replies.
    */
-  const owned = useRef(false);
-  const busyElsewhere = running && !owned.current && !live;
-  const busy = !!live || busyElsewhere;
+  const workingNow = !!detail && !detail.ended_at && Date.now() - detail.last_seen < IDLE_MS;
+  const busy = !!live || turnRunning || workingNow;
 
   const deliver = async (message: string) => {
     if (!cwd) return;
@@ -306,19 +337,26 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
       );
     } catch (e) {
       if (!(e instanceof DOMException && e.name === "AbortError")) {
+        const why = e instanceof ChatStreamError ? e.message : String(e);
+        // The server refused because a turn is already in flight. That is not a
+        // failure to report, it is a "not yet": put the message back at the
+        // front of the queue and let the drain send it when the agent is free.
+        if (/mid-turn|turn_in_flight/.test(why)) {
+          setTurnRunning(true);
+          setQueued((q) => [message, ...q]);
+          setSent(null);
+          setLive(null);
+          return;
+        }
         // A dropped connection is not a failed turn: the agent is very likely
         // still working, and telling someone their message failed when it did
         // not is how they end up sending it twice.
-        const why = e instanceof ChatStreamError ? e.message : String(e);
         setLive((p) => ({ text: p?.text ?? "", tools: p?.tools ?? [], error: why }));
       }
     } finally {
       streaming.current = false;
       abort.current = null;
       setStalled(false);
-      // We have now written to this session, so its liveness from here on is
-      // our own echo rather than someone else holding it. See `owned`.
-      owned.current = true;
       // Let the transcript take over: it is the same turn, written by the
       // scanner, and keeping our copy as well would show it twice. Held in a
       // ref so leaving the conversation cancels it rather than waking a
@@ -374,6 +412,15 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
 
       <div className="bd mb-thread" ref={scroller} onScroll={onScroll}>
         {!detail && <div className="text-[12px] py-6 text-center" style={{ color: "var(--text3)" }}>Loading the conversation…</div>}
+        {/* A chat started a moment ago: the first turn is running but the
+            transcript that carries it is written by the scanner and lands a
+            poll later. An empty thread here reads as a chat that failed to
+            start, which is what it looked like. */}
+        {detail && !turns.length && !live && !sent && (
+          <div className="text-[12px] py-6 text-center" style={{ color: "var(--text3)" }}>
+            {workingNow ? "Working on the first turn…" : "Nothing said yet."}
+          </div>
+        )}
 
         {turns.map((m, i) => <Bubble key={`${m.ts}-${i}`} role={m.role} text={m.text} ts={m.ts} />)}
         {sent && <Bubble role="user" text={sent} />}
@@ -401,9 +448,9 @@ function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; 
       )}
 
       <div className="ft" style={{ flexDirection: "column", alignItems: "stretch", gap: 8 }}>
-        {busyElsewhere && (
+        {busy && !live && (
           <div className="text-[10.5px]" style={{ color: "var(--warning)" }}>
-            This agent is running somewhere else. What you send waits until it stops.
+            Working. What you send goes out when this turn ends.
           </div>
         )}
         {detail && !cwd ? (

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -3,6 +3,8 @@ import { api, ChatStreamError } from "../lib/api.ts";
 import { toolTarget } from "../lib/chatStore.ts";
 import { pollWhileVisible } from "../lib/poll.ts";
 import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
+import { sessionIsLive } from "../lib/derive.ts";
+import { scopeSessions, openingScope, type ChatScope } from "./chatList.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
 import { recentTurns } from "./transcript.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
@@ -29,15 +31,38 @@ import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/t
  *  a connection that died quietly does not leave you watching a dead screen. */
 const STALL_MS = 45_000;
 
+/** The three ranges the list offers, narrowest first. */
+const SCOPES: [ChatScope, string][] = [["live", "Working"], ["today", "Today"], ["all", "All"]];
+
 /** A turn being streamed right now, before the transcript catches up. */
 type Live = { text: string; tools: string[]; error: string | null };
 
 export function MobileChats({ sessions, onRefresh }: { sessions: SessionRollup[]; onRefresh: () => void }) {
   const [openId, setOpenId] = useState<string | null>(null);
   const [composing, setComposing] = useState(false);
+  /**
+   * Where the open conversation runs, as far as this screen already knows.
+   *
+   * The session detail carries the same thing, but it takes a fetch to arrive,
+   * and a chat started here is seconds old — the row the scanner writes may not
+   * have a directory yet. Without this the composer replaced itself with "this
+   * session did not record where it ran", which is a claim about the session
+   * when the truth was "the answer has not come back yet". We picked the repo,
+   * so we can simply say so.
+   */
+  const [openCwd, setOpenCwd] = useState("");
+  /** Null until the first list arrives, so the opening scope is chosen from
+   *  real sessions rather than from the empty array of the first render. */
+  const [picked, setPicked] = useState<ChatScope | null>(null);
+  const scope = picked ?? openingScope(sessions);
+  const setScope = (s: ChatScope) => setPicked(s);
+  const shown = useMemo(() => scopeSessions(sessions, scope), [sessions, scope]);
+  const liveCount = useMemo(() => scopeSessions(sessions, "live").length, [sessions]);
 
-  if (composing) return <NewChat onCancel={() => setComposing(false)} onStarted={(id) => { setComposing(false); setOpenId(id); onRefresh(); }} />;
-  if (openId) return <Conversation id={openId} onBack={() => { setOpenId(null); onRefresh(); }} />;
+  const open = (id: string, cwd: string) => { setOpenCwd(cwd); setOpenId(id); };
+
+  if (composing) return <NewChat onCancel={() => setComposing(false)} onStarted={(id, cwd) => { setComposing(false); open(id, cwd); onRefresh(); }} />;
+  if (openId) return <Conversation id={openId} knownCwd={openCwd} onBack={() => { setOpenId(null); onRefresh(); }} />;
 
   return (
     <div className="flex flex-col gap-2">
@@ -47,17 +72,40 @@ export function MobileChats({ sessions, onRefresh }: { sessions: SessionRollup[]
         + New chat
       </button>
 
-      {!sessions.length && (
+      {/* Working, today, everything. The tab opens on the narrowest of these
+          that has anything in it, so the first screen is the agents you could
+          speak to rather than a scroll through the archive. */}
+      <div className="flex gap-1.5">
+        {SCOPES.map(([id, label]) => {
+          const on = scope === id;
+          return (
+            <button key={id} onClick={() => setScope(id)}
+              className="flex-1 rounded-lg text-[12px]"
+              style={{
+                minHeight: 38,
+                color: on ? "var(--primary-hover)" : "var(--text3)",
+                background: on ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent",
+                border: `1px solid color-mix(in srgb, var(--border) ${on ? 55 : 26}%, transparent)`,
+              }}>
+              {label}{id === "live" && liveCount ? ` ${liveCount}` : ""}
+            </button>
+          );
+        })}
+      </div>
+
+      {!shown.length && (
         <div className="rounded-2xl px-5 py-12 text-center" style={{ background: "color-mix(in srgb, var(--bg2) 45%, transparent)", border: "1px dashed color-mix(in srgb, var(--border) 45%, transparent)" }}>
-          <div className="text-[14px]">No agents yet</div>
-          <div className="text-[12px] mt-1.5" style={{ color: "var(--text2)" }}>Start one above and it keeps running on your machine.</div>
+          <div className="text-[14px]">{sessions.length ? "Nothing here" : "No agents yet"}</div>
+          <div className="text-[12px] mt-1.5" style={{ color: "var(--text2)" }}>
+            {sessions.length ? "Try a wider range above." : "Start one and it keeps running on your machine."}
+          </div>
         </div>
       )}
 
-      {sessions.map((s) => {
+      {shown.map((s) => {
         const running = !s.ended_at && Date.now() - s.last_seen < 120_000;
         return (
-          <button key={s.session_id} onClick={() => setOpenId(s.session_id)}
+          <button key={s.session_id} onClick={() => open(s.session_id, s.cwd_path || s.project_path || "")}
             className="w-full text-left rounded-xl px-3.5 py-3 flex flex-col gap-1.5"
             style={{ background: "color-mix(in srgb, var(--bg2) 60%, transparent)", border: `1px solid color-mix(in srgb, var(--border) ${running ? 55 : 32}%, transparent)` }}>
             <div className="flex items-center gap-2">
@@ -77,15 +125,34 @@ export function MobileChats({ sessions, onRefresh }: { sessions: SessionRollup[]
   );
 }
 
-/** One session: what it has done, and a box to answer it. */
-function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
+/**
+ * One session: what it has done, and a box to answer it.
+ *
+ * Laid out like every other chat application on the phone, because that is what
+ * it is: one bar at the top carrying back, title and status, the thread filling
+ * everything below it, the composer at the bottom. No app header above it and
+ * no tab bar under it — inside a conversation neither is doing anything, and
+ * between them they were taking 130 of 660 pixels and colliding while they did
+ * it. The screen is its own scroll container rather than a slice of a scrolling
+ * page, which is what stops the composer from drifting off when the browser's
+ * URL bar collapses.
+ */
+function Conversation({ id, knownCwd, onBack }: { id: string; knownCwd: string; onBack: () => void }) {
   const [detail, setDetail] = useState<SessionDetail | null>(null);
   const [draft, setDraft] = useState("");
   const [live, setLive] = useState<Live | null>(null);
   const [sent, setSent] = useState<string | null>(null);
+  /** Typed while the agent was busy, waiting its turn. See `deliver`. */
+  const [queued, setQueued] = useState<string[]>([]);
+  /** Turns that arrived while you were reading further up. */
+  const [behind, setBehind] = useState(0);
   const abort = useRef<AbortController | null>(null);
   const handover = useRef<ReturnType<typeof setTimeout> | null>(null);
   const foot = useRef<HTMLDivElement | null>(null);
+  const scroller = useRef<HTMLDivElement | null>(null);
+  /** Whether the thread is parked at the bottom. While it is, new turns follow
+   *  the conversation down; while it is not, they must not move the page. */
+  const pinned = useRef(true);
 
   // Leaving mid-turn must not leave a request or a timer running behind the
   // screen you just left.
@@ -132,25 +199,78 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
    *  transcript.ts for why the server's order is the other way round. */
   const turns = useMemo(() => recentTurns(detail?.conversation), [detail?.conversation]);
 
+  /** Jump the thread to the newest turn. */
+  const toBottom = useCallback((smooth = false) => {
+    const el = scroller.current;
+    if (!el) return;
+    el.scrollTo({ top: el.scrollHeight, behavior: smooth ? "smooth" : "auto" });
+    pinned.current = true;
+    setBehind(0);
+  }, []);
+
+  /** Track whether you are reading the bottom of the thread or somewhere above
+   *  it. 60px of slack: a thumb rarely lands exactly at the end. */
+  const onScroll = () => {
+    const el = scroller.current;
+    if (!el) return;
+    pinned.current = el.scrollHeight - el.scrollTop - el.clientHeight < 60;
+    if (pinned.current) setBehind(0);
+  };
+
   /**
-   * Land on the newest turn, every time one arrives.
+   * Follow the conversation down, unless you are reading further up.
    *
-   * Keyed on the newest timestamp rather than the count: the transcript is
-   * capped by a size budget on the server, so a long session can gain a turn
-   * and lose its oldest in the same poll and never change length. That is
-   * exactly the case where a message arrived and the view would have stayed
-   * where it was.
+   * Both halves matter. A chat that does not follow leaves you looking at an
+   * old turn while the answer you are waiting for lands off-screen; one that
+   * always follows snatches the page away mid-sentence whenever a poll brings
+   * something in. So: pinned to the bottom, stay pinned; scrolled up, count
+   * what arrived and offer it as a tap.
+   *
+   * Keyed on the newest timestamp as well as the count, because the transcript
+   * is capped by a size budget on the server — a long session can gain a turn
+   * and drop its oldest in the same poll without ever changing length.
    */
   const newestTs = turns.length ? turns[turns.length - 1]!.ts : 0;
-  useEffect(() => { foot.current?.scrollIntoView({ block: "end" }); }, [newestTs, turns.length, live?.text, sent]);
+  useEffect(() => {
+    if (!newestTs) return;
+    if (pinned.current) toBottom();
+    else setBehind((n) => n + 1);
+  }, [newestTs, turns.length, toBottom]);
 
-  const cwd = detail?.cwd_path || detail?.project_path || "";
-  const running = !!detail && !detail.ended_at && Date.now() - detail.last_seen < 120_000;
+  // Your own turn, streaming: always follow it. You just sent this.
+  useEffect(() => { if (pinned.current) toBottom(); }, [live?.text, sent, queued.length, toBottom]);
 
-  const send = async () => {
-    const message = draft.trim();
-    if (!message || !cwd) return;
-    setDraft("");
+  // The transcript's first arrival: land at the bottom with no animation, the
+  // way opening a chat should.
+  const landed = useRef(false);
+  useEffect(() => {
+    if (landed.current || !detail) return;
+    landed.current = true;
+    requestAnimationFrame(() => toBottom());
+  }, [detail, toBottom]);
+
+  const cwd = detail?.cwd_path || detail?.project_path || knownCwd;
+  const running = !!detail && sessionIsLive(detail);
+
+  /**
+   * Whether this agent has a writer other than us right now.
+   *
+   * A session has exactly one writer. Sending into one that is already running
+   * — in a terminal, or from the desktop app — puts a second `claude` on the
+   * same transcript, and what comes back is the turn being interrupted: the
+   * reply is cut off and the message is lost. The desktop has refused to resume
+   * a live session since it learned this; the phone was still doing it.
+   *
+   * `owned` is what keeps that from freezing the composer for two minutes after
+   * every reply: once a turn of ours has completed, the session is only "live"
+   * because of the events we just caused, and the next turn is ours to send.
+   */
+  const owned = useRef(false);
+  const busyElsewhere = running && !owned.current && !live;
+  const busy = !!live || busyElsewhere;
+
+  const deliver = async (message: string) => {
+    if (!cwd) return;
     setSent(message);
     setLive({ text: "", tools: [], error: null });
     setStalled(false);
@@ -176,6 +296,9 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
       streaming.current = false;
       abort.current = null;
       setStalled(false);
+      // We have now written to this session, so its liveness from here on is
+      // our own echo rather than someone else holding it. See `owned`.
+      owned.current = true;
       // Let the transcript take over: it is the same turn, written by the
       // scanner, and keeping our copy as well would show it twice. Held in a
       // ref so leaving the conversation cancels it rather than waking a
@@ -184,33 +307,60 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
     }
   };
 
+  // `deliver` closes over this render's state, and the queue drains from an
+  // effect that must not re-run every time any of it changes. A ref keeps the
+  // effect stable and the call current.
+  const deliverRef = useRef(deliver);
+  deliverRef.current = deliver;
+
+  /**
+   * Send, or get in line.
+   *
+   * The CLI queues what you type while it is working and sends it when the turn
+   * ends; typing at a busy agent should not mean losing the message, and it
+   * certainly should not mean interrupting it.
+   */
+  const send = () => {
+    const message = draft.trim();
+    if (!message || !cwd) return;
+    setDraft("");
+    if (busy) { setQueued((q) => [...q, message]); return; }
+    void deliverRef.current(message);
+  };
+
+  /** Drain the queue as soon as the agent is free, one turn at a time. */
+  useEffect(() => {
+    if (busy || !cwd || !queued.length) return;
+    const next = queued[0]!;
+    setQueued((q) => q.slice(1));
+    void deliverRef.current(next);
+  }, [busy, cwd, queued]);
+
   return (
-    <div className="flex flex-col gap-3">
-      <div className="sticky top-11 z-10 flex items-center gap-2 -mx-4 px-4 py-1.5"
-        style={{ background: "var(--bg)", borderBottom: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
-        <button onClick={onBack} className="text-[13px] px-2 py-2" style={{ color: "var(--text2)", minHeight: 44 }}>← Chats</button>
-        <div className="min-w-0 flex-1 text-right">
-          <div className="text-[12.5px] truncate">{detail ? sessionTitle(detail) : "…"}</div>
-          <div className="text-[10.5px] truncate" style={{ color: "var(--text3)" }}>{baseName(cwd)}</div>
+    <div className="mb-screen mb-chat on">
+      <div className="hd">
+        <button className="back" onClick={onBack} aria-label="Back to chats">←</button>
+        <div className="t">
+          <b>{detail ? sessionTitle(detail) : "…"}</b>
+          <span>
+            {baseName(cwd) || "…"}
+            {detail ? ` · ${detail.tools} tools · ${fmtUsd(detail.cost_usd)}` : ""}
+            {detail?.errors ? ` · ${detail.errors} errors` : ""}
+          </span>
         </div>
-        <span className="inline-block rounded-full shrink-0" style={{ width: 8, height: 8, background: running ? "var(--success)" : "var(--text3)" }} />
+        <span className="inline-block rounded-full shrink-0" title={running ? "Working" : "Idle"}
+          style={{ width: 9, height: 9, background: running ? "var(--success)" : "var(--text3)" }} />
       </div>
 
-      {detail && (
-        <div className="flex items-center gap-x-3 text-[10.5px] tabular-nums px-0.5" style={{ color: "var(--text3)" }}>
-          <span>{detail.tools} tools</span>
-          {!!detail.errors && <span style={{ color: "var(--error)" }}>{detail.errors} errors</span>}
-          <span>{fmtUsd(detail.cost_usd)}</span>
-          {!!detail.changes.length && <span>{detail.changes.length} files touched</span>}
-        </div>
-      )}
+      <div className="bd mb-thread" ref={scroller} onScroll={onScroll}>
+        {!detail && <div className="text-[12px] py-6 text-center" style={{ color: "var(--text3)" }}>Loading the conversation…</div>}
 
-      <div className="flex flex-col gap-2.5 pb-2">
         {turns.map((m, i) => <Bubble key={`${m.ts}-${i}`} role={m.role} text={m.text} ts={m.ts} />)}
         {sent && <Bubble role="user" text={sent} />}
         {live && (
           <Bubble role="assistant" text={live.text || "…"} streaming tools={live.tools} error={live.error} />
         )}
+        {queued.map((q, i) => <Bubble key={`q${i}`} role="user" text={q} pending />)}
         {stalled && !live?.error && (
           // Silence is ambiguous — a long tool call and a dead socket look
           // identical. Say which one we cannot tell rather than leaving a
@@ -222,22 +372,29 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
         <div ref={foot} />
       </div>
 
-      {/* Sticky, thumb-height, 16px type so iOS does not zoom the page when it
-          takes focus. */}
-      {/* Sits directly on top of the tab bar rather than under it: the nav is
-          fixed, so a composer at bottom-0 would be hidden behind it exactly
-          when the keyboard is open and it matters most. */}
-      <div className="sticky -mx-4 px-4 pt-2 pb-2 z-10"
-        style={{ bottom: "calc(56px + env(safe-area-inset-bottom))", background: "var(--bg)", borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
-        {!cwd ? (
-          <div className="text-[11px] px-1 pb-2" style={{ color: "var(--text3)" }}>
+      {/* Only while you are reading further up: the thread stays where you put
+          it, and this says what you would otherwise have been yanked to. */}
+      {behind > 0 && (
+        <button className="mb-jump" onClick={() => toBottom(true)}>
+          ↓ {behind} newer
+        </button>
+      )}
+
+      <div className="ft" style={{ flexDirection: "column", alignItems: "stretch", gap: 8 }}>
+        {busyElsewhere && (
+          <div className="text-[10.5px]" style={{ color: "var(--warning)" }}>
+            This agent is running somewhere else. What you send waits until it stops.
+          </div>
+        )}
+        {detail && !cwd ? (
+          <div className="text-[11px]" style={{ color: "var(--text3)" }}>
             This session did not record where it ran, so it cannot be resumed from here.
           </div>
         ) : (
           <div className="flex items-end gap-2">
             <textarea
               value={draft} onChange={(e) => setDraft(e.target.value)}
-              placeholder={live ? "Working…" : "Reply to this agent"}
+              placeholder={busy ? "Send when it is free…" : "Reply to this agent"}
               rows={1}
               className="flex-1 rounded-xl px-3 py-2.5 resize-none"
               style={{ fontSize: 16, minHeight: 48, maxHeight: 140, color: "var(--text)", background: "color-mix(in srgb, var(--bg2) 80%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
@@ -252,7 +409,7 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
               <button onClick={send} disabled={!draft.trim()}
                 className="rounded-xl px-4 text-[14px] font-medium"
                 style={{ minHeight: 48, opacity: draft.trim() ? 1 : 0.4, color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 18%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>
-                Send
+                {busy ? "Queue" : "Send"}
               </button>
             )}
           </div>
@@ -262,16 +419,20 @@ function Conversation({ id, onBack }: { id: string; onBack: () => void }) {
   );
 }
 
-function Bubble({ role, text, ts, streaming, tools, error }: {
+function Bubble({ role, text, ts, streaming, tools, error, pending }: {
   role: "user" | "assistant"; text: string; ts?: number; streaming?: boolean; tools?: string[]; error?: string | null;
+  /** Typed, accepted, not sent yet: waiting for the agent to be free. */
+  pending?: boolean;
 }) {
   const mine = role === "user";
   return (
     <div className={`flex ${mine ? "justify-end" : "justify-start"}`}>
       <div className="max-w-[86%] rounded-2xl px-3.5 py-2.5" style={{
         background: mine ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "color-mix(in srgb, var(--bg2) 70%, transparent)",
-        border: `1px solid color-mix(in srgb, var(--border) ${mine ? 45 : 32}%, transparent)`,
+        border: `1px ${pending ? "dashed" : "solid"} color-mix(in srgb, var(--border) ${mine ? 45 : 32}%, transparent)`,
+        opacity: pending ? 0.66 : 1,
       }}>
+        {pending && <div className="text-[9.5px] pb-1" style={{ color: "var(--warning)" }}>Queued</div>}
         {/* Tool runs are named, not expanded: on a phone the useful signal is
             "it is editing files / running commands", not the diff. */}
         {!!tools?.length && (
@@ -289,7 +450,7 @@ function Bubble({ role, text, ts, streaming, tools, error }: {
 }
 
 /** Start something new: a repo and a first message is the whole form. */
-function NewChat({ onCancel, onStarted }: { onCancel: () => void; onStarted: (sessionId: string) => void }) {
+function NewChat({ onCancel, onStarted }: { onCancel: () => void; onStarted: (sessionId: string, cwd: string) => void }) {
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [cwd, setCwd] = useState("");
   const [model, setModel] = useState(MODELS[0]!.id);
@@ -316,7 +477,10 @@ function NewChat({ onCancel, onStarted }: { onCancel: () => void; onStarted: (se
         // resumes, on this phone or at the desk.
         if (!started.current && o.type === "system" && typeof o.session_id === "string") {
           started.current = true;
-          onStarted(o.session_id);
+          // Hand the directory over with the id. The session row does not have
+          // it yet, and the conversation screen would otherwise announce that
+          // this brand new chat cannot be resumed.
+          onStarted(o.session_id, cwd);
         }
         setLive((prev) => reduce(prev, o));
       });

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -82,7 +82,9 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
     <>
       {askDialog}
       <Screen
-        open={open && diffAt == null}
+        // Stays open under its own file diff, which is drawn on top of it —
+        // closing it here made the diff open and shut in the same frame.
+        open={open}
         title={d ? `#${d.number} · ${d.author}` : number != null ? `#${number}` : ""}
         sub={d ? `${d.headRefName} → ${d.baseRefName}` : undefined}
         onBack={onBack}

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -91,14 +91,20 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   const [ctr, setCtr] = useState<DockerContainer | null>(null);
   const [diffAt, setDiffAt] = useState<number | null>(null);
 
-  const mine = useMemo(() => containers.filter((c) => (c.project ?? "") === repo?.name), [containers, repo]);
-
   /** The project's name, which is the main checkout's — a worktree is the same
    *  project on another branch, and titling the screen with the worktree's
    *  directory name is what made them look like separate repositories. */
   const projectName = checkouts.length > 1
     ? (checkouts.find((c) => !c.ref.worktreeOf)?.name ?? repo?.name ?? "")
     : (repo?.name ?? "");
+
+  // Containers belong to the project, not to the checkout you happen to be
+  // looking at: compose names them after the repository, so matching on a
+  // worktree's directory name finds nothing at all.
+  const mine = useMemo(
+    () => containers.filter((c) => (c.project ?? "") === projectName),
+    [containers, projectName]
+  );
 
   // Open on whatever is wrong: a container down beats uncommitted work beats
   // the pull request list. Landing on an empty tab is a wasted screen.

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -119,7 +119,12 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
     try {
       const r = await run();
       toast(r.ok ? label : (r.error || `${label} failed`), !r.ok);
-      if (r.ok) { loadTree(); onRefresh(); }
+      // Reload either way. A refused action leaves the repo as it was, and the
+      // switches on screen were drawn from the state before it — re-reading is
+      // what stops a failure from leaving a row showing something that never
+      // happened.
+      loadTree();
+      if (r.ok) onRefresh();
     } catch (e) { toast(String(e), true); }
   };
   const { ask, dialog: askDialog } = useAsk();
@@ -127,7 +132,11 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
   return (
     <>
       {askDialog}
-      <Screen open={open && !openPr && !ctr && diffAt == null} title={repo?.name ?? ""} sub={repo?.branch} onBack={onBack}>
+      {/* Stays open under whatever is stacked on top of it. The screens that
+          cover it are drawn later in this tree, so they paint over it anyway,
+          and closing it here made it push and pop history entries every time a
+          file was tapped — see useBackClose. */}
+      <Screen open={open} title={repo?.name ?? ""} sub={repo?.branch} onBack={onBack}>
         <Seg sticky value={facet} onPick={setFacet} options={[
           { id: "changes", label: "Changes", n: repo?.dirty || null },
           { id: "prs", label: "Pull requests", n: prs.length || null },

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -3,6 +3,7 @@ import { api } from "../lib/api.ts";
 import { Screen, Sheet, Seg, Empty, Row, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { MobilePr } from "./MobilePr.tsx";
+import { projectRows } from "./projects.ts";
 import type {
   GitRepoRef, WorkingTree, GitBranch, DockerContainer, DockerStat, PrSummary, GitFileChange,
 } from "../../../shared/types.ts";
@@ -30,7 +31,8 @@ export interface RepoSummary {
   down: number;
 }
 
-export function RepoList({ repos, onOpen }: { repos: RepoSummary[]; onOpen: (r: RepoSummary) => void }) {
+export function RepoList({ repos, onOpen }: { repos: RepoSummary[]; onOpen: (r: RepoSummary, siblings: RepoSummary[]) => void }) {
+  const groups = useMemo(() => projectRows(repos), [repos]);
   if (!repos.length) {
     return <Empty glyph="◇" title="No repositories yet"
       body="agentglass finds these from the projects your agents have worked in. Run one, and it appears here." />;
@@ -38,26 +40,39 @@ export function RepoList({ repos, onOpen }: { repos: RepoSummary[]; onOpen: (r: 
   return (
     <div className="flex flex-col gap-2.5">
       <div className="mb-eyebrow">Repositories</div>
-      {repos.map((r) => (
-        <Row key={r.ref.root}
-          tint={r.down ? "var(--error)" : r.dirty || r.ahead ? "var(--warning)" : "var(--success)"}
-          title={r.name}
-          sub={`${r.branch}${r.ahead ? ` · ↑${r.ahead}` : ""}${r.behind ? ` ↓${r.behind}` : ""}`}
-          right={[
-            r.dirty ? `${r.dirty} changed` : "",
-            r.prs ? `${r.prs} PR${r.prs > 1 ? "s" : ""}` : "",
-            r.down ? `${r.down} down` : "",
-          ].filter(Boolean).join(" · ") || "clean"}
-          onClick={() => onOpen(r)}
-        />
-      ))}
+      {groups.map(({ main, checkouts }) => {
+        // The project's state is every checkout's state: work sitting in a
+        // worktree is still work you have not committed.
+        const dirty = checkouts.reduce((n, c) => n + c.dirty, 0);
+        const prs = checkouts.reduce((n, c) => n + c.prs, 0);
+        const down = checkouts.reduce((n, c) => n + c.down, 0);
+        const others = checkouts.length - 1;
+        return (
+          <Row key={main.ref.root}
+            tint={down ? "var(--error)" : dirty || main.ahead ? "var(--warning)" : "var(--success)"}
+            title={main.name}
+            sub={`${main.branch}${main.ahead ? ` · ↑${main.ahead}` : ""}${main.behind ? ` ↓${main.behind}` : ""}`
+              + (others ? ` · ${others} worktree${others > 1 ? "s" : ""}` : "")}
+            right={[
+              dirty ? `${dirty} changed` : "",
+              prs ? `${prs} PR${prs > 1 ? "s" : ""}` : "",
+              down ? `${down} down` : "",
+            ].filter(Boolean).join(" · ") || "clean"}
+            onClick={() => onOpen(main, checkouts)}
+          />
+        );
+      })}
     </div>
   );
 }
 
-export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRefresh, onOpenChatWith }: {
+export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, containers, stats, onBack, toast, onRefresh, onOpenChatWith }: {
   open: boolean;
   repo: RepoSummary | null;
+  /** Every checkout of this project — the repo itself and its linked
+   *  worktrees. One project, several places the work can be. */
+  checkouts?: RepoSummary[];
+  onPickCheckout?: (r: RepoSummary) => void;
   containers: DockerContainer[];
   stats: DockerStat[];
   onBack: () => void;
@@ -77,6 +92,13 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
   const [diffAt, setDiffAt] = useState<number | null>(null);
 
   const mine = useMemo(() => containers.filter((c) => (c.project ?? "") === repo?.name), [containers, repo]);
+
+  /** The project's name, which is the main checkout's — a worktree is the same
+   *  project on another branch, and titling the screen with the worktree's
+   *  directory name is what made them look like separate repositories. */
+  const projectName = checkouts.length > 1
+    ? (checkouts.find((c) => !c.ref.worktreeOf)?.name ?? repo?.name ?? "")
+    : (repo?.name ?? "");
 
   // Open on whatever is wrong: a container down beats uncommitted work beats
   // the pull request list. Landing on an empty tab is a wasted screen.
@@ -136,7 +158,30 @@ export function RepoScreen({ open, repo, containers, stats, onBack, toast, onRef
           cover it are drawn later in this tree, so they paint over it anyway,
           and closing it here made it push and pop history entries every time a
           file was tapped — see useBackClose. */}
-      <Screen open={open} title={repo?.name ?? ""} sub={repo?.branch} onBack={onBack}>
+      <Screen open={open} title={projectName} sub={repo?.branch} onBack={onBack}>
+        {/* Which checkout of this project you are looking at. Only drawn when
+            there is a choice: one repo with no worktrees needs no picker, and
+            a row of one chip is furniture. */}
+        {checkouts.length > 1 && (
+          <div className="flex gap-1.5 overflow-x-auto pb-2.5 -mx-1 px-1" style={{ scrollbarWidth: "none" }}>
+            {checkouts.map((c) => {
+              const on = c.ref.root === repo?.ref.root;
+              return (
+                <button key={c.ref.root} onClick={() => onPickCheckout?.(c)}
+                  className="rounded-lg text-[11.5px] px-3 shrink-0"
+                  style={{
+                    minHeight: 36,
+                    color: on ? "var(--primary-hover)" : "var(--text3)",
+                    background: on ? "color-mix(in srgb, var(--primary) 16%, transparent)" : "transparent",
+                    border: `1px solid color-mix(in srgb, var(--border) ${on ? 55 : 26}%, transparent)`,
+                  }}>
+                  {c.branch}{c.dirty ? ` · ${c.dirty}` : ""}
+                </button>
+              );
+            })}
+          </div>
+        )}
+
         <Seg sticky value={facet} onPick={setFacet} options={[
           { id: "changes", label: "Changes", n: repo?.dirty || null },
           { id: "prs", label: "Pull requests", n: prs.length || null },

--- a/web/src/mobile/chatList.ts
+++ b/web/src/mobile/chatList.ts
@@ -1,0 +1,74 @@
+// Which agents the Chats tab offers you, and in what order.
+//
+// The phone was listing every session the scanner had ever recorded: a
+// hundred rows, most of them a day old, many of them named after their own id
+// because they never wrote a first line, some of them `<synthetic>` rows that
+// are not conversations at all. The desktop's Chats panel meanwhile lists the
+// handful you are actually talking to. Same word, two different meanings, and
+// the phone's meaning is the useless one — nobody opens a phone to scroll
+// yesterday's telemetry.
+//
+// So this narrows it to the same idea the desktop has: agents you could say
+// something to now. History is still reachable, one tap away, but it is not
+// what the tab opens on.
+
+/** What the list is showing. */
+export type ChatScope = "live" | "today" | "all";
+
+export interface ListedSession {
+  session_id: string;
+  ended_at?: number | null;
+  last_seen: number;
+  model_name?: string | null;
+  cost_usd?: number;
+}
+
+/** Sessions with a running owner (same rule the rest of the app uses). */
+const LIVE_MS = 120_000;
+const DAY_MS = 86_400_000;
+
+/**
+ * A row that is not a conversation.
+ *
+ * `<synthetic>` sessions are rolled up from telemetry with no transcript
+ * behind them, so opening one shows an empty thread and a composer that cannot
+ * resume anything. They belong in the fleet views, not in a list of people to
+ * talk to.
+ */
+export function isTalkable(s: ListedSession): boolean {
+  return s.model_name !== "<synthetic>";
+}
+
+/**
+ * The sessions this scope shows, newest first.
+ *
+ * `live` is what is running right now, `today` adds the last 24 hours — which
+ * is the working day you might still want to pick up — and `all` is the
+ * archive, unchanged from what the tab used to show by default.
+ */
+export function scopeSessions<T extends ListedSession>(
+  sessions: readonly T[],
+  scope: ChatScope,
+  now = Date.now(),
+): T[] {
+  const live = (s: T) => !s.ended_at && now - s.last_seen < LIVE_MS;
+  const kept = sessions.filter((s) => {
+    if (!isTalkable(s)) return false;
+    if (scope === "live") return live(s);
+    if (scope === "today") return now - s.last_seen < DAY_MS;
+    return true;
+  });
+  return kept.sort((a, b) => b.last_seen - a.last_seen);
+}
+
+/**
+ * Which scope to open on.
+ *
+ * Landing on an empty list is worse than landing on a longer one, so the tab
+ * opens on the narrowest scope that has something in it.
+ */
+export function openingScope(sessions: readonly ListedSession[], now = Date.now()): ChatScope {
+  if (scopeSessions(sessions, "live", now).length) return "live";
+  if (scopeSessions(sessions, "today", now).length) return "today";
+  return "all";
+}

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -118,6 +118,24 @@ export const MOBILE_CSS = `
   backdrop-filter:blur(16px);padding:11px 15px calc(env(safe-area-inset-bottom) + 11px);
   display:flex;gap:9px;align-items:center}
 
+/* ── conversation ─────────────────────────────────────────────────── */
+/* A chat screen, sized to the viewport that is actually visible.
+   inset:0 measures the LARGE viewport, the one that assumes the browser's URL
+   bar is hidden — so on Chrome for Android, whose bar sits at the bottom and
+   comes back on every upward scroll, the composer spent half its life
+   underneath it. 100dvh is the viewport as it stands right now, which also
+   means the keyboard opening shortens the thread rather than pushing the
+   composer off the screen. */
+.mb-chat{bottom:auto;height:100dvh}
+/* The thread is the only thing that scrolls, and it is chained: flicking past
+   the last message must not start dragging the page behind it. */
+.mb-chat .bd{display:flex;flex-direction:column;gap:10px;overscroll-behavior:contain;
+  padding:14px 15px 10px}
+.mb-jump{position:absolute;left:50%;transform:translateX(-50%);bottom:calc(env(safe-area-inset-bottom) + 84px);
+  z-index:2;font-size:11.5px;font-weight:600;padding:7px 14px;border-radius:999px;
+  color:#150c28;background:color-mix(in srgb,var(--primary) 90%,#000);
+  box-shadow:0 8px 20px -10px #000;border:none}
+
 /* ── sheet ────────────────────────────────────────────────────────── */
 .mb-scrim{position:fixed;inset:0;z-index:70;background:rgba(4,1,10,.66);opacity:0;pointer-events:none;
   transition:opacity .24s;backdrop-filter:blur(3px)}

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -143,12 +143,19 @@ export const MOBILE_CSS = `
 .mb-sheet{position:fixed;left:0;right:0;bottom:0;z-index:71;border-radius:24px 24px 0 0;
   background:linear-gradient(180deg,color-mix(in srgb,var(--bg3) 50%,var(--bg2)),var(--bg2));
   border-top:1px solid color-mix(in srgb,var(--primary) 38%,transparent);transform:translateY(100%);
-  transition:transform .3s cubic-bezier(.32,.72,0,1);max-height:88vh;display:flex;flex-direction:column;
+  transition:transform .3s cubic-bezier(.32,.72,0,1);max-height:88dvh;display:flex;flex-direction:column;
   box-shadow:0 -20px 50px -20px #000}
 .mb-sheet.on{transform:none}
 .mb-sheet .grab{width:40px;height:4px;border-radius:3px;flex:none;margin:10px auto 5px;
   background:color-mix(in srgb,var(--border) 72%,transparent)}
-.mb-sheet .in{padding:7px 16px calc(env(safe-area-inset-bottom) + 18px);overflow-y:auto}
+/* min-height:0 is what lets this scroll. A flex child will not shrink below its
+   content without it, so the sheet grew past its own max-height instead of
+   scrolling inside it — and the last rows were simply unreachable, which is
+   most obvious in landscape where there is half the height to work with.
+   The cap is dvh, not vh: vh measures the viewport as if the browser's URL bar
+   were hidden, which it usually is not. */
+.mb-sheet .in{padding:7px 16px calc(env(safe-area-inset-bottom) + 18px);overflow-y:auto;
+  min-height:0;flex:1;overscroll-behavior:contain}
 .mb-sheet h3{font-size:16px;font-weight:600}
 
 /* ── toasts ───────────────────────────────────────────────────────── */

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -90,16 +90,22 @@ export const MOBILE_CSS = `
 
 /* A switch, not a tick: viewed and staged are states you keep for the length
    of a review, and a checkbox does not say that. */
-/* Drawn 42x25 and hit at 44px tall: a switch this size is comfortable to read
-   and uncomfortable to hit, so the target grows without the shape growing. */
-.mb-sw{position:relative;width:42px;height:25px;border-radius:14px;flex:none;
-  background:color-mix(in srgb,var(--border) 52%,transparent);transition:background .2s;
-  box-sizing:content-box;border-top:10px solid transparent;border-bottom:9px solid transparent;
-  background-clip:padding-box}
-.mb-sw::after{content:"";position:absolute;top:3px;left:3px;width:19px;height:19px;border-radius:50%;
+/* Drawn 42x25, hit at 44px tall: a switch that size is comfortable to read and
+   uncomfortable to hit, so the target grows without the shape growing.
+
+   The track is drawn, not painted onto the element. The first version grew the
+   target with transparent top and bottom borders and clipped the background to
+   the padding box — which also clipped the 14px radius against the border box,
+   so the pill came out with flattened, chopped-looking ends. A button that is
+   purely a hit area with the shape inside it cannot do that. */
+.mb-sw{position:relative;width:42px;height:44px;flex:none;padding:0;border:0;background:transparent}
+.mb-sw::before{content:"";position:absolute;left:0;top:9px;width:42px;height:25px;border-radius:999px;
+  background:color-mix(in srgb,var(--border) 52%,transparent);transition:background .2s}
+.mb-sw::after{content:"";position:absolute;top:12px;left:3px;width:19px;height:19px;border-radius:50%;
   background:var(--text3);transition:transform .24s cubic-bezier(.3,1.5,.5,1),background .2s}
-.mb-sw[data-on="1"]{background:color-mix(in srgb,var(--success) 58%,transparent)}
+.mb-sw[data-on="1"]::before{background:color-mix(in srgb,var(--success) 58%,transparent)}
 .mb-sw[data-on="1"]::after{transform:translateX(17px);background:var(--success)}
+.mb-sw:focus-visible{outline:2px solid var(--primary);outline-offset:2px;border-radius:999px}
 
 /* ── screens ──────────────────────────────────────────────────────── */
 .mb-screen{position:fixed;inset:0;z-index:60;background:var(--bg);display:flex;flex-direction:column;

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -214,26 +214,69 @@ export function Toasts({ toasts, raised }: { toasts: Toast[]; raised?: boolean }
  * Without it, back leaves agentglass entirely from a diff three levels deep,
  * which is the fastest way to make a companion feel broken.
  */
+/**
+ * One stack for every screen, and one history entry that serves whichever is
+ * on top.
+ *
+ * The first version of this gave each screen its own entry, and closing one by
+ * button called `history.back()` to tidy that entry up. `history.back()` fires
+ * a popstate, and every *other* open screen was listening for popstate as its
+ * own cue to close. Opening a diff from the repo screen therefore did this:
+ * the repo screen's `open` went false (its condition excludes an open diff), it
+ * called back(), and the popstate landed on the diff that had just opened,
+ * which closed itself immediately. The file you tapped flashed and vanished,
+ * every time, and the app looked like it could not load a diff at all.
+ *
+ * So: the screens form a stack, only the top one answers a back gesture, and
+ * the entry a programmatic close consumes is ignored by everyone rather than
+ * broadcast to all of them.
+ */
+type ScreenEntry = { close: () => void };
+const screenStack: ScreenEntry[] = [];
+let entryOwned = false;
+let ignoreNextPop = false;
+
+function ensureEntry() {
+  if (entryOwned || typeof history === "undefined") return;
+  history.pushState({ mbScreen: true }, "");
+  entryOwned = true;
+}
+
+function onPopState() {
+  // Our own tidy-up, not a person pressing back.
+  if (ignoreNextPop) { ignoreNextPop = false; return; }
+  entryOwned = false;
+  const top = screenStack.pop();
+  top?.close();
+  // Still somewhere below the surface: keep an entry so the next press closes
+  // the next screen instead of leaving the app.
+  if (screenStack.length) ensureEntry();
+}
+
+if (typeof window !== "undefined") window.addEventListener("popstate", onPopState);
+
 export function useBackClose(open: boolean, close: () => void) {
-  const armed = useRef(false);
-  useEffect(() => {
-    if (open && !armed.current) {
-      armed.current = true;
-      history.pushState({ mb: true }, "");
-    }
-    if (!open && armed.current) {
-      armed.current = false;
-      // Closed by a button rather than by the gesture: drop the entry we added
-      // so the next back press does not have to be pressed twice.
-      if (history.state?.mb) history.back();
-    }
-  }, [open]);
+  // The latest close, without re-registering the entry on every render.
+  const latest = useRef(close);
+  latest.current = close;
+
   useEffect(() => {
     if (!open) return;
-    const pop = () => { armed.current = false; close(); };
-    window.addEventListener("popstate", pop);
-    return () => window.removeEventListener("popstate", pop);
-  }, [open, close]);
+    const entry: ScreenEntry = { close: () => latest.current() };
+    screenStack.push(entry);
+    ensureEntry();
+    return () => {
+      const at = screenStack.lastIndexOf(entry);
+      if (at >= 0) screenStack.splice(at, 1);
+      // Only when nothing is left is the entry ours to give back, and the
+      // popstate it causes is ours to swallow.
+      if (!screenStack.length && entryOwned) {
+        ignoreNextPop = true;
+        entryOwned = false;
+        history.back();
+      }
+    };
+  }, [open]);
 }
 
 export function Screen({ open, title, sub, onBack, right, foot, children }: {

--- a/web/src/mobile/projects.ts
+++ b/web/src/mobile/projects.ts
@@ -1,0 +1,47 @@
+// One row per project, not per checkout.
+//
+// A linked worktree is the same repository on another branch. The Repos tab
+// listed them side by side, so "agentglass" and "remote-phone" read as two
+// different projects when they are one project in two places — and the branch,
+// which is the thing you actually want to choose, was nowhere.
+//
+// The server already says which is which: `worktreeOf` names the main repo on
+// every linked checkout. This folds on that, and the screen offers the
+// checkouts inside — pick the repository, then pick the work.
+//
+// Its own module, with no imports, so a test of it does not pull the whole
+// application graph in behind it.
+
+export interface Checkout {
+  ref: { root: string; worktreeOf?: string };
+  name: string;
+}
+
+export interface ProjectRow<T extends Checkout> {
+  /** The checkout that represents the project: its main repo when we have it. */
+  main: T;
+  /** Every checkout of it, the main one first. */
+  checkouts: T[];
+}
+
+export function projectRows<T extends Checkout>(repos: readonly T[]): ProjectRow<T>[] {
+  const byRoot = new Map(repos.map((r) => [r.ref.root, r]));
+  const groups = new Map<string, ProjectRow<T>>();
+  for (const r of repos) {
+    const parent = r.ref.worktreeOf && byRoot.has(r.ref.worktreeOf) ? r.ref.worktreeOf : r.ref.root;
+    let g = groups.get(parent);
+    if (!g) {
+      // The parent may be absent from a scoped list. Then the worktree stands
+      // in for its own project rather than disappearing from the tab.
+      g = { main: byRoot.get(parent) ?? r, checkouts: [] };
+      groups.set(parent, g);
+    }
+    g.checkouts.push(r);
+  }
+  for (const g of groups.values()) {
+    g.checkouts.sort((a, b) =>
+      (a.ref.root === g.main.ref.root ? -1 : b.ref.root === g.main.ref.root ? 1 : 0)
+      || a.name.localeCompare(b.name));
+  }
+  return [...groups.values()].sort((a, b) => a.main.name.localeCompare(b.main.name));
+}

--- a/web/src/mobile/transcript.ts
+++ b/web/src/mobile/transcript.ts
@@ -25,3 +25,85 @@ export interface Turn {
 export function recentTurns<T extends Turn>(conversation: readonly T[] | undefined, limit = 40): T[] {
   return (conversation ?? []).slice(0, limit).reverse();
 }
+
+// ── what the agent DID, not only what it said ───────────────────────────
+//
+// The phone drew messages and nothing else, so an agent that spent twenty
+// minutes reading files, running tests and editing code appeared to have
+// produced three sentences. The terminal shows the work; the companion showed
+// the commentary. Everything needed is already in `SessionDetail.timeline` —
+// every tool run with what it acted on — it simply was not being rendered.
+//
+// Tool runs are grouped rather than listed one per row: a turn is routinely
+// twenty of them, and twenty rows of "Read" on a 412px screen buries the
+// sentence they belong to. One line per run of them, openable when you want the
+// detail, which is how the terminal reads too.
+
+export interface FeedTool {
+  ts: number;
+  tool?: string;
+  target?: string | null;
+  note?: string | null;
+  is_error?: boolean;
+}
+
+export interface FeedEntry extends FeedTool {
+  kind: "message" | "tool";
+  role?: "user" | "assistant";
+  text?: string;
+}
+
+export type FeedItem =
+  | { kind: "message"; ts: number; role: "user" | "assistant"; text: string }
+  /** Consecutive tool runs, oldest first, as one openable block. */
+  | { kind: "tools"; ts: number; runs: FeedTool[]; errors: number };
+
+/**
+ * The conversation as a feed: messages and the work between them, in order.
+ *
+ * `timeline` arrives newest-first (the server's budget drops the oldest), so
+ * this takes the newest `limit` entries and turns them back round.
+ */
+export function buildFeed(timeline: readonly FeedEntry[] | undefined, limit = 120): FeedItem[] {
+  const recent = (timeline ?? []).slice(0, limit).reverse();
+  const out: FeedItem[] = [];
+  for (const e of recent) {
+    if (e.kind === "message") {
+      if (!e.text) continue;
+      out.push({ kind: "message", ts: e.ts, role: e.role ?? "assistant", text: e.text });
+      continue;
+    }
+    const last = out[out.length - 1];
+    const run: FeedTool = { ts: e.ts, tool: e.tool, target: e.target, note: e.note, is_error: e.is_error };
+    if (last && last.kind === "tools") {
+      last.runs.push(run);
+      if (e.is_error) last.errors++;
+    } else {
+      out.push({ kind: "tools", ts: e.ts, runs: [run], errors: e.is_error ? 1 : 0 });
+    }
+  }
+  return out;
+}
+
+/** A one-line summary of a block of tool runs: what it did, and how much. */
+export function summariseRuns(runs: readonly FeedTool[]): string {
+  const counts = new Map<string, number>();
+  for (const r of runs) counts.set(r.tool || "tool", (counts.get(r.tool || "tool") ?? 0) + 1);
+  const parts = [...counts.entries()]
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, 3)
+    .map(([tool, n]) => (n > 1 ? `${tool} ×${n}` : tool));
+  const rest = counts.size > 3 ? ` +${counts.size - 3} more` : "";
+  return parts.join(" · ") + rest;
+}
+
+/** The end of a path, or the head of a command — the part that identifies a
+ *  run on a narrow screen. The rest is prefix you already know. */
+export function shortTarget(target: string | null | undefined, max = 46): string {
+  if (!target) return "";
+  const oneLine = target.replace(/\s+/g, " ").trim();
+  const tail = oneLine.includes("/") && !oneLine.includes(" ")
+    ? oneLine.split("/").slice(-2).join("/")
+    : oneLine;
+  return tail.length > max ? tail.slice(0, max - 1) + "…" : tail;
+}

--- a/web/src/mobile/transcript.ts
+++ b/web/src/mobile/transcript.ts
@@ -1,0 +1,27 @@
+// Which turns the phone draws, and in which direction.
+//
+// `SessionDetail.conversation` arrives newest-first: the server orders it that
+// way so its size budget drops the oldest turns rather than the ones you opened
+// the session to read (server/src/db.ts). Every reader has to turn it back
+// round before drawing it, and the phone did not — it rendered the array as it
+// came and took `slice(-40)`, which on a newest-first list is the OLDEST forty.
+// A long session therefore opened on ancient history, newest at the top, with
+// the turn you had just sent pinned below all of it.
+//
+// A chat reads downwards. That is not a preference, it is what every messaging
+// app on the device has taught the person holding it.
+
+/** One turn, reduced to what the ordering cares about. */
+export interface Turn {
+  ts: number;
+}
+
+/**
+ * The newest `limit` turns, oldest first.
+ *
+ * Take from the head (newest-first input), then reverse — the other way round
+ * keeps the wrong end of a long session.
+ */
+export function recentTurns<T extends Turn>(conversation: readonly T[] | undefined, limit = 40): T[] {
+  return (conversation ?? []).slice(0, limit).reverse();
+}

--- a/web/test/chat-busy-elsewhere.test.ts
+++ b/web/test/chat-busy-elsewhere.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, beforeAll, beforeEach } from "bun:test";
+
+// A session has exactly one writer. This browser knows about its own turns and
+// nothing about a turn started on the phone or in a terminal, so it asks the
+// server (GET /chat/active) and holds anything typed while someone else is
+// writing. Sending anyway interrupts their turn and loses both answers — the
+// failure that ate three replies in one afternoon.
+
+let store: typeof import("../src/lib/chatStore.ts");
+let api: typeof import("../src/lib/api.ts")["api"];
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  api = (await import("../src/lib/api.ts")).api;
+  store = await import("../src/lib/chatStore.ts");
+});
+
+function capture() {
+  const sent: string[] = [];
+  let finish = () => {};
+  api.chatStream = ((payload: { message: string }) => {
+    sent.push(payload.message);
+    return new Promise<void>((res) => { finish = res as () => void; });
+  }) as typeof api.chatStream;
+  return { sent, end: () => finish() };
+}
+
+const active = () => true;
+const tick = () => new Promise((r) => setTimeout(r, 0));
+
+beforeEach(() => store.setActiveTurns([]));
+
+test("a session someone else is writing is busy, and one we are writing is not", () => {
+  store.setActiveTurns(["s-1"]);
+  expect(store.busyElsewhere({ sessionId: "s-1", sending: false })).toBe(true);
+  // Our own in-flight turn is `sending`; that is a different wait with a
+  // different message, and treating it as someone else's would be wrong.
+  expect(store.busyElsewhere({ sessionId: "s-1", sending: true })).toBe(false);
+  expect(store.busyElsewhere({ sessionId: "s-2", sending: false })).toBe(false);
+  // A chat that has never run has no session to collide with.
+  expect(store.busyElsewhere({ sessionId: "", sending: false })).toBe(false);
+});
+
+test("sending into a session that is mid-turn elsewhere queues instead", async () => {
+  const chat = store.newChat("/tmp/repo", undefined, undefined, { sessionId: "s-live" });
+  const { sent } = capture();
+  store.setActiveTurns(["s-live"]);
+
+  await store.send(chat.id, "are you nearly done", active);
+  await tick();
+
+  expect(sent).toEqual([]);                                    // nothing was spawned
+  expect(store.getChat(chat.id)?.queued.map((q) => q.text)).toEqual(["are you nearly done"]);
+  expect(store.getChat(chat.id)?.sending).toBe(false);
+});
+
+test("the queue goes out by itself when the other writer finishes", async () => {
+  const chat = store.newChat("/tmp/repo", undefined, undefined, { sessionId: "s-free" });
+  const { sent } = capture();
+  store.setActiveTurns(["s-free"]);
+  await store.send(chat.id, "first", active);
+  await store.send(chat.id, "second", active);
+  await tick();
+  expect(sent).toEqual([]);
+  expect(store.getChat(chat.id)?.queued).toHaveLength(2);
+
+  // The other writer stops.
+  store.setActiveTurns([]);
+  await tick();
+
+  expect(sent).toEqual(["first"]);
+  expect(store.getChat(chat.id)?.queued.map((q) => q.text)).toEqual(["second"]);
+});
+
+test("a session that stays busy keeps its queue", async () => {
+  const chat = store.newChat("/tmp/repo", undefined, undefined, { sessionId: "s-still" });
+  const { sent } = capture();
+  store.setActiveTurns(["s-still"]);
+  await store.send(chat.id, "held", active);
+  await tick();
+
+  // A poll that reports the same thing must not re-fire the drain.
+  store.setActiveTurns(["s-still"]);
+  await tick();
+  expect(sent).toEqual([]);
+  expect(store.getChat(chat.id)?.queued).toHaveLength(1);
+});
+
+test("another session going idle does not drain this one", async () => {
+  const mine = store.newChat("/tmp/repo", undefined, undefined, { sessionId: "s-mine" });
+  const { sent } = capture();
+  store.setActiveTurns(["s-mine", "s-theirs"]);
+  await store.send(mine.id, "wait for me", active);
+  await tick();
+
+  store.setActiveTurns(["s-mine"]);   // theirs ended, mine did not
+  await tick();
+
+  expect(sent).toEqual([]);
+  expect(store.getChat(mine.id)?.queued).toHaveLength(1);
+});

--- a/web/test/chat-list.test.ts
+++ b/web/test/chat-list.test.ts
@@ -1,0 +1,63 @@
+// The phone's Chats tab listed every session ever recorded, which on a real
+// machine is a hundred rows of yesterday. These pin the narrowing.
+import { describe, expect, test } from "bun:test";
+import { scopeSessions, openingScope, isTalkable } from "../src/mobile/chatList.ts";
+
+const NOW = 1_800_000_000_000;
+const s = (id: string, agoMs: number, extra: Record<string, unknown> = {}) => ({
+  session_id: id,
+  last_seen: NOW - agoMs,
+  ended_at: null,
+  model_name: "claude-opus-5",
+  cost_usd: 1,
+  ...extra,
+});
+
+const MIN = 60_000;
+const HOUR = 3_600_000;
+
+describe("scopeSessions", () => {
+  const fleet = [
+    s("working", 30_000),
+    s("an-hour-ago", 2 * HOUR),
+    s("yesterday", 30 * HOUR),
+    s("ended", 30_000, { ended_at: NOW - 20_000 }),
+  ];
+
+  test("live is what has a running owner", () => {
+    expect(scopeSessions(fleet, "live", NOW).map((x) => x.session_id)).toEqual(["working"]);
+  });
+
+  test("today keeps the working day, not the archive", () => {
+    expect(scopeSessions(fleet, "today", NOW).map((x) => x.session_id))
+      .toEqual(["working", "ended", "an-hour-ago"]);
+  });
+
+  test("all keeps everything, newest first", () => {
+    expect(scopeSessions(fleet, "all", NOW).map((x) => x.session_id))
+      .toEqual(["working", "ended", "an-hour-ago", "yesterday"]);
+  });
+
+  test("synthetic rollups are not conversations and never listed", () => {
+    const withSynthetic = [...fleet, s("telemetry", 10_000, { model_name: "<synthetic>" })];
+    expect(isTalkable(withSynthetic[4]!)).toBe(false);
+    for (const scope of ["live", "today", "all"] as const) {
+      expect(scopeSessions(withSynthetic, scope, NOW).some((x) => x.session_id === "telemetry")).toBe(false);
+    }
+  });
+});
+
+describe("openingScope", () => {
+  test("opens on what is working when something is", () => {
+    expect(openingScope([s("a", 30 * MIN), s("b", 10_000)], NOW)).toBe("live");
+  });
+
+  test("falls back to today when nothing is running", () => {
+    expect(openingScope([s("a", 3 * HOUR)], NOW)).toBe("today");
+  });
+
+  test("falls back to all rather than opening on an empty list", () => {
+    expect(openingScope([s("a", 40 * HOUR)], NOW)).toBe("all");
+    expect(openingScope([], NOW)).toBe("all");
+  });
+});

--- a/web/test/feed.test.ts
+++ b/web/test/feed.test.ts
@@ -1,0 +1,94 @@
+// The phone drew what an agent said and never what it did, so twenty minutes
+// of reading, running and editing looked like three sentences. These pin the
+// feed that fixed it: same information as the desktop, grouped for a 412px
+// screen.
+import { describe, expect, test } from "bun:test";
+import { buildFeed, summariseRuns, shortTarget, type FeedEntry } from "../src/mobile/transcript.ts";
+
+/** The server's order: newest first. */
+const msg = (ts: number, text: string, role: "user" | "assistant" = "assistant"): FeedEntry =>
+  ({ kind: "message", ts, role, text });
+const tool = (ts: number, t: string, target?: string, is_error = false): FeedEntry =>
+  ({ kind: "tool", ts, tool: t, target: target ?? null, is_error });
+
+describe("buildFeed", () => {
+  test("oldest first, messages and work interleaved", () => {
+    const feed = buildFeed([
+      msg(500, "done"),
+      tool(400, "Edit", "/repo/web/src/app.tsx"),
+      tool(300, "Read", "/repo/web/src/app.tsx"),
+      msg(200, "have a look", "user"),
+    ]);
+    expect(feed.map((f) => f.kind)).toEqual(["message", "tools", "message"]);
+    expect((feed[0] as { text: string }).text).toBe("have a look");
+    expect((feed[2] as { text: string }).text).toBe("done");
+  });
+
+  test("consecutive runs collapse into one block, in order", () => {
+    const feed = buildFeed([tool(300, "Bash", "bun test"), tool(200, "Read", "a.ts"), tool(100, "Read", "b.ts")]);
+    expect(feed).toHaveLength(1);
+    const block = feed[0] as { kind: "tools"; runs: { tool?: string }[] };
+    expect(block.kind).toBe("tools");
+    expect(block.runs.map((r) => r.tool)).toEqual(["Read", "Read", "Bash"]);
+  });
+
+  test("a message between two runs breaks the block in two", () => {
+    const feed = buildFeed([tool(400, "Edit"), msg(300, "thinking"), tool(200, "Read")]);
+    expect(feed.map((f) => f.kind)).toEqual(["tools", "message", "tools"]);
+  });
+
+  test("failures are counted so the block can say so", () => {
+    const feed = buildFeed([tool(300, "Bash", "bun test", true), tool(200, "Bash", "bun x", false)]);
+    expect((feed[0] as { errors: number }).errors).toBe(1);
+  });
+
+  test("keeps the newest window, not the oldest", () => {
+    const many: FeedEntry[] = Array.from({ length: 200 }, (_, i) => msg(1000 - i, `m${i}`));
+    const feed = buildFeed(many, 10);
+    expect(feed).toHaveLength(10);
+    // Newest is last, and it is the newest of the whole list.
+    expect((feed[feed.length - 1] as { text: string }).text).toBe("m0");
+  });
+
+  test("an empty or missing timeline is an empty feed, not a crash", () => {
+    expect(buildFeed(undefined)).toEqual([]);
+    expect(buildFeed([])).toEqual([]);
+    // A message with no text carries nothing to draw.
+    expect(buildFeed([msg(1, "")])).toEqual([]);
+  });
+});
+
+describe("summariseRuns", () => {
+  test("names the tools and counts the repeats", () => {
+    expect(summariseRuns([{ ts: 1, tool: "Read" }, { ts: 2, tool: "Read" }, { ts: 3, tool: "Bash" }]))
+      .toBe("Read ×2 · Bash");
+  });
+
+  test("stops at three kinds and says how many more", () => {
+    const runs = ["Read", "Bash", "Edit", "Grep", "Write"].map((t, i) => ({ ts: i, tool: t }));
+    expect(summariseRuns(runs)).toContain("+2 more");
+  });
+
+  test("an unnamed run still reads as something", () => {
+    expect(summariseRuns([{ ts: 1 }])).toBe("tool");
+  });
+});
+
+describe("shortTarget", () => {
+  test("keeps the end of a path, which is the part that identifies it", () => {
+    expect(shortTarget("/home/me/code/app/web/src/mobile/MobileChats.tsx")).toBe("mobile/MobileChats.tsx");
+  });
+
+  test("a command stays a command", () => {
+    expect(shortTarget("bun test web/test")).toBe("bun test web/test");
+  });
+
+  test("long text is clipped, not wrapped", () => {
+    expect(shortTarget("x".repeat(100)).length).toBe(46);
+  });
+
+  test("nothing to show is empty, not 'null'", () => {
+    expect(shortTarget(null)).toBe("");
+    expect(shortTarget(undefined)).toBe("");
+  });
+});

--- a/web/test/project-rows.test.ts
+++ b/web/test/project-rows.test.ts
@@ -1,0 +1,50 @@
+// The Repos tab listed a linked worktree as if it were another project, so one
+// repository on two branches read as two repositories. They fold into one row;
+// the branch is chosen inside.
+import { describe, expect, test } from "bun:test";
+import { projectRows } from "../src/mobile/projects.ts";
+
+/** The shape the tab hands in: a checkout, its name, and what it holds. */
+const repo = (root: string, name: string, branch: string, extra: { worktreeOf?: string; dirty?: number } = {}) => ({
+  ref: { root, name, branch, dirty: 0, ahead: 0, behind: 0, ...(extra.worktreeOf ? { worktreeOf: extra.worktreeOf } : {}) },
+  name, branch, dirty: extra.dirty ?? 0, ahead: 0, behind: 0, prs: 0, down: 0,
+});
+
+describe("projectRows", () => {
+  test("a worktree folds into the repository it belongs to", () => {
+    const rows = projectRows([
+      repo("/code/agentglass", "agentglass", "main"),
+      repo("/code/agentglass/.claude/worktrees/remote-phone", "remote-phone", "fix/phone", { worktreeOf: "/code/agentglass", dirty: 5 }),
+    ]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.main.name).toBe("agentglass");
+    expect(rows[0]!.checkouts).toHaveLength(2);
+  });
+
+  test("the project's checkout comes first, whatever order they arrived in", () => {
+    const rows = projectRows([
+      repo("/code/app/.claude/worktrees/b", "b", "feat/b", { worktreeOf: "/code/app" }),
+      repo("/code/app", "app", "main"),
+      repo("/code/app/.claude/worktrees/a", "a", "feat/a", { worktreeOf: "/code/app" }),
+    ]);
+    expect(rows[0]!.checkouts[0]!.name).toBe("app");
+    expect(rows[0]!.checkouts.slice(1).map((c) => c.name)).toEqual(["a", "b"]);
+  });
+
+  test("separate repositories stay separate", () => {
+    const rows = projectRows([repo("/code/one", "one", "main"), repo("/code/two", "two", "main")]);
+    expect(rows.map((r) => r.main.name)).toEqual(["one", "two"]);
+  });
+
+  test("a worktree whose repository is not in the list stands on its own", () => {
+    // Scoped views can hand us the checkout without its parent; dropping it
+    // would make the work in it invisible.
+    const rows = projectRows([repo("/code/app/.claude/worktrees/x", "x", "feat/x", { worktreeOf: "/code/app", dirty: 2 })]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.main.name).toBe("x");
+  });
+
+  test("nothing in, nothing out", () => {
+    expect(projectRows([])).toEqual([]);
+  });
+});

--- a/web/test/transcript.test.ts
+++ b/web/test/transcript.test.ts
@@ -1,0 +1,45 @@
+// A chat reads downwards, and the phone showed it upwards.
+//
+// Two failures in one expression: the order was the server's (newest-first),
+// and the window was `slice(-40)`, which on a newest-first list keeps the
+// oldest forty turns. On a long session the phone opened on ancient history.
+import { describe, expect, test } from "bun:test";
+import { recentTurns } from "../src/mobile/transcript.ts";
+
+/** The shape the server sends: newest first. */
+const feed = (n: number) =>
+  Array.from({ length: n }, (_, i) => ({ ts: (n - i) * 1000, text: `turn ${n - i}` }));
+
+describe("recentTurns", () => {
+  test("oldest first, newest last", () => {
+    const out = recentTurns(feed(4));
+    expect(out.map((t) => t.ts)).toEqual([1000, 2000, 3000, 4000]);
+    expect(out[out.length - 1]!.text).toBe("turn 4");
+  });
+
+  test("keeps the newest turns when the session is longer than the window", () => {
+    const out = recentTurns(feed(100), 40);
+    expect(out).toHaveLength(40);
+    // The window ends at the newest turn and starts 40 back — not at turn 1.
+    expect(out[out.length - 1]!.ts).toBe(100_000);
+    expect(out[0]!.ts).toBe(61_000);
+  });
+
+  test("a new turn lands at the bottom", () => {
+    const before = recentTurns(feed(3));
+    const after = recentTurns([{ ts: 4000, text: "newest" }, ...feed(3)]);
+    expect(before[before.length - 1]!.ts).toBe(3000);
+    expect(after[after.length - 1]!.text).toBe("newest");
+  });
+
+  test("does not mutate what the server sent", () => {
+    const src = feed(3);
+    recentTurns(src);
+    expect(src.map((t) => t.ts)).toEqual([3000, 2000, 1000]);
+  });
+
+  test("survives a session with no conversation yet", () => {
+    expect(recentTurns(undefined)).toEqual([]);
+    expect(recentTurns([])).toEqual([]);
+  });
+});

--- a/web/test/viewport.test.ts
+++ b/web/test/viewport.test.ts
@@ -38,6 +38,22 @@ describe("wantsPhoneLayout", () => {
     expect(wantsPhoneLayout(1920, false, "mobile")).toBe(true);
     expect(wantsPhoneLayout(360, true, "desktop")).toBe(false);
   });
+
+  test("a page served off-box gets the phone application whatever it measures", () => {
+    // Chrome's "Desktop site" on a phone: 980px and a fine pointer reported by
+    // a device that is neither. This is the report that put the cockpit on a
+    // Pixel, and it must not be able to any more.
+    expect(wantsPhoneLayout(980, false, null, true)).toBe(true);
+    expect(wantsPhoneLayout(1440, false, null, true)).toBe(true);
+    // Beats the saved override too: the phone is the one browser that could set
+    // that for itself, so it cannot be the way back into the cockpit.
+    expect(wantsPhoneLayout(1440, false, "desktop", true)).toBe(true);
+  });
+
+  test("local pages are unaffected by the remote rule", () => {
+    expect(wantsPhoneLayout(1440, false, null, false)).toBe(false);
+    expect(wantsPhoneLayout(390, true, null, false)).toBe(true);
+  });
 });
 
 describe("readOverride", () => {


### PR DESCRIPTION
The phone companion, driven end to end for the first time. Every fault below was found by opening the app on a device — none of them was visible in code, and a full test suite was green throughout.

## What does this PR do?

**A device off this machine gets the phone app, never the cockpit.** Which application a device got was decided in the browser from viewport width, pointer type and a saved override — all three of which a phone can set for itself (Chrome's "Desktop site" reports 980px and a fine pointer). Scanning the QR code could therefore land on the full cockpit: a terminal, git write access and docker control behind a link scanned off a screen. The server now marks index.html per request from the peer address of the socket, and the bundle takes that as final, ahead of every measurement.

**A session has exactly one writer, and the server is the only one who knows.** Sending from the phone into a session that was mid-turn started a second `claude -p --resume` on the same transcript: the running turn was interrupted, both answers were lost, and the JSONL recorded `[Request interrupted by user]` — three times in one afternoon. No client-side signal can answer "is a turn in flight": the transcript arrives a poll late, and `last_seen` is equally recent for a session that finished ten seconds ago. The server spawned the process, so it now counts in-flight turns per session, answers `GET /chat/active`, and refuses a colliding resume with **409 `turn_in_flight`** before anything spawns. Both surfaces queue instead of colliding, and drain when the writer stops.

**The diff would not open.** Every screen pushed its own history entry, and a screen closed by a button called `history.back()` — whose popstate every *other* open screen took as its cue to close. Tapping a file opened the diff and closed it in the same frame. Screens now share one stack; only the top one answers a back gesture.

**Paths that could not be staged.** With `diff.mnemonicPrefix` set, git labels a diff `i/file` and `w/file`; the parser stripped only `a/`/`b/`, so staging ran `git add -- w/web/src/…` and failed with "did not match any files". Every git call now pins the config it parses (`mnemonicPrefix`, `noprefix`, `quotepath`, `color.ui`) as `-c` overrides, so no user setting can change our input again.

**A chat that reads like a chat.** One bar, no tab bar, the thread as the only scroller, the composer docked, sized with `100dvh` — `inset: 0` measures the viewport as if the browser's URL bar were hidden, which is why the composer kept disappearing. Newest turn at the bottom (the transcript arrives newest-first and was being rendered as-is, from the wrong end of the window), following while you are at the bottom and staying put with a "↓ n newer" chip while you are reading.

**The phone showed what an agent said and never what it did.** `SessionDetail.timeline` already carried every tool run. The transcript is now a feed: messages, and between them the runs grouped as `Edit ×4 · Bash ×2 · Read ×2`, openable to every file and command, with failures counted on the closed row.

**One row per project.** A linked worktree is the same repository on another branch; the Repos tab listed it as a second project. They fold under the project now, with the checkouts offered inside as chips. Containers are matched on the project name, not on the checkout's directory name.

**Smaller things:** the chat list opens on Working, then Today, with All a tap away, and no longer offers `<synthetic>` rollups that cannot be opened; the desktop Resume picker offers running sessions instead of hiding exactly the chat you just started on your phone; the Settings sheet scrolls instead of running off a short viewport; the stage switch is no longer clipped by its own hit area; a failed action reloads the tree so a refused stage cannot leave a switch showing something that never happened; a brand new chat no longer claims it cannot be resumed while its first turn is still running.

## How was it tested?

`bun test` — **1487 pass, 0 fail** (69 new). `bunx tsc --noEmit` and `bun run build` clean.

New: `scripts/phone-audit.ts` drives the companion in headless Chrome at 412x915 with touch emulation and checks **89 invariants** across the shell, chat list, conversation, repo, changes, diff, settings, new chat, staging, offline recovery and landscape — including a hygiene sweep of every screen for anything past the right edge, any tap target under 36px, and any text cut off without an ellipsis. **89/89 pass**, against the installed desktop app's own token-gated sidecar as well as a dev server. It is read-only unless `AUDIT_WRITE=1`, because it runs against a real fleet.

Driven by hand as well as by harness: a chat started from the phone, a second message sent while the first turn was still running, and the session transcript on disk checked afterwards — both turns present, in order, **zero interrupts**. Before this change that same sequence produced no answers at all. The desktop cockpit was smoke-tested separately for console errors and panel rendering, and the picker was checked adopting a live session.

## Not covered

The pull request detail screen and a gate approval could not be exercised: there is no open PR and no pending gate on this machine right now. Both render their empty states correctly.
