### PR TITLE
feat(mobile): put the phone on the live socket

### DIFF
--- a/web/src/lib/sessionBus.ts
+++ b/web/src/lib/sessionBus.ts
@@ -1,0 +1,31 @@
+/**
+ * "A session changed" — one signal, every consumer.
+ *
+ * The sibling of `gitBus`. The server already broadcasts a `session` frame
+ * every time it ingests an event, and the cockpit deliberately ignores it: its
+ * Sessions panel owns a poll and re-reads on its own clock, which is fine when
+ * the panel is a few feet from the machine.
+ *
+ * The companion cannot do that. A phone poll is a radio wake, so its interval
+ * was tuned for battery rather than for truth, and the result was a screen that
+ * was always a little bit wrong. This is how it finds out instead.
+ *
+ * Deliberately not coalesced here. The frame fires on every ingest — several a
+ * second under a busy fleet — and how much of that a consumer wants is the
+ * consumer's business: a list can wait a second, and an open conversation
+ * cannot. Debouncing centrally would impose the slowest answer on everyone.
+ */
+
+const listeners = new Set<(sessionId: string) => void>();
+
+/** Called by the live socket when the server reports a session rollup changed. */
+export function sessionChanged(sessionId: string): void {
+  for (const fn of listeners) {
+    try { fn(sessionId); } catch { /* one bad listener must not stop the rest */ }
+  }
+}
+
+export function subscribeSessionChanged(fn: (sessionId: string) => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -3,6 +3,7 @@ import type { WatchEvent, WsFrame, OpenToolCall } from "../../../shared/types.ts
 import { WS_URL, IS_DEMO, hasToken, probeAuth } from "./api.ts";
 import * as demo from "./demo.ts";
 import { gitChanged } from "./gitBus.ts";
+import { sessionChanged } from "./sessionBus.ts";
 import { emitControl } from "./controlBus.ts";
 import { recordNote, fireDesktopAlert } from "./sysNotify.ts";
 
@@ -28,8 +29,21 @@ export interface LiveData {
  * Single WebSocket with auto-reconnect. Incoming events are BUFFERED and
  * flushed on a timer (not per-message) so a busy fleet causes a few renders a
  * second instead of dozens. Rendering pauses entirely while the tab is hidden.
+ *
+ * `keepEvents` is what makes this usable on a phone. The event buffer is the
+ * expensive part — up to two thousand rows, re-set every 220ms — and it exists
+ * for the cockpit's event stream, which the companion does not draw. Everything
+ * the phone *does* need rides the same socket: `openTools` (what each agent has
+ * open right now), the connection state, and the git / control / alert frames
+ * that arrive as side effects. Turning the buffer off is not a smaller feature
+ * set, it is the same subscription without the one part nobody is looking at.
+ *
+ * A second socket for the phone was the alternative and would have been worse:
+ * the reconnect, the backoff, the give-up window and the auth probe below are
+ * subtle, and a copy of them would drift from this one the first time either
+ * was touched.
  */
-export function useLive(paused = false): LiveData {
+export function useLive(paused = false, keepEvents = true): LiveData {
   const [events, setEvents] = useState<WatchEvent[]>([]);
   const [conn, setConn] = useState<ConnState>("connecting");
   const [lastEvent, setLastEvent] = useState<WatchEvent | null>(null);
@@ -59,6 +73,8 @@ export function useLive(paused = false): LiveData {
   // without the callback being rebuilt on each toggle.
   const pausedRef = useRef(paused);
   pausedRef.current = paused;
+  const keepRef = useRef(keepEvents);
+  keepRef.current = keepEvents;
 
   const flush = useCallback(() => {
     flushScheduled.current = false;
@@ -174,12 +190,15 @@ export function useLive(paused = false): LiveData {
         return;
       }
       if (frame.type === "initial") {
+        // openTools is taken either way: it is the whole reason a phone opens
+        // this socket, and it rides on the same first frame.
+        setOpenTools(frame.openTools ?? []);
+        if (!keepRef.current) return;
         const initial = frame.data.slice(-MAX_EVENTS);
         seen.current = new Set(initial.map((e) => e.id));
         pending.current = [];
         setEvents(initial);
         setLastEvent(initial[initial.length - 1] ?? null);
-        setOpenTools(frame.openTools ?? []);
       } else if (frame.type === "openTools") {
         // The whole list, re-read with fresh evidence. Replaces rather than
         // merges: the server's answer is authoritative about what is open, and
@@ -188,10 +207,21 @@ export function useLive(paused = false): LiveData {
       } else if (frame.type === "event") {
         if (seen.current.has(frame.data.id)) return; // duplicate delivery
         seen.current.add(frame.data.id);
-        pending.current.push(frame.data);
-        scheduleFlush();
+        if (keepRef.current) {
+          pending.current.push(frame.data);
+          scheduleFlush();
+        } else if (seen.current.size > MAX_EVENTS) {
+          // Without the buffer nothing else ever trims this, so it would grow one
+          // id per event for as long as the phone is open. Ids arrive ascending,
+          // so keeping the newest half still catches every re-delivery that is
+          // close enough in time to matter.
+          seen.current = new Set([...seen.current].slice(-MAX_EVENTS / 2));
+        }
         // A Post closes its tool: drop the matching seed so it can't keep a
         // finished tool marked "running" after its Post later evicts the buffer.
+        // This runs whether or not the buffer is kept — a phone that draws only
+        // the open call needs the close more than the cockpit does, because it
+        // has no event list underneath to contradict a stale one.
         const ev = frame.data;
         if (ev.hook_event_type === "PostToolUse" || ev.hook_event_type === "PostToolUseFailure") {
           setOpenTools((cur) =>
@@ -200,8 +230,14 @@ export function useLive(paused = false): LiveData {
               : cur
           );
         }
+      } else if (frame.type === "session") {
+        // The cockpit's Sessions panel fetches its own roll-ups on its own
+        // clock and does not need this. The companion does: a phone poll costs
+        // a radio wake, so its interval was tuned for battery rather than for
+        // truth. Announced rather than handled, so each surface decides how
+        // much of a several-a-second frame it actually wants.
+        sessionChanged(frame.data.session_id);
       }
-      // "session" frames are ignored — the Sessions panel fetches its own roll-ups.
     };
   }, [scheduleFlush]);
 

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -1,12 +1,15 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { api } from "../lib/api.ts";
+import { useLive } from "../lib/useLive.ts";
+import { subscribeGitChanged } from "../lib/gitBus.ts";
+import { subscribeSessionChanged } from "../lib/sessionBus.ts";
 import { useStats } from "../lib/useStats.ts";
 import { fmtUsd, fmtTokens } from "../lib/format.ts";
 import { MobileChats } from "./MobileChats.tsx";
 import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobileUi.tsx";
 import { pollWhileVisible } from "../lib/poll.ts";
 import { DIFF_CSS } from "./MobileDiff.tsx";
-import { NOW_CSS, NowHero, NowStream, type NowAction } from "./MobileNow.tsx";
+import { NOW_CSS, NowHero, NowStream, type NowAction, type LiveCall } from "./MobileNow.tsx";
 import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
 import { projectRows } from "./projects.ts";
 import { MobilePr } from "./MobilePr.tsx";
@@ -35,16 +38,39 @@ import type {
  *   Repos  — go looking, for when you want to rather than need to.
  *
  * Nothing heavy mounts: no xterm, no charts, no radar. On a phone that is a
- * battery decision as much as a layout one, and it is why the fleet's pulse is
- * fourteen CSS-animated bars rather than a canvas.
+ * battery decision as much as a layout one.
+ *
+ * It is on the live socket, and that is what makes the rest of it honest. The
+ * first version polled and said so in a comment here — a reasonable-sounding
+ * trade that quietly gave up the product's whole premise, because a server with
+ * no channel to this device cannot tell it anything. What replaced the bars
+ * that used to stand in for telemetry is the server's own list of tool calls
+ * still open.
  */
 
 type Tab = "now" | "chats" | "repos";
 
-/** A gate is the only thing here that has an agent stopped dead, so it gets
- *  the fastest poll. Everything else moves on human timescales. */
-const GATE_MS = 4_000;
-const TREE_MS = 30_000;
+/** Live on the socket · reachable but not streaming · nothing answering. */
+type LinkState = "live" | "slow" | "offline";
+const LINK_WORD: Record<LinkState, string> = { live: "Live", slow: "Catching up", offline: "Offline" };
+const LINK_TONE: Record<LinkState, string> = {
+  live: "var(--success)", slow: "var(--warning)", offline: "var(--error)",
+};
+
+/**
+ * Fallback intervals, not the delivery mechanism.
+ *
+ * Everything below arrives on the socket now. These exist for the seconds
+ * between a socket dying and the reconnect landing, so they are set to what a
+ * *backstop* should cost rather than what a primary path has to be — a phone
+ * pays a radio wake for each one.
+ *
+ * Docker and pull requests keep real intervals because nothing pushes them:
+ * docker has no change feed we subscribe to, and GitHub has no route into this
+ * server.
+ */
+const GATE_MS = 20_000;
+const TREE_MS = 120_000;
 const DOCKER_MS = 15_000;
 const PR_MS = 60_000;
 
@@ -75,11 +101,27 @@ export function MobileApp() {
   const [immersive, setImmersive] = useState(false);
   const [dismissed, setDismissed] = useState<string[]>([]);
 
-  // ── polling ──────────────────────────────────────────────────────────
-  // Polled rather than streamed, deliberately. The live socket exists and
-  // works, but a phone spends most of its life with the screen off, and a
-  // socket reconnecting in the background is a worse deal than a few small
-  // requests at the moment you look at it.
+  // ── the live channel ─────────────────────────────────────────────────
+  //
+  // This used to be polling only, and the reasoning was written down here: a
+  // socket reconnecting behind a dark screen is a worse deal than a few small
+  // requests. The battery half of that is right and is kept — the socket closes
+  // with the screen and catches up on return, exactly as the polls did.
+  //
+  // What it got wrong is what it cost. Without a channel the server has no way
+  // to say anything, so nothing on this device could ever be current: a gate
+  // arrived up to four seconds late, a change made here took up to a minute to
+  // reach the desk, and "what is that agent doing right now" had no answer at
+  // all — which is why the home screen animated fourteen bars off a tool
+  // *count* and called them vitals.
+  //
+  // `keepEvents: false` is the phone's half of the bargain: the same socket,
+  // without the two-thousand-row event buffer the cockpit's stream needs and
+  // this app never draws.
+  const { conn, openTools } = useLive(false, false);
+
+  // The polls stay, slowed right down. They are no longer how anything gets
+  // here — they are what covers the gap between the socket dying and noticing.
   const loadFast = useCallback(() => {
     api.gatePending().then((r) => { setGates(r.gates); setReachable(true); }).catch(() => setReachable(false));
     api.sessions(40).then(setSessions).catch(() => { /* the gate poll reports reachability */ });
@@ -121,11 +163,52 @@ export function MobileApp() {
     return pollWhileVisible(loadFast, GATE_MS);
   }, [loadFast]);
 
+  /**
+   * The repository list, and everything gated on it.
+   *
+   * This was a single fetch on mount with an empty `catch`, and every other
+   * poll is gated on `repos.length` — so one failed request at boot (a sidecar
+   * still starting, a phone that woke on the wrong network) left the tree, the
+   * pull requests and docker permanently empty, with no refresh control
+   * anywhere on the phone to recover with. Killing the tab was the only way
+   * back.
+   *
+   * Now it retries, and it re-reads whenever git says something changed, which
+   * is also how a worktree created at the desk finally appears here.
+   */
+  const loadRepos = useCallback(() => {
+    api.gitRepos()
+      .then(({ repos: list }) => { setRepos(list); loadTrees(list); loadPrs(list); })
+      .catch(() => setRepos((cur) => cur));
+  }, [loadTrees, loadPrs]);
+
   useEffect(() => {
     api.prCapability().then((c) => setMe(c.login || "")).catch(() => {});
-    api.gitRepos().then(({ repos: list }) => { setRepos(list); loadTrees(list); loadPrs(list); }).catch(() => {});
+    loadRepos();
     loadDocker();
-  }, [loadDocker, loadTrees, loadPrs]);
+  }, [loadDocker, loadRepos]);
+
+  // Retry the one fetch everything else depends on until it lands.
+  useEffect(() => {
+    if (repos.length) return;
+    const t = setTimeout(loadRepos, 5_000);
+    return () => clearTimeout(t);
+  }, [repos.length, loadRepos]);
+
+  // ── pushed, not polled ───────────────────────────────────────────────
+  useEffect(() => subscribeGitChanged(() => { loadRepos(); }), [loadRepos]);
+
+  useEffect(() => {
+    // A `session` frame fires on every ingest — several a second under a busy
+    // fleet — and this list only needs to be right, not instantaneous. One
+    // trailing call per burst.
+    let t: ReturnType<typeof setTimeout> | null = null;
+    const off = subscribeSessionChanged(() => {
+      if (t) return;
+      t = setTimeout(() => { t = null; loadFast(); }, 1_200);
+    });
+    return () => { off(); if (t) clearTimeout(t); };
+  }, [loadFast]);
 
   useEffect(() => {
     if (!repos.length) return;
@@ -147,6 +230,22 @@ export function MobileApp() {
     () => sessions.filter((s) => !s.ended_at && Date.now() - s.last_seen < 120_000),
     [sessions]
   );
+
+  /** The server's own list of calls still running, in the order that reads
+   *  worst-first: the one that has been open longest is the one most likely to
+   *  be stuck rather than thinking. */
+  const openCalls: LiveCall[] = useMemo(() => {
+    const now = Date.now();
+    return [...openTools]
+      .sort((a, b) => a.since - b.since)
+      .map((t) => ({
+        key: `${t.session_id}:${t.tool_name}:${t.since}`,
+        tool: t.tool_name,
+        target: t.target ?? null,
+        app: t.source_app,
+        openMs: Math.max(0, now - t.since),
+      }));
+  }, [openTools]);
 
   const queue = useMemo(
     () => buildQueue({ gates, sessions, prs, containers, me, now: Date.now() })
@@ -258,6 +357,14 @@ export function MobileApp() {
   const stacked = !!openRepo || !!openPr;
   const spend = stats?.totals ? fmtUsd(stats.totals.cost_usd) : "—";
 
+  /**
+   * One word for the state of the link, and it distinguishes the three cases a
+   * single boolean could not: the socket is carrying data, the socket is gone
+   * but the server still answers (so nothing is lost, only late), and nothing
+   * is reachable at all.
+   */
+  const link: LinkState = conn === "open" ? "live" : reachable ? "slow" : "offline";
+
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
       <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}</style>
@@ -274,9 +381,12 @@ export function MobileApp() {
           agent<span style={{ color: "var(--primary-hover)" }}>glass</span>
         </span>
         <span className="flex-1" />
-        <span className="flex items-center gap-1.5 text-[11px]" style={{ color: reachable ? "var(--success)" : "var(--error)" }}>
+        {/* What this said before was that one four-second poll had succeeded,
+            on an app with no live connection — "Live" meant "the last request
+            came back". It is the socket now, so it can mean what it says. */}
+        <span className="flex items-center gap-1.5 text-[11px]" style={{ color: LINK_TONE[link] }}>
           <span className="mb-dot pulse" style={{ background: "currentColor", color: "currentColor" }} />
-          {reachable ? "Live" : "Offline"}
+          {LINK_WORD[link]}
         </span>
         <button className="mb-press grid place-items-center" aria-label="Settings"
           style={{ minHeight: 40, minWidth: 40, borderRadius: 11, fontSize: 15, color: "var(--text3)", background: "transparent" }}
@@ -292,10 +402,7 @@ export function MobileApp() {
           <>
             <NowHero
               pending={queue.length} working={live.length}
-              // The bars breathe at rates derived from each agent's own tool
-              // count, so the strip reads as several things working rather than
-              // one animation looping.
-              rates={live.map((s) => 1 + ((s.tool_count % 5) * 0.35))}
+              live={openCalls}
               spend={spend}
               repos={[...new Set(live.map((s) => (s.project_path || "").split("/").filter(Boolean).pop() || s.source_app))]}
             />

--- a/web/src/mobile/MobileNow.tsx
+++ b/web/src/mobile/MobileNow.tsx
@@ -26,17 +26,19 @@ export const NOW_CSS = `
 .mb-hero .w b{display:block;font-size:14px;font-weight:600;line-height:1.25}
 .mb-hero .w span{display:block;font-size:11.5px;color:var(--text3);margin-top:2px}
 
-/* Vitals: one bar per live agent, each on its own period, so the strip reads
-   as several things working rather than as one animation looping. */
-.mb-vitals{display:flex;align-items:flex-end;gap:3px;height:46px;margin:16px 17px 0;padding-bottom:7px;
-  position:relative;z-index:1;border-bottom:1px solid color-mix(in srgb,var(--border) 40%,transparent)}
-.mb-vitals i{flex:1;height:100%;border-radius:2px 2px 0 0;transform-origin:bottom;
-  background:linear-gradient(180deg,var(--primary-hover),color-mix(in srgb,var(--primary) 26%,transparent));
-  animation:mb-vit var(--p) ease-in-out infinite;animation-delay:var(--d);
-  box-shadow:0 0 10px -2px color-mix(in srgb,var(--primary) 60%,transparent)}
-@keyframes mb-vit{0%,100%{transform:scaleY(.14)}50%{transform:scaleY(1)}}
-.mb-vitals i.idle{background:color-mix(in srgb,var(--border) 48%,transparent);animation:none;
-  transform:scaleY(.1);box-shadow:none}
+/* What is open right now: one row per running tool call, from the socket. Not
+   a chart — the useful facts are which tool, what it is touching, and how long
+   it has been at it, and none of those is a magnitude. */
+.mb-open{position:relative;z-index:1;margin:15px 17px 0;padding-bottom:9px;
+  border-bottom:1px solid color-mix(in srgb,var(--border) 40%,transparent);
+  display:flex;flex-direction:column;gap:6px}
+.mb-open .r{display:flex;align-items:center;gap:8px;font-size:11px;min-width:0}
+.mb-open .r b{color:var(--primary-hover);font-weight:700;flex:none}
+.mb-open .r .t{color:var(--text2);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;
+  white-space:nowrap;direction:rtl;text-align:left}
+.mb-open .r .o{flex:none;color:var(--text3);font-variant-numeric:tabular-nums;font-size:10px}
+.mb-open .r .o.long{color:var(--warning)}
+.mb-open .more{font-size:10px;color:var(--text3)}
 .mb-vlabel{display:flex;align-items:center;gap:8px;padding:11px 17px 16px;font-size:10.5px;
   color:var(--text3);position:relative;z-index:1}
 .mb-vlabel b{color:var(--text2);font-weight:500}
@@ -74,13 +76,24 @@ export interface NowAction {
   run: () => Promise<string | void> | string | void;
 }
 
-export function NowHero({ pending, working, rates, spend, repos }: {
-  pending: number; working: number; rates: number[]; spend: string; repos: string[];
+/**
+ * The hero, and under it what the fleet is actually doing.
+ *
+ * This used to draw fourteen bars animated at rates derived from each session's
+ * tool *count* — `1 + ((s.tool_count % 5) * 0.35)`. They were `aria-hidden`
+ * decoration presented in the position telemetry would occupy, on an app that
+ * had no live connection and therefore nothing to tell you. Someone glancing at
+ * a phone to see whether an agent was moving was reading an animation.
+ *
+ * The socket carries the real answer: `openTools` is the server's authoritative
+ * list of calls still running, with what each one is touching and when that
+ * session last showed evidence of being alive. So the strip is now one row per
+ * open call, and when nothing is open it says so instead of pulsing.
+ */
+export function NowHero({ pending, working, live, spend, repos }: {
+  pending: number; working: number; live: LiveCall[]; spend: string; repos: string[];
 }) {
   const calm = pending === 0;
-  // A fixed number of slots, so the strip has the same shape whether one agent
-  // is running or six — it reads as capacity, not as a bar chart that resizes.
-  const SLOTS = 14;
   return (
     <div className={`mb-hero${calm ? " calm" : ""}`}>
       <div className="in">
@@ -90,14 +103,20 @@ export function NowHero({ pending, working, rates, spend, repos }: {
           <span>{calm ? "The fleet is running clean" : "Answer one and it leaves the queue"}</span>
         </span>
       </div>
-      <div className="mb-vitals" aria-hidden="true">
-        {Array.from({ length: SLOTS }, (_, i) => {
-          const r = rates[i];
-          return r == null
-            ? <i key={i} className="idle" />
-            : <i key={i} style={{ ["--p" as string]: `${(1.6 / r).toFixed(2)}s`, ["--d" as string]: `${(i * 0.23).toFixed(2)}s` }} />;
-        })}
-      </div>
+      {live.length > 0 && (
+        <div className="mb-open">
+          {live.slice(0, 3).map((c) => (
+            <div className="r" key={c.key}>
+              <b>{c.tool}</b>
+              <span className="t">{c.target || c.app}</span>
+              {/* How long it has been open is the difference between thinking
+                  and stuck, and it is the one number a count cannot give you. */}
+              <span className={`o${c.openMs > 60_000 ? " long" : ""}`}>{fmtAgo(Date.now() - c.openMs)}</span>
+            </div>
+          ))}
+          {live.length > 3 && <div className="more">+{live.length - 3} more open</div>}
+        </div>
+      )}
       <div className="mb-vlabel">
         <span className="mb-dot pulse" style={{ background: working ? "var(--success)" : "var(--text3)", color: "var(--success)" }} />
         <b>{working} working</b><span>·</span><span>{spend} today</span>
@@ -106,6 +125,16 @@ export function NowHero({ pending, working, rates, spend, repos }: {
       </div>
     </div>
   );
+}
+
+/** One open tool call, reduced to what the strip draws. */
+export interface LiveCall {
+  key: string;
+  tool: string;
+  target: string | null;
+  app: string;
+  /** How long the call has been open, in ms. */
+  openMs: number;
 }
 
 export function NowStream({ items, actionsFor, onOpen }: {

--- a/web/test/phone-live.test.ts
+++ b/web/test/phone-live.test.ts
@@ -1,0 +1,169 @@
+/*
+ * The phone had no live connection at all.
+ *
+ * `grep -rn WebSocket web/src/mobile/` returned nothing, and the reason was
+ * written down in MobileApp: a socket reconnecting behind a dark screen is a
+ * worse deal than a few small requests. The battery half of that is right. The
+ * conclusion gave up the product's premise — a server with no channel to a
+ * device cannot tell it anything — so a gate arrived up to four seconds late,
+ * an action taken here took up to a minute to reach the desk, and "what is that
+ * agent doing right now" had no answer, which is why the home screen animated
+ * fourteen bars off a tool COUNT and put them where telemetry goes.
+ *
+ * These are mostly rules over the tree rather than assertions about today's
+ * call sites. Wiring one screen to the socket is worth little if the next one
+ * is written the old way, and a decorative gauge is the kind of thing that
+ * grows back.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { sessionChanged, subscribeSessionChanged } from "../src/lib/sessionBus.ts";
+
+const SRC = join(import.meta.dir, "..", "src");
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+
+/**
+ * Source with its comments removed.
+ *
+ * The rule below is about what the code does, not about what the comments say —
+ * and the first thing it caught was the comment recording the formula it was
+ * written to ban. That comment earns its place: it is why the rule exists.
+ */
+function code(src: string): string {
+  return src.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+}
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+describe("the session bus", () => {
+  test("delivers the id to every subscriber", () => {
+    const seen: string[] = [];
+    const offA = subscribeSessionChanged((id) => seen.push("a:" + id));
+    const offB = subscribeSessionChanged((id) => seen.push("b:" + id));
+    sessionChanged("s1");
+    expect(seen).toEqual(["a:s1", "b:s1"]);
+    offA(); offB();
+  });
+
+  test("unsubscribing stops delivery", () => {
+    const seen: string[] = [];
+    const off = subscribeSessionChanged((id) => seen.push(id));
+    sessionChanged("s1");
+    off();
+    sessionChanged("s2");
+    expect(seen).toEqual(["s1"]);
+  });
+
+  test("one bad listener does not stop the rest", () => {
+    // A screen that throws while re-rendering must not silently stop every
+    // other screen from ever hearing about a change again.
+    const seen: string[] = [];
+    const offBad = subscribeSessionChanged(() => { throw new Error("boom"); });
+    const offGood = subscribeSessionChanged((id) => seen.push(id));
+    expect(() => sessionChanged("s1")).not.toThrow();
+    expect(seen).toEqual(["s1"]);
+    offBad(); offGood();
+  });
+});
+
+describe("the phone is on the socket", () => {
+  const app = read("mobile/MobileApp.tsx");
+
+  test("MobileApp subscribes, and without the cockpit's event buffer", () => {
+    // The second argument is what makes this affordable on a phone: the same
+    // subscription, minus the two-thousand-row buffer that exists for an event
+    // stream the companion does not draw.
+    expect(app).toContain("useLive(false, false)");
+    expect(app).toContain("openTools");
+  });
+
+  test("it listens to the git and session buses rather than polling for them", () => {
+    expect(app).toContain("subscribeGitChanged");
+    expect(app).toContain("subscribeSessionChanged");
+  });
+
+  test("useLive announces session frames instead of dropping them", () => {
+    const live = read("lib/useLive.ts");
+    expect(live).toContain("sessionChanged(frame.data.session_id)");
+    // The old comment claimed session frames were ignored on purpose. If that
+    // line comes back the wiring above has been undone.
+    expect(live).not.toContain('"session" frames are ignored');
+  });
+});
+
+describe("the polls are a backstop, not the delivery mechanism", () => {
+  const app = read("mobile/MobileApp.tsx");
+  const ms = (name: string) => {
+    const m = new RegExp(`const ${name} = ([0-9_]+);`).exec(app);
+    if (!m) throw new Error(`${name} not found`);
+    return Number(m[1].replace(/_/g, ""));
+  };
+
+  test("the gate poll is no longer a four-second heartbeat", () => {
+    // It was 4s because it was the only way a held gate could ever arrive.
+    // The socket carries that now, so this is what covers a dropped connection.
+    expect(ms("GATE_MS")).toBeGreaterThanOrEqual(15_000);
+  });
+
+  test("the working tree is not re-read every thirty seconds", () => {
+    expect(ms("TREE_MS")).toBeGreaterThanOrEqual(60_000);
+  });
+});
+
+describe("nothing on the phone draws telemetry it does not have", () => {
+  test("no gauge is driven by a tool count", () => {
+    // `1 + ((s.tool_count % 5) * 0.35)` fed fourteen animated bars that sat
+    // where live activity belongs. A count is not a rate, and an app with no
+    // connection had nothing to animate from — so the rule is that a tool
+    // count may not drive a duration, an animation or a size.
+    const offenders: string[] = [];
+    for (const file of walk(join(SRC, "mobile"))) {
+      if (/tool_count\s*%/.test(code(readFileSync(file, "utf8")))) offenders.push(file.replace(SRC, ""));
+    }
+    expect(offenders, "a tool count is being turned into an animation rate").toEqual([]);
+  });
+
+  test("the open-call strip comes from the server's list", () => {
+    const now = code(read("mobile/MobileNow.tsx"));
+    expect(now).toContain("LiveCall");
+    // The bars are gone, and so is the CSS that animated them.
+    expect(now).not.toContain("mb-vitals");
+    expect(now).not.toContain("@keyframes mb-vit");
+  });
+
+  test("the connection indicator reports the connection", () => {
+    const app = read("mobile/MobileApp.tsx");
+    // It used to say "Live" when one four-second poll had come back, on an app
+    // with no live connection. Three states now, because "the socket is gone
+    // but the server still answers" is neither of the other two.
+    expect(app).toContain("LinkState");
+    expect(app).toContain('conn === "open"');
+    expect(app).toContain("Catching up");
+  });
+});
+
+describe("one failed request at boot no longer disables the app", () => {
+  const app = read("mobile/MobileApp.tsx");
+
+  test("the repository list retries", () => {
+    // Every poll except gates is gated on `repos.length`, and this was a single
+    // fetch on mount with an empty catch — so one failure at boot left the
+    // tree, pull requests and docker permanently empty with no refresh control
+    // anywhere on the phone to recover with.
+    expect(app).toContain("loadRepos");
+    const retry = app.slice(app.indexOf("if (repos.length) return;"));
+    expect(retry.slice(0, 200)).toContain("setTimeout(loadRepos");
+  });
+
+  test("the gated poll effect is still gated, so the retry is what unblocks it", () => {
+    expect(app).toContain("if (!repos.length) return;");
+  });
+});


### PR DESCRIPTION
First of the companion rebuild. This is the root cause under most of the audit: the phone had no live connection, so the server had no way to tell it anything.

## What does this PR do?

`grep -rn WebSocket web/src/mobile/` returned nothing. The reason was written down in `MobileApp.tsx:79-82` — *"a socket reconnecting behind a dark screen is a worse deal than a few small requests"*. The battery half of that is right and is kept: the socket closes with the screen and catches up on return, exactly as the polls did.

What it gave up was the premise. Nothing on the device could ever be current — a held gate arrived up to 4s late, an action taken here took up to a minute to reach the desk, and *"what is that agent doing right now"* had no answer at all. Which is why the home screen animated fourteen bars at rates derived from each session's tool **count** (`1 + ((s.tool_count % 5) * 0.35)`) and put them exactly where telemetry goes. They were `aria-hidden` decoration in the position of a gauge, on an app with nothing to gauge.

**`useLive` gains a second argument.** The event buffer — 2000 rows, re-set every 220 ms — exists for the cockpit's event stream, which the companion does not draw. Everything the phone needs rides the same socket: `openTools`, the connection state, and the git / control / alert frames. Turning the buffer off is the same subscription minus the part nobody is looking at.

A second socket for the phone was the alternative and would have been worse. The reconnect, the backoff, the give-up window and the auth probe in `useLive` are subtle, and a copy of them would drift from the original the first time either was touched.

**Session frames were dropped, with a comment saying so deliberately.** Fair for the cockpit, whose Sessions panel owns a poll a few feet from the machine; wrong for a phone, where a poll is a radio wake and its interval was tuned for battery rather than for truth. They go on a bus now — the sibling of `gitBus` — uncoalesced, because the frame fires several times a second under a busy fleet and how much of that a consumer wants is the consumer's business.

**The polls stay as a backstop** for the seconds between a socket dying and the reconnect landing: gates 4s → 20s, working tree 30s → 120s. Docker and pull requests keep their intervals because nothing pushes them — docker has no change feed we subscribe to, and GitHub has no route into this server.

Two things fall out of being connected:

- **The header told you a poll had succeeded.** "Live" meant "the last request came back". Three states now, because *the socket is gone but the server still answers* is neither live nor offline.
- **One failed request at boot disabled the app.** The repository list was a single fetch on mount with an empty `catch`, and every other poll is gated on `repos.length` — so one failure left the tree, pull requests and docker permanently empty, with no refresh control anywhere on the phone to recover with. It retries now, and re-reads when git says something changed, which is also how a worktree created at the desk finally appears.

## How was it tested?

`web/test/phone-live.test.ts`, 13 tests. Unit tests for the new bus (delivery, unsubscribe, and that one throwing listener does not stop the rest), and the remainder as **rules over the tree** rather than assertions about today's call sites:

- No file under `mobile/` may turn a tool count into an animation rate — comments stripped first, since the rule is about code and the first thing it caught was the comment recording the formula it bans.
- The gate poll may not go back to being a heartbeat; the tree may not go back to 30s.
- `useLive` may not go back to ignoring session frames.
- The repository list must retry, and the gated poll effect must still be gated so the retry is what unblocks it.

Each guard was confirmed to fail against the code **without** its fix — five mutations applied and reverted, all five red: phone drops off the socket, session frames ignored again, gate poll back to 4s, decorative bars back, repo list stops retrying.

Full suites: `web/` 504 pass / 0 fail, `server/` 1040 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## Not covered

The freshness contract is only half satisfied by this. A gate raised while the phone is locked still cannot reach you — that needs a service worker and Web Push, fired where `pushGate` already runs, and it is its own change. Project identity is still re-derived from directory basenames in three disagreeing functions; that is the next one.