### PR TITLE
fix(mobile): make a destination something you can name

### DIFF
--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -5,7 +5,7 @@ import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { subscribeSessionChanged } from "../lib/sessionBus.ts";
 import { useStats } from "../lib/useStats.ts";
 import { fmtUsd, fmtTokens } from "../lib/format.ts";
-import { MobileChats } from "./MobileChats.tsx";
+import { MobileChats, type OpenChat, type Compose } from "./MobileChats.tsx";
 import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobileUi.tsx";
 import { pollWhileVisible } from "../lib/poll.ts";
 import { DIFF_CSS } from "./MobileDiff.tsx";
@@ -96,6 +96,16 @@ export function MobileApp() {
    *  separate projects. */
   const [openCheckouts, setOpenCheckouts] = useState<RepoSummary[]>([]);
   const [openPr, setOpenPr] = useState<{ root: string; number: number } | null>(null);
+  /**
+   * The chat destinations, held here so anything can name one.
+   *
+   * They lived inside MobileChats, which is why every route into it was
+   * approximate: the queue's "Open chat" could only reach the chats *tab*, and
+   * the two hand-offs that carry a directory and a prompt had nowhere to put
+   * them, so they never rendered.
+   */
+  const [openChat, setOpenChat] = useState<OpenChat | null>(null);
+  const [compose, setCompose] = useState<Compose | null>(null);
   const [settings, setSettings] = useState(false);
   /** A conversation is open and owns the whole screen: no app header, no tabs. */
   const [immersive, setImmersive] = useState(false);
@@ -297,6 +307,28 @@ export function MobileApp() {
     setOpenRepo(r);
   }, [repoSummaries]);
 
+  /** Open one specific conversation, wherever the tap came from. */
+  const openSession = useCallback((s: SessionRollup) => {
+    setOpenChat({ id: s.session_id, cwd: s.cwd_path || s.project_path || "" });
+    setTab("chats");
+  }, []);
+
+  /**
+   * "Review locally with Claude" and "Ask Claude why".
+   *
+   * Both screens have offered these behind `onOpenChatWith &&` since they were
+   * written, and nothing ever passed one — so neither button has ever been on
+   * screen. They arrive with the checkout the server put the pull request in
+   * and the prompt to open with, which is why NewChat takes a preset rather
+   * than always starting on the first repo in the list.
+   */
+  const openChatWith = useCallback((cwd: string, prompt: string) => {
+    setOpenPr(null);
+    setOpenRepo(null);
+    setCompose({ cwd, prompt });
+    setTab("chats");
+  }, []);
+
   const openContainerRepo = (c: DockerContainer) => {
     const r = repoSummaries.find((x) => x.name === (c.project ?? ""));
     if (r) openProject(r); else toast("That container is not in a repo agentglass knows", true);
@@ -312,7 +344,11 @@ export function MobileApp() {
         ];
       case "session":
         return [
-          { label: "Open chat", kind: "acc", run: () => { setTab("chats"); drop(it.id); } },
+          // This used to be `setTab("chats")` and a drop — you tapped the accent
+          // action on a stalled agent, landed on a list that by construction
+          // could not contain it (the list opens on "working"; this card exists
+          // because the agent went quiet), and the card was gone from the queue.
+          { label: "Open chat", kind: "acc", run: () => openSession(o.session) },
           { label: "Later", run: () => { drop(it.id); toast("Snoozed"); } },
         ];
       case "pr-red":
@@ -351,7 +387,7 @@ export function MobileApp() {
     const o = it.origin;
     if (o.t === "pr-red" || o.t === "pr-ready" || o.t === "pr-review") setOpenPr({ root: o.root, number: o.pr.number });
     else if (o.t === "container") openContainerRepo(o.container);
-    else if (o.t === "session") setTab("chats");
+    else if (o.t === "session") openSession(o.session);
   };
 
   const stacked = !!openRepo || !!openPr;
@@ -409,7 +445,8 @@ export function MobileApp() {
             <NowStream items={queue} actionsFor={actionsFor} onOpen={openItem} />
           </>
         )}
-        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} onImmersive={setImmersive} />}
+        {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} onImmersive={setImmersive}
+          openChat={openChat} onOpenChat={setOpenChat} compose={compose} onCompose={setCompose} />}
         {tab === "repos" && <RepoList repos={repoSummaries} onOpen={(r, siblings) => { setOpenCheckouts(siblings); setOpenRepo(r); }} />}
       </main>
 
@@ -427,10 +464,12 @@ export function MobileApp() {
       <RepoScreen open={!!openRepo && !openPr} repo={openRepo}
         checkouts={openCheckouts} onPickCheckout={setOpenRepo}
         containers={containers} stats={dstats}
-        onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll} />
+        onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll}
+        onOpenChatWith={openChatWith} />
 
       <MobilePr open={!!openPr} root={openPr?.root ?? ""} number={openPr?.number ?? null}
-        onBack={() => { setOpenPr(null); refreshAll(); }} toast={toast} />
+        onBack={() => { setOpenPr(null); refreshAll(); }} toast={toast}
+        onOpenChatWith={openChatWith} />
 
       <Sheet open={settings} title="Settings" sub="This device only." onClose={() => setSettings(false)}>
         <div className="flex flex-col gap-2.5">

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -6,6 +6,7 @@ import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
 import { sessionIsLive } from "../lib/derive.ts";
 import { scopeSessions, openingScope, type ChatScope } from "./chatList.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
+import { useBackClose } from "./mobileUi.tsx";
 import { recentTurns, buildFeed, summariseRuns, shortTarget, type FeedEntry, type FeedItem, type FeedTool } from "./transcript.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
 
@@ -48,9 +49,19 @@ const SCOPES: [ChatScope, string][] = [["live", "Working"], ["today", "Today"], 
 /** A turn being streamed right now, before the transcript catches up. */
 type Live = { text: string; tools: string[]; error: string | null };
 
-export function MobileChats({ sessions, onRefresh, onImmersive }: {
+/** A conversation somebody asked for by name. */
+export interface OpenChat { id: string; cwd: string }
+/** A chat to compose, optionally arriving with a directory and a prompt from
+ *  whoever handed it over. */
+export interface Compose { cwd?: string; prompt?: string }
+
+export function MobileChats({ sessions, onRefresh, onImmersive, openChat, onOpenChat, compose, onCompose }: {
   sessions: SessionRollup[];
   onRefresh: () => void;
+  openChat: OpenChat | null;
+  onOpenChat: (v: OpenChat | null) => void;
+  compose: Compose | null;
+  onCompose: (v: Compose | null) => void;
   /**
    * Tell the shell a conversation has the screen.
    *
@@ -63,19 +74,24 @@ export function MobileChats({ sessions, onRefresh, onImmersive }: {
    */
   onImmersive?: (on: boolean) => void;
 }) {
-  const [openId, setOpenId] = useState<string | null>(null);
-  const [composing, setComposing] = useState(false);
   /**
-   * Where the open conversation runs, as far as this screen already knows.
+   * Which conversation is open, and any chat waiting to be composed.
    *
-   * The session detail carries the same thing, but it takes a fetch to arrive,
-   * and a chat started here is seconds old — the row the scanner writes may not
-   * have a directory yet. Without this the composer replaced itself with "this
-   * session did not record where it ran", which is a claim about the session
-   * when the truth was "the answer has not come back yet". We picked the repo,
-   * so we can simply say so.
+   * Both used to be private state here, and that is what made every route into
+   * this screen approximate. Nothing outside could say "open *this* chat", so
+   * the queue's own "Open chat" button degraded to `setTab("chats")` — you
+   * tapped the accent action on a stalled agent, landed on a list of other
+   * agents, and the card you tapped was gone. Same for the two hand-offs that
+   * pass a directory and a prompt: `onOpenChatWith` was declared by the pull
+   * request and repo screens and passed by nobody, so "Review locally with
+   * Claude" and "Ask Claude why" could never render at all.
+   *
+   * Controlled from the shell now. A destination the rest of the app can name
+   * is the difference between a route and a guess.
    */
-  const [openCwd, setOpenCwd] = useState("");
+  const openId = openChat?.id ?? null;
+  const openCwd = openChat?.cwd ?? "";
+  const composing = !!compose;
   /** Null until the first list arrives, so the opening scope is chosen from
    *  real sessions rather than from the empty array of the first render. */
   const [picked, setPicked] = useState<ChatScope | null>(null);
@@ -84,7 +100,21 @@ export function MobileChats({ sessions, onRefresh, onImmersive }: {
   const shown = useMemo(() => scopeSessions(sessions, scope), [sessions, scope]);
   const liveCount = useMemo(() => scopeSessions(sessions, "live").length, [sessions]);
 
-  const open = (id: string, cwd: string) => { setOpenCwd(cwd); setOpenId(id); };
+  const closeConversation = useCallback(() => { onOpenChat(null); onRefresh(); }, [onOpenChat, onRefresh]);
+  const closeCompose = useCallback(() => onCompose(null), [onCompose]);
+
+  /**
+   * The back gesture closes the screen, not the app.
+   *
+   * `Screen` and `Sheet` have joined the shared stack since the diff started
+   * closing itself; these two never did, because they are early returns rather
+   * than Screens. So the one surface a person sits in for minutes — mid-reply,
+   * with a queued message — was the one where swiping back the way every other
+   * app on the device works left agentglass entirely, and took the draft with
+   * it. Called unconditionally: hooks cannot live behind the returns below.
+   */
+  useBackClose(!!openId, closeConversation);
+  useBackClose(composing, closeCompose);
 
   // Leaving the tab, or the app, must give the chrome back.
   useEffect(() => {
@@ -92,12 +122,15 @@ export function MobileChats({ sessions, onRefresh, onImmersive }: {
     return () => onImmersive?.(false);
   }, [openId, onImmersive]);
 
-  if (composing) return <NewChat onCancel={() => setComposing(false)} onStarted={(id, cwd) => { setComposing(false); open(id, cwd); onRefresh(); }} />;
-  if (openId) return <Conversation id={openId} knownCwd={openCwd} onBack={() => { setOpenId(null); onRefresh(); }} />;
+  if (compose) {
+    return <NewChat preset={compose} onCancel={closeCompose}
+      onStarted={(id, cwd) => { onCompose(null); onOpenChat({ id, cwd }); onRefresh(); }} />;
+  }
+  if (openId) return <Conversation id={openId} knownCwd={openCwd} onBack={closeConversation} />;
 
   return (
     <div className="flex flex-col gap-2">
-      <button onClick={() => setComposing(true)}
+      <button onClick={() => onCompose({})}
         className="rounded-xl text-[15px] font-medium"
         style={{ minHeight: 52, color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>
         + New chat
@@ -136,7 +169,7 @@ export function MobileChats({ sessions, onRefresh, onImmersive }: {
       {shown.map((s) => {
         const running = !s.ended_at && Date.now() - s.last_seen < 120_000;
         return (
-          <button key={s.session_id} onClick={() => open(s.session_id, s.cwd_path || s.project_path || "")}
+          <button key={s.session_id} onClick={() => onOpenChat({ id: s.session_id, cwd: s.cwd_path || s.project_path || "" })}
             className="w-full text-left rounded-xl px-3.5 py-3 flex flex-col gap-1.5"
             style={{ background: "color-mix(in srgb, var(--bg2) 60%, transparent)", border: `1px solid color-mix(in srgb, var(--border) ${running ? 55 : 32}%, transparent)` }}>
             <div className="flex items-center gap-2">
@@ -573,20 +606,27 @@ function Bubble({ role, text, ts, streaming, tools, error, pending }: {
 }
 
 /** Start something new: a repo and a first message is the whole form. */
-function NewChat({ onCancel, onStarted }: { onCancel: () => void; onStarted: (sessionId: string, cwd: string) => void }) {
+function NewChat({ preset, onCancel, onStarted }: {
+  preset: Compose;
+  onCancel: () => void;
+  onStarted: (sessionId: string, cwd: string) => void;
+}) {
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
-  const [cwd, setCwd] = useState("");
+  const [cwd, setCwd] = useState(preset.cwd ?? "");
   const [model, setModel] = useState(MODELS[0]!.id);
-  const [message, setMessage] = useState("");
+  const [message, setMessage] = useState(preset.prompt ?? "");
   const [live, setLive] = useState<Live | null>(null);
   const [failed, setFailed] = useState<string | null>(null);
   const started = useRef(false);
 
   useEffect(() => {
     api.gitRepos()
-      .then((r) => { setRepos(r.repos); if (r.repos[0]) setCwd(r.repos[0].root); })
+      // A handed-over chat already knows where it runs — the checkout the pull
+      // request was put in — and picking the first repo instead would silently
+      // run the review against the wrong tree.
+      .then((r) => { setRepos(r.repos); if (!preset.cwd && r.repos[0]) setCwd(r.repos[0].root); })
       .catch(() => setRepos([]));
-  }, []);
+  }, [preset.cwd]);
 
   const start = async () => {
     const text = message.trim();

--- a/web/test/phone-routes.test.ts
+++ b/web/test/phone-routes.test.ts
@@ -1,0 +1,132 @@
+/*
+ * Two faults with one cause: a destination on the phone could not be named.
+ *
+ * `MobileChats` owned `openId` privately, and `MobileApp` rendered it
+ * conditionally, so nothing outside could say "open THIS chat". Every intent
+ * that wanted to therefore degraded to the nearest expressible thing:
+ *
+ *   - the queue's "Open chat" became `setTab("chats")` and dropped the card, so
+ *     tapping the accent action on a stalled agent landed you on a list that by
+ *     construction could not contain it — the list opens on "working", and the
+ *     card exists precisely because that agent stopped working;
+ *   - `onOpenChatWith` was declared by the pull request and repo screens and
+ *     passed by nobody, so "Review locally with Claude" and "Ask Claude why"
+ *     have never once been on screen.
+ *
+ * And the conversation was not on the shared back stack, so the one surface a
+ * person sits in for minutes answered the phone's back gesture by quitting
+ * agentglass.
+ *
+ * The last test here is the one that matters over time: it is a rule over the
+ * tree, not an assertion about these two screens.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "..", "src");
+const MOBILE = join(SRC, "mobile");
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+describe("a conversation can be opened by name", () => {
+  const chats = read("mobile/MobileChats.tsx");
+  const app = read("mobile/MobileApp.tsx");
+
+  test("MobileChats takes the open chat as a prop instead of owning it", () => {
+    expect(chats).toContain("openChat: OpenChat | null");
+    expect(chats).toContain("onOpenChat:");
+    // The private state is what made it unaddressable.
+    expect(chats).not.toContain("const [openId, setOpenId]");
+    expect(chats).not.toContain("const [composing, setComposing]");
+  });
+
+  test("the shell holds it, so anything can set it", () => {
+    expect(app).toContain("useState<OpenChat | null>");
+    expect(app).toContain("openSession");
+  });
+
+  test("the queue's session card opens that session, not the tab", () => {
+    // The whole bug in one line: `run: () => { setTab("chats"); drop(it.id); }`.
+    const actions = app.slice(app.indexOf('case "session":'), app.indexOf('case "pr-red":'));
+    expect(actions).toContain("openSession(o.session)");
+    expect(actions).not.toContain('setTab("chats"); drop(');
+  });
+
+  test("opening a session carries where it runs, not just its id", () => {
+    // Without the directory the conversation announces that a chat it has only
+    // just been handed cannot be resumed.
+    const opener = app.slice(app.indexOf("const openSession"), app.indexOf("const openChatWith"));
+    expect(opener).toContain("cwd_path");
+  });
+});
+
+describe("the hand-offs are wired", () => {
+  const app = read("mobile/MobileApp.tsx");
+
+  test("MobileApp passes onOpenChatWith to both screens that offer it", () => {
+    // Both render their button behind `onOpenChatWith && …`, so an unpassed
+    // prop is not a broken button — it is no button at all.
+    const uses = app.split("onOpenChatWith={openChatWith}").length - 1;
+    expect(uses, "RepoScreen and MobilePr must both receive it").toBe(2);
+  });
+
+  test("every screen that declares the hand-off is given one", () => {
+    // The rule rather than the two call sites: a third screen offering this
+    // must not ship with it dangling.
+    const declared: string[] = [];
+    for (const file of walk(MOBILE)) {
+      const src = readFileSync(file, "utf8");
+      if (/onOpenChatWith\?:/.test(src)) declared.push(file.split("/").pop()!);
+    }
+    const wired = app.match(/onOpenChatWith=\{/g)?.length ?? 0;
+    expect(wired, `${declared.join(", ")} declare it`).toBe(declared.length);
+  });
+
+  test("the hand-off keeps the directory the server checked out into", () => {
+    const chats = read("mobile/MobileChats.tsx");
+    // Falling back to the first repo would run the review against a tree that
+    // is not the one the pull request was put in.
+    expect(chats).toContain("preset.cwd");
+    expect(chats).toContain("if (!preset.cwd && r.repos[0])");
+  });
+});
+
+describe("the back gesture closes a screen, not the app", () => {
+  test("the conversation and the composer are on the shared stack", () => {
+    const chats = read("mobile/MobileChats.tsx");
+    expect(chats).toContain("useBackClose");
+    // Both, not one: New chat loses a typed prompt just as a conversation
+    // loses a draft.
+    expect(chats.match(/useBackClose\(/g)?.length).toBe(2);
+  });
+
+  test("every full-screen surface joins the stack", () => {
+    /*
+     * The rule, over the tree.
+     *
+     * `Screen` and `Sheet` call `useBackClose` for you, which is why the diff
+     * and the sheets were fine and the two hand-rolled surfaces were not. A
+     * screen drawn by hand — `<div className="mb-screen …">` — has to say so
+     * itself, and the next one written that way must not silently reintroduce
+     * "back quits the app".
+     */
+    const offenders: string[] = [];
+    for (const file of walk(MOBILE)) {
+      const src = readFileSync(file, "utf8");
+      // Only the ones that DRAW a screen, not the module that defines it.
+      if (file.endsWith("mobileUi.tsx")) continue;
+      if (!/className=\{?["`][^"`]*mb-screen/.test(src)) continue;
+      if (!/useBackClose/.test(src)) offenders.push(file.replace(SRC, ""));
+    }
+    expect(offenders, "a hand-rolled screen that the back gesture would quit past").toEqual([]);
+  });
+});


### PR DESCRIPTION
Second of the companion rebuild. Three faults with one cause.

## What does this PR do?

`MobileChats` owned `openId` privately and `MobileApp.tsx:305` rendered it conditionally, so nothing outside could say *"open **this** chat"*. Every intent that wanted to therefore degraded to the nearest thing that could be expressed.

**The queue's "Open chat" became `setTab("chats")` and dropped the card.** You tapped the accent action on a stalled agent and landed on a list that by construction could not contain it — the list opens on "working" (`chatList.ts:71`) and that card exists precisely because the agent stopped working (`nowQueue.ts:86`, after 4 minutes of silence). The single most common thing you do from a phone, nudging the agent that stalled, had no working route. It also called `drop(it.id)`, so the card was gone from the queue with no way back except Settings → Restore.

**`onOpenChatWith` was declared by two screens and passed by nobody.** `MobilePr.tsx:182` and `MobileRepo.tsx:81` both render their button behind `onOpenChatWith && …`, so these were not broken buttons — *"Review locally with Claude"* and *"Ask Claude why"* have never once been on screen. They are wired now, and `NewChat` takes a preset: the checkout the server put the pull request in, and the prompt to open with. Falling back to the first repo in the list would run the review against a tree that is not the one the PR was checked out into.

**The conversation was not on the shared back stack.** `Screen` and `Sheet` have called `useBackClose` since the diff started closing itself, but the conversation (`MobileChats.tsx:413`) and New chat (`:618`) are early returns rather than `Screen`s. So the one surface a person sits in for minutes answered the phone's own back gesture by leaving agentglass — with the draft, and any queued message, in it.

## How was it tested?

`web/test/phone-routes.test.ts`, 9 tests. The one that matters over time is a **rule over the tree**, not an assertion about these two screens:

> Any file under `mobile/` that draws `className="mb-screen …"` by hand must also call `useBackClose`.

`Screen` and `Sheet` call it for you, which is why the diff and the sheets were already fine and the two hand-rolled surfaces were not. The next surface written that way cannot silently reintroduce "back quits the app". There is a matching rule for the hand-off: every screen that *declares* `onOpenChatWith?:` must be passed one, counted rather than listed, so a third screen offering it cannot ship dangling.

All five mutations confirmed red against the code without the fix:

```
RED  queue action goes back to switching tab
RED  hand-off is unpassed again                     (2 failing)
RED  conversation leaves the back stack
RED  a new hand-rolled screen forgets the stack
RED  preset cwd is ignored so the review runs in the wrong tree
```

The fourth was verified by inventing a rogue `<div className="mb-screen on" />` in `MobileDiff.tsx` and watching the tree rule catch it.

Full suites: `web/` 513 pass / 0 fail, `server/` 1040 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## Not covered

A container that resolves to no repo is still unreachable — the queue's "Logs" action calls `openContainerRepo`, which toasts and does nothing when the compose project is not a repo directory name. That is the project-identity change, and it is next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_