### PR TITLE
fix(mobile): one rule for what makes two things the same project

### DIFF
--- a/server/src/docker.ts
+++ b/server/src/docker.ts
@@ -5,6 +5,7 @@
 // they reach the CLI.
 
 import { basename } from "node:path";
+import { projectKey, inProject, type ProjectKey } from "../../shared/projectKey.ts";
 import type {
   DockerContainer, DockerStat, DockerImage, DockerVolume, DockerNetwork,
   DockerOverview, DockerScope, DockerActionResult, DockerCapability,
@@ -276,46 +277,36 @@ export function __expireDockerVersionForTest(): void {
 // for containers that carry just that.
 const WORKING_DIR_LABEL = "com.docker.compose.project.working_dir";
 
-// Compose lowercases the project name and drops everything outside [a-z0-9_-],
-// so a checkout at ~/code/My.App runs as project "myapp". Comparing the raw
-// basename would miss exactly those repos, which is the confusing half of the
-// bug rather than the obvious half.
-const normalizeProject = (s: string) => s.toLowerCase().replace(/[^a-z0-9_-]/g, "");
-
-export interface DockerScopeKey { dir: string; project: string }
-const trimSlash = (p: string) => p.replace(/\/+$/, "");
+/**
+ * The scope key and the matching rule live in shared/projectKey.ts now.
+ *
+ * They were correct here and copied nowhere — which was the problem. The phone
+ * needed the same answer and had no way to import it, so it grew three
+ * approximations of its own out of directory basenames, and those are what mix
+ * one project's containers into another's. One implementation, both surfaces.
+ */
+export type DockerScopeKey = ProjectKey;
 
 /** The open project expressed the way container labels express it, or null when
  *  this instance is machine-wide. */
 export function dockerScopeKey(root: string | null): DockerScopeKey | null {
-  if (!root) return null;
-  const dir = trimSlash(root);
-  return { dir, project: normalizeProject(basename(dir)) };
+  return root ? projectKey(root) : null;
 }
+
+export const containerInScope = inProject;
 
 /**
- * Whether a container belongs to the open project.
+ * The working-dir label travels with the container now.
  *
- * Either signal is enough. A directory match is authoritative — that stack was
- * literally launched from inside this checkout, whatever it named itself. A
- * name match is looser (two checkouts of the same repo in different directories
- * both answer to "myapp") but it is the only thing older compose versions give
- * us, and showing a sibling checkout's container is a far smaller failure than
- * showing none of them.
+ * It used to be stripped before serving, on the reasoning that it is a matching
+ * input rather than something the panel renders. That held while the server was
+ * the only thing matching. It is not: the companion has to decide which project
+ * a container belongs to as well, and without this it was left comparing a
+ * compose project name to a raw directory basename — which is how a container
+ * ends up filed under the wrong project, or under none.
  */
-export function containerInScope(c: { project: string | null; workingDir: string | null }, s: DockerScopeKey): boolean {
-  const wd = trimSlash(c.workingDir || "");
-  if (wd && (wd === s.dir || wd.startsWith(s.dir + "/"))) return true;
-  return !!s.project && normalizeProject(c.project || "") === s.project;
-}
-
-// Carries the working-dir label alongside the wire shape; it is a matching
-// input, not something the panel renders, so it is stripped before serving.
-type ScopedContainer = DockerContainer & { workingDir: string | null };
-const strip = (c: ScopedContainer): DockerContainer => {
-  const { workingDir: _wd, ...rest } = c;
-  return rest;
-};
+type ScopedContainer = DockerContainer;
+const strip = (c: ScopedContainer): DockerContainer => c;
 
 /**
  * Apply the scope to a container list.

--- a/server/test/docker-scope.test.ts
+++ b/server/test/docker-scope.test.ts
@@ -96,10 +96,23 @@ describe("applyScope", () => {
     expect(r.scope).toMatchObject({ matched: 0, showingAll: true });
   });
 
-  test("the working-dir label never reaches the wire shape", () => {
-    // It's a matching input, not something the panel renders.
+  test("the working-dir label travels with the container", () => {
+    /*
+     * This asserted the opposite until the companion needed it, and the old
+     * reason was sound as far as it went: the label is a matching input, not
+     * something the panel renders, so serving it was waste.
+     *
+     * What changed is who matches. The server is no longer the only one
+     * deciding which project a container belongs to — the phone groups by
+     * project as well, and with the label stripped it was left comparing a
+     * compose project name to a raw directory basename. Compose lowercases and
+     * drops punctuation, so `~/code/My.App` runs as `myapp` and no basename
+     * ever equals it; meanwhile two unrelated repositories both called `web`
+     * DO compare equal and claim each other's containers. That is the bug the
+     * owner hit, and this field is what closes it.
+     */
     const [only] = applyScope([c({ workingDir: "/home/x/code/myapp" })], key).containers;
-    expect(only).not.toHaveProperty("workingDir");
+    expect(only.workingDir).toBe("/home/x/code/myapp");
   });
 });
 

--- a/shared/projectKey.ts
+++ b/shared/projectKey.ts
@@ -1,0 +1,102 @@
+/**
+ * What makes two things the same project. One implementation, both surfaces.
+ *
+ * There were four. The server had this rule, correctly, in `docker.ts`. The
+ * phone had three more — `repoName` in MobileApp, `baseName` in MobileChats and
+ * `projectName` in nowQueue — each taking the last segment of a directory path
+ * and comparing it to a compose project name with `===`.
+ *
+ * That comparison cannot work, and the reason is worth stating because it is
+ * the confusing half of the container-mixing bug rather than the obvious half:
+ * compose lowercases the project name and drops everything outside `[a-z0-9_-]`,
+ * so a checkout at `~/code/My.App` runs as project `myapp`. No raw basename will
+ * ever equal it. Meanwhile two unrelated repositories both called `web` DO
+ * compare equal, so they claim each other's containers.
+ *
+ * The other half is the linked worktree. A stack brought up from
+ * `.claude/worktrees/remote-phone` has that as its working directory and
+ * `remote-phone` as its compose project — neither matches the project it
+ * belongs to by path or by name.
+ *
+ * Kept free of imports so both the server and the browser can take it, and so a
+ * test of it does not pull an application graph in behind it.
+ */
+
+/** A checkout, expressed the way container labels express it. */
+export interface ProjectKey {
+  /** The checkout directory, without a trailing slash. */
+  dir: string;
+  /** What compose would have called it. */
+  project: string;
+}
+
+/** The subset of a container this rule reads. */
+export interface ContainerRef {
+  project: string | null;
+  workingDir: string | null;
+}
+
+const trimSlash = (p: string): string => p.replace(/\/+$/, "");
+
+/** The last path segment, on either separator. Windows paths reach this from a
+ *  repo root recorded on a machine that uses them. */
+export function baseName(path: string): string {
+  return trimSlash(path).split(/[\\/]/).filter(Boolean).pop() || path;
+}
+
+/** Compose's own transformation of a directory name into a project name. */
+export function normaliseProject(s: string): string {
+  return s.toLowerCase().replace(/[^a-z0-9_-]/g, "");
+}
+
+/** The key for a checkout root. */
+export function projectKey(root: string): ProjectKey {
+  const dir = trimSlash(root);
+  return { dir, project: normaliseProject(baseName(dir)) };
+}
+
+/**
+ * Whether a container belongs to a checkout.
+ *
+ * Either signal is enough. A directory match is authoritative — that stack was
+ * literally launched from inside this checkout, whatever it named itself. A
+ * name match is looser (two checkouts of one repository in different
+ * directories both answer to `myapp`) but it is the only thing older compose
+ * versions give us, and showing a sibling checkout's container is a far smaller
+ * failure than showing none of them.
+ */
+export function inProject(c: ContainerRef, k: ProjectKey): boolean {
+  const wd = trimSlash(c.workingDir || "");
+  if (wd && (wd === k.dir || wd.startsWith(k.dir + "/"))) return true;
+  return !!k.project && normaliseProject(c.project || "") === k.project;
+}
+
+/**
+ * Which checkout a container belongs to, out of everything we know about.
+ *
+ * Directory matches are preferred over name matches, and the deepest directory
+ * wins: a worktree inside a repository is a better answer than the repository
+ * it lives under, and returning the parent would file the container under a
+ * checkout it was not started from.
+ *
+ * Null when nothing matches, and null is a real answer. The phone used to have
+ * no way to express it, so a container agentglass could not place simply had no
+ * screen — the queue offered a Logs button for it that raised a toast and did
+ * nothing.
+ */
+export function ownerOf(c: ContainerRef, roots: readonly string[]): string | null {
+  const keys = roots.map(projectKey);
+  const wd = trimSlash(c.workingDir || "");
+  let byDir: ProjectKey | null = null;
+  if (wd) {
+    for (const k of keys) {
+      if (wd !== k.dir && !wd.startsWith(k.dir + "/")) continue;
+      if (!byDir || k.dir.length > byDir.dir.length) byDir = k;
+    }
+  }
+  if (byDir) return byDir.dir;
+  const name = normaliseProject(c.project || "");
+  if (!name) return null;
+  const byName = keys.find((k) => k.project === name);
+  return byName ? byName.dir : null;
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -892,6 +892,19 @@ export interface DockerContainer {
   ports: string;
   project: string | null; // compose project
   service: string | null; // compose service
+  /**
+   * The directory the stack was brought up from, off compose's own
+   * `working_dir` label. Null when the container carries no such label.
+   *
+   * On the wire because deciding which project a container belongs to is not
+   * only the server's job any more — the companion has to group by project too,
+   * and without this it was left comparing a compose project name to a raw
+   * directory basename. Compose lowercases and strips punctuation, so
+   * `~/code/My.App` runs as `myapp` and no basename ever matches it, while two
+   * unrelated repositories both called `web` match each other. See
+   * shared/projectKey.ts, which is the one rule both surfaces use.
+   */
+  workingDir: string | null;
   runningFor: string;
   size: string;
 }

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -477,7 +477,7 @@ export function gitStashes(): { stashes: GitStash[] } {
 // --- docker panel (demo is read-only) ---
 export function dockerOverview(): DockerOverview {
   const c = (id: string, name: string, image: string, state: string, status: string, service: string, ports = "") =>
-    ({ id, name, image, state, status, ports, project: "shop", service, runningFor: status, size: "" });
+    ({ id, name, image, state, status, ports, project: "shop", service, workingDir: "/home/demo/code/shop", runningFor: status, size: "" });
   return {
     available: true, writeEnabled: false, version: "27.0.3",
     containers: [

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -10,8 +10,9 @@ import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobile
 import { pollWhileVisible } from "../lib/poll.ts";
 import { DIFF_CSS } from "./MobileDiff.tsx";
 import { NOW_CSS, NowHero, NowStream, type NowAction, type LiveCall } from "./MobileNow.tsx";
-import { RepoList, RepoScreen, type RepoSummary } from "./MobileRepo.tsx";
+import { RepoList, RepoScreen, ContainerScreen, type RepoSummary } from "./MobileRepo.tsx";
 import { projectRows } from "./projects.ts";
+import { baseName, ownerOf } from "../../../shared/projectKey.ts";
 import { MobilePr } from "./MobilePr.tsx";
 import { buildQueue, type NowItem } from "./nowQueue.ts";
 import type {
@@ -96,6 +97,9 @@ export function MobileApp() {
    *  separate projects. */
   const [openCheckouts, setOpenCheckouts] = useState<RepoSummary[]>([]);
   const [openPr, setOpenPr] = useState<{ root: string; number: number } | null>(null);
+  /** A container opened from anywhere — the queue, a project, the fleet. It
+   *  needs no repo context, so it does not have to have one. */
+  const [openCtr, setOpenCtr] = useState<DockerContainer | null>(null);
   /**
    * The chat destinations, held here so anything can name one.
    *
@@ -160,7 +164,7 @@ export function MobileApp() {
   const loadPrs = useCallback((list: GitRepoRef[]) => {
     Promise.all(list.flatMap((r) => (["mine", "review"] as const).map((scope) =>
       api.prList(r.root, scope, "open")
-        .then((res) => res.prs.map((pr) => ({ root: r.root, repo: repoName(r), pr, scope })))
+        .then((res) => res.prs.map((pr) => ({ root: r.root, repo: baseName(r.root), pr, scope })))
         .catch(() => [] as { root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[])
     ))).then((groups) => setPrs(groups.flat()));
   }, []);
@@ -263,17 +267,29 @@ export function MobileApp() {
     [gates, sessions, prs, containers, me, dismissed]
   );
 
+  /**
+   * Which checkout each container belongs to, decided once by the rule the
+   * server uses rather than by comparing a compose project name to a directory
+   * basename. Null is a real answer and gets a real screen.
+   */
+  const roots = useMemo(() => repos.map((r) => r.root), [repos]);
+  const ownerByContainer = useMemo(() => {
+    const m = new Map<string, string | null>();
+    for (const c of containers) m.set(c.id, ownerOf(c, roots));
+    return m;
+  }, [containers, roots]);
+
   const repoSummaries: RepoSummary[] = useMemo(() => repos.map((r) => {
     const t = trees[r.root];
-    const name = repoName(r);
     return {
-      ref: r, name,
+      ref: r, name: baseName(r.root),
       branch: t?.branch ?? "—",
       dirty: t?.dirty ?? 0, ahead: t?.ahead ?? 0, behind: t?.behind ?? 0,
       prs: prs.filter((p) => p.root === r.root).length,
-      down: containers.filter((c) => (c.project ?? "") === name && c.state !== "running" && c.state !== "created").length,
+      down: containers.filter((c) =>
+        ownerByContainer.get(c.id) === r.root && c.state !== "running" && c.state !== "created").length,
     };
-  }), [repos, trees, prs, containers]);
+  }), [repos, trees, prs, containers, ownerByContainer]);
 
   /** An answered item leaves the queue at once, before the next poll confirms
    *  it. Waiting four seconds to watch your own tap take effect is what makes
@@ -329,10 +345,16 @@ export function MobileApp() {
     setTab("chats");
   }, []);
 
-  const openContainerRepo = (c: DockerContainer) => {
-    const r = repoSummaries.find((x) => x.name === (c.project ?? ""));
-    if (r) openProject(r); else toast("That container is not in a repo agentglass knows", true);
-  };
+  /**
+   * Open a container, whatever agentglass does or does not know about it.
+   *
+   * This used to look for a repo whose directory basename equalled the compose
+   * project name and, failing that, raise a toast — so a container compose had
+   * renamed (`My.App` → `myapp`), or one started with plain `docker run`, had
+   * no screen at all. The queue offered it a "Logs" button that did nothing.
+   * A container agentglass cannot place is still yours and still running.
+   */
+  const openContainer = useCallback((c: DockerContainer) => setOpenCtr(c), []);
 
   const actionsFor = (it: NowItem): NowAction[] => {
     const o = it.origin;
@@ -377,7 +399,7 @@ export function MobileApp() {
         return [{ label: "Review", kind: "acc", run: () => setOpenPr({ root: o.root, number: o.pr.number }) }];
       case "container":
         return [
-          { label: "Logs", run: () => openContainerRepo(o.container) },
+          { label: "Logs", run: () => openContainer(o.container) },
           { label: "Restart", kind: "acc", run: () => settle(`Restarted ${o.container.name}`, () => api.dockerRestart(o.container.id)) },
         ];
     }
@@ -386,7 +408,7 @@ export function MobileApp() {
   const openItem = (it: NowItem) => {
     const o = it.origin;
     if (o.t === "pr-red" || o.t === "pr-ready" || o.t === "pr-review") setOpenPr({ root: o.root, number: o.pr.number });
-    else if (o.t === "container") openContainerRepo(o.container);
+    else if (o.t === "container") openContainer(o.container);
     else if (o.t === "session") openSession(o.session);
   };
 
@@ -463,9 +485,14 @@ export function MobileApp() {
 
       <RepoScreen open={!!openRepo && !openPr} repo={openRepo}
         checkouts={openCheckouts} onPickCheckout={setOpenRepo}
-        containers={containers} stats={dstats}
+        containers={containers.filter((c) => ownerByContainer.get(c.id) === openRepo?.ref.root)} stats={dstats}
+        onOpenContainer={openContainer}
         onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll}
         onOpenChatWith={openChatWith} />
+
+      <ContainerScreen open={!!openCtr} c={openCtr} stat={dstats.find((s) => s.id === openCtr?.id)}
+        project={openCtr ? ownerByContainer.get(openCtr.id) ?? null : null}
+        onBack={() => setOpenCtr(null)} toast={toast} onRefresh={refreshAll} />
 
       <MobilePr open={!!openPr} root={openPr?.root ?? ""} number={openPr?.number ?? null}
         onBack={() => { setOpenPr(null); refreshAll(); }} toast={toast}
@@ -514,7 +541,5 @@ function TabBtn({ id, tab, onPick, glyph, label, badge }: {
   );
 }
 
-/** The last path segment is what anybody calls a repo. */
-function repoName(r: GitRepoRef): string {
-  return r.root.split("/").filter(Boolean).pop() || r.root;
-}
+/** Naming a project is shared/projectKey.ts's job now — see baseName. This was
+ *  one of three copies of it on the phone, and they did not agree. */

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -7,6 +7,7 @@ import { sessionIsLive } from "../lib/derive.ts";
 import { scopeSessions, openingScope, type ChatScope } from "./chatList.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
 import { useBackClose } from "./mobileUi.tsx";
+import { baseName } from "../../../shared/projectKey.ts";
 import { recentTurns, buildFeed, summariseRuns, shortTarget, type FeedEntry, type FeedItem, type FeedTool } from "./transcript.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
 
@@ -725,4 +726,3 @@ function reduce(prev: Live | null, o: Record<string, unknown>): Live {
   return cur;
 }
 
-const baseName = (p: string) => (p ? p.split("/").filter(Boolean).pop() || p : "");

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
+import { baseName } from "../../../shared/projectKey.ts";
 import { api } from "../lib/api.ts";
 import { Screen, Sheet, Seg, Empty, Row, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
@@ -66,7 +67,7 @@ export function RepoList({ repos, onOpen }: { repos: RepoSummary[]; onOpen: (r: 
   );
 }
 
-export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, containers, stats, onBack, toast, onRefresh, onOpenChatWith }: {
+export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, containers, stats, onBack, toast, onRefresh, onOpenContainer, onOpenChatWith }: {
   open: boolean;
   repo: RepoSummary | null;
   /** Every checkout of this project — the repo itself and its linked
@@ -78,6 +79,9 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   onBack: () => void;
   toast: (m: string, bad?: boolean) => void;
   onRefresh: () => void;
+  /** Opening a container is the shell's job: it needs no repo context, and one
+   *  that belongs to no project must still have a screen. */
+  onOpenContainer: (c: DockerContainer) => void;
   onOpenChatWith?: (cwd: string, prompt: string) => void;
 }) {
   const root = repo?.ref.root ?? "";
@@ -88,7 +92,6 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   const [msg, setMsg] = useState("");
   const [branches, setBranches] = useState<GitBranch[] | null>(null);
   const [openPr, setOpenPr] = useState<number | null>(null);
-  const [ctr, setCtr] = useState<DockerContainer | null>(null);
   const [diffAt, setDiffAt] = useState<number | null>(null);
 
   /** The project's name, which is the main checkout's — a worktree is the same
@@ -98,13 +101,10 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
     ? (checkouts.find((c) => !c.ref.worktreeOf)?.name ?? repo?.name ?? "")
     : (repo?.name ?? "");
 
-  // Containers belong to the project, not to the checkout you happen to be
-  // looking at: compose names them after the repository, so matching on a
-  // worktree's directory name finds nothing at all.
-  const mine = useMemo(
-    () => containers.filter((c) => (c.project ?? "") === projectName),
-    [containers, projectName]
-  );
+  // Already scoped by the shell, using the same rule the server uses. This
+  // used to compare a compose project name to a directory basename here, which
+  // is how one project's containers ended up under another's.
+  const mine = containers;
 
   // Open on whatever is wrong: a container down beats uncommitted work beats
   // the pull request list. Landing on an empty tab is a wasted screen.
@@ -291,7 +291,7 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
                       title={c.service || c.name}
                       sub={`${c.status}${c.ports ? " · " + c.ports : ""}`}
                       right={up && st ? `${Math.round(st.cpu)}% cpu` : c.state}
-                      onClick={() => setCtr(c)} />
+                      onClick={() => onOpenContainer(c)} />
                   );
                 })}
               </div>
@@ -320,9 +320,6 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
       <MobilePr open={openPr != null} root={root} number={openPr} onBack={() => setOpenPr(null)}
         toast={toast} onOpenChatWith={onOpenChatWith} />
 
-      <ContainerScreen open={!!ctr} c={ctr} stat={stats.find((s) => s.id === ctr?.id)}
-        onBack={() => setCtr(null)} toast={toast} onRefresh={onRefresh} />
-
       <Sheet open={!!branches} title="Switch branch" sub="Uncommitted changes come with you."
         onClose={() => setBranches(null)}>
         <div className="flex flex-col gap-2.5">
@@ -345,8 +342,11 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
 
 /** One container: how hard it is working, what it has been saying, and the two
  *  or three things you would actually do to it from a phone. */
-function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
+export function ContainerScreen({ open, c, stat, project, onBack, toast, onRefresh }: {
   open: boolean; c: DockerContainer | null; stat?: DockerStat;
+  /** The checkout this container belongs to, or null when agentglass cannot
+   *  place it — which it says rather than guessing. */
+  project?: string | null;
   onBack: () => void; toast: (m: string, bad?: boolean) => void; onRefresh: () => void;
 }) {
   const [logs, setLogs] = useState("");
@@ -372,7 +372,13 @@ function ContainerScreen({ open, c, stat, onBack, toast, onRefresh }: {
   return (
     <>
       {askDialog}
-    <Screen open={open} title={c?.name ?? ""} sub={c ? `${c.image} · ${c.status}` : undefined} onBack={onBack}
+    {/* The subtitle names the project, because a container screen you reached
+        from a queue card gives you no other way to know which one it is — and
+        when agentglass cannot place it, it says so rather than leaving the
+        question open. */}
+    <Screen open={open} title={c?.name ?? ""}
+      sub={c ? `${project ? baseName(project) : "no project"} · ${c.image} · ${c.status}` : undefined}
+      onBack={onBack}
       foot={c ? (up ? (
         <>
           <Act small full onAct={() => run(`Restarted ${c.name}`, () => api.dockerRestart(c.id))}>Restart</Act>

--- a/web/src/mobile/nowQueue.ts
+++ b/web/src/mobile/nowQueue.ts
@@ -1,5 +1,6 @@
 import type { PendingGate, SessionRollup, PrSummary, DockerContainer } from "../../../shared/types.ts";
 import { sessionTitle } from "../lib/format.ts";
+import { baseName } from "../../../shared/projectKey.ts";
 
 /**
  * "What wants me right now", for a phone.
@@ -166,7 +167,9 @@ export function containerIsWrong(c: DockerContainer): boolean {
   return code == null ? true : code !== "0";
 }
 
+/** One rule for naming a project — see shared/projectKey.ts. This was the
+ *  third copy of it on the phone, and the three did not agree on separators or
+ *  on what to do when a path was empty. */
 function projectName(s: SessionRollup): string {
-  const p = s.project_path || "";
-  return p.split("/").filter(Boolean).pop() || s.source_app || "unknown";
+  return s.project_path ? baseName(s.project_path) : (s.source_app || "unknown");
 }

--- a/web/test/project-identity.test.ts
+++ b/web/test/project-identity.test.ts
@@ -1,0 +1,169 @@
+/*
+ * "It mixes up containers from different projects."
+ *
+ * The server had the right rule all along, in docker.ts, and no way to share
+ * it. So the phone grew three approximations out of directory basenames —
+ * `repoName` in MobileApp, `baseName` in MobileChats, `projectName` in
+ * nowQueue — and compared them to a compose project name with `===`.
+ *
+ * That comparison cannot work, for two reasons that pull in opposite
+ * directions:
+ *
+ *   - compose lowercases the project name and drops everything outside
+ *     [a-z0-9_-], so a checkout at ~/code/My.App runs as project "myapp" and NO
+ *     raw basename will ever equal it; and
+ *   - two unrelated repositories both called "web" DO compare equal, so each
+ *     claims the other's containers.
+ *
+ * One rule now, in shared/projectKey.ts, imported by both surfaces. The last
+ * describe is the one that keeps it that way.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { baseName, normaliseProject, projectKey, inProject, ownerOf } from "../../shared/projectKey.ts";
+
+const SRC = join(import.meta.dir, "..", "src");
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+/** The rule is about code; a comment quoting the old formula is not a breach. */
+const code = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+const ctr = (project: string | null, workingDir: string | null = null) => ({ project, workingDir });
+
+describe("naming a project", () => {
+  test("the last segment, on either separator", () => {
+    expect(baseName("/home/x/code/agentglass")).toBe("agentglass");
+    expect(baseName("/home/x/code/agentglass/")).toBe("agentglass");
+    expect(baseName("C:\\code\\agentglass")).toBe("agentglass");
+  });
+
+  test("compose's own transformation", () => {
+    // The case a basename comparison can never match.
+    expect(normaliseProject("My.App")).toBe("myapp");
+    expect(normaliseProject("orbit-WEB-1042")).toBe("orbit-web-1042");
+    expect(normaliseProject("a_b-c")).toBe("a_b-c");
+  });
+
+  test("a key carries both", () => {
+    expect(projectKey("/home/x/code/My.App/")).toEqual({ dir: "/home/x/code/My.App", project: "myapp" });
+  });
+});
+
+describe("whether a container belongs to a checkout", () => {
+  const k = projectKey("/home/x/code/myapp");
+
+  test("the directory it was brought up from is authoritative", () => {
+    expect(inProject(ctr("something-else", "/home/x/code/myapp"), k)).toBe(true);
+    expect(inProject(ctr(null, "/home/x/code/myapp/deploy"), k)).toBe(true);
+  });
+
+  test("a sibling directory with a matching prefix is not inside it", () => {
+    // `/home/x/code/myapp-old` starts with `/home/x/code/myapp`, and a plain
+    // startsWith would file its containers under this project.
+    expect(inProject(ctr(null, "/home/x/code/myapp-old"), k)).toBe(false);
+  });
+
+  test("the compose name matches after normalisation", () => {
+    expect(inProject(ctr("myapp"), projectKey("/home/x/code/My.App"))).toBe(true);
+  });
+
+  test("nothing matches a container with neither signal", () => {
+    expect(inProject(ctr(null, null), k)).toBe(false);
+  });
+});
+
+describe("which checkout a container belongs to, out of everything we know", () => {
+  const roots = [
+    "/home/x/code/agentglass",
+    "/home/x/code/agentglass/.claude/worktrees/remote-phone",
+    "/home/x/code/tmux-chat",
+  ];
+
+  test("the deepest directory wins", () => {
+    // A worktree lives inside its repository, so both match by path. Answering
+    // with the parent files the container under a checkout it was not started
+    // from — which is exactly the worktree half of the mixing bug.
+    expect(ownerOf(ctr(null, "/home/x/code/agentglass/.claude/worktrees/remote-phone"), roots))
+      .toBe("/home/x/code/agentglass/.claude/worktrees/remote-phone");
+  });
+
+  test("a directory match beats a name match", () => {
+    // Compose named it after the worktree; it was started from the main
+    // checkout. The path is the stronger claim.
+    expect(ownerOf(ctr("remote-phone", "/home/x/code/agentglass"), roots))
+      .toBe("/home/x/code/agentglass");
+  });
+
+  test("the compose name is used when there is no directory label", () => {
+    expect(ownerOf(ctr("tmux-chat"), roots)).toBe("/home/x/code/tmux-chat");
+  });
+
+  test("a container it cannot place gets null, which is a real answer", () => {
+    // The phone had no way to express this, so such a container had no screen
+    // at all — the queue offered it a Logs button that raised a toast.
+    expect(ownerOf(ctr("pg-scratch"), roots)).toBeNull();
+    expect(ownerOf(ctr(null, "/opt/stacks/monitoring"), roots)).toBeNull();
+  });
+
+  test("two repositories with the same basename do not claim each other", () => {
+    const two = ["/home/x/a/web", "/home/x/b/web"];
+    // By name alone they are indistinguishable, and that is the honest answer:
+    // the first is returned rather than both, and a directory label — which is
+    // what real compose writes — separates them properly.
+    expect(ownerOf(ctr(null, "/home/x/b/web"), two)).toBe("/home/x/b/web");
+    expect(ownerOf(ctr(null, "/home/x/a/web/svc"), two)).toBe("/home/x/a/web");
+  });
+});
+
+describe("the phone stops guessing", () => {
+  test("no mobile file compares a compose project to a directory name", () => {
+    /*
+     * The rule over the tree. Every one of these was a line like
+     * `(c.project ?? "") === name`, and each was written independently, which
+     * is how three of them ended up disagreeing about separators and about
+     * what an empty path means.
+     */
+    const offenders: string[] = [];
+    for (const file of walk(join(SRC, "mobile"))) {
+      const src = code(readFileSync(file, "utf8"));
+      if (/\.project\s*\?\?\s*""\)\s*===/.test(src) || /===\s*\(c\.project/.test(src)) {
+        offenders.push(file.replace(SRC, ""));
+      }
+    }
+    expect(offenders, "a container matched by name equality").toEqual([]);
+  });
+
+  test("attribution goes through the shared rule", () => {
+    const app = code(read("mobile/MobileApp.tsx"));
+    expect(app).toContain("ownerOf");
+    expect(app).toContain("ownerByContainer");
+  });
+
+  test("the three private copies of the naming rule are gone", () => {
+    // Each file may still USE baseName; none may define its own.
+    const defined: string[] = [];
+    for (const file of walk(join(SRC, "mobile"))) {
+      const src = code(readFileSync(file, "utf8"));
+      if (/(?:const|function)\s+(?:baseName|repoName)\s*[=(]/.test(src)) defined.push(file.replace(SRC, ""));
+    }
+    expect(defined, "a local copy of the project-naming rule").toEqual([]);
+  });
+
+  test("a container that belongs to no project is still reachable", () => {
+    const app = code(read("mobile/MobileApp.tsx"));
+    // It used to search for a repo by name and toast when it found none, so
+    // an unplaceable container had no screen.
+    expect(app).toContain("openContainer");
+    expect(app).toContain("ContainerScreen");
+    expect(app).not.toContain("is not in a repo agentglass knows");
+  });
+});


### PR DESCRIPTION
Third of the companion rebuild, and this is the one behind *"it mixes up containers from different projects"*.

## What does this PR do?

There were four rules. The server had the right one in `docker.ts` and no way to share it, so the phone grew three approximations out of directory basenames — `repoName` (`MobileApp.tsx:372`), `baseName` (`MobileChats.tsx:728`), `projectName` (`nowQueue.ts:169`) — and compared them to a compose project name with `===`.

That comparison fails in **both directions at once**:

- Compose lowercases the project name and drops everything outside `[a-z0-9_-]`, so a checkout at `~/code/My.App` runs as project `myapp`. No raw basename will ever equal it.
- Two unrelated repositories both called `web` **do** compare equal, so each claims the other's containers.

Add a linked worktree — brought up from `.claude/worktrees/remote-phone`, compose project `remote-phone` — and it matches the project it belongs to by neither path nor name.

**`shared/projectKey.ts` is the one rule**, imported by the server and the phone. It also answers the question neither had a way to ask: *which* checkout does this container belong to, out of everything we know about. A directory match beats a name match, and the deepest directory wins — a worktree inside a repository is a better answer than the repository it sits under, and returning the parent files the container under a checkout it was not started from.

**Null is a real answer, and it now has a screen.** A container agentglass cannot place — compose renamed it, or it was started with plain `docker run` — used to have no route at all: `openContainerRepo` searched for a repo whose basename equalled the compose project and, failing that, raised a toast. So the queue's "Logs" button on a down container did nothing. `ContainerScreen` never needed repo context in the first place, so it moves up to the shell, and the screen names the project it belongs to — or says "no project" rather than leaving the question open.

**The working-dir label travels with the container now.** It was stripped before serving on the reasoning that it is a matching input rather than something the panel renders, which held while the server was the only thing matching. It is not any more.

## How was it tested?

`web/test/project-identity.test.ts`, 16 tests. Unit tests for the rule, including the cases that motivated it:

- `~/code/My.App` → `myapp`, which no basename comparison reaches.
- `/home/x/code/myapp-old` is **not** inside `/home/x/code/myapp` — a plain `startsWith` would file its containers under the wrong project.
- A worktree beats its parent when both match by path.
- A directory label beats a compose name when they disagree.
- Two repositories both called `web` are separated by their directory labels.

Plus rules over the tree: no file under `mobile/` may match a container by name equality, and none may define its own copy of the naming rule.

The existing server test asserting `workingDir` never reaches the wire is **rewritten rather than deleted** — the old decision was right for its time, and the comment now says what changed and why.

All five mutations confirmed red against the code without the fix: prefix match filing a sibling directory wrongly, the parent winning over the worktree, compose normalisation dropped, the phone back to name equality, and the unplaceable container losing its screen again.

Full suites: `web/` 529 pass / 0 fail, `server/` 1040 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## Not covered

Sessions and pull requests are still counted per checkout rather than per project, so one open PR across three worktrees is three cards in the queue. That is the same identity idea applied to a different list, and it is next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_