### PR TITLE
fix(mobile): a chat list you can trust and search

### DIFF
--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -138,7 +138,12 @@ export function MobileApp() {
   // here — they are what covers the gap between the socket dying and noticing.
   const loadFast = useCallback(() => {
     api.gatePending().then((r) => { setGates(r.gates); setReachable(true); }).catch(() => setReachable(false));
-    api.sessions(40).then(setSessions).catch(() => { /* the gate poll reports reachability */ });
+    // 40 was the page size while the list had no search, and it made the scope
+    // called "All" mean "the newest forty" — a chat from three days ago was
+    // unreachable by any route. The desktop has always taken 200; a rollup row
+    // is small and this arrives once on the socket's nudge rather than on a
+    // four-second poll.
+    api.sessions(200).then(setSessions).catch(() => { /* the gate poll reports reachability */ });
   }, []);
 
   const loadDocker = useCallback(() => {

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -4,12 +4,13 @@ import { toolTarget } from "../lib/chatStore.ts";
 import { pollWhileVisible } from "../lib/poll.ts";
 import { fmtUsd, fmtAgo, sessionTitle, modelLabelOf } from "../lib/format.ts";
 import { sessionIsLive } from "../lib/derive.ts";
-import { scopeSessions, openingScope, type ChatScope } from "./chatList.ts";
+import { scopeSessions, openingScope, searchSessions, canResume, type ChatScope } from "./chatList.ts";
 import { MODELS, resumeModel } from "./resumeModel.ts";
 import { PERMISSION_MODES, DEFAULT_PERMISSION_MODE, asPermissionMode, permissionModeLabel,
   type PermissionModeId } from "./permissionMode.ts";
 import { useBackClose, Sheet } from "./mobileUi.tsx";
 import { baseName } from "../../../shared/projectKey.ts";
+import { Markdown } from "../lib/markdown.tsx";
 import { recentTurns, buildFeed, summariseRuns, shortTarget, type FeedEntry, type FeedItem, type FeedTool } from "./transcript.ts";
 import type { SessionDetail, SessionRollup, GitRepoRef } from "../../../shared/types.ts";
 
@@ -98,9 +99,21 @@ export function MobileChats({ sessions, onRefresh, onImmersive, openChat, onOpen
   /** Null until the first list arrives, so the opening scope is chosen from
    *  real sessions rather than from the empty array of the first render. */
   const [picked, setPicked] = useState<ChatScope | null>(null);
+  const [query, setQuery] = useState("");
   const scope = picked ?? openingScope(sessions);
   const setScope = (s: ChatScope) => setPicked(s);
-  const shown = useMemo(() => scopeSessions(sessions, scope), [sessions, scope]);
+  /**
+   * Searching looks at everything, not at the open scope.
+   *
+   * Someone typing a name is asking "where is that chat", and answering only
+   * out of the twenty rows already on screen is the least useful reading of the
+   * question — it is also the one that makes search feel broken, because the
+   * thing you are looking for is precisely the thing not in front of you.
+   */
+  const shown = useMemo(
+    () => (query.trim() ? searchSessions(sessions, query) : scopeSessions(sessions, scope)),
+    [sessions, scope, query]
+  );
   const liveCount = useMemo(() => scopeSessions(sessions, "live").length, [sessions]);
 
   const closeConversation = useCallback(() => { onOpenChat(null); onRefresh(); }, [onOpenChat, onRefresh]);
@@ -139,10 +152,27 @@ export function MobileChats({ sessions, onRefresh, onImmersive, openChat, onOpen
         + New chat
       </button>
 
+      {/* There was no search, and the list only ever held forty rows, so a chat
+          from three days ago was not reachable by any route at all. */}
+      <div className="flex items-center gap-2 rounded-xl px-3"
+        style={{ minHeight: 46, background: "color-mix(in srgb, var(--bg2) 78%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>
+        <span className="text-[14px] shrink-0" style={{ color: "var(--text3)" }}>⌕</span>
+        <input value={query} onChange={(e) => setQuery(e.target.value)}
+          placeholder="Search every chat" autoComplete="off" aria-label="Search chats"
+          className="flex-1 min-w-0 bg-transparent outline-none"
+          style={{ fontSize: 16, color: "var(--text)" }} />
+        {!!query && (
+          <button onClick={() => setQuery("")} aria-label="Clear search"
+            className="shrink-0 grid place-items-center"
+            style={{ minWidth: 34, minHeight: 44, color: "var(--text3)", fontSize: 13 }}>✕</button>
+        )}
+      </div>
+
       {/* Working, today, everything. The tab opens on the narrowest of these
           that has anything in it, so the first screen is the agents you could
-          speak to rather than a scroll through the archive. */}
-      <div className="flex gap-1.5">
+          speak to rather than a scroll through the archive. Hidden while
+          searching: a scope would only narrow an answer you asked for in full. */}
+      <div className="flex gap-1.5" hidden={!!query.trim()}>
         {SCOPES.map(([id, label]) => {
           const on = scope === id;
           return (
@@ -162,9 +192,13 @@ export function MobileChats({ sessions, onRefresh, onImmersive, openChat, onOpen
 
       {!shown.length && (
         <div className="rounded-2xl px-5 py-12 text-center" style={{ background: "color-mix(in srgb, var(--bg2) 45%, transparent)", border: "1px dashed color-mix(in srgb, var(--border) 45%, transparent)" }}>
-          <div className="text-[14px]">{sessions.length ? "Nothing here" : "No agents yet"}</div>
+          <div className="text-[14px]">
+            {query.trim() ? "No chat matches that" : sessions.length ? "Nothing here" : "No agents yet"}
+          </div>
           <div className="text-[12px] mt-1.5" style={{ color: "var(--text2)" }}>
-            {sessions.length ? "Try a wider range above." : "Start one and it keeps running on your machine."}
+            {query.trim()
+              ? "Search looks at every chat, not just the range above."
+              : sessions.length ? "Try a wider range above." : "Start one and it keeps running on your machine."}
           </div>
         </div>
       )}
@@ -182,6 +216,9 @@ export function MobileChats({ sessions, onRefresh, onImmersive, openChat, onOpen
             </div>
             <div className="flex items-center gap-x-3 text-[11px] tabular-nums" style={{ color: "var(--text2)" }}>
               <span className="truncate">{baseName(s.cwd_path || s.project_path || s.source_app)}</span>
+              {/* It cannot be picked up in place — a fact about the record, not
+                  a reason to leave you to discover it by opening it. */}
+              {!canResume(s) && <span className="shrink-0" style={{ color: "var(--text3)" }}>read-only</span>}
               <span className="ml-auto shrink-0">{modelLabelOf(s.model_name)}</span>
               <span className="shrink-0">{fmtUsd(s.cost_usd)}</span>
             </div>
@@ -691,7 +728,14 @@ function Bubble({ role, text, ts, streaming, tools, error, pending }: {
             {tools.slice(-4).map((t, i) => <span key={i} className="truncate">· {t}</span>)}
           </div>
         )}
-        <div className="text-[13.5px] leading-snug whitespace-pre-wrap break-words">{text}</div>
+        {/* Half of what an agent says is code. Rendered as plain text, a
+            fenced block arrived as literal backticks reflowed in a proportional
+            font — unreadable exactly where being readable matters. The desktop
+            has had this renderer all along; the phone simply never used it.
+            A message you typed stays verbatim: your own text is not markup. */}
+        <div className="text-[13.5px] leading-snug break-words mb-md">
+          {mine ? <span className="whitespace-pre-wrap">{text}</span> : <Markdown text={text} />}
+        </div>
         {streaming && <span className="inline-block ml-0.5 animate-pulse">▍</span>}
         {error && <div className="text-[11px] pt-1" style={{ color: "var(--error)" }}>{error}</div>}
         {ts && <div className="text-[9.5px] pt-1" style={{ color: "var(--text3)" }}>{fmtAgo(ts)}</div>}

--- a/web/src/mobile/chatList.ts
+++ b/web/src/mobile/chatList.ts
@@ -1,26 +1,29 @@
 // Which agents the Chats tab offers you, and in what order.
 //
-// The phone was listing every session the scanner had ever recorded: a
-// hundred rows, most of them a day old, many of them named after their own id
-// because they never wrote a first line, some of them `<synthetic>` rows that
-// are not conversations at all. The desktop's Chats panel meanwhile lists the
+// The phone was listing every session the scanner had ever recorded: a hundred
+// rows, most of them a day old, many named after their own id because they
+// never wrote a first line. The desktop's Chats panel meanwhile lists the
 // handful you are actually talking to. Same word, two different meanings, and
 // the phone's meaning is the useless one — nobody opens a phone to scroll
 // yesterday's telemetry.
 //
-// So this narrows it to the same idea the desktop has: agents you could say
-// something to now. History is still reachable, one tap away, but it is not
-// what the tab opens on.
+// So the tab opens on the agents you could say something to now. History is
+// still there, one tap or one search away, but it is not what you land on.
 
 /** What the list is showing. */
 export type ChatScope = "live" | "today" | "all";
 
 export interface ListedSession {
   session_id: string;
+  source_app?: string;
   ended_at?: number | null;
   last_seen: number;
   model_name?: string | null;
   cost_usd?: number;
+  cwd_path?: string | null;
+  project_path?: string | null;
+  custom_title?: string | null;
+  ai_title?: string | null;
 }
 
 /** Sessions with a running owner (same rule the rest of the app uses). */
@@ -28,23 +31,34 @@ const LIVE_MS = 120_000;
 const DAY_MS = 86_400_000;
 
 /**
- * A row that is not a conversation.
+ * Whether this session can be picked up where it left off.
  *
- * `<synthetic>` sessions are rolled up from telemetry with no transcript
- * behind them, so opening one shows an empty thread and a composer that cannot
- * resume anything. They belong in the fleet views, not in a list of people to
- * talk to.
+ * A resume needs a directory to run in. Rows recorded before agentglass tracked
+ * one cannot be resumed in place, and that is a fact about the record rather
+ * than a reason to hide the conversation — the transcript is still worth
+ * reading, and the screen says so and offers the next move.
  */
-export function isTalkable(s: ListedSession): boolean {
-  return s.model_name !== "<synthetic>";
+export function canResume(s: ListedSession): boolean {
+  return !!(s.cwd_path || s.project_path);
 }
 
 /**
  * The sessions this scope shows, newest first.
  *
- * `live` is what is running right now, `today` adds the last 24 hours — which
- * is the working day you might still want to pick up — and `all` is the
- * archive, unchanged from what the tab used to show by default.
+ * `live` is what is running right now, `today` adds the last 24 hours — the
+ * working day you might still want to pick up — and `all` is the archive.
+ *
+ * Nothing is hidden any more. This used to drop every row whose `model_name`
+ * was `<synthetic>`, on the reasoning that such rows are telemetry rollups with
+ * no transcript behind them. The reasoning was right about what those rows are
+ * and wrong about how to spot one: `model_name` is the last model-bearing line
+ * in the transcript, and Claude Code writes `<synthetic>` for an injected or
+ * interrupted turn. So a real conversation that happened to end on one
+ * disappeared from EVERY scope, including "all", with nothing to say it had.
+ *
+ * A list you cannot trust to contain your chat is worse than a longer list, and
+ * the wall of rows the filter was aimed at is what search and the two narrower
+ * scopes are for.
  */
 export function scopeSessions<T extends ListedSession>(
   sessions: readonly T[],
@@ -53,7 +67,6 @@ export function scopeSessions<T extends ListedSession>(
 ): T[] {
   const live = (s: T) => !s.ended_at && now - s.last_seen < LIVE_MS;
   const kept = sessions.filter((s) => {
-    if (!isTalkable(s)) return false;
     if (scope === "live") return live(s);
     if (scope === "today") return now - s.last_seen < DAY_MS;
     return true;
@@ -71,4 +84,27 @@ export function openingScope(sessions: readonly ListedSession[], now = Date.now(
   if (scopeSessions(sessions, "live", now).length) return "live";
   if (scopeSessions(sessions, "today", now).length) return "today";
   return "all";
+}
+
+/**
+ * Sessions matching a typed query.
+ *
+ * There was no search at all, and the list only ever held forty rows, so a chat
+ * from three days ago was not reachable by any means — "All" meant "the newest
+ * forty" and said "All".
+ *
+ * Matches the title, the project, the model and the id, because those are the
+ * four things somebody actually remembers about a conversation. Every term must
+ * match something, so typing two words narrows rather than widens.
+ */
+export function searchSessions<T extends ListedSession>(sessions: readonly T[], query: string): T[] {
+  const terms = query.toLowerCase().split(/\s+/).filter(Boolean);
+  if (!terms.length) return [...sessions];
+  return sessions.filter((s) => {
+    const hay = [
+      s.custom_title, s.ai_title, s.cwd_path, s.project_path,
+      s.model_name, s.source_app, s.session_id,
+    ].filter(Boolean).join(" ").toLowerCase();
+    return terms.every((t) => hay.includes(t));
+  });
 }

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -137,6 +137,24 @@ export const MOBILE_CSS = `
    the last message must not start dragging the page behind it. */
 .mb-chat .bd{display:flex;flex-direction:column;gap:10px;overscroll-behavior:contain;
   padding:14px 15px 10px}
+/* Markdown inside a bubble. The renderer is the desktop's; what it needs here
+   is a code block that scrolls sideways rather than one that reflows a command
+   into prose, and a bubble that does not go wider than the thread because of
+   one long line. */
+.mb-md pre{overflow-x:auto;max-width:100%;border-radius:9px;padding:9px 11px;margin:7px 0;
+  font-size:11px;line-height:1.6;background:color-mix(in srgb,#000 40%,var(--bg2));
+  border:1px solid color-mix(in srgb,var(--border) 34%,transparent)}
+.mb-md code{font-size:11.5px;word-break:break-word}
+.mb-md :not(pre) > code{padding:1px 5px;border-radius:5px;
+  background:color-mix(in srgb,var(--primary) 15%,transparent);color:var(--primary-hover)}
+.mb-md ul,.mb-md ol{padding-left:18px;margin:5px 0}
+.mb-md li{margin:2px 0}
+.mb-md a{color:var(--primary-hover);word-break:break-word}
+.mb-md h1,.mb-md h2,.mb-md h3{font-size:13.5px;font-weight:650;margin:8px 0 4px}
+.mb-md blockquote{border-left:2px solid color-mix(in srgb,var(--border) 60%,transparent);
+  padding-left:9px;margin:6px 0;color:var(--text3)}
+.mb-md table{display:block;overflow-x:auto;max-width:100%}
+
 .mb-jump{position:absolute;left:50%;transform:translateX(-50%);bottom:calc(env(safe-area-inset-bottom) + 84px);
   z-index:2;font-size:11.5px;font-weight:600;padding:7px 14px;border-radius:999px;
   color:#150c28;background:color-mix(in srgb,var(--primary) 90%,#000);

--- a/web/test/chat-find.test.ts
+++ b/web/test/chat-find.test.ts
@@ -1,0 +1,115 @@
+/*
+ * Finding a chat.
+ *
+ * The list had no search, held forty rows, and hid some of them. So "All" meant
+ * "the newest forty", said "All", and a conversation whose last model-bearing
+ * line happened to be `<synthetic>` was not in it — or in any other scope —
+ * with nothing anywhere to say so.
+ *
+ * Claude Code writes `<synthetic>` for an injected or interrupted turn, so that
+ * filter was using the model name as a proxy for "has a transcript", and the
+ * proxy is wrong in exactly the case that matters: a long conversation you
+ * interrupted.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { scopeSessions, searchSessions, canResume } from "../src/mobile/chatList.ts";
+
+const SRC = join(import.meta.dir, "..", "src");
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+const code = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+const NOW = 1_800_000_000_000;
+const s = (id: string, over: Record<string, unknown> = {}) => ({
+  session_id: id, last_seen: NOW - 10_000, ended_at: null,
+  model_name: "claude-opus-5", cost_usd: 1, ...over,
+});
+
+const FLEET = [
+  s("a", { ai_title: "Rebuild the companion UI", cwd_path: "/home/x/code/agentglass", model_name: "claude-opus-5" }),
+  s("b", { custom_title: "Port the pane resize handler", cwd_path: "/home/x/code/tmux-chat", model_name: "claude-haiku-4-5" }),
+  s("c", { project_path: "/home/x/code/agentglass", source_app: "claude-code" }),
+];
+
+describe("search", () => {
+  test("finds a chat by its title", () => {
+    expect(searchSessions(FLEET, "companion").map((x) => x.session_id)).toEqual(["a"]);
+  });
+
+  test("finds one by its project", () => {
+    expect(searchSessions(FLEET, "tmux").map((x) => x.session_id)).toEqual(["b"]);
+  });
+
+  test("finds one by its model", () => {
+    expect(searchSessions(FLEET, "haiku").map((x) => x.session_id)).toEqual(["b"]);
+  });
+
+  test("finds one with no title at all, by id", () => {
+    // The rows that read `agentglass:cd3fa401` are exactly the ones you cannot
+    // pick out by eye, so the id has to be searchable.
+    expect(searchSessions(FLEET, "c").some((x) => x.session_id === "c")).toBe(true);
+  });
+
+  test("every term must match, so two words narrow", () => {
+    expect(searchSessions(FLEET, "companion tmux")).toHaveLength(0);
+    expect(searchSessions(FLEET, "companion agentglass").map((x) => x.session_id)).toEqual(["a"]);
+  });
+
+  test("an empty query is not a filter", () => {
+    expect(searchSessions(FLEET, "   ")).toHaveLength(3);
+  });
+
+  test("it is case insensitive", () => {
+    expect(searchSessions(FLEET, "COMPANION").map((x) => x.session_id)).toEqual(["a"]);
+  });
+});
+
+describe("nothing is hidden", () => {
+  test("a synthetic model name does not remove a session from any scope", () => {
+    const withSynthetic = [...FLEET, s("interrupted", { model_name: "<synthetic>" })];
+    for (const scope of ["live", "today", "all"] as const) {
+      expect(
+        scopeSessions(withSynthetic, scope, NOW).some((x) => x.session_id === "interrupted"),
+        `scope ${scope}`,
+      ).toBe(true);
+    }
+  });
+
+  test("a session with nowhere to run is listed and marked", () => {
+    expect(canResume(s("orphan"))).toBe(false);
+    expect(canResume(s("placed", { cwd_path: "/home/x/code/app" }))).toBe(true);
+    expect(canResume(s("byproject", { project_path: "/home/x/code/app" }))).toBe(true);
+  });
+});
+
+describe("the wiring", () => {
+  test("the list fetches a page worth searching", () => {
+    // 40 was the size while there was no search, and it is what made "All" a
+    // lie. The desktop has always taken 200.
+    const app = code(read("mobile/MobileApp.tsx"));
+    expect(app).toContain("api.sessions(200)");
+    expect(app).not.toContain("api.sessions(40)");
+  });
+
+  test("searching looks past the open scope", () => {
+    // Answering out of the rows already on screen makes search feel broken:
+    // the chat you are looking for is precisely the one not in front of you.
+    const chats = code(read("mobile/MobileChats.tsx"));
+    expect(chats).toContain("searchSessions(sessions, query)");
+  });
+
+  test("what an agent says is rendered as markdown", () => {
+    // Half of it is code. As plain text a fenced block arrived as literal
+    // backticks reflowed in a proportional font.
+    const chats = code(read("mobile/MobileChats.tsx"));
+    expect(chats).toContain("<Markdown text={text} />");
+    // Your own message is not markup and stays verbatim.
+    expect(chats).toContain("mine ?");
+  });
+
+  test("a code block scrolls rather than reflowing", () => {
+    const ui = read("mobile/mobileUi.tsx");
+    expect(ui).toContain(".mb-md pre{overflow-x:auto");
+  });
+});

--- a/web/test/chat-list.test.ts
+++ b/web/test/chat-list.test.ts
@@ -1,7 +1,7 @@
 // The phone's Chats tab listed every session ever recorded, which on a real
 // machine is a hundred rows of yesterday. These pin the narrowing.
 import { describe, expect, test } from "bun:test";
-import { scopeSessions, openingScope, isTalkable } from "../src/mobile/chatList.ts";
+import { scopeSessions, openingScope, canResume, searchSessions } from "../src/mobile/chatList.ts";
 
 const NOW = 1_800_000_000_000;
 const s = (id: string, agoMs: number, extra: Record<string, unknown> = {}) => ({
@@ -38,12 +38,31 @@ describe("scopeSessions", () => {
       .toEqual(["working", "ended", "an-hour-ago", "yesterday"]);
   });
 
-  test("synthetic rollups are not conversations and never listed", () => {
+  test("a synthetic model name no longer hides a session", () => {
+    /*
+     * This asserted the opposite, and the reasoning behind it was half right:
+     * some rows really are telemetry rollups with no transcript behind them,
+     * and listing those is noise.
+     *
+     * The half that was wrong is how it spotted one. `model_name` is the last
+     * model-bearing line in the transcript, and Claude Code writes
+     * `<synthetic>` for an injected or interrupted turn — so a real
+     * conversation that happened to end on one vanished from EVERY scope,
+     * including "all", with nothing anywhere to say it had. A list you cannot
+     * trust to contain your chat is worse than a longer list, and the wall of
+     * rows this was aimed at is what search and the two narrower scopes are
+     * for.
+     */
     const withSynthetic = [...fleet, s("telemetry", 10_000, { model_name: "<synthetic>" })];
-    expect(isTalkable(withSynthetic[4]!)).toBe(false);
-    for (const scope of ["live", "today", "all"] as const) {
-      expect(scopeSessions(withSynthetic, scope, NOW).some((x) => x.session_id === "telemetry")).toBe(false);
-    }
+    expect(scopeSessions(withSynthetic, "all", NOW).some((x) => x.session_id === "telemetry")).toBe(true);
+  });
+
+  test("a session with nowhere to run is listed, and marked", () => {
+    // It cannot be resumed in place; that is a fact about the record, not a
+    // reason to hide the transcript.
+    expect(canResume(s("orphan", 10_000))).toBe(false);
+    expect(canResume(s("placed", 10_000, { cwd_path: "/home/x/code/app" }))).toBe(true);
+    expect(scopeSessions([s("orphan", 10_000)], "all", NOW)).toHaveLength(1);
   });
 });
 


### PR DESCRIPTION
Fifth of the companion rebuild. Three things stopped you finding a conversation, and the first is the worst because it was silent.

## What does this PR do?

**A real chat could vanish from every scope.** `isTalkable` dropped any row whose `model_name` was `<synthetic>`. The reasoning was sound about what such rows usually are — telemetry rollups with no transcript behind them — and wrong about how to spot one. `model_name` is the *last model-bearing line in the transcript*, and Claude Code writes `<synthetic>` for an injected or interrupted turn. So a real conversation that happened to end on one disappeared from `live`, `today` **and** `all`, with nothing anywhere to say it had.

That is the worst failure a list can have, and it fires precisely on the long sessions you interrupted — which are the ones you most want back.

Nothing is hidden now. A session with nowhere to run is **listed and marked read-only** rather than suppressed: it cannot be resumed in place, but the transcript is worth reading, and that is a fact about the record rather than a reason to pretend it does not exist.

**There was no search, and the page size was forty.** So the scope called "All" meant "the newest forty" and said "All" — a chat from three days ago was unreachable by any route. Search matches the title, the project, the model and the id, because those are the four things somebody actually remembers about a conversation; the id matters because it is what identifies the rows that read `agentglass:cd3fa401` and cannot be picked out by eye. Every term must match, so two words narrow rather than widen.

It deliberately **looks past the open scope**. Answering out of the rows already on screen is what makes a search feel broken: the chat you are hunting is precisely the one not in front of you. The page is 200, which is what the desktop has always taken (`App.tsx:238`) — a rollup row is small, and it now arrives on the socket's nudge rather than on a four-second poll.

**And what an agent says is rendered as markdown.** Half of it is code, and as plain text a fenced block arrived as literal backticks reflowed in a proportional font — unreadable exactly where being readable matters. The renderer is the desktop's `web/src/lib/markdown.tsx`; the phone had simply never used it. Code blocks scroll sideways rather than reflowing a command into prose. Your own messages stay verbatim, because what you typed is not markup.

## How was it tested?

`web/test/chat-find.test.ts`, 13 tests: search by title, project, model and id; two terms narrowing; case insensitivity; an empty query not acting as a filter; a `<synthetic>` row present in **every** scope; `canResume` for both `cwd_path` and `project_path`; and the wiring — page size, search looking past the scope, markdown for the agent and verbatim for you, and code blocks scrolling.

The existing `chat-list.test.ts` case asserting *"synthetic rollups are never listed"* is **rewritten rather than deleted**, with the reason it changed — the same treatment as the docker one in #394. The old assertion encoded a decision that was half right, and the comment says which half.

All six mutations confirmed red against the code without the fix: the synthetic filter returning (2 failing), search narrowed to titles (4), terms widening instead of narrowing, page size back to forty, search confined to the scope, and assistant text back to plain.

Full suites: `web/` 558 pass / 0 fail, `server/` 1040 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## Not covered

Most rows are still titled `agentglass:cd3fa401` — `sessionTitle` falls back to `source_app:sessionId.slice(0,8)` when a session has neither a custom nor an AI title, and nothing on the phone's path ever writes one. Search makes those rows reachable; it does not make them recognisable. Giving them a name from the first thing you said is a server-side change and its own piece of work.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_