### PR TITLE
fix(mobile): say what is actually wrong

### DIFF
--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -88,6 +88,10 @@ export function MobileApp() {
   const [trees, setTrees] = useState<Record<string, { branch: string; dirty: number; ahead: number; behind: number }>>({});
   const [containers, setContainers] = useState<DockerContainer[]>([]);
   const [dstats, setDstats] = useState<DockerStat[]>([]);
+  /** Whether docker answered at all, and what it said if not. The server
+   *  distinguishes "not installed" from "daemon down" from "no answer yet"; the
+   *  phone used to collapse all three into an empty list. */
+  const [docker, setDocker] = useState<{ available: boolean; error: string | null }>({ available: true, error: null });
   const [prs, setPrs] = useState<{ root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[]>([]);
   const [me, setMe] = useState("");
 
@@ -147,7 +151,13 @@ export function MobileApp() {
   }, []);
 
   const loadDocker = useCallback(() => {
-    api.dockerOverview().then((o) => setContainers(o.available ? o.containers : [])).catch(() => setContainers([]));
+    // `available` and `error` were dropped, so "docker is not running on this
+    // machine" and "this project has no containers" rendered as the same
+    // sentence — and only one of them is something you can act on.
+    api.dockerOverview().then((o) => {
+      setContainers(o.available ? o.containers : []);
+      setDocker({ available: o.available, error: o.error ?? null });
+    }).catch((e) => { setContainers([]); setDocker({ available: false, error: String(e) }); });
     api.dockerStats().then((r) => setDstats(r.stats)).catch(() => setDstats([]));
   }, []);
 
@@ -491,7 +501,7 @@ export function MobileApp() {
       <RepoScreen open={!!openRepo && !openPr} repo={openRepo}
         checkouts={openCheckouts} onPickCheckout={setOpenRepo}
         containers={containers.filter((c) => ownerByContainer.get(c.id) === openRepo?.ref.root)} stats={dstats}
-        onOpenContainer={openContainer}
+        onOpenContainer={openContainer} docker={docker}
         onBack={() => setOpenRepo(null)} toast={toast} onRefresh={refreshAll}
         onOpenChatWith={openChatWith} />
 

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -5,8 +5,10 @@ import { Screen, Sheet, Seg, Empty, Row, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { MobilePr } from "./MobilePr.tsx";
 import { projectRows } from "./projects.ts";
+import { listState, dockerState } from "./listState.ts";
 import type {
   GitRepoRef, WorkingTree, GitBranch, DockerContainer, DockerStat, PrSummary, GitFileChange,
+  PrListResponse,
 } from "../../../shared/types.ts";
 
 /**
@@ -67,7 +69,7 @@ export function RepoList({ repos, onOpen }: { repos: RepoSummary[]; onOpen: (r: 
   );
 }
 
-export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, containers, stats, onBack, toast, onRefresh, onOpenContainer, onOpenChatWith }: {
+export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, containers, stats, onBack, toast, onRefresh, onOpenContainer, docker, onOpenChatWith }: {
   open: boolean;
   repo: RepoSummary | null;
   /** Every checkout of this project — the repo itself and its linked
@@ -82,17 +84,35 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   /** Opening a container is the shell's job: it needs no repo context, and one
    *  that belongs to no project must still have a screen. */
   onOpenContainer: (c: DockerContainer) => void;
+  /** Whether docker answered, and why not. */
+  docker?: { available: boolean; error: string | null };
   onOpenChatWith?: (cwd: string, prompt: string) => void;
 }) {
   const root = repo?.ref.root ?? "";
   const [facet, setFacet] = useState<Facet>("changes");
   const [tree, setTree] = useState<WorkingTree | null>(null);
-  const [prs, setPrs] = useState<PrSummary[]>([]);
+  /**
+   * The pull request list, and everything the server said about it.
+   *
+   * This kept `.prs` and threw the rest away, so three completely different
+   * situations all rendered as "No open pull requests": `gh` missing or logged
+   * out (which the response calls out as `needsAuth` — its own type says "a
+   * first-class state, not an error toast"), a request that failed, and a cache
+   * that had not warmed yet. The app said a calm, confident, false thing in all
+   * three, and offered nothing to do about any of them.
+   */
+  const [prState, setPrState] = useState<PrListResponse | null>(null);
+  const prs = prState?.prs ?? [];
   const [prsLoading, setPrsLoading] = useState(false);
+  const prList = useMemo(
+    () => listState(prsLoading && !prState ? null : prState),
+    [prState, prsLoading]
+  );
   const [msg, setMsg] = useState("");
   const [branches, setBranches] = useState<GitBranch[] | null>(null);
   const [openPr, setOpenPr] = useState<number | null>(null);
   const [diffAt, setDiffAt] = useState<number | null>(null);
+  const [prNonce, setPrNonce] = useState(0);
 
   /** The project's name, which is the main checkout's — a worktree is the same
    *  project on another branch, and titling the screen with the worktree's
@@ -105,13 +125,14 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   // used to compare a compose project name to a directory basename here, which
   // is how one project's containers ended up under another's.
   const mine = containers;
+  const ctrList = useMemo(() => dockerState(docker, mine.length), [docker, mine.length]);
 
   // Open on whatever is wrong: a container down beats uncommitted work beats
   // the pull request list. Landing on an empty tab is a wasted screen.
   useEffect(() => {
     if (!repo) return;
     setFacet(repo.down ? "containers" : repo.dirty ? "changes" : "prs");
-    setTree(null); setPrs([]); setMsg(""); setBranches(null);
+    setTree(null); setPrState(null); setMsg(""); setBranches(null);
   }, [repo]);
 
   const loadTree = useCallback(() => {
@@ -123,9 +144,25 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   useEffect(() => {
     if (!open || facet !== "prs" || !root) return;
     setPrsLoading(true);
-    api.prList(root, "all", "open").then((r) => setPrs(r.prs)).catch(() => setPrs([]))
+    api.prList(root, "all", "open")
+      .then(setPrState)
+      .catch((e) => setPrState({ ok: false, repo: null, prs: [], fetchedAt: Date.now(), stale: false, loading: false, error: String(e) }))
       .finally(() => setPrsLoading(false));
-  }, [open, facet, root]);
+  }, [open, facet, root, prNonce]);
+
+  /**
+   * A cold cache is not an empty list.
+   *
+   * The server answers immediately with `loading: true` and no rows while it
+   * fetches behind the response, and this was a one-shot call that treated that
+   * as "none" and never asked again — so opening the tab a second too early
+   * meant no pull requests until you left the screen and came back.
+   */
+  useEffect(() => {
+    if (!open || facet !== "prs" || !prState?.loading) return;
+    const t = setTimeout(() => setPrNonce((n) => n + 1), 1_500);
+    return () => clearTimeout(t);
+  }, [open, facet, prState?.loading]);
 
   // The tree hands staged and unstaged back separately; the phone shows one
   // list with a switch per row, so they are merged and deduplicated here —
@@ -261,8 +298,17 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
         )}
 
         {facet === "prs" && (
-          prsLoading && !prs.length ? <div className="text-[11.5px] p-3" style={{ color: "var(--text3)" }}>Loading pull requests…</div>
-          : prs.length === 0 ? <Empty glyph="⑂" title="No open pull requests" body={`Nothing is waiting to land on ${repo?.name}.`} />
+          // Four different answers, and only one of them is "there are none".
+          // Which one is a decision about data, so listState() makes it.
+          prList.kind === "needs-auth"
+            ? <Empty glyph="⑂" title="GitHub is not signed in"
+                body={`agentglass reads pull requests through the gh CLI, and it is missing or logged out on this machine. Run \`gh auth login\` there and this fills in — it is not that ${repo?.name} has none.`} />
+          : prList.kind === "error"
+            ? <Empty glyph="⑂" title="Could not read pull requests" body={prList.message} />
+          : prList.kind === "loading"
+            ? <div className="text-[11.5px] p-3" style={{ color: "var(--text3)" }}>Reading pull requests from GitHub…</div>
+          : prList.kind === "empty"
+            ? <Empty glyph="⑂" title="No open pull requests" body={`Nothing is waiting to land on ${repo?.name}.`} />
           : (
             <div className="flex flex-col gap-2.5">
               {prs.map((p) => (
@@ -273,12 +319,21 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
                   right={`+${p.additions} −${p.deletions}`}
                   onClick={() => setOpenPr(p.number)} />
               ))}
+              {/* Only the first page arrived. Saying so beats a list that looks
+                  complete and is not. */}
+              {prList.kind === "rows" && prList.truncated && (
+                <div className="text-[10.5px] px-1 pt-1" style={{ color: "var(--text3)" }}>
+                  Showing {prs.length}{prState?.total ? ` of ${prState.total}` : ""} — open the repository on the desktop for the rest.
+                </div>
+              )}
             </div>
           )
         )}
 
         {facet === "containers" && (
-          mine.length === 0
+          ctrList.kind === "unavailable"
+            ? <Empty glyph="▣" title="Docker is not answering" body={ctrList.message} />
+          : ctrList.kind === "empty"
             ? <Empty glyph="▣" title="No containers" body={`Nothing from ${repo?.name} is running under Docker.`} />
             : (
               <div className="flex flex-col gap-2.5">

--- a/web/src/mobile/listState.ts
+++ b/web/src/mobile/listState.ts
@@ -1,0 +1,76 @@
+/**
+ * Which of several situations an empty list is actually in.
+ *
+ * `listPrs` answers with `needsAuth`, `error`, `loading`, `prs`, `hasNext` and
+ * `total`. The phone kept `.prs` and dropped the rest, so four different
+ * situations all rendered as "No open pull requests. Nothing is waiting to
+ * land": gh missing or logged out, the request failing, a cache that had not
+ * warmed, and there genuinely being none. Only the last of those is true, and
+ * only the first two are things you could act on.
+ *
+ * A wrong answer delivered in the voice reserved for right ones is worse than
+ * an error, because there is nothing to react to.
+ *
+ * This is a function rather than a ternary in the markup so it can be tested as
+ * data — the first version of the guard for it asserted that the words "GitHub
+ * is not signed in" appeared in the file, which stayed true when the branch
+ * that shows them was disabled.
+ */
+
+export type ListState =
+  /** gh is missing or logged out. Fixable, and the fix is a command. */
+  | { kind: "needs-auth" }
+  /** The request failed, and we can say how. */
+  | { kind: "error"; message: string }
+  /** The server is fetching behind its own response; ask again shortly. */
+  | { kind: "loading" }
+  /** It really is empty. */
+  | { kind: "empty" }
+  /** Rows, and whether they are all of them. */
+  | { kind: "rows"; truncated: boolean };
+
+export interface ListLike {
+  prs?: unknown[];
+  needsAuth?: boolean;
+  error?: string;
+  loading?: boolean;
+  hasNext?: boolean;
+}
+
+/**
+ * Order matters. `needsAuth` outranks everything: a signed-out gh also reports
+ * zero rows and often an error, and naming the underlying cause is the only one
+ * of the three that leads anywhere. `loading` only wins while there is nothing
+ * to show — once rows have arrived, a background refresh is not a reason to
+ * take them off the screen.
+ */
+export function listState(r: ListLike | null | undefined): ListState {
+  if (!r) return { kind: "loading" };
+  if (r.needsAuth) return { kind: "needs-auth" };
+  const rows = r.prs?.length ?? 0;
+  if (r.error && !rows) return { kind: "error", message: r.error };
+  if (rows) return { kind: "rows", truncated: !!r.hasNext };
+  if (r.loading) return { kind: "loading" };
+  return { kind: "empty" };
+}
+
+/** What docker said, when it said anything. */
+export type DockerState =
+  | { kind: "unavailable"; message: string }
+  | { kind: "empty" }
+  | { kind: "rows" };
+
+export function dockerState(
+  d: { available: boolean; error: string | null } | undefined,
+  count: number,
+): DockerState {
+  // "The daemon is down" and "this project has nothing running" are different
+  // facts, and only one of them is something you can do anything about.
+  if (d && !d.available) {
+    return {
+      kind: "unavailable",
+      message: d.error || "agentglass cannot reach the docker daemon, so it cannot tell you what is running.",
+    };
+  }
+  return count ? { kind: "rows" } : { kind: "empty" };
+}

--- a/web/test/honest-states.test.ts
+++ b/web/test/honest-states.test.ts
@@ -1,0 +1,160 @@
+/*
+ * The app told you a calm, confident, false thing.
+ *
+ * `listPrs` answers with `needsAuth`, `error`, `loading`, `hasNext` and `total`.
+ * The phone kept `.prs` and dropped the rest, so FOUR different situations all
+ * rendered as "No open pull requests. Nothing is waiting to land":
+ *
+ *   - `gh` missing or logged out — whose own type calls it "a first-class
+ *     state, not an error toast";
+ *   - the request failed;
+ *   - the cache had not warmed yet, and the one-shot fetch never asked again;
+ *   - there genuinely are none.
+ *
+ * Same for docker: the server distinguishes "not installed" from "daemon down"
+ * from "no answer yet", and the phone collapsed all three into an empty list
+ * captioned "nothing from this repo is running under Docker".
+ *
+ * A wrong answer delivered in the voice reserved for right ones is worse than
+ * an error, because there is nothing to react to. These are rules over the
+ * source: the fields must be read, and the empty state must not be the only
+ * thing that can be drawn.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { listState, dockerState } from "../src/mobile/listState.ts";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "..", "src");
+const read = (p: string) => readFileSync(join(SRC, p), "utf8");
+const code = (s: string) => s.replace(/\/\*[\s\S]*?\*\//g, "").replace(/(^|[^:])\/\/.*$/gm, "$1");
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+
+describe("which situation an empty list is in", () => {
+  /*
+   * Tested as data rather than by looking for the words in the markup. The
+   * first version of this did the latter — and stayed green when the branch
+   * that shows those words was disabled, because the strings were still in the
+   * file. That is the whole reason the decision is a function now.
+   */
+  test("a signed-out gh outranks everything else it also reports", () => {
+    // It reports zero rows and usually an error too, and neither of those
+    // leads anywhere. The cause does.
+    expect(listState({ prs: [], needsAuth: true, error: "gh: not found", loading: false }))
+      .toEqual({ kind: "needs-auth" });
+  });
+
+  test("a failure is not an empty list", () => {
+    expect(listState({ prs: [], error: "network is unreachable" }))
+      .toEqual({ kind: "error", message: "network is unreachable" });
+  });
+
+  test("a cold cache is not an empty list either", () => {
+    expect(listState({ prs: [], loading: true })).toEqual({ kind: "loading" });
+  });
+
+  test("nothing fetched yet is loading, not empty", () => {
+    expect(listState(null)).toEqual({ kind: "loading" });
+  });
+
+  test("genuinely none is the only thing that reads as none", () => {
+    expect(listState({ prs: [], loading: false })).toEqual({ kind: "empty" });
+  });
+
+  test("rows stay on screen through a background refresh", () => {
+    // Once there is something to show, a refresh is not a reason to take it
+    // away and replace it with a spinner.
+    expect(listState({ prs: [{}], loading: true })).toEqual({ kind: "rows", truncated: false });
+    expect(listState({ prs: [{}], error: "stale" })).toEqual({ kind: "rows", truncated: false });
+  });
+
+  test("a truncated list says so", () => {
+    expect(listState({ prs: [{}], hasNext: true })).toEqual({ kind: "rows", truncated: true });
+  });
+});
+
+describe("the pull request screen is wired to it", () => {
+  const repo = read("mobile/MobileRepo.tsx");
+
+  test("the whole response is kept, not just the rows", () => {
+    expect(code(repo)).toContain("PrListResponse");
+    expect(code(repo)).not.toContain("then((r) => setPrs(r.prs))");
+  });
+
+  test("every branch listState can return is drawn", () => {
+    const src = code(repo);
+    for (const kind of ["needs-auth", "error", "loading", "empty"]) {
+      expect(src, `no branch for ${kind}`).toContain(`prList.kind === "${kind}"`);
+    }
+  });
+
+  test("the signed-out state says what to do about it", () => {
+    expect(repo).toContain("gh auth login");
+  });
+
+  test("a cold cache retries instead of reporting none", () => {
+    const cold = code(repo).slice(code(repo).indexOf("prState?.loading"));
+    expect(cold).toContain("setPrNonce");
+  });
+});
+
+describe("docker", () => {
+  test("a daemon that is down is not an empty project", () => {
+    expect(dockerState({ available: false, error: "is the daemon running?" }, 0))
+      .toEqual({ kind: "unavailable", message: "is the daemon running?" });
+  });
+
+  test("it says something even when the server did not", () => {
+    const s = dockerState({ available: false, error: null }, 0);
+    expect(s.kind).toBe("unavailable");
+    expect((s as { message: string }).message).toContain("cannot reach the docker daemon");
+  });
+
+  test("available and empty really is empty", () => {
+    expect(dockerState({ available: true, error: null }, 0)).toEqual({ kind: "empty" });
+    expect(dockerState({ available: true, error: null }, 2)).toEqual({ kind: "rows" });
+  });
+
+  test("the phone keeps whether docker answered", () => {
+    const app = code(read("mobile/MobileApp.tsx"));
+    expect(app).toContain("setDocker(");
+    expect(app).toContain("o.available");
+  });
+
+  test("the containers facet is wired to it", () => {
+    const src = code(read("mobile/MobileRepo.tsx"));
+    expect(src).toContain('ctrList.kind === "unavailable"');
+    expect(src).toContain('ctrList.kind === "empty"');
+  });
+});
+
+describe("the rule, over the tree", () => {
+  test("no mobile screen throws away a response's own error state", () => {
+    /*
+     * Both faults were the same shape: a `.then` that reached past an outer
+     * object for the array inside it. The rest of that object is how the server
+     * says what went wrong, and dropping it is what leaves the UI with nothing
+     * to draw but the empty case.
+     *
+     * The rule is narrow on purpose — it names the two response shapes that
+     * carry a first-class error state, rather than banning destructuring.
+     */
+    const offenders: string[] = [];
+    for (const file of walk(join(SRC, "mobile"))) {
+      const src = code(readFileSync(file, "utf8"));
+      if (/api\.prList\([^)]*\)[\s\S]{0,80}?\.then\(\s*\(\s*\w+\s*\)\s*=>\s*set\w+\(\s*\w+\.prs\s*\)/.test(src)
+        || /api\.dockerOverview\(\)[\s\S]{0,80}?\.then\(\s*\(\s*\w+\s*\)\s*=>\s*set\w+\(\s*\w+\.containers\s*\)/.test(src)) {
+        offenders.push(file.replace(SRC, ""));
+      }
+    }
+    expect(offenders, "a response's error state is being discarded at the call site").toEqual([]);
+  });
+});


### PR DESCRIPTION
Sixth of the companion rebuild. This is the class of fault where the app tells you a calm, confident, false thing.

## What does this PR do?

`listPrs` answers with `needsAuth`, `error`, `loading`, `hasNext` and `total`. The phone kept `.prs` and dropped the rest, so **four different situations all rendered as "No open pull requests. Nothing is waiting to land"**:

- `gh` missing or logged out — whose own type says *"a first-class state, not an error toast"* (`shared/types.ts:1438`)
- the request failed
- the cache had not warmed, and the one-shot fetch never asked again
- there genuinely are none

Only the last is true, and only the first two lead anywhere.

**Docker had the same shape.** The server distinguishes "not installed" from "daemon down" from "no answer yet" (`server/src/docker.ts:449-456`), and the phone collapsed all three into an empty list captioned *"nothing from this repo is running under Docker"*. One of those you can fix; the caption suggests there is nothing to fix.

A wrong answer delivered in the voice reserved for right ones is worse than an error, because there is nothing to react to.

**A cold cache retries.** The server answers immediately with `loading: true` and no rows while it fetches behind the response (`prs.ts:789`), and `MobileRepo.tsx:126` was a one-shot call that treated that as "none" — so opening the tab a second too early meant no pull requests until you left the screen and came back.

## How was it tested?

`web/test/honest-states.test.ts`, 17 tests.

**The decision is a function now rather than a chain of ternaries in the markup, and that came out of the tests rather than out of taste.** The first version of the guard asserted that the words "GitHub is not signed in" appeared in the file — and it stayed **green** when I disabled the branch that shows them, because the strings were still there. A guard that a mutation walks through is not a guard.

So `listState()` and `dockerState()` are tested as data: that `needsAuth` outranks the zero rows *and* the error it also reports; that a failure, a cold cache and a genuine empty are three different answers; that nothing-fetched-yet is loading rather than empty; and that rows already on screen are **not** swapped for a spinner by a background refresh. Plus a wiring check that every branch `listState` can return is actually drawn, and a rule over the tree that no mobile screen reaches past a response for the array inside it.

All eight mutations confirmed red — including the one the first version let through:

```
RED  gh signed-out no longer outranks the empty list
RED  the signed-out branch is disabled in the markup
RED  a failure reads as empty again
RED  a cold cache reads as empty
RED  rows are swapped for a spinner on refresh
RED  a down daemon reads as an empty project
RED  cold cache stops retrying
RED  the call site reaches past the response again
```

Full suites: `web/` 575 pass / 0 fail, `server/` 1040 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## Not covered

A repository left mid-merge or mid-rebase still has no representation and no way out — `branch.state` carries `merging`/`rebasing` and the phone reads only `branch.name`. That is the same shape of fault as these, and it needs a conflict screen rather than just an honest empty state, so it is its own change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_