### PR TITLE
feat(sessions): name a chat after what you asked it to do

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -257,6 +257,10 @@ try {
 } catch { /* already present */ }
 db.exec("CREATE INDEX IF NOT EXISTS idx_events_pre_open ON events(session_id, tool_name, paired, id)");
 db.exec("CREATE INDEX IF NOT EXISTS idx_events_provider_ts ON events(provider, timestamp)");
+// Finding a session's FIRST prompt: the list asks for up to two hundred of
+// them at once, and without this it is a scan of every UserPromptSubmit on the
+// machine per refresh. See firstPrompts().
+db.exec("CREATE INDEX IF NOT EXISTS idx_events_first_prompt ON events(hook_event_type, session_id, timestamp)");
 
 // Covering indexes for /stats — the endpoint that freezes the terminal.
 //
@@ -1454,6 +1458,41 @@ function computeFilterOptions() {
 const SESSIONS_TTL_MS = 1000;
 const sessionsCache = new Map<string, { at: number; data: SessionRollup[] }>();
 
+/**
+ * What each of these sessions was first asked to do.
+ *
+ * Most sessions have no name. `custom_title` is a rename by hand and `ai_title`
+ * is one the agent generated, and both come from lines Claude Code writes into
+ * the transcript — a session that never got one shows its own uuid forever,
+ * which is why a real machine's list reads `agentglass:cd3fa401` thirty times
+ * over and cannot be scanned by eye at all.
+ *
+ * The first thing you typed is a better name than a uuid and it has been in the
+ * database the whole time: every prompt is already ingested as a
+ * `UserPromptSubmit` event. So this is a query rather than a new column, an
+ * ingest change or a backfill — and it names sessions recorded long before the
+ * idea existed.
+ *
+ * One statement for the whole page rather than one per row. SQLite's
+ * bare-column rule makes `payload` come from the row that produced `MIN(...)`,
+ * which is exactly the first prompt.
+ */
+function firstPrompts(ids: string[]): Map<string, string> {
+  const out = new Map<string, string>();
+  if (!ids.length) return out;
+  const holes = ids.map(() => "?").join(",");
+  for (const r of db.query<{ session_id: string; payload: string }, string[]>(
+    `SELECT session_id, payload, MIN(timestamp) FROM events
+     WHERE hook_event_type = 'UserPromptSubmit' AND session_id IN (${holes})
+     GROUP BY session_id`).all(...ids)) {
+    try {
+      const p = JSON.parse(r.payload)?.prompt;
+      if (typeof p === "string" && p.trim()) out.set(r.session_id, p);
+    } catch { /* a payload we cannot read is not a name */ }
+  }
+  return out;
+}
+
 export function getSessions(limit = 100, provider?: string): SessionRollup[] {
   const key = `${limit}|${provider ?? ""}|${workspaceRoot() ?? ""}`;
   const hit = sessionsCache.get(key);
@@ -1473,6 +1512,16 @@ export function getSessions(limit = 100, provider?: string): SessionRollup[] {
     )
     .all(...prov.args, ...s.args, limit)
     .map(parseSessionRow);
+  // Only for the rows that need one: a session with a real title does not want
+  // its first prompt, and asking for it would be work thrown away.
+  const nameless = data.filter((d) => !d.custom_title && !d.ai_title).map((d) => d.session_id);
+  if (nameless.length) {
+    const prompts = firstPrompts(nameless);
+    for (const d of data) {
+      const p = prompts.get(d.session_id);
+      if (p) d.first_prompt = p;
+    }
+  }
   sessionsCache.set(key, { at: Date.now(), data });
   // One entry per (limit, provider, scope); the limit set is tiny and scope
   // rarely changes, so prune stale entries anyway so a long-lived server cannot

--- a/server/test/session-first-prompt.test.ts
+++ b/server/test/session-first-prompt.test.ts
@@ -1,0 +1,114 @@
+/*
+ * Most sessions have no name.
+ *
+ * `custom_title` is a rename by hand and `ai_title` is one the agent generated,
+ * and both come from lines Claude Code writes into the transcript. A session
+ * that never got one shows its own uuid forever — which on a real machine is
+ * most of them, and a phone list of thirty rows reading `agentglass:cd3fa401`
+ * cannot be scanned by eye at all.
+ *
+ * The first thing you typed has been in the database the whole time: every
+ * prompt is ingested as a `UserPromptSubmit` event. So the rollup carries it,
+ * which also means sessions recorded long before this existed get named.
+ */
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-names-"));
+const ROOT = join(dir, "proj");
+mkdirSync(ROOT, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "names.db");
+process.env.XDG_CONFIG_HOME = dir;
+process.env.AGENTGLASS_ROOT = ROOT;
+
+let db: typeof import("../src/db.ts");
+const T0 = Date.now() - 3_600_000;
+
+const event = (over: Record<string, unknown> = {}) => ({
+  source_app: "proj",
+  session_id: "s1",
+  hook_event_type: "PostToolUse",
+  tool_name: "Bash",
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-5",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 10, output_tokens: 5, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "x",
+  timestamp: T0,
+  payload: { project_path: ROOT },
+  chat: null,
+  ...over,
+});
+
+const prompt = (session_id: string, text: string, timestamp: number) =>
+  event({ session_id, hook_event_type: "UserPromptSubmit", tool_name: null, timestamp,
+          payload: { project_path: ROOT, prompt: text } });
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+
+  // Two prompts, out of order on the way in — the FIRST is the name.
+  db.insertEvent(prompt("s1", "And now make it instant", T0 + 2_000) as any);
+  db.insertEvent(prompt("s1", "Rework the companion", T0 + 1_000) as any);
+  db.insertEvent(event({ session_id: "s1", timestamp: T0 + 3_000 }) as any);
+
+  // Named by hand: does not need one, and must not be given one.
+  db.insertEvent(prompt("s2", "Something I typed", T0 + 1_000) as any);
+  db.insertEvent(event({ session_id: "s2", timestamp: T0 + 2_000 }) as any);
+  db.setSessionTitles("s2", "Nightly sweep", null);
+
+  // No prompt at all — a hook-only session. Nothing to invent.
+  db.insertEvent(event({ session_id: "s3", timestamp: T0 + 1_000 }) as any);
+
+  // A payload that is not readable as JSON must not take a session down with it.
+  db.insertEvent(event({ session_id: "s4", hook_event_type: "UserPromptSubmit",
+    tool_name: null, timestamp: T0 + 1_000, payload: { project_path: ROOT } }) as any);
+});
+
+/**
+ * `bun test` shares one process, so another suite's module-level
+ * `AGENTGLASS_ROOT` can be the one in force by the time these run — and
+ * getSessions scopes by it, which silently removes every row here. config()
+ * keys its cache on the value asked for, so re-asserting it at read time is
+ * enough to get our own scope back. The alternative was asserting on rows that
+ * a leaked scope had already filtered out, which is how a passing test can
+ * mean nothing.
+ */
+const bySession = () => {
+  process.env.AGENTGLASS_ROOT = ROOT;
+  return new Map(db.getSessions(50).map((s) => [s.session_id, s]));
+};
+
+describe("the rollup carries what the session was first asked to do", () => {
+  test("the earliest prompt wins, not the most recent", () => {
+    expect(bySession().get("s1")?.first_prompt).toBe("Rework the companion");
+  });
+
+  test("a session with a title is not given one", () => {
+    // It would be work thrown away, and the title is the better name anyway.
+    const s2 = bySession().get("s2");
+    expect(s2?.custom_title).toBe("Nightly sweep");
+    expect(s2?.first_prompt).toBeFalsy();
+  });
+
+  test("a session that never prompted gets nothing rather than a guess", () => {
+    expect(bySession().get("s3")?.first_prompt).toBeFalsy();
+  });
+
+  test("a prompt-shaped event with no prompt in it is skipped", () => {
+    expect(bySession().get("s4")?.first_prompt).toBeFalsy();
+  });
+
+  test("every session still comes back", () => {
+    // The lookup is a second query merged onto the page; a session missing a
+    // prompt must not fall out of the list because of it.
+    const ids = [...bySession().keys()].sort();
+    expect(ids).toEqual(["s1", "s2", "s3", "s4"]);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -78,6 +78,16 @@ export interface SessionRollup {
    *  reading them directly — the precedence is the whole point. */
   custom_title?: string | null;
   ai_title?: string | null;
+  /**
+   * The first thing you asked this session to do.
+   *
+   * Only present when there is no title, because that is the only time it is
+   * needed — and it is what stops a list of thirty rows all reading
+   * `agentglass:cd3fa401`. Derived from the `UserPromptSubmit` event that is
+   * already in the database, so it names sessions recorded long before anyone
+   * thought to write a title.
+   */
+  first_prompt?: string | null;
   started_at: number;
   ended_at: number | null;
   last_seen: number;
@@ -410,6 +420,16 @@ export interface SessionDetail {
   /** See SessionRollup — same fields, same precedence. */
   custom_title?: string | null;
   ai_title?: string | null;
+  /**
+   * The first thing you asked this session to do.
+   *
+   * Only present when there is no title, because that is the only time it is
+   * needed — and it is what stops a list of thirty rows all reading
+   * `agentglass:cd3fa401`. Derived from the `UserPromptSubmit` event that is
+   * already in the database, so it names sessions recorded long before anyone
+   * thought to write a title.
+   */
+  first_prompt?: string | null;
   started_at: number;
   ended_at: number | null;
   last_seen: number;

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -78,13 +78,47 @@ export const agentKey = (e: { source_app: string; session_id: string }) =>
  * every hook-only session (titles live in the transcript).
  */
 export const sessionTitle = (
-  s: { source_app?: string; session_id: string; custom_title?: string | null; ai_title?: string | null },
+  s: {
+    source_app?: string; session_id: string;
+    custom_title?: string | null; ai_title?: string | null; first_prompt?: string | null;
+  },
   max = 60
 ): string => {
   const t = (s.custom_title || s.ai_title || "").trim();
-  if (t) return t.length > max ? t.slice(0, max - 1) + "…" : t;
+  if (t) return clipTitle(t, max);
+  // What you first asked for, when nobody ever named it. A uuid identifies a
+  // session and describes nothing, and on a real machine most rows have no
+  // title at all — a list of thirty reading `agentglass:cd3fa401` cannot be
+  // scanned by eye, which is the same as not having a list.
+  const p = promptTitle(s.first_prompt);
+  if (p) return clipTitle(p, max);
   return s.source_app ? `${s.source_app}:${s.session_id.slice(0, 8)}` : s.session_id.slice(0, 8);
 };
+
+/**
+ * A prompt, reduced to something that reads as a name.
+ *
+ * The first line is almost always the ask; what follows is context, pasted
+ * output or a checklist, and none of it belongs in a row 300px wide. Fenced
+ * blocks and quoted material are skipped for the same reason — a prompt that
+ * opens with a stack trace would otherwise be titled with one.
+ */
+export function promptTitle(prompt: string | null | undefined): string {
+  if (!prompt) return "";
+  let inFence = false;
+  for (const raw of prompt.split("\n")) {
+    const line = raw.trim();
+    if (line.startsWith("```")) { inFence = !inFence; continue; }
+    if (inFence || !line) continue;
+    // Slash commands, quotes and markup are not what the session is about.
+    if (line.startsWith(">") || line.startsWith("#") || line.startsWith("<")) continue;
+    return line.replace(/\s+/g, " ");
+  }
+  return "";
+}
+
+const clipTitle = (t: string, max: number): string =>
+  t.length > max ? t.slice(0, max - 1).trimEnd() + "…" : t;
 
 // Deterministic color from a string (agent lanes, model chips).
 export function hashColor(s: string): string {

--- a/web/src/mobile/chatList.ts
+++ b/web/src/mobile/chatList.ts
@@ -24,6 +24,7 @@ export interface ListedSession {
   project_path?: string | null;
   custom_title?: string | null;
   ai_title?: string | null;
+  first_prompt?: string | null;
 }
 
 /** Sessions with a running owner (same rule the rest of the app uses). */
@@ -102,7 +103,7 @@ export function searchSessions<T extends ListedSession>(sessions: readonly T[], 
   if (!terms.length) return [...sessions];
   return sessions.filter((s) => {
     const hay = [
-      s.custom_title, s.ai_title, s.cwd_path, s.project_path,
+      s.custom_title, s.ai_title, s.first_prompt, s.cwd_path, s.project_path,
       s.model_name, s.source_app, s.session_id,
     ].filter(Boolean).join(" ").toLowerCase();
     return terms.every((t) => hay.includes(t));

--- a/web/test/session-names.test.ts
+++ b/web/test/session-names.test.ts
@@ -1,0 +1,79 @@
+/*
+ * A list of thirty rows all reading `agentglass:cd3fa401`.
+ *
+ * `custom_title` is a rename by hand and `ai_title` is one the agent generated,
+ * and both come from lines Claude Code writes into the transcript. A session
+ * that never got one shows its own uuid forever — which on a real machine is
+ * most of them, and a list nobody can scan by eye is the same as not having
+ * one.
+ *
+ * The first thing you typed is a better name than a uuid, and it has been in
+ * the database the whole time as a `UserPromptSubmit` event.
+ */
+import { describe, expect, test } from "bun:test";
+import { sessionTitle, promptTitle } from "../src/lib/format.ts";
+
+const base = { session_id: "cd3fa401-7cb5-4652-ac0b-785ed3751479", source_app: "agentglass" };
+
+describe("what a session is called", () => {
+  test("a rename wins over everything", () => {
+    expect(sessionTitle({ ...base, custom_title: "Nightly", ai_title: "Something", first_prompt: "hello" }))
+      .toBe("Nightly");
+  });
+
+  test("an AI title wins over the prompt", () => {
+    // It was written to be a name; the prompt merely is one.
+    expect(sessionTitle({ ...base, ai_title: "Rebuild the companion", first_prompt: "rework it" }))
+      .toBe("Rebuild the companion");
+  });
+
+  test("the first prompt names a session nobody titled", () => {
+    expect(sessionTitle({ ...base, first_prompt: "Rework the companion so it is instant" }))
+      .toBe("Rework the companion so it is instant");
+  });
+
+  test("the uuid is the last resort, not the first", () => {
+    expect(sessionTitle(base)).toBe("agentglass:cd3fa401");
+  });
+
+  test("a long prompt is clipped without a dangling space", () => {
+    const t = sessionTitle({ ...base, first_prompt: "a".repeat(200) }, 20);
+    expect(t).toHaveLength(20);
+    expect(t.endsWith("…")).toBe(true);
+    expect(sessionTitle({ ...base, first_prompt: "word ".repeat(50) }, 12)).not.toContain(" …");
+  });
+});
+
+describe("reducing a prompt to a name", () => {
+  test("the first line is the ask; the rest is context", () => {
+    expect(promptTitle("Fix the egress path\n\nHere is the stack trace:\n...lots..."))
+      .toBe("Fix the egress path");
+  });
+
+  test("a prompt that opens with a fenced block is not titled with code", () => {
+    expect(promptTitle("```\nTypeError: undefined\n  at x.ts:1\n```\nWhy does this happen?"))
+      .toBe("Why does this happen?");
+  });
+
+  test("quotes and markup are skipped", () => {
+    expect(promptTitle("> pasted from the issue\n# Heading\nMake the diff open"))
+      .toBe("Make the diff open");
+  });
+
+  test("whitespace is collapsed so a row does not gap", () => {
+    expect(promptTitle("  Fix    the   egress\tpath  ")).toBe("Fix the egress path");
+  });
+
+  test("nothing usable is an empty string, not a guess", () => {
+    expect(promptTitle("```\nonly code\n```")).toBe("");
+    expect(promptTitle("")).toBe("");
+    expect(promptTitle(null)).toBe("");
+    expect(promptTitle(undefined)).toBe("");
+  });
+
+  test("an unterminated fence does not swallow the whole prompt", () => {
+    // A prompt ending mid-block is common when something was pasted; the lines
+    // before it are still the ask.
+    expect(promptTitle("Why is this failing?\n```\nsome output")).toBe("Why is this failing?");
+  });
+});


### PR DESCRIPTION
Seventh of the companion rebuild. #396 made every chat *reachable* by search; this makes them *recognisable*.

## What does this PR do?

A real machine's chat list reads `agentglass:cd3fa401` thirty times over. `custom_title` is a rename by hand and `ai_title` is one the agent generated, and both come from lines Claude Code writes into the transcript — so a session that never got one shows its own uuid forever, and for a finished session that is permanent (`backfillTitles` only reads title lines; it cannot invent one).

**The first thing you typed is a better name than a uuid, and it has been in the database the whole time.** Every prompt is already ingested as a `UserPromptSubmit` event. So this is a query rather than a new column, an ingest change or a backfill pass — which also means it names sessions recorded long before the idea existed.

One statement for the whole page rather than one per row, and only for the rows that need one: a session with a real title does not want its first prompt, and asking would be work thrown away. SQLite's bare-column rule makes `payload` come from the row that produced `MIN(timestamp)`, which is exactly the first prompt. A new index on `(hook_event_type, session_id, timestamp)` keeps it off a full scan of every prompt on the machine.

`promptTitle` reduces it to something that reads as a name. The first line is almost always the ask; what follows is context, pasted output or a checklist, and none of that belongs in a row 300px wide. Fenced blocks, quotes and markup are skipped, so a prompt that opens with a stack trace is not titled with one — and an unterminated fence, which is what you get when something was pasted mid-block, does not swallow the whole prompt.

The prompt is also searchable, so #396's search now reaches the content of the chats it could only find by id before.

## How was it tested?

`server/test/session-first-prompt.test.ts` (5) against a real database: the earliest prompt wins with events inserted out of order; a titled session is not given one; a session that never prompted gets nothing rather than a guess; a prompt-shaped event with no prompt in it is skipped; and every session still comes back, because the lookup is a second query merged onto the page and a session missing a prompt must not fall out of the list.

`web/test/session-names.test.ts` (11) for the precedence and the reduction, including the fenced-block, quote, whitespace and unterminated-fence cases.

All eight mutations confirmed red across both.

**One note on the test, because it is the interesting part.** It passed alone and failed in the full suite: `bun test` shares a process, another file's module-level `AGENTGLASS_ROOT` was in force by the time it ran, and `getSessions` scopes by that — so every row it had just written was filtered out and `first_prompt` came back `undefined`. `config()` keys its cache on the value asked for, so the scope is re-asserted at read time. Worth calling out because the alternative was a test asserting on rows a leaked scope had already removed, which is how a passing test comes to mean nothing. (`config.ts:137` warns about exactly this hazard.)

Full suites: `web/` 586 pass / 0 fail, `server/` 1045 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## Not covered

A repository left mid-merge still has no exit, and pull requests are still counted once per checkout so one open PR across three worktrees is three queue cards. Both are next.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_