### PR TITLE
fix(mobile): four faults only opening the app could find

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -173,6 +173,19 @@ const tap = async (cdp: CDP, sel: string, needle?: string) => {
   return !!hit;
 };
 
+/**
+ * Whether Chrome will refuse to start under its own sandbox.
+ *
+ * True for root, which is what CI and most containers run as. `AUDIT_NO_SANDBOX`
+ * forces it for the cases uid does not describe — an unprivileged user in a
+ * container without the right kernel namespaces.
+ */
+function needsNoSandbox(): boolean {
+  if (process.env.AUDIT_NO_SANDBOX === "1") return true;
+  if (process.env.AUDIT_NO_SANDBOX === "0") return false;
+  return typeof process.getuid === "function" && process.getuid() === 0;
+}
+
 async function main() {
   mkdirSync(SHOTS, { recursive: true });
   const profile = mkdtempSync(join(tmpdir(), "agx-audit-"));
@@ -184,6 +197,11 @@ async function main() {
     "--headless=new",
     "--hide-scrollbars",
     "--no-first-run",
+    // Chrome's sandbox needs privileges root does not have inside a container,
+    // and refuses to start without them — so in CI or a devcontainer this
+    // script died at "no page target" with nothing to say about why. Only
+    // where it is actually required: on a normal machine the sandbox stays on.
+    ...(needsNoSandbox() ? ["--no-sandbox", "--disable-dev-shm-usage"] : []),
     `--window-size=${PHONE.w},${PHONE.h}`,
     "about:blank",
   ], { stdout: "ignore", stderr: "ignore" });

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -2152,6 +2152,21 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     session_id: sessionId,
     source_app: agg.source_app,
     model_name: agg.model_name ?? roll?.model_name ?? null,
+    /*
+     * What this session is called.
+     *
+     * The type has declared these since it was written and nothing ever filled
+     * them in, so `sessionTitle(detail)` had nothing to work with and every
+     * conversation header — on the phone and at the desk — showed a uuid, next
+     * to a list row that showed the real name. The row is right there in
+     * `roll`; it was simply never copied across.
+     */
+    custom_title: roll?.custom_title ?? null,
+    ai_title: roll?.ai_title ?? null,
+    // Same rule as the list: only when there is no title to use instead.
+    first_prompt: roll?.custom_title || roll?.ai_title
+      ? null
+      : firstPrompts([sessionId]).get(sessionId) ?? null,
     // Prefer the session row; fall back to the events for one that predates the
     // column. Without a directory the UI can't offer to resume the session.
     project_path: roll?.project_path ?? agg.project_path ?? null,

--- a/server/test/session-first-prompt.test.ts
+++ b/server/test/session-first-prompt.test.ts
@@ -105,6 +105,25 @@ describe("the rollup carries what the session was first asked to do", () => {
     expect(bySession().get("s4")?.first_prompt).toBeFalsy();
   });
 
+  test("the detail carries the name too, not just the list", () => {
+    /*
+     * The type declared custom_title, ai_title and first_prompt on
+     * SessionDetail since it was written, and getSession never filled any of
+     * them in — so sessionTitle(detail) had nothing to work with and every
+     * conversation header showed a uuid, next to a list row showing the real
+     * name. Nothing caught it because nothing asserted on the detail's title,
+     * and it took opening the app to see.
+     */
+    const named = db.getSession("s2");
+    expect(named?.custom_title).toBe("Nightly sweep");
+    // A titled session does not also carry a prompt: same rule as the list.
+    expect(named?.first_prompt).toBeFalsy();
+
+    const nameless = db.getSession("s1");
+    expect(nameless?.custom_title).toBeFalsy();
+    expect(nameless?.first_prompt).toBe("Rework the companion");
+  });
+
   test("every session still comes back", () => {
     // The lookup is a second query merged onto the page; a session missing a
     // prompt must not fall out of the list because of it.

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { api } from "../lib/api.ts";
+import { api, probeServer } from "../lib/api.ts";
 import { useLive } from "../lib/useLive.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { subscribeSessionChanged } from "../lib/sessionBus.ts";
@@ -57,6 +57,23 @@ const LINK_WORD: Record<LinkState, string> = { live: "Live", slow: "Catching up"
 const LINK_TONE: Record<LinkState, string> = {
   live: "var(--success)", slow: "var(--warning)", offline: "var(--error)",
 };
+
+/**
+ * How often the phone asks whether the machine is still there.
+ *
+ * Separate from the data polls on purpose, and this is a correction to the
+ * change that put the phone on the socket. Reachability used to be a side
+ * effect of the four-second gate poll, and slowing that poll to a backstop
+ * slowed the *indicator* with it — so the header went on claiming a live
+ * connection for up to twenty seconds after the server stopped answering, and
+ * claimed it outright whenever the socket happened to still be open while every
+ * request was failing. Saying "Live" over stale numbers is the one thing an
+ * availability indicator must never do.
+ *
+ * `/health` is a few bytes and touches no database, and this only ticks while
+ * somebody is looking at the screen.
+ */
+const HEALTH_MS = 5_000;
 
 /**
  * Fallback intervals, not the delivery mechanism.
@@ -182,6 +199,14 @@ export function MobileApp() {
         .then((res) => res.prs.map((pr) => ({ root: r.root, repo: baseName(r.root), pr, scope })))
         .catch(() => [] as { root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[])
     ))).then((groups) => setPrs(groups.flat()));
+  }, []);
+
+  // Is the machine still there? Its own probe, so the answer is never as old as
+  // the slowest data poll.
+  useEffect(() => {
+    const ping = () => probeServer(2_000).then((id) => setReachable(id === "ours")).catch(() => setReachable(false));
+    ping();
+    return pollWhileVisible(ping, HEALTH_MS);
   }, []);
 
   useEffect(() => {
@@ -436,7 +461,7 @@ export function MobileApp() {
    * but the server still answers (so nothing is lost, only late), and nothing
    * is reachable at all.
    */
-  const link: LinkState = conn === "open" ? "live" : reachable ? "slow" : "offline";
+  const link: LinkState = !reachable ? "offline" : conn === "open" ? "live" : "slow";
 
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>

--- a/web/src/mobile/MobileChats.tsx
+++ b/web/src/mobile/MobileChats.tsx
@@ -673,7 +673,11 @@ function ToolBlock({ runs, errors, agent }: { runs: FeedTool[]; errors: number; 
         )}
         <span className="text-[11px] truncate flex-1">{summariseRuns(runs)}</span>
         {!!errors && <span className="text-[10px] shrink-0" style={{ color: "var(--error)" }}>{errors} failed</span>}
-        <span className="text-[10px] shrink-0 tabular-nums" style={{ opacity: 0.7 }}>{runs.length}</span>
+        {/* Named, because next to a "1 failed" chip a bare number reads as
+            part of it — "1 failed 1". */}
+        <span className="text-[10px] shrink-0 tabular-nums" style={{ opacity: 0.7 }}>
+          {runs.length} run{runs.length === 1 ? "" : "s"}
+        </span>
       </button>
       {open && (
         <div className="flex flex-col gap-1 px-2.5 pt-1.5">

--- a/web/src/mobile/MobileNow.tsx
+++ b/web/src/mobile/MobileNow.tsx
@@ -1,5 +1,6 @@
 import { Act, Empty } from "./mobileUi.tsx";
 import { fmtAgo } from "../lib/format.ts";
+import { shortTarget } from "./transcript.ts";
 import type { NowItem, NowTone } from "./nowQueue.ts";
 
 /**
@@ -35,7 +36,7 @@ export const NOW_CSS = `
 .mb-open .r{display:flex;align-items:center;gap:8px;font-size:11px;min-width:0}
 .mb-open .r b{color:var(--primary-hover);font-weight:700;flex:none}
 .mb-open .r .t{color:var(--text2);flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis;
-  white-space:nowrap;direction:rtl;text-align:left}
+  white-space:nowrap}
 .mb-open .r .o{flex:none;color:var(--text3);font-variant-numeric:tabular-nums;font-size:10px}
 .mb-open .r .o.long{color:var(--warning)}
 .mb-open .more{font-size:10px;color:var(--text3)}
@@ -60,9 +61,13 @@ export const NOW_CSS = `
 .mb-item.bad .k{color:var(--error)}
 .mb-item.good .k{color:var(--success)}
 .mb-item .at{margin-left:auto;font-size:10.5px;color:var(--text3);white-space:nowrap}
-.mb-item .t{padding:6px 14px 0 17px;font-size:14.5px;line-height:1.38;color:var(--text);text-wrap:balance;
+/* The whole header is the way in, so it is one target and it is comfortably
+   over 44px — the title alone was 26. */
+.mb-item .tt{display:block;padding:6px 0 4px}
+.mb-item .t{display:block;padding:0 14px 0 17px;font-size:14.5px;line-height:1.38;color:var(--text);
+  text-wrap:balance;overflow-wrap:anywhere}
+.mb-item .s{display:block;padding:6px 14px 0 17px;font-size:11.5px;color:var(--text3);line-height:1.5;
   overflow-wrap:anywhere}
-.mb-item .s{padding:6px 14px 0 17px;font-size:11.5px;color:var(--text3);line-height:1.5;overflow-wrap:anywhere}
 .mb-item .code{margin:9px 14px 0 17px;padding:9px 11px;border-radius:9px;font-size:11px;color:var(--warning);
   background:color-mix(in srgb,#000 40%,transparent);overflow-wrap:anywhere;
   border-left:2px solid color-mix(in srgb,var(--warning) 55%,transparent)}
@@ -108,7 +113,11 @@ export function NowHero({ pending, working, live, spend, repos }: {
           {live.slice(0, 3).map((c) => (
             <div className="r" key={c.key}>
               <b>{c.tool}</b>
-              <span className="t">{c.target || c.app}</span>
+              {/* Shortened here rather than with `direction: rtl`, which does
+                  keep the filename but re-orders the leading slash of an
+                  absolute path to the end — `…/live/root/shared/types.ts/`.
+                  Bidi reordering is not a truncation strategy. */}
+              <span className="t">{shortTarget(c.target) || c.app}</span>
               {/* How long it has been open is the difference between thinking
                   and stuck, and it is the one number a count cannot give you. */}
               <span className={`o${c.openMs > 60_000 ? " long" : ""}`}>{fmtAgo(Date.now() - c.openMs)}</span>
@@ -156,10 +165,15 @@ export function NowStream({ items, actionsFor, onOpen }: {
             <span className="k">{it.kind}</span>
             <span className="at">{fmtAgo(it.ts)}</span>
           </div>
-          <button className="t mb-press w-full text-left" style={{ background: "transparent" }} onClick={() => onOpen(it)}>
-            {it.title}
+          {/* Title and subtitle are one target, not a 26px line of text with
+              dead space under it. A queue card's whole point is that you can
+              open it, and the only way in was a strip barely half a fingertip
+              tall — which on a card you are already scrolling past is a miss
+              more often than a hit. */}
+          <button className="tt mb-press w-full text-left" style={{ background: "transparent" }} onClick={() => onOpen(it)}>
+            <span className="t">{it.title}</span>
+            <span className="s">{it.sub}</span>
           </button>
-          <div className="s">{it.sub}</div>
           {it.code && <div className="code">{it.code}</div>}
           <div className="acts">
             {actionsFor(it).map((a) => (


### PR DESCRIPTION
Everything in this rebuild so far shipped on green suites — and that is exactly the state the companion was in when it was called unusable. So this time the thing was actually booted: a real server on a seeded fleet, with `scripts/phone-audit.ts` driving it in a phone-sized browser. It found four faults. **One of them I introduced.**

## What does this PR do?

**The audit could not run here at all.** Chrome's sandbox needs privileges root does not have inside a container and refuses to start without them, so in CI or a devcontainer the script died at `no page target` with nothing to say about why. `--no-sandbox` is passed only where it is actually required, decided by uid, with `AUDIT_NO_SANDBOX` for the cases uid does not describe. On a normal machine the sandbox stays on.

**The regression.** #392 put the phone on the socket and slowed the gate poll from 4s to 20s — and reachability was a *side effect* of that poll. So the header went on claiming a live connection for up to twenty seconds after the server stopped answering, and claimed it outright whenever the socket happened to still be open while every request was failing. Saying "Live" over stale numbers is the one thing an availability indicator must never do. It has its own `/health` probe now — a few bytes, no database work, on a 5s visible-only tick — and `offline` outranks a socket that has not noticed yet.

**A Now card's only way in was its title:** a 380×26 strip, barely half a fingertip, on a card you are already scrolling past. Title and subtitle are one target now, comfortably over 44px.

**The conversation header showed a uuid for every session ever** — next to a list row showing the real name. `SessionDetail` has declared `custom_title`, `ai_title` and `first_prompt` since it was written, and `getSession` never filled any of them in, so `sessionTitle(detail)` had nothing to work with. The row was right there in `roll`; it was simply never copied across. **This one is not phone-specific** — the desktop's session view had it too.

And two things the eye caught that no assertion would have:

- The open-tool line read `Edit …f400/scratchpad/live/root/shared/types.ts/`. I had used `direction: rtl` to keep the filename when truncating, which also re-orders the leading slash of an absolute path to the end. Bidi reordering is not a truncation strategy; `shortTarget` does it properly.
- A tool block with a failure read **"1 failed 1"** — a bare count next to an error chip reads as part of it. It says `1 run` now.

## How was it tested?

A throwaway database seeded with a plausible fleet — sessions with and without titles, prompts, 24 tool runs, a failure with output, an open call — served by a real `server/src/index.ts` on a real port, driven by `phone-audit.ts` at 412×915 with touch emulation.

**Before:** 72/76 checks, with `now · every control is big enough to hit` naming the 380×26 button and `offline · says the connection is gone` failing outright. **After: 89/89.** Both UI fixes are confirmed red-before-green by direct observation rather than by assertion — I watched them fail first.

The detail-title fix has a unit guard in `server/test/session-first-prompt.test.ts`, confirmed red without it. The screenshots were read by eye afterwards, which is where the path-reordering and the "1 failed 1" came from — the sweep passes on both.

Full suites: `web/` 586 pass / 0 fail, `server/` 1046 pass / 0 fail. `bunx tsc --noEmit` clean in both. `bun run build` clean.

## What this changes about the rest of the work

The audit now runs in a container, so it can gate the remaining companion changes instead of being something that only works on your machine. Every PR after this one should carry an audit run, not just a suite run.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_