### PR TITLE
Make the Now queue count once and mean "Later"

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -476,6 +476,55 @@ async function main() {
     note("now", "offers an action per item, or none at all",
       !actions.some((a) => a === ""), `${actions.length} buttons`);
     await shot(cdp, "11-now-queue");
+    await hygiene(cdp, "now");
+
+    // "Later" has to mean what the Settings row says it means. This is the one
+    // place the audit changes anything, and what it changes is localStorage in
+    // a throwaway Chrome profile — nothing on the machine, nothing on GitHub,
+    // no agent touched.
+    if (await cdp.ev(`[...document.querySelectorAll("main .mb-item .acts button")].some(b=>b.textContent.trim()==="Later")`)) {
+      const before = await cdp.ev(`document.querySelectorAll("main .mb-item").length`);
+      const gone = await cdp.ev(`(()=>{const card=[...document.querySelectorAll("main .mb-item")]
+        .find(c=>[...c.querySelectorAll(".acts button")].some(b=>b.textContent.trim()==="Later"));
+        if(!card)return null;const t=card.querySelector(".t")?.textContent||"";
+        [...card.querySelectorAll(".acts button")].find(b=>b.textContent.trim()==="Later").click();return t})()`);
+      await Bun.sleep(700);
+      const after = await cdp.ev(`document.querySelectorAll("main .mb-item").length`);
+      note("later", "the card leaves the queue", after === before - 1, `${before} → ${after}`);
+
+      // The failure this replaces: the list was component state, so the queue
+      // you emptied was full again on the next load.
+      await cdp.send("Page.reload");
+      await until(cdp, `document.querySelector(".mb")`, "the shell after a reload", 25_000);
+      await Bun.sleep(2200);
+      await tap(cdp, "nav button", "Now");
+      await Bun.sleep(1600);
+      note("later", "and stays gone across a reload",
+        !(await cdp.ev(`document.body.textContent.includes(${JSON.stringify(String(gone).slice(0, 40))})`)),
+        `card was: ${gone}`);
+
+      // The count the Settings row shows has to be the store's, not a list in
+      // memory that a reload has already thrown away.
+      await tap(cdp, "header button", "⚙");
+      await Bun.sleep(700);
+      note("later", "Settings counts it as hidden",
+        await cdp.ev(`/1 hidden until they change/.test(document.body.textContent)`),
+        await cdp.ev(`(document.body.textContent.match(/Snoozed[^]{0,40}/)||[""])[0]`));
+      const restored = await tap(cdp, "button", "Restore");
+      note("later", "Restore is offered", restored);
+      await Bun.sleep(600);
+      await cdp.ev(`document.querySelector(".mb-scrim, [data-scrim]")?.click()`);
+      await Bun.sleep(700);
+      // The card itself, not the words in the sheet: "Nothing snoozed" is
+      // trivially true on a device where nothing was ever hidden, so on its own
+      // it cannot tell a working Restore from a Later that never took.
+      note("later", "and Restore actually brings the card back",
+        restored && await cdp.ev(`document.querySelectorAll("main .mb-item").length`) === before,
+        `queue is ${await cdp.ev(`document.querySelectorAll("main .mb-item").length`)}, was ${before}`);
+      await shot(cdp, "11b-later");
+      await hygiene(cdp, "later");
+      await drain(cdp, "later");
+    }
     await drain(cdp, "now");
 
     // ---- the server going away ---------------------------------------

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
 import { api, probeServer } from "../lib/api.ts";
 import { useLive } from "../lib/useLive.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
@@ -15,6 +15,8 @@ import { projectRows } from "./projects.ts";
 import { baseName, ownerOf } from "../../../shared/projectKey.ts";
 import { MobilePr } from "./MobilePr.tsx";
 import { buildQueue, type NowItem } from "./nowQueue.ts";
+import { dedupePrs, mainCheckouts } from "./prRows.ts";
+import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
 import type {
   PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef,
 } from "../../../shared/types.ts";
@@ -134,7 +136,20 @@ export function MobileApp() {
   const [settings, setSettings] = useState(false);
   /** A conversation is open and owns the whole screen: no app header, no tabs. */
   const [immersive, setImmersive] = useState(false);
-  const [dismissed, setDismissed] = useState<string[]>([]);
+  /**
+   * Two different things used to share one list.
+   *
+   * `answered` is a bridge: you allowed a gate or merged a pull request, and
+   * the card should go now rather than when the next poll confirms what you
+   * already know. It is per-mount on purpose — the underlying row is gone from
+   * the server too, so there is nothing to remember.
+   *
+   * "Later" is not that. It outlives the tab and it is keyed on what the card
+   * reports, so it lifts itself the moment there is news — see snooze.ts.
+   */
+  const [answered, setAnswered] = useState<string[]>([]);
+  const snoozeStore = useMemo(() => deviceStore(), []);
+  const [snoozeRev, bumpSnooze] = useReducer((n: number) => n + 1, 0);
 
   // ── the live channel ─────────────────────────────────────────────────
   //
@@ -193,12 +208,27 @@ export function MobileApp() {
     }
   }, []);
 
+  /**
+   * Pull requests, once per project rather than once per checkout.
+   *
+   * Three worktrees of one repository are three entries in this list and one
+   * repository on GitHub, so every open pull request was fetched three times
+   * and queued three times — the same card, three rows apart, and a count of
+   * three where there was one thing to do. `worktreeOf` names the checkout a
+   * worktree belongs to, so only the mains are asked.
+   *
+   * Deduplicated on the answer as well, because two projects can legitimately
+   * point at one GitHub repository (a fork and its upstream, a repo checked out
+   * twice) and folding by path would not catch that. "mine" wins over "review":
+   * a pull request that is both is one you have to fix, not one you have to
+   * look at.
+   */
   const loadPrs = useCallback((list: GitRepoRef[]) => {
-    Promise.all(list.flatMap((r) => (["mine", "review"] as const).map((scope) =>
+    Promise.all(mainCheckouts(list).flatMap((r) => (["mine", "review"] as const).map((scope) =>
       api.prList(r.root, scope, "open")
         .then((res) => res.prs.map((pr) => ({ root: r.root, repo: baseName(r.root), pr, scope })))
         .catch(() => [] as { root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[])
-    ))).then((groups) => setPrs(groups.flat()));
+    ))).then((groups) => setPrs(dedupePrs(groups.flat())));
   }, []);
 
   // Is the machine still there? Its own probe, so the answer is never as old as
@@ -301,10 +331,15 @@ export function MobileApp() {
       }));
   }, [openTools]);
 
-  const queue = useMemo(
+  /** Everything that would be in the queue if nothing had been put away. */
+  const pending = useMemo(
     () => buildQueue({ gates, sessions, prs, containers, me, now: Date.now() })
-      .filter((i) => !dismissed.includes(i.id)),
-    [gates, sessions, prs, containers, me, dismissed]
+      .filter((i) => !answered.includes(i.id)),
+    [gates, sessions, prs, containers, me, answered]
+  );
+  const queue = useMemo(
+    () => unsnoozed(snoozeStore, pending),
+    [pending, snoozeStore, snoozeRev]
   );
 
   /**
@@ -334,7 +369,14 @@ export function MobileApp() {
   /** An answered item leaves the queue at once, before the next poll confirms
    *  it. Waiting four seconds to watch your own tap take effect is what makes
    *  a companion feel like a web page. */
-  const drop = (id: string) => setDismissed((d) => [...d, id]);
+  const drop = (id: string) => setAnswered((d) => [...d, id]);
+
+  /** Put it away until it has something new to say. */
+  const later = (it: NowItem) => {
+    snooze(snoozeStore, it);
+    bumpSnooze();
+    toast("Snoozed — back when it changes");
+  };
 
   const decide = async (id: string, d: "allow" | "deny", itemId: string) => {
     try {
@@ -411,12 +453,13 @@ export function MobileApp() {
           // could not contain it (the list opens on "working"; this card exists
           // because the agent went quiet), and the card was gone from the queue.
           { label: "Open chat", kind: "acc", run: () => openSession(o.session) },
-          { label: "Later", run: () => { drop(it.id); toast("Snoozed"); } },
+          { label: "Later", tight: true, run: () => later(it) },
         ];
       case "pr-red":
         return [
           { label: "See the log", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
           { label: "Re-run", kind: "acc", run: () => settle("Re-running the failed checks", () => api.prRerun(o.root, o.pr.number)) },
+          { label: "Later", tight: true, run: () => later(it) },
         ];
       case "pr-ready":
         return [
@@ -436,11 +479,15 @@ export function MobileApp() {
           { label: "Review", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
         ];
       case "pr-review":
-        return [{ label: "Review", kind: "acc", run: () => setOpenPr({ root: o.root, number: o.pr.number }) }];
+        return [
+          { label: "Review", kind: "acc", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
+          { label: "Later", tight: true, run: () => later(it) },
+        ];
       case "container":
         return [
           { label: "Logs", run: () => openContainer(o.container) },
           { label: "Restart", kind: "acc", run: () => settle(`Restarted ${o.container.name}`, () => api.dockerRestart(o.container.id)) },
+          { label: "Later", tight: true, run: () => later(it) },
         ];
     }
   };
@@ -454,6 +501,16 @@ export function MobileApp() {
 
   const stacked = !!openRepo || !!openPr;
   const spend = stats?.totals ? fmtUsd(stats.totals.cost_usd) : "—";
+  /**
+   * How many cards the queue is hiding *right now*.
+   *
+   * Not the size of the store, which is the number I reached for first and is a
+   * different claim: a snoozed agent that has since ended is an entry nobody
+   * can restore, and counting it would put a Restore button on the sheet that
+   * changes nothing when you press it. The difference between the two lists is
+   * the only figure that survives being acted on.
+   */
+  const snoozed = pending.length - queue.length;
 
   /**
    * One word for the state of the link, and it distinguishes the three cases a
@@ -545,9 +602,9 @@ export function MobileApp() {
           <Row title="Tool errors" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.errors) : "—"} />
         </div>
         <div className="mb-eyebrow" style={{ margin: "16px 0 9px" }}>Queue</div>
-        <Row title="Snoozed" sub={dismissed.length ? `${dismissed.length} hidden until they change` : "Nothing snoozed"}
-          right={dismissed.length
-            ? <Act small onAct={() => { setDismissed([]); toast("Queue restored"); }}>Restore</Act>
+        <Row title="Snoozed" sub={snoozed ? `${snoozed} hidden until they change` : "Nothing snoozed"}
+          right={snoozed
+            ? <Act small onAct={() => { restoreAll(snoozeStore); bumpSnooze(); toast("Queue restored"); }}>Restore</Act>
             : undefined} />
         <p className="text-[10.5px] mt-4 leading-relaxed" style={{ color: "var(--text3)" }}>
           The cockpit stays at the desk. This is the part of agentglass worth having in a pocket.

--- a/web/src/mobile/MobileNow.tsx
+++ b/web/src/mobile/MobileNow.tsx
@@ -73,11 +73,18 @@ export const NOW_CSS = `
   border-left:2px solid color-mix(in srgb,var(--warning) 55%,transparent)}
 .mb-item .acts{display:flex;gap:9px;padding:13px 14px 14px 17px}
 .mb-item .acts>*{flex:1;min-height:50px;border-radius:13px}
+/* "Later" sits beside the real answers rather than sharing their width: three
+   equal thirds put "See the log" on two lines, and putting something away is
+   not the same size of decision as re-running it. */
+.mb-item .acts>.tight{flex:none;display:flex}
+.mb-item .acts>.tight>.mb-btn{min-height:50px;border-radius:13px;padding:0 15px}
 `;
 
 export interface NowAction {
   label: string;
   kind?: "acc" | "ok" | "no" | "dang";
+  /** Sized to its own label instead of taking an equal share of the row. */
+  tight?: boolean;
   run: () => Promise<string | void> | string | void;
 }
 
@@ -176,8 +183,9 @@ export function NowStream({ items, actionsFor, onOpen }: {
           </button>
           {it.code && <div className="code">{it.code}</div>}
           <div className="acts">
-            {actionsFor(it).map((a) => (
-              <Act key={a.label} kind={a.kind} onAct={a.run}>{a.label}</Act>
+            {actionsFor(it).map((a) => (a.tight
+              ? <span className="tight" key={a.label}><Act kind={a.kind} onAct={a.run}>{a.label}</Act></span>
+              : <Act key={a.label} kind={a.kind} onAct={a.run}>{a.label}</Act>
             ))}
           </div>
         </div>

--- a/web/src/mobile/nowQueue.ts
+++ b/web/src/mobile/nowQueue.ts
@@ -30,6 +30,17 @@ export type NowOrigin =
 
 export interface NowItem {
   id: string;
+  /**
+   * What this card is reporting, as a string that stays put while the item does
+   * and differs the moment its state moves. It is what "Later" is keyed on, so
+   * a card comes back by itself once there is something new to say — see
+   * snooze.ts.
+   *
+   * Every kind writes its own, because only the kind knows which of its fields
+   * are the news and which merely tick. `idle 5m` and `Exited (1) 3 hours ago`
+   * are in the copy and are not in here.
+   */
+  mark: string;
   tone: NowTone;
   /** The eyebrow: what kind of thing this is, in the user's words. */
   kind: string;
@@ -72,7 +83,7 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
 
   for (const g of gates) {
     out.push({
-      id: `gate:${g.id}`, tone: "crit",
+      id: `gate:${g.id}`, mark: `gate:${g.id}`, tone: "crit",
       kind: "Blocked · waiting on you",
       title: g.summary || g.tool_name,
       sub: `${g.source_app} · the agent is stopped until you answer`,
@@ -86,7 +97,10 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
     const quiet = now - s.last_seen;
     if (quiet < QUIET_MS || quiet > STALE_MS) continue;
     out.push({
-      id: `session:${s.session_id}`, tone: "plain",
+      id: `session:${s.session_id}`,
+      // It spoke again: that is the change, even if it has since gone quiet.
+      mark: `session:${s.session_id}:${s.last_seen}`,
+      tone: "plain",
       kind: "Stopped · wants direction",
       title: sessionTitle(s),
       sub: `${projectName(s)} · idle ${Math.round(quiet / 60_000)}m`,
@@ -103,7 +117,11 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
     // Yours and broken: nobody else is going to fix it.
     if (mine && red) {
       out.push({
-        id: `red:${repo}#${pr.number}`, tone: "bad",
+        id: `red:${repo}#${pr.number}`,
+        // A push moves `updatedAt`; a re-run that fails somewhere else moves
+        // the failing set. Either is worth surfacing again.
+        mark: `red:${repo}#${pr.number}:${pr.updatedAt}:${pr.checks.failing.map((f) => f.name).sort().join(",")}`,
+        tone: "bad",
         kind: "CI went red",
         title: `${pr.checks.failing[0]?.name ?? "A check"} is failing on #${pr.number}`,
         sub: `${pr.title} · ${repo}`,
@@ -115,7 +133,9 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
     // here that finishes rather than starts work.
     if (mine && green && pr.reviewDecision === "APPROVED" && !pr.isDraft) {
       out.push({
-        id: `ready:${repo}#${pr.number}`, tone: "good",
+        id: `ready:${repo}#${pr.number}`,
+        mark: `ready:${repo}#${pr.number}:${pr.updatedAt}`,
+        tone: "good",
         kind: "Ready to merge",
         title: `#${pr.number} ${pr.title}`,
         sub: `Approved · ${pr.checks.total} checks green · ${repo}`,
@@ -126,7 +146,9 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
     // Somebody asked for your eyes.
     if (!mine && scope === "review") {
       out.push({
-        id: `review:${repo}#${pr.number}`, tone: "plain",
+        id: `review:${repo}#${pr.number}`,
+        mark: `review:${repo}#${pr.number}:${pr.updatedAt}`,
+        tone: "plain",
         kind: "Review requested",
         title: `#${pr.number} ${pr.title}`,
         sub: `${pr.author} asked you · +${pr.additions} −${pr.deletions} across ${pr.changedFiles} files`,
@@ -139,7 +161,11 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
     if (!containerIsWrong(c)) continue;
     const looping = c.state === "restarting";
     out.push({
-      id: `ctr:${c.id}`, tone: "bad",
+      id: `ctr:${c.id}`,
+      // Not the status line: docker rewrites that every minute ("Exited (1) 3
+      // hours ago"), and a mark that ticks is a snooze that never holds.
+      mark: `ctr:${c.id}:${c.state}:${exitCode(c) ?? "?"}`,
+      tone: "bad",
       kind: "Container down",
       title: looping ? `${c.name} is restarting in a loop` : `${c.name} is ${c.state}`,
       sub: `${c.project ? c.project + " · " : ""}${c.status}`,
@@ -162,9 +188,13 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
 export function containerIsWrong(c: DockerContainer): boolean {
   if (c.state === "running" || c.state === "created") return false;
   if (c.state === "restarting" || c.state === "dead") return true;
-  // Docker writes the code into the status: "Exited (0) 3 hours ago".
-  const code = c.status.match(/\((\d+)\)/)?.[1];
+  const code = exitCode(c);
   return code == null ? true : code !== "0";
+}
+
+/** Docker writes the code into the status: "Exited (0) 3 hours ago". */
+function exitCode(c: DockerContainer): string | null {
+  return c.status.match(/\((\d+)\)/)?.[1] ?? null;
 }
 
 /** One rule for naming a project — see shared/projectKey.ts. This was the

--- a/web/src/mobile/prRows.ts
+++ b/web/src/mobile/prRows.ts
@@ -1,0 +1,55 @@
+/**
+ * Which directories to ask about, and what to do when they answer the same.
+ *
+ * This machine keeps several linked worktrees of the same repository — that is
+ * the point of them — and the phone asked every one of them for its open pull
+ * requests. GitHub answered each with the same list, because a worktree is not
+ * a fork: it is the same remote and the same pull requests. So one red pull
+ * request drew three identical cards, the Now hero counted three things wanting
+ * you, and the tab badge agreed with it.
+ *
+ * Both halves live here rather than inline in the fetch, so both can be tested
+ * without the application graph behind them.
+ */
+
+/** A checkout, reduced to what deciding this needs. */
+export interface Checkout {
+  root: string;
+  /** Set when this checkout is a linked worktree of another one — see
+   *  GitRepoRef in shared/types.ts. */
+  worktreeOf?: string;
+}
+
+/**
+ * The checkouts worth asking, which is one per repository.
+ *
+ * A worktree whose main checkout is *not* in the list is kept: the answer has
+ * to come from somewhere, and dropping it would lose the pull requests of a
+ * repository the phone can otherwise see.
+ */
+export function mainCheckouts<T extends Checkout>(list: readonly T[]): T[] {
+  const roots = new Set(list.map((r) => r.root));
+  return list.filter((r) => !(r.worktreeOf && roots.has(r.worktreeOf)));
+}
+
+/**
+ * One row per pull request, however many checkouts asked about it.
+ *
+ * Keyed on the pull request's own identity — its URL, falling back to the
+ * repository and number — rather than on the directory that happened to fetch
+ * it. `mine` is kept over `review` when both come back: a pull request you own
+ * and were also asked to review is a thing to fix, and the queue should say so.
+ */
+export function dedupePrs<T extends { repo: string; pr: { number: number; url?: string }; scope: "mine" | "review" }>(
+  rows: readonly T[],
+): T[] {
+  const out = new Map<string, T>();
+  for (const row of rows) {
+    // The URL identifies the pull request on GitHub; the local directory name
+    // does not, and two checkouts of one repo do not have to share it.
+    const key = row.pr.url || `${row.repo}#${row.pr.number}`;
+    const seen = out.get(key);
+    if (!seen || (seen.scope === "review" && row.scope === "mine")) out.set(key, row);
+  }
+  return [...out.values()];
+}

--- a/web/src/mobile/snooze.ts
+++ b/web/src/mobile/snooze.ts
@@ -1,0 +1,115 @@
+/**
+ * "Later", and what it means.
+ *
+ * The Settings row promised "hidden until they change". It was a lie twice
+ * over: the list lived in component state, so the queue you emptied refilled on
+ * every reload — and it was keyed on the item's id, which for a stalled agent
+ * or a red pull request never changes, so a card really was hidden forever
+ * rather than until anything about it moved.
+ *
+ * Both halves matter, and the second is the interesting one. A queue you can
+ * empty is the whole idea of the Now tab; a queue that hides a pull request
+ * whose checks have since gone from red to green is worse than one that never
+ * hid anything, because you would never learn.
+ *
+ * So an item is snoozed by a mark: a string the queue builder writes to say
+ * what state this card is reporting. Change the state and it comes back on its
+ * own. What a mark must *not* contain is anything that moves while the item
+ * sits still — a first attempt keyed this on the card's own copy, which reads
+ * `idle 5m` on a stalled agent and `Exited (1) 3 hours ago` on a container, so
+ * every snooze would have expired inside a minute. See nowQueue.ts, where each
+ * kind decides for itself.
+ *
+ * Its own module, with no imports, so a test of it does not pull the whole
+ * application graph in behind it.
+ */
+
+/** How long a snooze survives even if nothing about the item changes. */
+const MAX_MS = 12 * 60 * 60_000;
+
+export interface SnoozeItem {
+  /** What this card is currently reporting — see nowQueue.ts. */
+  mark: string;
+}
+
+export interface SnoozeStore {
+  getItem(key: string): string | null;
+  setItem(key: string, value: string): void;
+}
+
+const KEY = "mb.snoozed";
+
+type Entry = { at: number };
+type Saved = Record<string, Entry>;
+
+function read(store: SnoozeStore, now: number): Saved {
+  try {
+    const raw = store.getItem(KEY);
+    if (!raw) return {};
+    const parsed = JSON.parse(raw) as Saved;
+    if (!parsed || typeof parsed !== "object") return {};
+    // Drop anything past the ceiling on the way in, so a device that has been
+    // used for months does not accumulate a snooze list nobody remembers
+    // making.
+    const kept: Saved = {};
+    for (const [k, v] of Object.entries(parsed)) {
+      if (v && typeof v.at === "number" && now - v.at < MAX_MS) kept[k] = v;
+    }
+    return kept;
+  } catch {
+    // A corrupt or foreign value is not worth failing the tab over; the cost of
+    // being wrong here is that a card you dismissed comes back once.
+    return {};
+  }
+}
+
+function write(store: SnoozeStore, saved: Saved): void {
+  try { store.setItem(KEY, JSON.stringify(saved)); } catch { /* private mode, quota */ }
+}
+
+/** Hide this card until what it reports changes, or until the ceiling. */
+export function snooze(store: SnoozeStore, it: SnoozeItem, now = Date.now()): void {
+  const saved = read(store, now);
+  saved[it.mark] = { at: now };
+  write(store, saved);
+}
+
+export function restoreAll(store: SnoozeStore): void {
+  write(store, {});
+}
+
+/** The items still worth showing. */
+export function unsnoozed<T extends SnoozeItem>(
+  store: SnoozeStore,
+  items: readonly T[],
+  now = Date.now(),
+): T[] {
+  const saved = read(store, now);
+  if (!Object.keys(saved).length) return [...items];
+  return items.filter((it) => !saved[it.mark]);
+}
+
+const memory = new Map<string, string>();
+
+/**
+ * Where a snooze lives on this device.
+ *
+ * Probed with a write rather than a read, because the mode that actually bites
+ * is the one where reading works and `setItem` throws — Safari with site data
+ * blocked, or a full quota. A read probe passes there, and then every "Later"
+ * you tap is silently a no-op, which is the exact promise this module exists to
+ * stop breaking. Falling back costs the snooze its durability and keeps it
+ * working for as long as the tab lives, which is what everybody had before.
+ */
+export function deviceStore(): SnoozeStore {
+  try {
+    const probe = KEY + ".probe";
+    localStorage.setItem(probe, "1");
+    localStorage.removeItem(probe);
+    return localStorage;
+  } catch { /* blocked by policy, or out of quota */ }
+  return {
+    getItem: (k) => memory.get(k) ?? null,
+    setItem: (k, v) => { memory.set(k, v); },
+  };
+}

--- a/web/test/queue-truth.test.ts
+++ b/web/test/queue-truth.test.ts
@@ -1,0 +1,284 @@
+/*
+ * A queue you can believe, in the two ways it was lying.
+ *
+ * One: the count. Pull requests were fetched per *checkout*, and this machine
+ * keeps three worktrees of the same repository, so one red pull request drew
+ * three identical cards and told you there were three things to do.
+ *
+ * Two: "Later". The Settings row said "hidden until they change" and neither
+ * half held — the list was component state, so the queue you emptied refilled
+ * on reload, and it was keyed on the item's id, which for a stalled agent or a
+ * red pull request never changes at all.
+ *
+ * The fix for the second turns on `mark`: what a card is reporting, written by
+ * the kind that knows which of its fields are news. The trap it has to avoid is
+ * the copy, which reads `idle 5m` and `Exited (1) 3 hours ago` — key a snooze
+ * on that and every one of them expires within the minute.
+ */
+import { describe, expect, it } from "bun:test";
+import { buildQueue, type NowInput } from "../src/mobile/nowQueue.ts";
+import { dedupePrs, mainCheckouts } from "../src/mobile/prRows.ts";
+import {
+  deviceStore, restoreAll, snooze, unsnoozed, type SnoozeStore,
+} from "../src/mobile/snooze.ts";
+import type { SessionRollup, PrSummary, DockerContainer } from "../../shared/types.ts";
+
+const NOW = 1_700_000_000_000;
+const base: NowInput = { gates: [], sessions: [], prs: [], containers: [], me: "me", now: NOW };
+
+const rollup = (over: Partial<PrSummary["checks"]> = {}) => ({
+  total: 5, success: 5, failure: 0, skipped: 0, pending: 0,
+  allDone: true, verdict: "green" as const, failing: [], ...over,
+});
+
+const pr = (over: Partial<PrSummary> = {}): PrSummary => ({
+  number: 482, title: "Round prices at the cart boundary", author: "me",
+  state: "OPEN", isDraft: false, headRefName: "fix/x", baseRefName: "main",
+  url: "https://github.com/a/b/pull/482", updatedAt: new Date(NOW - 60_000).toISOString(),
+  reviewDecision: null, additions: 84, deletions: 31, changedFiles: 6,
+  labels: [], assignees: [], milestone: null, checks: rollup(), checksLoaded: true, ...over,
+});
+
+const session = (over: Partial<SessionRollup> = {}): SessionRollup => ({
+  session_id: "s1", source_app: "claude-code", model_name: "opus",
+  project_path: "/home/me/shop-api", ai_title: "Round prices at the boundary",
+  started_at: NOW - 3_600_000, ended_at: null, last_seen: NOW - 6 * 60_000,
+  event_count: 10, tool_count: 4, error_count: 0,
+  input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: 1,
+  ...over,
+});
+
+const ctr = (over: Partial<DockerContainer> = {}): DockerContainer => ({
+  id: "c1", name: "otel-collector", image: "otel/collector", state: "exited",
+  status: "Exited (1) 3 hours ago", ports: "", project: "infra", service: "otel",
+  runningFor: "3 hours", size: "0B", ...over,
+});
+
+/** A localStorage that is only a Map, so a test can hold two of them. */
+function fakeStore(): SnoozeStore & { raw: Map<string, string> } {
+  const raw = new Map<string, string>();
+  return { raw, getItem: (k) => raw.get(k) ?? null, setItem: (k, v) => { raw.set(k, v); } };
+}
+
+// ── one pull request is one card ───────────────────────────────────────
+
+describe("counting a pull request once", () => {
+  const rows = (scope: "mine" | "review", repo = "shop-api", number = 482) =>
+    ({ repo, scope, pr: { number, url: `https://github.com/a/${repo}/pull/${number}` } });
+
+  it("three worktrees of one repository still make one card", () => {
+    // Every checkout of a repository answers the same question with the same
+    // answer. Before this, the queue said "3 things want you" and the hero's
+    // number was the number of directories on disk.
+    expect(dedupePrs([rows("mine"), rows("mine"), rows("mine")])).toHaveLength(1);
+  });
+
+  it("yours wins over asked-to-review when both come back", () => {
+    // A pull request you own and were also added to is a thing to fix, not a
+    // thing to read. Whichever order the two fetches land in.
+    expect(dedupePrs([rows("review"), rows("mine")])[0]!.scope).toBe("mine");
+    expect(dedupePrs([rows("mine"), rows("review")])[0]!.scope).toBe("mine");
+  });
+
+  it("the same number in two repositories is two things", () => {
+    const out = dedupePrs([rows("mine", "shop-api"), rows("mine", "shop-web")]);
+    expect(out).toHaveLength(2);
+  });
+
+  it("asks one checkout per repository, not one per directory", () => {
+    // The root cause. Three worktrees is a normal way to work here, and each
+    // one answered GitHub's question identically because a worktree shares the
+    // remote — so the fix is to stop asking three times, and dedupe is the
+    // belt to that pair of braces.
+    const list = [
+      { root: "/w/shop-api" },
+      { root: "/w/shop-api-fix", worktreeOf: "/w/shop-api" },
+      { root: "/w/shop-api-spike", worktreeOf: "/w/shop-api" },
+      { root: "/w/shop-web" },
+    ];
+    expect(mainCheckouts(list).map((r) => r.root)).toEqual(["/w/shop-api", "/w/shop-web"]);
+  });
+
+  it("keeps a worktree whose main checkout the phone cannot see", () => {
+    // Otherwise that repository's pull requests vanish entirely, which is a
+    // worse bug than counting them twice.
+    const list = [{ root: "/w/detached", worktreeOf: "/elsewhere/shop-api" }];
+    expect(mainCheckouts(list)).toHaveLength(1);
+  });
+
+  it("falls back to repo and number when there is no url", () => {
+    const bare = (scope: "mine" | "review") => ({ repo: "shop-api", scope, pr: { number: 482 } });
+    expect(dedupePrs([bare("mine"), bare("review")])).toHaveLength(1);
+  });
+});
+
+// ── what "unchanged" means ─────────────────────────────────────────────
+
+describe("the mark a snooze is keyed on", () => {
+  const input: NowInput = {
+    ...base,
+    sessions: [session()],
+    containers: [ctr()],
+    prs: [{ root: "/r", repo: "shop-api", scope: "mine", pr: pr({ checks: rollup({ failure: 1, failing: [{ name: "test" }] as PrSummary["checks"]["failing"] }) }) }],
+  };
+
+  it("does not move just because time passed", () => {
+    // The rule, over every kind at once: nothing in a mark may be derived from
+    // `now`. An hour and a half is far past the minute at which `idle 5m` and
+    // docker's "3 hours ago" both roll over.
+    const later = 90 * 60_000;
+    const a = buildQueue(input);
+    const b = buildQueue({
+      ...input,
+      now: NOW + later,
+      sessions: input.sessions.map((s) => ({ ...s })),
+      containers: [ctr({ status: "Exited (1) 4 hours ago" })],
+    });
+    expect(b.map((i) => i.mark)).toEqual(a.map((i) => i.mark));
+  });
+
+  it("and the copy does move, which is why it cannot be the key", () => {
+    // Guards the guard above: if the subtitles were static, the test would pass
+    // for the wrong reason.
+    const a = buildQueue(input);
+    const b = buildQueue({ ...input, now: NOW + 90 * 60_000 });
+    expect(b.map((i) => i.sub)).not.toEqual(a.map((i) => i.sub));
+  });
+
+  it("moves when the agent speaks again", () => {
+    const a = buildQueue({ ...base, sessions: [session({ last_seen: NOW - 6 * 60_000 })] });
+    const b = buildQueue({ ...base, sessions: [session({ last_seen: NOW - 5 * 60_000 })] });
+    expect(b[0]!.mark).not.toBe(a[0]!.mark);
+    expect(b[0]!.id).toBe(a[0]!.id);
+  });
+
+  it("moves when a different check is the one failing", () => {
+    const red = (name: string) => buildQueue({
+      ...base,
+      prs: [{ root: "/r", repo: "shop-api", scope: "mine", pr: pr({ checks: rollup({ failure: 1, failing: [{ name }] as PrSummary["checks"]["failing"] }) }) }],
+    })[0]!;
+    expect(red("unit").mark).not.toBe(red("e2e").mark);
+  });
+
+  it("moves when a container's exit code changes but not when its age does", () => {
+    const mark = (over: Partial<DockerContainer>) =>
+      buildQueue({ ...base, containers: [ctr(over)] })[0]!.mark;
+    expect(mark({ status: "Exited (1) 3 hours ago" }))
+      .toBe(mark({ status: "Exited (1) 9 hours ago" }));
+    expect(mark({ status: "Exited (1) 3 hours ago" }))
+      .not.toBe(mark({ status: "Exited (137) 3 hours ago" }));
+  });
+});
+
+// ── later, and how it lifts ────────────────────────────────────────────
+
+describe("Later", () => {
+  const item = (mark: string) => ({ mark });
+
+  it("hides the card", () => {
+    const s = fakeStore();
+    snooze(s, item("a"), NOW);
+    expect(unsnoozed(s, [item("a"), item("b")], NOW).map((i) => i.mark)).toEqual(["b"]);
+  });
+
+  it("survives the tab being closed", () => {
+    // The whole failure of the old one: `dismissed` was useState, so a queue
+    // you emptied on the train was full again at the office.
+    const s = fakeStore();
+    snooze(s, item("a"), NOW);
+    const reopened: SnoozeStore = { getItem: (k) => s.raw.get(k) ?? null, setItem: () => {} };
+    expect(unsnoozed(reopened, [item("a")], NOW)).toHaveLength(0);
+  });
+
+  it("lifts itself the moment the card has something new to say", () => {
+    const s = fakeStore();
+    snooze(s, item("red:shop#482:T1:unit"), NOW);
+    // Checks re-ran and a different one failed.
+    expect(unsnoozed(s, [item("red:shop#482:T1:e2e")], NOW)).toHaveLength(1);
+  });
+
+  it("lifts after twelve hours even if nothing changed", () => {
+    const s = fakeStore();
+    snooze(s, item("a"), NOW);
+    expect(unsnoozed(s, [item("a")], NOW + 11 * 3_600_000)).toHaveLength(0);
+    expect(unsnoozed(s, [item("a")], NOW + 13 * 3_600_000)).toHaveLength(1);
+  });
+
+  it("Restore brings back everything at once", () => {
+    const s = fakeStore();
+    snooze(s, item("a"), NOW);
+    snooze(s, item("b"), NOW);
+    expect(unsnoozed(s, [item("a"), item("b")], NOW)).toHaveLength(0);
+    restoreAll(s);
+    expect(unsnoozed(s, [item("a"), item("b")], NOW)).toHaveLength(2);
+  });
+
+  it("does not accumulate expired entries on the way through", () => {
+    const s = fakeStore();
+    snooze(s, item("old"), NOW);
+    snooze(s, item("new"), NOW + 13 * 3_600_000);
+    expect(JSON.parse(s.raw.get("mb.snoozed")!)).toEqual({ new: { at: NOW + 13 * 3_600_000 } });
+  });
+
+  it("shows everything rather than failing on a value it cannot read", () => {
+    const bad: SnoozeStore = { getItem: () => "{not json", setItem: () => {} };
+    expect(unsnoozed(bad, [item("a")], NOW)).toHaveLength(1);
+    expect(unsnoozed({ getItem: () => "[1,2,3]", setItem: () => {} }, [item("a")], NOW)).toHaveLength(1);
+  });
+
+  /** Runs `fn` with `localStorage` replaced, however it is broken today. */
+  function withStorage(desc: PropertyDescriptor, fn: () => void) {
+    const real = Object.getOwnPropertyDescriptor(globalThis, "localStorage");
+    Object.defineProperty(globalThis, "localStorage", { configurable: true, ...desc });
+    try { fn(); } finally {
+      if (real) Object.defineProperty(globalThis, "localStorage", real);
+      else delete (globalThis as Record<string, unknown>).localStorage;
+    }
+  }
+
+  it("keeps working where touching localStorage throws", () => {
+    // Safari with site data blocked throws on access rather than returning
+    // null. A phone in that mode should get the tab-lifetime behaviour
+    // everybody had before this module, not a crashed queue.
+    withStorage({ get() { throw new Error("SecurityError"); } }, () => {
+      const s = deviceStore();
+      restoreAll(s);
+      snooze(s, item("a"), NOW);
+      expect(unsnoozed(s, [item("a")], NOW)).toHaveLength(0);
+    });
+  });
+
+  it("keeps working where reads succeed and writes throw", () => {
+    // The case a read probe cannot see, and the one that matters most: every
+    // "Later" you tap would be accepted and do nothing at all.
+    withStorage({
+      value: {
+        getItem: () => null,
+        setItem: () => { throw new Error("QuotaExceededError"); },
+        removeItem: () => {},
+      },
+    }, () => {
+      const s = deviceStore();
+      restoreAll(s);
+      snooze(s, item("a"), NOW);
+      expect(unsnoozed(s, [item("a")], NOW)).toHaveLength(0);
+    });
+  });
+
+  it("uses localStorage when localStorage works", () => {
+    // And the other way round: the fallback must not swallow the durable path,
+    // or nothing survives a reload and we are back where we started.
+    const raw = new Map<string, string>();
+    withStorage({
+      value: {
+        getItem: (k: string) => raw.get(k) ?? null,
+        setItem: (k: string, v: string) => { raw.set(k, v); },
+        removeItem: (k: string) => { raw.delete(k); },
+      },
+    }, () => {
+      snooze(deviceStore(), item("a"), NOW);
+      expect(raw.get("mb.snoozed")).toContain("\"a\"");
+      expect([...raw.keys()]).toEqual(["mb.snoozed"]);
+    });
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Two things the Now queue was saying that were not true.

**The count.** Pull requests were fetched once per checkout. A linked worktree is not a fork — it shares the remote and therefore the pull requests — so three worktrees of one repository drew three identical cards, the hero counted three things wanting you, and the tab badge agreed with it. Only the mains are asked now, and the answers are deduplicated on the pull request's own URL as well, because two projects can legitimately point at one GitHub repository. `mine` wins over `review`: a pull request that is both is one you have to fix, not one you have to read.

**"Later".** The Settings row promised *hidden until they change* and neither half held. The list lived in component state, so a queue emptied on the train was full again at the office. And it was keyed on the item's id, which for a stalled agent or a red pull request never changes — so a card stayed hidden until the tab closed, and stayed hidden even after its checks went green, which is worse than never hiding anything, because you would never learn.

A snooze is now keyed on a `mark`: what the card is reporting, written by the kind of item that knows which of its fields are news. The first attempt keyed it on the card's rendered copy, and that copy reads `idle 5m` and `Exited (1) 3 hours ago` — every snooze would have expired inside a minute. So a container's mark carries its exit code and not docker's status line, and a session's carries `last_seen`, which moving means the agent spoke. Twelve hours is the ceiling either way.

The Settings row counts the difference between the queue with and without the hidden items, not the size of the store. A snoozed agent that has since ended is an entry nobody can restore, and offering a Restore button that changes nothing when pressed is the same lie in miniature.

"Later" is now on every card except a blocked agent, which has to be answered. It is sized to its own label rather than taking an equal third of the row, which put "See the log" on two lines.

## How was it tested?

`web/test/queue-truth.test.ts`, 21 tests. Both suites green: 607 in `web/`, 1046 in `server/`.

Every guard was run red first, by mutating the thing it claims to protect and confirming the failure — fifteen mutations, each reverted:

- `mainCheckouts` returns the list unchanged, `dedupePrs` keys on something unique per row, first-scope-wins instead of mine-wins
- the container mark carries docker's status line; the session mark drops `last_seen`; the session mark is derived from `now`; the red mark drops the failing set
- a snooze never expires; `unsnoozed` shows everything; the snooze keyed on identity rather than on what the card reports (write side and read side separately); expired entries still counted as hidden
- `deviceStore` probes with a read instead of a write; `deviceStore` always falls back to memory

The strongest of these is a rule rather than an assertion about today's call sites: advancing the clock by ninety minutes, with every input otherwise identical, must not change any item's mark — over every kind at once. A second test guards that one by confirming the *copy* does change over the same ninety minutes, so the first cannot pass because the subtitles happen to be static.

`deviceStore` is probed with a write, not a read. The mode that bites is the one where reading works and `setItem` throws — Safari with site data blocked, or a full quota. A read probe passes there, and then every "Later" you tap is silently a no-op, which is the exact promise this change exists to stop breaking. Three storage modes are covered: access throws, writes throw, and everything works (that last one so the fallback cannot quietly swallow the durable path).

**Driven on a real server, not only in the suites.** `scripts/phone-audit.ts` now walks the whole journey at a phone viewport against a live fleet: snooze a card, confirm it leaves, reload the page, confirm it is still gone, open Settings, confirm the count, press Restore, confirm the card comes back. 102/102 checks pass.

That journey was itself verified by breaking it: making the store's `write` a no-op — exactly the old component-state behaviour — turns four of the five red. The fifth stayed green, because it was asserting on the words "Nothing snoozed", which are trivially true on a device where nothing was ever hidden. It now asserts the card itself returned to the queue.