### PR TITLE
Give a repository stopped part-way a face and a way out

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -73,7 +73,7 @@ const drain = async (cdp: CDP, screen: string) => {
  * than only the ones someone thought to look at.
  */
 const HYGIENE = `(() => {
-  const bad = { overflow: [], tiny: [], clipped: [], covered: [] };
+  const bad = { overflow: [], tiny: [], clipped: [], covered: [], inert: [] };
   const vw = innerWidth, vh = innerHeight;
   // A screen that is closed is still mounted, parked one viewport to the right.
   // Everything inside it "overflows" by exactly that much and none of it is on
@@ -114,6 +114,15 @@ const HYGIENE = `(() => {
       || el.getAttribute("role") === "tab" || el.tagName === "A";
     if (tappable && (r.height < 36 || r.width < 24)) bad.tiny.push(name(el) + " " + Math.round(r.width) + "x" + Math.round(r.height));
 
+    // A control that will do nothing has to look like it will do nothing. The
+    // costly version of this is a filled, primary-coloured button that is the
+    // most prominent thing on the screen and is inert — "Finish the merge"
+    // before the conflicts are resolved. \`.mb-press:disabled\` dims to .38 and
+    // this is what stops a later rule from quietly out-specifying it.
+    if (el.tagName === "BUTTON" && el.disabled && Number(getComputedStyle(el).opacity) > 0.75) {
+      bad.inert.push(name(el) + " opacity=" + getComputedStyle(el).opacity);
+    }
+
     // Text cut off with no ellipsis and no way to scroll to it.
     const s = getComputedStyle(el);
     if (el.children.length === 0 && el.textContent && el.textContent.trim()
@@ -130,6 +139,7 @@ const hygiene = async (cdp: CDP, screen: string) => {
   note(screen, "nothing reaches past the right edge", !b.overflow?.length, b.overflow?.slice(0, 3).join(" | "));
   note(screen, "every control is big enough to hit", !b.tiny?.length, b.tiny?.slice(0, 3).join(" | "));
   note(screen, "no text is cut off without an ellipsis", !b.clipped?.length, b.clipped?.slice(0, 3).join(" | "));
+  note(screen, "a control that does nothing looks like it", !b.inert?.length, b.inert?.slice(0, 3).join(" | "));
 };
 
 const shot = async (cdp: CDP, name: string) => {
@@ -341,10 +351,42 @@ async function main() {
       await tap(cdp, ".mb-screen.on button", "Changes");
       await Bun.sleep(1600);
       const files = await texts(cdp, ".mb-screen .mb-row b");
-      note("changes", "lists the changed files", files.length > 0, `${files.length} rows`);
-      note("changes", "file paths carry no diff prefix",
-        files.length > 0 && !files.some((f) => /^[abciwo]\//.test(f)),
-        files.filter((f) => /^[abciwo]\//.test(f)).join(", ") || "(list was empty)");
+
+      // A checkout git stopped half-way through is a different repository to
+      // check. `git diff` emits a combined diff for an unmerged path and the
+      // tree parser does not turn that into a file row, so the one file you
+      // have to act on is the one the changes list omits — which is why the
+      // banner lists it itself. Assert what is true of the state the repo is
+      // actually in rather than lowering the bar for every repo.
+      const halted = await cdp.ev(`!!document.querySelector(".mb-screen.on .mb-halt")`);
+      if (halted) {
+        note("halt", "a stopped repository says so", true,
+          await cdp.ev(`document.querySelector(".mb-screen.on .mb-halt .hh b")?.textContent`));
+        note("halt", "and does not claim the tree is clean",
+          !(await cdp.ev(`(document.querySelector(".mb-screen.on")?.textContent||"").includes("The working tree is clean")`)));
+        note("halt", "lists what is in the way",
+          await cdp.ev(`document.querySelectorAll(".mb-screen.on .mb-halt .cr").length > 0`),
+          `${await cdp.ev(`document.querySelectorAll(".mb-screen.on .mb-halt .cr").length`)} conflicted`);
+        note("halt", "offers a way out",
+          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .mb-halt .ha button")]
+            .some(b=>/abandon|end the/i.test(b.textContent))`));
+        note("halt", "will not offer to finish while anything is conflicted",
+          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .mb-halt .ha button")]
+            .filter(b=>/finish|continue/i.test(b.textContent)).every(b=>b.disabled)`));
+        // A long path must not push the verbs off the right edge.
+        note("halt", "the path yields and the verbs do not",
+          await cdp.ev(`[...document.querySelectorAll(".mb-screen.on .mb-halt .cr")].every(r=>{
+            const rr=r.getBoundingClientRect();
+            return [...r.children].every(c=>c.getBoundingClientRect().right<=rr.right+1);})`));
+        await shot(cdp, "05b-halted");
+        await hygiene(cdp, "halt");
+        await drain(cdp, "halt");
+      } else {
+        note("changes", "lists the changed files", files.length > 0, `${files.length} rows`);
+        note("changes", "file paths carry no diff prefix",
+          files.length > 0 && !files.some((f) => /^[abciwo]\//.test(f)),
+          files.filter((f) => /^[abciwo]\//.test(f)).join(", ") || "(list was empty)");
+      }
       await shot(cdp, "05-changes");
       await drain(cdp, "changes");
       await hygiene(cdp, "changes");

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1443,6 +1443,11 @@ export function mergeAbort(rootIn: unknown): GitActionResult {
   if (state === "rebasing") return run(root, ["rebase", "--abort"]);
   if (state === "cherry-picking") return run(root, ["cherry-pick", "--abort"]);
   if (state === "reverting") return run(root, ["revert", "--abort"]);
+  // A bisect is not a merge, and the fallthrough treated it as one: this ran
+  // `git merge --abort` and came back with "There is no merge to abort", so a
+  // repository left mid-bisect was a dead end on every surface — treeState()
+  // named the state, the header showed it, and nothing could leave it.
+  if (state === "bisecting") return run(root, ["bisect", "reset"]);
   return run(root, ["merge", "--abort"]);
 }
 

--- a/server/test/conflicts.test.ts
+++ b/server/test/conflicts.test.ts
@@ -68,6 +68,25 @@ describe("merge conflicts", () => {
     expect(gw.conflicts(repo).state).toBe("clean");
   });
 
+  it("gets a repository out of a bisect", () => {
+    // The fallthrough treated every state that was not a rebase, a cherry-pick
+    // or a revert as a merge, so this ran `git merge --abort` and came back
+    // with "There is no merge to abort". treeState() named the state and the
+    // header showed it; nothing could leave it.
+    const head = run(repo, "rev-parse", "HEAD").stdout.trim();
+    run(repo, "bisect", "start");
+    run(repo, "bisect", "bad", "HEAD");
+    run(repo, "bisect", "good", "HEAD~2");
+    expect(gw.conflicts(repo).state).toBe("bisecting");
+
+    const r = gw.mergeAbort(repo);
+    expect(r.ok).toBe(true);
+    expect(gw.conflicts(repo).state).toBe("clean");
+    // And back on the commit you started from, not on whichever one the search
+    // had checked out.
+    expect(run(repo, "rev-parse", "HEAD").stdout.trim()).toBe(head);
+  });
+
   it("aborts a merge and leaves the tree as it was", () => {
     const before = readFileSync(join(repo, "shared.txt"), "utf8");
     run(repo, "checkout", "-q", "-b", "second", "HEAD~1");

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -10,7 +10,7 @@ import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobile
 import { pollWhileVisible } from "../lib/poll.ts";
 import { DIFF_CSS } from "./MobileDiff.tsx";
 import { NOW_CSS, NowHero, NowStream, type NowAction, type LiveCall } from "./MobileNow.tsx";
-import { RepoList, RepoScreen, ContainerScreen, type RepoSummary } from "./MobileRepo.tsx";
+import { RepoList, RepoScreen, ContainerScreen, HALT_CSS, type RepoSummary } from "./MobileRepo.tsx";
 import { projectRows } from "./projects.ts";
 import { baseName, ownerOf } from "../../../shared/projectKey.ts";
 import { MobilePr } from "./MobilePr.tsx";
@@ -18,7 +18,7 @@ import { buildQueue, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
 import type {
-  PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef,
+  PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef, GitTreeState,
 } from "../../../shared/types.ts";
 
 /**
@@ -104,7 +104,13 @@ export function MobileApp() {
   const [sessions, setSessions] = useState<SessionRollup[]>([]);
   const [reachable, setReachable] = useState(true);
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
-  const [trees, setTrees] = useState<Record<string, { branch: string; dirty: number; ahead: number; behind: number }>>({});
+  const [trees, setTrees] = useState<Record<string, {
+    branch: string; dirty: number; ahead: number; behind: number;
+    /** What git is in the middle of, and what is in the way of finishing it.
+     *  Read from the tree the poll already fetches; the conflicted paths cost
+     *  a second request, made only for a checkout that is actually stopped. */
+    state?: GitTreeState; conflicts: string[];
+  }>>({});
   const [containers, setContainers] = useState<DockerContainer[]>([]);
   const [dstats, setDstats] = useState<DockerStat[]>([]);
   /** Whether docker answered at all, and what it said if not. The server
@@ -195,16 +201,30 @@ export function MobileApp() {
 
   const loadTrees = useCallback((list: GitRepoRef[]) => {
     for (const r of list) {
-      api.gitTree(r.root).then((t) => setTrees((cur) => ({
-        ...cur,
-        [r.root]: {
-          branch: t.branch.name,
-          // A file part-staged appears in both lists; counting it twice would
-          // report more work outstanding than there is.
-          dirty: new Set([...t.staged, ...t.unstaged].map((f) => f.file_path)).size,
-          ahead: t.branch.ahead, behind: t.branch.behind,
-        },
-      }))).catch(() => { /* a repo that will not open is not worth a toast on a poll */ });
+      api.gitTree(r.root).then(async (t) => {
+        const state = t.branch.state;
+        // Only a stopped checkout pays for the second request, and normally
+        // none of them are stopped — so the poll costs exactly what it did.
+        const conflicts = state && state !== "clean"
+          ? await api.gitConflicts(r.root).then((c) => c.files).catch(() => [] as string[])
+          : [];
+        setTrees((cur) => ({
+          ...cur,
+          [r.root]: {
+            branch: t.branch.name,
+            // A file part-staged appears in both lists; counting it twice would
+            // report more work outstanding than there is.
+            // Conflicted paths are counted too. `git diff` emits a combined
+            // diff for an unmerged file and the tree parser makes no row out of
+            // it, so a checkout whose only outstanding work is a conflict
+            // reported nothing dirty at all — the list row was silent about the
+            // one repository on the machine that could not move.
+            dirty: new Set([...t.staged, ...t.unstaged].map((f) => f.file_path).concat(conflicts)).size,
+            ahead: t.branch.ahead, behind: t.branch.behind,
+            state, conflicts,
+          },
+        }));
+      }).catch(() => { /* a repo that will not open is not worth a toast on a poll */ });
     }
   }, []);
 
@@ -333,9 +353,9 @@ export function MobileApp() {
 
   /** Everything that would be in the queue if nothing had been put away. */
   const pending = useMemo(
-    () => buildQueue({ gates, sessions, prs, containers, me, now: Date.now() })
+    () => buildQueue({ gates, sessions, prs, containers, trees, me, now: Date.now() })
       .filter((i) => !answered.includes(i.id)),
-    [gates, sessions, prs, containers, me, answered]
+    [gates, sessions, prs, containers, trees, me, answered]
   );
   const queue = useMemo(
     () => unsnoozed(snoozeStore, pending),
@@ -404,6 +424,12 @@ export function MobileApp() {
     setOpenCheckouts(group?.checkouts ?? [r]);
     setOpenRepo(r);
   }, [repoSummaries]);
+
+  /** The same screen, reached from a card that only knows a path. */
+  const openRoot = useCallback((root: string) => {
+    const r = repoSummaries.find((s) => s.ref.root === root);
+    if (r) openProject(r);
+  }, [repoSummaries, openProject]);
 
   /** Open one specific conversation, wherever the tap came from. */
   const openSession = useCallback((s: SessionRollup) => {
@@ -489,6 +515,39 @@ export function MobileApp() {
           { label: "Restart", kind: "acc", run: () => settle(`Restarted ${o.container.name}`, () => api.dockerRestart(o.container.id)) },
           { label: "Later", tight: true, run: () => later(it) },
         ];
+      case "halt": {
+        const h = o.halt;
+        return [
+          {
+            // Abandoning is the move that is always safe and the one people
+            // reach for first — but it throws away whatever was resolved, so
+            // from a phone it asks.
+            label: h.abortLabel, kind: "no",
+            run: async () => {
+              if (!(await ask({
+                title: h.abortLabel + "?", danger: true, confirmLabel: "Abandon",
+                body: h.state === "bisecting"
+                  ? "The search ends and the tree goes back to the commit you started from."
+                  : "The tree goes back to exactly how it was before this started. Anything already resolved is lost.",
+              }))) return;
+              await settle(`Abandoned — ${baseName(o.root)} is back where it was`,
+                () => api.gitMergeAbort(o.root), it.id);
+            },
+          },
+          ...(h.canContinue
+            ? [{
+                label: h.continueLabel!, kind: "ok" as const,
+                run: () => settle(`Finished — ${baseName(o.root)} is clean`,
+                  () => api.gitMergeContinue(o.root), it.id),
+              }]
+            : []),
+          // No "Later": a repository nothing can move until somebody decides is
+          // not a thing to put off, and hiding it is how you find it tomorrow.
+          ...(h.conflicts.length
+            ? [{ label: "Resolve", kind: "acc" as const, run: () => openRoot(o.root) }]
+            : []),
+        ];
+      }
     }
   };
 
@@ -497,6 +556,7 @@ export function MobileApp() {
     if (o.t === "pr-red" || o.t === "pr-ready" || o.t === "pr-review") setOpenPr({ root: o.root, number: o.pr.number });
     else if (o.t === "container") openContainer(o.container);
     else if (o.t === "session") openSession(o.session);
+    else if (o.t === "halt") openRoot(o.root);
   };
 
   const stacked = !!openRepo || !!openPr;
@@ -522,7 +582,7 @@ export function MobileApp() {
 
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
-      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}</style>
+      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}{HALT_CSS}</style>
       {askDialog}
       <div className="mb-sky" />
 

--- a/web/src/mobile/MobileNow.tsx
+++ b/web/src/mobile/MobileNow.tsx
@@ -170,7 +170,7 @@ export function NowStream({ items, actionsFor, onOpen }: {
         <div key={it.id} className={`mb-item ${toneClass(it.tone)}`} style={{ animationDelay: `${i * 55}ms` }}>
           <div className="ih">
             <span className="k">{it.kind}</span>
-            <span className="at">{fmtAgo(it.ts)}</span>
+            {it.ts != null && <span className="at">{fmtAgo(it.ts)}</span>}
           </div>
           {/* Title and subtitle are one target, not a 26px line of text with
               dead space under it. A queue card's whole point is that you can

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -6,6 +6,7 @@ import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { MobilePr } from "./MobilePr.tsx";
 import { projectRows } from "./projects.ts";
 import { listState, dockerState } from "./listState.ts";
+import { halt, type Halt } from "./haltState.ts";
 import type {
   GitRepoRef, WorkingTree, GitBranch, DockerContainer, DockerStat, PrSummary, GitFileChange,
   PrListResponse,
@@ -127,20 +128,42 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   const mine = containers;
   const ctrList = useMemo(() => dockerState(docker, mine.length), [docker, mine.length]);
 
+  /**
+   * What git is in the middle of, and what is in the way of finishing it.
+   *
+   * The tree already carried `branch.state` and this screen ignored it, so a
+   * checkout stopped half-way through a rebase rendered as "Nothing to commit —
+   * the working tree is clean", which is both wrong and the most confident
+   * possible way to be wrong. The conflicted paths need a second request, made
+   * only when there is actually something to say.
+   */
+  const [stopped, setStopped] = useState<Halt | null>(null);
+
   // Open on whatever is wrong: a container down beats uncommitted work beats
   // the pull request list. Landing on an empty tab is a wasted screen.
   useEffect(() => {
     if (!repo) return;
     setFacet(repo.down ? "containers" : repo.dirty ? "changes" : "prs");
-    setTree(null); setPrState(null); setMsg(""); setBranches(null);
+    setTree(null); setStopped(null); setPrState(null); setMsg(""); setBranches(null);
   }, [repo]);
 
   const loadTree = useCallback(() => {
     if (!root) return;
-    api.gitTree(root).then(setTree).catch(() => setTree(null));
+    api.gitTree(root).then(async (t) => {
+      setTree(t);
+      const state = t.branch.state;
+      const conflicts = state && state !== "clean"
+        ? await api.gitConflicts(root).then((c) => c.files).catch(() => [] as string[])
+        : [];
+      setStopped(halt({ state, conflicts }));
+    }).catch(() => { setTree(null); setStopped(null); });
   }, [root]);
 
-  useEffect(() => { if (open && facet === "changes") loadTree(); }, [open, facet, loadTree]);
+  // Whenever the screen is open, not only on the Changes facet. The banner sits
+  // above the tabs and has to be there whichever one you land on — a repository
+  // stopped part-way through a rebase would otherwise be invisible from the
+  // pull request list, which is exactly where a clean-looking checkout opens.
+  useEffect(() => { if (open) loadTree(); }, [open, facet, loadTree]);
   useEffect(() => {
     if (!open || facet !== "prs" || !root) return;
     setPrsLoading(true);
@@ -225,6 +248,23 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
           </div>
         )}
 
+        {stopped && (
+          <HaltBanner halt={stopped} rel={rel}
+            onAbort={async () => {
+              if (!(await ask({
+                title: stopped.abortLabel + "?", danger: true, confirmLabel: "Abandon",
+                body: stopped.state === "bisecting"
+                  ? "The search ends and the tree goes back to the commit you started from."
+                  : "The tree goes back to exactly how it was before this started. Anything already resolved is lost.",
+              }))) return;
+              await act("Abandoned — the tree is back where it was", () => api.gitMergeAbort(root));
+            }}
+            onContinue={() => act("Finished — the tree is clean", () => api.gitMergeContinue(root))}
+            onResolve={(path, side) => act(
+              `Kept ${side === "ours" ? "this branch's" : "the other side's"} version`,
+              () => api.gitResolve(root, [path], side))} />
+        )}
+
         <Seg sticky value={facet} onPick={setFacet} options={[
           { id: "changes", label: "Changes", n: repo?.dirty || null },
           { id: "prs", label: "Pull requests", n: prs.length || null },
@@ -233,8 +273,16 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
 
         {facet === "changes" && (
           changed.length === 0 ? (
+            // "The working tree is clean" is a false sentence in the middle of
+            // a rebase, and it is the confident kind of false: it is exactly
+            // what someone reads to decide it is safe to walk away.
+            stopped ? (
+              <Empty glyph="⚠" title="Nothing to commit yet"
+                body="Git is part-way through the operation above. Finish it or abandon it, and this becomes a normal working tree again." />
+            ) : (
             <Empty glyph="◈" title="Nothing to commit"
               body={`The working tree is clean${repo?.ahead ? ` — but you are ${repo.ahead} commit${repo.ahead > 1 ? "s" : ""} ahead of the remote.` : " and level with the remote."}`} />
+            )
           ) : (
             <>
               <div className="flex gap-2 mb-3">
@@ -471,3 +519,72 @@ export function ContainerScreen({ open, c, stat, project, onBack, toast, onRefre
     </>
   );
 }
+
+/**
+ * A repository git stopped half-way through, and the two ways out.
+ *
+ * Loud on purpose. This is not a status line: nothing in this checkout moves
+ * again — not a commit, not a branch switch, not an agent working in it — until
+ * somebody finishes or abandons, and the screen said "the working tree is
+ * clean" instead.
+ *
+ * Conflicts are listed with the two resolutions that need no editor and cover
+ * most of them: a lockfile, a generated migration, a file the other side
+ * deleted. Anything needing real judgement is a job for the desk, and saying so
+ * is better than a text box in a card.
+ */
+function HaltBanner({ halt: h, rel, onAbort, onContinue, onResolve }: {
+  halt: Halt;
+  rel: (abs: string) => string;
+  onAbort: () => void;
+  onContinue: () => void;
+  onResolve: (path: string, side: "ours" | "theirs") => void;
+}) {
+  return (
+    <div className="mb-halt">
+      <div className="hh">
+        <b>{h.title}</b>
+        <span>{h.sub}</span>
+      </div>
+      {h.conflicts.length > 0 && (
+        <div className="hc">
+          {h.conflicts.map((p) => (
+            <div className="cr" key={p}>
+              <span className="p" title={rel(p)}>{rel(p)}</span>
+              <Act small onAct={() => onResolve(p, "ours")}>Keep ours</Act>
+              <Act small onAct={() => onResolve(p, "theirs")}>Keep theirs</Act>
+            </div>
+          ))}
+        </div>
+      )}
+      <div className="ha">
+        <Act small full kind="no" onAct={onAbort}>{h.abortLabel}</Act>
+        {h.continueLabel && (
+          <Act small full kind="ok" disabled={!h.canContinue}
+            title={h.canContinue ? undefined : "Resolve everything above first"}
+            onAct={onContinue}>{h.continueLabel}</Act>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export const HALT_CSS = `
+.mb-halt{border-radius:16px;margin-bottom:13px;overflow:hidden;
+  background:color-mix(in srgb,var(--warning) 11%,var(--bg2));
+  border:1px solid color-mix(in srgb,var(--warning) 46%,transparent);
+  box-shadow:var(--mb-edge),0 12px 30px -18px color-mix(in srgb,var(--warning) 55%,#000)}
+.mb-halt .hh{padding:13px 15px 0}
+.mb-halt .hh b{display:block;font-size:13.5px;color:var(--warning);font-weight:650}
+.mb-halt .hh span{display:block;font-size:11.5px;color:var(--text3);margin-top:3px}
+.mb-halt .hc{margin:11px 15px 0;padding-top:9px;display:flex;flex-direction:column;gap:7px;
+  border-top:1px solid color-mix(in srgb,var(--border) 40%,transparent)}
+.mb-halt .cr{display:flex;align-items:center;gap:7px;min-width:0}
+/* The path shrinks and the two verbs do not: a long path must not push
+   "Keep theirs" off the right edge, which is where it ends up when every child
+   of a flex row is allowed to size itself. */
+.mb-halt .cr .p{flex:1;min-width:0;font-size:11px;color:var(--text2);
+  overflow:hidden;text-overflow:ellipsis;white-space:nowrap;direction:ltr}
+.mb-halt .cr .mb-btn{flex:none}
+.mb-halt .ha{display:flex;gap:9px;padding:13px 15px 14px}
+`;

--- a/web/src/mobile/haltState.ts
+++ b/web/src/mobile/haltState.ts
@@ -1,0 +1,89 @@
+import type { GitTreeState } from "../../../shared/types.ts";
+
+/**
+ * A repository that git has stopped halfway through.
+ *
+ * `treeState()` on the server has reported this since the beginning — it is one
+ * stat per state against `.git`, and it is how git itself decides. The phone
+ * never read it. `loadTrees` copies `branch.name`, `ahead` and `behind` off the
+ * tree and drops `branch.state` on the floor, so a checkout sitting on a
+ * half-finished rebase looked exactly like a clean one: a branch name, a dirty
+ * count, and no way out. The one place the phone is *for* — you left the desk
+ * and something needs a person — and it was the one state it could not show.
+ *
+ * What makes it worth a module rather than a ternary in the view is that the
+ * five states are not the same shape. Continuing a rebase and continuing a
+ * bisect are different verbs; a bisect has no conflicts to resolve and nothing
+ * to continue *to*; and until this change, aborting a bisect ran
+ * `git merge --abort` and failed, because mergeAbort's fallthrough assumed
+ * anything that was not a rebase, a cherry-pick or a revert was a merge.
+ *
+ * So: the decision as data, one place, tested.
+ */
+
+export interface HaltInput {
+  state?: GitTreeState;
+  /** Paths git reports as unmerged — `UU` and friends. */
+  conflicts: readonly string[];
+}
+
+export interface Halt {
+  state: Exclude<GitTreeState, "clean">;
+  /** What is going on, in the user's words. */
+  title: string;
+  /** What happens if they do nothing. */
+  sub: string;
+  /** The label on the way out. Always available: abandoning is the move that
+   *  is always safe and the one people reach for first. */
+  abortLabel: string;
+  /** The label on the way forward, or null where finishing is not a thing this
+   *  state does. */
+  continueLabel: string | null;
+  /** Whether finishing is possible *now*, as opposed to in principle. */
+  canContinue: boolean;
+  conflicts: readonly string[];
+}
+
+const COPY: Record<Exclude<GitTreeState, "clean">, {
+  title: string; abort: string; cont: string | null;
+}> = {
+  rebasing: { title: "Rebase stopped part-way", abort: "Abandon the rebase", cont: "Continue" },
+  merging: { title: "Merge stopped part-way", abort: "Abandon the merge", cont: "Finish the merge" },
+  "cherry-picking": { title: "Cherry-pick stopped part-way", abort: "Abandon it", cont: "Continue" },
+  reverting: { title: "Revert stopped part-way", abort: "Abandon it", cont: "Continue" },
+  // A bisect is a search, not a transaction: there is nothing to "continue" to
+  // from a phone, because the next step is a verdict on the checked-out commit
+  // and that means running the thing. Ending the search and going back to where
+  // you started is the honest offer.
+  bisecting: { title: "A bisect is still running", abort: "End the bisect", cont: null },
+};
+
+/**
+ * What to say and what to offer, or null when there is nothing to say.
+ *
+ * Absent state is "clean" deliberately — `GitBranchInfo.state` is optional
+ * because it postdates the payload, and treating a missing field as an
+ * emergency would put a red banner on every repository served by an older
+ * sidecar.
+ */
+export function halt(tree: HaltInput | null | undefined): Halt | null {
+  const state = tree?.state;
+  if (!state || state === "clean") return null;
+  const copy = COPY[state];
+  const conflicts = tree?.conflicts ?? [];
+  return {
+    state,
+    title: copy.title,
+    sub: conflicts.length
+      ? `${conflicts.length} file${conflicts.length > 1 ? "s" : ""} still conflicted`
+      : copy.cont
+        ? "Nothing is conflicted — it is waiting to be finished"
+        : "The tree is on a commit the search picked, not on your branch",
+    abortLabel: copy.abort,
+    continueLabel: copy.cont,
+    // Every conflict has to be resolved first; the server refuses otherwise,
+    // and a button that always fails is worse than one that is not offered.
+    canContinue: copy.cont !== null && conflicts.length === 0,
+    conflicts,
+  };
+}

--- a/web/src/mobile/nowQueue.ts
+++ b/web/src/mobile/nowQueue.ts
@@ -1,6 +1,7 @@
 import type { PendingGate, SessionRollup, PrSummary, DockerContainer } from "../../../shared/types.ts";
 import { sessionTitle } from "../lib/format.ts";
 import { baseName } from "../../../shared/projectKey.ts";
+import { halt, type Halt, type HaltInput } from "./haltState.ts";
 
 /**
  * "What wants me right now", for a phone.
@@ -26,7 +27,8 @@ export type NowOrigin =
   | { t: "pr-red"; pr: PrSummary; root: string }
   | { t: "pr-ready"; pr: PrSummary; root: string }
   | { t: "pr-review"; pr: PrSummary; root: string }
-  | { t: "container"; container: DockerContainer };
+  | { t: "container"; container: DockerContainer }
+  | { t: "halt"; root: string; halt: Halt };
 
 export interface NowItem {
   id: string;
@@ -48,7 +50,16 @@ export interface NowItem {
   sub: string;
   /** A command or other verbatim string worth showing exactly as it is. */
   code?: string;
-  ts: number;
+  /**
+   * When this happened — absent when the item honestly has no moment.
+   *
+   * A halted repository and a stopped container both used `now`, which is not a
+   * timestamp: it made the card's header read "now" forever, and inside a band
+   * it made the item beat everything real, so a repository mid-rebase sorted
+   * above an agent that was blocked and waiting. Items without one sort last in
+   * their band and draw no age at all.
+   */
+  ts?: number;
   origin: NowOrigin;
 }
 
@@ -73,13 +84,38 @@ export interface NowInput {
    *  your review", so it is what that claim rests on rather than a guess. */
   prs: { root: string; repo: string; pr: PrSummary; scope: "mine" | "review" }[];
   containers: DockerContainer[];
+  /**
+   * Each checkout's git state, keyed by root. A repository stopped half-way
+   * through a rebase is the purest form of "something needs a person": nothing
+   * in it will move again until somebody decides, and until now the phone was
+   * the one place that could not even see it.
+   */
+  trees?: Record<string, HaltInput | undefined>;
   /** Logins the viewer answers to, for "is this mine". */
   me: string;
   now: number;
 }
 
-export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInput): NowItem[] {
+export function buildQueue({ gates, sessions, prs, containers, trees, me, now }: NowInput): NowItem[] {
   const out: NowItem[] = [];
+
+  for (const [root, tree] of Object.entries(trees ?? {})) {
+    const h = halt(tree);
+    if (!h) continue;
+    out.push({
+      id: `halt:${root}`,
+      // The state and how many files are still in the way. Resolving one of
+      // three is progress worth being told about; the clock is not in here.
+      mark: `halt:${root}:${h.state}:${h.conflicts.length}`,
+      tone: "crit",
+      kind: "Stopped part-way",
+      title: `${baseName(root)}: ${h.title.toLowerCase()}`,
+      sub: h.sub,
+      // No `ts`: git does not record when it stopped, and the only number to
+      // hand is the clock.
+      origin: { t: "halt", root, halt: h },
+    });
+  }
 
   for (const g of gates) {
     out.push({
@@ -168,12 +204,18 @@ export function buildQueue({ gates, sessions, prs, containers, me, now }: NowInp
       tone: "bad",
       kind: "Container down",
       title: looping ? `${c.name} is restarting in a loop` : `${c.name} is ${c.state}`,
+      // Docker's own status carries the age — "Exited (1) 3 hours ago" — and
+      // it is already in the subtitle above. The header used to read "now" on
+      // every one of them.
       sub: `${c.project ? c.project + " · " : ""}${c.status}`,
-      ts: now, origin: { t: "container", container: c },
+      origin: { t: "container", container: c },
     });
   }
 
-  return out.sort((a, b) => RANK[a.tone] - RANK[b.tone] || b.ts - a.ts);
+  // Inside a band, newest first — and anything without a real moment after
+  // everything that has one, rather than ahead of all of it.
+  return out.sort((a, b) =>
+    RANK[a.tone] - RANK[b.tone] || (b.ts ?? -Infinity) - (a.ts ?? -Infinity));
 }
 
 /**

--- a/web/test/now-queue.test.ts
+++ b/web/test/now-queue.test.ts
@@ -39,6 +39,51 @@ const ctr = (over: Partial<DockerContainer> = {}): DockerContainer => ({
   runningFor: "2 hours", size: "0B", ...over,
 });
 
+describe("a repository git stopped part-way", () => {
+  // `treeState()` has reported this from the server since the beginning and the
+  // phone read `branch.name` and nothing else, so a checkout sitting on a
+  // half-finished rebase was indistinguishable from a clean one — on the one
+  // surface whose whole job is telling you something needs a person.
+  it("reaches the queue at all", () => {
+    const q = buildQueue({ ...base, trees: { "/w/shop-api": { state: "merging", conflicts: ["/w/shop-api/a.ts"] } } });
+    expect(q).toHaveLength(1);
+    expect(q[0]!.id).toBe("halt:/w/shop-api");
+    expect(q[0]!.origin.t).toBe("halt");
+  });
+
+  it("outranks everything except a blocked agent", () => {
+    // Nothing in that checkout moves again — not a commit, not a branch switch,
+    // not an agent working in it — until somebody decides.
+    const q = buildQueue({
+      ...base,
+      gates: [gate()],
+      containers: [ctr({ state: "exited", status: "Exited (1) 3 hours ago" })],
+      trees: { "/w/shop-api": { state: "rebasing", conflicts: [] } },
+    });
+    expect(q[0]!.origin.t).toBe("gate");
+    expect(q[1]!.origin.t).toBe("halt");
+  });
+
+  it("draws no age, because git does not record when it stopped", () => {
+    // `ts: now` made the header read "now" forever and, inside the band, made
+    // this item beat everything that had a real moment.
+    const q = buildQueue({ ...base, trees: { "/w/a": { state: "merging", conflicts: [] } } });
+    expect(q[0]!.ts).toBeUndefined();
+  });
+
+  it("names the repository, because the queue spans all of them", () => {
+    const q = buildQueue({ ...base, trees: { "/w/shop-api": { state: "merging", conflicts: [] } } });
+    expect(q[0]!.title).toContain("shop-api");
+  });
+
+  it("says nothing about clean checkouts, or about none at all", () => {
+    expect(buildQueue({ ...base, trees: { "/w/a": { state: "clean", conflicts: [] } } })).toHaveLength(0);
+    expect(buildQueue({ ...base, trees: { "/w/a": { conflicts: [] } } })).toHaveLength(0);
+    expect(buildQueue({ ...base, trees: {} })).toHaveLength(0);
+    expect(buildQueue(base)).toHaveLength(0);
+  });
+});
+
 describe("buildQueue", () => {
   it("puts a blocked agent above everything else", () => {
     const q = buildQueue({

--- a/web/test/queue-truth.test.ts
+++ b/web/test/queue-truth.test.ts
@@ -119,6 +119,10 @@ describe("the mark a snooze is keyed on", () => {
     ...base,
     sessions: [session()],
     containers: [ctr()],
+    // A halted checkout is in here so the time-invariance rule below covers it
+    // too: this card has no timestamp of its own and takes `now` as its sort
+    // key, which is exactly the shape that leaks a clock into a mark.
+    trees: { "/w/shop-api": { state: "merging", conflicts: ["/w/shop-api/a.ts"] } },
     prs: [{ root: "/r", repo: "shop-api", scope: "mine", pr: pr({ checks: rollup({ failure: 1, failing: [{ name: "test" }] as PrSummary["checks"]["failing"] }) }) }],
   };
 
@@ -158,6 +162,17 @@ describe("the mark a snooze is keyed on", () => {
       prs: [{ root: "/r", repo: "shop-api", scope: "mine", pr: pr({ checks: rollup({ failure: 1, failing: [{ name }] as PrSummary["checks"]["failing"] }) }) }],
     })[0]!;
     expect(red("unit").mark).not.toBe(red("e2e").mark);
+  });
+
+  it("moves when a conflict is resolved, so progress is not hidden", () => {
+    // Two of three resolved is news: the card should come back saying so rather
+    // than staying put because it is "the same repository".
+    const m = (n: number) => buildQueue({
+      ...base,
+      trees: { "/w/a": { state: "merging", conflicts: Array.from({ length: n }, (_, i) => `f${i}`) } },
+    })[0]!.mark;
+    expect(m(3)).not.toBe(m(1));
+    expect(m(3)).toBe(m(3));
   });
 
   it("moves when a container's exit code changes but not when its age does", () => {

--- a/web/test/repo-halt.test.ts
+++ b/web/test/repo-halt.test.ts
@@ -1,0 +1,84 @@
+/*
+ * A repository git stopped halfway through, and the phone's total silence
+ * about it.
+ *
+ * `treeState()` has probed `.git` for this since the beginning — it is how git
+ * itself decides, and it is one stat per state. The phone's `loadTrees` copied
+ * `branch.name`, `ahead` and `behind` off the tree and dropped `branch.state`,
+ * so a checkout sitting on a half-finished rebase rendered exactly like a clean
+ * one: a branch name, a dirty count, no banner, no way out. That is the single
+ * situation the companion exists for — you walked away and something needs a
+ * person — and it was the one it could not show.
+ */
+import { describe, expect, it } from "bun:test";
+import { halt } from "../src/mobile/haltState.ts";
+import type { GitTreeState } from "../../shared/types.ts";
+
+const STOPPED: Exclude<GitTreeState, "clean">[] =
+  ["rebasing", "merging", "cherry-picking", "reverting", "bisecting"];
+
+describe("a repository stopped part-way", () => {
+  it("says nothing about a clean one", () => {
+    expect(halt({ state: "clean", conflicts: [] })).toBeNull();
+  });
+
+  it("treats a missing state as clean rather than as an emergency", () => {
+    // `GitBranchInfo.state` is optional because it postdates the payload. An
+    // older sidecar must not paint a red banner on every repository it serves.
+    expect(halt({ conflicts: [] })).toBeNull();
+    expect(halt(null)).toBeNull();
+    expect(halt(undefined)).toBeNull();
+  });
+
+  it("has something to say, and a way out, for every state git can stop in", () => {
+    // The rule over the type rather than over today's five: adding a state to
+    // GitTreeState without giving it copy would leave a card reading
+    // "undefined" with a dead button on it.
+    for (const state of STOPPED) {
+      const h = halt({ state, conflicts: [] })!;
+      expect(h).not.toBeNull();
+      expect(h.title.length).toBeGreaterThan(8);
+      expect(h.title).not.toContain("undefined");
+      expect(h.abortLabel.length).toBeGreaterThan(2);
+      expect(h.sub.length).toBeGreaterThan(8);
+    }
+  });
+
+  it("counts the conflicts in the words a person would use", () => {
+    expect(halt({ state: "merging", conflicts: ["a"] })!.sub).toContain("1 file");
+    expect(halt({ state: "merging", conflicts: ["a"] })!.sub).not.toContain("1 files");
+    expect(halt({ state: "merging", conflicts: ["a", "b"] })!.sub).toContain("2 files");
+  });
+
+  it("will not offer to finish while anything is still conflicted", () => {
+    // The server refuses in this state, and a button that always fails is
+    // worse than one that is not offered.
+    expect(halt({ state: "merging", conflicts: ["a"] })!.canContinue).toBe(false);
+    expect(halt({ state: "merging", conflicts: [] })!.canContinue).toBe(true);
+  });
+
+  it("offers no way to finish a bisect, because there is not one", () => {
+    // A bisect is a search, not a transaction: the next step is a verdict on
+    // the checked-out commit, which means running the thing. Ending the search
+    // is the only honest offer from a phone.
+    const b = halt({ state: "bisecting", conflicts: [] })!;
+    expect(b.continueLabel).toBeNull();
+    expect(b.canContinue).toBe(false);
+    // And it must not claim there is nothing left to do.
+    expect(b.sub).not.toContain("waiting to be finished");
+  });
+
+  it("distinguishes the states rather than calling everything a merge", () => {
+    // "Abandon the merge" on a stopped rebase is the wrong sentence about the
+    // wrong operation, and the reader has no other source of truth on a phone.
+    const titles = STOPPED.map((s) => halt({ state: s, conflicts: [] })!.title);
+    expect(new Set(titles).size).toBe(STOPPED.length);
+    expect(halt({ state: "rebasing", conflicts: [] })!.title.toLowerCase()).toContain("rebase");
+    expect(halt({ state: "merging", conflicts: [] })!.title.toLowerCase()).toContain("merge");
+  });
+
+  it("passes the conflicted paths through for the list to render", () => {
+    expect(halt({ state: "merging", conflicts: ["/r/a.ts", "/r/b.ts"] })!.conflicts)
+      .toEqual(["/r/a.ts", "/r/b.ts"]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`treeState()` has probed `.git` for this since the beginning — it is how git itself decides, and it costs one stat per state. The phone never read it. `loadTrees` copied `branch.name`, `ahead` and `behind` off the tree and dropped `branch.state`, so a checkout sitting on a half-finished rebase looked exactly like a clean one: a branch name, a dirty count, no banner, no way out. The Changes tab said *"Nothing to commit — the working tree is clean"*, which is both false and the most confident possible way to be false, since it is what someone reads to decide it is safe to walk away. That is the single situation the companion exists for, and it was the one it could not show.

A halted checkout now leads the Now queue and carries a banner on its own screen, with the two verbs that state actually has. Conflicts are listed with **Keep ours** and **Keep theirs** — the two resolutions that need no editor and cover most of them (a lockfile, a generated migration, a file the other side deleted). Anything needing judgement is a job for the desk, and saying so beats a text box in a card.

The five states are not one shape, so the decision is a module rather than a ternary in the view. Continuing a rebase and continuing a bisect are different verbs; a bisect has no conflicts and nothing to continue *to* from a phone, because its next step is a verdict on the checked-out commit and that means running the thing. Ending the search is the honest offer.

**And a bisect had no way out at all, on any surface.** `mergeAbort`'s fallthrough treated everything that was not a rebase, a cherry-pick or a revert as a merge, so aborting one ran `git merge --abort` and came back with *"There is no merge to abort"*. `treeState()` named the state, the desktop header showed it, and nothing could leave it.

## How was it tested?

`web/test/repo-halt.test.ts` (8 tests), plus new cases in `now-queue` and `queue-truth`. Both suites green: 621 in `web/`, 1047 in `server/`.

Eleven mutations, each reverted after confirming the failure: a missing state treated as an emergency; a bisect offered a Continue; Finish offered while files are conflicted; every state called a merge; "1 files"; conflicted paths dropped; a halted repo never reaching the queue; a halted repo outranking a blocked agent; an item with no moment sorting ahead of every real one; the halt mark ignoring progress on the conflicts; the halt mark ticking with the clock.

The first pass of that exercise is why this description is longer than it looked. Three of those mutations walked straight through green tests — the halt module was tested and its wiring into the queue was not — so the queue-side cases exist because a mutation found them missing, not because they were planned. The server-side bisect fix goes red the same way: removing the line breaks the new test *and* cascades into the next one, because the repository stays mid-bisect.

**Driven on a real server against real git**, which is where the rest of this came from. A merge conflict was created in the audit fixture and the whole journey pressed by hand at a phone viewport: queue card → Resolve → Keep theirs → Finish, ending in an actual merge commit and a clean tree. Then a real bisect, ended from the queue card, landing back on the commit it started from. Then a rebase. `scripts/phone-audit.ts` gained a halt section (107/107 on a halted repo, 111/111 on a clean one — both branches of the new conditional exercised).

Two faults that only pressing the buttons found:

- The banner sits above the tabs, but the tree was only fetched on the Changes facet — and a checkout with no dirty files opens on Pull requests, which is exactly the shape a halted-but-clean repository has. It fetches whenever the screen is open now.
- A halted repository sorted **above a blocked agent**. It has no timestamp of its own and was taking `now` as one, which inside its band beats everything real. `ts` is optional now: absent means "no honest moment", it sorts last in its band, and the card draws no age. Stopped containers had the same borrowed `now`, so their headers read "now" forever while the actual age sat in the subtitle two lines below.

Conflicted paths are also counted as dirty. `git diff` emits a combined diff for an unmerged file and the tree parser makes no row out of it, so a checkout whose only outstanding work was a conflict reported nothing dirty at all — the list row was silent about the one repository on the machine that could not move. It is also why the banner lists the conflicts itself rather than pointing at the Changes tab.

One correction to something I checked mid-way and got wrong: I read a screenshot as showing the disabled "Finish the merge" button at full strength and started adding a `:disabled` rule, then measured it in the browser — `.mb-press:disabled` already dims it to 0.38 and always did. That addition was reverted. What stayed is a hygiene rule in the audit asserting no disabled control renders above 0.75 opacity, on every screen, so a later rule cannot quietly out-specify it. Mutating the existing rule to `.99` turns it red on exactly the two screens that have an inert control.