### PR TITLE
Let a review happen on the phone, and address it correctly

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -112,7 +112,15 @@ const HYGIENE = `(() => {
     // A tap target you have to aim at. 40px is the floor everyone agrees on.
     const tappable = el.tagName === "BUTTON" || el.getAttribute("role") === "switch"
       || el.getAttribute("role") === "tab" || el.tagName === "A";
-    if (tappable && (r.height < 36 || r.width < 24)) bad.tiny.push(name(el) + " " + Math.round(r.width) + "x" + Math.round(r.height));
+    // A diff line is the one control that cannot meet the floor: a phone-sized
+    // diff at 44px a line shows eighteen of them, and reading a change is the
+    // whole point of the screen. It is exempt because a mis-tap is *visible and
+    // free* — the sheet opens naming the file, the line and the side before a
+    // word is written, and Cancel costs nothing. Nothing else gets this.
+    const dense = el.classList.contains("mb-dl");
+    if (tappable && !dense && (r.height < 36 || r.width < 24)) bad.tiny.push(name(el) + " " + Math.round(r.width) + "x" + Math.round(r.height));
+    // It is not exempt from being hittable at all, though.
+    if (tappable && dense && (r.height < 18 || r.width < 24)) bad.tiny.push(name(el) + " (diff line) " + Math.round(r.width) + "x" + Math.round(r.height));
 
     // A control that will do nothing has to look like it will do nothing. The
     // costly version of this is a filled, primary-coloured button that is the
@@ -469,6 +477,86 @@ async function main() {
           await drain(cdp, facet.toLowerCase());
         }
       }
+      // ---- reviewing a pull request --------------------------------
+      //
+      // Read-only, deliberately: everything up to and including the state of
+      // the Submit button, and nothing that would post a review to GitHub. The
+      // one thing this cannot check is the payload, which is checked by hand
+      // against a stubbed `gh` — see the note on `onLine` in reviewDraft.ts.
+      await tap(cdp, ".mb-screen.on button", "Pull requests");
+      await Bun.sleep(2400);
+      // A pull request row IS a button; a file row CONTAINS one. Reaching for
+      // `.mb-row button` on the list found nothing and skipped this whole
+      // section silently, which is the failure mode a conditional audit has.
+      // A section that skips silently reads as a section that passed. This one
+      // skipped for two full runs because of the selector above, and the only
+      // sign was a check count nobody was watching.
+      if (!(await cdp.ev(`!!${TOP}.querySelector("button.mb-row")`))) {
+        console.log("  skip  review · no open pull request on this repository to review");
+      } else {
+        await cdp.ev(`${TOP}.querySelector("button.mb-row").click()`);
+        await Bun.sleep(2600);
+        if (await tap(cdp, ".mb-screen.on .mb-seg button", "Files")) {
+          await Bun.sleep(1500);
+          if (await cdp.ev(`!!${TOP}.querySelector(".mb-row button")`)) {
+            await cdp.ev(`${TOP}.querySelector(".mb-row button").click()`);
+            await Bun.sleep(1800);
+            const taps = await cdp.ev(`${TOP}.querySelectorAll("button.mb-dl").length`);
+            // `MobileDiff` has rendered every line as a button and printed "Tap
+            // a line to comment on it" since it was written, and nothing ever
+            // passed it an `onLine` — so the invitation was there and the
+            // gesture did nothing.
+            note("review", "diff lines can actually be tapped", taps > 0, `${taps} lines`);
+
+            const del = await cdp.ev(`(()=>{const b=${TOP}.querySelector("button.mb-dl.del");
+              if(!b) return null; b.click(); return b.querySelector(".g").textContent})()`);
+            if (del) {
+              // A deleted line is numbered in the OLD file. If the sheet claims
+              // the new one, the remark is addressed to the wrong place and
+              // nothing downstream can tell.
+              note("review", "a deleted line is named as the old file",
+                await cdp.ev(`/the old file/.test(document.querySelector(".mb-sheet.on")?.textContent || "")`),
+                await cdp.ev(`document.querySelector(".mb-sheet.on .hd span")?.textContent`));
+              await cdp.ev(`(()=>{const t=document.querySelector(".mb-sheet.on textarea");
+                const set=Object.getOwnPropertyDescriptor(HTMLTextAreaElement.prototype,"value").set;
+                set.call(t,"An audit remark, never sent.");
+                t.dispatchEvent(new Event("input",{bubbles:true}));})()`);
+              await Bun.sleep(300);
+              await tap(cdp, ".mb-sheet.on button", "Save");
+              await Bun.sleep(1000);
+              note("review", "the annotated line is marked in the diff",
+                await cdp.ev(`${TOP}.querySelectorAll("button.mb-dl.said").length > 0`));
+              note("review", "and the way to finish appears",
+                await cdp.ev(`[...${TOP}.querySelectorAll("button")].some(b=>/Finish review/.test(b.textContent))`));
+
+              await cdp.ev(`[...${TOP}.querySelectorAll("button")].find(b=>/Finish review/.test(b.textContent))?.click()`);
+              await Bun.sleep(900);
+              const sheet = `document.querySelector(".mb-sheet.on")`;
+              note("review", "all three verbs are offered",
+                await cdp.ev(`[...${sheet}.querySelectorAll("button.mb-row")].length === 3`),
+                await cdp.ev(`JSON.stringify([...${sheet}.querySelectorAll("button.mb-row b")].map(b=>b.textContent))`));
+              note("review", "submitting is refused until a verb is chosen, with a reason",
+                await cdp.ev(`[...${sheet}.querySelectorAll("button")].find(b=>/Submit review/.test(b.textContent))?.disabled === true`)
+                && await cdp.ev(`[...${sheet}.querySelectorAll("p")].some(p=>p.textContent.length > 12)`));
+              await cdp.ev(`[...${sheet}.querySelectorAll("button.mb-row")].find(b=>/Comment/.test(b.textContent))?.click()`);
+              await Bun.sleep(500);
+              note("review", "and allowed once one is",
+                await cdp.ev(`[...${sheet}.querySelectorAll("button")].find(b=>/Submit review/.test(b.textContent))?.disabled === false`));
+              await shot(cdp, "07b-review");
+              await hygiene(cdp, "review");
+              await drain(cdp, "review");
+              // Leave without sending anything.
+              await cdp.ev(`document.querySelector(".mb-scrim.on")?.click()`);
+              await Bun.sleep(500);
+            }
+          }
+          await tap(cdp, ".mb-screen.on .hd .back");
+          await Bun.sleep(600);
+        }
+        await tap(cdp, ".mb-screen.on .hd .back");
+        await Bun.sleep(600);
+      }
+
       await tap(cdp, ".mb-screen.on .hd .back");
       await Bun.sleep(600);
     }

--- a/web/src/mobile/MobileDiff.tsx
+++ b/web/src/mobile/MobileDiff.tsx
@@ -1,6 +1,9 @@
 import { useMemo, useState } from "react";
 import { Screen } from "./mobileUi.tsx";
 import type { DiffHunk } from "../../../shared/types.ts";
+// One rule for which file a line number lives in, shared with the draft that
+// stores the remark, so the renderer and the payload cannot disagree.
+import { sideFor } from "./reviewDraft.ts";
 
 /**
  * A diff you can actually read on a phone.
@@ -24,6 +27,12 @@ export const DIFF_CSS = `
   border:1px solid color-mix(in srgb,var(--border) 32%,transparent);
   background:color-mix(in srgb,#000 30%,transparent)}
 .mb-dl{display:flex;width:100%;text-align:left;align-items:flex-start;background:transparent}
+/* Only where a line is a control. A diff has to stay dense to be readable at
+   all — 44px a line shows eighteen of them, which is not reading code — so this
+   buys what it can without turning the screen into a list. What actually makes
+   a mis-tap survivable is the sheet: it opens naming the file, the line and
+   which side of the diff it is, before anything has been written. */
+button.mb-dl{padding:3px 0}
 .mb-dl .g{flex:none;width:34px;padding:1px 7px 1px 0;text-align:right;color:var(--text4);opacity:.5;
   user-select:none;font-size:10px;font-variant-numeric:tabular-nums}
 .mb-dl .s{flex:none;width:12px;user-select:none;opacity:.9}
@@ -35,12 +44,19 @@ export const DIFF_CSS = `
 .mb-dl.add{background:color-mix(in srgb,var(--success) 13%,transparent)}
 .mb-dl.add .g,.mb-dl.add .s{color:var(--success);opacity:.95}
 .mb-dl.del{background:color-mix(in srgb,var(--error) 12%,transparent)}
+/* A line you have already said something about. The marker is on the gutter
+   rather than the whole row so it reads against an added line's green and a
+   deleted line's red alike. */
+.mb-dl.said{background:color-mix(in srgb,var(--primary) 17%,transparent)}
+.mb-dl.said .g{color:var(--primary-hover);opacity:1;font-weight:700}
+.mb-dl.said .g::after{content:"●";font-size:7px;vertical-align:top;margin-left:2px}
 .mb-dl.del .g,.mb-dl.del .s{color:var(--error);opacity:.95}
 .mb-dl.hdr{background:color-mix(in srgb,var(--primary) 10%,transparent);color:var(--text4);
   font-size:10.5px;padding:4px 0}
 `;
 
 type Line = { kind: "ctx" | "add" | "del" | "hdr"; n: string; text: string };
+
 
 /** Anything carrying hunks: a working-tree change or a parsed pull request
  *  diff. Both already speak this shape, so neither needs translating. */
@@ -63,7 +79,7 @@ function toLines(f: Hunked | undefined): Line[] {
   return out;
 }
 
-export function MobileDiff({ open, file, files, index, onIndex, onBack, onLine, extra }: {
+export function MobileDiff({ open, file, files, index, onIndex, onBack, onLine, markOn, extra }: {
   open: boolean;
   file: Hunked | undefined;
   /** Paths in order, for prev/next and for the "3 of 11" the footer shows. */
@@ -71,9 +87,20 @@ export function MobileDiff({ open, file, files, index, onIndex, onBack, onLine, 
   index: number;
   onIndex: (i: number) => void;
   onBack: () => void;
-  /** Tapping a line — a review comment on a pull request, nothing on a working
-   *  tree diff, where the line has no stable identity to hang a comment on. */
-  onLine?: (path: string, line: number) => void;
+  /**
+   * Tapping a line — a review comment on a pull request, nothing on a working
+   * tree diff, where the line has no stable identity to hang a comment on.
+   *
+   * The side is not decoration, it is half the address: a deleted line is
+   * numbered in the old file and everything else in the new one, so `(path,
+   * line)` alone is ambiguous and resolving it the wrong way puts the remark on
+   * unrelated code. This handed over only `(path, line)` for as long as nothing
+   * passed it — see reviewDraft.ts.
+   */
+  onLine?: (path: string, line: number, side: "LEFT" | "RIGHT") => void;
+  /** How many remarks are already queued on a given line, so a line you have
+   *  annotated looks different from one you have not. */
+  markOn?: (path: string, line: number, side: "LEFT" | "RIGHT") => boolean;
   extra?: React.ReactNode;
 }) {
   const [wrap, setWrap] = useState(true);
@@ -110,9 +137,14 @@ export function MobileDiff({ open, file, files, index, onIndex, onBack, onLine, 
               return <div key={i} className="mb-dl hdr"><span className="g" /><span className="s" /><span className="c">{l.text}</span></div>;
             }
             const body = <><span className="g">{l.n}</span><span className="s">{sign}</span><span className="c">{l.text}</span></>;
-            return onLine
-              ? <button key={i} className={`mb-dl ${l.kind} mb-press`} onClick={() => onLine(path, Number(l.n) || 0)}>{body}</button>
-              : <div key={i} className={`mb-dl ${l.kind}`}>{body}</div>;
+            if (!onLine) return <div key={i} className={`mb-dl ${l.kind}`}>{body}</div>;
+            const n = Number(l.n) || 0;
+            const side = sideFor(l.kind);
+            const said = markOn?.(path, n, side) ?? false;
+            return (
+              <button key={i} className={`mb-dl ${l.kind} mb-press${said ? " said" : ""}`}
+                onClick={() => onLine(path, n, side)}>{body}</button>
+            );
           })}
         </div>
       )}

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -5,6 +5,10 @@ import { Screen, Sheet, Seg, Empty, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { fmtAgo } from "../lib/format.ts";
 import type { PrDetail, PrCheck } from "../../../shared/types.ts";
+import {
+  EMPTY, canSubmit, commentAt, countFor, annotatedPaths, setComment as withRemark, summarise,
+  type ReviewDraft, type Side, type Verb,
+} from "./reviewDraft.ts";
 
 /**
  * Reviewing a pull request from a phone.
@@ -46,10 +50,28 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
   const [more, setMore] = useState(false);
   const [openLog, setOpenLog] = useState<string | null>(null);
   const [comment, setComment] = useState("");
+  /**
+   * The review being written, and where it is being written.
+   *
+   * GitHub's own model: you read, you leave remarks as you go, and you submit
+   * them together with a verdict — one notification for the author instead of a
+   * scatter. `MobileDiff` has rendered every line as a button and printed "Tap
+   * a line to comment on it" since it was written, and nothing ever passed it
+   * an `onLine`, so none of this was reachable from a phone.
+   */
+  const [draft, setDraft] = useState<ReviewDraft>(EMPTY);
+  const [at, setAt] = useState<{ path: string; line: number; side: Side } | null>(null);
+  const [note, setNote] = useState("");
+  const [reviewing, setReviewing] = useState(false);
+  const [verb, setVerb] = useState<Verb | null>(null);
+  const verdict = canSubmit(draft, verb, !!d?.viewerDidAuthor);
 
   useEffect(() => {
     if (!open || number == null) return;
     setTab("overview"); setD(null); setErr(""); setDiff(""); setSeen([]); setComment("");
+    // A review is written about one pull request. Carrying remarks from the
+    // last one into the next would post them against lines that mean nothing.
+    setDraft(EMPTY); setVerb(null); setAt(null); setNote(""); setReviewing(false);
     api.prDetail(root, number).then((r) => {
       if (r.ok && r.detail) setD(r.detail); else setErr(r.error || "Could not load it");
     }).catch((e) => setErr(String(e)));
@@ -76,6 +98,7 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
   const { ask, dialog: askDialog } = useAsk();
 
   const canMerge = d?.mergeState === "CLEAN";
+
   const openThreads = d?.threads.filter((t) => !t.isResolved).length ?? 0;
 
   return (
@@ -234,7 +257,53 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
 
       <MobileDiff open={diffAt != null} files={paths} index={diffAt ?? 0} onIndex={setDiffAt}
         file={diffAt != null ? byPath.get(paths[diffAt] ?? "") : undefined}
-        onBack={() => setDiffAt(null)} />
+        onBack={() => setDiffAt(null)}
+        onLine={(path, line, side) => {
+          if (!line) return; // a hunk header has no address
+          setAt({ path, line, side });
+          setNote(commentAt(draft, path, line, side)?.body ?? "");
+        }}
+        markOn={(path, line, side) => !!commentAt(draft, path, line, side)}
+        extra={draft.comments.length > 0 ? (
+          <Act small kind="acc" onAct={() => setReviewing(true)}>
+            Finish review · {draft.comments.length}
+          </Act>
+        ) : undefined} />
+
+      {/* One line, one remark. Opening on a line you have already annotated
+          pre-fills it, so editing and deleting are the same gesture as writing. */}
+      <Sheet open={!!at} title={at ? `Line ${at.line}` : ""}
+        sub={at ? `${at.path.split("/").pop()} · ${at.side === "LEFT" ? "the old file" : "the new file"}` : undefined}
+        onClose={() => setAt(null)}>
+        <textarea value={note} onChange={(e) => setNote(e.target.value)} rows={5}
+          placeholder="What is wrong with this line, or what you would rather see"
+          className="w-full rounded-xl p-3 text-[13px]"
+          style={{ background: "var(--bg2)", border: "1px solid var(--mb-line)", color: "var(--text)", resize: "vertical" }} />
+        <div className="flex gap-2 mt-3">
+          <Act small full onAct={() => setAt(null)}>Cancel</Act>
+          <Act small full kind="acc" onAct={() => {
+            if (!at) return;
+            setDraft((cur) => withRemark(cur, at.path, at.line, at.side, note));
+            // Saying it is queued matters more here than anywhere else: nothing
+            // has gone to GitHub yet, and a remark that vanished into a closing
+            // sheet would be written twice or not at all.
+            toast(note.trim() ? "Queued for the review" : "Remark removed");
+            setAt(null);
+          }}>{note.trim() ? "Save" : "Remove"}</Act>
+        </div>
+      </Sheet>
+
+      <ReviewSheet open={reviewing} draft={draft} verb={verb} verdict={verdict}
+        mine={!!d?.viewerDidAuthor}
+        onVerb={setVerb} onBody={(b) => setDraft((cur) => ({ ...cur, body: b }))}
+        onDrop={(c) => setDraft((cur) => withRemark(cur, c.path, c.line, c.side, ""))}
+        onClose={() => setReviewing(false)}
+        onSubmit={async () => {
+          if (!d || !verdict.ok || !verb) return;
+          await act(verb === "approve" ? "Approved" : verb === "request_changes" ? "Changes requested" : "Review sent",
+            () => api.prReviewWith(root, d.number, verb, draft.body, draft.comments));
+          setDraft(EMPTY); setVerb(null); setReviewing(false);
+        }} />
 
       <Sheet open={more} title="Pull request" sub="Things you do to it, rather than in it."
         onClose={() => setMore(false)}>
@@ -396,4 +465,104 @@ async function handOver(
     onOpenChatWith(r.cwd, r.prompt && prompt.startsWith("Review pull request") ? r.prompt : prompt);
     toast(`Checked out #${number} — it is waiting in chat`);
   } catch (e) { toast(String(e), true); }
+}
+
+/**
+ * The verdict, and everything queued under it.
+ *
+ * Three verbs, not one. The screen could approve and it could merge, which
+ * covers exactly the review that has nothing to say — and a phone is where you
+ * are most likely to be reading something you want to push back on, because you
+ * are not at the keyboard that would let you fix it yourself.
+ *
+ * The queued remarks are listed and removable from here, so the last thing you
+ * see before sending is everything you are about to send. A review you cannot
+ * re-read before submitting is one you write more carefully than you should
+ * have to.
+ */
+function ReviewSheet({ open, draft, verb, verdict, mine, onVerb, onBody, onDrop, onClose, onSubmit }: {
+  open: boolean;
+  draft: ReviewDraft;
+  verb: Verb | null;
+  verdict: { ok: true } | { ok: false; why: string };
+  mine: boolean;
+  onVerb: (v: Verb) => void;
+  onBody: (b: string) => void;
+  onDrop: (c: { path: string; line: number; side: Side }) => void;
+  onClose: () => void;
+  onSubmit: () => void;
+}) {
+  const VERBS: { id: Verb; label: string; hint: string }[] = [
+    { id: "approve", label: "Approve", hint: "It can go in" },
+    { id: "request_changes", label: "Request changes", hint: "Not until these are addressed" },
+    { id: "comment", label: "Comment", hint: "Thoughts, no verdict" },
+  ];
+  return (
+    <Sheet open={open} title="Submit review" sub={summarise(draft)} onClose={onClose}>
+      <div className="flex flex-col gap-2">
+        {VERBS.map((v) => {
+          // Both of these are refused by GitHub on your own pull request. Saying
+          // so on the option is better than letting it be chosen and then
+          // disabling the button underneath with a reason nobody connects to it.
+          const barred = mine && v.id !== "comment";
+          const on = verb === v.id;
+          return (
+            <button key={v.id} disabled={barred} onClick={() => onVerb(v.id)}
+              className={`mb-row mb-press${barred ? " dis" : ""}`}
+              style={{
+                opacity: barred ? 0.4 : 1,
+                borderColor: on ? "var(--primary-hover)" : undefined,
+                background: on ? "color-mix(in srgb, var(--primary) 14%, transparent)" : undefined,
+              }}>
+              <span className="i">
+                <b style={{ color: on ? "var(--primary-hover)" : undefined }}>{v.label}</b>
+                <span>{barred ? "Not on your own pull request" : v.hint}</span>
+              </span>
+              {on && <span className="r" style={{ color: "var(--primary-hover)" }}>✓</span>}
+            </button>
+          );
+        })}
+      </div>
+
+      <textarea value={draft.body} onChange={(e) => onBody(e.target.value)} rows={4}
+        placeholder="A covering note (optional for an approval)"
+        className="w-full rounded-xl p-3 text-[13px] mt-3"
+        style={{ background: "var(--bg2)", border: "1px solid var(--mb-line)", color: "var(--text)", resize: "vertical" }} />
+
+      {annotatedPaths(draft).length > 0 && (
+        <>
+          <div className="mb-eyebrow" style={{ margin: "16px 0 8px" }}>Queued remarks</div>
+          <div className="flex flex-col gap-2">
+            {annotatedPaths(draft).map((path) => (
+              <div key={path}>
+                <div className="text-[10.5px] mb-1.5 truncate" style={{ color: "var(--text3)" }}>
+                  {path} · {countFor(draft, path)}
+                </div>
+                {draft.comments.filter((c) => c.path === path).map((c) => (
+                  <div key={`${c.side}${c.line}`} className="flex items-start gap-2 mb-1.5">
+                    <span className="mb-tnum text-[10.5px] pt-1" style={{ color: "var(--text3)", flex: "none", minWidth: 34 }}>
+                      {c.side === "LEFT" ? "−" : "+"}{c.line}
+                    </span>
+                    <span className="flex-1 min-w-0 text-[11.5px]" style={{ color: "var(--text2)", overflowWrap: "anywhere" }}>
+                      {c.body}
+                    </span>
+                    <button className="mb-press" aria-label={`Remove the remark on line ${c.line}`}
+                      onClick={() => onDrop(c)}
+                      style={{ flex: "none", minHeight: 40, minWidth: 40, borderRadius: 10, color: "var(--text3)", background: "transparent" }}>✕</button>
+                  </div>
+                ))}
+              </div>
+            ))}
+          </div>
+        </>
+      )}
+
+      {!verdict.ok && (
+        <p className="text-[11px] mt-4" style={{ color: "var(--warning)" }}>{verdict.why}</p>
+      )}
+      <div className="mt-3">
+        <Act full kind="acc" disabled={!verdict.ok} onAct={onSubmit}>Submit review</Act>
+      </div>
+    </Sheet>
+  );
 }

--- a/web/src/mobile/reviewDraft.ts
+++ b/web/src/mobile/reviewDraft.ts
@@ -1,0 +1,133 @@
+/**
+ * Reviewing a pull request from a phone, properly.
+ *
+ * The screen could approve and it could merge, and that was the whole of it:
+ * no "request changes", no "comment", and no way to say anything about a
+ * specific line. `MobileDiff` has taken an `onLine` prop since it was written —
+ * it renders every line as a button when you pass one, and the footer even says
+ * "Tap a line to comment on it" — and nothing has ever passed it. So the
+ * feature was built, shipped, and unreachable.
+ *
+ * Wiring it up as it stood would have been worse than leaving it. `onLine` gave
+ * the caller `(path, line)` and nothing else, and a diff has two coordinate
+ * systems: an added or context line carries its number in the *new* file, and a
+ * deleted line carries its number in the *old* one. Posting a deleted line's
+ * number as a RIGHT-side comment either lands on unrelated code that happens to
+ * sit at that number now, or is rejected outright. The side is not decoration;
+ * it is half the address.
+ *
+ * GitHub's own model is a *pending review*: you read, you leave remarks as you
+ * go, and you submit them together with a verdict — one notification for the
+ * author instead of a scatter of them. That is what this holds.
+ *
+ * Its own module, with no imports, so the rules can be tested without the
+ * screen around them.
+ */
+
+export type Verb = "approve" | "request_changes" | "comment";
+export type Side = "LEFT" | "RIGHT";
+
+/** The three kinds of line a diff renders that can carry a comment. */
+export type LineKind = "add" | "del" | "ctx";
+
+export interface DraftComment {
+  path: string;
+  line: number;
+  side: Side;
+  body: string;
+}
+
+export interface ReviewDraft {
+  /** The covering note. Optional for an approval, load-bearing otherwise. */
+  body: string;
+  comments: DraftComment[];
+}
+
+export const EMPTY: ReviewDraft = { body: "", comments: [] };
+
+/**
+ * Which file a line number belongs to.
+ *
+ * A deleted line only exists on the left; everything else is addressed on the
+ * right. Context lines are numbered in the new file by the renderer, so they
+ * are RIGHT too — which is also what GitHub expects for an unchanged line.
+ */
+export function sideFor(kind: LineKind): Side {
+  return kind === "del" ? "LEFT" : "RIGHT";
+}
+
+/** One remark can occupy one address, so a second on the same line replaces it
+ *  rather than stacking two comments the reader has to reconcile. */
+function sameSpot(a: DraftComment, path: string, line: number, side: Side): boolean {
+  return a.path === path && a.line === line && a.side === side;
+}
+
+export function commentAt(
+  d: ReviewDraft, path: string, line: number, side: Side,
+): DraftComment | null {
+  return d.comments.find((c) => sameSpot(c, path, line, side)) ?? null;
+}
+
+/**
+ * Leave a remark, replace one, or clear it.
+ *
+ * An empty body is a deletion rather than a comment saying nothing: the composer
+ * opens pre-filled when you tap a line you have already annotated, so clearing
+ * the box and confirming is the obvious way to take it back.
+ */
+export function setComment(
+  d: ReviewDraft, path: string, line: number, side: Side, body: string,
+): ReviewDraft {
+  const text = body.trim();
+  const rest = d.comments.filter((c) => !sameSpot(c, path, line, side));
+  if (!text || !path || !Number.isInteger(line) || line <= 0) return { ...d, comments: rest };
+  return { ...d, comments: [...rest, { path, line, side, body: text }] };
+}
+
+/** Every path this draft has something to say about, in the order first said. */
+export function annotatedPaths(d: ReviewDraft): string[] {
+  return [...new Set(d.comments.map((c) => c.path))];
+}
+
+export function countFor(d: ReviewDraft, path: string): number {
+  return d.comments.filter((c) => c.path === path).length;
+}
+
+export interface Refusal { ok: false; why: string }
+export type Verdict = { ok: true } | Refusal;
+
+/**
+ * Whether this verb can be submitted, and if not, the sentence to show.
+ *
+ * The rules are GitHub's, mirrored here so a button is disabled with a reason
+ * on it rather than a request coming back red. The server checks the same
+ * things — it has to, since it is reachable from the desktop too — and the
+ * wording is kept close so the two do not tell different stories.
+ */
+export function canSubmit(
+  d: ReviewDraft, verb: Verb | null, viewerDidAuthor: boolean,
+): Verdict {
+  if (!verb) return { ok: false, why: "Choose approve, request changes, or comment" };
+  // GitHub refuses both of these on your own pull request. Commenting on it is
+  // allowed, and is the useful one — that is how you answer a reviewer.
+  if (viewerDidAuthor && verb === "approve") {
+    return { ok: false, why: "You cannot approve your own pull request" };
+  }
+  if (viewerDidAuthor && verb === "request_changes") {
+    return { ok: false, why: "You cannot request changes on your own pull request" };
+  }
+  // An empty COMMENT review is rejected outright, and a REQUEST_CHANGES with
+  // nothing said is unkind to whoever receives it.
+  if (verb !== "approve" && !d.body.trim() && !d.comments.length) {
+    return { ok: false, why: "Say something, or leave at least one line comment" };
+  }
+  return { ok: true };
+}
+
+/** What the header says you are about to send. */
+export function summarise(d: ReviewDraft): string {
+  const n = d.comments.length;
+  const files = annotatedPaths(d).length;
+  if (!n) return d.body.trim() ? "A note, with no line comments" : "Nothing queued yet";
+  return `${n} comment${n > 1 ? "s" : ""} on ${files} file${files > 1 ? "s" : ""}`;
+}

--- a/web/test/review-draft.test.ts
+++ b/web/test/review-draft.test.ts
@@ -1,0 +1,161 @@
+/*
+ * Reviewing a pull request from a phone.
+ *
+ * The screen could approve and it could merge. There was no "request changes",
+ * no "comment", and no way to say anything about a specific line — even though
+ * `MobileDiff` has taken an `onLine` prop since it was written, renders every
+ * line as a button when you pass one, and prints "Tap a line to comment on it"
+ * under the diff. Nothing ever passed it. Built, shipped, unreachable.
+ *
+ * The reason it could not simply be plugged in is the interesting half. A diff
+ * has two coordinate systems, and `onLine` only ever handed over `(path, line)`.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  EMPTY, sideFor, setComment, commentAt, annotatedPaths, countFor, canSubmit, summarise,
+  type ReviewDraft, type Verb,
+} from "../src/mobile/reviewDraft.ts";
+
+const draft = (over: Partial<ReviewDraft> = {}): ReviewDraft => ({ ...EMPTY, ...over });
+
+describe("which file a line number belongs to", () => {
+  it("addresses a deleted line on the left and everything else on the right", () => {
+    // The renderer numbers a deleted line in the OLD file and an added or
+    // context line in the NEW one. Sending a deleted line's number as a
+    // RIGHT-side comment lands it on whatever code happens to sit at that
+    // number now, or is rejected — either way the remark is not where it was
+    // meant to go, and the reader has no way to tell.
+    expect(sideFor("del")).toBe("LEFT");
+    expect(sideFor("add")).toBe("RIGHT");
+    expect(sideFor("ctx")).toBe("RIGHT");
+  });
+});
+
+describe("leaving remarks while you read", () => {
+  it("keeps a comment against its address", () => {
+    const d = setComment(EMPTY, "src/a.ts", 12, "RIGHT", "This allocates per row");
+    expect(d.comments).toEqual([{ path: "src/a.ts", line: 12, side: "RIGHT", body: "This allocates per row" }]);
+    expect(commentAt(d, "src/a.ts", 12, "RIGHT")?.body).toBe("This allocates per row");
+  });
+
+  it("treats the two sides of one line number as different places", () => {
+    // The same number on the left and on the right are different lines of
+    // different files. Folding them together would silently overwrite one.
+    let d = setComment(EMPTY, "src/a.ts", 12, "RIGHT", "the new one");
+    d = setComment(d, "src/a.ts", 12, "LEFT", "the old one");
+    expect(d.comments).toHaveLength(2);
+    expect(commentAt(d, "src/a.ts", 12, "LEFT")?.body).toBe("the old one");
+    expect(commentAt(d, "src/a.ts", 12, "RIGHT")?.body).toBe("the new one");
+  });
+
+  it("replaces rather than stacks when you come back to a line", () => {
+    let d = setComment(EMPTY, "src/a.ts", 12, "RIGHT", "first thought");
+    d = setComment(d, "src/a.ts", 12, "RIGHT", "better thought");
+    expect(d.comments).toHaveLength(1);
+    expect(d.comments[0]!.body).toBe("better thought");
+  });
+
+  it("clearing the box takes the remark back", () => {
+    let d = setComment(EMPTY, "src/a.ts", 12, "RIGHT", "never mind");
+    d = setComment(d, "src/a.ts", 12, "RIGHT", "   ");
+    expect(d.comments).toHaveLength(0);
+    expect(commentAt(d, "src/a.ts", 12, "RIGHT")).toBeNull();
+  });
+
+  it("refuses an address that is not one", () => {
+    // `onLine` passes `Number(l.n) || 0`, and a hunk header has no number at
+    // all — so 0 is reachable from the screen and must not become a comment
+    // GitHub rejects at submit time, after the review is written.
+    expect(setComment(EMPTY, "src/a.ts", 0, "RIGHT", "on nothing").comments).toHaveLength(0);
+    expect(setComment(EMPTY, "", 12, "RIGHT", "nowhere").comments).toHaveLength(0);
+    expect(setComment(EMPTY, "src/a.ts", 1.5, "RIGHT", "between lines").comments).toHaveLength(0);
+  });
+
+  it("trims, so an accidental newline is not a comment", () => {
+    expect(setComment(EMPTY, "a.ts", 1, "RIGHT", "  said  ").comments[0]!.body).toBe("said");
+  });
+
+  it("groups by file for the list, in the order they were first written", () => {
+    let d = setComment(EMPTY, "b.ts", 3, "RIGHT", "x");
+    d = setComment(d, "a.ts", 9, "RIGHT", "y");
+    d = setComment(d, "b.ts", 40, "RIGHT", "z");
+    expect(annotatedPaths(d)).toEqual(["b.ts", "a.ts"]);
+    expect(countFor(d, "b.ts")).toBe(2);
+    expect(countFor(d, "a.ts")).toBe(1);
+    expect(countFor(d, "never.ts")).toBe(0);
+  });
+});
+
+describe("what may be submitted", () => {
+  const verbs: Verb[] = ["approve", "request_changes", "comment"];
+
+  it("needs a verb", () => {
+    expect(canSubmit(draft({ body: "looks fine" }), null, false)).toEqual({
+      ok: false, why: "Choose approve, request changes, or comment",
+    });
+  });
+
+  it("lets an approval carry no words at all", () => {
+    expect(canSubmit(EMPTY, "approve", false)).toEqual({ ok: true });
+  });
+
+  it("will not let you approve or demand changes on your own", () => {
+    // GitHub refuses both. A button that always comes back red is worse than a
+    // button that says why before you press it.
+    expect(canSubmit(draft({ body: "ok" }), "approve", true).ok).toBe(false);
+    expect(canSubmit(draft({ body: "no" }), "request_changes", true).ok).toBe(false);
+    // Commenting on your own is allowed, and is how you answer a reviewer.
+    expect(canSubmit(draft({ body: "answering the thread" }), "comment", true)).toEqual({ ok: true });
+  });
+
+  it("will not send a verdict with nothing said", () => {
+    // The same rule the server applies, so this disables a button instead of
+    // losing a review to an error toast.
+    expect(canSubmit(EMPTY, "comment", false).ok).toBe(false);
+    expect(canSubmit(EMPTY, "request_changes", false).ok).toBe(false);
+    expect(canSubmit(draft({ body: "   " }), "comment", false).ok).toBe(false);
+  });
+
+  it("counts line comments as having said something", () => {
+    const d = setComment(EMPTY, "a.ts", 4, "RIGHT", "this leaks");
+    expect(canSubmit(d, "request_changes", false)).toEqual({ ok: true });
+    expect(canSubmit(d, "comment", false)).toEqual({ ok: true });
+  });
+
+  it("always explains a refusal in a sentence a person can act on", () => {
+    // The rule over the verbs rather than over the three cases above: any
+    // refusal the screen can reach has to arrive with its reason.
+    for (const v of verbs) {
+      for (const mine of [true, false]) {
+        const r = canSubmit(EMPTY, v, mine);
+        if (r.ok) continue;
+        expect(r.why.length).toBeGreaterThan(12);
+        expect(r.why).not.toContain("undefined");
+      }
+    }
+  });
+});
+
+describe("what the header says you are about to send", () => {
+  it("counts the remarks and the files they are on", () => {
+    let d = setComment(EMPTY, "a.ts", 1, "RIGHT", "x");
+    expect(summarise(d)).toBe("1 comment on 1 file");
+    d = setComment(d, "b.ts", 2, "RIGHT", "y");
+    expect(summarise(d)).toBe("2 comments on 2 files");
+  });
+
+  it("counts files, not remarks, as the files", () => {
+    // Three remarks all on one file is "3 comments on 1 file". With one remark
+    // per file the two numbers are equal, which is how a summary that says
+    // `${n} comments on ${n} files` passes every test written without this one.
+    let d = setComment(EMPTY, "a.ts", 1, "RIGHT", "x");
+    d = setComment(d, "a.ts", 2, "RIGHT", "y");
+    d = setComment(d, "a.ts", 3, "RIGHT", "z");
+    expect(summarise(d)).toBe("3 comments on 1 file");
+  });
+
+  it("distinguishes a bare note from an empty draft", () => {
+    expect(summarise(EMPTY)).toBe("Nothing queued yet");
+    expect(summarise(draft({ body: "one thought" }))).toBe("A note, with no line comments");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The pull request screen could approve and it could merge. That is the whole of the review that has nothing to say — and a phone is where you are most likely to be reading something you want to push back on, because you are not at the keyboard that would let you fix it yourself. There was no *request changes*, no *comment*, and nothing to say about a specific line.

The last of those was built, shipped and unreachable. `MobileDiff` has taken an `onLine` prop since it was written, renders every line as a button when you pass one, and prints *"Tap a line to comment on it"* under the diff. Nothing has ever passed it.

**Plugging it in as it stood would have been worse than leaving it alone.** `onLine` handed the caller `(path, line)` and nothing else, and a diff has two coordinate systems: an added or context line carries its number in the *new* file, a deleted line carries its number in the *old* one. A deleted line's number sent as a RIGHT-side comment either lands on whatever code sits at that number now or is rejected outright, and the reader has no way to tell which. The side is not decoration, it is half the address. It is `onLine`'s third argument now, and one rule decides it for both the renderer and the payload.

What this adds is GitHub's own model — a pending review. Read, leave remarks as you go, submit them together with a verdict, one notification for the author instead of a scatter. The remarks are listed and removable from the submit sheet, so the last thing you see before sending is everything you are about to send. Tapping a line you have already annotated re-opens it pre-filled, so editing and deleting are the same gesture as writing.

The rules about what may be submitted are the server's, mirrored so a button is disabled with a reason rather than a request coming back red: approve needs no words, the other two need a note or at least one line comment, and GitHub refuses approve and request-changes on your own pull request while allowing a comment — which is how you answer a reviewer.

## How was it tested?

`web/test/review-draft.test.ts`, 17 tests. Both suites green: 638 in `web/`, 1047 in `server/`.

Thirteen mutations, each reverted after confirming the failure: every line addressed on the right; the side dropped from an address; a second remark stacking instead of replacing; clearing the box keeping the old remark; line 0 accepted as an address; approving your own; demanding changes on your own; commenting on your own barred too; an empty verdict allowed; line comments not counting as having said something; an approval required to carry words; a missing verb allowed through; the summary counting remarks as files.

The last of those walked through the first time, because every summary case I had written put one remark on one file — where "N comments on N files" is indistinguishable from the correct answer. There is now a case with three remarks on one file.

**Driven on a real server.** This container has no `gh`, so the entire pull request half of the phone could not be opened at all — which meant the screen this change is about was unreachable for testing. I put a stub on `PATH` serving the three calls the screen makes (`auth status`, the detail GraphQL query, `pr diff`), logging anything written back. Getting there found a detail worth writing down: `ghGraphql` prefers a direct HTTPS call using `gh auth token` and only falls back to shelling out, so the stub has to *refuse* to hand over a token.

With that, the whole journey at a phone viewport: repo → Pull requests → #482 → Files → open the diff → tap the deleted line → write → save → Finish review → pick a verb → submit. The payload the server would have sent to GitHub:

```json
{ "event": "REQUEST_CHANGES",
  "comments": [{ "path": "src/cart.ts", "line": 12, "side": "LEFT",
                 "body": "This dropped the per-line rounding — deliberate?" }] }
```

`side: "LEFT"` with the old-file line number — which is the entire point, and exactly what the old signature could not have produced.

`scripts/phone-audit.ts` gained a review section covering everything up to and including the state of the Submit button, and nothing that posts. 124/124.

Two things the audit itself turned up:

- **It skipped the whole section for two runs.** A pull request row *is* a button; a file row *contains* one. Reaching for `.mb-row button` on the list matched nothing, and the only sign was a check count nobody was watching. Fixed, and the section now prints a visible `skip` line when there is no pull request to review — a conditional section that stays quiet reads as one that passed.
- **A diff line was a 19px tap target.** Lines are taller now (25px), and the floor is relaxed for diff lines alone with the reason written down: a phone-sized diff at 44px a line shows eighteen of them, and reading the change is the point of the screen. What makes a mis-tap survivable is that the sheet opens naming the file, the line and the side before a word is written. Nothing else gets that exemption, and a diff line still has to clear 18px — raising that floor to 40 turns the check red on exactly the review screen.