### PR TITLE
Read the thread, not its first line

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -171,6 +171,9 @@ const texts = (cdp: CDP, sel: string) =>
  */
 const TOP = `[...document.querySelectorAll(".mb-screen.on")].pop()`;
 
+/** Close the screen that is actually on top. */
+const closeTop = (cdp: CDP) => cdp.ev(`(()=>{const b=${TOP}?.querySelector(".hd .back");b?.click();return !!b})()`);
+
 /** Click inside the topmost screen only. */
 const tapTop = async (cdp: CDP, sel: string, needle?: string) => {
   const hit = await cdp.ev(`(()=>{const s=${TOP}; if(!s) return false;
@@ -548,6 +551,47 @@ async function main() {
               // Leave without sending anything.
               await cdp.ev(`document.querySelector(".mb-scrim.on")?.click()`);
               await Bun.sleep(500);
+            }
+          }
+          // The TOP screen's back, not the first one in the document. Screens
+          // stay mounted under their children, so `.mb-screen.on .hd .back`
+          // matches the repository's back button first and closes the wrong
+          // thing — which is why the section below saw a diff where it expected
+          // a pull request. Same trap the TOP helper exists for.
+          await closeTop(cdp);
+          await Bun.sleep(700);
+
+          // ---- line threads --------------------------------------------
+          //
+          // Read-only again: what is drawn and in what order. Replying and
+          // resolving are writes and are not pressed here.
+          if (await tap(cdp, ".mb-screen.on .mb-seg button", "Talk")) {
+            await Bun.sleep(1600);
+            const threads = await cdp.ev(`${TOP}.querySelectorAll(".mb-thr").length`);
+            if (!threads) {
+              console.log("  skip  threads · no line threads on this pull request");
+            } else {
+              // Every reply, not a count. The old rendering folded a thread into
+              // its opening sentence and dropped the answers — which is the part
+              // that decides anything.
+              note("threads", "every reply is on screen, not a count",
+                await cdp.ev(`[...${TOP}.querySelectorAll(".mb-thr")].some(t=>t.querySelectorAll(".tc").length > 1)`),
+                await cdp.ev(`JSON.stringify([...${TOP}.querySelectorAll(".mb-thr")].map(t=>t.querySelectorAll(".tc").length))`));
+              note("threads", "what is still open is read first",
+                await cdp.ev(`(()=>{const q=[...${TOP}.querySelectorAll(".mb-thr")].map(t=>t.classList.contains("quiet"));
+                  return q.indexOf(false) === -1 || q.lastIndexOf(false) < (q.indexOf(true) === -1 ? q.length : q.indexOf(true));})()`),
+                await cdp.ev(`JSON.stringify([...${TOP}.querySelectorAll(".mb-thr .th")].map(e=>e.textContent))`));
+              note("threads", "a settled thread says which kind of settled",
+                await cdp.ev(`[...${TOP}.querySelectorAll(".mb-thr.quiet")].every(t=>/resolved|outdated/.test(t.textContent))`));
+              note("threads", "each one can be answered and closed",
+                await cdp.ev(`[...${TOP}.querySelectorAll(".mb-thr")].every(t=>{
+                  const v=[...t.querySelectorAll(".ta button")].map(b=>b.textContent.trim());
+                  return v.includes("Reply") && (v.includes("Resolve") || v.includes("Reopen"));})`));
+              note("threads", "a line with no current number does not print one",
+                !(await cdp.ev(`/:(null|undefined|NaN)/.test(${TOP}.textContent)`)));
+              await shot(cdp, "07c-threads");
+              await hygiene(cdp, "threads");
+              await drain(cdp, "threads");
             }
           }
           await tap(cdp, ".mb-screen.on .hd .back");

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -13,7 +13,7 @@ import { NOW_CSS, NowHero, NowStream, type NowAction, type LiveCall } from "./Mo
 import { RepoList, RepoScreen, ContainerScreen, HALT_CSS, type RepoSummary } from "./MobileRepo.tsx";
 import { projectRows } from "./projects.ts";
 import { baseName, ownerOf } from "../../../shared/projectKey.ts";
-import { MobilePr } from "./MobilePr.tsx";
+import { MobilePr, THREAD_CSS } from "./MobilePr.tsx";
 import { buildQueue, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
@@ -582,7 +582,7 @@ export function MobileApp() {
 
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
-      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}{HALT_CSS}</style>
+      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}{HALT_CSS}{THREAD_CSS}</style>
       {askDialog}
       <div className="mb-sky" />
 

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -9,6 +9,7 @@ import {
   EMPTY, canSubmit, commentAt, countFor, annotatedPaths, setComment as withRemark, summarise,
   type ReviewDraft, type Side, type Verb,
 } from "./reviewDraft.ts";
+import { orderThreads, openCount, type ThreadRow } from "./threads.ts";
 
 /**
  * Reviewing a pull request from a phone.
@@ -63,6 +64,8 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
   const [at, setAt] = useState<{ path: string; line: number; side: Side } | null>(null);
   const [note, setNote] = useState("");
   const [reviewing, setReviewing] = useState(false);
+  const [replyTo, setReplyTo] = useState<ThreadRow | null>(null);
+  const [replyText, setReplyText] = useState("");
   const [verb, setVerb] = useState<Verb | null>(null);
   const verdict = canSubmit(draft, verb, !!d?.viewerDidAuthor);
 
@@ -72,6 +75,7 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
     // A review is written about one pull request. Carrying remarks from the
     // last one into the next would post them against lines that mean nothing.
     setDraft(EMPTY); setVerb(null); setAt(null); setNote(""); setReviewing(false);
+    setReplyTo(null); setReplyText("");
     api.prDetail(root, number).then((r) => {
       if (r.ok && r.detail) setD(r.detail); else setErr(r.error || "Could not load it");
     }).catch((e) => setErr(String(e)));
@@ -235,7 +239,11 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
 
             {tab === "talk" && (
               <>
-                <Talk d={d} />
+                <Talk d={d}
+                  onReply={(t) => { setReplyTo(t); setReplyText(""); }}
+                  onResolve={(t) => act(
+                    t.thread.isResolved ? "Reopened" : "Resolved",
+                    () => api.prSetThreadResolved(root, t.thread.id, !t.thread.isResolved))} />
                 <div className="mb-card overflow-hidden mt-3">
                   <textarea value={comment} onChange={(e) => setComment(e.target.value)}
                     placeholder="Leave a comment…"
@@ -290,6 +298,22 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
             toast(note.trim() ? "Queued for the review" : "Remark removed");
             setAt(null);
           }}>{note.trim() ? "Save" : "Remove"}</Act>
+        </div>
+      </Sheet>
+
+      <Sheet open={!!replyTo} title="Reply" sub={replyTo?.where} onClose={() => setReplyTo(null)}>
+        <textarea value={replyText} onChange={(e) => setReplyText(e.target.value)} rows={5}
+          placeholder="Answer the thread"
+          className="w-full rounded-xl p-3 text-[13px]"
+          style={{ background: "var(--bg2)", border: "1px solid var(--mb-line)", color: "var(--text)", resize: "vertical" }} />
+        <div className="flex gap-2 mt-3">
+          <Act small full onAct={() => setReplyTo(null)}>Cancel</Act>
+          <Act small full kind="acc" disabled={!replyText.trim() || !d || replyTo?.replyTo == null}
+            onAct={async () => {
+              if (!d || !replyTo || replyTo.replyTo == null) return;
+              await act("Replied", () => api.prReply(root, d.number, replyTo.replyTo!, replyText));
+              setReplyTo(null); setReplyText("");
+            }}>Send</Act>
         </div>
       </Sheet>
 
@@ -412,8 +436,45 @@ function Checks({ d, openLog, onOpenLog, onRerun, onAsk }: {
   );
 }
 
-/** One timeline, oldest first — the order the replies were written in. */
-function Talk({ d }: { d: PrDetail }) {
+/**
+ * A line thread, drawn as one.
+ *
+ * Every reply is shown. A collapsed "3 replies" is the shape that made the old
+ * rendering useless in the first place: the count is never the thing you needed
+ * — the answer is — and on a phone there is nowhere else to go and read it.
+ */
+export const THREAD_CSS = `
+.mb-thr{border-radius:15px;overflow:hidden;background:var(--mb-card);
+  border:1px solid color-mix(in srgb,var(--border) 38%,transparent);box-shadow:var(--mb-edge)}
+.mb-thr.quiet{opacity:.62;border-style:dashed}
+.mb-thr .th{display:flex;align-items:center;gap:8px;padding:9px 12px;font-size:11px;
+  background:color-mix(in srgb,var(--bg3) 44%,transparent);min-width:0}
+.mb-thr .th b{font-weight:600;color:var(--primary-hover);min-width:0}
+.mb-thr .tc{padding:10px 12px 0}
+.mb-thr .tc .w{display:flex;align-items:center;gap:7px;font-size:11px}
+.mb-thr .tc .w b{font-weight:600}
+.mb-thr .tc .b{font-size:12.5px;line-height:1.55;color:var(--text2);margin-top:4px;
+  white-space:pre-wrap;overflow-wrap:anywhere}
+/* Between the opening remark and the answers to it, so a thread reads as a
+   question with replies rather than as a stack of equals. */
+.mb-thr .tc .sep{height:1px;margin:10px 0 0;background:color-mix(in srgb,var(--border) 40%,transparent)}
+.mb-thr .ta{display:flex;gap:9px;padding:11px 12px 12px}
+`;
+
+/**
+ * One timeline, oldest first — the order the replies were written in.
+ *
+ * Line threads are drawn as threads now rather than folded into this list as
+ * their opening sentence. The conversation about one line is the thing that
+ * decides whether a pull request can merge, and it was the one part of the
+ * screen reduced to a single quote with every answer discarded.
+ */
+function Talk({ d, onReply, onResolve }: {
+  d: PrDetail;
+  onReply: (t: ThreadRow) => void;
+  onResolve: (t: ThreadRow) => void;
+}) {
+  const rows = useMemo(() => orderThreads(d.threads), [d.threads]);
   const entries = useMemo(() => {
     const out: { at: string; who: string; verdict?: string; body: string; bot: boolean }[] = [];
     for (const r of d.reviews) {
@@ -425,17 +486,59 @@ function Talk({ d }: { d: PrDetail }) {
       });
     }
     for (const c of d.comments) out.push({ at: c.createdAt, who: c.author, bot: c.isBot, body: c.digest || c.body });
-    for (const t of d.threads) {
-      const first = t.comments[0];
-      if (first) out.push({ at: first.createdAt, who: first.author, bot: first.isBot, body: `${t.path}${t.line ? `:${t.line}` : ""} — ${first.body}` });
-    }
     return out.sort((a, b) => a.at.localeCompare(b.at));
   }, [d]);
 
-  if (!entries.length) return <Empty glyph="▤" title="Nobody has said anything" body="No reviews, comments or line threads on this pull request yet." />;
+  if (!entries.length && !rows.length) {
+    return <Empty glyph="▤" title="Nobody has said anything" body="No reviews, comments or line threads on this pull request yet." />;
+  }
+
+  const threadList = rows.length > 0 && (
+    <>
+      <div className="mb-eyebrow" style={{ margin: "0 0 9px" }}>
+        Line threads · {openCount(d.threads)} open of {rows.length}
+      </div>
+      <div className="flex flex-col gap-2.5 mb-4">
+        {rows.map((r) => (
+          <div key={r.thread.id} className={`mb-thr${r.quiet ? " quiet" : ""}`}>
+            <div className="th">
+              <b className="truncate">{r.where}</b>
+              {r.quiet && <span className="mb-chip" style={{ color: "var(--text3)" }}>{r.quiet}</span>}
+            </div>
+            {r.thread.comments.map((c, i) => (
+              <div className="tc" key={c.id}>
+                <div className="w">
+                  <b>{c.author}</b>
+                  {c.isBot && <span className="mb-chip" style={{ color: "var(--info)" }}>bot</span>}
+                  <span className="ml-auto" style={{ color: "var(--text3)" }}>{fmtAgo(Date.parse(c.createdAt))}</span>
+                </div>
+                <div className="b">{c.body}</div>
+                {/* Every reply is shown. The count under a collapsed thread is
+                    the thing nobody can act on. */}
+                {i === 0 && r.replies > 0 && <div className="sep" />}
+              </div>
+            ))}
+            <div className="ta">
+              <Act small full disabled={r.replyTo == null}
+                title={r.replyTo == null ? "GitHub gave this thread no id to reply to" : undefined}
+                onAct={() => onReply(r)}>Reply</Act>
+              <Act small full kind={r.thread.isResolved ? undefined : "ok"} onAct={() => onResolve(r)}>
+                {r.thread.isResolved ? "Reopen" : "Resolve"}
+              </Act>
+            </div>
+          </div>
+        ))}
+      </div>
+    </>
+  );
+
+  if (!entries.length) return <div>{threadList}</div>;
 
   return (
-    <div className="flex flex-col gap-2.5">
+    <div>
+      {threadList}
+      {rows.length > 0 && <div className="mb-eyebrow" style={{ margin: "0 0 9px" }}>Conversation</div>}
+      <div className="flex flex-col gap-2.5">
       {entries.map((e, i) => (
         <div key={i} className="mb-card overflow-hidden">
           <div className="flex items-center gap-2 px-3 py-2.5 text-[11.5px]" style={{ background: "color-mix(in srgb, var(--bg3) 44%, transparent)" }}>
@@ -447,6 +550,7 @@ function Talk({ d }: { d: PrDetail }) {
           <div className="p-3 text-[12.5px] leading-relaxed whitespace-pre-wrap break-words" style={{ color: "var(--text2)" }}>{e.body}</div>
         </div>
       ))}
+      </div>
     </div>
   );
 }

--- a/web/src/mobile/threads.ts
+++ b/web/src/mobile/threads.ts
@@ -1,0 +1,96 @@
+import type { PrThread } from "../../../shared/types.ts";
+
+/**
+ * Line threads, which the phone had flattened into their first sentence.
+ *
+ * The Talk tab took each thread, threw away every reply, and printed
+ * `path:line — <the first comment>` as one more entry in a sorted list. So the
+ * conversation you most need to read on a phone — the back-and-forth about one
+ * line, the one that decides whether you can merge — was the one thing reduced
+ * to its opening remark. Resolved and unresolved looked identical. Outdated
+ * looked identical. There was no way to reply and no way to resolve, though
+ * `replyToThread` and `resolveReviewThread` have been on the server all along.
+ *
+ * What is worth testing here is the ordering and the addressing, not the
+ * markup: which threads a person needs to see first, and which comment id a
+ * reply has to attach to. Both are easy to get subtly wrong and impossible to
+ * notice afterwards.
+ */
+
+export interface ThreadRow {
+  thread: PrThread;
+  /** Where it happened, in the words the header uses. */
+  where: string;
+  /** Everything after the opening remark. */
+  replies: number;
+  /** The comment a reply attaches to. */
+  replyTo: number | null;
+  /** Why this is not worth your attention, or null when it is. */
+  quiet: "resolved" | "outdated" | null;
+}
+
+/**
+ * `path:line`, or the range, or just the file.
+ *
+ * A thread on a deleted or heavily rewritten file can arrive with no line at
+ * all, and printing `src/cart.ts:null` is how that reads today.
+ */
+export function where(t: PrThread): string {
+  const name = t.path || "(unknown file)";
+  const end = t.line ?? t.originalLine ?? null;
+  if (end == null) return name;
+  const start = t.startLine ?? null;
+  return start && start < end ? `${name}:${start}–${end}` : `${name}:${end}`;
+}
+
+/**
+ * Which comment a reply hangs off.
+ *
+ * GitHub's replies endpoint is `/pulls/{n}/comments/{id}/replies`, and the id
+ * has to be one that is actually in the thread. The first comment is the stable
+ * choice: it exists for as long as the thread does, whereas the last one moves
+ * every time anybody answers — so a screen holding a stale copy would post
+ * against an id the server has already superseded.
+ */
+export function replyTarget(t: PrThread): number | null {
+  for (const c of t.comments) {
+    if (typeof c.databaseId === "number" && c.databaseId > 0) return c.databaseId;
+  }
+  return null;
+}
+
+/**
+ * Threads in the order a person needs them.
+ *
+ * Open first, because those are the ones standing between this and a merge.
+ * Then outdated — the code under them has moved, so they are usually safe to
+ * skip but not always. Resolved last: kept, because "what did we decide about
+ * this line" is a real question, and dropped from the count.
+ *
+ * Inside a band, by file and then by line, so reading down the list is reading
+ * down the diff rather than following the order GitHub happened to return.
+ */
+export function orderThreads(threads: readonly PrThread[]): ThreadRow[] {
+  const rank = (t: PrThread) => (t.isResolved ? 2 : t.isOutdated ? 1 : 0);
+  return [...threads]
+    .sort((a, b) =>
+      rank(a) - rank(b) ||
+      (a.path || "").localeCompare(b.path || "") ||
+      (a.line ?? a.originalLine ?? 0) - (b.line ?? b.originalLine ?? 0))
+    .map((t) => ({
+      thread: t,
+      where: where(t),
+      replies: Math.max(0, t.comments.length - 1),
+      replyTo: replyTarget(t),
+      // Resolved wins over outdated: it is the stronger statement, and a thread
+      // that is both should read as settled rather than as stale.
+      quiet: t.isResolved ? "resolved" : t.isOutdated ? "outdated" : null,
+    }));
+}
+
+/** How many still want an answer — the number the tab badge and the overview
+ *  line are both claiming. Outdated counts: the code moved, the question may
+ *  not have been answered. */
+export function openCount(threads: readonly PrThread[]): number {
+  return threads.filter((t) => !t.isResolved).length;
+}

--- a/web/test/pr-threads.test.ts
+++ b/web/test/pr-threads.test.ts
@@ -1,0 +1,131 @@
+/*
+ * Line threads, which the phone had flattened into their first sentence.
+ *
+ * The Talk tab took each thread, threw away every reply, and printed
+ * `path:line — <the first comment>` as one entry in a sorted list. The
+ * back-and-forth about one line — the conversation that decides whether a pull
+ * request can merge, and the one you are most likely to be catching up on from
+ * a phone — was the one thing reduced to its opening remark. Resolved and
+ * unresolved read identically; so did outdated. There was no way to reply and
+ * no way to resolve, though the server has had both all along.
+ */
+import { describe, expect, it } from "bun:test";
+import { orderThreads, openCount, replyTarget, where } from "../src/mobile/threads.ts";
+import type { PrThread, PrThreadComment } from "../../shared/types.ts";
+
+const c = (over: Partial<PrThreadComment> = {}): PrThreadComment => ({
+  id: "IC_1", databaseId: 5001, author: "dana", isBot: false,
+  body: "This allocates per row", createdAt: "2026-07-28T08:00:00Z", ...over,
+} as PrThreadComment);
+
+const t = (over: Partial<PrThread> = {}): PrThread => ({
+  id: "PRRT_1", path: "src/cart.ts", line: 12, startLine: null,
+  isResolved: false, isOutdated: false, comments: [c()], ...over,
+});
+
+describe("where a thread is", () => {
+  it("names the file and the line", () => {
+    expect(where(t())).toBe("src/cart.ts:12");
+  });
+
+  it("names a range as a range", () => {
+    expect(where(t({ startLine: 8, line: 12 }))).toBe("src/cart.ts:8–12");
+  });
+
+  it("falls back to where the line used to be", () => {
+    // An outdated thread has no current line; the original is the only handle
+    // left, and it is more use than nothing.
+    expect(where(t({ line: null, originalLine: 40 }))).toBe("src/cart.ts:40");
+  });
+
+  it("says just the file rather than a line that is not there", () => {
+    // A thread on a deleted or heavily rewritten file arrives with no line at
+    // all, and `src/cart.ts:null` is what the old template printed.
+    expect(where(t({ line: null, originalLine: null }))).toBe("src/cart.ts");
+    expect(where(t({ path: "", line: null }))).toBe("(unknown file)");
+  });
+
+  it("does not call a range a range when it is one line", () => {
+    expect(where(t({ startLine: 12, line: 12 }))).toBe("src/cart.ts:12");
+  });
+});
+
+describe("what a reply attaches to", () => {
+  it("uses the first comment, which is the one that does not move", () => {
+    // The endpoint is `/pulls/{n}/comments/{id}/replies` and the id has to be
+    // in the thread. The last comment changes every time somebody answers, so
+    // a screen holding a copy from a minute ago would post against an id the
+    // server has already superseded.
+    const th = t({ comments: [c({ databaseId: 5001 }), c({ databaseId: 5002 }), c({ databaseId: 5003 })] });
+    expect(replyTarget(th)).toBe(5001);
+  });
+
+  it("skips a comment with no numeric id rather than sending a node id", () => {
+    // `id` is a GraphQL node id and `databaseId` is what REST wants; the two
+    // are not interchangeable, and sending the wrong one fails at the far end.
+    const th = t({ comments: [c({ databaseId: null }), c({ databaseId: 5002 })] });
+    expect(replyTarget(th)).toBe(5002);
+  });
+
+  it("is null when nothing in the thread can be replied to", () => {
+    expect(replyTarget(t({ comments: [] }))).toBeNull();
+    expect(replyTarget(t({ comments: [c({ databaseId: undefined })] }))).toBeNull();
+    expect(replyTarget(t({ comments: [c({ databaseId: 0 })] }))).toBeNull();
+  });
+});
+
+describe("the order they are read in", () => {
+  it("puts what is still open above what is not", () => {
+    const rows = orderThreads([
+      t({ id: "resolved", isResolved: true }),
+      t({ id: "outdated", isOutdated: true }),
+      t({ id: "open" }),
+    ]);
+    expect(rows.map((r) => r.thread.id)).toEqual(["open", "outdated", "resolved"]);
+  });
+
+  it("reads down the diff inside a band, not in GitHub's order", () => {
+    const rows = orderThreads([
+      t({ id: "c", path: "src/price.ts", line: 4 }),
+      t({ id: "b", path: "src/cart.ts", line: 90 }),
+      t({ id: "a", path: "src/cart.ts", line: 12 }),
+    ]);
+    expect(rows.map((r) => r.thread.id)).toEqual(["a", "b", "c"]);
+  });
+
+  it("calls a thread that is both resolved and outdated settled", () => {
+    // Resolved is the stronger statement: somebody decided. Reading it as
+    // merely stale invites re-litigating a closed question.
+    const [row] = orderThreads([t({ isResolved: true, isOutdated: true })]);
+    expect(row!.quiet).toBe("resolved");
+  });
+
+  it("marks an open thread as wanting nothing said about it", () => {
+    expect(orderThreads([t()])[0]!.quiet).toBeNull();
+    expect(orderThreads([t({ isOutdated: true })])[0]!.quiet).toBe("outdated");
+  });
+
+  it("counts the replies, not the comments", () => {
+    // The opening remark is the thread; what came after it is the conversation,
+    // and "3 comments" on a thread nobody answered is a lie about activity.
+    expect(orderThreads([t({ comments: [c()] })])[0]!.replies).toBe(0);
+    expect(orderThreads([t({ comments: [c(), c(), c()] })])[0]!.replies).toBe(2);
+    expect(orderThreads([t({ comments: [] })])[0]!.replies).toBe(0);
+  });
+
+  it("leaves the caller's array alone", () => {
+    // The detail payload is shared with the overview and the tab badge; sorting
+    // it where it lies would reorder those too.
+    const given = [t({ id: "b", isResolved: true }), t({ id: "a" })];
+    orderThreads(given);
+    expect(given.map((x) => x.id)).toEqual(["b", "a"]);
+  });
+});
+
+describe("how many still want an answer", () => {
+  it("counts everything unresolved, outdated included", () => {
+    // The code moved; that does not mean the question was answered.
+    expect(openCount([t(), t({ isOutdated: true }), t({ isResolved: true })])).toBe(2);
+    expect(openCount([])).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The Talk tab took every line thread, threw away every reply, and printed `path:line — <the opening remark>` as one more entry in a sorted list. So the conversation about one line — the one that decides whether a pull request can merge, and the one you are most likely to be catching up on from a phone — was the single thing on the screen reduced to its first sentence. Resolved and unresolved read identically. Outdated read identically. There was no way to reply and no way to resolve, though `replyToThread` and `resolveReviewThread` have been on the server the whole time.

Threads are drawn as threads now, above the conversation, with every reply on screen. Not a "3 replies" count: the count is never what you needed, the answer is, and on a phone there is nowhere else to go and read it.

Open first, then outdated, then resolved — and inside a band by file and line, so reading down the list is reading down the diff rather than following whatever order GitHub returned. Resolved beats outdated when a thread is both: somebody decided, and reading that as merely stale invites re-litigating a closed question.

Two details that are easy to get wrong and impossible to notice afterwards, so both are decided in one tested place:

- **A reply attaches to the *first* comment.** The endpoint is `/pulls/{n}/comments/{id}/replies` and the id has to be one that is in the thread. The last comment changes every time anybody answers, so a screen holding a copy from a minute ago would post against an id the server has already superseded. It also has to be `databaseId` and not `id` — the latter is a GraphQL node id and the two are not interchangeable.
- **`path:line` is not always available.** A thread on a deleted or rewritten file arrives with no current line, and the old template printed `src/cart.ts:null`. It falls back to where the line used to be, and to the bare filename when there is nothing at all.

## How was it tested?

`web/test/pr-threads.test.ts`, 15 tests. Both suites green: 653 in `web/`, 1047 in `server/`.

Twelve mutations, each reverted after confirming the failure: resolved threads read first; GitHub's order kept inside a band; the caller's array sorted where it lies; a reply attached to the last comment; a node id sent where a numeric one is wanted; comment zero accepted as a target; a missing line printed as `null`; the original line not used as a fallback; one line called a range; outdated winning over resolved; comments counted as replies; outdated threads counted as answered.

**Driven on a real server** with three threads in the fixture — one open with two replies, one outdated with none, one resolved with one — checking both the rendering and the exact payloads. The reply went to `POST repos/acme/shop/pulls/482/comments/5001/replies`, which is the *first* comment of a three-comment thread, and the resolve to `resolveReviewThread(threadId: "PRRT_open")`.

Getting an honest answer there needed a fix to the harness: the stub was returning a query's payload for every GraphQL call, so a mutation could not have failed visibly. It answers mutations separately now and logs them.

`scripts/phone-audit.ts` gained a threads section — ordering, every reply visible, the settled label, both verbs present, and no `:null` anywhere on the screen. Replying and resolving are writes and are not pressed. 135/135.

The audit section did not run the first time, and why is worth recording: **it closed the wrong screen.** Screens stay mounted under their children, so `.mb-screen.on .hd .back` matches the *repository's* back button first — document order, not stack order, which is exactly the trap the `TOP` helper already existed for. There is a `closeTop` now. The section also prints a visible `skip` line when there is nothing to check, for the same reason as the review section: a conditional block that stays quiet reads as one that passed.