### PR TITLE
Put the next move on the merge button, not the word "Blocked"

### DIFF
--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -1668,7 +1668,9 @@ async function runPr(rootIn: unknown, number: number, args: string[], stdin?: st
   const r = await gh([...args, "-R", repo.nameWithOwner], undefined, stdin);
   invalidate(repo, number);
   if (r.code !== 0) return { ok: false, error: (r.stderr || r.stdout).trim().split("\n")[0] || "gh failed" };
-  return { ok: true, detail: r.stdout.trim() || undefined };
+  // The first line, the same as the error path above. This is shown in a toast
+  // — a phone-width one — and some of these commands print a paragraph.
+  return { ok: true, detail: r.stdout.trim().split("\n")[0] || undefined };
 }
 
 const REVIEW_FLAG = { approve: "--approve", request_changes: "--request-changes", comment: "--comment" } as const;

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -10,6 +10,7 @@ import {
   type ReviewDraft, type Side, type Verb,
 } from "./reviewDraft.ts";
 import { orderThreads, openCount, type ThreadRow } from "./threads.ts";
+import { mergeMove, MERGE_WHY, whyBlocked } from "./mergeMove.ts";
 
 /**
  * Reviewing a pull request from a phone.
@@ -27,15 +28,6 @@ import { orderThreads, openCount, type ThreadRow } from "./threads.ts";
 
 type Tab = "overview" | "files" | "checks" | "talk";
 
-const MERGE_WHY: Record<string, string> = {
-  BLOCKED: "A required review or check has not passed",
-  BEHIND: "The base branch has moved — update the branch first",
-  DIRTY: "There are conflicts with the base branch",
-  UNSTABLE: "A check is failing",
-  DRAFT: "This is a draft",
-  HAS_HOOKS: "A repository hook is blocking the merge",
-  UNKNOWN: "GitHub has not finished working it out",
-};
 
 export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: {
   open: boolean; root: string; number: number | null; onBack: () => void;
@@ -102,6 +94,14 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
   const { ask, dialog: askDialog } = useAsk();
 
   const canMerge = d?.mergeState === "CLEAN";
+  /** The one thing worth putting on the primary button — see mergeMove.ts. */
+  const mergeFacts = d && {
+    state: d.mergeState, isDraft: d.isDraft,
+    autoMerge: !!d.autoMerge,
+    anyFailing: d.checks.failure > 0,
+  };
+  const move = mergeFacts ? mergeMove(mergeFacts) : null;
+  const why = mergeFacts ? whyBlocked(mergeFacts) : "";
 
   const openThreads = d?.threads.filter((t) => !t.isResolved).length ?? 0;
 
@@ -119,26 +119,45 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
           onClick={() => setMore(true)} aria-label="More">⋯</button>}
         foot={d ? (
           <>
-            {!canMerge && (
+            {move?.kind !== "merge" && (
               <div className="absolute left-0 right-0 text-center text-[10.5px] px-4"
                 style={{ top: -21, color: "var(--text3)" }}>
-                {MERGE_WHY[d.mergeState] ?? "Not mergeable"}
+                {why}
               </div>
             )}
             <Act small onAct={() => act("Approved", () => api.prReview(root, d.number, "approve", ""))}
               disabled={d.viewerDidAuthor} title={d.viewerDidAuthor ? "You cannot approve your own pull request" : undefined}>
               ✓ Approve
             </Act>
-            <Act kind="acc" full disabled={!canMerge}
-              title={canMerge ? undefined : MERGE_WHY[d.mergeState]}
+            {/* The next useful move rather than a dead "Blocked". The reason
+                stays above it either way — it was the good part. */}
+            <Act kind={move?.kind === "merge" ? "acc" : move?.kind === "none" ? undefined : "ok"}
+              full disabled={!move || move.kind === "none"}
+              title={move?.kind === "none" ? why : undefined}
               onAct={async () => {
-                if (!(await ask({
-                  title: `Squash & merge #${d.number}?`, danger: true, confirmLabel: "Squash & merge",
-                  body: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
-                }))) return;
-                await act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true }));
+                if (!move) return;
+                if (move.kind === "merge") {
+                  if (!(await ask({
+                    title: `Squash & merge #${d.number}?`, danger: true, confirmLabel: "Squash & merge",
+                    body: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
+                  }))) return;
+                  await act(`Merged #${d.number}`, () => api.prMerge(root, d.number, "squash", { deleteBranch: true }));
+                } else if (move.kind === "update") {
+                  await act("Branch updated from the base", () => api.prUpdateBranch(root, d.number));
+                } else if (move.kind === "auto") {
+                  // Arming this is a decision that outlives the screen: it
+                  // merges without you when the run turns green.
+                  if (!(await ask({
+                    title: `Merge #${d.number} when the checks pass?`, confirmLabel: "Arm it",
+                    body: "GitHub squashes and merges it on its own the moment everything required is green, and deletes the head branch. Nobody presses anything.",
+                  }))) return;
+                  await act("Armed — it merges when the checks pass",
+                    () => api.prMerge(root, d.number, "squash", { auto: true, deleteBranch: true }));
+                } else if (move.kind === "rerun") {
+                  await act("Re-running the failed checks", () => api.prRerun(root, d.number));
+                }
               }}>
-              {canMerge ? "Squash & merge" : "Blocked"}
+              {move?.label ?? "…"}
             </Act>
           </>
         ) : undefined}
@@ -183,7 +202,7 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
                     <span>
                       <b className="block text-[14.5px]">{canMerge ? "Ready to merge" : "Merging is blocked"}</b>
                       <span className="block text-[11.5px] mt-0.5" style={{ color: "var(--text3)" }}>
-                        {canMerge ? "Nothing is standing in the way" : (MERGE_WHY[d.mergeState] ?? "Not mergeable")}
+                        {canMerge ? MERGE_WHY.CLEAN : why}
                       </span>
                     </span>
                   </div>

--- a/web/src/mobile/mergeMove.ts
+++ b/web/src/mobile/mergeMove.ts
@@ -1,0 +1,98 @@
+import type { PrMergeState } from "../../../shared/types.ts";
+
+/**
+ * What to do about a pull request that will not merge.
+ *
+ * The footer had one button and two states: "Squash & merge" when GitHub said
+ * CLEAN, and a disabled "Blocked" the rest of the time with the reason printed
+ * above it. The reason is good — a greyed-out primary with no explanation is
+ * the commonest lie a review UI tells, and this screen already knew that. But
+ * for half the states the reason names something the phone could have *done*,
+ * and offered nothing:
+ *
+ *   BEHIND    "the base branch has moved — update the branch first", and
+ *             `prUpdateBranch` has been in the client all along.
+ *   BLOCKED   waiting on a review or a required check. Nothing to do now, but
+ *             arming auto-merge is exactly the move for someone who is not at
+ *             their desk and will not be back to press a button.
+ *   UNSTABLE  a check is failing; re-running it is one call away.
+ *
+ * That is the difference between a companion and a status page: the same
+ * sentence, with the next move attached.
+ *
+ * DIRTY is the honest "not from here". Resolving a conflict against a base
+ * branch is a job for the machine with the checkout on it, and pretending
+ * otherwise would put someone in a bad place with no editor.
+ */
+
+export type MergeMove =
+  | { kind: "merge"; label: string }
+  | { kind: "update"; label: string }
+  | { kind: "auto"; label: string }
+  | { kind: "rerun"; label: string }
+  | { kind: "none"; label: string };
+
+export interface MergeInput {
+  state: PrMergeState;
+  isDraft: boolean;
+  /** Whether auto-merge is already armed, so the offer is not made twice. */
+  autoMerge?: boolean;
+  /** Whether any check has actually failed, as opposed to merely not passed. */
+  anyFailing?: boolean;
+}
+
+/**
+ * Why it will not merge, in a sentence.
+ *
+ * Use `whyBlocked` rather than reaching in here directly: GitHub's UNSTABLE
+ * covers both "a check failed" and "a check has not finished", and the fixed
+ * string said the first of those while the button offered the move for the
+ * second. A reason that contradicts the action under it is worse than no
+ * reason, because someone acts on the sentence.
+ */
+export const MERGE_WHY: Record<PrMergeState, string> = {
+  CLEAN: "Nothing is standing in the way",
+  BLOCKED: "A required review or check has not passed",
+  BEHIND: "The base branch has moved — update the branch first",
+  DIRTY: "There are conflicts with the base branch",
+  UNSTABLE: "A check is failing",
+  DRAFT: "This is a draft",
+  HAS_HOOKS: "A repository hook is blocking the merge",
+  UNKNOWN: "GitHub has not finished working it out",
+};
+
+export function whyBlocked(pr: MergeInput): string {
+  if (pr.state === "UNSTABLE" && !pr.anyFailing) return "A check has not finished yet";
+  if (pr.state === "BLOCKED" && pr.anyFailing) return "A check is failing";
+  return MERGE_WHY[pr.state];
+}
+
+/**
+ * The one thing worth putting on the primary button.
+ *
+ * Ordered by what unblocks soonest, not by what is most dramatic: a branch that
+ * is merely behind is one call from mergeable, so that beats arming auto-merge
+ * even though auto-merge is the more impressive-sounding offer.
+ */
+export function mergeMove(pr: MergeInput): MergeMove {
+  // A draft is a decision somebody made, and undrafting from the merge button
+  // would be a surprise. The ⋯ sheet has that verb.
+  if (pr.isDraft) return { kind: "none", label: "Draft" };
+  if (pr.state === "CLEAN") return { kind: "merge", label: "Squash & merge" };
+  if (pr.state === "BEHIND") return { kind: "update", label: "Update branch" };
+  if (pr.state === "DIRTY") return { kind: "none", label: "Conflicts" };
+  // Already armed: saying so beats offering to arm it again.
+  if (pr.autoMerge) return { kind: "none", label: "Merging when green" };
+  // Only where a check is the story. `anyFailing` on its own was short-
+  // circuiting every remaining state, so a repository hook blocking the merge
+  // offered "Re-run checks" over a sentence about hooks — re-running would not
+  // have touched it.
+  if (pr.state === "BLOCKED" || pr.state === "UNSTABLE") {
+    // Something is red rather than merely unfinished. Arming auto-merge on a
+    // failing run would only wait for the failure.
+    return pr.anyFailing
+      ? { kind: "rerun", label: "Re-run checks" }
+      : { kind: "auto", label: "Merge when green" };
+  }
+  return { kind: "none", label: "Blocked" };
+}

--- a/web/test/merge-move.test.ts
+++ b/web/test/merge-move.test.ts
@@ -1,0 +1,125 @@
+/*
+ * What to do about a pull request that will not merge.
+ *
+ * The footer had one button and two states: "Squash & merge" when GitHub said
+ * CLEAN, and a disabled "Blocked" the rest of the time. The reason was printed
+ * above it, which is more than most review UIs manage — but for half the states
+ * that reason names something the phone could have done and did not offer.
+ * "The base branch has moved — update the branch first" sat above a dead
+ * button, with `prUpdateBranch` in the client the whole time.
+ */
+import { describe, expect, it } from "bun:test";
+import { mergeMove, MERGE_WHY, whyBlocked, type MergeInput } from "../src/mobile/mergeMove.ts";
+import type { PrMergeState } from "../../shared/types.ts";
+
+const STATES: PrMergeState[] =
+  ["CLEAN", "BLOCKED", "BEHIND", "DIRTY", "UNSTABLE", "DRAFT", "HAS_HOOKS", "UNKNOWN"];
+
+const pr = (over: Partial<MergeInput> = {}): MergeInput =>
+  ({ state: "CLEAN", isDraft: false, ...over });
+
+describe("the move on the primary button", () => {
+  it("merges what is mergeable", () => {
+    expect(mergeMove(pr())).toEqual({ kind: "merge", label: "Squash & merge" });
+  });
+
+  it("offers to update a branch that is merely behind", () => {
+    // One call from mergeable, and the sentence above the button has been
+    // telling people to do exactly this while offering no way to.
+    expect(mergeMove(pr({ state: "BEHIND" })).kind).toBe("update");
+  });
+
+  it("arms auto-merge when the wait is the only problem", () => {
+    // The move for someone who is not at their desk and will not be back to
+    // press a button when the run goes green.
+    expect(mergeMove(pr({ state: "BLOCKED" })).kind).toBe("auto");
+    expect(mergeMove(pr({ state: "UNSTABLE" })).kind).toBe("auto");
+  });
+
+  it("re-runs instead of arming when something has actually failed", () => {
+    // Auto-merge on a failing run waits for a failure. Fix the failure.
+    expect(mergeMove(pr({ state: "UNSTABLE", anyFailing: true })).kind).toBe("rerun");
+    expect(mergeMove(pr({ state: "BLOCKED", anyFailing: true })).kind).toBe("rerun");
+  });
+
+  it("does not offer to arm what is already armed", () => {
+    const m = mergeMove(pr({ state: "BLOCKED", autoMerge: true }));
+    expect(m.kind).toBe("none");
+    expect(m.label).toBe("Merging when green");
+  });
+
+  it("prefers updating a behind branch over arming auto-merge", () => {
+    // Ordered by what unblocks soonest, not by what sounds most capable.
+    expect(mergeMove(pr({ state: "BEHIND", anyFailing: true })).kind).toBe("update");
+    expect(mergeMove(pr({ state: "BEHIND", autoMerge: true })).kind).toBe("update");
+  });
+
+  it("admits that conflicts are not a phone job", () => {
+    // Resolving against a base branch needs the machine with the checkout on
+    // it. Offering it here would strand someone with no editor.
+    const m = mergeMove(pr({ state: "DIRTY" }));
+    expect(m.kind).toBe("none");
+    expect(m.label).toBe("Conflicts");
+  });
+
+  it("leaves a draft alone", () => {
+    // Being a draft is a decision somebody made; undrafting from the merge
+    // button would be a surprise, and the ⋯ sheet has that verb.
+    expect(mergeMove(pr({ state: "CLEAN", isDraft: true })).kind).toBe("none");
+    expect(mergeMove(pr({ state: "DRAFT", isDraft: true })).kind).toBe("none");
+  });
+
+  it("never puts an empty or nonsense label on the button", () => {
+    // The rule over the whole state type rather than over today's eight cases:
+    // adding a state to PrMergeState must not produce a blank primary.
+    for (const state of STATES) {
+      for (const isDraft of [true, false]) {
+        for (const anyFailing of [true, false]) {
+          const m = mergeMove({ state, isDraft, anyFailing });
+          expect(m.label.length).toBeGreaterThan(3);
+          expect(m.label).not.toContain("undefined");
+          expect(["merge", "update", "auto", "rerun", "none"]).toContain(m.kind);
+        }
+      }
+    }
+  });
+
+  it("has a reason for every state it can be in", () => {
+    for (const state of STATES) {
+      expect(MERGE_WHY[state]).toBeTruthy();
+      expect(MERGE_WHY[state]!.length).toBeGreaterThan(12);
+    }
+  });
+});
+
+describe("the reason above the button", () => {
+  it("does not claim a failure when nothing has failed", () => {
+    // GitHub's UNSTABLE covers both "a check failed" and "a check has not
+    // finished". The fixed string said the first while the button offered the
+    // move for the second, and someone acts on the sentence, not the button.
+    expect(whyBlocked(pr({ state: "UNSTABLE", anyFailing: false }))).toBe("A check has not finished yet");
+    expect(whyBlocked(pr({ state: "UNSTABLE", anyFailing: true }))).toBe("A check is failing");
+  });
+
+  it("names the failure when BLOCKED is really a red check", () => {
+    expect(whyBlocked(pr({ state: "BLOCKED", anyFailing: true }))).toBe("A check is failing");
+    expect(whyBlocked(pr({ state: "BLOCKED", anyFailing: false })))
+      .toBe("A required review or check has not passed");
+  });
+
+  it("never disagrees with the move offered under it", () => {
+    // The rule that matters: if the button says "Merge when green" the sentence
+    // above it must not say something has already gone red, and the other way
+    // round. This is the pair that was actually wrong on screen.
+    for (const state of STATES) {
+      for (const anyFailing of [true, false]) {
+        const input = pr({ state, anyFailing });
+        const said = whyBlocked(input);
+        const kind = mergeMove(input).kind;
+        if (kind === "auto") expect(said).not.toMatch(/is failing/);
+        if (kind === "rerun") expect(said).toMatch(/failing/);
+        expect(said.length).toBeGreaterThan(12);
+      }
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The footer had one button and two states: "Squash & merge" when GitHub said CLEAN, and a disabled "Blocked" the rest of the time with the reason printed above it. The reason was the good part — a greyed-out primary with no explanation is the commonest lie a review UI tells, and this screen already knew that. But for half the states that reason named something the phone could have *done* and did not offer. *"The base branch has moved — update the branch first"* sat above a dead button, with `prUpdateBranch` in the client the whole time.

The button is now the next useful move:

| state | button |
|---|---|
| `BEHIND` | **Update branch** — one call from mergeable |
| `BLOCKED` / `UNSTABLE`, nothing red | **Merge when green** — arms auto-merge, which is exactly the move for someone who is not at their desk and will not be back to press anything |
| something actually failing | **Re-run checks** — arming auto-merge on a red run only waits for the failure |
| `DIRTY` | nothing. Resolving against a base branch needs the machine with the checkout on it, and pretending otherwise would strand someone with no editor |
| already armed | says **Merging when green** rather than offering to arm it twice |

Ordered by what unblocks soonest rather than by what sounds most capable: a branch that is merely behind gets "Update branch" even when auto-merge would also apply. Arming auto-merge asks first — it is a decision that outlives the screen.

The reason above the button answers to the same facts now. GitHub's `UNSTABLE` covers both *"a check failed"* and *"a check has not finished"*, and the fixed string said the first of those while the button offered the move for the second.

## How was it tested?

`web/test/merge-move.test.ts`, 13 tests. Both suites green: 666 in `web/`, 1047 in `server/`. Audit 135/135.

Nine mutations, each reverted after confirming the failure: a behind branch treated as just blocked; conflicts offered a merge; auto-merge offered on a red run; re-run offered whatever the state; an armed pull request offered auto-merge again; a draft merged from the merge button; auto-merge beating a behind branch; the reason never adapting; `BLOCKED` never naming a failure.

**The rule that earned its keep** is "no reason may disagree with the move under it", written over the whole `PrMergeState` type rather than over the cases I had in mind. It went red on a second contradiction I had just introduced: `anyFailing` was short-circuiting every remaining state, so a repository hook blocking a merge offered "Re-run checks" above a sentence about hooks — and re-running would not have touched it. That is the fix, not the test.

**Driven on a real server** across every state, reading the button and the sentence together:

```
BEHIND    → Update branch        | The base branch has moved — update the branch first
BLOCKED   → Merge when green     | A required review or check has not passed
UNSTABLE  → Merge when green     | A check has not finished yet
HAS_HOOKS → Blocked (disabled)   | A repository hook is blocking the merge
DIRTY     → Conflicts (disabled) | There are conflicts with the base branch
CLEAN     → Squash & merge       |
```

Then pressed, checking what actually goes out: `gh pr update-branch 482 -R acme/shop` and `gh pr merge 482 --squash --auto --delete-branch -R acme/shop`.

One thing that only pressing found: a pull request action's toast showed `gh`'s whole stdout, while the error path beside it took only the first line. `gh pr update-branch` prints three lines of git plumbing, and measured at a phone viewport that is an 82px toast reading *"To github.com:acme/shop.git / abc1234..def5678 fix/rounding -> fix/rounding"*. First line only: 47px. Both numbers measured in the browser, with and without the change — my first attempt to check this read only the first line of a multi-line string out of `grep` and told me nothing.