### PR TITLE
A Fleet tab, because all of this was already being computed

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -701,6 +701,39 @@ async function main() {
     }
     await drain(cdp, "now");
 
+    // ---- the fleet ---------------------------------------------------
+    await tap(cdp, "nav button", "Fleet");
+    await Bun.sleep(1800);
+    note("fleet", "the tab exists and renders",
+      await cdp.ev(`(document.querySelector("main")?.textContent || "").trim().length > 60`));
+    const cards = await cdp.ev(`document.querySelectorAll("main .mb-ins").length`);
+    if (!cards) {
+      console.log("  skip  fleet · nothing is misbehaving on this machine");
+      note("fleet", "an empty fleet says so rather than showing nothing",
+        await cdp.ev(`/Nothing is misbehaving/.test(document.body.textContent)`));
+    } else {
+      // Worst first, same as the Now queue and for the same reason.
+      note("fleet", "the worst is at the top",
+        await cdp.ev(`(()=>{const r=[...document.querySelectorAll("main .mb-ins")]
+          .map(e=>e.classList.contains("bad")?0:e.classList.contains("warn")?1:2);
+          return r.every((v,i)=>i===0||r[i-1]<=v)})()`),
+        await cdp.ev(`JSON.stringify([...document.querySelectorAll("main .mb-ins")].map(e=>e.querySelector(".t").textContent))`));
+      note("fleet", "an insight is a way in, not a headline",
+        await cdp.ev(`[...document.querySelectorAll("main .mb-ins")].every(e=>e.tagName === "BUTTON")`));
+    }
+    // A bar you cannot see is not a comparison. These are spans, and an inline
+    // element silently ignores a height — which drew every track 0px tall.
+    note("fleet", "the bars are actually drawn",
+      await cdp.ev(`[...document.querySelectorAll("main .mb-bar .g")].every(e=>e.getBoundingClientRect().height >= 4)`),
+      await cdp.ev(`JSON.stringify([...document.querySelectorAll("main .mb-bar .g")].map(e=>Math.round(e.getBoundingClientRect().height)))`));
+    note("fleet", "no figure renders as NaN or undefined",
+      !(await cdp.ev(`/NaN|undefined|Infinity/.test(document.querySelector("main")?.textContent || "")`)));
+    await shot(cdp, "14-fleet");
+    await hygiene(cdp, "fleet");
+    await drain(cdp, "fleet");
+    await tap(cdp, "nav button", "Now");
+    await Bun.sleep(900);
+
     // ---- the server going away ---------------------------------------
     // A companion that silently shows stale numbers when the machine it is
     // watching has gone is worse than one that says so.

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -14,11 +14,13 @@ import { RepoList, RepoScreen, ContainerScreen, HALT_CSS, type RepoSummary } fro
 import { projectRows } from "./projects.ts";
 import { baseName, ownerOf } from "../../../shared/projectKey.ts";
 import { MobilePr, THREAD_CSS } from "./MobilePr.tsx";
+import { MobileFleet, FLEET_CSS } from "./MobileFleet.tsx";
+import { sessionForInsight } from "./fleet.ts";
 import { buildQueue, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
 import type {
-  PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef, GitTreeState,
+  PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef, GitTreeState, Insight,
 } from "../../../shared/types.ts";
 
 /**
@@ -51,7 +53,7 @@ import type {
  * still open.
  */
 
-type Tab = "now" | "chats" | "repos";
+type Tab = "now" | "chats" | "repos" | "fleet";
 
 /** Live on the socket · reachable but not streaming · nothing answering. */
 type LinkState = "live" | "slow" | "offline";
@@ -93,6 +95,9 @@ const GATE_MS = 20_000;
 const TREE_MS = 120_000;
 const DOCKER_MS = 15_000;
 const PR_MS = 60_000;
+/** Insights are computed over a window of hours; asking oftener than the answer
+ *  can change is a radio wake for nothing. */
+const INSIGHT_MS = 90_000;
 
 export function MobileApp() {
   const [tab, setTab] = useState<Tab>("now");
@@ -154,6 +159,7 @@ export function MobileApp() {
    * reports, so it lifts itself the moment there is news — see snooze.ts.
    */
   const [answered, setAnswered] = useState<string[]>([]);
+  const [insights, setInsights] = useState<Insight[]>([]);
   const snoozeStore = useMemo(() => deviceStore(), []);
   const [snoozeRev, bumpSnooze] = useReducer((n: number) => n + 1, 0);
 
@@ -257,6 +263,12 @@ export function MobileApp() {
     const ping = () => probeServer(2_000).then((id) => setReachable(id === "ours")).catch(() => setReachable(false));
     ping();
     return pollWhileVisible(ping, HEALTH_MS);
+  }, []);
+
+  useEffect(() => {
+    const load = () => api.insights().then((r) => setInsights(r.insights || [])).catch(() => { /* a poll */ });
+    load();
+    return pollWhileVisible(load, INSIGHT_MS);
   }, []);
 
   useEffect(() => {
@@ -582,7 +594,7 @@ export function MobileApp() {
 
   return (
     <div className="mb min-h-[100dvh] flex flex-col" style={{ background: "var(--bg)", color: "var(--text)" }}>
-      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}{HALT_CSS}{THREAD_CSS}</style>
+      <style>{MOBILE_CSS}{DIFF_CSS}{NOW_CSS}{HALT_CSS}{THREAD_CSS}{FLEET_CSS}</style>
       {askDialog}
       <div className="mb-sky" />
 
@@ -627,6 +639,14 @@ export function MobileApp() {
         {tab === "chats" && <MobileChats sessions={sessions} onRefresh={loadFast} onImmersive={setImmersive}
           openChat={openChat} onOpenChat={setOpenChat} compose={compose} onCompose={setCompose} />}
         {tab === "repos" && <RepoList repos={repoSummaries} onOpen={(r, siblings) => { setOpenCheckouts(siblings); setOpenRepo(r); }} />}
+        {tab === "fleet" && <MobileFleet insights={insights} stats={stats}
+          onOpenInsight={(i) => {
+            const found = sessionForInsight(i.session, sessions);
+            // Nothing to open is a real answer here: the label is eight hex
+            // characters and an app name, and two sessions can share them.
+            if (found) openSession(found);
+            else toast(i.session ? "That agent is no longer in the list" : "This one is about the fleet, not one agent");
+          }} />}
       </main>
 
       {!immersive && <nav className="fixed left-0 right-0 bottom-0 z-40 flex"
@@ -638,6 +658,10 @@ export function MobileApp() {
         <TabBtn id="now" tab={tab} onPick={setTab} glyph="◎" label="Now" badge={queue.length} />
         <TabBtn id="chats" tab={tab} onPick={setTab} glyph="▤" label="Chats" />
         <TabBtn id="repos" tab={tab} onPick={setTab} glyph="◇" label="Repos" />
+        {/* Everything on this tab was computed and served from the beginning
+            and had no route to a phone. The badge is what is misbehaving. */}
+        <TabBtn id="fleet" tab={tab} onPick={setTab} glyph="◈" label="Fleet"
+          badge={insights.filter((i) => i.severity === "bad").length} />
       </nav>}
 
       <RepoScreen open={!!openRepo && !openPr} repo={openRepo}

--- a/web/src/mobile/MobileFleet.tsx
+++ b/web/src/mobile/MobileFleet.tsx
@@ -1,0 +1,158 @@
+import { Empty } from "./mobileUi.tsx";
+import { fmtAgo, fmtUsd, fmtTokens } from "../lib/format.ts";
+import { orderInsights, spendByModel, spendByApp, errorRate, type SpendRow } from "./fleet.ts";
+import type { Insight, StatsSummary } from "../../../shared/types.ts";
+
+/**
+ * The fleet, as a whole.
+ *
+ * Everything here was already computed and served and had no route to a phone.
+ * `/insights` names the session going in circles, the one burning tokens, the
+ * one throwing errors; `/stats` says which model and which runtime the money
+ * went to. The Settings sheet showed three numbers and stopped, so the two
+ * questions you actually have when you are away from the desk — "is anything
+ * stuck" and "what is this costing me" — had no answer on the device in your
+ * hand.
+ *
+ * Deliberately not a chart. On a phone a bar is a comparison and nothing else:
+ * these are ranked lists with a width, which is a comparison you can read at
+ * arm's length, and the number is printed beside it for the case where you
+ * cannot.
+ */
+export const FLEET_CSS = `
+.mb-ins{border-radius:16px;overflow:hidden;background:var(--mb-card);
+  border:1px solid color-mix(in srgb,var(--border) 38%,transparent);box-shadow:var(--mb-edge);
+  position:relative;width:100%;text-align:left}
+.mb-ins::before{content:"";position:absolute;left:0;top:0;bottom:0;width:3px;background:var(--text3)}
+.mb-ins.bad::before{background:var(--error);width:4px}
+.mb-ins.warn::before{background:var(--warning)}
+.mb-ins .ih{display:flex;align-items:baseline;gap:8px;padding:11px 13px 0 16px}
+.mb-ins .k{font-size:9.5px;letter-spacing:.15em;text-transform:uppercase;color:var(--text3);font-weight:600}
+.mb-ins.bad .k{color:var(--error)}
+.mb-ins.warn .k{color:var(--warning)}
+.mb-ins .at{margin-left:auto;font-size:10.5px;color:var(--text3);white-space:nowrap}
+.mb-ins .t{display:block;padding:5px 13px 0 16px;font-size:13.5px;line-height:1.35;color:var(--text)}
+.mb-ins .s{display:block;padding:5px 13px 12px 16px;font-size:11.5px;color:var(--text3);line-height:1.5;
+  overflow-wrap:anywhere}
+
+/* A ranked list with a width. The number stays printed beside it — a bar you
+   cannot put a value on is decoration, which is what the home screen's
+   fourteen animated bars were before they were taken out. */
+.mb-bar{display:block;margin-bottom:9px}
+.mb-bar .l{display:flex;align-items:baseline;gap:8px;font-size:11.5px;margin-bottom:4px}
+.mb-bar .l b{font-weight:500;color:var(--text2);min-width:0;overflow:hidden;text-overflow:ellipsis;
+  white-space:nowrap}
+.mb-bar .l .v{margin-left:auto;flex:none;color:var(--text3);font-variant-numeric:tabular-nums}
+/* display:block, because these are spans — a button may not contain a div, and
+   an inline element silently ignores a height, so the track and its fill were
+   both drawn 0px tall and the whole comparison was invisible. */
+.mb-bar .g{display:block;height:7px;border-radius:4px;
+  background:color-mix(in srgb,var(--border) 34%,transparent);overflow:hidden}
+.mb-bar .g i{display:block;height:100%;border-radius:4px;background:var(--primary-hover);
+  transition:width .4s cubic-bezier(.2,.85,.25,1)}
+.mb-bar.dim .g i{background:var(--text3)}
+`;
+
+const KIND: Record<Insight["kind"], string> = {
+  loop: "Going in circles",
+  spend: "Spending",
+  errors: "Errors",
+  burn: "Burn rate",
+};
+
+export function MobileFleet({ insights, stats, onOpenInsight }: {
+  insights: Insight[];
+  stats: StatsSummary | null;
+  /** Null when the insight names no session, or names one this device cannot
+   *  resolve — see sessionForInsight. */
+  onOpenInsight: (i: Insight) => void;
+}) {
+  const rows = orderInsights(insights);
+  const models = stats ? spendByModel(stats.by_model) : [];
+  const apps = stats ? spendByApp(stats.by_app) : [];
+  const rate = errorRate(stats?.totals);
+  const t = stats?.totals;
+
+  return (
+    <div className="flex flex-col gap-4">
+      <div>
+        <div className="mb-eyebrow" style={{ marginBottom: 9 }}>
+          What needs looking at{rows.length ? ` · ${rows.length}` : ""}
+        </div>
+        {rows.length === 0 ? (
+          <Empty glyph="◎" title="Nothing is misbehaving"
+            body="No loops, no runaway spend, no bursts of errors in the window." />
+        ) : (
+          <div className="flex flex-col gap-2.5">
+            {rows.map((i) => (
+              <button key={i.id} className={`mb-ins mb-press ${i.severity}`} onClick={() => onOpenInsight(i)}>
+                <span className="ih">
+                  <span className="k">{KIND[i.kind]}</span>
+                  <span className="at">{fmtAgo(i.ts)}</span>
+                </span>
+                <span className="t">{i.title}</span>
+                <span className="s">{i.detail}</span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        <div className="mb-eyebrow" style={{ marginBottom: 9 }}>Today</div>
+        <div className="mb-card p-3 flex flex-col gap-2">
+          <Fig label="Spent" value={t ? fmtUsd(t.cost_usd) : "—"} />
+          <Fig label="Tokens" value={t ? fmtTokens(t.input_tokens + t.output_tokens) : "—"} />
+          <Fig label="Sessions" value={t ? String(t.sessions) : "—"} />
+          <Fig label="Tool calls" value={t?.tool_calls != null ? String(t.tool_calls) : "—"} />
+          {/* Null rather than a number, when the server did not send the
+              narrower count — see errorRate. A wrong rate is worse than none. */}
+          <Fig label="Failed calls"
+            value={rate == null ? "—" : `${(rate * 100).toFixed(rate < 0.1 ? 1 : 0)}%`}
+            tint={rate != null && rate > 0.05 ? "var(--warning)" : undefined} />
+        </div>
+      </div>
+
+      <Bars title="Where the money went" rows={models} empty="Nothing has been spent in this window." />
+      <Bars title="By runtime" rows={apps} empty="No agent has run in this window." />
+    </div>
+  );
+}
+
+function Fig({ label, value, tint }: { label: string; value: string; tint?: string }) {
+  return (
+    <div className="flex items-baseline gap-3 text-[12px]">
+      <span style={{ color: "var(--text3)" }}>{label}</span>
+      <span className="flex-1" />
+      <span className="mb-tnum font-semibold" style={{ color: tint ?? "var(--text)" }}>{value}</span>
+    </div>
+  );
+}
+
+function Bars({ title, rows, empty }: { title: string; rows: SpendRow[]; empty: string }) {
+  return (
+    <div>
+      <div className="mb-eyebrow" style={{ marginBottom: 9 }}>{title}</div>
+      {rows.length === 0 ? (
+        <p className="text-[11.5px]" style={{ color: "var(--text3)" }}>{empty}</p>
+      ) : (
+        <div className="mb-card p-3">
+          {rows.map((r) => (
+            <div key={r.name} className={`mb-bar${r.unpriced ? " dim" : ""}`}>
+              <span className="l">
+                <b>{r.name}</b>
+                <span className="v">
+                  {/* A model with no published price has no cost, and printing
+                      $0.00 would read as "this one was free". */}
+                  {r.unpriced ? "no price" : fmtUsd(r.cost)}
+                  {r.sessions ? ` · ${r.sessions}` : ""}
+                </span>
+              </span>
+              <span className="g"><i style={{ width: `${Math.round(r.share * 100)}%` }} /></span>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/mobile/fleet.ts
+++ b/web/src/mobile/fleet.ts
@@ -1,0 +1,114 @@
+import type { Insight, CostByModel, AppUsage, SessionRollup } from "../../../shared/types.ts";
+
+/**
+ * What the fleet is costing and where it is going wrong.
+ *
+ * The server has computed all of this from the beginning — `/insights` names
+ * the session stuck in a loop, the one burning tokens, the one throwing errors;
+ * `/stats` breaks spend down by model and by app. The phone showed three
+ * numbers in a Settings sheet (spend, sessions, tool errors) and had no route
+ * to any of the rest. "Which agent is the expensive one" and "is anything
+ * looping right now" were unanswerable from the device you are holding when
+ * you are away from the desk, which is the only time it matters.
+ *
+ * The two decisions worth testing are here: which insight to read first, and
+ * how to get from an insight back to the conversation it is about.
+ */
+
+/**
+ * From an insight to a session you can open.
+ *
+ * The server labels an insight `"<app>:<first 8 of the uuid>"` — enough for a
+ * human to recognise and not enough to open. Matching it back is a prefix
+ * lookup, and it has to be anchored on both halves: eight hex characters
+ * collide often enough on a busy machine, and opening the wrong conversation
+ * from an alert about a runaway agent is worse than opening none.
+ */
+export function sessionForInsight(
+  label: string | null | undefined,
+  sessions: readonly SessionRollup[],
+): SessionRollup | null {
+  if (!label) return null;
+  const cut = label.lastIndexOf(":");
+  if (cut < 1) return null;
+  const app = label.slice(0, cut);
+  const prefix = label.slice(cut + 1);
+  if (!prefix) return null;
+  const hits = sessions.filter((s) => s.source_app === app && s.session_id.startsWith(prefix));
+  // Exactly one, or nothing. Two matches means the prefix is not an identity
+  // here, and picking either is a coin toss dressed up as an answer.
+  return hits.length === 1 ? hits[0]! : null;
+}
+
+const SEVERITY: Record<Insight["severity"], number> = { bad: 0, warn: 1, info: 2 };
+
+/** Worst first, then newest. Same shape as the Now queue, for the same reason:
+ *  the top of the list has to be the thing to look at. */
+export function orderInsights(insights: readonly Insight[]): Insight[] {
+  return [...insights].sort((a, b) => SEVERITY[a.severity] - SEVERITY[b.severity] || b.ts - a.ts);
+}
+
+export interface SpendRow {
+  name: string;
+  cost: number;
+  /** Of the total, 0–1. */
+  share: number;
+  sessions: number;
+  /** The model reported no price, so its cost is not a cost — it is a blank. */
+  unpriced: boolean;
+}
+
+/**
+ * Spend by model, biggest first, with each one's share of the total.
+ *
+ * A bar needs a denominator, and the denominator has to be the sum of what is
+ * drawn rather than the fleet's total spend: `by_model` can omit a model whose
+ * price is unknown, and dividing by a larger total would draw every bar short
+ * and quietly understate all of them.
+ */
+export function spendByModel(rows: readonly CostByModel[]): SpendRow[] {
+  const total = rows.reduce((n, r) => n + (r.cost_usd || 0), 0);
+  return [...rows]
+    .sort((a, b) => (b.cost_usd || 0) - (a.cost_usd || 0))
+    .map((r) => ({
+      name: r.model_name || "unknown",
+      cost: r.cost_usd || 0,
+      // No division by zero, and no bar at all when nothing has been spent —
+      // a full-width bar for $0.00 is the wrong answer to "where did it go".
+      share: total > 0 ? (r.cost_usd || 0) / total : 0,
+      sessions: r.sessions || 0,
+      unpriced: !!r.unpriced,
+    }));
+}
+
+/** The same, per agent runtime. */
+export function spendByApp(rows: readonly AppUsage[]): SpendRow[] {
+  const total = rows.reduce((n, r) => n + (r.cost_usd || 0), 0);
+  return [...rows]
+    .sort((a, b) => (b.cost_usd || 0) - (a.cost_usd || 0))
+    .map((r) => ({
+      name: r.source_app || "unknown",
+      cost: r.cost_usd || 0,
+      share: total > 0 ? (r.cost_usd || 0) / total : 0,
+      sessions: r.sessions || 0,
+      unpriced: false,
+    }));
+}
+
+/**
+ * The share of tool calls that failed.
+ *
+ * `errors` counts LLM spans and notifications too, so dividing it by
+ * `tool_calls` is comparing two different populations — see the note on
+ * `tool_errors` in shared/types.ts. Null when the server did not send the
+ * narrower figure, because a wrong rate is worse than no rate.
+ */
+export function errorRate(totals: {
+  tool_calls?: number; tool_errors?: number;
+} | null | undefined): number | null {
+  if (!totals) return null;
+  const calls = totals.tool_calls ?? 0;
+  const errs = totals.tool_errors;
+  if (errs == null || calls <= 0) return null;
+  return errs / calls;
+}

--- a/web/test/fleet.test.ts
+++ b/web/test/fleet.test.ts
@@ -1,0 +1,161 @@
+/*
+ * What the fleet is costing and where it is going wrong.
+ *
+ * The server has computed all of this from the beginning — `/insights` names
+ * the session stuck in a loop, the one burning tokens, the one throwing errors;
+ * `/stats` breaks spend down by model and by app. The phone showed three
+ * numbers in a Settings sheet and had no route to any of the rest, so "which
+ * agent is the expensive one" and "is anything looping right now" could not be
+ * answered from the device you are holding when you are away from the desk —
+ * which is the only time the question is urgent.
+ */
+import { describe, expect, it } from "bun:test";
+import { sessionForInsight, orderInsights, spendByModel, spendByApp, errorRate } from "../src/mobile/fleet.ts";
+import type { Insight, CostByModel, SessionRollup } from "../../shared/types.ts";
+
+const NOW = 1_700_000_000_000;
+
+const s = (id: string, app = "claude-code"): SessionRollup => ({
+  session_id: id, source_app: app, model_name: "opus", project_path: "/w/a",
+  started_at: NOW, ended_at: null, last_seen: NOW,
+  event_count: 1, tool_count: 1, error_count: 0,
+  input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: 0,
+});
+
+const ins = (over: Partial<Insight> = {}): Insight => ({
+  id: "i1", severity: "warn", kind: "loop", title: "Going in circles",
+  detail: "Read on the same file eleven times", session: "claude-code:cd3fa401", ts: NOW, ...over,
+});
+
+const model = (over: Partial<CostByModel> = {}): CostByModel => ({
+  model_name: "opus", input_tokens: 0, output_tokens: 0,
+  cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: 1, sessions: 1, unpriced: false, ...over,
+} as CostByModel);
+
+describe("from an insight to the conversation it is about", () => {
+  const list = [s("cd3fa401-7cb5-4652-ac0b-785ed3751479"), s("aa119900-0000-4000-8000-000000000000")];
+
+  it("finds the session behind the label", () => {
+    // The server writes `<app>:<first 8 of the uuid>` — enough to recognise,
+    // not enough to open. This is what makes the card tappable.
+    expect(sessionForInsight("claude-code:cd3fa401", list)?.session_id)
+      .toBe("cd3fa401-7cb5-4652-ac0b-785ed3751479");
+  });
+
+  it("will not cross runtimes on a matching prefix", () => {
+    // Eight hex characters collide often enough on a busy machine; the app half
+    // of the label is not decoration.
+    expect(sessionForInsight("codex:cd3fa401", list)).toBeNull();
+  });
+
+  it("opens nothing rather than the wrong thing when the prefix is ambiguous", () => {
+    // Two matches is not an answer. Opening the wrong conversation from an
+    // alert about a runaway agent is worse than opening none.
+    const twins = [s("cd3fa401-1111-4000-8000-000000000000"), s("cd3fa401-2222-4000-8000-000000000000")];
+    expect(sessionForInsight("claude-code:cd3fa401", twins)).toBeNull();
+  });
+
+  it("survives a label that is not one", () => {
+    expect(sessionForInsight(null, list)).toBeNull();
+    expect(sessionForInsight("", list)).toBeNull();
+    expect(sessionForInsight("nocolon", list)).toBeNull();
+    expect(sessionForInsight(":cd3fa401", list)).toBeNull();
+  });
+
+  it("an empty prefix resolves to nothing, even against one session", () => {
+    // `startsWith("")` is true of everything, so with a two-session list the
+    // ambiguity check catches this by accident — and with one session it does
+    // not, and a truncated label would open whatever happened to be there.
+    expect(sessionForInsight("claude-code:", list)).toBeNull();
+    expect(sessionForInsight("claude-code:", [s("cd3fa401-7cb5-4652-ac0b-785ed3751479")])).toBeNull();
+  });
+
+  it("splits on the last colon, because a runtime name can contain one", () => {
+    const odd = [s("cd3fa401-7cb5-4652-ac0b-785ed3751479", "acme:agent")];
+    expect(sessionForInsight("acme:agent:cd3fa401", odd)?.source_app).toBe("acme:agent");
+  });
+});
+
+describe("which insight to read first", () => {
+  it("puts the worst at the top, then the newest", () => {
+    const out = orderInsights([
+      ins({ id: "old-bad", severity: "bad", ts: NOW - 60_000 }),
+      ins({ id: "info", severity: "info", ts: NOW }),
+      ins({ id: "new-bad", severity: "bad", ts: NOW }),
+      ins({ id: "warn", severity: "warn", ts: NOW }),
+    ]);
+    expect(out.map((i) => i.id)).toEqual(["new-bad", "old-bad", "warn", "info"]);
+  });
+
+  it("leaves the caller's array alone", () => {
+    const given = [ins({ id: "a", severity: "info" }), ins({ id: "b", severity: "bad" })];
+    orderInsights(given);
+    expect(given.map((i) => i.id)).toEqual(["a", "b"]);
+  });
+});
+
+describe("where the money went", () => {
+  it("ranks by cost and shares add up", () => {
+    const rows = spendByModel([
+      model({ model_name: "haiku", cost_usd: 1 }),
+      model({ model_name: "opus", cost_usd: 3 }),
+    ]);
+    expect(rows.map((r) => r.name)).toEqual(["opus", "haiku"]);
+    expect(rows[0]!.share).toBeCloseTo(0.75);
+    expect(rows.reduce((n, r) => n + r.share, 0)).toBeCloseTo(1);
+  });
+
+  it("divides by what is drawn, not by the fleet's total", () => {
+    // `by_model` can omit a model whose price is unknown. Dividing by a larger
+    // number would draw every bar short and understate all of them at once,
+    // which reads as "nothing is expensive".
+    const rows = spendByModel([model({ cost_usd: 2 })]);
+    expect(rows[0]!.share).toBe(1);
+  });
+
+  it("draws no bar at all when nothing has been spent", () => {
+    // A full-width bar for $0.00 is the wrong answer to "where did it go".
+    const rows = spendByModel([model({ cost_usd: 0 }), model({ model_name: "haiku", cost_usd: 0 })]);
+    expect(rows.every((r) => r.share === 0)).toBe(true);
+    expect(rows.every((r) => Number.isFinite(r.share))).toBe(true);
+  });
+
+  it("keeps the unpriced flag, so a blank is not read as free", () => {
+    expect(spendByModel([model({ unpriced: true })])[0]!.unpriced).toBe(true);
+  });
+
+  it("names a model that arrived without one", () => {
+    expect(spendByModel([model({ model_name: "" })])[0]!.name).toBe("unknown");
+  });
+
+  it("does the same by runtime", () => {
+    const rows = spendByApp([
+      { source_app: "codex", events: 1, sessions: 1, tool_calls: 1, cost_usd: 1, tokens: 1 },
+      { source_app: "claude-code", events: 1, sessions: 2, tool_calls: 1, cost_usd: 3, tokens: 1 },
+    ]);
+    expect(rows[0]!.name).toBe("claude-code");
+    expect(rows[0]!.share).toBeCloseTo(0.75);
+  });
+
+  it("handles an empty breakdown without dividing by zero", () => {
+    expect(spendByModel([])).toEqual([]);
+    expect(spendByApp([])).toEqual([]);
+  });
+});
+
+describe("how often a tool call fails", () => {
+  it("uses the narrower numerator", () => {
+    expect(errorRate({ tool_calls: 100, tool_errors: 4 })).toBeCloseTo(0.04);
+  });
+
+  it("says nothing rather than something wrong", () => {
+    // `errors` counts LLM spans and notifications, which never enter
+    // `tool_calls` — see shared/types.ts. An older server sends no
+    // `tool_errors`, and a rate computed from the wider count would be a
+    // confident overstatement.
+    expect(errorRate({ tool_calls: 100 })).toBeNull();
+    expect(errorRate({ tool_calls: 0, tool_errors: 0 })).toBeNull();
+    expect(errorRate(null)).toBeNull();
+    expect(errorRate(undefined)).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`/insights` names the session going in circles, the one burning tokens, the one throwing errors. `/stats` says which model and which runtime the money went to. Both have been served since long before the companion existed, and the phone's answer to all of it was three numbers in a Settings sheet: spend, sessions, tool errors.

So the two questions you actually have when you are away from the desk — *is anything stuck* and *what is this costing me* — had no answer on the device in your hand, which is the only time they are urgent.

Fourth tab. Insights worst-first, each one a way **into** the conversation it is about rather than a headline about it. The day's figures. Spend by model and by runtime as ranked lists with a width.

Deliberately not a chart. On a phone a bar is a comparison and nothing else, and the number stays printed beside it — a bar you cannot put a value on is decoration, which is exactly what the home screen's fourteen animated bars were before they came out.

Two things decide whether any of this is trustworthy, so both are tested rather than assumed:

- **Getting from an insight back to a session.** The server labels one `<app>:<first 8 of the uuid>` — enough for a human to recognise, not enough to open. Resolving it is a prefix match anchored on *both* halves, and two matches resolve to nothing: eight hex characters collide often enough on a busy machine, and opening the wrong conversation from an alert about a runaway agent is worse than opening none.
- **The denominator under a bar.** It is the sum of what is drawn, not the fleet's total — `by_model` can omit a model whose price is unknown, and dividing by the larger figure would draw every bar short and understate all of them at once, which reads as "nothing is expensive". A model with no published price says "no price" rather than `$0.00`, and nothing spent draws no bar rather than a full one.

The failed-call rate uses `tool_errors` and shows `—` when the server did not send it. `errors` counts LLM spans and notifications, which never enter `tool_calls`, so that ratio compares two different populations — a confident wrong number, which is the worst kind on a small screen.

## How was it tested?

`web/test/fleet.test.ts`, 17 tests. Both suites green: 683 in `web/`, 1047 in `server/`. Audit 146/146.

Thirteen mutations, each reverted after confirming the failure: the app half of a label ignored; an ambiguous prefix picking the first; the label split on the first colon; an empty prefix matching everything; insights ordered newest-first regardless of severity; info outranking bad; the caller's array sorted in place; shares dividing by zero; models listed cheapest first; a nameless model left nameless; the unpriced flag dropped; the error rate using the wide error count; the error rate dividing by zero calls.

"An empty prefix matches everything" walked through the first time — with a two-session list, `startsWith("")` matches both and the *ambiguity* guard catches it by accident. Against a single session it does not, and a truncated label would open whatever happened to be there. There is now a one-session case.

**Driven on a real server** with a seeded loop (18 identical Bash commands in half an hour) and a seeded burn (~$33 in fifteen minutes), which produces one insight of each severity:

```
tabs:   ["◎ Now 6", "▤ Chats", "◇ Repos", "◈ Fleet 1"]
cards:  bad  | Possible loop · 18× identical command
        warn | Burning fast · $33.00 in 15m
        info | Spend velocity · $33.03/hr
tapped the loop card → landed in the looping session's conversation
```

**One fault that no suite could have caught and only looking did:** the bars were invisible. They are `<span>`s — a `<button>` may not contain a `<div>` — and an inline element silently ignores a height, so every track and fill was drawn 0px tall. The unit tests were green, the drive reported `w=100%`, and the screenshot showed nothing. The audit measures the rendered height on every run now; reverting the `display:block` turns it red with `[0, 0]`.

## Not in this change

Web Push. A gate reaching a locked phone is still the biggest gap, and it needs RFC 8291 payload encryption plus a live push service — neither of which can be exercised in this container. Shipping crypto I cannot drive would break the discipline that found the bar bug, the merge-state contradiction and the wrong-screen back button. It wants its own change, on a machine where it can be tested.