### PR TITLE
Read the failure on the phone, instead of being sent to a browser

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -561,6 +561,50 @@ async function main() {
           await closeTop(cdp);
           await Bun.sleep(700);
 
+          // ---- a failing check's log -----------------------------------
+          //
+          // The tab used to print "the phone does not download run logs" under
+          // every failure, while the endpoint sat on the server. Reading a log
+          // is a read, so this one presses the button.
+          if (await tap(cdp, ".mb-screen.on .mb-seg button", "Checks")) {
+            await Bun.sleep(2600);
+            const failing = await cdp.ev(`(()=>{const b=[...${TOP}.querySelectorAll("button")]
+              .find(b=>/FAILURE|failure/.test(b.textContent) && !b.disabled);
+              if(!b) return null; b.click(); return b.textContent.trim().slice(0,40)})()`);
+            if (!failing) {
+              console.log("  skip  job log · no failing check on this pull request");
+            } else {
+              await Bun.sleep(900);
+              note("job log", "the phone no longer sends you to a browser",
+                !(await cdp.ev(`/does not download run logs/.test(${TOP}.textContent)`)));
+              const opened = await cdp.ev(`(()=>{const b=[...${TOP}.querySelectorAll("button")]
+                .find(b=>/Show the failure/.test(b.textContent)); if(!b||b.disabled) return false; b.click(); return true})()`);
+              note("job log", "a failing check offers its log", opened, failing);
+              if (opened) {
+                await Bun.sleep(2600);
+                note("job log", "the log arrives",
+                  await cdp.ev(`(${TOP}.querySelector(".mb-log pre")?.textContent || "").trim().length > 40`));
+                note("job log", "and says which part of it this is",
+                  await cdp.ev(`(${TOP}.querySelector(".mb-log .lh")?.textContent || "").length > 8`),
+                  await cdp.ev(`${TOP}.querySelector(".mb-log .lh")?.textContent`));
+                note("job log", "the timestamps are gone",
+                  !(await cdp.ev(`/\\d{4}-\\d{2}-\\d{2}T\\d{2}:\\d{2}:\\d{2}\\.\\d+Z/.test(${TOP}.querySelector(".mb-log pre")?.textContent || "")`)));
+                // The whole point: you land on the failure. A window taller
+                // than its box that opens at the top is a log you scroll.
+                note("job log", "it opens at the failure, not at the top",
+                  await cdp.ev(`(()=>{const p=${TOP}.querySelector(".mb-log pre");const e=p?.querySelector(".e");
+                    if(!p) return false; if(!e) return true;
+                    const pr=p.getBoundingClientRect(), er=e.getBoundingClientRect();
+                    return er.top >= pr.top - 1 && er.bottom <= pr.bottom + 1})()`),
+                  await cdp.ev(`(()=>{const p=${TOP}.querySelector(".mb-log pre");
+                    return p ? p.clientHeight+"/"+p.scrollHeight+" at "+Math.round(p.scrollTop) : "?"})()`));
+                await shot(cdp, "07d-joblog");
+                await hygiene(cdp, "job log");
+                await drain(cdp, "job log");
+              }
+            }
+          }
+
           // ---- line threads --------------------------------------------
           //
           // Read-only again: what is drawn and in what order. Replying and

--- a/web/src/mobile/MobilePr.tsx
+++ b/web/src/mobile/MobilePr.tsx
@@ -4,13 +4,14 @@ import { parseUnifiedDiff } from "../lib/prBody.ts";
 import { Screen, Sheet, Seg, Empty, Act, useAsk } from "./mobileUi.tsx";
 import { MobileDiff, FileRow } from "./MobileDiff.tsx";
 import { fmtAgo } from "../lib/format.ts";
-import type { PrDetail, PrCheck } from "../../../shared/types.ts";
+import type { PrDetail, PrCheck, PrCheckJob } from "../../../shared/types.ts";
 import {
   EMPTY, canSubmit, commentAt, countFor, annotatedPaths, setComment as withRemark, summarise,
   type ReviewDraft, type Side, type Verb,
 } from "./reviewDraft.ts";
 import { orderThreads, openCount, type ThreadRow } from "./threads.ts";
 import { mergeMove, MERGE_WHY, whyBlocked } from "./mergeMove.ts";
+import { failureWindow, jobFor, type LogWindow } from "./joblog.ts";
 
 /**
  * Reviewing a pull request from a phone.
@@ -42,6 +43,17 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
   const [diffAt, setDiffAt] = useState<number | null>(null);
   const [more, setMore] = useState(false);
   const [openLog, setOpenLog] = useState<string | null>(null);
+  /**
+   * The jobs behind the checks, and the log of whichever one is open.
+   *
+   * The tab said "the phone does not download run logs" under every failure,
+   * while `jobLog` was on the server and `api.prJobLog` was in the client — so
+   * the queue card you are most likely to be woken by ended at a sentence
+   * telling you to go and use a browser.
+   */
+  const [jobs, setJobs] = useState<PrCheckJob[]>([]);
+  const [log, setLog] = useState<{ for: string; window: LogWindow; truncated: boolean } | null>(null);
+  const [logging, setLogging] = useState(false);
   const [comment, setComment] = useState("");
   /**
    * The review being written, and where it is being written.
@@ -68,6 +80,7 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
     // last one into the next would post them against lines that mean nothing.
     setDraft(EMPTY); setVerb(null); setAt(null); setNote(""); setReviewing(false);
     setReplyTo(null); setReplyText("");
+    setJobs([]); setLog(null); setLogging(false);
     api.prDetail(root, number).then((r) => {
       if (r.ok && r.detail) setD(r.detail); else setErr(r.error || "Could not load it");
     }).catch((e) => setErr(String(e)));
@@ -91,6 +104,25 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
       if (r.ok) reload();
     } catch (e) { toast(String(e), true); }
   };
+  // Only when the tab is opened: this is several requests to GitHub behind the
+  // scenes and most visits to a pull request never look at the checks.
+  useEffect(() => {
+    if (!open || tab !== "checks" || number == null || jobs.length) return;
+    api.prCheckJobs(root, number).then((r) => { if (r.ok && r.jobs) setJobs(r.jobs); }).catch(() => {});
+  }, [open, tab, root, number, jobs.length]);
+
+  const fetchLog = async (check: PrCheck) => {
+    const job = jobFor(check.name, jobs);
+    if (!job) { toast("No job on this run matches that check", true); return; }
+    setLogging(true);
+    try {
+      const r = await api.prJobLog(root, job.id);
+      if (!r.ok || !r.text) { toast(r.error || "Could not read the log", true); return; }
+      setLog({ for: check.name, window: failureWindow(r.text), truncated: !!r.truncated });
+    } catch (e) { toast(String(e), true); }
+    finally { setLogging(false); }
+  };
+
   const { ask, dialog: askDialog } = useAsk();
 
   const canMerge = d?.mergeState === "CLEAN";
@@ -250,7 +282,8 @@ export function MobilePr({ open, root, number, onBack, toast, onOpenChatWith }: 
               </>
             )}
 
-            {tab === "checks" && <Checks d={d} openLog={openLog} onOpenLog={setOpenLog}
+            {tab === "checks" && <Checks d={d} openLog={openLog} onOpenLog={(k) => { setOpenLog(k); setLog(null); }}
+              jobs={jobs} log={log} logging={logging} onFetchLog={fetchLog}
               onRerun={() => act("Re-running the failed checks", () => api.prRerun(root, d.number))}
               onAsk={onOpenChatWith ? (c) => handOver(root, d.number,
                 `The check "${c.name}" is failing on pull request #${d.number} (${d.title}). Work out why and propose the fix.`,
@@ -395,8 +428,12 @@ function Why({ glyph, tint, children, onGo }: { glyph: string; tint: string; chi
   );
 }
 
-function Checks({ d, openLog, onOpenLog, onRerun, onAsk }: {
+function Checks({ d, openLog, onOpenLog, jobs, log, logging, onFetchLog, onRerun, onAsk }: {
   d: PrDetail; openLog: string | null; onOpenLog: (k: string | null) => void;
+  jobs: PrCheckJob[];
+  log: { for: string; window: LogWindow; truncated: boolean } | null;
+  logging: boolean;
+  onFetchLog: (c: PrCheck) => void;
   onRerun: () => void; onAsk?: (c: PrCheck) => void;
 }) {
   const groups = useMemo(() => {
@@ -437,12 +474,46 @@ function Checks({ d, openLog, onOpenLog, onRerun, onAsk }: {
                     style={{ color: bad ? "var(--error)" : "var(--text3)" }}>{k.state}</span>
                 </button>
                 {on && (
-                  <div className="px-3 pb-3 flex gap-2 flex-wrap">
-                    {onAsk && <Act small kind="acc" onAct={() => onAsk(k)}>✦ Ask Claude why</Act>}
-                    {k.url && <Act small onAct={() => { window.open(k.url, "_blank", "noopener,noreferrer"); }}>Open run ↗</Act>}
-                    <Act small onAct={onRerun}>↻ Re-run failed</Act>
-                    <div className="text-[10px] w-full mt-1" style={{ color: "var(--text3)" }}>
-                      The log itself lives on GitHub — the phone does not download run logs.
+                  <div className="px-3 pb-3">
+                    {log?.for === k.name ? (
+                      <div className="mb-log">
+                        <div className="lh">
+                          <b>{log.window.why}</b>
+                          {log.window.hidden > 0 && <span>· {log.window.hidden} lines above</span>}
+                          {log.truncated && <span>· the start was cut by the server</span>}
+                        </div>
+                        {/* Opened at the failure, not at the top of the
+                            window. Twenty-four lines of context is right when
+                            you want it and wrong as a thing to scroll past —
+                            a run that printed a hundred "✓ suite passed" lines
+                            fills the box with them otherwise. */}
+                        <pre ref={(el) => {
+                          if (!el || log.window.at < 0) return;
+                          const line = el.children[log.window.at] as HTMLElement | undefined;
+                          if (line) el.scrollTop = Math.max(0, line.offsetTop - el.clientHeight * 0.55);
+                        }}>{log.window.lines.map((l, n) => (
+                          <span key={n} className={l.startsWith("##[error]") ? "e" : undefined}>
+                            {l.replace(/^##\[error\]/, "")}{"\n"}
+                          </span>
+                        ))}</pre>
+                      </div>
+                    ) : (
+                      <div className="mb-2.5">
+                        {/* The reason a phone shows a window rather than a
+                            file: an Actions log is tens of thousands of lines
+                            with a 28-character timestamp on every one. */}
+                        <Act small full kind="acc" disabled={logging || !jobFor(k.name, jobs)}
+                          title={jobFor(k.name, jobs) ? undefined
+                            : jobs.length ? "No job on this run matches that check" : "Still finding the job"}
+                          onAct={() => onFetchLog(k)}>
+                          {logging ? "Reading the log…" : "Show the failure"}
+                        </Act>
+                      </div>
+                    )}
+                    <div className="flex gap-2 flex-wrap">
+                      {onAsk && <Act small kind="acc" onAct={() => onAsk(k)}>✦ Ask Claude why</Act>}
+                      {k.url && <Act small onAct={() => { window.open(k.url, "_blank", "noopener,noreferrer"); }}>Open run ↗</Act>}
+                      <Act small onAct={onRerun}>↻ Re-run failed</Act>
                     </div>
                   </div>
                 )}
@@ -463,6 +534,18 @@ function Checks({ d, openLog, onOpenLog, onRerun, onAsk }: {
  * — the answer is — and on a phone there is nowhere else to go and read it.
  */
 export const THREAD_CSS = `
+/* A CI log on a phone. Monospace and small, wrapping rather than scrolling
+   sideways — a stack trace read one word at a time is not read. */
+.mb-log{border-radius:11px;overflow:hidden;margin-bottom:10px;
+  background:color-mix(in srgb,#000 45%,transparent);
+  border:1px solid color-mix(in srgb,var(--border) 34%,transparent)}
+.mb-log .lh{display:flex;flex-wrap:wrap;gap:6px;padding:8px 10px;font-size:10px;color:var(--text3);
+  background:color-mix(in srgb,var(--bg3) 40%,transparent)}
+.mb-log .lh b{color:var(--text2);font-weight:600}
+.mb-log pre{margin:0;padding:9px 10px;font-size:10.5px;line-height:1.5;color:var(--text2);
+  white-space:pre-wrap;overflow-wrap:anywhere;max-height:52vh;overflow-y:auto}
+.mb-log pre .e{color:var(--error);font-weight:600}
+
 .mb-thr{border-radius:15px;overflow:hidden;background:var(--mb-card);
   border:1px solid color-mix(in srgb,var(--border) 38%,transparent);box-shadow:var(--mb-edge)}
 .mb-thr.quiet{opacity:.62;border-style:dashed}

--- a/web/src/mobile/joblog.ts
+++ b/web/src/mobile/joblog.ts
@@ -1,0 +1,124 @@
+/**
+ * A CI log, reduced to the part you came for.
+ *
+ * The Checks tab printed "The log itself lives on GitHub — the phone does not
+ * download run logs" under every failure, while `jobLog` sat on the server and
+ * `api.prJobLog` sat in the client. So "CI went red" — which is one of the Now
+ * queue's four card kinds, and the one you are most likely to be woken by —
+ * ended at a sentence telling you to go and use a browser.
+ *
+ * The reason not to just dump the text is real, though. A GitHub Actions log is
+ * tens of thousands of lines, every one of them prefixed with a 28-character
+ * ISO timestamp, and on a 390px screen that prefix alone eats most of the
+ * width. What you want is the failure and the twenty lines before it.
+ *
+ * So: strip what is structure rather than content, find the failure, and show
+ * around it — with the whole thing one tap away for the times the window is
+ * wrong. Its own module, and the decisions are tested, because "which lines
+ * matter" is exactly the kind of judgement that quietly stops being right.
+ */
+
+/** `2026-07-29T00:12:34.5678901Z ` — every line, and 28 characters of a 390px
+ *  screen. It is the same for the whole log, so it carries nothing. */
+const STAMP = /^\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}\.\d+Z\s?/;
+
+/** Actions' own markers. `##[group]` and `##[endgroup]` are folding, which a
+ *  phone has no use for; `##[error]` is the thing we are looking for. */
+const GROUP = /^##\[(group|endgroup|section|debug)\]/;
+const ERROR = /^##\[error\]/;
+
+export interface LogWindow {
+  lines: string[];
+  /** Index within `lines` of the line the window was chosen for, or -1 when it
+   *  is just the tail. */
+  at: number;
+  /** How many lines were left above. */
+  hidden: number;
+  /** Why this window and not another, in the user's words. */
+  why: string;
+}
+
+export function stripStamp(line: string): string {
+  return line.replace(STAMP, "");
+}
+
+/**
+ * The log as lines worth showing: timestamps gone, folding markers gone,
+ * trailing blanks gone.
+ *
+ * Blank lines in the middle stay — they are how a stack trace is separated from
+ * the assertion above it, and collapsing them makes a log harder to read rather
+ * than shorter in any way that matters.
+ */
+export function cleanLines(text: string): string[] {
+  const out = text
+    .split("\n")
+    .map(stripStamp)
+    .filter((l) => !GROUP.test(l))
+    .map((l) => l.replace(/\r$/, ""));
+  while (out.length && !out[out.length - 1]!.trim()) out.pop();
+  return out;
+}
+
+/**
+ * Where to open the log.
+ *
+ * The LAST `##[error]`, not the first: a run that fails, retries and fails
+ * again reports the earlier one too, and the last is the one that ended the
+ * job. Falling back to the tail is not a defeat — a job killed by a timeout or
+ * an OOM never writes an error marker at all, and the last thing it managed to
+ * say is exactly what you want.
+ */
+export function failureWindow(text: string, before = 24, after = 6): LogWindow {
+  const lines = cleanLines(text);
+  if (!lines.length) return { lines: [], at: -1, hidden: 0, why: "The log is empty" };
+
+  let mark = -1;
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (ERROR.test(lines[i]!)) { mark = i; break; }
+  }
+
+  if (mark < 0) {
+    const start = Math.max(0, lines.length - (before + after));
+    return {
+      lines: lines.slice(start),
+      at: -1,
+      hidden: start,
+      why: start > 0 ? "No error was marked — the end of the log" : "The whole log",
+    };
+  }
+  const start = Math.max(0, mark - before);
+  const end = Math.min(lines.length, mark + 1 + after);
+  return {
+    lines: lines.slice(start, end),
+    at: mark - start,
+    hidden: start,
+    why: start > 0 ? "Around the failure" : "The whole log",
+  };
+}
+
+/**
+ * The job behind a check.
+ *
+ * GitHub names a check run after its job, and names it `workflow / job` when a
+ * workflow has several — so the check called `build` and the check called
+ * `CI / build` are both the job `build`. Matched on the segment after the last
+ * slash, trimmed, case-insensitively, because these are written by hand in YAML
+ * and the casing is nobody's contract.
+ *
+ * A matrix job carries its parameters — `test (20.x, ubuntu-latest)` — and
+ * those are part of the name on both sides, so they are left alone rather than
+ * stripped: two matrix legs are two different jobs with two different logs, and
+ * folding them would open the wrong one.
+ */
+export function jobFor<T extends { name: string }>(
+  checkName: string, jobs: readonly T[],
+): T | null {
+  const norm = (s: string) => (s.split("/").pop() ?? s).trim().toLowerCase();
+  const want = norm(checkName);
+  if (!want) return null;
+  const hits = jobs.filter((j) => norm(j.name) === want);
+  // Exactly one. Two jobs of the same name in one pull request means the name
+  // is not an identity here, and opening either is a guess.
+  return hits.length === 1 ? hits[0]! : null;
+}

--- a/web/test/job-log.test.ts
+++ b/web/test/job-log.test.ts
@@ -1,0 +1,155 @@
+/*
+ * A CI log, reduced to the part you came for.
+ *
+ * The Checks tab printed "The log itself lives on GitHub — the phone does not
+ * download run logs" under every failure, while `jobLog` sat on the server and
+ * `api.prJobLog` sat in the client. "CI went red" is one of the Now queue's
+ * four card kinds and the one you are most likely to be woken by, and it ended
+ * at a sentence telling you to go and use a browser.
+ */
+import { describe, expect, it } from "bun:test";
+import { stripStamp, cleanLines, failureWindow, jobFor } from "../src/mobile/joblog.ts";
+
+/** A real Actions prefix. Minutes and seconds are two digits each, so the
+ *  index has to be split across them — a line-400 stamp of `00:400:00` is not
+ *  one, and the code correctly declines to strip it. */
+const stamp = (n: number) =>
+  `2026-07-29T00:${String(Math.floor(n / 60) % 60).padStart(2, "0")}:${String(n % 60).padStart(2, "0")}.1234567Z `;
+const log = (...lines: string[]) => lines.map((l, i) => stamp(i) + l).join("\n");
+
+describe("what is structure and what is content", () => {
+  it("takes the timestamp off, because it is the same on every line", () => {
+    // Twenty-eight characters of a 390px screen, carrying nothing.
+    expect(stripStamp("2026-07-29T00:12:34.5678901Z bun test")).toBe("bun test");
+  });
+
+  it("leaves a line that merely looks like one alone", () => {
+    expect(stripStamp("Started at 2026-07-29T00:12:34.5678901Z")).toBe("Started at 2026-07-29T00:12:34.5678901Z");
+    expect(stripStamp("plain")).toBe("plain");
+  });
+
+  it("drops folding markers, which a phone cannot fold", () => {
+    const out = cleanLines(log("##[group]Run tests", "1 failing", "##[endgroup]"));
+    expect(out).toEqual(["1 failing"]);
+  });
+
+  it("keeps blank lines in the middle", () => {
+    // They are how an assertion is separated from the stack under it, and
+    // collapsing them makes a log harder to read without making it shorter in
+    // any way that matters.
+    expect(cleanLines(log("expected 1", "", "  at x.ts:4"))).toEqual(["expected 1", "", "  at x.ts:4"]);
+  });
+
+  it("drops trailing blanks, which are just space at the bottom", () => {
+    expect(cleanLines(log("done", "", ""))).toEqual(["done"]);
+  });
+
+  it("survives carriage returns from a Windows runner", () => {
+    expect(cleanLines("2026-07-29T00:00:00.0000000Z done\r")).toEqual(["done"]);
+  });
+});
+
+describe("where to open the log", () => {
+  it("opens at the failure, not at the top", () => {
+    const w = failureWindow(log("step 1", "step 2", "##[error]Process completed with exit code 1"), 1, 0);
+    expect(w.lines[w.at]).toContain("exit code 1");
+    expect(w.why).toBe("Around the failure");
+  });
+
+  it("uses the LAST error, not the first", () => {
+    // A run that fails, retries and fails again reports the earlier one too.
+    // The last is the one that ended the job.
+    const w = failureWindow(log("##[error]first attempt", "retrying", "##[error]second attempt"), 5, 0);
+    expect(w.lines[w.at]).toContain("second attempt");
+  });
+
+  it("shows the lines leading up to it, which are the ones that explain it", () => {
+    const w = failureWindow(log("a", "b", "c", "d", "##[error]boom"), 2, 0);
+    expect(w.lines).toEqual(["c", "d", "##[error]boom"]);
+    expect(w.hidden).toBe(2);
+  });
+
+  it("shows what came after, for a runner that keeps talking", () => {
+    const w = failureWindow(log("##[error]boom", "cleaning up", "done"), 0, 2);
+    expect(w.lines).toEqual(["##[error]boom", "cleaning up", "done"]);
+  });
+
+  it("falls back to the end when nothing was marked", () => {
+    // A job killed by a timeout or an OOM never writes an error marker, and the
+    // last thing it managed to say is exactly what you want.
+    const w = failureWindow(log("a", "b", "c", "d", "e"), 2, 1);
+    expect(w.lines).toEqual(["c", "d", "e"]);
+    expect(w.at).toBe(-1);
+    expect(w.why).toContain("end of the log");
+    // The count on the tail branch too, not only on the marked one: it is what
+    // the header prints, and "402 lines above" over a 25-line window is a
+    // sentence nobody can check.
+    expect(w.hidden).toBe(2);
+  });
+
+  it("counts what is above, not what exists, on either branch", () => {
+    // The rule that ties them together: `hidden` plus what is shown can never
+    // exceed the log.
+    const marked = failureWindow(log("a", "b", "c", "##[error]boom"), 1, 0);
+    const tail = failureWindow(log("a", "b", "c", "d"), 1, 1);
+    for (const w of [marked, tail]) {
+      expect(w.hidden + w.lines.length).toBeLessThanOrEqual(4);
+      expect(w.hidden).toBeGreaterThanOrEqual(0);
+    }
+  });
+
+  it("does not claim lines are hidden when they are not", () => {
+    const w = failureWindow(log("only", "##[error]boom"), 50, 50);
+    expect(w.hidden).toBe(0);
+    expect(w.why).toBe("The whole log");
+  });
+
+  it("says so rather than rendering an empty box", () => {
+    expect(failureWindow("").lines).toEqual([]);
+    expect(failureWindow("").why).toBe("The log is empty");
+    expect(failureWindow("\n\n\n").lines).toEqual([]);
+  });
+
+  it("never returns a window that does not contain its own mark", () => {
+    // The rule, over a log long enough for the arithmetic to be wrong: `at` is
+    // an index into `lines`, and an off-by-one here points the highlight at
+    // some unrelated line with total confidence.
+    const many = log(...Array.from({ length: 400 }, (_, i) => `line ${i}`), "##[error]boom");
+    for (const before of [0, 1, 24, 500]) {
+      const w = failureWindow(many, before, 3);
+      expect(w.at).toBeGreaterThanOrEqual(0);
+      expect(w.lines[w.at]).toContain("boom");
+    }
+  });
+});
+
+describe("which job a check belongs to", () => {
+  const jobs = [{ name: "build" }, { name: "test (20.x, ubuntu-latest)" }, { name: "test (22.x, ubuntu-latest)" }];
+
+  it("matches the plain name", () => {
+    expect(jobFor("build", jobs)?.name).toBe("build");
+  });
+
+  it("matches a check named for its workflow too", () => {
+    // GitHub writes `workflow / job` when a workflow has several jobs.
+    expect(jobFor("CI / build", jobs)?.name).toBe("build");
+  });
+
+  it("does not fold two legs of a matrix together", () => {
+    // Two legs are two jobs with two logs. Stripping the parameters would open
+    // whichever one came back first, and it is a coin toss which that is.
+    expect(jobFor("test (20.x, ubuntu-latest)", jobs)?.name).toBe("test (20.x, ubuntu-latest)");
+    expect(jobFor("test", jobs)).toBeNull();
+  });
+
+  it("ignores casing and padding, which nobody promised", () => {
+    expect(jobFor(" CI /  Build ", jobs)?.name).toBe("build");
+  });
+
+  it("opens nothing rather than a guess when the name is not an identity", () => {
+    expect(jobFor("build", [{ name: "build" }, { name: "build" }])).toBeNull();
+    expect(jobFor("nothing like it", jobs)).toBeNull();
+    expect(jobFor("", jobs)).toBeNull();
+    expect(jobFor("build", [])).toBeNull();
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Under every failing check the Checks tab printed *"The log itself lives on GitHub — the phone does not download run logs"*, while `jobLog` sat on the server and `api.prJobLog` sat in the client. "CI went red" is one of the Now queue's four card kinds and the one you are most likely to be woken by, and it ended at a sentence telling you to go and use a browser.

The reason not to simply dump the text is real, though. A GitHub Actions log is tens of thousands of lines, every one prefixed with a 28-character ISO timestamp, and on a 390px screen that prefix alone eats most of the width. So: strip what is structure rather than content, find the failure, show around it.

- **The last error marker, not the first.** A run that fails, retries and fails again reports the earlier one too; the last is the one that ended the job.
- **Falling back to the tail is not a defeat.** A job killed by a timeout or an OOM never writes a marker at all, and the last thing it managed to say is exactly what you want. The header says which of the two you are looking at, and how many lines are above.
- **Timestamps and `##[group]` folding go. Blank lines in the middle stay** — they are how an assertion is separated from the stack under it, and collapsing them makes a log harder to read without making it shorter in any way that matters.
- **Matching a check to its job** is its own small decision. GitHub names a check after its job and writes `workflow / job` when a workflow has several, so both forms resolve to the same job. A matrix leg keeps its parameters: `test (20.x, …)` and `test (22.x, …)` are two jobs with two logs, and folding them would open the wrong one. Two jobs of one name resolve to nothing rather than to a guess.
- **It opens *at* the failure.** Twenty-four lines of context is right when you want it and wrong as a thing to scroll past — a run that printed a hundred `✓ suite passed` lines fills the box with them otherwise.

## How was it tested?

`web/test/job-log.test.ts`, 21 tests. Both suites green: 703 in `web/`, 1047 in `server/`. Audit 158/158.

Fifteen mutations, each reverted after confirming the failure: the timestamp left on; the timestamp regex unanchored; folding markers kept; mid-blanks collapsed; trailing blanks kept; the *first* error used; the window index not rebased; no context before the failure; the tail fallback dropped; hidden lines miscounted; an empty log rendering an empty box; a check matched on its full name only; matrix legs folded together; an ambiguous job name picking the first; casing treated as part of a job name.

"Hidden lines are miscounted" walked through the first time — I had only asserted `hidden` on the marked branch, never on the tail one. There is now a case for each, plus a rule that `hidden + shown` can never exceed the log.

**Driven on a real server** against a 136-line log with groups, timestamps, 120 lines of passing-suite noise and a real assertion failure at the end. It reduces to a 25-line window headed *"Around the failure · 107 lines above"*, with the `##[error]` line picked out.

**Two things I got wrong by reading a screenshot and had to measure instead.** I thought the log box was ignoring its `max-height` and that the footer's reason line was overlapping the buttons. Both were false: the box was 443px of a 476px allowance, and the overlap was content scrolling *under* a translucent footer, by design. What the measuring did find is that the scroll-to-failure code never ran at that size, because the window fit — so the fixture now has lines long enough to wrap, the box overflows properly (869px of content in 476px, scrolled to 393), and disabling that one line puts the failure 845px below the fold. The audit asserts it on every run.