### PR TITLE
Hand a project's own commands to an agent

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -408,7 +408,13 @@ async function main() {
       // looks exactly like a click that did nothing.
       if (files.length && await tap(cdp, ".mb-screen.on .mb-row button")) {
         await Bun.sleep(2200);
-        note("diff", "the diff screen opens", (await topTitle(cdp)).includes("."), await topTitle(cdp));
+        // The title has to be the file that was tapped. This used to assert it
+        // "contains a dot", which is a stand-in for "looks like a filename" and
+        // is wrong about `Makefile`, `Dockerfile`, `LICENSE` and every other
+        // extensionless file a repository has.
+        const want = (files[0] || "").split("/").pop() || "";
+        note("diff", "the diff screen opens on the file that was tapped",
+          !!want && (await topTitle(cdp)).includes(want), `${await topTitle(cdp)} vs ${want}`);
         const lines = await cdp.ev(`document.querySelectorAll(".mb-dl, .mb-diff-line, .mb-hunk").length`);
         const said = await cdp.ev(`(document.querySelector(".mb-screen.on")?.textContent || "")
           .includes("Nothing to show") ? "empty" : ""`);
@@ -480,6 +486,33 @@ async function main() {
           await drain(cdp, facet.toLowerCase());
         }
       }
+      // ---- the project's own commands -------------------------------
+      if (await tap(cdp, ".mb-screen.on .mb-seg button", "Commands")) {
+        await Bun.sleep(2200);
+        const rows = await cdp.ev(`${TOP}.querySelectorAll(".mb-row").length`);
+        if (!rows) {
+          console.log("  skip  commands · no Makefile or package.json in this checkout");
+          note("commands", "an empty list says which kind of empty it is",
+            await cdp.ev(`(${TOP}.querySelector(".mb-empty span")?.textContent || "").length > 12`),
+            await cdp.ev(`${TOP}.querySelector(".mb-empty span")?.textContent`));
+        } else {
+          // The command itself, not a target name: `up` means nothing out of
+          // context and is what you would be handing to an agent.
+          note("commands", "each row shows the command that would run",
+            await cdp.ev(`[...${TOP}.querySelectorAll(".mb-row .i b")].every(e=>/\\S/.test(e.textContent))`),
+            await cdp.ev(`JSON.stringify([...${TOP}.querySelectorAll(".mb-row .i b")].map(e=>e.textContent).slice(0,4))`));
+          note("commands", "a Makefile target is offered before a script",
+            await cdp.ev(`(()=>{const k=[...${TOP}.querySelectorAll(".mb-row .r")].map(e=>e.textContent.trim());
+              const i=k.indexOf("script"); return i === -1 || !k.slice(i).includes("make")})()`),
+            await cdp.ev(`JSON.stringify([...${TOP}.querySelectorAll(".mb-row .r")].map(e=>e.textContent.trim()))`));
+          note("commands", "and each one is a way to hand it over",
+            await cdp.ev(`[...${TOP}.querySelectorAll(".mb-row")].every(e=>e.tagName === "BUTTON" || !!e.querySelector("button"))`));
+        }
+        await shot(cdp, "06b-commands");
+        await hygiene(cdp, "commands");
+        await drain(cdp, "commands");
+      }
+
       // ---- reviewing a pull request --------------------------------
       //
       // Read-only, deliberately: everything up to and including the state of

--- a/web/src/mobile/MobileRepo.tsx
+++ b/web/src/mobile/MobileRepo.tsx
@@ -7,9 +7,10 @@ import { MobilePr } from "./MobilePr.tsx";
 import { projectRows } from "./projects.ts";
 import { listState, dockerState } from "./listState.ts";
 import { halt, type Halt } from "./haltState.ts";
+import { commandRows, promptFor, commandsEmpty } from "./commands.ts";
 import type {
   GitRepoRef, WorkingTree, GitBranch, DockerContainer, DockerStat, PrSummary, GitFileChange,
-  PrListResponse,
+  PrListResponse, TerminalCommands,
 } from "../../../shared/types.ts";
 
 /**
@@ -22,7 +23,7 @@ import type {
  * separate panels each asking which repo you meant.
  */
 
-type Facet = "changes" | "prs" | "containers";
+type Facet = "changes" | "prs" | "containers" | "commands";
 
 export interface RepoSummary {
   ref: GitRepoRef;
@@ -111,6 +112,10 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   );
   const [msg, setMsg] = useState("");
   const [branches, setBranches] = useState<GitBranch[] | null>(null);
+  /** The project's own Makefile targets and package.json scripts. Fetched when
+   *  the facet is opened — one walk of the checkout, and most visits never
+   *  ask. */
+  const [cmds, setCmds] = useState<TerminalCommands | null>(null);
   const [openPr, setOpenPr] = useState<number | null>(null);
   const [diffAt, setDiffAt] = useState<number | null>(null);
   const [prNonce, setPrNonce] = useState(0);
@@ -164,6 +169,12 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
   // stopped part-way through a rebase would otherwise be invisible from the
   // pull request list, which is exactly where a clean-looking checkout opens.
   useEffect(() => { if (open) loadTree(); }, [open, facet, loadTree]);
+  useEffect(() => {
+    if (!open || facet !== "commands" || !root) return;
+    setCmds(null);
+    api.terminalCommands(root).then(setCmds).catch(() => setCmds({ enabled: true, make: [], scripts: [] }));
+  }, [open, facet, root]);
+
   useEffect(() => {
     if (!open || facet !== "prs" || !root) return;
     setPrsLoading(true);
@@ -269,6 +280,7 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
           { id: "changes", label: "Changes", n: repo?.dirty || null },
           { id: "prs", label: "Pull requests", n: prs.length || null },
           { id: "containers", label: "Containers", n: mine.length || null },
+          { id: "commands", label: "Commands", n: null },
         ]} />
 
         {facet === "changes" && (
@@ -400,6 +412,32 @@ export function RepoScreen({ open, repo, checkouts = [], onPickCheckout, contain
               </div>
             )
         )}
+
+        {facet === "commands" && (() => {
+          const why = commandsEmpty(cmds);
+          if (why) return <Empty glyph="▷" title="Nothing to run from here" body={why} />;
+          return (
+            <>
+              {/* Nothing runs behind your back. The command goes to an agent in
+                  this checkout, which is something you can watch and interrupt
+                  — the only kind of remote execution worth having in a pocket. */}
+              <p className="text-[11px] mb-2.5" style={{ color: "var(--text3)" }}>
+                {onOpenChatWith
+                  ? "Tap one to hand it to an agent in this checkout."
+                  : "Read-only here — this build has no way to open a conversation."}
+              </p>
+              <div className="flex flex-col gap-2.5">
+                {commandRows(cmds).map((c) => (
+                  <Row key={c.key}
+                    title={c.cmd}
+                    sub={[c.desc?.trim(), c.dir || null].filter(Boolean).join(" · ") || c.kind}
+                    right={c.kind === "make" ? "make" : "script"}
+                    onClick={onOpenChatWith ? () => onOpenChatWith(root, promptFor(c)) : undefined} />
+                ))}
+              </div>
+            </>
+          );
+        })()}
       </Screen>
 
       <MobileDiff

--- a/web/src/mobile/commands.ts
+++ b/web/src/mobile/commands.ts
@@ -1,0 +1,96 @@
+import type { ProjectCommand, TerminalCommands } from "../../../shared/types.ts";
+
+/**
+ * A project's own commands, on a device with no terminal.
+ *
+ * `/terminal/commands` reads the Makefile targets and the package.json scripts
+ * of every directory in a checkout, with the comment above each target as its
+ * description. The cockpit puts them above the shell as one-tap buttons. The
+ * phone never asked for them, because a phone has no shell to put them above —
+ * and that is the wrong conclusion. What a phone has is an agent, and "run the
+ * suite and tell me what broke" is a better use of one than typing it out.
+ *
+ * So the action is a hand-off, not an execution: it opens a conversation in
+ * that directory with the command in the prompt. Nothing runs behind your back,
+ * and what does run is something you can watch and interrupt — which is the
+ * only kind of remote execution worth having from a pocket.
+ */
+
+export interface CommandRow extends ProjectCommand {
+  /** Where it came from, for the eyebrow. */
+  kind: "make" | "script";
+  /** Stable across a re-fetch, and unique per command. */
+  key: string;
+}
+
+/**
+ * Every command, in a reading order.
+ *
+ * `make test` and `npm run test` are two different commands that happen to
+ * share a name, and both belong on the list — a project with a Makefile
+ * wrapping its scripts is the common case, and hiding one of them means the
+ * list quietly disagrees with the repository. Deduplication is on the command
+ * itself plus its directory, which is what actually identifies it.
+ *
+ * Root first, then by directory, so a monorepo reads top-down instead of
+ * interleaving four packages' `build` scripts.
+ */
+export function commandRows(tc: TerminalCommands | null | undefined): CommandRow[] {
+  if (!tc) return [];
+  const rows: CommandRow[] = [];
+  const seen = new Set<string>();
+  const take = (list: readonly ProjectCommand[] | undefined, kind: "make" | "script") => {
+    for (const c of list ?? []) {
+      if (!c?.cmd?.trim()) continue;
+      // A separator that cannot occur in either half. A space would do until a
+      // Makefile has a target with one in it, which is legal and rare enough
+      // that the bug would be found by somebody else.
+      const key = `${c.dir}\u0000${c.cmd}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      rows.push({ ...c, kind, key });
+    }
+  };
+  // Make first: a Makefile target is usually the intended entry point, and the
+  // scripts under it are the implementation.
+  take(tc.make, "make");
+  take(tc.scripts, "script");
+  // Directory, then make before scripts, then name. Sorting by name alone
+  // discarded the make-first intent above, which is the point of collecting
+  // them in that order in the first place.
+  //
+  // The root needs no special case: "" sorts before every other string, so it
+  // is first for free. An earlier version spelled that out with a ternary,
+  // which no mutation could break — dead code dressed as care.
+  return rows.sort((a, b) =>
+    a.dir.localeCompare(b.dir) ||
+    (a.kind === b.kind ? 0 : a.kind === "make" ? -1 : 1) ||
+    a.name.localeCompare(b.name));
+}
+
+/**
+ * What to ask the agent.
+ *
+ * The command verbatim, because paraphrasing it is how you end up running
+ * something else. The description when there is one, because a target called
+ * `up` means nothing out of context and the agent has no more idea than you do.
+ */
+export function promptFor(c: ProjectCommand): string {
+  const where = c.dir ? ` in ${c.dir}` : "";
+  const why = c.desc?.trim() ? `\n\nWhat it does: ${c.desc.trim()}` : "";
+  return `Run \`${c.cmd}\`${where} and tell me what happened. ` +
+    `If it fails, show me the part of the output that explains why.${why}`;
+}
+
+/** Why there is nothing to show, in a sentence — the three cases are different
+ *  and an empty list said the same thing about all of them. */
+export function commandsEmpty(tc: TerminalCommands | null | undefined): string | null {
+  if (!tc) return "Still reading the project";
+  if (!tc.enabled) {
+    return tc.reason === "windows" ? "The shell backend does not run on this host"
+      : tc.reason === "env" ? "The terminal is switched off on this server"
+      : "The terminal is not available on this server";
+  }
+  if (commandRows(tc).length) return null;
+  return "No Makefile targets and no package.json scripts in this checkout";
+}

--- a/web/test/commands.test.ts
+++ b/web/test/commands.test.ts
@@ -1,0 +1,143 @@
+/*
+ * A project's own commands, on a device with no terminal.
+ *
+ * `/terminal/commands` reads the Makefile targets and package.json scripts of
+ * every directory in a checkout, with the comment above each target as its
+ * description. The cockpit puts them above the shell as one-tap buttons. The
+ * phone never asked for them, because a phone has no shell to put them above —
+ * and that is the wrong conclusion. What a phone has is an agent.
+ */
+import { describe, expect, it } from "bun:test";
+import { commandRows, promptFor, commandsEmpty } from "../src/mobile/commands.ts";
+import type { ProjectCommand, TerminalCommands } from "../../shared/types.ts";
+
+const c = (over: Partial<ProjectCommand> = {}): ProjectCommand =>
+  ({ name: "test", cmd: "make test", desc: "", dir: "", ...over });
+
+const tc = (over: Partial<TerminalCommands> = {}): TerminalCommands =>
+  ({ enabled: true, make: [], scripts: [], ...over });
+
+describe("the list", () => {
+  it("keeps a make target and a script that share a name", () => {
+    // `make test` and `npm run test` are two different commands. A project
+    // whose Makefile wraps its scripts is the common case, and dropping either
+    // makes the list quietly disagree with the repository.
+    const rows = commandRows(tc({
+      make: [c({ name: "test", cmd: "make test" })],
+      scripts: [c({ name: "test", cmd: "npm run test" })],
+    }));
+    expect(rows.map((r) => r.cmd)).toEqual(["make test", "npm run test"]);
+  });
+
+  it("drops a genuine duplicate", () => {
+    const rows = commandRows(tc({
+      make: [c({ cmd: "make test" }), c({ cmd: "make test" })],
+    }));
+    expect(rows).toHaveLength(1);
+  });
+
+  it("treats the same command in two packages as two commands", () => {
+    // A monorepo runs `npm run build` in each of them, and they are not the
+    // same build.
+    const rows = commandRows(tc({
+      scripts: [c({ name: "build", cmd: "npm run build", dir: "web" }),
+                c({ name: "build", cmd: "npm run build", dir: "server" })],
+    }));
+    expect(rows).toHaveLength(2);
+  });
+
+  it("puts the root first, then reads a monorepo top-down", () => {
+    const rows = commandRows(tc({
+      scripts: [
+        c({ name: "build", cmd: "a", dir: "web" }),
+        c({ name: "build", cmd: "b", dir: "server" }),
+        c({ name: "dev", cmd: "c", dir: "" }),
+      ],
+    }));
+    expect(rows.map((r) => r.dir)).toEqual(["", "server", "web"]);
+  });
+
+  it("keeps the make version when a Makefile and a script are the same command", () => {
+    // Rare, and the reason the two lists are collected in that order rather
+    // than merged: `make test` written in both places is one command, and the
+    // Makefile is where the project says so.
+    const rows = commandRows(tc({
+      make: [c({ name: "test", cmd: "make test" })],
+      scripts: [c({ name: "t", cmd: "make test" })],
+    }));
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe("make");
+  });
+
+  it("puts make above scripts, because a target is the entry point", () => {
+    const rows = commandRows(tc({
+      make: [c({ name: "zzz", cmd: "make zzz" })],
+      scripts: [c({ name: "aaa", cmd: "npm run aaa" })],
+    }));
+    expect(rows[0]!.kind).toBe("make");
+  });
+
+  it("gives every row a key that is unique and stable", () => {
+    const input = tc({
+      make: [c({ cmd: "make test" })],
+      scripts: [c({ name: "test", cmd: "npm run test" }), c({ name: "b", cmd: "npm run b", dir: "web" })],
+    });
+    const keys = commandRows(input).map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+    expect(commandRows(input).map((r) => r.key)).toEqual(keys);
+  });
+
+  it("ignores a command with nothing to run", () => {
+    expect(commandRows(tc({ make: [c({ cmd: "" }), c({ cmd: "   " })] }))).toEqual([]);
+  });
+
+  it("survives a payload that is not there yet", () => {
+    expect(commandRows(null)).toEqual([]);
+    expect(commandRows(undefined)).toEqual([]);
+    expect(commandRows({ enabled: true } as TerminalCommands)).toEqual([]);
+  });
+});
+
+describe("what the agent is asked", () => {
+  it("carries the command verbatim", () => {
+    // Paraphrasing it is how you end up running something else.
+    expect(promptFor(c({ cmd: "make test" }))).toContain("`make test`");
+  });
+
+  it("says where, when it is not the root", () => {
+    expect(promptFor(c({ cmd: "npm run build", dir: "web" }))).toContain("in web");
+    expect(promptFor(c({ cmd: "npm run build", dir: "" }))).not.toContain(" in ");
+  });
+
+  it("passes on the description, because a target called `up` means nothing", () => {
+    expect(promptFor(c({ cmd: "make up", desc: "Bring the stack up" })))
+      .toContain("Bring the stack up");
+    expect(promptFor(c({ desc: "   " }))).not.toContain("What it does");
+  });
+
+  it("asks for the failure, not just the outcome", () => {
+    expect(promptFor(c())).toMatch(/fails/);
+  });
+});
+
+describe("why there is nothing to show", () => {
+  it("distinguishes the three ways of being empty", () => {
+    // An empty list said the same thing about a project with no scripts, a
+    // server with the terminal switched off, and a payload that had not
+    // arrived. They are different facts and two of them are not about you.
+    expect(commandsEmpty(null)).toBe("Still reading the project");
+    expect(commandsEmpty(tc({ enabled: false, reason: "env" }))).toContain("switched off");
+    expect(commandsEmpty(tc({ enabled: false, reason: "windows" }))).toContain("host");
+    expect(commandsEmpty(tc())).toContain("No Makefile targets");
+  });
+
+  it("says nothing when there is something to say it about", () => {
+    expect(commandsEmpty(tc({ make: [c()] }))).toBeNull();
+  });
+
+  it("explains a disabled terminal even without a reason", () => {
+    const why = commandsEmpty(tc({ enabled: false }));
+    expect(why).toBeTruthy();
+    expect(why).not.toContain("undefined");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`/terminal/commands` reads the Makefile targets and package.json scripts of every directory in a checkout, with the comment above each target as its description. The cockpit puts them above the shell as one-tap buttons. The phone never asked for them, because a phone has no shell to put them above — and that is the wrong conclusion. What a phone *has* is an agent, and "run the suite and tell me what broke" is a better use of one than typing it out on glass.

So the action is a **hand-off, not an execution**: tapping a command opens a conversation in that checkout with the command in the prompt, verbatim. Nothing runs behind your back, and what does run is something you can watch and interrupt — the only kind of remote execution worth having from a pocket.

- **`make test` and `npm run test` both stay.** They are two different commands that happen to share a name; a Makefile wrapping its scripts is the common case, and dropping either makes the list quietly disagree with the repository. Deduplication is on the command *plus its directory*, which is what actually identifies it — a monorepo runs `npm run build` in four packages and they are not the same build.
- **Make targets come first, per directory**, because a Makefile target is usually the intended entry point and the scripts under it are the implementation.
- **An empty list says which kind of empty it is.** A project with no scripts, a server with the terminal switched off, a host with no PTY backend, and a payload that has not arrived were four different facts rendering as the same blank — and two of them are not about you.

## How was it tested?

`web/test/commands.test.ts`, 16 tests. Both suites green: 719 in `web/`, 1047 in `server/`. Audit 167/167.

Thirteen mutations, each reverted after confirming the failure: make and scripts deduped by name; the directory dropped from a command's identity; duplicates kept; make losing its place to alphabetical order; scripts collected before make; a command with nothing to run listed; the prompt paraphrasing the command; the directory left out of the prompt; the description dropped; a blank description becoming a heading with nothing under it; every empty list saying the same thing; a disabled terminal reading as a project with no scripts; a disabled terminal with no reason printing `undefined`.

**Driven on a real server** against a fixture with both a Makefile and a package.json:

```
make test     | Run the full suite, both packages | make
make up       | Bring the stack up                | make
npm run build | vite build                        | script
npm run dev   | vite --host                       | script
```

Tapping `make test` lands in the composer with:

> Run `make test` and tell me what happened. If it fails, show me the part of the output that explains why.
>
> What it does: Run the full suite, both packages

## Three things the exercise found rather than confirmed

- **The sort was undoing the grouping it existed to preserve.** Collecting make before scripts and then sorting by name alone throws that away, so `aaa` (script) beat `zzz` (make). The mutation caught it; the fix is in the code, not the test.
- **A special case putting the root directory first was dead code** — the empty string already sorts before every other string. No mutation could break it, which is what dead code dressed as care looks like. Removed.
- **A NUL byte had got into the dedup key's separator.** It works fine as a separator, so every test passed; it also made the file binary to `grep`, which is how I found it. Written as an explicit escape now, with the reason a space is not used: a Makefile target may legally contain one.

And one in the harness: the audit's diff check asserted that a filename *"contains a dot"*. It does not, for `Makefile`, `Dockerfile` or `LICENSE` — adding a Makefile to the fixture turned it red. It compares against the file that was actually tapped now, which is what it meant all along.