### PR TITLE
Make the audit survive a machine nobody has used yet

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -278,8 +278,16 @@ async function main() {
     await Bun.sleep(900);
     const liveRows = await cdp.ev(`document.querySelectorAll("main button.w-full").length`);
     note("chats", "Working narrows it", liveRows <= allRows, `${allRows} → ${liveRows}`);
+    // Any sentence, not one particular sentence. "Try a wider range" is the
+    // right words when other scopes have rows; a machine with no agents at all
+    // says "No agents yet", which is better — and asserting the first wording
+    // turned a correct cold-start screen red. An audit that fails on a
+    // legitimate state teaches you to ignore it.
     note("chats", "an empty scope explains itself",
-      liveRows > 0 || await cdp.ev(`document.body.textContent.includes("Try a wider range")`));
+      liveRows > 0 || await cdp.ev(`(()=>{const m=document.querySelector("main");
+        if(!m) return false; const t=m.textContent||"";
+        return /Try a wider range|No agents yet|Nothing here/i.test(t)})()`),
+      await cdp.ev(`(document.querySelector("main")?.textContent||"").trim().replace(/\s+/g," ").slice(-90)`));
     await tap(cdp, "main button", "Today");
     await Bun.sleep(900);
     await drain(cdp, "chats");
@@ -392,11 +400,17 @@ async function main() {
         await shot(cdp, "05b-halted");
         await hygiene(cdp, "halt");
         await drain(cdp, "halt");
+      } else if (!files.length) {
+        // A clean checkout is not a broken one. This asserted rows
+        // unconditionally, so a brand-new machine — the state every user is in
+        // once — came back red on a screen that was doing exactly its job.
+        console.log("  skip  changes · this checkout has nothing uncommitted");
+        note("changes", "a clean tree says so", await cdp.ev(`/Nothing to commit/.test(${TOP}.textContent)`));
       } else {
         note("changes", "lists the changed files", files.length > 0, `${files.length} rows`);
         note("changes", "file paths carry no diff prefix",
-          files.length > 0 && !files.some((f) => /^[abciwo]\//.test(f)),
-          files.filter((f) => /^[abciwo]\//.test(f)).join(", ") || "(list was empty)");
+          !files.some((f) => /^[abciwo]\//.test(f)),
+          files.filter((f) => /^[abciwo]\//.test(f)).join(", ") || "(none)");
       }
       await shot(cdp, "05-changes");
       await drain(cdp, "changes");


### PR DESCRIPTION
## What does this PR do?

Every run of `scripts/phone-audit.ts` so far has been against a populated fixture: agents in the database, a dirty checkout, a pull request, a failing job. That is the machine I built the checks on. It is not the machine every user is on exactly once.

Pointed at a cold server — empty database, one clean repo, no GitHub — **the companion itself was fine.** Every tab said what it should:

| tab | what it said |
|---|---|
| Now | "The queue is empty", and what would put something in it |
| Chats | "No agents yet · Start one and it keeps running on your machine" |
| Repos | the one repo, clean |
| Fleet | "Nothing is misbehaving", zeroes, "Nothing has been spent in this window" |

Three checks went red anyway, and all three were the harness asserting wording that only fits a populated machine:

- **"An empty scope explains itself"** looked for the literal string *"Try a wider range"*. That is the right sentence when other scopes have rows and this one does not; a machine with no agents at all says *"No agents yet"*, which is a better sentence, and the check called it a failure. It accepts any of them now, and prints what it actually found.
- **"Lists the changed files"** and **"file paths carry no diff prefix"** both asserted rows unconditionally. A clean checkout has none — that is the tree doing its job — so the cold start came back red on a correct screen. A clean tree is now its own visible `skip`, plus one assertion that the screen says so.

An audit that fails on a legitimate state is worse than one check fewer, because it teaches you to read past the red.

## How was it tested?

Both ends, on real servers:

```
cold machine (empty db, one clean repo, no gh)     87/87
  skip  changes  · this checkout has nothing uncommitted
  skip  commands · no Makefile or package.json in this checkout
  skip  review   · no open pull request on this repository to review
  skip  fleet    · nothing is misbehaving on this machine

populated machine                                 167/167
```

Four named skips rather than four silent ones — the same reason the review and threads sections gained theirs earlier: a conditional block that stays quiet reads as one that passed, which is how the review section went missing for two runs without anyone noticing.

`web/` suite unchanged and green (719). No application code in this change.