### PR TITLE
Web Push: the envelope, verified against another implementation

### DIFF
--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -1,0 +1,232 @@
+/**
+ * Web Push: the envelope, and only the envelope.
+ *
+ * `deliver()` in alerts.ts reaches three places — an outgoing webhook, a
+ * connected desktop client over the socket, and notify-send. None of them
+ * reaches a phone with its screen off, and the phone's socket closes with the
+ * screen *on purpose* (a socket reconnecting behind a dark screen is a worse
+ * deal than a poll). So the one thing the companion exists for — you walked
+ * away, and an agent is now blocked waiting on a person — is the one thing that
+ * could not reach you.
+ *
+ * Web Push is the only mechanism that can, and it is end-to-end encrypted by
+ * design: the push service relays a blob it cannot read. That means this file
+ * has to get real cryptography exactly right, and "it ran and did not throw" is
+ * not evidence of anything — a wrong key schedule produces a perfectly
+ * well-formed body that the receiving browser silently discards.
+ *
+ * So it is verified against a vector produced by `http_ece`, which is the
+ * library `web-push` uses and therefore the code that actually feeds FCM and
+ * Mozilla's service for a large slice of the web. Byte-for-byte agreement with
+ * an independent implementation is the strongest check available without a
+ * device on the other end. See server/test/push-encrypt.test.ts.
+ *
+ * What is NOT here: subscription storage, the routes, the service worker, and
+ * the call from `deliver()`. This is the part that is hard to get right and
+ * possible to prove; the rest is plumbing and wants a machine where a real
+ * phone can confirm it.
+ *
+ * RFC 8291 (message encryption) over RFC 8188 (aes128gcm content encoding),
+ * with RFC 8292 (VAPID) for the authorization header.
+ */
+
+const enc = new TextEncoder();
+
+// ── base64url, which is what every value in this protocol travels as ──
+
+export function b64uDecode(s: string): Uint8Array {
+  // Padding is stripped before it is re-added. Browsers hand `p256dh` and
+  // `auth` over unpadded, but nothing in the spec forbids a client or a proxy
+  // from padding them, and appending `=` to a string that already ends in one
+  // makes it invalid — a subscription that would simply never work.
+  const pad = s.replace(/-/g, "+").replace(/_/g, "/").replace(/=+$/, "");
+  const bin = atob(pad + "=".repeat((4 - (pad.length % 4)) % 4));
+  const out = new Uint8Array(bin.length);
+  for (let i = 0; i < bin.length; i++) out[i] = bin.charCodeAt(i);
+  return out;
+}
+
+export function b64uEncode(b: Uint8Array): string {
+  let s = "";
+  for (const byte of b) s += String.fromCharCode(byte);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+function concat(...parts: Uint8Array[]): Uint8Array {
+  const out = new Uint8Array(parts.reduce((n, p) => n + p.length, 0));
+  let at = 0;
+  for (const p of parts) { out.set(p, at); at += p.length; }
+  return out;
+}
+
+/** One HKDF-Extract-and-Expand. WebCrypto does both in `deriveBits`. */
+async function hkdf(ikm: Uint8Array, salt: Uint8Array, info: Uint8Array, bytes: number): Promise<Uint8Array> {
+  const key = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveBits"]);
+  const bits = await crypto.subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", salt: salt, info: info },
+    key, bytes * 8,
+  );
+  return new Uint8Array(bits);
+}
+
+/** A subscription, exactly as `PushSubscription.toJSON()` hands it over. */
+export interface PushSubscription {
+  endpoint: string;
+  keys: {
+    /** The receiver's ECDH public key, uncompressed P-256, base64url. */
+    p256dh: string;
+    /** The 16-byte shared authentication secret, base64url. */
+    auth: string;
+  };
+}
+
+/**
+ * Everything the encryption needs that is not the message.
+ *
+ * `salt` and the sender keypair are separate arguments rather than generated
+ * inside, only so a test can pin them. Production calls `encryptPush`, which
+ * generates both fresh per message — reusing either would be a serious mistake,
+ * since the nonce is derived from the salt and AES-GCM fails catastrophically
+ * on nonce reuse.
+ */
+export interface PushKeying {
+  salt: Uint8Array;
+  senderPrivate: CryptoKey;
+  senderPublicRaw: Uint8Array;
+}
+
+const RECORD_SIZE = 4096;
+/**
+ * The most plaintext one record can hold: the record size, less the 16-byte
+ * GCM tag, less the one-byte padding delimiter.
+ *
+ * This writes a single record, which is all a notification needs — and past
+ * this it would emit a record longer than the size it declares in its own
+ * header, which a receiver drops. Silently, on a device that is not in front of
+ * you. Push services refuse payloads over 4096 bytes anyway, so the ceiling is
+ * theirs as much as ours; what matters is that going over it fails here, loudly,
+ * rather than at the far end, invisibly.
+ */
+export const MAX_PAYLOAD = RECORD_SIZE - 16 - 1;
+
+/**
+ * The body of a Web Push message.
+ *
+ * The layout is RFC 8188's: salt (16) ‖ record size (4, big-endian) ‖ key id
+ * length (1) ‖ key id ‖ ciphertext. For Web Push the key id is the sender's
+ * public key, which is how the receiver knows which ECDH to run.
+ *
+ * The plaintext gets a single 0x02 appended before encryption. That is the
+ * padding delimiter for a *final* record — 0x01 means "more records follow",
+ * and a receiver that finds the wrong one rejects the message. A single record
+ * is all a notification needs.
+ */
+export async function encryptWith(
+  plaintext: Uint8Array, sub: PushSubscription, keying: PushKeying,
+): Promise<Uint8Array> {
+  if (plaintext.length > MAX_PAYLOAD) {
+    throw new Error(`push payload is ${plaintext.length} bytes; one record holds ${MAX_PAYLOAD}`);
+  }
+  const uaPublicRaw = b64uDecode(sub.keys.p256dh);
+  const authSecret = b64uDecode(sub.keys.auth);
+
+  const uaPublic = await crypto.subtle.importKey(
+    "raw", uaPublicRaw, { name: "ECDH", namedCurve: "P-256" }, false, [],
+  );
+  const shared = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "ECDH", public: uaPublic }, keying.senderPrivate, 256,
+  ));
+
+  // RFC 8291 §3.4. The order is receiver-then-sender and it is not symmetric:
+  // swapping them derives a key the browser will not arrive at, and the only
+  // symptom is a notification that never appears.
+  const authInfo = concat(enc.encode("WebPush: info"), new Uint8Array([0]), uaPublicRaw, keying.senderPublicRaw);
+  const ikm = await hkdf(shared, authSecret, authInfo, 32);
+
+  const cek = await hkdf(ikm, keying.salt, enc.encode("Content-Encoding: aes128gcm\0"), 16);
+  const nonce = await hkdf(ikm, keying.salt, enc.encode("Content-Encoding: nonce\0"), 12);
+
+  const key = await crypto.subtle.importKey("raw", cek, "AES-GCM", false, ["encrypt"]);
+  const padded = concat(plaintext, new Uint8Array([0x02]));
+  const ciphertext = new Uint8Array(await crypto.subtle.encrypt(
+    { name: "AES-GCM", iv: nonce, tagLength: 128 }, key, padded,
+  ));
+
+  const rs = new Uint8Array(4);
+  new DataView(rs.buffer).setUint32(0, RECORD_SIZE, false);
+  return concat(keying.salt, rs, new Uint8Array([keying.senderPublicRaw.length]), keying.senderPublicRaw, ciphertext);
+}
+
+/** A fresh salt and a fresh sender keypair, per message. Both must be new every
+ *  time — see the note on PushKeying. */
+export async function freshKeying(): Promise<PushKeying> {
+  const pair = await crypto.subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, true, ["deriveBits"]);
+  return {
+    salt: crypto.getRandomValues(new Uint8Array(16)),
+    senderPrivate: pair.privateKey,
+    senderPublicRaw: new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey)),
+  };
+}
+
+export async function encryptPush(plaintext: Uint8Array, sub: PushSubscription): Promise<Uint8Array> {
+  return encryptWith(plaintext, sub, await freshKeying());
+}
+
+// ── VAPID (RFC 8292): who is asking the push service to deliver this ──
+
+export interface VapidKeys {
+  /** Uncompressed P-256 public key, base64url — what the browser is given so
+   *  it can pin the subscription to this server. */
+  publicKey: string;
+  /** The private scalar, base64url. */
+  privateKey: string;
+}
+
+export async function generateVapidKeys(): Promise<VapidKeys> {
+  const pair = await crypto.subtle.generateKey({ name: "ECDSA", namedCurve: "P-256" }, true, ["sign", "verify"]);
+  const jwk = await crypto.subtle.exportKey("jwk", pair.privateKey);
+  return {
+    publicKey: b64uEncode(new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey))),
+    privateKey: jwk.d!,
+  };
+}
+
+/** The `aud` a push service expects: the scheme and host of the endpoint, and
+ *  nothing else. Sending the whole endpoint is rejected. */
+export function audienceOf(endpoint: string): string {
+  const u = new URL(endpoint);
+  return `${u.protocol}//${u.host}`;
+}
+
+/**
+ * The `Authorization: vapid t=<jwt>, k=<public key>` header.
+ *
+ * ES256, which in JWS is the raw 64-byte r‖s — not the DER encoding OpenSSL
+ * hands back by default. WebCrypto already produces the raw form, which is why
+ * this can be four lines instead of a DER parser.
+ */
+export async function vapidHeader(
+  endpoint: string, keys: VapidKeys, subject: string, now = Date.now(),
+): Promise<string> {
+  const header = b64uEncode(enc.encode(JSON.stringify({ typ: "JWT", alg: "ES256" })));
+  const claims = b64uEncode(enc.encode(JSON.stringify({
+    aud: audienceOf(endpoint),
+    // Twelve hours. A push service rejects anything more than 24h out, and a
+    // short life is worth little here: the token is sent over TLS to one host.
+    exp: Math.floor(now / 1000) + 12 * 60 * 60,
+    sub: subject,
+  })));
+  const signing = `${header}.${claims}`;
+
+  const pub = b64uDecode(keys.publicKey);
+  const key = await crypto.subtle.importKey("jwk", {
+    kty: "EC", crv: "P-256", d: keys.privateKey,
+    x: b64uEncode(pub.slice(1, 33)), y: b64uEncode(pub.slice(33, 65)),
+    ext: true,
+  }, { name: "ECDSA", namedCurve: "P-256" }, false, ["sign"]);
+
+  const sig = new Uint8Array(await crypto.subtle.sign(
+    { name: "ECDSA", hash: "SHA-256" }, key, enc.encode(signing),
+  ));
+  return `vapid t=${signing}.${b64uEncode(sig)}, k=${keys.publicKey}`;
+}

--- a/server/test/push-encrypt.test.ts
+++ b/server/test/push-encrypt.test.ts
@@ -1,0 +1,244 @@
+/*
+ * Web Push encryption, against an independent implementation.
+ *
+ * `deliver()` reaches a webhook, a connected desktop client, and notify-send.
+ * None of them reaches a phone with its screen off — and the phone's socket
+ * closes with the screen on purpose. So the one thing the companion exists for,
+ * an agent blocked waiting on a person while you are away from the desk, is the
+ * one thing that could not reach you.
+ *
+ * Web Push can, and it is end-to-end encrypted: the push service relays a blob
+ * it cannot read. Which means "it ran and did not throw" proves nothing here. A
+ * wrong key schedule produces a perfectly well-formed body of the right length
+ * that the receiving browser silently discards, and the only symptom is a
+ * notification that never arrives — on a device that is not in front of you.
+ *
+ * So these are fixed vectors produced by `http_ece`, the library `web-push`
+ * uses and therefore the code that actually feeds FCM and Mozilla's push
+ * service for a large slice of the web. Byte-for-byte agreement with a
+ * second implementation is the strongest evidence available without a real
+ * device on the far end, and it is much stronger than a round trip against
+ * myself, which would pass just as happily with both halves wrong.
+ *
+ * Generated once with http_ece@1.2.1:
+ *   ece.encrypt(plaintext, { version: "aes128gcm", salt, privateKey: as,
+ *                            dh: ua.getPublicKey(), authSecret: auth })
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  b64uDecode, b64uEncode, encryptWith, encryptPush, freshKeying,
+  audienceOf, generateVapidKeys, vapidHeader, MAX_PAYLOAD, type PushSubscription,
+} from "../src/push.ts";
+
+/**
+ * Deliberately not secrets, and deliberately not shaped like them.
+ *
+ * The scalars here are 1..32 and a repeated byte. Both are perfectly valid
+ * P-256 private keys and neither is a credential for anything — which matters,
+ * because a real-looking random scalar committed to a repository is a finding
+ * for every secret scanner that ever reads it, correctly. The first version of
+ * this file pinned one and GitGuardian caught it, which is the scanner doing
+ * its job; the fix is to not commit a key, not to teach the scanner to ignore
+ * one.
+ */
+const asPrivateBytes = Uint8Array.from({ length: 32 }, (_, i) => i + 1);
+
+const V = {
+  uaPublic: "BAyQHUI8gxyoXifHPCY7oTJyG7nXqExPA4CypnVv1gEzHIhwI03sh4UEwXQUT6SxS2amUWkWBtgXPlW9N-OBVp4",
+  asPublic: "BFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIhUCvvDVfgjFOyzApW8X2fk1Q",
+  /** Sixteen 0x11 bytes. */
+  auth: b64uEncode(new Uint8Array(16).fill(0x11)),
+  /** Sixteen 0x22 bytes, which is why every vector below starts "IiIi". */
+  salt: b64uEncode(new Uint8Array(16).fill(0x22)),
+};
+
+const sub: PushSubscription = {
+  endpoint: "https://fcm.googleapis.com/fcm/send/abc123",
+  keys: { p256dh: V.uaPublic, auth: V.auth },
+};
+
+/** The pinned sender key, imported as the ECDH private key the code wants. */
+async function pinnedKeying() {
+  const pub = b64uDecode(V.asPublic);
+  const senderPrivate = await crypto.subtle.importKey("jwk", {
+    kty: "EC", crv: "P-256", d: b64uEncode(asPrivateBytes),
+    x: b64uEncode(pub.slice(1, 33)), y: b64uEncode(pub.slice(33, 65)), ext: true,
+  }, { name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
+  return { salt: b64uDecode(V.salt), senderPrivate, senderPublicRaw: pub };
+}
+
+const body = async (text: string) =>
+  b64uEncode(await encryptWith(new TextEncoder().encode(text), sub, await pinnedKeying()));
+
+describe("the encrypted body, against http_ece", () => {
+  it("matches on the sentence the RFC uses", async () => {
+    expect(await body("When I grow up, I want to be a watermelon")).toBe(
+      "IiIiIiIiIiIiIiIiIiIiIgAAEABBBFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIh" +
+      "UCvvDVfgjFOyzApW8X2fk1QuOgle9Zc--RvStPHwLpA7r34CjaxfJmhEwGTMYU-mPrTahojimbvGafOC1cicCQUBkXEg" +
+      "ywgmn1Ak");
+  });
+
+  it("matches on an empty message", async () => {
+    // Not a case anybody sends, and exactly where an off-by-one in the padding
+    // delimiter would show up on its own.
+    expect(await body("")).toBe(
+      "IiIiIiIiIiIiIiIiIiIiIgAAEABBBFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIh" +
+      "UCvvDVfgjFOyzApW8X2fk1R7IiFR93KnEd6OgaJMFKR0ag");
+  });
+
+  it("matches on an actual gate notification, multi-byte characters and all", async () => {
+    const real = JSON.stringify({
+      title: "✋ Approval needed",
+      body: "claude-code wants to run Bash: rm -rf build",
+    });
+    expect(await body(real)).toBe(
+      "IiIiIiIiIiIiIiIiIiIiIgAAEABBBFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIh" +
+      "UCvvDVfgjFOyzApW8X2fk1QCcBhZobJ7vFOfIU0Ofv1rliwamqNHJnJOhWLMJQyqa7fBh4OtxvXKa5AWj6y_osOArmpJ" +
+      "_pXPYOudrz872_cgZRRySXugy-hXRu24yzm7-29R69Wk2llBTvo-YLNnN65W44VLtg");
+  });
+});
+
+describe("the shape of the body", () => {
+  it("is salt, record size, key id length, key id, ciphertext", async () => {
+    // RFC 8188's header. Getting the record size endianness wrong, or the key
+    // id length off by one, shifts everything after it — and the failure is
+    // silent at the far end.
+    const out = await encryptWith(new TextEncoder().encode("hi"), sub, await pinnedKeying());
+    expect([...out.slice(0, 16)]).toEqual([...b64uDecode(V.salt)]);
+    expect(new DataView(out.buffer, out.byteOffset).getUint32(16, false)).toBe(4096);
+    expect(out[20]).toBe(65);
+    expect([...out.slice(21, 86)]).toEqual([...b64uDecode(V.asPublic)]);
+    // Two bytes of plaintext, one delimiter, sixteen of GCM tag.
+    expect(out.length).toBe(86 + 2 + 1 + 16);
+  });
+
+  it("carries the sender's key, which is how the receiver knows what to do", async () => {
+    const k = await freshKeying();
+    const out = await encryptWith(new TextEncoder().encode("x"), sub, k);
+    expect([...out.slice(21, 86)]).toEqual([...k.senderPublicRaw]);
+  });
+});
+
+describe("how much fits", () => {
+  it("fills a record exactly, and refuses one byte more", async () => {
+    // Past this it would emit a record longer than the size its own header
+    // declares, which a receiver drops — silently, on a device that is not in
+    // front of you. A notification is nowhere near this big; the point is that
+    // it fails here rather than there.
+    const k = await pinnedKeying();
+    const at = await encryptWith(new Uint8Array(MAX_PAYLOAD).fill(121), sub, k);
+    expect(at.length - 86).toBe(4096);
+    await expect(encryptWith(new Uint8Array(MAX_PAYLOAD + 1).fill(121), sub, k))
+      .rejects.toThrow(/4079/);
+  });
+
+  it("matches the reference right up to the boundary", async () => {
+    // 4000 bytes, which is well past anything the alert path sends and is where
+    // a second record would appear if the padding were off by even a little.
+    expect((await body("x".repeat(4000))).startsWith(
+      "IiIiIiIiIiIiIiIiIiIiIgAAEABBBFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIh" +
+      "UCvvDVfgjFOyzApW8X2fk1QBKhRIraZm5hHFu6n9JsRjniYNlLpTfmRTmH7ROVb-Ma3Wm4L3hK_Rf4kbk7HqudScszJG")).toBe(true);
+  });
+});
+
+describe("what must never repeat", () => {
+  it("uses a new salt and a new sender key for every message", async () => {
+    // The nonce is derived from the salt, and AES-GCM fails catastrophically on
+    // nonce reuse — reusing a salt with the same key leaks the plaintexts. This
+    // is why encryptPush generates rather than accepts them.
+    const a = await encryptPush(new TextEncoder().encode("same text"), sub);
+    const b = await encryptPush(new TextEncoder().encode("same text"), sub);
+    expect([...a.slice(0, 16)]).not.toEqual([...b.slice(0, 16)]);   // salt
+    expect([...a.slice(21, 86)]).not.toEqual([...b.slice(21, 86)]); // sender key
+    expect([...a]).not.toEqual([...b]);
+  });
+
+  it("produces a different body for a different subscriber", async () => {
+    const other: PushSubscription = {
+      ...sub,
+      keys: { ...sub.keys, auth: b64uEncode(new Uint8Array(16).fill(9)) },
+    };
+    const k = await pinnedKeying();
+    const mine = await encryptWith(new TextEncoder().encode("x"), sub, k);
+    const theirs = await encryptWith(new TextEncoder().encode("x"), other, k);
+    // Same header, different ciphertext: the auth secret is in the key schedule.
+    expect([...mine.slice(0, 86)]).toEqual([...theirs.slice(0, 86)]);
+    expect([...mine.slice(86)]).not.toEqual([...theirs.slice(86)]);
+  });
+});
+
+describe("base64url, which everything here travels as", () => {
+  it("round-trips bytes that need both substitutions", async () => {
+    // `+` and `/` are exactly the characters that break a URL, and a P-256 key
+    // hits them constantly.
+    const bytes = new Uint8Array([0xfb, 0xff, 0x3e, 0x00, 0x7f, 0xfe]);
+    expect([...b64uDecode(b64uEncode(bytes))]).toEqual([...bytes]);
+    expect(b64uEncode(bytes)).not.toContain("+");
+    expect(b64uEncode(bytes)).not.toContain("/");
+    expect(b64uEncode(bytes)).not.toContain("=");
+  });
+
+  it("accepts input with or without padding", async () => {
+    // Browsers send `p256dh` unpadded; some libraries pad. Both are the key.
+    expect([...b64uDecode("YWJj")]).toEqual([...b64uDecode("YWJj=")]);
+    expect(b64uDecode(V.uaPublic).length).toBe(65);
+  });
+});
+
+describe("VAPID, which says who is asking", () => {
+  const keys = { publicKey: V.asPublic, privateKey: b64uEncode(asPrivateBytes) };
+
+  it("addresses the push service and not the endpoint", async () => {
+    // A service rejects a token whose `aud` is the full endpoint — it is the
+    // origin, and only the origin.
+    expect(audienceOf("https://fcm.googleapis.com/fcm/send/abc123?x=1"))
+      .toBe("https://fcm.googleapis.com");
+    expect(audienceOf("https://updates.push.services.mozilla.com/wpush/v2/gAAA"))
+      .toBe("https://updates.push.services.mozilla.com");
+  });
+
+  it("signs a token a push service can verify", async () => {
+    const h = await vapidHeader(sub.endpoint, keys, "mailto:me@example.com", 1_700_000_000_000);
+    const [, t] = /t=([^,]+)/.exec(h)!;
+    const [head, claims, sig] = t!.split(".");
+    expect(JSON.parse(new TextDecoder().decode(b64uDecode(head!)))).toEqual({ typ: "JWT", alg: "ES256" });
+    const c = JSON.parse(new TextDecoder().decode(b64uDecode(claims!)));
+    expect(c.aud).toBe("https://fcm.googleapis.com");
+    expect(c.sub).toBe("mailto:me@example.com");
+    expect(c.exp).toBe(1_700_000_000 + 12 * 60 * 60);
+
+    // ES256 in JWS is the raw r‖s, 64 bytes — not the DER sequence OpenSSL
+    // returns by default, which is the classic way this goes wrong.
+    expect(b64uDecode(sig!).length).toBe(64);
+
+    const pub = b64uDecode(V.asPublic);
+    const verifier = await crypto.subtle.importKey("jwk", {
+      kty: "EC", crv: "P-256",
+      x: b64uEncode(pub.slice(1, 33)), y: b64uEncode(pub.slice(33, 65)), ext: true,
+    }, { name: "ECDSA", namedCurve: "P-256" }, false, ["verify"]);
+    const ok = await crypto.subtle.verify(
+      { name: "ECDSA", hash: "SHA-256" }, verifier,
+      b64uDecode(sig!), new TextEncoder().encode(`${head}.${claims}`),
+    );
+    expect(ok).toBe(true);
+  });
+
+  it("carries the public key beside the token, which is what pins the subscription", async () => {
+    const h = await vapidHeader(sub.endpoint, keys, "mailto:me@example.com");
+    expect(h.startsWith("vapid t=")).toBe(true);
+    expect(h).toContain(`, k=${V.asPublic}`);
+  });
+
+  it("generates a keypair in the shape a browser will accept", async () => {
+    const g = await generateVapidKeys();
+    const raw = b64uDecode(g.publicKey);
+    // Uncompressed point: 0x04 and two 32-byte coordinates. A browser rejects
+    // anything else outright.
+    expect(raw.length).toBe(65);
+    expect(raw[0]).toBe(0x04);
+    expect(b64uDecode(g.privateKey).length).toBe(32);
+    // And it must actually sign.
+    const h = await vapidHeader(sub.endpoint, g, "mailto:me@example.com");
+    expect(h).toContain(`, k=${g.publicKey}`);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

`deliver()` in `alerts.ts` reaches three places — an outgoing webhook, a connected desktop client over the socket, and `notify-send`. None of them reaches a phone with its screen off, and the phone's socket closes with the screen *on purpose*. So the one thing the companion exists for — you walked away, and an agent is now blocked waiting on a person — is the one thing that could not reach you.

Web Push is the only mechanism that can, and it is end-to-end encrypted by design: the push service relays a blob it cannot read. Which means **"it ran and did not throw" is worth nothing here.** A wrong key schedule produces a perfectly well-formed body of exactly the right length that the receiving browser silently discards, and the only symptom is a notification that never arrives, on a device that is not in front of you.

RFC 8291 over RFC 8188, with RFC 8292 for the VAPID header.

## How was it tested?

Byte-for-byte against fixed vectors produced by `http_ece` — the library `web-push` uses, and therefore the code that actually feeds FCM and Mozilla's push service for a large slice of the web. Agreement with a *second implementation* is much stronger than a round trip against myself, which would pass just as happily with both halves wrong.

15 tests. Server suite green: 1062. Web unchanged: 719.

**Nineteen mutations, every one caught:**

| | |
|---|---|
| key schedule | ECDH key order in `auth_info` swapped · auth secret dropped as the HKDF salt · missing `NUL` in a context string · nonce derived with the CEK's context · CEK 32 bytes · nonce 16 bytes · salt dropped |
| record format | padding delimiter `0x01` · no delimiter at all · little-endian record size · missing key-id length byte |
| must-never-repeat | reused salt · reused sender keypair |
| encoding | base64url keeping `+` and `/` · padded input rejected |
| VAPID | audience is the whole endpoint · JWT signed over the claims only · header with no `k=` |

Every one of the key-schedule mutations is the exact shape of failure I was worried about: the body still comes out the right length and the right structure, and it is simply undeliverable. The vectors catch all of them.

**Three things the exercise found rather than confirmed:**

- Padded base64url input **threw**, because the padding was appended rather than replaced. Browsers send `p256dh` unpadded, but nothing forbids a client or a proxy from padding it, and the symptom would be a subscription that simply never works.
- A payload over one record's worth emitted a record **longer than the size its own header declares**, which a receiver drops silently. It refuses now, with the number in the message.
- The first version of the test pinned a real random P-256 scalar as its sender key, and **GitGuardian flagged it — correctly.** A key-shaped random string committed to a repository is a finding for every scanner that ever reads it. The vectors are regenerated against scalars of `1..32` and a repeated byte, which are perfectly valid P-256 keys and are credentials for nothing. The fix for a scanner finding a key is to not commit a key, not to teach the scanner to ignore one. (Branch squashed, since the scanner reads every commit in a push.)

## What is deliberately not here

Subscription storage, the routes, the service worker, and the call from `deliver()`. **Nothing imports this yet.**

The reason for stopping at the envelope is that the remaining half cannot be verified in this container: delivery needs a real push service and a real device, and outbound here is proxied. Everything in this PR is my code and is provably correct against an independent implementation. The rest is plumbing, and it wants a machine where a phone can confirm it actually buzzes.

I said earlier tonight that Web Push couldn't be verified here and left it out. That was right about delivery and wrong about the cryptography — which is the part that is hard to get right, and the part where a mistake is invisible.