### PR TITLE
Send a push, and remember which phone to send it to

### DIFF
--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -230,3 +230,74 @@ export async function vapidHeader(
   ));
   return `vapid t=${signing}.${b64uEncode(sig)}, k=${keys.publicKey}`;
 }
+
+// ── sending ───────────────────────────────────────────────────────────
+
+export interface PushResult {
+  ok: boolean;
+  status: number;
+  /**
+   * The subscription is dead and should be forgotten.
+   *
+   * 404 and 410 are the push service saying so, and they are the only two
+   * answers that mean it — a 429 or a 503 is the service being busy, and
+   * dropping a subscription over one would silently unsubscribe a phone that
+   * was working perfectly. This distinction is the whole reason the caller
+   * cannot just treat "not ok" as "delete".
+   */
+  gone: boolean;
+  error?: string;
+}
+
+export interface SendOptions {
+  /** How long the service should hold it for a phone that is offline. */
+  ttlSeconds?: number;
+  /** `high` wakes the device; a gate is worth it, a status change is not. */
+  urgency?: "very-low" | "low" | "normal" | "high";
+  subject?: string;
+  now?: number;
+  fetchImpl?: typeof fetch;
+}
+
+/**
+ * One message, to one subscription.
+ *
+ * Never throws for a transport failure: the caller is an alert path, and an
+ * unreachable push service must not take down the notification that was also
+ * going to the desktop.
+ */
+export async function sendPush(
+  sub: PushSubscription, payload: Uint8Array, vapid: VapidKeys, opts: SendOptions = {},
+): Promise<PushResult> {
+  const doFetch = opts.fetchImpl ?? fetch;
+  try {
+    const body = await encryptPush(payload, sub);
+    const auth = await vapidHeader(
+      sub.endpoint, vapid, opts.subject ?? "mailto:agentglass@localhost", opts.now,
+    );
+    const res = await doFetch(sub.endpoint, {
+      method: "POST",
+      headers: {
+        authorization: auth,
+        // Both are required by RFC 8291 and a service rejects the message
+        // without them, with a 400 that says nothing useful.
+        "content-encoding": "aes128gcm",
+        "content-type": "application/octet-stream",
+        ttl: String(opts.ttlSeconds ?? 12 * 60 * 60),
+        urgency: opts.urgency ?? "high",
+      },
+      body,
+    });
+    return {
+      ok: res.ok,
+      status: res.status,
+      gone: res.status === 404 || res.status === 410,
+      ...(res.ok ? {} : { error: `push service answered ${res.status}` }),
+    };
+  } catch (e) {
+    // Status 0 rather than a made-up one: nothing answered, and pretending a
+    // number came back would let a caller reason about a response that does
+    // not exist.
+    return { ok: false, status: 0, gone: false, error: String(e) };
+  }
+}

--- a/server/src/pushstore.ts
+++ b/server/src/pushstore.ts
@@ -1,0 +1,139 @@
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { tmpdir, homedir } from "node:os";
+import { generateVapidKeys, type PushSubscription, type VapidKeys } from "./push.ts";
+
+/**
+ * Where a device's push subscription lives, and the key this server signs with.
+ *
+ * Its own file rather than config.json, for two reasons. It holds a private
+ * key, so it wants 0600 and a config people paste into issues does not. And a
+ * subscription is machine state, not a setting — nobody edits one by hand, and
+ * losing it should cost a re-subscribe rather than a lost preference.
+ *
+ * Not the events database either, which is retention-scoped: subscriptions
+ * would silently evaporate after eight days and the only symptom would be a
+ * phone that quietly stopped buzzing.
+ */
+
+export function pushPath(): string {
+  return join(
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+    "agentglass",
+    "push.json",
+  );
+}
+
+/**
+ * The same rule the settings file follows: under `bun test`, only the scratch
+ * directory is readable or writable. A suite must never read the developer's
+ * real subscriptions, and must never overwrite them with fixtures.
+ */
+const IS_TEST = process.env.NODE_ENV === "test";
+function offLimits(p: string): boolean {
+  const scratch = tmpdir();
+  return IS_TEST && p !== scratch && !p.startsWith(scratch + "/");
+}
+
+/** A subscription, plus what this machine knows about the device it came from. */
+export interface StoredSubscription extends PushSubscription {
+  /** Whatever the phone called itself. Free text, only ever shown back. */
+  label?: string;
+  addedAt: number;
+  /** When a push to it last succeeded, so a dead one can be recognised. */
+  lastOkAt?: number;
+}
+
+interface PushFile {
+  vapid?: VapidKeys;
+  subs?: StoredSubscription[];
+}
+
+function read(): PushFile {
+  const p = pushPath();
+  if (offLimits(p) || !existsSync(p)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf8")) as PushFile;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch {
+    // A corrupt file must not take the server down on boot. The cost of being
+    // wrong is a re-subscribe, which is one tap.
+    return {};
+  }
+}
+
+function write(f: PushFile): boolean {
+  const p = pushPath();
+  if (offLimits(p)) return false;
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify(f, null, 2) + "\n");
+    // It contains a signing key. Best effort: some filesystems will not.
+    try { chmodSync(p, 0o600); } catch { /* not every fs has modes */ }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * This server's VAPID identity, generated once and kept.
+ *
+ * It has to be stable: a browser pins a subscription to the key that created
+ * it, so regenerating invalidates every subscription on every phone at once —
+ * and the failure is silent, because the push service simply stops accepting
+ * the token. Generating on every boot would look fine in every test and buzz
+ * nobody.
+ */
+let memo: VapidKeys | null = null;
+export async function vapidKeys(): Promise<VapidKeys> {
+  if (memo) return memo;
+  const f = read();
+  if (f.vapid?.publicKey && f.vapid?.privateKey) { memo = f.vapid; return memo; }
+  const fresh = await generateVapidKeys();
+  write({ ...f, vapid: fresh });
+  memo = fresh;
+  return fresh;
+}
+
+/** Only for tests, which run several servers in one process. */
+export function forgetVapid(): void { memo = null; }
+
+export function subscriptions(): StoredSubscription[] {
+  return read().subs ?? [];
+}
+
+/**
+ * Remember a device, or update what is known about it.
+ *
+ * The endpoint is the identity. A browser hands back the same endpoint for the
+ * same subscription, and a *new* one when the user clears site data or the push
+ * service rotates it — so matching on endpoint is what stops one phone becoming
+ * four entries and getting four buzzes for one gate.
+ */
+export function addSubscription(sub: PushSubscription, label?: string, now = Date.now()): StoredSubscription[] {
+  if (!sub?.endpoint || !sub.keys?.p256dh || !sub.keys?.auth) return subscriptions();
+  const f = read();
+  const subs = (f.subs ?? []).filter((s) => s.endpoint !== sub.endpoint);
+  subs.push({
+    endpoint: sub.endpoint,
+    keys: { p256dh: sub.keys.p256dh, auth: sub.keys.auth },
+    ...(label ? { label } : {}),
+    addedAt: now,
+  });
+  write({ ...f, subs });
+  return subs;
+}
+
+export function removeSubscription(endpoint: string): StoredSubscription[] {
+  const f = read();
+  const subs = (f.subs ?? []).filter((s) => s.endpoint !== endpoint);
+  write({ ...f, subs });
+  return subs;
+}
+
+export function markDelivered(endpoint: string, now = Date.now()): void {
+  const f = read();
+  const subs = (f.subs ?? []).map((s) => (s.endpoint === endpoint ? { ...s, lastOkAt: now } : s));
+  write({ ...f, subs });
+}

--- a/server/test/push-send.test.ts
+++ b/server/test/push-send.test.ts
@@ -1,0 +1,267 @@
+/*
+ * Sending, and remembering who to send to.
+ *
+ * The encryption is checked against another implementation in
+ * push-encrypt.test.ts. This is the rest of what has to be right before a
+ * phone can buzz: the headers a push service demands, which of its answers
+ * mean "forget this device", and a store that survives a restart.
+ *
+ * The push service here is a real HTTP server on localhost that records what
+ * arrives. That proves everything except whether FCM accepts it — which is not
+ * this repository's code, and is the one thing a container cannot answer.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, existsSync, statSync, readFileSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { sendPush, b64uEncode, type PushSubscription } from "../src/push.ts";
+import {
+  pushPath, vapidKeys, forgetVapid, subscriptions,
+  addSubscription, removeSubscription, markDelivered,
+} from "../src/pushstore.ts";
+
+const sub: PushSubscription = {
+  endpoint: "",
+  keys: {
+    p256dh: "BAyQHUI8gxyoXifHPCY7oTJyG7nXqExPA4CypnVv1gEzHIhwI03sh4UEwXQUT6SxS2amUWkWBtgXPlW9N-OBVp4",
+    auth: b64uEncode(new Uint8Array(16).fill(0x11)),
+  },
+};
+
+const vapid = {
+  publicKey: "BFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIhUCvvDVfgjFOyzApW8X2fk1Q",
+  privateKey: b64uEncode(Uint8Array.from({ length: 32 }, (_, i) => i + 1)),
+};
+
+/** A push service, near enough: it records the request and answers how it is told. */
+function fakeService(status = 201) {
+  const seen: { headers: Record<string, string>; body: Uint8Array }[] = [];
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => { headers[k] = v; });
+      seen.push({ headers, body: new Uint8Array(await req.arrayBuffer()) });
+      return new Response("", { status });
+    },
+  });
+  return { seen, url: `http://127.0.0.1:${server.port}/push/abc`, stop: () => server.stop(true) };
+}
+
+describe("what actually goes over the wire", () => {
+  it("carries the headers a push service refuses to work without", async () => {
+    const svc = fakeService();
+    try {
+      const r = await sendPush({ ...sub, endpoint: svc.url }, new TextEncoder().encode("hi"), vapid);
+      expect(r.ok).toBe(true);
+      const [got] = svc.seen;
+      expect(got).toBeDefined();
+      // Without either of these the service answers 400 and says nothing useful.
+      expect(got!.headers["content-encoding"]).toBe("aes128gcm");
+      expect(got!.headers["content-type"]).toBe("application/octet-stream");
+      // The token, and the key that pins the subscription to this server.
+      expect(got!.headers["authorization"]).toMatch(/^vapid t=[\w-]+\.[\w-]+\.[\w-]+, k=/);
+      expect(got!.headers["authorization"]).toContain(vapid.publicKey);
+    } finally { svc.stop(); }
+  });
+
+  it("asks the service to hold it for a phone that is asleep", async () => {
+    // TTL 0 means "deliver now or drop it", which is exactly wrong for the case
+    // this whole feature exists for: a locked phone in a pocket.
+    const svc = fakeService();
+    try {
+      await sendPush({ ...sub, endpoint: svc.url }, new TextEncoder().encode("hi"), vapid);
+      expect(Number(svc.seen[0]!.headers["ttl"])).toBeGreaterThan(0);
+      expect(svc.seen[0]!.headers["urgency"]).toBe("high");
+      await sendPush({ ...sub, endpoint: svc.url }, new TextEncoder().encode("hi"), vapid,
+        { ttlSeconds: 60, urgency: "low" });
+      expect(svc.seen[1]!.headers["ttl"]).toBe("60");
+      expect(svc.seen[1]!.headers["urgency"]).toBe("low");
+    } finally { svc.stop(); }
+  });
+
+  it("sends the encrypted body and never the plaintext", async () => {
+    const svc = fakeService();
+    try {
+      const secret = "rm -rf /very/secret/path";
+      await sendPush({ ...sub, endpoint: svc.url }, new TextEncoder().encode(secret), vapid);
+      const body = svc.seen[0]!.body;
+      expect(new TextDecoder().decode(body)).not.toContain(secret);
+      // Header (86) + the message + its delimiter + a 16-byte tag.
+      expect(body.length).toBe(86 + secret.length + 1 + 16);
+    } finally { svc.stop(); }
+  });
+});
+
+describe("which answers mean forget this phone", () => {
+  it("treats 404 and 410 as gone, and nothing else", async () => {
+    // A 429 or a 503 is the service being busy. Dropping a subscription over
+    // one would silently unsubscribe a phone that was working perfectly, and
+    // nobody would find out until the next gate went unanswered.
+    for (const [status, gone] of [[404, true], [410, true], [429, false], [500, false], [503, false]] as const) {
+      const svc = fakeService(status);
+      try {
+        const r = await sendPush({ ...sub, endpoint: svc.url }, new TextEncoder().encode("x"), vapid);
+        expect(r.status).toBe(status);
+        expect(r.gone).toBe(gone);
+        expect(r.ok).toBe(false);
+      } finally { svc.stop(); }
+    }
+  });
+
+  it("does not throw when nothing answers at all", async () => {
+    // The caller is an alert path. A push service that is unreachable must not
+    // take down the notification that was also going to the desktop.
+    const r = await sendPush(
+      { ...sub, endpoint: "http://127.0.0.1:1/nowhere" }, new TextEncoder().encode("x"), vapid,
+    );
+    expect(r.ok).toBe(false);
+    // Status 0, not a made-up number: nothing came back, and a caller must not
+    // be able to reason about a response that does not exist.
+    expect(r.status).toBe(0);
+    expect(r.gone).toBe(false);
+    expect(r.error).toBeTruthy();
+  });
+});
+
+describe("the store", () => {
+  let dir: string | null = null;
+  const scratch = () => {
+    dir = mkdtempSync(join(tmpdir(), "agx-push-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    forgetVapid();
+    return dir;
+  };
+  afterEach(() => {
+    if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ } dir = null; }
+    delete process.env.XDG_CONFIG_HOME;
+    forgetVapid();
+  });
+
+  it("keeps one entry per device, however many times it subscribes", async () => {
+    // A browser hands back the same endpoint for the same subscription. Without
+    // this, one phone becomes four rows and gets four buzzes for one gate.
+    scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "Pixel");
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "Pixel");
+    addSubscription({ ...sub, endpoint: "https://push/two" });
+    expect(subscriptions().map((s) => s.endpoint)).toEqual(["https://push/one", "https://push/two"]);
+  });
+
+  it("moves a device to the end when it re-subscribes", async () => {
+    // Not cosmetic: re-adding removes and re-appends, and that is what makes
+    // the dedupe above a replace rather than a silent no-op. The newest label
+    // and keys are the ones that win.
+    scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "old name");
+    addSubscription({ ...sub, endpoint: "https://push/two" });
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "new name");
+    expect(subscriptions().map((s) => s.endpoint)).toEqual(["https://push/two", "https://push/one"]);
+    expect(subscriptions().at(-1)!.label).toBe("new name");
+  });
+
+  it("survives a restart, which is the whole point of a file", async () => {
+    const d = scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "Pixel");
+    const onDisk = JSON.parse(readFileSync(join(d, "agentglass", "push.json"), "utf8"));
+    expect(onDisk.subs[0].endpoint).toBe("https://push/one");
+    expect(onDisk.subs[0].label).toBe("Pixel");
+  });
+
+  it("forgets one on request, and leaves the others", async () => {
+    scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" });
+    addSubscription({ ...sub, endpoint: "https://push/two" });
+    expect(removeSubscription("https://push/one").map((s) => s.endpoint)).toEqual(["https://push/two"]);
+    expect(subscriptions()).toHaveLength(1);
+    // Removing something that was never there is not an error.
+    expect(removeSubscription("https://push/nope")).toHaveLength(1);
+  });
+
+  it("refuses a subscription that is missing its keys", async () => {
+    // A half-written one would be stored, fail to encrypt on every alert, and
+    // look like a phone that is simply not receiving.
+    scratch();
+    addSubscription({ endpoint: "https://push/one", keys: { p256dh: "", auth: "" } });
+    addSubscription({ endpoint: "", keys: sub.keys });
+    expect(subscriptions()).toHaveLength(0);
+  });
+
+  it("reads a corrupt file as empty rather than failing to boot", async () => {
+    // This is read on the alert path and on startup. A half-written file — a
+    // machine that lost power mid-save — must cost a re-subscribe, which is one
+    // tap, not a server that will not come up.
+    const d = scratch();
+    mkdirSync(join(d, "agentglass"), { recursive: true });
+    writeFileSync(join(d, "agentglass", "push.json"), "{ this is not json");
+    expect(subscriptions()).toEqual([]);
+    // And it recovers: the next write replaces the garbage.
+    addSubscription({ ...sub, endpoint: "https://push/one" });
+    expect(subscriptions().map((s) => s.endpoint)).toEqual(["https://push/one"]);
+  });
+
+  it("reads valid json of the wrong shape as empty", async () => {
+    const d = scratch();
+    mkdirSync(join(d, "agentglass"), { recursive: true });
+    writeFileSync(join(d, "agentglass", "push.json"), "[1,2,3]");
+    expect(subscriptions()).toEqual([]);
+  });
+
+  it("records when a device last actually received something", async () => {
+    scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" });
+    markDelivered("https://push/one", 1_700_000_000_000);
+    expect(subscriptions()[0]!.lastOkAt).toBe(1_700_000_000_000);
+  });
+});
+
+describe("the VAPID identity", () => {
+  let dir: string | null = null;
+  afterEach(() => {
+    if (dir) { try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ } dir = null; }
+    delete process.env.XDG_CONFIG_HOME;
+    forgetVapid();
+  });
+
+  it("is generated once and never again", async () => {
+    // A browser pins a subscription to the key that created it. Regenerating
+    // invalidates every subscription on every phone at once, and the failure is
+    // silent — the service simply stops accepting the token.
+    dir = mkdtempSync(join(tmpdir(), "agx-push-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    forgetVapid();
+
+    const first = await vapidKeys();
+    forgetVapid();                        // as if the server restarted
+    const second = await vapidKeys();
+    expect(second.publicKey).toBe(first.publicKey);
+    expect(second.privateKey).toBe(first.privateKey);
+  });
+
+  it("is written where only this user can read it", async () => {
+    dir = mkdtempSync(join(tmpdir(), "agx-push-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    forgetVapid();
+    await vapidKeys();
+    const p = join(dir, "agentglass", "push.json");
+    expect(existsSync(p)).toBe(true);
+    // It holds a signing key. 0600, not whatever the umask happened to be.
+    expect(statSync(p).mode & 0o077).toBe(0);
+  });
+
+  it("stays out of the real config directory under test", async () => {
+    // The same rule the settings file follows. A suite must never read the
+    // developer's own subscriptions, and must never write over them.
+    delete process.env.XDG_CONFIG_HOME;
+    forgetVapid();
+    expect(pushPath()).not.toContain(tmpdir());
+    // Content, not existence. A machine that already has one — including one
+    // left behind by a previous run of this very check with the guard disabled,
+    // which is how I found this — would make an existence test pass for the
+    // wrong reason forever after.
+    const before = existsSync(pushPath()) ? readFileSync(pushPath(), "utf8") : null;
+    await vapidKeys();
+    const after = existsSync(pushPath()) ? readFileSync(pushPath(), "utf8") : null;
+    expect(after).toBe(before);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The envelope landed in #409 with nothing calling it. This is the rest of the server half: who to send to, how to ask a push service to deliver it, and which of its answers mean a device is gone.

- **Subscriptions live in their own file** next to `config.json` rather than in it. It holds a signing key, so it wants `0600`, and a config people paste into issues does not. Not the events database either, which is retention-scoped — subscriptions would evaporate after eight days and the only symptom would be a phone that quietly stopped buzzing.
- **The VAPID identity is generated once and kept.** A browser pins a subscription to the key that created it, so regenerating invalidates every subscription on every phone at once, *silently*: the service just stops accepting the token. Generating per boot would pass every test and buzz nobody.
- **404 and 410 mean forget this device. Nothing else does.** A 429 or a 503 is the service being busy, and dropping a subscription over one would unsubscribe a working phone with no symptom until the next gate went unanswered. That distinction is exactly why a caller cannot treat "not ok" as "delete".
- **A transport failure returns rather than throws**, with status `0` rather than an invented number. The caller is the alert path, and an unreachable push service must not take down the notification that was also going to the desktop.

## How was it tested?

Against a **real HTTP server on localhost standing in for the push service**, so the assertions are on what actually arrives rather than on what I meant to send: the headers, an encrypted body that does not contain the plaintext, a TTL that is not zero, and each status code's verdict.

16 tests. Both suites green: 1078 server, 719 web.

**Sixteen mutations, all caught:** content-encoding dropped · content-type as JSON · TTL zero · urgency ignored · a busy service read as a dead phone · 410 not treated as gone · a transport failure thrown at the caller · a failure inventing a status · **the plaintext sent instead of the ciphertext** · subscriptions not deduped by endpoint · a keyless subscription stored · the VAPID key regenerated every boot · the key file left world-readable · a test allowed to write the real config directory · removing forgetting everything · a corrupt file taking the server down.

**Two things found rather than confirmed:**

- An assertion of mine had the dedupe order backwards — the behaviour was right, my expectation wasn't. There is now an explicit case for the replace, which is what makes the dedupe a replace rather than a silent no-op.
- The mutation that disables *"tests may not touch the real config directory"* **wrote a VAPID key into `~/.config/agentglass/push.json` on this machine.** The guard bit exactly as intended — that is why it went red — but the residue then made the check pass for the wrong reason on the next run, which is how I noticed. It compares the file's *contents* now, not whether it exists, so a machine that already has one cannot mask the guard. (Residue removed.)

## What is still not here

The routes, the service worker, the phone's toggle, and the call from `deliver()`.

The one remaining unverifiable step is `PushManager.subscribe` against a real push service, and the relay itself. Everything up to that line is now covered by tests that inspect real bytes on a real socket.