### PR TITLE
Actually push: deliver() now reaches a phone with its screen off

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -13,6 +13,8 @@
 // desktop setting can suppress. Treat everything below as best-effort reach
 // for when nobody is looking at agentglass at all.
 import type { WatchEvent, AlertNote } from "../../shared/types.ts";
+import { sendPush } from "./push.ts";
+import { vapidKeys, subscriptions, removeSubscription, markDelivered } from "./pushstore.ts";
 
 const WEBHOOK = process.env.AGENTGLASS_WEBHOOK;
 const DESKTOP = process.env.AGENTGLASS_NOTIFY === "1";
@@ -60,6 +62,34 @@ function shouldSend(key: string): boolean {
   return true;
 }
 
+/**
+ * Every phone that asked to be told, in parallel, best effort.
+ *
+ * This is the only channel that reaches a device with its screen off. The
+ * others cannot: a webhook goes to a chat app, notify-send goes to a desktop
+ * that may not exist, and the socket closes with the phone's screen on purpose.
+ *
+ * A push service answering 404 or 410 means that subscription is dead — the
+ * user cleared site data, or the browser rotated it — so it is forgotten. Any
+ * other failure is the service having a bad minute and the device is kept: an
+ * over-eager prune would silently unsubscribe a working phone, and nobody would
+ * find out until a gate went unanswered.
+ */
+async function pushEveryone(title: string, body: string, urgency: 0 | 1 | 2) {
+  const subs = subscriptions();
+  if (!subs.length) return;
+  const keys = await vapidKeys();
+  const payload = new TextEncoder().encode(JSON.stringify({ title, body, at: Date.now() }));
+  await Promise.all(subs.map(async (s) => {
+    const r = await sendPush(s, payload, keys, {
+      // A gate is worth waking the device for; a tool error is not.
+      urgency: urgency === 2 ? "high" : "normal",
+    });
+    if (r.gone) removeSubscription(s.endpoint);
+    else if (r.ok) markDelivered(s.endpoint);
+  }));
+}
+
 async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
   if (WEBHOOK && !IS_TEST) {
     try {
@@ -72,6 +102,16 @@ async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
       console.warn("[alerts] webhook failed:", e);
     }
   }
+  // Before the desktop branch and outside it: a phone is subscribed whether or
+  // not AGENTGLASS_NOTIFY is on, and the desktop path returns early when a
+  // client is attached — which would have skipped the phone entirely in the
+  // one case where somebody is at the desk and the phone still wants to know.
+  if (!IS_TEST) {
+    // Never awaited: an unreachable push service must not hold up the
+    // notification that is also going to the desktop.
+    pushEveryone(title, body, urgency).catch((e) => console.warn("[alerts] push failed:", e));
+  }
+
   if (DESKTOP) {
     // A connected client shows a native OS notification (cross-platform).
     // notify-send is the fallback only when nothing is attached to show it.

--- a/server/test/push-alert.test.ts
+++ b/server/test/push-alert.test.ts
@@ -1,0 +1,260 @@
+/*
+ * The whole point, end to end: an event arrives, and a phone hears about it.
+ *
+ * `deliver()` already reached a webhook, a connected desktop client and
+ * notify-send. None of them reaches a device with its screen off, and the
+ * phone's socket closes with the screen on purpose — so the case the companion
+ * exists for was the one case nothing covered.
+ *
+ * Run against a real server in its own process, with a real HTTP server
+ * standing in for the push service. Nothing is stubbed inside the server: the
+ * event goes in through `/ingest`, and the assertion is on what arrives at the
+ * far end. The only thing this cannot prove is that FCM would have relayed it,
+ * which is not this repository's code.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { b64uEncode, b64uDecode } from "../src/push.ts";
+
+const AUTH = b64uEncode(new Uint8Array(16).fill(0x11));
+
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+let svc: { seen: { headers: Record<string, string>; body: Uint8Array }[]; url: string; stop: () => void; status: number };
+
+/**
+ * A subscription this test holds the private half of, so it can read what the
+ * server sent — which is the only way to check the *contents* rather than just
+ * that something ciphertext-shaped went out.
+ */
+let device: { p256dh: string; publicRaw: Uint8Array; privateKey: CryptoKey };
+
+async function makeDevice() {
+  const pair = await crypto.subtle.generateKey(
+    { name: "ECDH", namedCurve: "P-256" }, true, ["deriveBits"],
+  );
+  const publicRaw = new Uint8Array(await crypto.subtle.exportKey("raw", pair.publicKey));
+  return { p256dh: b64uEncode(publicRaw), publicRaw, privateKey: pair.privateKey };
+}
+
+async function hkdf(ikm: Uint8Array, salt: Uint8Array, info: Uint8Array, bytes: number) {
+  const k = await crypto.subtle.importKey("raw", ikm, "HKDF", false, ["deriveBits"]);
+  return new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", salt, info }, k, bytes * 8,
+  ));
+}
+
+/**
+ * The browser's side of RFC 8291, near enough: unwrap the aes128gcm record and
+ * hand back what the service worker's `event.data` would say.
+ *
+ * That the encryption itself is correct is settled elsewhere — push-encrypt.
+ * test.ts pins it byte-for-byte against `http_ece`, the library `web-push`
+ * uses. This exists to read the plaintext back out, because the thing worth
+ * asserting here is what the service worker will find inside: a notification
+ * needs a title and a body, and an alert that arrives carrying neither is a
+ * push that buzzes a phone with nothing to show.
+ */
+async function decrypt(body: Uint8Array, auth: string): Promise<string> {
+  const salt = body.slice(0, 16);
+  const idLen = body[20]!;
+  const senderPublicRaw = body.slice(21, 21 + idLen);
+  const ciphertext = body.slice(21 + idLen);
+
+  const senderPublic = await crypto.subtle.importKey(
+    "raw", senderPublicRaw, { name: "ECDH", namedCurve: "P-256" }, false, [],
+  );
+  const shared = new Uint8Array(await crypto.subtle.deriveBits(
+    { name: "ECDH", public: senderPublic }, device.privateKey, 256,
+  ));
+  const enc = new TextEncoder();
+  const authInfo = new Uint8Array([
+    ...enc.encode("WebPush: info"), 0, ...device.publicRaw, ...senderPublicRaw,
+  ]);
+  const ikm = await hkdf(shared, b64uDecode(auth), authInfo, 32);
+  const cek = await hkdf(ikm, salt, enc.encode("Content-Encoding: aes128gcm\0"), 16);
+  const nonce = await hkdf(ikm, salt, enc.encode("Content-Encoding: nonce\0"), 12);
+
+  const key = await crypto.subtle.importKey("raw", cek, "AES-GCM", false, ["decrypt"]);
+  const padded = new Uint8Array(await crypto.subtle.decrypt(
+    { name: "AES-GCM", iv: nonce, tagLength: 128 }, key, ciphertext,
+  ));
+  // The trailing byte is RFC 8188's padding delimiter, not content.
+  return new TextDecoder().decode(padded.slice(0, -1));
+}
+
+/** A push service that records, and can be told to answer differently. */
+function fakeService() {
+  const seen: { headers: Record<string, string>; body: Uint8Array }[] = [];
+  const state = { status: 201 };
+  const server = Bun.serve({
+    port: 0,
+    async fetch(req) {
+      const headers: Record<string, string> = {};
+      req.headers.forEach((v, k) => { headers[k] = v; });
+      seen.push({ headers, body: new Uint8Array(await req.arrayBuffer()) });
+      return new Response("", { status: state.status });
+    },
+  });
+  return {
+    seen, url: `http://127.0.0.1:${server.port}/push/device`,
+    stop: () => server.stop(true),
+    get status() { return state.status; },
+    set status(v: number) { state.status = v; },
+  };
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-alert-"));
+  device = await makeDevice();
+  svc = fakeService();
+  const port = 4700 + Math.floor(Math.random() * 250);
+  base = `http://127.0.0.1:${port}`;
+  // A named environment, not `...process.env` — see push-routes.test.ts. And
+  // NOT NODE_ENV=test: the whole point is to exercise the real delivery path,
+  // which a test run deliberately switches off so a suite can never put an
+  // approval prompt on somebody's desktop or post to their Slack.
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+    },
+    stdout: "ignore", stderr: "ignore",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) break; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  await fetch(base + "/push/subscribe", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify({
+      subscription: { endpoint: svc.url, keys: { p256dh: device.p256dh, auth: AUTH } },
+      label: "Pixel",
+    }),
+  });
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { svc?.stop(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+/** An event of the kind that stops an agent dead. */
+const permissionRequest = (session: string) => ({
+  source_app: "claude-code",
+  session_id: session,
+  hook_event_type: "PermissionRequest",
+  // Inside the payload, which is where a hook actually puts it — `normalize()`
+  // reads `payload.tool_name` and ignores a top-level one. Put it at the top
+  // level and the alert still fires, just without saying which tool, so the
+  // wrong shape here would have quietly weakened the assertion below rather
+  // than failed.
+  payload: { tool_name: "Bash", message: "wants to run rm -rf build" },
+});
+
+async function ingest(event: unknown) {
+  const res = await fetch(base + "/ingest", {
+    method: "POST", headers: { "content-type": "application/json" },
+    body: JSON.stringify(event),
+  });
+  return res;
+}
+
+/** Delivery is fire-and-forget on purpose, so wait for it rather than assume. */
+async function waitForPush(atLeast: number, ms = 5000): Promise<boolean> {
+  const until = Date.now() + ms;
+  while (Date.now() < until) {
+    if (svc.seen.length >= atLeast) return true;
+    await Bun.sleep(50);
+  }
+  return false;
+}
+
+describe("an agent stops, and the phone hears", () => {
+  it("pushes when something is waiting on a human", async () => {
+    expect((await ingest(permissionRequest("s-alert-1"))).ok).toBe(true);
+    expect(await waitForPush(1)).toBe(true);
+
+    const got = svc.seen[0]!;
+    expect(got.headers["content-encoding"]).toBe("aes128gcm");
+    expect(got.headers["authorization"]).toMatch(/^vapid t=/);
+    // A held gate is worth waking a locked phone for.
+    expect(got.headers["urgency"]).toBe("high");
+    expect(Number(got.headers["ttl"])).toBeGreaterThan(0);
+  });
+
+  it("sends the notification encrypted, not as text on the wire", async () => {
+    // The push service is a relay and is not trusted with the contents: it
+    // learns that this machine sent something to this device, and nothing else.
+    const body = new TextDecoder().decode(svc.seen[0]!.body);
+    expect(body).not.toContain("rm -rf build");
+    expect(body).not.toContain("Approval");
+    expect(svc.seen[0]!.body.length).toBeGreaterThan(86);
+  });
+
+  it("carries a notification the service worker can actually show", async () => {
+    // Encrypted is not the same as useful. The service worker reads
+    // `event.data.json()` and needs a title and a body to build a notification
+    // from; anything else buzzes a phone with nothing on it, and — because the
+    // wire is ciphertext either way — every check above would still pass.
+    const text = await decrypt(svc.seen[0]!.body, AUTH);
+    const msg = JSON.parse(text) as { title?: string; body?: string; at?: number };
+    expect(typeof msg.title).toBe("string");
+    expect(typeof msg.body).toBe("string");
+    expect(msg.title).toContain("Approval needed");
+    // And it says which agent, so a phone on a lock screen is enough to decide.
+    expect(msg.body).toContain("claude-code:");
+    expect(msg.body).toContain("Bash");
+    // A timestamp, so the worker can tell a fresh alert from one the service
+    // held while the phone was offline — TTL is 12h, so this is not theoretical.
+    expect(msg.at).toBeGreaterThan(0);
+  });
+
+  it("records that the device actually received it", async () => {
+    const { devices } = await (await fetch(base + "/push/devices")).json() as {
+      devices: { label: string; lastOkAt: number | null }[];
+    };
+    const pixel = devices.find((d) => d.label === "Pixel");
+    expect(pixel?.lastOkAt).toBeGreaterThan(0);
+  });
+});
+
+describe("a device that has gone away", () => {
+  it("is forgotten when the push service says it is gone, and only then", async () => {
+    // 429 is the service being busy. Pruning on it would silently unsubscribe a
+    // working phone, and nobody would find out until a gate went unanswered.
+    svc.status = 429;
+    const before = svc.seen.length;
+    await ingest(permissionRequest("s-alert-busy"));
+    expect(await waitForPush(before + 1)).toBe(true);
+    let devices = (await (await fetch(base + "/push/devices")).json() as { devices: unknown[] }).devices;
+    expect(devices).toHaveLength(1);
+
+    // 410 is the service saying that subscription no longer exists.
+    svc.status = 410;
+    const before2 = svc.seen.length;
+    await ingest(permissionRequest("s-alert-gone"));
+    expect(await waitForPush(before2 + 1)).toBe(true);
+    // The prune happens after the response, so give it a moment to land.
+    for (let i = 0; i < 50; i++) {
+      devices = (await (await fetch(base + "/push/devices")).json() as { devices: unknown[] }).devices;
+      if (!devices.length) break;
+      await Bun.sleep(50);
+    }
+    expect(devices).toHaveLength(0);
+  });
+
+  it("stops sending once there is nobody to send to", async () => {
+    const before = svc.seen.length;
+    await ingest(permissionRequest("s-alert-after"));
+    await Bun.sleep(600);
+    expect(svc.seen.length).toBe(before);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The encryption (#409), the store (#410) and the routes (#411) all landed, and nothing called them. An alert still went to a webhook, a connected desktop client and `notify-send` — none of which reach the case the companion exists for: you walked away, and an agent is now blocked waiting on a person.

`deliver()` now pushes too.

**`pushEveryone()` sits before the desktop branch and outside it, on purpose.** A phone is subscribed whether or not `AGENTGLASS_NOTIFY` is on, and the desktop path returns early when a client is attached — putting the push inside it would have skipped the phone in exactly the case where somebody is at the desk and the phone still wants to know. It is not awaited: an unreachable push service must not hold up the notification that was also going to the desktop.

**404 and 410 prune the subscription; nothing else does.** A 429 is the service having a bad minute, and dropping a device over one would silently unsubscribe a working phone — discovered only when a gate went unanswered.

## How was it tested?

End to end against a real server in its own process, with a real HTTP server standing in for the push service. Nothing is stubbed inside the server: a `PermissionRequest` goes in through `/ingest`, and the assertion is on what arrives at the far end.

The test holds the device's private key, so it decrypts the body and asserts what the service worker will actually find inside — a title, a body naming the agent and the tool, and a timestamp.

Eleven mutations, all red: no push at all, push only when the desktop channel is on, a busy service unsubscribing the phone, a gone device kept forever, delivery never recorded, a gate not waking the device, and five on the payload's shape.

Suites green: 1096 server, 719 web.

## The one that walked through first

The wire is ciphertext either way, so `expect(body).not.toContain("rm -rf build")` passes whether the payload is JSON or plain concatenated text. A mutation replacing `JSON.stringify({ title, body, at })` with `title + " " + body` went straight through green tests — and that payload is exactly what a service worker calls `.json()` on to build a notification from. Encrypted is not the same as useful.

The fix is that the test now generates its own ECDH keypair for the fake device, so it can read the plaintext back out rather than only confirm it is unreadable. That the encryption itself is right is settled elsewhere — push-encrypt.test.ts pins it byte-for-byte against `http_ece`, the library `web-push` uses.

Writing that assertion also found the fixture was wrong: `normalize()` reads `payload.tool_name` and ignores a top-level one, which is where a real hook puts it. The alert still fired with it in the wrong place, just without saying which tool — so the bad fixture would have quietly weakened the check rather than failed it.

## Still to come

The service worker and the phone's Settings toggle. The one step that cannot be verified in a container remains `PushManager.subscribe` against a real push service.
