### PR TITLE
The service worker, and the switch that turns it on

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -706,6 +706,34 @@ async function main() {
         await cdp.ev(`(()=>{const s=document.querySelector(".mb-sheet.on");if(!s)return false;
           const r=s.getBoundingClientRect();
           return r.bottom<=innerHeight+1 && r.top>=-1;})()`));
+
+      // Push is the only channel that reaches this device with its screen off,
+      // and the row is the only way to turn it on. Checked here rather than
+      // trusted: the state comes from three separate places — browser support,
+      // notification permission, and whether a subscription exists — and the
+      // wrong answer looks exactly like the right one.
+      const pushRow = `[...document.querySelectorAll(".mb-sheet.on .mb-row")]
+        .find(r => r.textContent.includes("Push to this phone"))`;
+      note("settings", "offers push to this device",
+        await cdp.ev(`!!(${pushRow})`));
+      // Never "Checking…" by the time the sheet is up and painted: that is the
+      // placeholder, and a row stuck on it says nothing and does nothing.
+      const pushText = await cdp.ev(`(${pushRow})?.innerText?.replace(/\\n/g, " · ") || ""`);
+      note("settings", "says where this device actually stands",
+        !!pushText && !pushText.includes("Checking"), pushText);
+      // A button only where pressing one could do something. Chrome here has
+      // no reachable push service, so "Turn on" is the honest state; a browser
+      // that cannot do this at all must offer no button rather than a dead one.
+      const pushBtn = await cdp.ev(`(${pushRow})?.querySelector("button")?.innerText || ""`);
+      note("settings", "the button matches what the row says",
+        (pushText.includes("cannot receive") || pushText.includes("blocked"))
+          ? pushBtn === ""
+          : /Turn on|Turn off/.test(pushBtn),
+        `row "${pushText}" / button "${pushBtn || "(none)"}"`);
+      note("settings", "the worker that receives a push is registered",
+        await cdp.ev(`navigator.serviceWorker.getRegistrations().then(r =>
+          r.some(x => (x.active?.scriptURL || "").endsWith("/sw.js")))`));
+
       await shot(cdp, "08-settings");
       await drain(cdp, "settings");
       await hygiene(cdp, "settings");

--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -79,7 +79,12 @@ async function pushEveryone(title: string, body: string, urgency: 0 | 1 | 2) {
   const subs = subscriptions();
   if (!subs.length) return;
   const keys = await vapidKeys();
-  const payload = new TextEncoder().encode(JSON.stringify({ title, body, at: Date.now() }));
+  // `urgency` travels inside the encrypted payload as well as in the header.
+  // The header is for the push service, which decides whether to wake the
+  // radio; the field is for the service worker, which decides whether the
+  // notification stays on screen until it is dealt with. Only one of the two
+  // can read the body, and only one of the two can wake the device.
+  const payload = new TextEncoder().encode(JSON.stringify({ title, body, at: Date.now(), urgency }));
   await Promise.all(subs.map(async (s) => {
     const r = await sendPush(s, payload, keys, {
       // A gate is worth waking the device for; a tool error is not.

--- a/server/src/push.ts
+++ b/server/src/push.ts
@@ -35,10 +35,12 @@ const enc = new TextEncoder();
 // ── base64url, which is what every value in this protocol travels as ──
 
 export function b64uDecode(s: string): Uint8Array {
-  // Padding is stripped before it is re-added. Browsers hand `p256dh` and
-  // `auth` over unpadded, but nothing in the spec forbids a client or a proxy
-  // from padding them, and appending `=` to a string that already ends in one
-  // makes it invalid — a subscription that would simply never work.
+  // Padding is stripped before it is recomputed. That is a no-op for a
+  // correctly padded string, which is already a multiple of four so nothing is
+  // added back — the earlier note here claimed otherwise and was wrong. What it
+  // actually buys is that a *mis*-padded value decodes instead of throwing.
+  // Browsers hand `p256dh` and `auth` over unpadded, so anything that turns up
+  // padded came from a client or a proxy that added its own.
   const pad = s.replace(/-/g, "+").replace(/_/g, "/").replace(/=+$/, "");
   const bin = atob(pad + "=".repeat((4 - (pad.length % 4)) % 4));
   const out = new Uint8Array(bin.length);

--- a/server/test/push-alert.test.ts
+++ b/server/test/push-alert.test.ts
@@ -205,7 +205,7 @@ describe("an agent stops, and the phone hears", () => {
     // from; anything else buzzes a phone with nothing on it, and — because the
     // wire is ciphertext either way — every check above would still pass.
     const text = await decrypt(svc.seen[0]!.body, AUTH);
-    const msg = JSON.parse(text) as { title?: string; body?: string; at?: number };
+    const msg = JSON.parse(text) as { title?: string; body?: string; at?: number; urgency?: number };
     expect(typeof msg.title).toBe("string");
     expect(typeof msg.body).toBe("string");
     expect(msg.title).toContain("Approval needed");
@@ -215,6 +215,11 @@ describe("an agent stops, and the phone hears", () => {
     // A timestamp, so the worker can tell a fresh alert from one the service
     // held while the phone was offline — TTL is 12h, so this is not theoretical.
     expect(msg.at).toBeGreaterThan(0);
+    // And the urgency inside the payload, not only in the header. The header
+    // is for the push service, which decides whether to wake the radio; this
+    // is for the service worker, which decides whether the notification stays
+    // on screen until it is dealt with. Only one of the two can read the body.
+    expect(msg.urgency).toBe(2);
   });
 
   it("records that the device actually received it", async () => {

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -1,0 +1,121 @@
+/*
+ * The service worker: the only part of agentglass that runs when the app is not.
+ *
+ * A Web Push message is delivered to this file, by the browser, with the tab
+ * closed and the phone in a pocket. That is the entire point of the feature —
+ * everything else in the notification path (a webhook, a desktop toast, the
+ * socket) needs somebody already looking.
+ *
+ * Deliberately plain JavaScript in `public/`, copied verbatim by Vite rather
+ * than bundled. A service worker is fetched by the browser at its own URL and
+ * has no import map, no JSX and no TypeScript; making it a build target would
+ * buy nothing and would let a bundler decide what runs in the one context that
+ * has to keep working after everything else is gone. It is tested by being
+ * evaluated as-is — see web/test/service-worker.test.ts — so what the suite
+ * checks is this file, not a copy of it.
+ *
+ * Nothing here is cached. This is not an offline shell: the app is useless
+ * without the server it reports on, and a stale cached bundle pretending
+ * otherwise would be worse than a failed load.
+ */
+
+/**
+ * Take over as soon as installed, rather than waiting for every tab to close.
+ *
+ * Without these, a phone that already had the app open keeps the previous
+ * worker until every tab is gone — so the first subscribe after an update
+ * would register against a worker that has no push handler, and the alerts
+ * would simply not arrive, with nothing to see anywhere.
+ */
+self.addEventListener("install", () => self.skipWaiting());
+self.addEventListener("activate", (event) => event.waitUntil(self.clients.claim()));
+
+var FALLBACK = { title: "agentglass", body: "Something needs you." };
+
+/**
+ * What arrived, as something showable.
+ *
+ * A push payload is JSON from this machine's own server, but "own server" is
+ * not a guarantee of shape: an older server pushing to a newer worker is the
+ * normal state of affairs for a few minutes after an update, and a phone is
+ * exactly where nobody will see a console error. So every field is checked,
+ * and anything missing falls back rather than throwing.
+ *
+ * Throwing here is not neutral. A push handler that rejects makes the browser
+ * show its own "This site has been updated in the background" notification —
+ * which tells the user nothing, cannot be acted on, and looks like a bug in
+ * the app rather than a bug in the message.
+ */
+function toNotification(raw) {
+  var data = null;
+  try {
+    data = raw && typeof raw.json === "function" ? raw.json() : null;
+  } catch (e) {
+    // Not JSON. Fall through to the text form below.
+  }
+  if (!data || typeof data !== "object") {
+    var text = "";
+    try { text = raw && typeof raw.text === "function" ? raw.text() : ""; } catch (e) { /* nothing usable */ }
+    data = text ? { body: text } : {};
+  }
+  var title = typeof data.title === "string" && data.title ? data.title : FALLBACK.title;
+  var body = typeof data.body === "string" && data.body ? data.body : FALLBACK.body;
+  return {
+    title: title,
+    options: {
+      body: body,
+      icon: "./favicon.svg",
+      badge: "./favicon.svg",
+      // Two pushes carrying the same thing collapse into one notification
+      // instead of stacking. The server already debounces by key, so a repeat
+      // means a retry or a reconnect, not a second event — and a lock screen
+      // with the same approval on it four times is how people learn to swipe
+      // the whole app away.
+      tag: title + "\n" + body,
+      // A held gate stays on screen until it is dealt with: an agent is
+      // stopped until a human answers, and a toast that fades after four
+      // seconds while the phone is face-down is the same as no toast. Anything
+      // less than urgency 2 is informational and is allowed to disappear.
+      requireInteraction: data.urgency === 2,
+      // The timestamp the server stamped, not the moment of delivery. A push
+      // service holds a message for up to the TTL — twelve hours here — so a
+      // phone coming back online shows "3h ago", which is the truth, rather
+      // than "now", which is not.
+      timestamp: typeof data.at === "number" ? data.at : undefined,
+      renotify: false,
+    },
+  };
+}
+
+self.addEventListener("push", function (event) {
+  var n = toNotification(event.data);
+  // waitUntil, or the worker may be killed before the notification is shown —
+  // the push arrives, the process is torn down, and nothing appears.
+  event.waitUntil(self.registration.showNotification(n.title, n.options));
+});
+
+/**
+ * Tapping the notification puts the app in front of you.
+ *
+ * Focus an existing window if there is one, rather than opening a second copy:
+ * the app holds live socket state and a back stack, and a fresh tab throws
+ * both away — you would tap an approval and land on a cold start.
+ *
+ * `includeUncontrolled` matters: a tab loaded before this worker took over is
+ * not controlled by it, and without the flag it is invisible here. That tab is
+ * the single most likely one to exist.
+ */
+self.addEventListener("notificationclick", function (event) {
+  event.notification.close();
+  var home = new URL("./", self.registration.scope).href;
+  event.waitUntil(
+    self.clients.matchAll({ type: "window", includeUncontrolled: true }).then(function (all) {
+      for (var i = 0; i < all.length; i++) {
+        if (all[i].url.indexOf(self.registration.scope) === 0 && "focus" in all[i]) {
+          return all[i].focus();
+        }
+      }
+      return self.clients.openWindow(home);
+    }),
+  );
+});

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -575,6 +575,18 @@ const realApi = {
   dockerStop: (id: string) => post<DockerActionResult>("/docker/stop", { id }),
   dockerRestart: (id: string) => post<DockerActionResult>("/docker/restart", { id }),
   dockerRm: (id: string) => post<DockerActionResult>("/docker/rm", { id }),
+
+  // Web Push. `pushKey` is this server's VAPID public key, which a browser
+  // needs before it can subscribe at all; the other two are the register and
+  // forget. `pushDevices` never returns an endpoint or a key — an endpoint is
+  // a capability, and anyone holding one can wake that phone forever.
+  pushKey: () => get<{ key: string }>("/push/key"),
+  pushSubscribe: (subscription: unknown, label: string) =>
+    post<{ ok: boolean; devices?: number; error?: string }>("/push/subscribe", { subscription, label }),
+  pushUnsubscribe: (endpoint: string) =>
+    post<{ ok: boolean; devices?: number }>("/push/unsubscribe", { endpoint }),
+  pushDevices: () =>
+    get<{ devices: { label: string; addedAt: number; lastOkAt: number | null }[] }>("/push/devices"),
 };
 
 // In demo mode every call resolves against the fabricated dataset — no server.
@@ -698,6 +710,15 @@ const demoApi: typeof realApi = {
   dockerStop: (_id: string) => D(demo.dockerActionUnavailable()),
   dockerRestart: (_id: string) => D(demo.dockerActionUnavailable()),
   dockerRm: (_id: string) => D(demo.dockerActionUnavailable()),
+
+  // There is no server behind the demo, so there is no key to subscribe
+  // against and nothing that could ever push. An empty key is what the UI
+  // already treats as "the server did not hand over a key", so the toggle
+  // fails honestly instead of appearing to work.
+  pushKey: () => D({ key: "" }),
+  pushSubscribe: (_s: unknown, _l: string) => D({ ok: false, error: "not available in the demo" }),
+  pushUnsubscribe: (_e: string) => D({ ok: true }),
+  pushDevices: () => D({ devices: [] as { label: string; addedAt: number; lastOkAt: number | null }[] }),
 
   // The demo has no GitHub behind it, and pretending otherwise would put a
   // fake PR list in front of someone evaluating the app. It reports the same

--- a/web/src/lib/webpush.ts
+++ b/web/src/lib/webpush.ts
@@ -1,0 +1,279 @@
+/*
+ * Turning push on, from the phone's side.
+ *
+ * Three separate things have to line up before an alert can reach a locked
+ * screen, and each fails differently: the browser has to support push at all,
+ * the user has to grant notification permission, and a subscription has to be
+ * registered with both the push service and this machine's server. This module
+ * is about telling those three apart, because a single "it didn't work" is
+ * useless — one is "your browser can't", one is "you said no and only you can
+ * undo it", and one is "the server is unreachable, try again".
+ *
+ * The logic that decides what to say is pure and lives at the top. The part
+ * that touches `navigator` takes its dependencies as arguments, so the whole
+ * flow can be driven in a test without a browser — which matters here more
+ * than usual, since the one step no container can perform is the real
+ * `PushManager.subscribe` against a real push service.
+ */
+
+/**
+ * Base64url to bytes, for `applicationServerKey`.
+ *
+ * The server hands the VAPID public key over as base64url, and
+ * `PushManager.subscribe` will only take a BufferSource. Passing the string
+ * through is not a type error in JavaScript — it is accepted, then fails at
+ * subscribe time with a message that names neither the key nor the format.
+ *
+ * Padding is stripped before it is recomputed. For well-formed base64 that is
+ * a no-op, whatever the arithmetic looks like: a correctly padded string is
+ * already a multiple of four, so nothing is added back. What it buys is that a
+ * *mis*-padded one decodes instead of throwing — and a 65-byte key is 88
+ * characters, which needs no padding at all, so any padding that turns up here
+ * came from something that added its own.
+ */
+export function decodeKey(b64url: string): Uint8Array {
+  const pad = b64url.replace(/-/g, "+").replace(/_/g, "/").replace(/=+$/, "");
+  const raw = atob(pad + "=".repeat((4 - (pad.length % 4)) % 4));
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out;
+}
+
+export type PushState =
+  /** No service worker or no PushManager: Safari before 16.4, or an insecure origin. */
+  | "unsupported"
+  /** The user denied notifications. Only they can undo this, in browser settings. */
+  | "blocked"
+  /** Supported and allowed, but this device is not registered. */
+  | "off"
+  /** Registered. Alerts reach this device with its screen off. */
+  | "on";
+
+export function pushStateOf(env: {
+  supported: boolean;
+  permission: "default" | "granted" | "denied";
+  subscribed: boolean;
+}): PushState {
+  if (!env.supported) return "unsupported";
+  // Subscribed wins over permission on purpose. A browser can report
+  // "default" while an active subscription exists — permission is per-origin
+  // and can be reset without the subscription being torn down — and showing
+  // "off" for a device that is in fact receiving is the one wrong answer that
+  // would have somebody turn it on twice and get two of every alert.
+  if (env.subscribed) return "on";
+  if (env.permission === "denied") return "blocked";
+  return "off";
+}
+
+/** What the settings row says, for each of the four ways this can stand. */
+export function pushCopy(state: PushState): { sub: string; action: string | null } {
+  switch (state) {
+    case "on":
+      return { sub: "Alerts reach this phone with the screen off", action: "Turn off" };
+    case "off":
+      return { sub: "Get held gates on this phone, screen off", action: "Turn on" };
+    case "blocked":
+      // No button: the browser will not ask again, and a button that silently
+      // does nothing is worse than none. Say where the switch actually is.
+      return { sub: "Notifications are blocked in your browser settings", action: null };
+    case "unsupported":
+      return { sub: "This browser cannot receive push notifications", action: null };
+  }
+}
+
+/** Whatever the phone should call itself in the device list. Free text, only
+ *  ever shown back — a name, not an identifier. */
+export function deviceLabel(ua: string): string {
+  // Order matters: an iPad reports "Macintosh" on iPadOS, and every Android
+  // browser string also contains "Linux".
+  if (/iPhone/i.test(ua)) return "iPhone";
+  if (/iPad/i.test(ua)) return "iPad";
+  if (/Android/i.test(ua)) return /Mobile/i.test(ua) ? "Android phone" : "Android tablet";
+  if (/Macintosh/i.test(ua)) return "Mac";
+  if (/Windows/i.test(ua)) return "Windows PC";
+  if (/Linux/i.test(ua)) return "Linux";
+  return "This device";
+}
+
+export interface PushEnv {
+  /** Usually `navigator.serviceWorker`. */
+  sw: {
+    register: (url: string, opts?: { scope?: string }) => Promise<ServiceWorkerRegistrationLike>;
+    ready: Promise<ServiceWorkerRegistrationLike>;
+  } | null;
+  hasPushManager: boolean;
+  permission: "default" | "granted" | "denied";
+  requestPermission: () => Promise<"default" | "granted" | "denied">;
+  ua: string;
+  /** This app's server. */
+  getKey: () => Promise<{ key: string }>;
+  subscribe: (sub: unknown, label: string) => Promise<{ ok: boolean; error?: string }>;
+  unsubscribe: (endpoint: string) => Promise<{ ok: boolean }>;
+  /** Injected so the timeout above can be exercised without a 20s test. */
+  sleep?: (ms: number) => Promise<void>;
+  timeoutMs?: number;
+}
+
+export interface ServiceWorkerRegistrationLike {
+  pushManager: {
+    getSubscription: () => Promise<PushSubscriptionLike | null>;
+    subscribe: (o: { userVisibleOnly: boolean; applicationServerKey: Uint8Array }) => Promise<PushSubscriptionLike>;
+  };
+}
+
+export interface PushSubscriptionLike {
+  endpoint: string;
+  toJSON: () => unknown;
+  unsubscribe: () => Promise<boolean>;
+}
+
+export type PushResult =
+  | { ok: true; state: PushState }
+  | { ok: false; state: PushState; error: string };
+
+/**
+ * How long to wait for the browser to produce a subscription.
+ *
+ * `PushManager.subscribe` talks to the push service over the network, and when
+ * it cannot reach one it does not fail — it waits, for minutes, with no signal
+ * of any kind. In a real browser with the service unreachable the settings
+ * toggle sat on "…" indefinitely, which is the worst of the three outcomes:
+ * not on, not off, and not saying so. This is the bound that turns that into
+ * an answer.
+ */
+export const SUBSCRIBE_TIMEOUT_MS = 20_000;
+
+function withTimeout<T>(p: Promise<T>, ms: number, sleep: (ms: number) => Promise<void>): Promise<T> {
+  // No "did it already land" guard: the race is settled by whichever finishes
+  // first, and a rejection from the loser afterwards is discarded — `race`
+  // attaches its own handler to both, so it is not an unhandled rejection
+  // either. A guard here looked like caution and could never fire, which a
+  // mutation proved by walking straight through it.
+  return Promise.race([
+    p,
+    sleep(ms).then<T>(() => {
+      throw new Error("The push service could not be reached. Check the connection and try again.");
+    }),
+  ]);
+}
+
+/**
+ * Register the worker and find out where this device currently stands.
+ *
+ * Registering on every open, not only when the toggle is used: a worker is
+ * replaced by an update, and `navigator.serviceWorker.register` with an
+ * unchanged file is a no-op, so this is the cheapest way to make sure the
+ * shipped worker is the one that will receive the next push.
+ */
+export async function currentPushState(env: PushEnv): Promise<PushState> {
+  if (!env.sw || !env.hasPushManager) return "unsupported";
+  try {
+    await env.sw.register("./sw.js");
+    const reg = await env.sw.ready;
+    const sub = await reg.pushManager.getSubscription();
+    return pushStateOf({ supported: true, permission: env.permission, subscribed: !!sub });
+  } catch {
+    // A registration that throws means no worker, which means no push —
+    // whatever the browser claims to support.
+    return "unsupported";
+  }
+}
+
+/**
+ * Turn it on: permission, then a subscription, then tell the server.
+ *
+ * The order is not arbitrary. Permission must be requested from a user
+ * gesture or the browser refuses without asking, and `subscribe()` fails
+ * outright unless permission is already granted — so a flow that subscribed
+ * first would fail on every phone, every time.
+ */
+export async function enablePush(env: PushEnv): Promise<PushResult> {
+  if (!env.sw || !env.hasPushManager) {
+    return { ok: false, state: "unsupported", error: "This browser cannot receive push notifications." };
+  }
+  try {
+    const permission = env.permission === "granted" ? "granted" : await env.requestPermission();
+    if (permission !== "granted") {
+      return {
+        ok: false,
+        state: permission === "denied" ? "blocked" : "off",
+        error: permission === "denied"
+          ? "Notifications are blocked. Allow them for this site in your browser settings."
+          : "Notifications were not allowed.",
+      };
+    }
+
+    await env.sw.register("./sw.js");
+    const reg = await env.sw.ready;
+
+    // The key is fetched before subscribing, and a failure here stops the
+    // flow. Subscribing against the wrong key produces a subscription the
+    // server can never send to: the push service rejects its token, and the
+    // phone shows a perfectly healthy-looking "on".
+    const { key } = await env.getKey();
+    if (!key) return { ok: false, state: "off", error: "The server did not hand over a key." };
+
+    // An existing subscription is reused rather than replaced. It may have
+    // been made against this same key and simply not be known to the server —
+    // a restored config, or a server that lost its file — and re-subscribing
+    // would mint a second endpoint for one phone.
+    const sleep = env.sleep ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+    const sub = await reg.pushManager.getSubscription()
+      ?? await withTimeout(reg.pushManager.subscribe({
+        // Required, and enforced: a browser will revoke a subscription that
+        // receives pushes and shows nothing. Every push this server sends
+        // does show something, so this costs nothing and is honest.
+        userVisibleOnly: true,
+        applicationServerKey: decodeKey(key),
+      }), env.timeoutMs ?? SUBSCRIBE_TIMEOUT_MS, sleep);
+
+    const res = await env.subscribe(sub.toJSON(), deviceLabel(env.ua));
+    if (!res.ok) return { ok: false, state: "off", error: res.error || "The server would not take the subscription." };
+    return { ok: true, state: "on" };
+  } catch (e) {
+    return { ok: false, state: "off", error: String((e as Error)?.message ?? e) };
+  }
+}
+
+/**
+ * Turn it off, at both ends.
+ *
+ * The server is told first. If the browser's `unsubscribe()` succeeded and
+ * the server call then failed, this machine would keep pushing to a dead
+ * endpoint until the push service answered 410 — which is eventual, silent,
+ * and leaves a phone listed as a device it no longer is.
+ */
+export async function disablePush(env: PushEnv): Promise<PushResult> {
+  if (!env.sw) return { ok: true, state: "unsupported" };
+  try {
+    const reg = await env.sw.ready;
+    const sub = await reg.pushManager.getSubscription();
+    if (!sub) return { ok: true, state: "off" };
+    await env.unsubscribe(sub.endpoint);
+    await sub.unsubscribe();
+    return { ok: true, state: "off" };
+  } catch (e) {
+    return { ok: false, state: "on", error: String((e as Error)?.message ?? e) };
+  }
+}
+
+/** The live browser, wired to this app's server. Split out so the flow above
+ *  never touches a global and can be driven whole in a test. */
+export function browserPushEnv(api: {
+  pushKey: () => Promise<{ key: string }>;
+  pushSubscribe: (sub: unknown, label: string) => Promise<{ ok: boolean; error?: string }>;
+  pushUnsubscribe: (endpoint: string) => Promise<{ ok: boolean }>;
+}): PushEnv {
+  const nav = typeof navigator === "undefined" ? null : navigator;
+  const canNotify = typeof Notification !== "undefined";
+  return {
+    sw: nav && "serviceWorker" in nav ? (nav.serviceWorker as unknown as PushEnv["sw"]) : null,
+    hasPushManager: typeof PushManager !== "undefined",
+    permission: canNotify ? Notification.permission : "denied",
+    requestPermission: () => (canNotify ? Notification.requestPermission() : Promise.resolve("denied" as const)),
+    ua: nav?.userAgent ?? "",
+    getKey: api.pushKey,
+    subscribe: api.pushSubscribe,
+    unsubscribe: api.pushUnsubscribe,
+  };
+}

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -19,6 +19,9 @@ import { sessionForInsight } from "./fleet.ts";
 import { buildQueue, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
+import {
+  browserPushEnv, currentPushState, disablePush, enablePush, pushCopy, type PushState,
+} from "../lib/webpush.ts";
 import type {
   PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef, GitTreeState, Insight,
 } from "../../../shared/types.ts";
@@ -145,6 +148,17 @@ export function MobileApp() {
   const [openChat, setOpenChat] = useState<OpenChat | null>(null);
   const [compose, setCompose] = useState<Compose | null>(null);
   const [settings, setSettings] = useState(false);
+  /**
+   * Whether this phone gets alerts with its screen off.
+   *
+   * `null` while it is being worked out: three separate things decide it — the
+   * browser's support, the notification permission, and whether a subscription
+   * exists — and only the first is known synchronously. Rendering a guess in
+   * the meantime would flash "Turn on" at a phone that is already subscribed,
+   * which is exactly the mistake that ends with two of every alert.
+   */
+  const [pushState, setPushState] = useState<PushState | null>(null);
+  const [pushBusy, setPushBusy] = useState(false);
   /** A conversation is open and owns the whole screen: no app header, no tabs. */
   const [immersive, setImmersive] = useState(false);
   /**
@@ -162,6 +176,36 @@ export function MobileApp() {
   const [insights, setInsights] = useState<Insight[]>([]);
   const snoozeStore = useMemo(() => deviceStore(), []);
   const [snoozeRev, bumpSnooze] = useReducer((n: number) => n + 1, 0);
+
+  // ── push ─────────────────────────────────────────────────────────────
+  //
+  // Resolved on mount, and again whenever Settings is opened. `currentPushState`
+  // registers the worker as a side effect, which is the point of doing it on
+  // mount rather than only when the toggle is used: registering an unchanged
+  // file is a no-op, and it means the worker that receives the next push is the
+  // one that shipped, not one left over from an older build.
+  const pushEnv = useMemo(() => browserPushEnv(api), []);
+  useEffect(() => {
+    let live = true;
+    currentPushState(pushEnv).then((s) => { if (live) setPushState(s); });
+    return () => { live = false; };
+  }, [pushEnv, settings]);
+
+  const togglePush = useCallback(async () => {
+    setPushBusy(true);
+    // The result carries the state it ended in, including the failures: a
+    // denied permission lands on "blocked", which has no button, because the
+    // browser will not ask again and only the user can undo it.
+    const r = pushState === "on" ? await disablePush(pushEnv) : await enablePush(pushEnv);
+    setPushState(r.state);
+    setPushBusy(false);
+    // The second argument is what makes it a failure toast. Without it a
+    // browser reporting "the push service could not be reached" arrived under
+    // a green tick — which is how a real run of this looked before it was
+    // fixed, and it read as though push had been turned on.
+    if (r.ok) toast(r.state === "on" ? "This phone will be alerted" : "Alerts off on this phone");
+    else toast(r.error, true);
+  }, [pushEnv, pushState]);
 
   // ── the live channel ─────────────────────────────────────────────────
   //
@@ -685,6 +729,18 @@ export function MobileApp() {
           <Row title="Sessions" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.sessions) : "—"} />
           <Row title="Tool errors" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.errors) : "—"} />
         </div>
+        <div className="mb-eyebrow" style={{ margin: "16px 0 9px" }}>Alerts</div>
+        {/* The one channel that reaches a phone in a pocket. The socket closes
+            with the screen on purpose, and a webhook or a desktop toast needs
+            somebody already looking — so without this, the case the companion
+            exists for is the one case nothing covers. */}
+        <Row title="Push to this phone"
+          sub={pushState === null ? "Checking…" : pushCopy(pushState).sub}
+          right={pushState !== null && pushCopy(pushState).action
+            ? <Act small disabled={pushBusy} onAct={togglePush}>
+                {pushBusy ? "…" : pushCopy(pushState).action}
+              </Act>
+            : undefined} />
         <div className="mb-eyebrow" style={{ margin: "16px 0 9px" }}>Queue</div>
         <Row title="Snoozed" sub={snoozed ? `${snoozed} hidden until they change` : "Nothing snoozed"}
           right={snoozed

--- a/web/test/service-worker.test.ts
+++ b/web/test/service-worker.test.ts
@@ -1,0 +1,231 @@
+/*
+ * The service worker, evaluated as the browser evaluates it.
+ *
+ * public/sw.js is the one file in the project that runs when nothing else
+ * does: the tab is closed, the app is not loaded, and a push message arrives
+ * anyway. There is no console to read and no UI to look at, so a mistake in it
+ * is invisible — the phone simply never buzzes, or buzzes with the browser's
+ * own "This site has been updated in the background", which says nothing.
+ *
+ * So this reads the shipped file and runs it against a fake global scope,
+ * rather than testing a TypeScript copy of the same logic. A copy would drift,
+ * and the copy is not what gets served.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SRC = readFileSync(new URL("../public/sw.js", import.meta.url).pathname, "utf8");
+
+interface Shown { title: string; options: Record<string, any> }
+
+/** Enough of a ServiceWorkerGlobalScope to run the file and see what it did. */
+function loadWorker(opts: { clients?: any[] } = {}) {
+  const listeners = new Map<string, (e: any) => void>();
+  const shown: Shown[] = [];
+  const opened: string[] = [];
+  const focused: string[] = [];
+  const waits: Promise<unknown>[] = [];
+  let claimed = false, skipped = false;
+
+  const windows = (opts.clients ?? []).map((c) => ({
+    ...c,
+    focus() { focused.push(c.url); return Promise.resolve(this); },
+  }));
+
+  const scope = {
+    addEventListener: (type: string, fn: (e: any) => void) => { listeners.set(type, fn); },
+    skipWaiting: () => { skipped = true; },
+    registration: {
+      scope: "https://box.local/",
+      showNotification: (title: string, options: Record<string, any>) => {
+        shown.push({ title, options });
+        return Promise.resolve();
+      },
+    },
+    clients: {
+      claim: () => { claimed = true; return Promise.resolve(); },
+      matchAll: () => Promise.resolve(windows),
+      openWindow: (url: string) => { opened.push(url); return Promise.resolve(null); },
+    },
+  };
+
+  // The real thing, run the way the browser runs it: as a script with `self`
+  // as its global.
+  new Function("self", SRC)(scope);
+
+  const fire = async (type: string, event: Record<string, any>) => {
+    const fn = listeners.get(type);
+    if (!fn) throw new Error(`sw.js registered no ${type} listener`);
+    fn({ waitUntil: (p: Promise<unknown>) => { waits.push(p); }, ...event });
+    await Promise.all(waits);
+  };
+
+  return { fire, shown, opened, focused, listeners, waits,
+    get claimed() { return claimed; }, get skipped() { return skipped; } };
+}
+
+/** A PushMessageData, as the browser hands it over. */
+const pushData = (payload: unknown) => ({
+  json: () => {
+    if (typeof payload === "string") return JSON.parse(payload); // throws, on purpose
+    return payload;
+  },
+  text: () => (typeof payload === "string" ? payload : JSON.stringify(payload)),
+});
+
+describe("taking over", () => {
+  it("activates without waiting for every tab to close", async () => {
+    // A phone that already has the app open keeps the previous worker until
+    // every tab is gone. The first subscribe after an update would then attach
+    // to a worker with no push handler, and the alerts would silently not
+    // arrive — the worst possible failure for this feature, because there is
+    // nothing anywhere to see.
+    const w = loadWorker();
+    await w.fire("install", {});
+    expect(w.skipped).toBe(true);
+    await w.fire("activate", {});
+    expect(w.claimed).toBe(true);
+  });
+});
+
+describe("a push arrives", () => {
+  it("shows what the server sent", async () => {
+    const w = loadWorker();
+    await w.fire("push", {
+      data: pushData({ title: "⏳ Approval needed", body: "claude-code:a1b2 is waiting (Bash).", at: 1_700_000_000_000, urgency: 2 }),
+    });
+    expect(w.shown).toHaveLength(1);
+    expect(w.shown[0]!.title).toBe("⏳ Approval needed");
+    expect(w.shown[0]!.options.body).toBe("claude-code:a1b2 is waiting (Bash).");
+  });
+
+  it("waits for the notification before letting the worker die", async () => {
+    // Without waitUntil the browser is free to tear the worker down the moment
+    // the handler returns. The push arrives, the process ends, and nothing is
+    // ever shown — intermittently, and only on a real device.
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ title: "t", body: "b" }) });
+    expect(w.waits.length).toBeGreaterThan(0);
+  });
+
+  it("keeps a held gate on screen, and lets an FYI fade", async () => {
+    // An agent is stopped until somebody answers. A notification that fades
+    // after four seconds while the phone is face-down is the same as no
+    // notification at all.
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ title: "✋", body: "gate", urgency: 2 }) });
+    expect(w.shown[0]!.options.requireInteraction).toBe(true);
+    await w.fire("push", { data: pushData({ title: "🔔", body: "note", urgency: 1 }) });
+    expect(w.shown[1]!.options.requireInteraction).toBe(false);
+  });
+
+  it("shows when it happened, not when it was delivered", async () => {
+    // A push service holds a message for up to the TTL — twelve hours. A phone
+    // coming back online should say "3h ago", which is true, not "now".
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ title: "t", body: "b", at: 1_700_000_000_000 }) });
+    expect(w.shown[0]!.options.timestamp).toBe(1_700_000_000_000);
+  });
+
+  it("collapses an exact repeat instead of stacking it", async () => {
+    // The server debounces by key, so a repeat is a retry or a reconnect, not
+    // a second event. Four copies of one approval on a lock screen is how
+    // people learn to swipe the whole app away.
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ title: "✋ Approval needed", body: "same" }) });
+    await w.fire("push", { data: pushData({ title: "✋ Approval needed", body: "same" }) });
+    await w.fire("push", { data: pushData({ title: "✋ Approval needed", body: "different" }) });
+    expect(w.shown[0]!.options.tag).toBeTruthy();
+    // Same alert, same tag: the second replaces the first on the lock screen.
+    expect(w.shown[1]!.options.tag).toBe(w.shown[0]!.options.tag);
+    // A different alert must not be swallowed by the one before it, which is
+    // the mistake a single constant tag would make.
+    expect(w.shown[2]!.options.tag).not.toBe(w.shown[0]!.options.tag);
+    // And it must not silently re-buzz for the repeat.
+    expect(w.shown[0]!.options.renotify).toBe(false);
+  });
+});
+
+describe("a payload that is not what this worker expected", () => {
+  // An older server pushing to a newer worker is the normal state of affairs
+  // for a few minutes after an update, and a phone is exactly where nobody
+  // sees a console error.
+
+  it("still shows something when the payload is not JSON", async () => {
+    const w = loadWorker();
+    await w.fire("push", { data: pushData("not json at all") });
+    expect(w.shown).toHaveLength(1);
+    expect(w.shown[0]!.options.body).toBe("not json at all");
+  });
+
+  it("still shows something when there is no payload at all", async () => {
+    const w = loadWorker();
+    await w.fire("push", { data: null });
+    expect(w.shown).toHaveLength(1);
+    expect(w.shown[0]!.title).toBe("agentglass");
+    expect(w.shown[0]!.options.body).toBeTruthy();
+  });
+
+  it("fills in a missing title or body rather than showing 'undefined'", async () => {
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ body: "only a body" }) });
+    expect(w.shown[0]!.title).toBe("agentglass");
+    expect(w.shown[0]!.options.body).toBe("only a body");
+    await w.fire("push", { data: pushData({ title: "only a title" }) });
+    expect(w.shown[1]!.title).toBe("only a title");
+    expect(String(w.shown[1]!.options.body)).not.toContain("undefined");
+  });
+
+  it("ignores fields of the wrong type instead of trusting them", async () => {
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ title: 42, body: { nested: true }, at: "yesterday" }) });
+    expect(w.shown[0]!.title).toBe("agentglass");
+    expect(typeof w.shown[0]!.options.body).toBe("string");
+    expect(w.shown[0]!.options.body).not.toContain("[object Object]");
+    expect(w.shown[0]!.options.timestamp).toBeUndefined();
+  });
+});
+
+describe("tapping it", () => {
+  it("focuses the app that is already open rather than opening a second one", async () => {
+    // The app holds live socket state and a back stack. A fresh tab throws
+    // both away: you tap an approval and land on a cold start.
+    const w = loadWorker({ clients: [{ url: "https://box.local/#now" }] });
+    await w.fire("notificationclick", { notification: { close() {} } });
+    expect(w.focused).toEqual(["https://box.local/#now"]);
+    expect(w.opened).toEqual([]);
+  });
+
+  it("opens one when nothing is running", async () => {
+    const w = loadWorker({ clients: [] });
+    await w.fire("notificationclick", { notification: { close() {} } });
+    expect(w.opened).toEqual(["https://box.local/"]);
+  });
+
+  it("does not focus a window belonging to some other site", async () => {
+    // matchAll with includeUncontrolled returns windows this worker can see
+    // but does not own. Focusing one would raise an unrelated page when
+    // somebody tapped an agentglass approval.
+    const w = loadWorker({ clients: [{ url: "https://elsewhere.example/x" }] });
+    await w.fire("notificationclick", { notification: { close() {} } });
+    expect(w.focused).toEqual([]);
+    expect(w.opened).toEqual(["https://box.local/"]);
+  });
+
+  it("dismisses the notification it came from", async () => {
+    let closed = false;
+    const w = loadWorker({ clients: [{ url: "https://box.local/" }] });
+    await w.fire("notificationclick", { notification: { close() { closed = true; } } });
+    expect(closed).toBe(true);
+  });
+});
+
+describe("what this worker deliberately does not do", () => {
+  it("caches nothing", async () => {
+    // Not an offline shell. The app is useless without the server it reports
+    // on, and a stale cached bundle pretending otherwise is worse than a
+    // failed load — it would show yesterday's fleet as if it were now.
+    expect(SRC).not.toContain("caches.open");
+    expect(SRC).not.toContain("addEventListener(\"fetch\"");
+  });
+});

--- a/web/test/webpush.test.ts
+++ b/web/test/webpush.test.ts
@@ -1,0 +1,384 @@
+/*
+ * Turning push on from the phone, without a phone.
+ *
+ * The one step no container can perform is the real `PushManager.subscribe`
+ * against a real push service — that needs a device and a network this machine
+ * does not have. Everything either side of it can be driven here, and is:
+ * which of the three failures happened, what order the two ends are told in,
+ * and what actually gets handed to `subscribe()`.
+ *
+ * That last one is worth the trouble. `applicationServerKey` accepts a string
+ * without complaint and then fails at subscribe time with a message naming
+ * neither the key nor the format — the kind of thing that costs an evening on
+ * a phone with no console attached.
+ */
+import { describe, expect, it } from "bun:test";
+import {
+  decodeKey, deviceLabel, pushCopy, pushStateOf,
+  currentPushState, enablePush, disablePush,
+  type PushEnv, type PushState,
+} from "../src/lib/webpush.ts";
+
+// A real VAPID public key shape: uncompressed P-256, 65 bytes, leading 0x04.
+const KEY = "BFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIhUCvvDVfgjFOyzApW8X2fk1Q";
+
+interface Calls {
+  registered: string[];
+  subscribedWith: { userVisibleOnly: boolean; applicationServerKey: unknown }[];
+  toldServer: { sub: unknown; label: string }[];
+  toldServerToForget: string[];
+  browserUnsubscribed: number;
+  permissionAsked: number;
+  order: string[];
+}
+
+function fakeEnv(over: Partial<PushEnv> & {
+  existing?: { endpoint: string } | null;
+  serverTakesIt?: { ok: boolean; error?: string };
+  registerThrows?: boolean;
+  subscribeThrows?: string;
+} = {}) {
+  const calls: Calls = {
+    registered: [], subscribedWith: [], toldServer: [], toldServerToForget: [],
+    browserUnsubscribed: 0, permissionAsked: 0, order: [],
+  };
+  let current = over.existing ?? null;
+
+  const registration = {
+    pushManager: {
+      getSubscription: async () => (current
+        ? {
+          endpoint: current.endpoint,
+          toJSON: () => ({ endpoint: current!.endpoint, keys: { p256dh: "p", auth: "a" } }),
+          unsubscribe: async () => {
+            calls.order.push("browser-unsubscribe");
+            calls.browserUnsubscribed++;
+            current = null;
+            return true;
+          },
+        }
+        : null),
+      subscribe: async (o: { userVisibleOnly: boolean; applicationServerKey: unknown }) => {
+        if (over.subscribeThrows) throw new Error(over.subscribeThrows);
+        calls.order.push("browser-subscribe");
+        calls.subscribedWith.push(o);
+        current = { endpoint: "https://push.example/new" };
+        return {
+          endpoint: current.endpoint,
+          toJSON: () => ({ endpoint: current!.endpoint, keys: { p256dh: "p", auth: "a" } }),
+          unsubscribe: async () => { calls.browserUnsubscribed++; current = null; return true; },
+        };
+      },
+    },
+  };
+
+  const env: PushEnv = {
+    sw: {
+      register: async (url: string) => {
+        if (over.registerThrows) throw new Error("no service worker here");
+        calls.registered.push(url);
+        return registration as never;
+      },
+      ready: Promise.resolve(registration as never),
+    },
+    hasPushManager: true,
+    permission: "default",
+    requestPermission: async () => { calls.permissionAsked++; return "granted"; },
+    ua: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile",
+    getKey: async () => ({ key: KEY }),
+    subscribe: async (sub: unknown, label: string) => {
+      calls.order.push("server-subscribe");
+      calls.toldServer.push({ sub, label });
+      return over.serverTakesIt ?? { ok: true };
+    },
+    unsubscribe: async (endpoint: string) => {
+      calls.order.push("server-unsubscribe");
+      calls.toldServerToForget.push(endpoint);
+      return { ok: true };
+    },
+    ...over,
+  };
+  return { env, calls };
+}
+
+describe("the key the browser is given", () => {
+  it("becomes bytes, because a string is silently accepted and then fails", async () => {
+    const bytes = decodeKey(KEY);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    // Uncompressed P-256. A browser rejects anything else outright.
+    expect(bytes.length).toBe(65);
+    expect(bytes[0]).toBe(0x04);
+  });
+
+  it("reads it padded, unpadded, or mis-padded", async () => {
+    // A 65-byte key is 88 characters and needs no padding, so any that turns
+    // up came from something that added its own — and the only form that would
+    // actually throw without normalising is the over-padded one. Which is the
+    // only reason the normalising is there; the rest of this is arithmetic
+    // that happens to agree.
+    expect(Array.from(decodeKey("AQID"))).toEqual([1, 2, 3]);
+    expect(Array.from(decodeKey("AQIDBA=="))).toEqual([1, 2, 3, 4]);
+    expect(Array.from(decodeKey("AQID="))).toEqual([1, 2, 3]);
+    // base64url's two substitutions, which plain atob does not know.
+    expect(Array.from(decodeKey("-_8"))).toEqual([251, 255]);
+  });
+
+  it("is handed to subscribe() as bytes, not as the string it arrived as", async () => {
+    const { env, calls } = fakeEnv({ permission: "granted" });
+    await enablePush(env);
+    const key = calls.subscribedWith[0]!.applicationServerKey;
+    expect(key).toBeInstanceOf(Uint8Array);
+    expect((key as Uint8Array).length).toBe(65);
+  });
+});
+
+describe("which of the three ways this can fail", () => {
+  const state = (o: Parameters<typeof pushStateOf>[0]) => pushStateOf(o);
+
+  it("tells an unsupported browser from a blocked one from an unregistered one", async () => {
+    expect(state({ supported: false, permission: "granted", subscribed: false })).toBe("unsupported");
+    expect(state({ supported: true, permission: "denied", subscribed: false })).toBe("blocked");
+    expect(state({ supported: true, permission: "default", subscribed: false })).toBe("off");
+    expect(state({ supported: true, permission: "granted", subscribed: true })).toBe("on");
+  });
+
+  it("says 'on' for a subscribed device whose permission reads default", async () => {
+    // A browser can report "default" while a live subscription exists —
+    // permission is per-origin and can be reset without the subscription being
+    // torn down. Showing "off" there is the one wrong answer that has somebody
+    // turn it on twice and get two of every alert.
+    expect(state({ supported: true, permission: "default", subscribed: true })).toBe("on");
+    expect(state({ supported: true, permission: "denied", subscribed: true })).toBe("on");
+  });
+
+  it("offers a button only where pressing one could do something", async () => {
+    // The browser will not ask again once denied, and an unsupported browser
+    // never could. A button that silently does nothing is worse than none.
+    expect(pushCopy("on").action).toBeTruthy();
+    expect(pushCopy("off").action).toBeTruthy();
+    expect(pushCopy("blocked").action).toBeNull();
+    expect(pushCopy("unsupported").action).toBeNull();
+    // And each says something different, so the row is never ambiguous.
+    const subs = (["on", "off", "blocked", "unsupported"] as PushState[]).map((s) => pushCopy(s).sub);
+    expect(new Set(subs).size).toBe(4);
+    // Blocked has to say where the switch actually is, since it is not here.
+    expect(pushCopy("blocked").sub).toContain("browser");
+  });
+});
+
+describe("naming the device", () => {
+  it("does not call an iPad a Mac, or an Android a Linux box", async () => {
+    // Order matters in both cases: iPadOS reports "Macintosh", and every
+    // Android browser string also contains "Linux".
+    expect(deviceLabel("Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) Macintosh")).toBe("iPad");
+    expect(deviceLabel("Mozilla/5.0 (Linux; Android 14; Pixel 8) Mobile")).toBe("Android phone");
+    expect(deviceLabel("Mozilla/5.0 (Linux; Android 14; SM-X200)")).toBe("Android tablet");
+    expect(deviceLabel("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0)")).toBe("iPhone");
+    expect(deviceLabel("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")).toBe("Mac");
+    expect(deviceLabel("Mozilla/5.0 (Windows NT 10.0; Win64)")).toBe("Windows PC");
+    expect(deviceLabel("")).toBe("This device");
+  });
+
+  it("sends the name to the server, so the device list is readable", async () => {
+    const { env, calls } = fakeEnv({ permission: "granted" });
+    await enablePush(env);
+    expect(calls.toldServer[0]!.label).toBe("Android phone");
+  });
+});
+
+describe("turning it on", () => {
+  it("asks for permission before subscribing, because the other order always fails", async () => {
+    // `subscribe()` fails outright unless permission is already granted, so a
+    // flow that subscribed first would fail on every phone, every time.
+    const { env, calls } = fakeEnv();
+    const r = await enablePush(env);
+    expect(r.ok).toBe(true);
+    expect(r.state).toBe("on");
+    expect(calls.permissionAsked).toBe(1);
+    expect(calls.subscribedWith).toHaveLength(1);
+  });
+
+  it("does not re-ask when permission was already granted", async () => {
+    const { env, calls } = fakeEnv({ permission: "granted" });
+    await enablePush(env);
+    expect(calls.permissionAsked).toBe(0);
+  });
+
+  it("stops at a denied permission and says who can undo it", async () => {
+    const { env, calls } = fakeEnv({ requestPermission: async () => "denied" });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(r.state).toBe("blocked");
+    expect(r.error).toContain("browser settings");
+    expect(calls.subscribedWith).toHaveLength(0);
+    expect(calls.toldServer).toHaveLength(0);
+  });
+
+  it("stops at a dismissed prompt without calling it blocked", async () => {
+    // "default" is the user swiping the prompt away. They can be asked again;
+    // "denied" means they cannot. Conflating the two hides a working button.
+    const { env } = fakeEnv({ requestPermission: async () => "default" });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(r.state).toBe("off");
+  });
+
+  it("refuses to subscribe against a key the server did not give", async () => {
+    // Subscribing against the wrong key mints a subscription this server can
+    // never send to — the push service rejects its token — while the phone
+    // shows a perfectly healthy "on".
+    const { env, calls } = fakeEnv({ permission: "granted", getKey: async () => ({ key: "" }) });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(calls.subscribedWith).toHaveLength(0);
+  });
+
+  it("reuses a subscription the browser already has", async () => {
+    // It may have been made against this same key and simply not be known to
+    // the server — a restored config, or a server that lost its file. Minting
+    // a second one gives one phone two endpoints and two of every alert.
+    const { env, calls } = fakeEnv({ permission: "granted", existing: { endpoint: "https://push.example/old" } });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(true);
+    expect(calls.subscribedWith).toHaveLength(0);
+    expect(calls.toldServer[0]!.sub).toMatchObject({ endpoint: "https://push.example/old" });
+  });
+
+  it("asks for userVisibleOnly, which the browser enforces anyway", async () => {
+    // A browser revokes a subscription that receives pushes and shows nothing.
+    const { env, calls } = fakeEnv({ permission: "granted" });
+    await enablePush(env);
+    expect(calls.subscribedWith[0]!.userVisibleOnly).toBe(true);
+  });
+
+  it("does not claim success when the server would not take it", async () => {
+    const { env } = fakeEnv({ permission: "granted", serverTakesIt: { ok: false, error: "no room" } });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(r.state).toBe("off");
+    expect(r.error).toContain("no room");
+  });
+
+  it("answers rather than throwing when the browser refuses mid-flow", async () => {
+    // This runs from a tap in a settings sheet. An exception here would take
+    // the sheet — and on a phone, that is the whole screen.
+    const { env } = fakeEnv({ permission: "granted", subscribeThrows: "AbortError: registration failed" });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(String(r.ok === false && r.error)).toContain("AbortError");
+  });
+
+  it("gives up on a subscribe that never comes back", async () => {
+    // Found in a real browser, not reasoned about: with no reachable push
+    // service `subscribe()` does not fail, it waits — minutes, silently — and
+    // the settings toggle sat on "…" forever. Not on, not off, and not saying
+    // so is the worst of the three.
+    const { env, calls } = fakeEnv({
+      permission: "granted",
+      timeoutMs: 5,
+      sleep: (ms: number) => new Promise<void>((r) => setTimeout(r, ms)),
+    });
+    env.sw!.ready = Promise.resolve({
+      pushManager: {
+        getSubscription: async () => null,
+        subscribe: () => new Promise(() => { /* never */ }),
+      },
+    } as never);
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(r.state).toBe("off");
+    expect(String(r.ok === false && r.error)).toContain("could not be reached");
+    // And it never told the server about a subscription it does not have.
+    expect(calls.toldServer).toHaveLength(0);
+  });
+
+  it("does not fail a subscribe that lands just inside the bound", async () => {
+    // A slow phone on a slow network is the normal case this feature exists
+    // for. A timeout that fires on merely-slow would make it unusable there.
+    const { env } = fakeEnv({ permission: "granted", timeoutMs: 50 });
+    const slow = env.sw!.ready;
+    env.sw!.ready = Promise.resolve({
+      pushManager: {
+        getSubscription: async () => null,
+        subscribe: async (o: unknown) => {
+          await new Promise((r) => setTimeout(r, 10));
+          return (await slow).pushManager.subscribe(o as never);
+        },
+      },
+    } as never);
+    const r = await enablePush(env);
+    expect(r.ok).toBe(true);
+    expect(r.state).toBe("on");
+  });
+
+  it("says so plainly on a browser that cannot do this at all", async () => {
+    const { env, calls } = fakeEnv({ hasPushManager: false });
+    const r = await enablePush(env);
+    expect(r.state).toBe("unsupported");
+    expect(calls.permissionAsked).toBe(0);
+  });
+});
+
+describe("turning it off", () => {
+  it("tells the server before it tells the browser", async () => {
+    // The other order leaves this machine pushing to an endpoint the browser
+    // has already dropped, until the push service eventually answers 410 —
+    // silently, while the phone is still listed as a device it no longer is.
+    const { env, calls } = fakeEnv({ existing: { endpoint: "https://push.example/old" } });
+    const r = await disablePush(env);
+    expect(r.ok).toBe(true);
+    expect(r.state).toBe("off");
+    expect(calls.order).toEqual(["server-unsubscribe", "browser-unsubscribe"]);
+    expect(calls.toldServerToForget).toEqual(["https://push.example/old"]);
+  });
+
+  it("is not an error when there was nothing subscribed", async () => {
+    const { env, calls } = fakeEnv({ existing: null });
+    const r = await disablePush(env);
+    expect(r.ok).toBe(true);
+    expect(r.state).toBe("off");
+    expect(calls.toldServerToForget).toEqual([]);
+  });
+
+  it("stays on when it could not be turned off", async () => {
+    // Reporting "off" for a device that is still subscribed would leave the
+    // row lying, and the next alert would arrive on a phone told it wouldn't.
+    const { env } = fakeEnv({
+      existing: { endpoint: "https://push.example/old" },
+      unsubscribe: async () => { throw new Error("server unreachable"); },
+    });
+    const r = await disablePush(env);
+    expect(r.ok).toBe(false);
+    expect(r.state).toBe("on");
+  });
+});
+
+describe("working out where this device stands", () => {
+  it("registers the worker while it looks", async () => {
+    // Registering an unchanged file is a no-op, so doing it here is what makes
+    // the worker receiving the next push the one that shipped, rather than one
+    // left over from an older build.
+    const { env, calls } = fakeEnv({ permission: "granted", existing: { endpoint: "e" } });
+    expect(await currentPushState(env)).toBe("on");
+    expect(calls.registered).toEqual(["./sw.js"]);
+  });
+
+  it("registers relative to the app, not to the host root", async () => {
+    // The demo build is served from a sub-path. An absolute "/sw.js" would
+    // 404 there and take the scope with it.
+    const { env, calls } = fakeEnv({ permission: "granted" });
+    await currentPushState(env);
+    expect(calls.registered[0]!.startsWith("/")).toBe(false);
+  });
+
+  it("reports unsupported when the worker will not register", async () => {
+    // No worker means no push, whatever the browser claims to support.
+    const { env } = fakeEnv({ registerThrows: true });
+    expect(await currentPushState(env)).toBe("unsupported");
+  });
+
+  it("reports unsupported with no service worker at all", async () => {
+    const { env } = fakeEnv({ sw: null });
+    expect(await currentPushState(env)).toBe("unsupported");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

The push path reached from an event all the way to a push service (#409, #410, #411, #412) and stopped there: nothing on the phone could receive it, and there was no way to subscribe. This is both ends.

**`web/public/sw.js`** — the only part of agentglass that runs when the app does not. Deliberately plain JavaScript copied verbatim rather than bundled: a service worker is fetched by the browser at its own URL, has no import map, and is the one context that has to keep working after everything else is gone. It is tested by being *evaluated as-is* against a fake global scope, so what the suite checks is the shipped file rather than a copy that would drift.

It shows the server's title and body, keeps a held gate on screen until it is dealt with (an FYI is allowed to fade), stamps the notification with when the event happened rather than when a push service got round to delivering it, collapses an exact repeat instead of stacking four copies of one approval on a lock screen, and **never throws** — a rejecting push handler makes the browser show its own "This site has been updated in the background", which says nothing and looks like a bug in the app. It caches nothing: this is not an offline shell, and a stale bundle would show yesterday's fleet as if it were now.

**The Settings row** tells the three failures apart, because a single "it didn't work" is useless: the browser cannot, you said no and only you can undo it, or the server is unreachable. Only the last two are worth a button, so the other two do not get one.

**`urgency` now travels inside the encrypted payload** as well as in the header. The header is for the push service, which decides whether to wake the radio; the field is for the worker, which decides whether the notification waits for you. Only one of the two can read the body.

## How was it tested?

In a real Chrome against a real server, not only in the suites. The worker registers from the app's own mount path (not from the test), a push delivered through the browser's own pipeline via `ServiceWorker.deliverPushMessage` produces the right notification, and a non-JSON payload still shows something:

```
registration: {"scope":"http://127.0.0.1:4088/","script":".../sw.js","state":"activated"}
a real gate  -> [{"title":"⏳ Approval needed","body":"claude-code:a1b2 is waiting (Bash).",
                  "timestamp":1700000000000,"requireInteraction":true}]
a non-JSON payload -> [{"title":"agentglass","body":"not json at all","requireInteraction":false}]
```

Twenty-six mutations on the client and fifteen on the worker, all red.

170/170 phone audit checks against a real server, four of them new — including that the row never sits on its "Checking…" placeholder, that the button matches what the row says, and that the worker is in fact registered.

Suites green: 1096 server, 761 web.

## Two things the browser found that nothing else would have

**`PushManager.subscribe` does not fail when it cannot reach a push service — it waits, silently, for minutes.** The toggle sat on "…" indefinitely: not on, not off, and not saying so, which is the worst of the three. It is bounded now, and says what happened.

**The failure then arrived under a green tick,** reading as though push had been turned on. The toast takes its failure flag now.

Neither is reachable from a unit test, because both are about what a real browser does when the network it wants is not there.

## The one that walked through

The timeout I wrote carried a "did it already land" guard. It could never fire — `Promise.race` is settled by whichever finishes first, and a later rejection from the loser is discarded and handled. A mutation flipping it to `if (false)` changed nothing. It is gone rather than explained: the same shape as the dead per-route origin checks in #411.

## What is left

`PushManager.subscribe` against a real push service is the one step no container can perform — it needs a device and a route to FCM. Everything either side of it is covered here.
