### PR TITLE
An iPhone in a tab was told something false

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -721,14 +721,18 @@ async function main() {
       const pushText = await cdp.ev(`(${pushRow})?.innerText?.replace(/\\n/g, " · ") || ""`);
       note("settings", "says where this device actually stands",
         !!pushText && !pushText.includes("Checking"), pushText);
-      // A button only where pressing one could do something. Chrome here has
-      // no reachable push service, so "Turn on" is the honest state; a browser
-      // that cannot do this at all must offer no button rather than a dead one.
+      // A button exactly where pressing one could do something.
+      //
+      // Keyed on the two states that are actually actionable rather than on
+      // the ones that are not: "blocked", "unsupported" and "add to Home
+      // Screen" are three different dead ends and a fourth could be added, and
+      // a rule written as "not those" would silently start demanding a button
+      // for whatever came next. Chrome here has no reachable push service, so
+      // "Turn on" is the honest state.
       const pushBtn = await cdp.ev(`(${pushRow})?.querySelector("button")?.innerText || ""`);
+      const actionable = /Alerts reach|Get held gates/.test(pushText);
       note("settings", "the button matches what the row says",
-        (pushText.includes("cannot receive") || pushText.includes("blocked"))
-          ? pushBtn === ""
-          : /Turn on|Turn off/.test(pushBtn),
+        actionable ? /Turn on|Turn off/.test(pushBtn) : pushBtn === "",
         `row "${pushText}" / button "${pushBtn || "(none)"}"`);
       note("settings", "the worker that receives a push is registered",
         await cdp.ev(`navigator.serviceWorker.getRegistrations().then(r =>

--- a/web/src/lib/webpush.ts
+++ b/web/src/lib/webpush.ts
@@ -42,6 +42,16 @@ export function decodeKey(b64url: string): Uint8Array {
 export type PushState =
   /** No service worker or no PushManager: Safari before 16.4, or an insecure origin. */
   | "unsupported"
+  /**
+   * iOS, in a browser tab.
+   *
+   * Not the same as unsupported, and the difference is most of the phones this
+   * companion is for. Safari has had Web Push since 16.4, but *only* for a site
+   * added to the Home Screen — in a tab, `window.PushManager` simply does not
+   * exist. Telling that user "this browser cannot receive push notifications"
+   * is both false and a dead end, when the fix is one entry in the share sheet.
+   */
+  | "needs-install"
   /** The user denied notifications. Only they can undo this, in browser settings. */
   | "blocked"
   /** Supported and allowed, but this device is not registered. */
@@ -49,12 +59,40 @@ export type PushState =
   /** Registered. Alerts reach this device with its screen off. */
   | "on";
 
+/**
+ * Is this an Apple phone or tablet?
+ *
+ * iPadOS 13 and later report a desktop Safari user agent — "Macintosh", no
+ * "iPad" anywhere — so the string alone says Mac. A touchscreen is what tells
+ * them apart: a real Mac reports `maxTouchPoints` 0.
+ */
+export function isApplePortable(ua: string, maxTouchPoints: number): boolean {
+  if (/iPhone|iPad|iPod/i.test(ua)) return true;
+  return /Macintosh/i.test(ua) && maxTouchPoints > 1;
+}
+
+/**
+ * Would this device support push, but only once it is on the Home Screen?
+ *
+ * Asked only when push is missing: if `PushManager` is there, the question
+ * does not arise, and an installed PWA that somehow lost it should not be told
+ * to install itself again.
+ */
+export function needsHomeScreen(env: {
+  hasPushManager: boolean; ua: string; maxTouchPoints: number; standalone: boolean;
+}): boolean {
+  if (env.hasPushManager) return false;
+  return isApplePortable(env.ua, env.maxTouchPoints) && !env.standalone;
+}
+
 export function pushStateOf(env: {
   supported: boolean;
   permission: "default" | "granted" | "denied";
   subscribed: boolean;
+  /** Set when the only thing missing is Add to Home Screen. */
+  needsInstall?: boolean;
 }): PushState {
-  if (!env.supported) return "unsupported";
+  if (!env.supported) return env.needsInstall ? "needs-install" : "unsupported";
   // Subscribed wins over permission on purpose. A browser can report
   // "default" while an active subscription exists — permission is per-origin
   // and can be reset without the subscription being torn down — and showing
@@ -65,9 +103,14 @@ export function pushStateOf(env: {
   return "off";
 }
 
-/** What the settings row says, for each of the four ways this can stand. */
+/** What the settings row says, for each of the five ways this can stand. */
 export function pushCopy(state: PushState): { sub: string; action: string | null } {
   switch (state) {
+    case "needs-install":
+      // No button, because there is nothing here to press — the action is in
+      // Safari's share sheet. So the row has to name it, or it is the same
+      // dead end as saying "unsupported".
+      return { sub: "Add to Home Screen first — Share ⇧, then Add to Home Screen", action: null };
     case "on":
       return { sub: "Alerts reach this phone with the screen off", action: "Turn off" };
     case "off":
@@ -105,6 +148,10 @@ export interface PushEnv {
   permission: "default" | "granted" | "denied";
   requestPermission: () => Promise<"default" | "granted" | "denied">;
   ua: string;
+  /** iPadOS reports a Mac user agent; a touchscreen is what gives it away. */
+  maxTouchPoints: number;
+  /** Running from the Home Screen rather than in a browser tab. */
+  standalone: boolean;
   /** This app's server. */
   getKey: () => Promise<{ key: string }>;
   subscribe: (sub: unknown, label: string) => Promise<{ ok: boolean; error?: string }>;
@@ -166,7 +213,9 @@ function withTimeout<T>(p: Promise<T>, ms: number, sleep: (ms: number) => Promis
  * shipped worker is the one that will receive the next push.
  */
 export async function currentPushState(env: PushEnv): Promise<PushState> {
-  if (!env.sw || !env.hasPushManager) return "unsupported";
+  const cannot = (): PushState =>
+    pushStateOf({ supported: false, permission: env.permission, subscribed: false, needsInstall: needsHomeScreen(env) });
+  if (!env.sw || !env.hasPushManager) return cannot();
   try {
     await env.sw.register("./sw.js");
     const reg = await env.sw.ready;
@@ -175,6 +224,12 @@ export async function currentPushState(env: PushEnv): Promise<PushState> {
   } catch {
     // A registration that throws means no worker, which means no push —
     // whatever the browser claims to support.
+    //
+    // Plainly "unsupported", not the Home Screen hint: reaching here means
+    // `hasPushManager` was true, so this is not an iOS tab and telling anyone
+    // to install something would be wrong. Routing it through the same helper
+    // as the branch above looked more careful and could only ever return this
+    // — a mutation swapping the two changed nothing, which is how that showed.
     return "unsupported";
   }
 }
@@ -189,7 +244,9 @@ export async function currentPushState(env: PushEnv): Promise<PushState> {
  */
 export async function enablePush(env: PushEnv): Promise<PushResult> {
   if (!env.sw || !env.hasPushManager) {
-    return { ok: false, state: "unsupported", error: "This browser cannot receive push notifications." };
+    return needsHomeScreen(env)
+      ? { ok: false, state: "needs-install", error: pushCopy("needs-install").sub }
+      : { ok: false, state: "unsupported", error: "This browser cannot receive push notifications." };
   }
   try {
     const permission = env.permission === "granted" ? "granted" : await env.requestPermission();
@@ -266,12 +323,26 @@ export function browserPushEnv(api: {
 }): PushEnv {
   const nav = typeof navigator === "undefined" ? null : navigator;
   const canNotify = typeof Notification !== "undefined";
+  // Two ways to be on the Home Screen, because the reliable one on iOS is
+  // Apple's own non-standard flag: `display-mode: standalone` is honoured
+  // there, but it is the media query that arrived late and the flag has been
+  // right since long before Web Push existed. Either counts.
+  const standalone = (() => {
+    try {
+      if ((nav as { standalone?: boolean } | null)?.standalone) return true;
+      return typeof matchMedia === "function" && matchMedia("(display-mode: standalone)").matches;
+    } catch {
+      return false;
+    }
+  })();
   return {
     sw: nav && "serviceWorker" in nav ? (nav.serviceWorker as unknown as PushEnv["sw"]) : null,
     hasPushManager: typeof PushManager !== "undefined",
     permission: canNotify ? Notification.permission : "denied",
     requestPermission: () => (canNotify ? Notification.requestPermission() : Promise.resolve("denied" as const)),
     ua: nav?.userAgent ?? "",
+    maxTouchPoints: nav?.maxTouchPoints ?? 0,
+    standalone,
     getKey: api.pushKey,
     subscribe: api.pushSubscribe,
     unsubscribe: api.pushUnsubscribe,

--- a/web/test/webpush.test.ts
+++ b/web/test/webpush.test.ts
@@ -16,8 +16,14 @@ import { describe, expect, it } from "bun:test";
 import {
   decodeKey, deviceLabel, pushCopy, pushStateOf,
   currentPushState, enablePush, disablePush,
+  isApplePortable, needsHomeScreen,
   type PushEnv, type PushState,
 } from "../src/lib/webpush.ts";
+
+const IPHONE = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 Version/17.4 Mobile/15E148 Safari/604.1";
+// iPadOS 13+ reports a desktop Safari string: no "iPad" anywhere in it.
+const IPAD = "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 Version/17.4 Safari/605.1.15";
+const MAC = IPAD;
 
 // A real VAPID public key shape: uncompressed P-256, 65 bytes, leading 0x04.
 const KEY = "BFFcPW6545a5BNP-yn9U_c0MwemXvzddylFa0KbDtANfRTa-OlDzGPv5pUdZAqIhUCvvDVfgjFOyzApW8X2fk1Q";
@@ -85,6 +91,8 @@ function fakeEnv(over: Partial<PushEnv> & {
     permission: "default",
     requestPermission: async () => { calls.permissionAsked++; return "granted"; },
     ua: "Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 Mobile",
+    maxTouchPoints: 5,
+    standalone: false,
     getKey: async () => ({ key: KEY }),
     subscribe: async (sub: unknown, label: string) => {
       calls.order.push("server-subscribe");
@@ -158,11 +166,64 @@ describe("which of the three ways this can fail", () => {
     expect(pushCopy("off").action).toBeTruthy();
     expect(pushCopy("blocked").action).toBeNull();
     expect(pushCopy("unsupported").action).toBeNull();
+    expect(pushCopy("needs-install").action).toBeNull();
     // And each says something different, so the row is never ambiguous.
-    const subs = (["on", "off", "blocked", "unsupported"] as PushState[]).map((s) => pushCopy(s).sub);
-    expect(new Set(subs).size).toBe(4);
+    const all: PushState[] = ["on", "off", "blocked", "unsupported", "needs-install"];
+    const subs = all.map((s) => pushCopy(s).sub);
+    expect(new Set(subs).size).toBe(all.length);
+    // None of them is empty, which is what a missing switch arm would produce.
+    for (const s of subs) expect(s.length).toBeGreaterThan(10);
     // Blocked has to say where the switch actually is, since it is not here.
     expect(pushCopy("blocked").sub).toContain("browser");
+  });
+});
+
+describe("an iPhone in a browser tab", () => {
+  // This is most of the phones this companion is for, and it was being told
+  // something false. Safari has had Web Push since 16.4 — but only for a site
+  // added to the Home Screen. In a tab, `window.PushManager` does not exist,
+  // which is indistinguishable from "this browser cannot" unless you look at
+  // what the browser actually is.
+
+  it("is not confused with a Mac, even when it says it is one", async () => {
+    expect(isApplePortable(IPHONE, 5)).toBe(true);
+    // An iPad reports a desktop Safari string. A touchscreen gives it away;
+    // a real Mac reports zero touch points.
+    expect(isApplePortable(IPAD, 5)).toBe(true);
+    expect(isApplePortable(MAC, 0)).toBe(false);
+    expect(isApplePortable("Mozilla/5.0 (Linux; Android 14) Mobile", 5)).toBe(false);
+  });
+
+  it("is told to add it to the Home Screen, not that its browser cannot", async () => {
+    const { env } = fakeEnv({ hasPushManager: false, ua: IPHONE, maxTouchPoints: 5, standalone: false });
+    expect(await currentPushState(env)).toBe("needs-install");
+    const r = await enablePush(env);
+    expect(r.state).toBe("needs-install");
+    // And the row names the actual gesture, since the button cannot be here.
+    expect(pushCopy("needs-install").sub).toContain("Home Screen");
+    expect(pushCopy("needs-install").action).toBeNull();
+    expect(pushCopy("needs-install").sub).not.toBe(pushCopy("unsupported").sub);
+  });
+
+  it("does not tell an installed app to install itself", async () => {
+    // Standalone and still no PushManager is an iOS older than 16.4. Nothing
+    // the user does to the Home Screen will change that, so saying so would
+    // send them round a loop.
+    const { env } = fakeEnv({ hasPushManager: false, ua: IPHONE, maxTouchPoints: 5, standalone: true });
+    expect(await currentPushState(env)).toBe("unsupported");
+  });
+
+  it("does not tell a working browser to install anything", async () => {
+    // The question only arises when push is missing. An installed PWA that has
+    // it must never be sent to the share sheet.
+    expect(needsHomeScreen({ hasPushManager: true, ua: IPHONE, maxTouchPoints: 5, standalone: false })).toBe(false);
+  });
+
+  it("leaves a desktop browser without push saying exactly that", async () => {
+    // A Mac or a Linux desktop on an old browser has nothing to add to a home
+    // screen, and telling it to would be nonsense.
+    const { env } = fakeEnv({ hasPushManager: false, ua: MAC, maxTouchPoints: 0 });
+    expect(await currentPushState(env)).toBe("unsupported");
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Safari has had Web Push since 16.4 — but **only for a site added to the Home Screen**. In a browser tab `window.PushManager` does not exist at all, which from inside the app is indistinguishable from a browser that cannot do this. So the settings row said *"This browser cannot receive push notifications"* to an iPhone that could, one entry in the share sheet away.

That is most of the phones this companion is for, and it is a dead end rather than a wrong word: the row named no way forward.

There is a fifth state now — `needs-install` — and it names the gesture, because the button cannot be here: the action is in Safari's share sheet.

It is offered only where it would actually help:

| situation | what the row says |
|---|---|
| iPhone/iPad, browser tab, no PushManager | Add to Home Screen first — Share ⇧, then Add to Home Screen |
| iPhone/iPad, already installed, still no PushManager | This browser cannot receive push notifications |
| Mac or Linux desktop, no PushManager | This browser cannot receive push notifications |
| browser that has PushManager | Turn on / Turn off, as before |

An installed app that still has no push is an iOS older than 16.4, and nothing done to the Home Screen will change that — telling it to install itself would send the user round a loop.

**An iPad reports a desktop Safari user agent.** No "iPad" anywhere in it, so the string alone says Mac. A touchscreen is what separates them: a real Mac reports zero touch points.

## How was it tested?

In a real Chrome with the user agent overridden and `PushManager` deleted before any page script runs — both as an iPhone and as an iPad-reporting-as-a-Mac:

```
ua: Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 …) Version/17.4 Mobile/15E148 Safari/604.1
PushManager present: false
row: {"text":"Push to this phone · Add to Home Screen first — Share ⇧, then Add to Home Screen","button":null}

ua: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) … Version/17.4 Safari/605.1.15   ← an iPad
PushManager present: false
row: {"text":"Push to this phone · Add to Home Screen first — Share ⇧, then Add to Home Screen","button":null}
```

Eight further mutations, all red.

170/170 phone audit checks. Suites green: 1096 server, 766 web.

## The one that walked through

Routing the registration failure through the same helper as the missing-PushManager branch looked more careful. But reaching that `catch` means `PushManager` *was* there — so the helper could only ever return `"unsupported"`, and a mutation swapping the two changed nothing. Gone rather than explained; the second of those tonight.

## One audit rule rewritten rather than extended

The check that a button appears only where pressing one could do something was written as "not blocked, not unsupported". Adding a third dead end would have made it quietly start demanding a button for the new state. It keys on the two actionable states now, so the next one added is safe by default.
