### PR TITLE
Prove it works, without waiting for an agent to block

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -75,9 +75,21 @@ function shouldSend(key: string): boolean {
  * over-eager prune would silently unsubscribe a working phone, and nobody would
  * find out until a gate went unanswered.
  */
-async function pushEveryone(title: string, body: string, urgency: 0 | 1 | 2) {
+export interface PushFanout {
+  /** How many devices the push service accepted it for. */
+  sent: number;
+  /** How many refused for a reason that is not "this device is gone". */
+  failed: number;
+  /** How many were forgotten because the service said they no longer exist. */
+  pruned: number;
+}
+
+export async function pushEveryone(
+  title: string, body: string, urgency: 0 | 1 | 2,
+): Promise<PushFanout> {
   const subs = subscriptions();
-  if (!subs.length) return;
+  const out: PushFanout = { sent: 0, failed: 0, pruned: 0 };
+  if (!subs.length) return out;
   const keys = await vapidKeys();
   // `urgency` travels inside the encrypted payload as well as in the header.
   // The header is for the push service, which decides whether to wake the
@@ -90,9 +102,11 @@ async function pushEveryone(title: string, body: string, urgency: 0 | 1 | 2) {
       // A gate is worth waking the device for; a tool error is not.
       urgency: urgency === 2 ? "high" : "normal",
     });
-    if (r.gone) removeSubscription(s.endpoint);
-    else if (r.ok) markDelivered(s.endpoint);
+    if (r.gone) { removeSubscription(s.endpoint); out.pruned++; }
+    else if (r.ok) { markDelivered(s.endpoint); out.sent++; }
+    else out.failed++;
   }));
+  return out;
 }
 
 async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -24,7 +24,7 @@ import {
   getGate,
   actionLog,
 } from "./db.ts";
-import { maybeAlert, setAlertSink } from "./alerts.ts";
+import { maybeAlert, setAlertSink, pushEveryone } from "./alerts.ts";
 import { noteAction } from "./actions.ts";
 import { getSkills, catalogMarkdown, catalogCsv, usageSince } from "./skills.ts";
 import { getInsights } from "./insights.ts";
@@ -739,6 +739,23 @@ const server = Bun.serve<WsData>({
           label: s.label ?? "", addedAt: s.addedAt, lastOkAt: s.lastOkAt ?? null,
         })),
       });
+    }
+    if (pathname === "/push/test" && req.method === "POST") {
+      // Until an agent happens to block while nobody is looking, there is no
+      // way to find out whether any of this works — and the way you would find
+      // out is by missing the one thing it exists for. This is the same fan-out
+      // the alert path uses, not a special case: same encryption, same headers,
+      // same pruning on 404/410. A test that took a different route could pass
+      // while the real one was broken.
+      const r = await pushEveryone(
+        "✅ agentglass",
+        "Push is working. This is what a held gate will look like.",
+        // Deliberately not 2: a test should not be the thing that teaches
+        // somebody to swipe these away, and a notification that will not
+        // dismiss itself is a poor introduction.
+        1,
+      );
+      return json({ ok: r.sent > 0, ...r });
     }
 
     if (pathname === "/gate/decide" && req.method === "POST") {

--- a/server/test/push-alert.test.ts
+++ b/server/test/push-alert.test.ts
@@ -231,6 +231,84 @@ describe("an agent stops, and the phone hears", () => {
   });
 });
 
+describe("proving it works, without waiting for an agent to block", () => {
+  // Before this existed the only way to find out whether push worked was to
+  // walk away and see whether anything arrived — so a silent failure looked
+  // exactly like a quiet afternoon, and you learned by missing the one thing
+  // the feature is for.
+
+  it("sends a real push down the real path", async () => {
+    const before = svc.seen.length;
+    const r = await (await fetch(base + "/push/test", {
+      method: "POST", headers: { "content-type": "application/json" }, body: "{}",
+    })).json() as { ok: boolean; sent: number; failed: number; pruned: number };
+    expect(r).toMatchObject({ ok: true, sent: 1, failed: 0, pruned: 0 });
+    expect(await waitForPush(before + 1)).toBe(true);
+
+    // The same route an alert takes, not a special case: same encryption, same
+    // headers. A test that went a different way could pass while the real one
+    // was broken, which would be worse than having no test button.
+    const got = svc.seen[before]!;
+    expect(got.headers["content-encoding"]).toBe("aes128gcm");
+    expect(got.headers["authorization"]).toMatch(/^vapid t=/);
+    const msg = JSON.parse(await decrypt(got.body, AUTH)) as { title?: string; body?: string; urgency?: number };
+    expect(msg.title).toBeTruthy();
+    expect(msg.body).toBeTruthy();
+    // Not urgency 2: a test must not be the thing that teaches somebody to
+    // swipe these away, and one that will not dismiss itself is a poor
+    // introduction.
+    expect(msg.urgency).not.toBe(2);
+  });
+
+  it("says nothing was sent rather than claiming success", async () => {
+    // A green tick for a push that reached nobody is the one answer that would
+    // make this button worse than useless.
+    svc.status = 500;
+    const r = await (await fetch(base + "/push/test", { method: "POST", body: "{}" })).json() as
+      { ok: boolean; sent: number; failed: number };
+    expect(r.ok).toBe(false);
+    expect(r.sent).toBe(0);
+    expect(r.failed).toBe(1);
+    svc.status = 201;
+  });
+
+  it("tells a device it is no longer registered, rather than merely failing", async () => {
+    // The phone branches on this to say "turn it on again", which is the only
+    // useful thing to say — the subscription is gone at both ends and no
+    // amount of retrying will bring it back. Reported as a plain failure it
+    // would read as "the network is having a moment", and somebody would wait.
+    svc.status = 410;
+    const r = await (await fetch(base + "/push/test", { method: "POST", body: "{}" })).json() as
+      { ok: boolean; sent: number; failed: number; pruned: number };
+    expect(r).toMatchObject({ ok: false, sent: 0, failed: 0, pruned: 1 });
+    expect((await (await fetch(base + "/push/devices")).json() as { devices: unknown[] }).devices).toHaveLength(0);
+
+    // Put it back: the rest of this file is about a device that exists.
+    svc.status = 201;
+    await fetch(base + "/push/subscribe", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        subscription: { endpoint: svc.url, keys: { p256dh: device.p256dh, auth: AUTH } },
+        label: "Pixel",
+      }),
+    });
+  });
+
+  it("is refused from another origin, like every other write", async () => {
+    const res = await fetch(base + "/push/test", {
+      method: "POST", headers: { origin: "https://evil.example" }, body: "{}",
+    });
+    expect(res.ok).toBe(false);
+  });
+
+  it("does not send one over GET", async () => {
+    const before = svc.seen.length;
+    await fetch(base + "/push/test");
+    await Bun.sleep(400);
+    expect(svc.seen.length).toBe(before);
+  });
+});
+
 describe("a device that has gone away", () => {
   it("is forgotten when the push service says it is gone, and only then", async () => {
     // 429 is the service being busy. Pruning on it would silently unsubscribe a

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -587,6 +587,10 @@ const realApi = {
     post<{ ok: boolean; devices?: number }>("/push/unsubscribe", { endpoint }),
   pushDevices: () =>
     get<{ devices: { label: string; addedAt: number; lastOkAt: number | null }[] }>("/push/devices"),
+  // The same fan-out an alert uses. Without it the only way to find out
+  // whether push works is to miss the one thing it exists for.
+  pushTest: () =>
+    post<{ ok: boolean; sent: number; failed: number; pruned: number }>("/push/test", {}),
 };
 
 // In demo mode every call resolves against the fabricated dataset — no server.
@@ -719,6 +723,7 @@ const demoApi: typeof realApi = {
   pushSubscribe: (_s: unknown, _l: string) => D({ ok: false, error: "not available in the demo" }),
   pushUnsubscribe: (_e: string) => D({ ok: true }),
   pushDevices: () => D({ devices: [] as { label: string; addedAt: number; lastOkAt: number | null }[] }),
+  pushTest: () => D({ ok: false, sent: 0, failed: 0, pruned: 0 }),
 
   // The demo has no GitHub behind it, and pretending otherwise would put a
   // fake PR list in front of someone evaluating the app. It reports the same

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -159,6 +159,7 @@ export function MobileApp() {
    */
   const [pushState, setPushState] = useState<PushState | null>(null);
   const [pushBusy, setPushBusy] = useState(false);
+  const [pushTesting, setPushTesting] = useState(false);
   /** A conversation is open and owns the whole screen: no app header, no tabs. */
   const [immersive, setImmersive] = useState(false);
   /**
@@ -206,6 +207,31 @@ export function MobileApp() {
     if (r.ok) toast(r.state === "on" ? "This phone will be alerted" : "Alerts off on this phone");
     else toast(r.error, true);
   }, [pushEnv, pushState]);
+
+  /**
+   * Prove it, now, rather than the next time an agent blocks.
+   *
+   * Until this existed the only way to find out whether push worked was to
+   * walk away and see whether anything arrived — so a silent failure was
+   * indistinguishable from a quiet afternoon, and you learned by missing the
+   * one thing the feature is for.
+   */
+  const testPush = useCallback(async () => {
+    setPushTesting(true);
+    try {
+      const r = await api.pushTest();
+      // Three different outcomes, because they need three different reactions:
+      // it arrived, this device is no longer registered (turn it on again), or
+      // nothing is subscribed at all.
+      if (r.sent > 0) toast(r.sent === 1 ? "Sent — check your notifications" : `Sent to ${r.sent} devices`);
+      else if (r.pruned > 0) { setPushState("off"); toast("This device is no longer registered — turn it on again", true); }
+      else if (r.failed > 0) toast("The push service would not take it", true);
+      else toast("No device is subscribed", true);
+    } catch {
+      toast("The server could not be reached", true);
+    }
+    setPushTesting(false);
+  }, []);
 
   // ── the live channel ─────────────────────────────────────────────────
   //
@@ -736,11 +762,22 @@ export function MobileApp() {
             exists for is the one case nothing covers. */}
         <Row title="Push to this phone"
           sub={pushState === null ? "Checking…" : pushCopy(pushState).sub}
-          right={pushState !== null && pushCopy(pushState).action
-            ? <Act small disabled={pushBusy} onAct={togglePush}>
-                {pushBusy ? "…" : pushCopy(pushState).action}
-              </Act>
-            : undefined} />
+          right={pushState === null ? undefined : (
+            <span className="flex items-center gap-1.5">
+              {/* Only once it is on: a Test that could only ever fail is not a
+                  test, it is a second way to be told no. */}
+              {pushState === "on" && (
+                <Act small disabled={pushTesting || pushBusy} onAct={testPush}>
+                  {pushTesting ? "…" : "Test"}
+                </Act>
+              )}
+              {pushCopy(pushState).action && (
+                <Act small disabled={pushBusy || pushTesting} onAct={togglePush}>
+                  {pushBusy ? "…" : pushCopy(pushState).action}
+                </Act>
+              )}
+            </span>
+          )} />
         <div className="mb-eyebrow" style={{ margin: "16px 0 9px" }}>Queue</div>
         <Row title="Snoozed" sub={snoozed ? `${snoozed} hidden until they change` : "Nothing snoozed"}
           right={snoozed


### PR DESCRIPTION
## What does this PR do?

Until now the only way to find out whether push worked was to walk away and see whether anything arrived. A silent failure looked exactly like a quiet afternoon, and you learned about it by missing the one thing the feature exists for.

`POST /push/test` sends a **real push down the real path** — not a special case: the same fan-out an alert uses, so the same encryption, the same headers, the same pruning on 404/410. A test that took a different route could pass while the real one was broken, which is worse than having no test at all.

Urgency 1, not 2, deliberately. A test must not be the thing that teaches somebody to swipe these away, and a notification that will not dismiss itself is a poor introduction.

**The fan-out counts what happened** rather than returning nothing, because three outcomes need three different reactions:

| result | what the phone says |
|---|---|
| `sent > 0` | Sent — check your notifications |
| `pruned > 0` | This device is no longer registered — turn it on again |
| `failed > 0` | The push service would not take it |
| all zero | No device is subscribed |

"It failed" for all four would have somebody waiting on a network that is fine.

The button appears only once push is on — a Test that could only ever fail is not a test, it is a second way to be told no.

## How was it tested?

End to end in a real browser. `PushManager.subscribe` is stubbed to hand back a subscription pointing at a local recorder — with a real P-256 key generated in the page, so the server's encryption runs for real. Everything else is the shipped code:

```
before:            Push to this phone · Get held gates on this phone, screen off · [Turn on]
after turning on:  Push to this phone · Alerts reach this phone with the screen off · [Test] [Turn off]
server devices:    [{"label":"Linux","addedAt":…,"lastOkAt":null}]
push arrived:      true  {"enc":"aes128gcm","urgency":"normal","bytes":227}
toast:             ✓ Sent — check your notifications
after turning off: Push to this phone · Get held gates on this phone, screen off · [Turn on]
server devices:    []
page errors:       none
```

Nine mutations, all red. 170/170 phone audit checks. Suites green: 1101 server, 766 web.

## The one that walked through

Nothing covered a 410 arriving *during a test*, so counting a pruned device as a delivered one changed nothing — and that is exactly the branch the phone reads to say "turn it on again". Covered now, including putting the subscription back so the rest of the file still describes a device that exists.

## Also found on the way

The server I had been driving the browser against was started before the route existed, so the first run reported no push and no toast. Worth writing down because the symptom — button does nothing, no error anywhere — is exactly what a real 404 on this route would look like to a user, and it is the reason the phone distinguishes "nothing subscribed" from "the server could not be reached".
