### PR TITLE
The other phone

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -546,9 +546,22 @@ async function main() {
       } else {
         await cdp.ev(`${TOP}.querySelector("button.mb-row").click()`);
         await Bun.sleep(2600);
-        if (await tap(cdp, ".mb-screen.on .mb-seg button", "Files")) {
+        // Every skip below says so out loud, including this one.
+        //
+        // The note above is about a selector that made this section vanish for
+        // two runs. The same thing happened again, one level in: the pull
+        // request opened, `Files` was not there to tap, and twenty-four checks
+        // quietly stopped running — the count went from 170 to 134 and nothing
+        // said why. A silent skip reads as a section that passed, so a skip
+        // that prints nothing is the same bug as before wearing a different
+        // condition.
+        if (!(await tap(cdp, ".mb-screen.on .mb-seg button", "Files"))) {
+          console.log("  skip  review · the pull request opened but has no Files tab to review");
+        } else {
           await Bun.sleep(1500);
-          if (await cdp.ev(`!!${TOP}.querySelector(".mb-row button")`)) {
+          if (!(await cdp.ev(`!!${TOP}.querySelector(".mb-row button")`))) {
+            console.log("  skip  review · the pull request has no changed files listed");
+          } else {
             await cdp.ev(`${TOP}.querySelector(".mb-row button").click()`);
             await Bun.sleep(1800);
             const taps = await cdp.ev(`${TOP}.querySelectorAll("button.mb-dl").length`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -28,7 +28,7 @@ import { maybeAlert, setAlertSink, pushEveryone } from "./alerts.ts";
 import { noteAction } from "./actions.ts";
 import { getSkills, catalogMarkdown, catalogCsv, usageSince } from "./skills.ts";
 import { getInsights } from "./insights.ts";
-import { vapidKeys, addSubscription, removeSubscription, subscriptions } from "./pushstore.ts";
+import { vapidKeys, addSubscription, removeSubscription, removeDevice, deviceId, subscriptions } from "./pushstore.ts";
 import { getUsage } from "./usage.ts";
 import { submitGate, decideGate, pendingGates, awaitGate, restoreGates, GATE_MAX_MS } from "./gate.ts";
 import { parseControlCmd } from "./control.ts";
@@ -726,7 +726,12 @@ const server = Bun.serve<WsData>({
     if (pathname === "/push/unsubscribe" && req.method === "POST") {
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "bad body" }); }
-      const subs = removeSubscription(String(b?.endpoint || ""));
+      // Either handle. The phone knows its own endpoint and unsubscribes with
+      // that; the device list only ever saw an id, because an endpoint is a
+      // capability and this response goes to whatever is asking.
+      const subs = b?.id
+        ? removeDevice(String(b.id))
+        : removeSubscription(String(b?.endpoint || ""));
       return json({ ok: true, devices: subs.length });
     }
     if (pathname === "/push/devices") {
@@ -736,6 +741,9 @@ const server = Bun.serve<WsData>({
       // called".
       return json({
         devices: subscriptions().map((s) => ({
+          // A one-way handle, not the endpoint: enough to forget this device
+          // against this server, and useless anywhere else.
+          id: deviceId(s.endpoint),
           label: s.label ?? "", addedAt: s.addedAt, lastOkAt: s.lastOkAt ?? null,
         })),
       });

--- a/server/src/pushstore.ts
+++ b/server/src/pushstore.ts
@@ -1,3 +1,4 @@
+import { createHash } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { dirname, join } from "node:path";
 import { tmpdir, homedir } from "node:os";
@@ -101,6 +102,33 @@ export function forgetVapid(): void { memo = null; }
 
 export function subscriptions(): StoredSubscription[] {
   return read().subs ?? [];
+}
+
+/**
+ * A stable handle for a device, safe to hand to a client.
+ *
+ * Derived from the endpoint rather than stored, so there is nothing to migrate
+ * onto existing files and it survives a restart on its own. And it is one-way:
+ * it cannot be turned back into the endpoint, which is the whole reason
+ * /push/devices can carry it. An endpoint is a capability — anyone holding one
+ * can ask a push service to wake that phone, forever, with no further
+ * credential — and this is only a name for one, usable against this server and
+ * nowhere else.
+ *
+ * Sixteen hex characters of SHA-256. Long enough that a collision would take
+ * billions of devices; short enough to read in a log.
+ */
+export function deviceId(endpoint: string): string {
+  return createHash("sha256").update(endpoint).digest("hex").slice(0, 16);
+}
+
+/** Forget a device by its handle. Same as removeSubscription, from the other
+ *  end: the caller here never had the endpoint to begin with. */
+export function removeDevice(id: string): StoredSubscription[] {
+  const f = read();
+  const subs = (f.subs ?? []).filter((s) => deviceId(s.endpoint) !== id);
+  write({ ...f, subs });
+  return subs;
 }
 
 /**

--- a/server/test/push-routes.test.ts
+++ b/server/test/push-routes.test.ts
@@ -16,6 +16,7 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { b64uEncode } from "../src/push.ts";
+import { deviceId } from "../src/pushstore.ts";
 
 const P256DH = "BAyQHUI8gxyoXifHPCY7oTJyG7nXqExPA4CypnVv1gEzHIhwI03sh4UEwXQUT6SxS2amUWkWBtgXPlW9N-OBVp4";
 const AUTH = b64uEncode(new Uint8Array(16).fill(0x11));
@@ -159,7 +160,41 @@ describe("what the device list is allowed to say", () => {
     expect(text).not.toContain(AUTH);
     const { devices } = JSON.parse(text);
     expect(devices.some((d: { label: string }) => d.label === "Pixel")).toBe(true);
-    for (const d of devices) expect(Object.keys(d).sort()).toEqual(["addedAt", "label", "lastOkAt"]);
+    for (const d of devices) expect(Object.keys(d).sort()).toEqual(["addedAt", "id", "label", "lastOkAt"]);
+  });
+
+  it("names each device with a handle that is not its endpoint", async () => {
+    // The list has to be actionable — you cannot forget a phone you cannot
+    // refer to — and the endpoint is the one thing it may not say. A one-way
+    // handle is both: usable against this server, useless anywhere else.
+    await post("/push/subscribe", { subscription: sub("https://push/aaa"), label: "A" });
+    await post("/push/subscribe", { subscription: sub("https://push/bbb"), label: "B" });
+    const { devices } = await getJson("/push/devices");
+    const ids: string[] = devices.map((d: { id: string }) => d.id);
+    expect(new Set(ids).size).toBe(ids.length);           // one per device
+    for (const id of ids) {
+      expect(id).toMatch(/^[0-9a-f]{16}$/);
+      // Not the endpoint, encoded or otherwise: nothing in the handle spells
+      // out where to send.
+      expect(Buffer.from(id, "hex").toString("latin1")).not.toContain("push");
+    }
+  });
+
+  it("derives the handle the phone will derive too", async () => {
+    // The same string is pinned in web/test/webpush.test.ts. These are two
+    // implementations of one hash, in two different crypto APIs, and if they
+    // ever disagree the symptom is silent: the device list stops marking which
+    // phone you are holding, and you forget the wrong one.
+    expect(deviceId("https://push.example/device/abc")).toBe("981f012daaac75bc");
+  });
+
+  it("hands back the same handle for the same device every time", async () => {
+    // It is derived, not stored, so a restart must not renumber the list —
+    // otherwise a Forget button would refer to whatever happened to be there
+    // before the server came back.
+    const a = (await getJson("/push/devices")).devices;
+    const b = (await getJson("/push/devices")).devices;
+    expect(b.map((d: { id: string }) => d.id)).toEqual(a.map((d: { id: string }) => d.id));
   });
 });
 
@@ -170,6 +205,24 @@ describe("unsubscribing", () => {
     const r = await postJson("/push/unsubscribe", { endpoint: "https://push/bye" });
     expect(r.ok).toBe(true);
     expect(r.devices).toBe(before - 1);
+  });
+
+  it("forgets one by the handle the device list gave out", async () => {
+    // The list never saw an endpoint, so this is the only way it could offer a
+    // Forget button at all.
+    await post("/push/subscribe", { subscription: sub("https://push/by-id"), label: "Old phone" });
+    const before = (await getJson("/push/devices")).devices;
+    const target = before.find((d: { label: string }) => d.label === "Old phone");
+    expect(target.id).toBeTruthy();
+    const r = await postJson("/push/unsubscribe", { id: target.id });
+    expect(r.ok).toBe(true);
+    const after = (await getJson("/push/devices")).devices;
+    expect(after).toHaveLength(before.length - 1);
+    // The right one, and only the right one.
+    expect(after.some((d: { label: string }) => d.label === "Old phone")).toBe(false);
+    expect(after.map((d: { id: string }) => d.id)).toEqual(
+      before.filter((d: { id: string }) => d.id !== target.id).map((d: { id: string }) => d.id),
+    );
   });
 
   it("is not an error to forget something twice", async () => {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -585,8 +585,12 @@ const realApi = {
     post<{ ok: boolean; devices?: number; error?: string }>("/push/subscribe", { subscription, label }),
   pushUnsubscribe: (endpoint: string) =>
     post<{ ok: boolean; devices?: number }>("/push/unsubscribe", { endpoint }),
+  // By the handle the device list gave out, which is the only reference a
+  // client other than the device itself ever has.
+  pushForget: (id: string) =>
+    post<{ ok: boolean; devices?: number }>("/push/unsubscribe", { id }),
   pushDevices: () =>
-    get<{ devices: { label: string; addedAt: number; lastOkAt: number | null }[] }>("/push/devices"),
+    get<{ devices: PushDevice[] }>("/push/devices"),
   // The same fan-out an alert uses. Without it the only way to find out
   // whether push works is to miss the one thing it exists for.
   pushTest: () =>
@@ -722,7 +726,8 @@ const demoApi: typeof realApi = {
   pushKey: () => D({ key: "" }),
   pushSubscribe: (_s: unknown, _l: string) => D({ ok: false, error: "not available in the demo" }),
   pushUnsubscribe: (_e: string) => D({ ok: true }),
-  pushDevices: () => D({ devices: [] as { label: string; addedAt: number; lastOkAt: number | null }[] }),
+  pushForget: (_id: string) => D({ ok: true }),
+  pushDevices: () => D({ devices: [] as PushDevice[] }),
   pushTest: () => D({ ok: false, sent: 0, failed: 0, pruned: 0 }),
 
   // The demo has no GitHub behind it, and pretending otherwise would put a
@@ -771,6 +776,21 @@ const demoApi: typeof realApi = {
 };
 
 export const api = IS_DEMO ? demoApi : realApi;
+
+/**
+ * A subscribed device, as the server is willing to describe one.
+ *
+ * No endpoint and no keys, ever: an endpoint is a capability — anyone holding
+ * one can ask a push service to wake that phone, forever, with no further
+ * credential. `id` is a one-way handle over it, enough to forget the device
+ * against this server and useless anywhere else.
+ */
+export interface PushDevice {
+  id: string;
+  label: string;
+  addedAt: number;
+  lastOkAt: number | null;
+}
 
 export interface UsageWindow {
   utilization: number;

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -55,6 +55,14 @@ export function fmtAgo(ts: number): string {
   return Math.floor(d / 86_400_000) + "d";
 }
 
+/** fmtAgo as a sentence. It answers "now" under a second, and "now ago" is not
+ *  English — which is exactly the value a "last seen" row shows right after the
+ *  thing it is describing happened. */
+export function since(ts: number): string {
+  const d = fmtAgo(ts);
+  return d === "now" ? "just now" : `${d} ago`;
+}
+
 export const fmtTime = (ts: number) =>
   new Date(ts).toLocaleTimeString([], { hour12: false });
 

--- a/web/src/lib/webpush.ts
+++ b/web/src/lib/webpush.ts
@@ -124,6 +124,32 @@ export function pushCopy(state: PushState): { sub: string; action: string | null
   }
 }
 
+/**
+ * The same handle the server derives, so this device can find itself in the
+ * list it is shown.
+ *
+ * Recomputed here rather than asked for, because asking would mean the server
+ * answering "and which of these is you" — which it can only do by matching on
+ * the endpoint the client sent, and that is a request this client would then
+ * be making with an endpoint in it for no reason. The hash is one-way in both
+ * places; agreeing on it costs four lines.
+ */
+export async function deviceIdOf(endpoint: string): Promise<string> {
+  const digest = await crypto.subtle.digest("SHA-256", new TextEncoder().encode(endpoint));
+  return [...new Uint8Array(digest)].map((b) => b.toString(16).padStart(2, "0")).join("").slice(0, 16);
+}
+
+/** This device's handle, or null when it is not subscribed at all. */
+export async function myDeviceId(env: PushEnv): Promise<string | null> {
+  if (!env.sw) return null;
+  try {
+    const sub = await (await env.sw.ready).pushManager.getSubscription();
+    return sub ? await deviceIdOf(sub.endpoint) : null;
+  } catch {
+    return null;
+  }
+}
+
 /** Whatever the phone should call itself in the device list. Free text, only
  *  ever shown back — a name, not an identifier. */
 export function deviceLabel(ua: string): string {

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -4,7 +4,7 @@ import { useLive } from "../lib/useLive.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { subscribeSessionChanged } from "../lib/sessionBus.ts";
 import { useStats } from "../lib/useStats.ts";
-import { fmtUsd, fmtTokens } from "../lib/format.ts";
+import { fmtUsd, fmtTokens, since } from "../lib/format.ts";
 import { MobileChats, type OpenChat, type Compose } from "./MobileChats.tsx";
 import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobileUi.tsx";
 import { pollWhileVisible } from "../lib/poll.ts";
@@ -20,8 +20,9 @@ import { buildQueue, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
 import {
-  browserPushEnv, currentPushState, disablePush, enablePush, pushCopy, type PushState,
+  browserPushEnv, currentPushState, disablePush, enablePush, myDeviceId, pushCopy, type PushState,
 } from "../lib/webpush.ts";
+import type { PushDevice } from "../lib/api.ts";
 import type {
   PendingGate, SessionRollup, DockerContainer, DockerStat, PrSummary, GitRepoRef, GitTreeState, Insight,
 } from "../../../shared/types.ts";
@@ -191,6 +192,41 @@ export function MobileApp() {
     currentPushState(pushEnv).then((s) => { if (live) setPushState(s); });
     return () => { live = false; };
   }, [pushEnv, settings]);
+
+  /**
+   * Every device subscribed to this machine, not only this one.
+   *
+   * The row above speaks for the phone in your hand; a phone you replaced last
+   * year is still on the list and still being pushed to, and the only place
+   * that could ever be seen or stopped is here. Read when Settings opens
+   * rather than polled — nothing about it changes while the sheet is shut.
+   */
+  const [devices, setDevices] = useState<PushDevice[]>([]);
+  const [myDevice, setMyDevice] = useState<string | null>(null);
+  const [forgetting, setForgetting] = useState<string | null>(null);
+  const refreshDevices = useCallback(() => {
+    api.pushDevices()
+      .then((r) => setDevices(r.devices ?? []))
+      .catch(() => { /* the sheet works without it; the row above is the point */ });
+    myDeviceId(pushEnv).then(setMyDevice).catch(() => setMyDevice(null));
+  }, [pushEnv]);
+  useEffect(() => { if (settings) refreshDevices(); }, [settings, refreshDevices, pushState]);
+
+  const forgetDevice = useCallback(async (d: PushDevice) => {
+    setForgetting(d.id);
+    try {
+      await api.pushForget(d.id);
+      // If it was this phone, the switch above has to stop saying "on" — the
+      // browser still holds a subscription the server no longer knows about,
+      // and that is precisely the state where alerts silently stop.
+      if (d.id === myDevice) { await disablePush(pushEnv); setPushState("off"); }
+      refreshDevices();
+      toast(d.id === myDevice ? "Alerts off on this phone" : `${d.label || "That device"} will no longer be alerted`);
+    } catch {
+      toast("Could not reach the server", true);
+    }
+    setForgetting(null);
+  }, [myDevice, pushEnv, refreshDevices]);
 
   const togglePush = useCallback(async () => {
     setPushBusy(true);
@@ -778,6 +814,29 @@ export function MobileApp() {
               )}
             </span>
           )} />
+        {/* Every device, not only this one. A phone you replaced last year is
+            still subscribed and still being pushed to, and this is the only
+            place it can be seen — or stopped. Hidden when there is nothing to
+            manage: one device is already fully described by the row above. */}
+        {devices.length > 1 && (
+          <div className="flex flex-col gap-2.5" style={{ marginTop: 10 }}>
+            {devices.map((d) => (
+              <Row key={d.id}
+                title={`${d.label || "A device"}${d.id === myDevice ? " · this phone" : ""}`}
+                sub={d.lastOkAt
+                  ? `Last alerted ${since(d.lastOkAt)}`
+                  // Added but never delivered to is worth saying plainly: it is
+                  // what a subscription that never worked looks like, and it is
+                  // otherwise indistinguishable from a quiet week.
+                  : `Added ${since(d.addedAt)} · never alerted`}
+                right={
+                  <Act small disabled={forgetting === d.id} onAct={() => forgetDevice(d)}>
+                    {forgetting === d.id ? "…" : "Forget"}
+                  </Act>
+                } />
+            ))}
+          </div>
+        )}
         <div className="mb-eyebrow" style={{ margin: "16px 0 9px" }}>Queue</div>
         <Row title="Snoozed" sub={snoozed ? `${snoozed} hidden until they change` : "Nothing snoozed"}
           right={snoozed

--- a/web/test/webpush.test.ts
+++ b/web/test/webpush.test.ts
@@ -16,9 +16,10 @@ import { describe, expect, it } from "bun:test";
 import {
   decodeKey, deviceLabel, pushCopy, pushStateOf,
   currentPushState, enablePush, disablePush,
-  isApplePortable, needsHomeScreen,
+  isApplePortable, needsHomeScreen, deviceIdOf, myDeviceId,
   type PushEnv, type PushState,
 } from "../src/lib/webpush.ts";
+import { since } from "../src/lib/format.ts";
 
 const IPHONE = "Mozilla/5.0 (iPhone; CPU iPhone OS 17_4 like Mac OS X) AppleWebKit/605.1.15 Version/17.4 Mobile/15E148 Safari/604.1";
 // iPadOS 13+ reports a desktop Safari string: no "iPad" anywhere in it.
@@ -224,6 +225,28 @@ describe("an iPhone in a browser tab", () => {
     // screen, and telling it to would be nonsense.
     const { env } = fakeEnv({ hasPushManager: false, ua: MAC, maxTouchPoints: 0 });
     expect(await currentPushState(env)).toBe("unsupported");
+  });
+});
+
+describe("finding this phone in the list of devices", () => {
+  it("derives the same handle the server does", async () => {
+    // Pinned on both sides — server/test/push-routes.test.ts asserts the same
+    // string for the same endpoint. These are two implementations of one hash
+    // in two languages' crypto APIs, and if they ever disagree the symptom is
+    // silent: the device list simply stops marking which one you are holding,
+    // and you forget the wrong phone.
+    expect(await deviceIdOf("https://push.example/device/abc")).toBe("981f012daaac75bc");
+    expect(await deviceIdOf("https://push.example/device/abd")).not.toBe("981f012daaac75bc");
+  });
+
+  it("says nothing when this device is not subscribed", async () => {
+    const { env } = fakeEnv({ existing: null });
+    expect(await myDeviceId(env)).toBeNull();
+  });
+
+  it("names this device when it is", async () => {
+    const { env } = fakeEnv({ existing: { endpoint: "https://push.example/device/abc" } });
+    expect(await myDeviceId(env)).toBe("981f012daaac75bc");
   });
 });
 
@@ -441,5 +464,15 @@ describe("working out where this device stands", () => {
   it("reports unsupported with no service worker at all", async () => {
     const { env } = fakeEnv({ sw: null });
     expect(await currentPushState(env)).toBe("unsupported");
+  });
+});
+
+describe("how long ago a device last heard anything", () => {
+  it("does not say 'now ago'", async () => {
+    // fmtAgo answers "now" under a second, which is exactly the value this row
+    // shows immediately after pressing Test.
+    expect(since(Date.now())).toBe("just now");
+    expect(since(Date.now() - 5_000)).toBe("5s ago");
+    expect(since(Date.now() - 3 * 3_600_000)).toBe("3h ago");
   });
 });


### PR DESCRIPTION
## What does this PR do?

The switch spoke for the device in your hand. A phone you replaced last year is still subscribed and still being pushed to, and there was nowhere to see that and nothing to do about it — the only thing that ever stopped it was the push service eventually answering 410, which needs the old phone to have been *wiped* rather than merely put in a drawer.

Settings lists every device now: what it is called, when it last actually received something, and a way to forget it. Shown only when there is more than one — a single device is already fully described by the switch above it.

```
Push to this phone   Alerts reach this phone with the screen off   [Test] [Turn off]

Linux · this phone   Last alerted 1s ago                           [Forget]
Old iPhone           Added 1s ago · never alerted                  [Forget]
```

**Forgetting needs a name for a device, and the device list may not say the one thing that would work.** An endpoint is a capability: anyone holding one can ask a push service to wake that phone forever, with no further credential. So each entry carries sixteen hex characters of SHA-256 over the endpoint — derived rather than stored, so there is nothing to migrate onto existing files and a restart does not renumber the list, and one-way, so it cannot be turned back into a way to reach the device.

The phone derives the same handle for its own subscription, which is how the list can say which one you are holding. Two implementations of one hash in two crypto APIs, so **the same string is pinned on both sides** — if they ever disagree the symptom is silent, and you forget the wrong phone.

Forgetting *this* phone also turns the switch off. Otherwise the browser keeps a subscription the server no longer knows about, which is precisely the state where alerts stop and nothing says so.

## How was it tested?

Eleven mutations, all red. Verified in a real browser: two devices listed, this one marked, Forget removing the right one and only the right one, and the list collapsing back when only one is left.

```
after adding a second device: [{"id":"76048bba…","label":"Linux",…},{"id":"6afe5f5c…","label":"Old iPhone",…}]
device list: ["Linux · this phone | Last alerted 1s ago | Forget",
              "Old iPhone | Added 1s ago · never alerted | Forget"]
after forgetting the old one: [{"id":"76048bba…","label":"Linux",…}]
list now: []
page errors: none
```

170/170 phone audit checks. Suites green: 1105 server, 770 web.

## The audit stopped saying why it skipped things

Partway through this the check count dropped from 170 to 134 with nothing to explain it. The pull request opened, `Files` was not there to tap, and twenty-four checks quietly stopped running — the same bug as the selector noted in the comment directly above that line, wearing a different condition. A silent skip reads as a section that passed. Both inner skips print now.

The drop itself turned out to be a fixture that had lost its stubbed `gh` when I restarted it. That was settled rather than assumed: a control run on **unmodified main** against the same server gave the same 134. Restoring the stub's fixture paths brought it back to 170.
