### PR TITLE
Tapping the alert shows the thing it was about — and the README says push exists

### DIFF
--- a/README.md
+++ b/README.md
@@ -300,6 +300,38 @@ otherwise the phone shows a white page and nothing anywhere says why.
 The page ships a web manifest, so **Add to home screen** gives you an icon that
 opens without browser chrome.
 
+### Alerts that reach a locked phone
+
+Everything else agentglass can say needs somebody already looking. A webhook
+goes to a chat app, `notify-send` goes to a desktop that may not exist, and the
+phone's socket closes with the screen **on purpose** — a socket reconnecting
+behind a dark screen is a worse deal than a poll. So the one case the companion
+exists for, you walked away and an agent is now blocked waiting on a person,
+was the one case nothing covered.
+
+**Settings ▸ Push to this phone**, one switch. After that a held gate buzzes the
+phone in your pocket, and tapping it opens the queue with the decision on it.
+
+It is end-to-end encrypted by design: the push service relays a blob it cannot
+read (RFC 8291 over RFC 8188, VAPID for the token). Your machine generates its
+own signing key on first use and keeps it in `~/.config/agentglass/push.json`
+at 0600 — nothing is registered with anybody, and the only thing that leaves is
+ciphertext addressed to your own device.
+
+- **Test** sends a real notification down the real path, so you find out now
+  rather than by missing something later.
+- More than one device gets a list — what each is called, when it last actually
+  received an alert, and a way to forget one. A phone you replaced keeps
+  receiving until you say otherwise, and the list is where you say it.
+- A held gate stays on the lock screen until you deal with it; anything less
+  urgent is allowed to fade.
+- **On iPhone and iPad this needs the Home Screen icon first.** Safari has had
+  Web Push since 16.4, but only for an installed site — in a browser tab the
+  switch will say so and point at the share sheet.
+
+Independent of `AGENTGLASS_NOTIFY`, which is the desktop channel: a phone is
+subscribed whether or not the machine it watches has a screen.
+
 ---
 
 ![the phone companion — the queue, a repository's changes, and the chat list](.github/assets/mobile.png)
@@ -332,7 +364,7 @@ Most agent dashboards show a live event feed and forget everything on refresh. a
 | 📈 **Anthropic plan usage** | 5-hour + weekly plan-limit meters — shown only when you're viewing Anthropic (the one provider with a usage API), on wide screens. |
 | ⌨ **Command palette + shortcuts** | `Ctrl-K` to filter, switch theme, change window, export; `d` diffs · `g` git · `p` pull requests · `o` Docker · `t` terminal · `c` chat · `k` skills · `s` stats · `/` search; click any event for full details; click an agent to filter to it. |
 | 🎨 **22 themes** | 11 dark palettes (Midnight Purple, Forest, Ember, Nord, …), each with a light twin — instant switch, remembered. |
-| 🔔 **Push alerts** | Webhook (Slack/Discord) + desktop notify + optional in-app chime on approvals and errors. |
+| 🔔 **Alerts** | Web Push to a locked phone (end-to-end encrypted, no account anywhere) + webhook (Slack/Discord) + desktop notify + optional in-app chime, on approvals and errors. |
 | 📤 **Export** | One-click CSV / JSON of all events. |
 
 ### Themes
@@ -652,7 +684,16 @@ are:
   using your own credentials), the update check against the GitHub releases API,
   the **Pull requests** panel through your own authenticated `gh` CLI, the AI
   **Explain** walkthrough through a local `claude` (or your `ANTHROPIC_API_KEY`),
-  and anything *you* configure (webhook alerts).
+  Web Push once you turn it on for a phone, and anything *you* configure
+  (webhook alerts).
+- **Push, specifically.** Turning it on means this machine posts to whichever
+  push service your phone's browser nominated — Google's for Chrome, Mozilla's
+  for Firefox, Apple's for Safari. The body is encrypted end to end (RFC 8291),
+  so that service relays something it cannot read: it learns that this machine
+  sent something to that device, and nothing else — not the project, not the
+  command, not the agent. No account is created anywhere, and the signing key is
+  generated locally and never leaves (`~/.config/agentglass/push.json`, 0600).
+  Off until you switch it on, per device, and revocable from the same list.
 
 ---
 
@@ -792,7 +833,7 @@ in its own buckets rather than charged again as ordinary input.
 | `AGENTGLASS_RETENTION_DAYS` | `8` | Days of **raw events** to keep (pruned hourly). Covers the full 7d stats window; `0` = keep forever. Expiring days are folded into a daily rollup first, so spend history outlives the rows — see *spend per day* in Statistics. |
 | `AGENTGLASS_PRICING` | — | Path to a JSON pricing override (see `server/src/pricing.ts`). |
 | `AGENTGLASS_WEBHOOK` | — | POST `{text}` alerts here (Slack/Discord compatible). |
-| `AGENTGLASS_NOTIFY` | — | `1` → fire desktop alerts. A connected client (browser or desktop app) raises a **native OS notification** on any platform; `notify-send` is the fallback for a headless server with nothing attached to show it. |
+| `AGENTGLASS_NOTIFY` | — | `1` → fire desktop alerts. A connected client (browser or desktop app) raises a **native OS notification** on any platform; `notify-send` is the fallback for a headless server with nothing attached to show it. Does **not** gate Web Push to a phone, which is subscribed per device from the companion's own settings — see [Alerts that reach a locked phone](#alerts-that-reach-a-locked-phone). |
 | `AGENTGLASS_SERVER` | `http://localhost:4000` | Used by the hook/seed scripts. Refused unless it points at this machine — see the next row. |
 | `AGENTGLASS_ALLOW_REMOTE` | — | `1` → let the hook scripts post to a **non-local** `AGENTGLASS_SERVER`. Off by default and deliberately awkward: those payloads carry full session transcripts, and `AGENTGLASS_SERVER` can be set by a repo-local `settings.json` — so a cloned repository could otherwise redirect your transcripts to somebody else's host. Set it only if you genuinely run the server on another machine. |
 | `VITE_CW_SERVER` | `http://<host>:4000` | UI → server URL (build/dev time). Unset, the UI resolves same-origin when the server itself served it (single-port mode), `:4000` otherwise. |
@@ -880,6 +921,7 @@ cannot be configured by `export` at all.
 | `GET /insights` | Derived warnings — loops, fast burn, high failure rate, spend velocity. |
 | `GET /search?q=` | Full-text search across all captured prompts/commands/outputs. |
 | `POST /gate` · `GET /gate/pending` · `POST /gate/decide` | Control-plane approve/deny for the opt-in `PreToolUse` gate. |
+| `GET /push/key · /push/devices` · `POST /push/subscribe · /push/unsubscribe · /push/test` | Web Push to a phone: this machine's VAPID public key, the subscribed devices, registering and forgetting one, and sending a real test alert down the real path. `/push/devices` answers *how many and what are they called* and never an endpoint or a key — an endpoint is a capability, and anyone holding one could wake that phone forever. |
 | `GET /actions?limit=&before=` | Every write the cockpit performed — git, docker, pull requests, gate decisions — with the address it came from. Append-only; unscoped on purpose. |
 | `POST /control` | Drive the dashboard's own UI (switch view, toggle workspace, theme, zoom, new chat) from an external controller — a Stream Deck, a phone. Validated then rebroadcast on `/stream`; changes only what's shown, grants no capability the keyboard doesn't. See [`docs/EXTENDING.md`](docs/EXTENDING.md). |
 | `GET /export?format=csv\|json` | Download all events (bounded by retention). |

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -95,7 +95,7 @@ self.addEventListener("push", function (event) {
 });
 
 /**
- * Tapping the notification puts the app in front of you.
+ * Tapping the notification puts the decision in front of you.
  *
  * Focus an existing window if there is one, rather than opening a second copy:
  * the app holds live socket state and a back stack, and a fresh tab throws
@@ -104,6 +104,12 @@ self.addEventListener("push", function (event) {
  * `includeUncontrolled` matters: a tab loaded before this worker took over is
  * not controlled by it, and without the flag it is invisible here. That tab is
  * the single most likely one to exist.
+ *
+ * Focusing alone is not enough, though. The app is wherever it was left — the
+ * fleet, a diff, a conversation — so tapping "Approval needed" would raise a
+ * window showing something else entirely, and the thing you were woken for
+ * would be one or two taps away and unmentioned. So the window is also told
+ * why it was raised. A fresh one needs no telling: it opens on the queue.
  */
 self.addEventListener("notificationclick", function (event) {
   event.notification.close();
@@ -112,7 +118,12 @@ self.addEventListener("notificationclick", function (event) {
     self.clients.matchAll({ type: "window", includeUncontrolled: true }).then(function (all) {
       for (var i = 0; i < all.length; i++) {
         if (all[i].url.indexOf(self.registration.scope) === 0 && "focus" in all[i]) {
-          return all[i].focus();
+          var client = all[i];
+          // Told before focusing, not after: `focus()` resolves when the window
+          // is actually raised, which on a phone waking from a locked screen is
+          // long enough to see the wrong screen first.
+          try { client.postMessage({ type: "agentglass:opened-from-notification" }); } catch (e) { /* gone */ }
+          return client.focus();
         }
       }
       return self.clients.openWindow(home);

--- a/web/src/lib/webpush.ts
+++ b/web/src/lib/webpush.ts
@@ -150,6 +150,20 @@ export async function myDeviceId(env: PushEnv): Promise<string | null> {
   }
 }
 
+/**
+ * The message the worker sends the app when a notification is tapped.
+ *
+ * Checked rather than assumed: a page with a service worker receives messages
+ * from anything else that worker talks to, and acting on a bare truthy `data`
+ * would let an unrelated message yank somebody out of a conversation they were
+ * typing in.
+ */
+export const OPENED_FROM_NOTIFICATION = "agentglass:opened-from-notification";
+export function isOpenedFromNotification(data: unknown): boolean {
+  return !!data && typeof data === "object"
+    && (data as { type?: unknown }).type === OPENED_FROM_NOTIFICATION;
+}
+
 /** Whatever the phone should call itself in the device list. Free text, only
  *  ever shown back — a name, not an identifier. */
 export function deviceLabel(ua: string): string {

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -20,7 +20,8 @@ import { buildQueue, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
 import {
-  browserPushEnv, currentPushState, disablePush, enablePush, myDeviceId, pushCopy, type PushState,
+  browserPushEnv, currentPushState, disablePush, enablePush, isOpenedFromNotification,
+  myDeviceId, pushCopy, type PushState,
 } from "../lib/webpush.ts";
 import type { PushDevice } from "../lib/api.ts";
 import type {
@@ -564,6 +565,35 @@ export function MobileApp() {
    * and the prompt to open with, which is why NewChat takes a preset rather
    * than always starting on the first repo in the list.
    */
+  /**
+   * A notification was tapped, so show what it was about.
+   *
+   * Focusing the window is not enough on its own: the app is wherever it was
+   * left — the fleet, a diff, a conversation — so tapping "Approval needed"
+   * raised a screen showing something else, and the thing that woke you was
+   * one or two taps away and unmentioned.
+   *
+   * Everything open is closed rather than the tab merely switched, because a
+   * parked screen sits *over* the tabs: setting the tab underneath a diff
+   * changes nothing anybody can see.
+   */
+  useEffect(() => {
+    const sw = typeof navigator === "undefined" ? null : navigator.serviceWorker;
+    if (!sw) return;
+    const onMessage = (e: MessageEvent) => {
+      if (!isOpenedFromNotification(e.data)) return;
+      setOpenPr(null);
+      setOpenRepo(null);
+      setOpenCtr(null);
+      setOpenChat(null);
+      setCompose(null);
+      setSettings(false);
+      setTab("now");
+    };
+    sw.addEventListener("message", onMessage);
+    return () => sw.removeEventListener("message", onMessage);
+  }, []);
+
   const openChatWith = useCallback((cwd: string, prompt: string) => {
     setOpenPr(null);
     setOpenRepo(null);

--- a/web/test/service-worker.test.ts
+++ b/web/test/service-worker.test.ts
@@ -27,9 +27,13 @@ function loadWorker(opts: { clients?: any[] } = {}) {
   const waits: Promise<unknown>[] = [];
   let claimed = false, skipped = false;
 
+  const messaged: { url: string; data: unknown }[] = [];
+  // One list, so the order of the two is a fact rather than an inference.
+  const order: string[] = [];
   const windows = (opts.clients ?? []).map((c) => ({
     ...c,
-    focus() { focused.push(c.url); return Promise.resolve(this); },
+    focus() { order.push("focus"); focused.push(c.url); return Promise.resolve(this); },
+    postMessage(data: unknown) { order.push("message"); messaged.push({ url: c.url, data }); },
   }));
 
   const scope = {
@@ -60,7 +64,7 @@ function loadWorker(opts: { clients?: any[] } = {}) {
     await Promise.all(waits);
   };
 
-  return { fire, shown, opened, focused, listeners, waits,
+  return { fire, shown, opened, focused, messaged, order, listeners, waits,
     get claimed() { return claimed; }, get skipped() { return skipped; } };
 }
 
@@ -210,6 +214,32 @@ describe("tapping it", () => {
     await w.fire("notificationclick", { notification: { close() {} } });
     expect(w.focused).toEqual([]);
     expect(w.opened).toEqual(["https://box.local/"]);
+  });
+
+  it("tells the window why it was raised", async () => {
+    // Focusing alone raises the app wherever it was left — the fleet, a diff, a
+    // conversation. Tapping "Approval needed" would then show something else
+    // entirely, with the thing you were woken for two taps away and
+    // unmentioned.
+    const w = loadWorker({ clients: [{ url: "https://box.local/#fleet" }] });
+    await w.fire("notificationclick", { notification: { close() {} } });
+    expect(w.messaged).toHaveLength(1);
+    expect(w.messaged[0]!.data).toEqual({ type: "agentglass:opened-from-notification" });
+  });
+
+  it("says so before raising the window, not after", async () => {
+    // `focus()` resolves when the window is actually up, which on a phone
+    // waking from a locked screen is long enough to watch the wrong screen
+    // paint first.
+    const w = loadWorker({ clients: [{ url: "https://box.local/" }] });
+    await w.fire("notificationclick", { notification: { close() {} } });
+    expect(w.order).toEqual(["message", "focus"]);
+  });
+
+  it("does not message a window belonging to some other site", async () => {
+    const w = loadWorker({ clients: [{ url: "https://elsewhere.example/x" }] });
+    await w.fire("notificationclick", { notification: { close() {} } });
+    expect(w.messaged).toEqual([]);
   });
 
   it("dismisses the notification it came from", async () => {

--- a/web/test/webpush.test.ts
+++ b/web/test/webpush.test.ts
@@ -13,10 +13,12 @@
  * a phone with no console attached.
  */
 import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
 import {
   decodeKey, deviceLabel, pushCopy, pushStateOf,
   currentPushState, enablePush, disablePush,
   isApplePortable, needsHomeScreen, deviceIdOf, myDeviceId,
+  isOpenedFromNotification, OPENED_FROM_NOTIFICATION,
   type PushEnv, type PushState,
 } from "../src/lib/webpush.ts";
 import { since } from "../src/lib/format.ts";
@@ -225,6 +227,36 @@ describe("an iPhone in a browser tab", () => {
     // screen, and telling it to would be nonsense.
     const { env } = fakeEnv({ hasPushManager: false, ua: MAC, maxTouchPoints: 0 });
     expect(await currentPushState(env)).toBe("unsupported");
+  });
+});
+
+describe("the message the worker sends when a notification is tapped", () => {
+  it("is recognised", async () => {
+    expect(isOpenedFromNotification({ type: OPENED_FROM_NOTIFICATION })).toBe(true);
+  });
+
+  it("is not confused with anything else a worker might say", async () => {
+    // A page with a service worker receives messages from everything else that
+    // worker talks to. Acting on a bare truthy `data` would yank somebody out
+    // of a conversation they were typing in, for a message that was never
+    // about them.
+    for (const other of [
+      null, undefined, "", 0, "agentglass:opened-from-notification",
+      {}, { type: "" }, { type: "workbox-broadcast-update" }, { data: { type: OPENED_FROM_NOTIFICATION } },
+      // Ours, near enough to look right and not the same thing. An exact
+      // match, not a prefix: this app will send other messages one day.
+      { type: OPENED_FROM_NOTIFICATION + "-v2" }, { type: "agentglass:something-else" },
+      [{ type: OPENED_FROM_NOTIFICATION }],
+    ]) {
+      expect(isOpenedFromNotification(other)).toBe(false);
+    }
+  });
+
+  it("is the string the worker actually sends", async () => {
+    // Pinned against public/sw.js, which is plain JavaScript and cannot import
+    // this constant. Two spellings of one name, so they are checked to agree.
+    const sw = readFileSync(new URL("../public/sw.js", import.meta.url).pathname, "utf8");
+    expect(sw).toContain(OPENED_FROM_NOTIFICATION);
   });
 });
 


### PR DESCRIPTION
Two things, because the second is what makes the first reachable by anyone who did not write it.

## Tapping the alert shows the thing it was about

The notification woke you, you tapped it, and the app came up **wherever it had been left** — the fleet, a diff, a conversation from yesterday. The gate that was holding an agent was one or two taps away and nothing on screen mentioned it.

The worker now tells the window why it was raised, and the window empties itself back to the queue.

**Told before focusing, not after.** `focus()` resolves when the window is actually up, which on a phone waking from a locked screen is long enough to watch the wrong screen paint first.

**Told only to a window belonging to this app.** `matchAll` with `includeUncontrolled` returns windows the worker can see but does not own.

**Everything open is closed, not just the tab switched.** A parked screen sits *over* the tabs, so setting the tab underneath a diff changes nothing anybody can see.

**The message is checked rather than assumed.** A page with a service worker receives messages from everything else that worker talks to; acting on a bare truthy `data` would yank somebody out of a conversation they were typing in, for a message that was never about them. Exact match on the name, not a prefix — this app will send other messages one day. The name itself is pinned against `public/sw.js`, which is plain JavaScript and cannot import the constant.

## The README said the alert story was webhook plus desktop notify

Which is exactly the set that cannot reach the case the companion exists for. Web Push shipped across six changes and nothing told anyone it was there — and a feature nobody is told about is off for everybody.

There is a section under the phone companion now: what it is for, the one switch, Test, the device list, and the iOS Home Screen requirement — which is the thing most likely to look like a bug rather than a rule.

**The security section needed the correction more than the feature section did.** "Your data stays local" enumerated what leaves the machine and did not list this. It now says plainly that turning push on means posting to whichever push service the phone's browser nominated, that the body is encrypted end to end so the service relays something it cannot read, that no account is created anywhere, and that the signing key is generated locally and stays at 0600.

Plus the routes table, and a note on `AGENTGLASS_NOTIFY`: it is the desktop channel and does not gate this one — a phone is subscribed whether or not the machine it watches has a screen.

## How was it tested?

Six mutations, all red.

In a real browser, **both halves separately**, because Chrome offers no way to click a notification programmatically. The worker's half — that it posts, to the right window, before focusing — runs against the shipped `sw.js` in the suite. The app's half was driven live, with the message dispatched on `navigator.serviceWorker` exactly as the worker delivers it:

```
on load:                    Now,    0 screens, no sheet
after wandering off:        Repos,  1 screen,  sheet open
after the tap:              Now,    0 screens, no sheet
after an unrelated message: Fleet,  0 screens, no sheet
page errors:                none
```

170/170 phone audit checks. Suites green: 1105 server, 776 web.

## What this completes

Web Push runs end to end now: an event blocks an agent → `deliver()` encrypts and sends → the push service relays → the service worker shows it on a locked phone → tapping it puts the decision in front of you. The one step no container can perform remains `PushManager.subscribe` against a real push service.
