### PR TITLE
The key could be generated twice, and the loser was silent

### DIFF
--- a/server/src/pushstore.ts
+++ b/server/src/pushstore.ts
@@ -86,15 +86,37 @@ function write(f: PushFile): boolean {
  * the token. Generating on every boot would look fine in every test and buzz
  * nobody.
  */
-let memo: VapidKeys | null = null;
-export async function vapidKeys(): Promise<VapidKeys> {
-  if (memo) return memo;
-  const f = read();
-  if (f.vapid?.publicKey && f.vapid?.privateKey) { memo = f.vapid; return memo; }
-  const fresh = await generateVapidKeys();
-  write({ ...f, vapid: fresh });
-  memo = fresh;
-  return fresh;
+/**
+ * The *promise* is memoized, not the result, and that is the whole point.
+ *
+ * Holding the result meant the `await` on key generation sat between the
+ * check and the assignment, so two callers arriving together on a fresh
+ * install both generated, both wrote, and the first one returned a key that
+ * was no longer the one on disk. A phone subscribing in that window is pinned
+ * to a key this server will never sign with again — and the failure is exactly
+ * the silent one described above: the push service simply stops accepting the
+ * token, and nothing anywhere says so.
+ *
+ * Not theoretical on first use: the phone asks for `/push/key` while the first
+ * alert may already be fanning out.
+ */
+let memo: Promise<VapidKeys> | null = null;
+export function vapidKeys(): Promise<VapidKeys> {
+  if (!memo) {
+    memo = (async () => {
+      const f = read();
+      if (f.vapid?.publicKey && f.vapid?.privateKey) return f.vapid;
+      const fresh = await generateVapidKeys();
+      write({ ...f, vapid: fresh });
+      return fresh;
+    })().catch((e) => {
+      // A failure must not be cached, or one bad moment makes push dead for
+      // the lifetime of the process.
+      memo = null;
+      throw e;
+    });
+  }
+  return memo;
 }
 
 /** Only for tests, which run several servers in one process. */

--- a/server/test/push-send.test.ts
+++ b/server/test/push-send.test.ts
@@ -238,6 +238,30 @@ describe("the VAPID identity", () => {
     expect(second.privateKey).toBe(first.privateKey);
   });
 
+  it("is generated once even when several callers ask at the same moment", async () => {
+    // The phone asks for /push/key while the first alert may already be
+    // fanning out, which is exactly the window this used to lose: the `await`
+    // on key generation sat between the check and the memo assignment, so both
+    // callers generated, both wrote, and the first one was handed a key that
+    // was no longer the one on disk. A phone subscribing there is pinned to a
+    // key this server will never sign with again — and the push service just
+    // stops accepting the token, silently, forever.
+    dir = mkdtempSync(join(tmpdir(), "agx-push-"));
+    process.env.XDG_CONFIG_HOME = dir;
+    forgetVapid();
+
+    const many = await Promise.all(Array.from({ length: 8 }, () => vapidKeys()));
+    const keys = new Set(many.map((k) => k.publicKey));
+    expect(keys.size).toBe(1);
+
+    // And the one everybody got is the one that was written down. Comparing
+    // the callers to each other is not enough: they could all agree on a key
+    // that a later write replaced on disk, which is the same failure.
+    const onDisk = JSON.parse(readFileSync(join(dir, "agentglass", "push.json"), "utf8"));
+    expect(onDisk.vapid.publicKey).toBe(many[0]!.publicKey);
+    expect(onDisk.vapid.privateKey).toBe(many[0]!.privateKey);
+  });
+
   it("is written where only this user can read it", async () => {
     dir = mkdtempSync(join(tmpdir(), "agx-push-"));
     process.env.XDG_CONFIG_HOME = dir;


### PR DESCRIPTION
## What does this PR do?

`vapidKeys()` memoized the **result**, so the `await` on key generation sat between the check and the assignment:

```ts
if (memo) return memo;
const f = read();
if (f.vapid?.publicKey && f.vapid?.privateKey) { memo = f.vapid; return memo; }
const fresh = await generateVapidKeys();   // ← two callers both get here
write({ ...f, vapid: fresh });
memo = fresh;
return fresh;
```

Two callers arriving together on a fresh install both generate, both write, and the first one is handed a key that is no longer the one on disk.

**A phone subscribing in that window is pinned to a key this server will never sign with again.** The failure is exactly the one this function's own comment warns about: the push service simply stops accepting the token, and nothing anywhere says so. It looks like a phone that quietly stopped receiving.

Not theoretical on first use — the phone asks for `/push/key` while the first alert may already be fanning out through `pushEveryone`. That is the only moment both paths reach this at once, and also the only moment the file is empty.

The fix memoizes the **promise**. A rejection clears it rather than being cached, or one bad moment would make push dead for the lifetime of the process.

## How was it tested?

The test fires eight callers at once and checks two things, because the first alone is not enough:

- they all got the same key, and
- the key they got is the one on disk.

Eight callers can agree on a key that a later write has already replaced, which is the same bug wearing a passing assertion.

Three mutations, all red — including one that reverts to the old shape, which is what shows the race was real rather than argued:

```
RED   the result is memoized instead of the promise, so a race splits the key
RED   nothing is written down at all
RED   an existing key is regenerated on every boot
```

Suites green: 1106 server, 776 web.
