### PR TITLE
A device that re-subscribes kept its history — it did not

### DIFF
--- a/server/src/pushstore.ts
+++ b/server/src/pushstore.ts
@@ -160,16 +160,32 @@ export function removeDevice(id: string): StoredSubscription[] {
  * same subscription, and a *new* one when the user clears site data or the push
  * service rotates it — so matching on endpoint is what stops one phone becoming
  * four entries and getting four buzzes for one gate.
+ *
+ * "Update what is known about it" was a claim this did not honour: a device
+ * that re-subscribed was replaced rather than updated, so its history went with
+ * it. Re-subscribing is not rare — turning the switch on when the browser
+ * already holds a subscription posts the same endpoint again, which happens
+ * whenever this machine has lost its file and the phone has not — and the row
+ * afterwards read "Added just now · never alerted" for a phone that had been
+ * receiving for weeks. A device list that resets itself is a device list nobody
+ * can use to decide anything.
+ *
+ * So the keys are replaced, because those are what encryption needs and the
+ * newest ones are the true ones; everything the machine learned about the
+ * device is carried forward. A label only when a new one is offered — the
+ * phone sends one on subscribe and not on every call.
  */
 export function addSubscription(sub: PushSubscription, label?: string, now = Date.now()): StoredSubscription[] {
   if (!sub?.endpoint || !sub.keys?.p256dh || !sub.keys?.auth) return subscriptions();
   const f = read();
+  const prior = (f.subs ?? []).find((s) => s.endpoint === sub.endpoint);
   const subs = (f.subs ?? []).filter((s) => s.endpoint !== sub.endpoint);
   subs.push({
     endpoint: sub.endpoint,
     keys: { p256dh: sub.keys.p256dh, auth: sub.keys.auth },
-    ...(label ? { label } : {}),
-    addedAt: now,
+    ...(label ?? prior?.label ? { label: label ?? prior!.label! } : {}),
+    addedAt: prior?.addedAt ?? now,
+    ...(prior?.lastOkAt ? { lastOkAt: prior.lastOkAt } : {}),
   });
   write({ ...f, subs });
   return subs;

--- a/server/test/push-send.test.ts
+++ b/server/test/push-send.test.ts
@@ -160,6 +160,35 @@ describe("the store", () => {
     expect(subscriptions().at(-1)!.label).toBe("new name");
   });
 
+  it("keeps what it knows about a device that re-subscribes", async () => {
+    // Re-subscribing is not rare: turning the switch on when the browser
+    // already holds a subscription posts the same endpoint again, which is
+    // what happens whenever this machine has lost its file and the phone has
+    // not. Replacing the entry threw the history away, and the device list
+    // then read "Added just now · never alerted" for a phone that had been
+    // receiving for weeks — a list that resets itself cannot be used to decide
+    // which device to forget.
+    scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "Pixel", 1_000);
+    markDelivered("https://push/one", 2_000);
+    addSubscription({ ...sub, endpoint: "https://push/one" }, undefined, 9_000);
+    const [only] = subscriptions();
+    expect(only!.addedAt).toBe(1_000);
+    expect(only!.lastOkAt).toBe(2_000);
+    // And the name, which the phone sends on subscribe and not on every call.
+    expect(only!.label).toBe("Pixel");
+  });
+
+  it("takes the newest keys, because those are the ones that will encrypt", async () => {
+    // The rest is carried forward; the keys are not. A browser that rotated
+    // them and kept the endpoint would otherwise be encrypted to with the old
+    // pair forever, and every push would be quietly undecryptable.
+    scratch();
+    addSubscription({ ...sub, endpoint: "https://push/one" }, "Pixel");
+    addSubscription({ endpoint: "https://push/one", keys: { p256dh: "NEWKEY", auth: "NEWAUTH" } });
+    expect(subscriptions()[0]!.keys).toEqual({ p256dh: "NEWKEY", auth: "NEWAUTH" });
+  });
+
   it("survives a restart, which is the whole point of a file", async () => {
     const d = scratch();
     addSubscription({ ...sub, endpoint: "https://push/one" }, "Pixel");


### PR DESCRIPTION
## What does this PR do?

> *"Remember a device, or update what is known about it."*

That was the comment on `addSubscription`. The code replaced the entry rather than updating it, so everything the machine had learned about a device went with the old row.

**Re-subscribing is not rare.** Turning the switch on when the browser already holds a subscription posts the same endpoint again — which is exactly what happens whenever this machine has lost its file and the phone has not. The device list then read:

```
Old iPhone    Added just now · never alerted    [Forget]
```

…for a phone that had been receiving for weeks. A list that resets itself cannot be used to decide which device to forget, which is the only thing it is for.

**The keys are still replaced**, because those are what encryption needs and the newest ones are the true ones: a browser that rotated its keys and kept the endpoint would otherwise be encrypted to with the old pair forever, and every push would be quietly undecryptable. Everything else is carried forward. A label only when a new one is offered — the phone sends one on subscribe and not on every call.

## How was it tested?

Six mutations, all red — including **both directions on the label**, because an old name that never gets replaced and a new one that never wins are different bugs:

```
RED   a re-subscribe forgets when the device was added
RED   a re-subscribe forgets that it ever received anything
RED   a re-subscribe forgets the name
RED   a new name never wins
RED   rotated keys are ignored
RED   the device is no longer moved to the end
```

Suites green: 1108 server.
