### PR TITLE
Only something an agent is stopped on is worth waking a pocket for

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -75,6 +75,25 @@ function shouldSend(key: string): boolean {
  * over-eager prune would silently unsubscribe a working phone, and nobody would
  * find out until a gate went unanswered.
  */
+/**
+ * What a phone should do about an alert — which is not the same question as
+ * how loud the desktop should be, and conflating the two was a mistake.
+ *
+ * `urgency` is freedesktop's 0/1/2, and a tool error has been *critical* there
+ * on purpose since long before any of this: you are at the machine, and a
+ * failed tool call is worth a notification that does not time out. When push
+ * arrived, that same number was reused to decide two new things — whether to
+ * wake the device's radio, and whether the notification stays on the lock
+ * screen until it is dealt with. So a failed `grep` on one of eight agents
+ * lit up a phone in a pocket and pinned a notification to it that would not
+ * go away, which is precisely how somebody learns to swipe the whole app away.
+ *
+ * `wake` means an agent is stopped until a person answers. Nothing else is.
+ * The default is `tell` so that a new kind of alert is quiet on a phone until
+ * somebody decides otherwise, rather than loud until somebody notices.
+ */
+export type Reach = "wake" | "tell";
+
 export interface PushFanout {
   /** How many devices the push service accepted it for. */
   sent: number;
@@ -85,22 +104,26 @@ export interface PushFanout {
 }
 
 export async function pushEveryone(
-  title: string, body: string, urgency: 0 | 1 | 2,
+  title: string, body: string, reach: Reach,
 ): Promise<PushFanout> {
   const subs = subscriptions();
   const out: PushFanout = { sent: 0, failed: 0, pruned: 0 };
   if (!subs.length) return out;
   const keys = await vapidKeys();
-  // `urgency` travels inside the encrypted payload as well as in the header.
-  // The header is for the push service, which decides whether to wake the
-  // radio; the field is for the service worker, which decides whether the
-  // notification stays on screen until it is dealt with. Only one of the two
-  // can read the body, and only one of the two can wake the device.
-  const payload = new TextEncoder().encode(JSON.stringify({ title, body, at: Date.now(), urgency }));
+  // `reach` travels inside the encrypted payload as well as in the header, as
+  // the same 0/1/2 the worker already reads. The header is for the push
+  // service, which decides whether to wake the radio; the field is for the
+  // service worker, which decides whether the notification stays on screen
+  // until it is dealt with. Only one of the two can read the body, and only
+  // one of the two can wake the device.
+  const wake = reach === "wake";
+  const payload = new TextEncoder().encode(
+    JSON.stringify({ title, body, at: Date.now(), urgency: wake ? 2 : 1 }),
+  );
   await Promise.all(subs.map(async (s) => {
     const r = await sendPush(s, payload, keys, {
-      // A gate is worth waking the device for; a tool error is not.
-      urgency: urgency === 2 ? "high" : "normal",
+      // Only something an agent is stopped on is worth waking a pocket for.
+      urgency: wake ? "high" : "normal",
     });
     if (r.gone) { removeSubscription(s.endpoint); out.pruned++; }
     else if (r.ok) { markDelivered(s.endpoint); out.sent++; }
@@ -109,7 +132,7 @@ export async function pushEveryone(
   return out;
 }
 
-async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
+async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2, reach: Reach = "tell") {
   if (WEBHOOK && !IS_TEST) {
     try {
       await fetch(WEBHOOK, {
@@ -128,7 +151,7 @@ async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2) {
   if (!IS_TEST) {
     // Never awaited: an unreachable push service must not hold up the
     // notification that is also going to the desktop.
-    pushEveryone(title, body, urgency).catch((e) => console.warn("[alerts] push failed:", e));
+    pushEveryone(title, body, reach).catch((e) => console.warn("[alerts] push failed:", e));
   }
 
   if (DESKTOP) {
@@ -163,7 +186,11 @@ let warnedNoNotifySend = false;
 /** A tool call is being held at the control-plane gate — ping the human. */
 export function pushGate(agent: string, tool: string, summary: string) {
   if (shouldSend(`gate:${agent}:${summary}`))
-    deliver("✋ Approval needed", `${agent} wants to run ${tool}${summary ? `: ${summary.slice(0, 200)}` : ""} — approve or deny in agentglass.`);
+    deliver(
+      "✋ Approval needed",
+      `${agent} wants to run ${tool}${summary ? `: ${summary.slice(0, 200)}` : ""} — approve or deny in agentglass.`,
+      2, "wake",
+    );
 }
 
 /** Inspect an event and fire an alert if it warrants one. */
@@ -172,7 +199,13 @@ export function maybeAlert(e: WatchEvent) {
 
   if (e.hook_event_type === "PermissionRequest") {
     if (shouldSend(`perm:${e.session_id}`))
-      deliver("⏳ Approval needed", `${agent} is waiting on a permission request${e.tool_name ? ` (${e.tool_name})` : ""}.`);
+      deliver(
+        "⏳ Approval needed",
+        `${agent} is waiting on a permission request${e.tool_name ? ` (${e.tool_name})` : ""}.`,
+        // The other one an agent is stopped on. Everything below this line is
+        // news rather than a blockage, and reaches a phone quietly.
+        2, "wake",
+      );
     return;
   }
   if (e.hook_event_type === "Notification") {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -758,10 +758,10 @@ const server = Bun.serve<WsData>({
       const r = await pushEveryone(
         "✅ agentglass",
         "Push is working. This is what a held gate will look like.",
-        // Deliberately not 2: a test should not be the thing that teaches
+        // Deliberately not "wake": a test should not be the thing that teaches
         // somebody to swipe these away, and a notification that will not
         // dismiss itself is a poor introduction.
-        1,
+        "tell",
       );
       return json({ ok: r.sent > 0, ...r });
     }

--- a/server/test/push-alert.test.ts
+++ b/server/test/push-alert.test.ts
@@ -125,11 +125,19 @@ beforeAll(async () => {
       AGENTGLASS_SCAN_DISABLED: "1",
       AGENTGLASS_PORT: String(port),
     },
-    stdout: "ignore", stderr: "ignore",
+    stdout: "ignore", stderr: "pipe",
   });
+  // Say so when it does not come up. This used to break out of the loop and
+  // carry on, so a server that had died at boot showed as nine assertion
+  // failures about connection refused and nothing about the actual cause.
+  let up = false;
   for (let i = 0; i < 100; i++) {
-    try { if ((await fetch(base + "/health")).ok) break; } catch { /* not up yet */ }
+    try { if ((await fetch(base + "/health")).ok) { up = true; break; } } catch { /* not up yet */ }
     await Bun.sleep(100);
+  }
+  if (!up) {
+    const err = await new Response(proc.stderr as ReadableStream).text();
+    throw new Error("the server did not come up: " + err.slice(0, 600));
   }
   await fetch(base + "/push/subscribe", {
     method: "POST", headers: { "content-type": "application/json" },
@@ -167,8 +175,15 @@ async function ingest(event: unknown) {
   return res;
 }
 
-/** Delivery is fire-and-forget on purpose, so wait for it rather than assume. */
-async function waitForPush(atLeast: number, ms = 5000): Promise<boolean> {
+/**
+ * Delivery is fire-and-forget on purpose, so wait for it rather than assume.
+ *
+ * Under bun's own 5s test timeout, deliberately. Matching it meant a push that
+ * never arrived killed the whole run rather than failing one test — and every
+ * test after it then reported a connection refused to a server the runner had
+ * already torn down, which says nothing about the one thing that was wrong.
+ */
+async function waitForPush(atLeast: number, ms = 3000): Promise<boolean> {
   const until = Date.now() + ms;
   while (Date.now() < until) {
     if (svc.seen.length >= atLeast) return true;
@@ -228,6 +243,84 @@ describe("an agent stops, and the phone hears", () => {
     };
     const pixel = devices.find((d) => d.label === "Pixel");
     expect(pixel?.lastOkAt).toBeGreaterThan(0);
+  });
+});
+
+/** An event of the kind that happens all day and stops nothing. */
+const toolError = (session: string) => ({
+  source_app: "claude-code",
+  session_id: session,
+  hook_event_type: "PostToolUse",
+  payload: {
+    tool_name: "Bash",
+    // A shape `detectError` actually recognises. The first version of this
+    // fixture paired a stderr string with `interrupted: false`, which is not a
+    // failure by any of its rules — so no alert fired, no push arrived, and the
+    // test sat waiting for one that was never coming.
+    tool_response: { stdout: "", stderr: "grep: fixtures: No such file or directory", returnCodeInterpretation: "error" },
+  },
+});
+
+describe("what is worth waking a pocket for", () => {
+  it("does not wake the phone for a tool that merely failed", async () => {
+    // A failed tool call is *critical* on the desktop and has been on purpose
+    // since long before push existed: you are at the machine, and a
+    // notification that does not time out is right there. Reusing that same
+    // number to decide whether to wake a radio and pin a lock-screen
+    // notification meant a failed grep on one of eight agents lit up a phone
+    // in a pocket with something that would not go away. That is how somebody
+    // learns to swipe the whole app away, and then the gate goes unanswered
+    // too.
+    const before = svc.seen.length;
+    expect((await ingest(toolError("s-err-1"))).ok).toBe(true);
+    expect(await waitForPush(before + 1)).toBe(true);
+
+    const got = svc.seen[before]!;
+    expect(got.headers["urgency"]).toBe("normal");
+    const msg = JSON.parse(await decrypt(got.body, AUTH)) as { title?: string; urgency?: number };
+    expect(msg.title).toContain("error");
+    // Not 2: the worker reads this to decide whether the notification waits
+    // for you, and this one has no reason to.
+    expect(msg.urgency).toBe(1);
+  });
+
+  it("wakes it for a tool call held at the gate, which is the whole point", async () => {
+    // The control-plane hold: the agent is not merely waiting, it is stopped
+    // at a `PreToolUse` until a person answers, and the hook's own request is
+    // open the entire time. If any alert deserves a locked screen lighting up
+    // and staying lit, it is this one — and nothing covered it, which a
+    // mutation dropping its wake proved by walking straight through.
+    const before = svc.seen.length;
+    // Not awaited: /gate holds the connection open until it is decided or
+    // times out, which is exactly what the hook does.
+    const held = fetch(base + "/gate", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source_app: "claude-code", session_id: "s-gate-1",
+        tool_name: "Bash", tool_input: { command: "rm -rf build" }, timeout_ms: 2000,
+      }),
+    }).catch(() => null);
+
+    expect(await waitForPush(before + 1)).toBe(true);
+    expect(svc.seen[before]!.headers["urgency"]).toBe("high");
+    const msg = JSON.parse(await decrypt(svc.seen[before]!.body, AUTH)) as { title?: string; body?: string; urgency?: number };
+    expect(msg.urgency).toBe(2);
+    expect(msg.title).toContain("Approval needed");
+    // And it says what is being asked for, which is what makes it answerable
+    // from a lock screen.
+    expect(msg.body).toContain("rm -rf build");
+    await held;
+  });
+
+  it("still wakes it for something an agent is stopped on", async () => {
+    // The contrast is the point. Both arrive; only one is worth a locked
+    // screen lighting up and staying lit.
+    const before = svc.seen.length;
+    await ingest(permissionRequest("s-wake-again"));
+    expect(await waitForPush(before + 1)).toBe(true);
+    expect(svc.seen[before]!.headers["urgency"]).toBe("high");
+    const msg = JSON.parse(await decrypt(svc.seen[before]!.body, AUTH)) as { urgency?: number };
+    expect(msg.urgency).toBe(2);
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

A failed tool call is **critical** on the desktop, and has been on purpose since long before any of this — you are at the machine, and a notification that does not time out is right there in front of you. There is a test asserting it.

When push landed I reused that same number to decide two new things: whether to **wake the device's radio**, and whether the notification **stays on the lock screen until it is dealt with**. So a failed `grep` on one of eight agents lit up a phone in a pocket with something that would not go away. That is precisely how somebody learns to swipe the whole app away — and then the gate goes unanswered too.

They are different questions and they get different answers now:

| | desktop `urgency` | phone `reach` |
|---|---|---|
| gate held at `PreToolUse` | 2 critical | **wake** |
| permission request | 2 critical | **wake** |
| agent notification | 1 normal | tell |
| tool error | 2 critical *(unchanged)* | tell |
| the Test button | — | tell |

`urgency` stays exactly what freedesktop means by it and the desktop behaviour is untouched. The default for `reach` is `tell`, so a new kind of alert is quiet on a phone until somebody decides otherwise, rather than loud until somebody notices.

## How was it tested?

Eight mutations, all red.

**One walked through:** nothing covered the control plane's own hold reaching a phone — which is the single most important thing this feature does. `/gate` is answered by the hook, not by `/ingest`, so the permission-request test never touched it, and a mutation dropping `pushGate`'s wake changed nothing. Covered now, with the connection held open the way the hook holds it.

Suites green: 1111 server, 776 web.

## Two things the harness was hiding

Both found by chasing a single failure that reported itself as nine connection-refused errors.

**The tool-error fixture was not a tool error.** It paired a stderr string with `interrupted: false`, which `detectError` does not consider a failure by any of its rules — so no alert fired and the test waited for a push that was never coming.

**And it waited five seconds, which is exactly bun's test timeout.** A push that never arrives therefore killed the whole run rather than failing one test, and every test after it reported a connection refused to a server the runner had already torn down — saying nothing at all about the one thing that was actually wrong. Three seconds now, and the spawned server's own stderr is surfaced when it fails to come up instead of being swallowed by a loop that just gave up quietly.
