### PR TITLE
The demo installed a service worker on strangers' browsers

### DIFF
--- a/web/src/lib/webpush.ts
+++ b/web/src/lib/webpush.ts
@@ -57,7 +57,18 @@ export type PushState =
   /** Supported and allowed, but this device is not registered. */
   | "off"
   /** Registered. Alerts reach this device with its screen off. */
-  | "on";
+  | "on"
+  /**
+   * The published demo, which is a static site with nobody behind it.
+   *
+   * Its own state rather than "unsupported", which would be false — the
+   * browser is fine, there is simply no machine to be alerted about. And it is
+   * the reason the demo must not reach the code below: registering a worker
+   * would leave one installed on a public page for a feature that cannot work
+   * there, and offering the switch would ask a visitor for notification
+   * permission and then fail. Both of those shipped before this existed.
+   */
+  | "demo";
 
 /**
  * Is this an Apple phone or tablet?
@@ -103,9 +114,13 @@ export function pushStateOf(env: {
   return "off";
 }
 
-/** What the settings row says, for each of the five ways this can stand. */
+/** What the settings row says, for each of the six ways this can stand. */
 export function pushCopy(state: PushState): { sub: string; action: string | null } {
   switch (state) {
+    case "demo":
+      // No button, and it says why rather than pretending the browser is at
+      // fault: there is no machine behind the demo to be alerted about one.
+      return { sub: "Not in the demo — this needs agentglass running on your machine", action: null };
     case "needs-install":
       // No button, because there is nothing here to press — the action is in
       // Safari's share sheet. So the row has to name it, or it is the same
@@ -199,6 +214,8 @@ export interface PushEnv {
   /** Injected so the timeout above can be exercised without a 20s test. */
   sleep?: (ms: number) => Promise<void>;
   timeoutMs?: number;
+  /** The published demo: a static site, no server, nothing that can push. */
+  demo?: boolean;
 }
 
 export interface ServiceWorkerRegistrationLike {
@@ -253,6 +270,11 @@ function withTimeout<T>(p: Promise<T>, ms: number, sleep: (ms: number) => Promis
  * shipped worker is the one that will receive the next push.
  */
 export async function currentPushState(env: PushEnv): Promise<PushState> {
+  // First, and before anything is registered. The demo is served from a static
+  // host with no agentglass behind it, so a worker installed there could only
+  // ever sit on a stranger's browser doing nothing — and it would outlive the
+  // visit, with nothing in the UI able to remove it.
+  if (env.demo) return "demo";
   const cannot = (): PushState =>
     pushStateOf({ supported: false, permission: env.permission, subscribed: false, needsInstall: needsHomeScreen(env) });
   if (!env.sw || !env.hasPushManager) return cannot();
@@ -283,6 +305,10 @@ export async function currentPushState(env: PushEnv): Promise<PushState> {
  * first would fail on every phone, every time.
  */
 export async function enablePush(env: PushEnv): Promise<PushResult> {
+  // Never ask a demo visitor for notification permission. The prompt is the
+  // most intrusive thing this app can do to somebody who is only looking, and
+  // granting it would buy them nothing at all.
+  if (env.demo) return { ok: false, state: "demo", error: pushCopy("demo").sub };
   if (!env.sw || !env.hasPushManager) {
     return needsHomeScreen(env)
       ? { ok: false, state: "needs-install", error: pushCopy("needs-install").sub }
@@ -360,7 +386,7 @@ export function browserPushEnv(api: {
   pushKey: () => Promise<{ key: string }>;
   pushSubscribe: (sub: unknown, label: string) => Promise<{ ok: boolean; error?: string }>;
   pushUnsubscribe: (endpoint: string) => Promise<{ ok: boolean }>;
-}): PushEnv {
+}, demo = false): PushEnv {
   const nav = typeof navigator === "undefined" ? null : navigator;
   const canNotify = typeof Notification !== "undefined";
   // Two ways to be on the Home Screen, because the reliable one on iOS is
@@ -386,5 +412,6 @@ export function browserPushEnv(api: {
     getKey: api.pushKey,
     subscribe: api.pushSubscribe,
     unsubscribe: api.pushUnsubscribe,
+    demo,
   };
 }

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -1,5 +1,5 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
-import { api, probeServer } from "../lib/api.ts";
+import { api, probeServer, IS_DEMO } from "../lib/api.ts";
 import { useLive } from "../lib/useLive.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { subscribeSessionChanged } from "../lib/sessionBus.ts";
@@ -187,7 +187,7 @@ export function MobileApp() {
   // mount rather than only when the toggle is used: registering an unchanged
   // file is a no-op, and it means the worker that receives the next push is the
   // one that shipped, not one left over from an older build.
-  const pushEnv = useMemo(() => browserPushEnv(api), []);
+  const pushEnv = useMemo(() => browserPushEnv(api, IS_DEMO), []);
   useEffect(() => {
     let live = true;
     currentPushState(pushEnv).then((s) => { if (live) setPushState(s); });

--- a/web/test/webpush.test.ts
+++ b/web/test/webpush.test.ts
@@ -18,7 +18,7 @@ import {
   decodeKey, deviceLabel, pushCopy, pushStateOf,
   currentPushState, enablePush, disablePush,
   isApplePortable, needsHomeScreen, deviceIdOf, myDeviceId,
-  isOpenedFromNotification, OPENED_FROM_NOTIFICATION,
+  isOpenedFromNotification, OPENED_FROM_NOTIFICATION, browserPushEnv,
   type PushEnv, type PushState,
 } from "../src/lib/webpush.ts";
 import { since } from "../src/lib/format.ts";
@@ -170,14 +170,92 @@ describe("which of the three ways this can fail", () => {
     expect(pushCopy("blocked").action).toBeNull();
     expect(pushCopy("unsupported").action).toBeNull();
     expect(pushCopy("needs-install").action).toBeNull();
+    expect(pushCopy("demo").action).toBeNull();
     // And each says something different, so the row is never ambiguous.
-    const all: PushState[] = ["on", "off", "blocked", "unsupported", "needs-install"];
+    const all: PushState[] = ["on", "off", "blocked", "unsupported", "needs-install", "demo"];
     const subs = all.map((s) => pushCopy(s).sub);
     expect(new Set(subs).size).toBe(all.length);
     // None of them is empty, which is what a missing switch arm would produce.
     for (const s of subs) expect(s.length).toBeGreaterThan(10);
     // Blocked has to say where the switch actually is, since it is not here.
     expect(pushCopy("blocked").sub).toContain("browser");
+  });
+});
+
+describe("the published demo, which has no server behind it", () => {
+  // Both of these shipped before this test existed, on a public page.
+
+  it("registers no service worker at all", async () => {
+    // A worker installed from the demo would sit in a stranger's browser for a
+    // feature that cannot work there, outliving the visit, with nothing in the
+    // UI able to remove it.
+    const { env, calls } = fakeEnv({ demo: true });
+    expect(await currentPushState(env)).toBe("demo");
+    expect(calls.registered).toEqual([]);
+  });
+
+  it("never asks a visitor for notification permission", async () => {
+    // The most intrusive thing this app can do to somebody who is only
+    // looking — and granting it would buy them nothing, because the next step
+    // fails on a key no server is there to hand over.
+    const { env, calls } = fakeEnv({ demo: true });
+    const r = await enablePush(env);
+    expect(r.ok).toBe(false);
+    expect(r.state).toBe("demo");
+    expect(calls.permissionAsked).toBe(0);
+    expect(calls.subscribedWith).toEqual([]);
+    expect(calls.toldServer).toEqual([]);
+  });
+
+  it("says why, rather than blaming the browser", async () => {
+    expect(pushCopy("demo").action).toBeNull();
+    expect(pushCopy("demo").sub).not.toBe(pushCopy("unsupported").sub);
+    expect(pushCopy("demo").sub.toLowerCase()).toContain("demo");
+  });
+
+  it("leaves a real install alone", async () => {
+    // The flag is the only thing that turns this on; everything else behaves
+    // exactly as before.
+    const { env, calls } = fakeEnv({ permission: "granted" });
+    expect(await currentPushState(env)).toBe("off");
+    expect(calls.registered).toEqual(["./sw.js"]);
+  });
+});
+
+describe("the wiring between the app and all of the above", () => {
+  // browserPushEnv is where the flags are actually read, and it was the one
+  // part with no test — which is precisely where the demo bug lived. Two
+  // mutations proved it: `demo = true` as the default, and dropping the field
+  // on its way into the env, both changed nothing that anything checked.
+  const fakeApi = {
+    pushKey: async () => ({ key: "" }),
+    pushSubscribe: async () => ({ ok: false }),
+    pushUnsubscribe: async () => ({ ok: true }),
+  };
+
+  it("carries the demo flag all the way to the answer", async () => {
+    // Asserted through `currentPushState` rather than by reading the field
+    // back, so what is pinned is the behaviour and not the plumbing.
+    expect(await currentPushState(browserPushEnv(fakeApi, true))).toBe("demo");
+  });
+
+  it("does not call a real install a demo", async () => {
+    // The default matters: every other caller relies on it, and a `true`
+    // default would silently switch push off everywhere.
+    expect(await currentPushState(browserPushEnv(fakeApi))).not.toBe("demo");
+  });
+
+  it("builds without a browser at all", async () => {
+    // This module is imported by the desktop cockpit too, where `Notification`
+    // and `PushManager` may simply not exist. Reading a missing global is a
+    // ReferenceError, not undefined, so this has to be a probe rather than an
+    // access — and the failure would be at import time, taking the app with it.
+    const env = browserPushEnv(fakeApi);
+    expect(env.permission).toBe("denied");
+    expect(env.hasPushManager).toBe(false);
+    expect(typeof env.ua).toBe("string");
+    expect(env.standalone).toBe(false);
+    expect(await env.requestPermission()).toBe("denied");
   });
 });
 
@@ -205,6 +283,7 @@ describe("an iPhone in a browser tab", () => {
     // And the row names the actual gesture, since the button cannot be here.
     expect(pushCopy("needs-install").sub).toContain("Home Screen");
     expect(pushCopy("needs-install").action).toBeNull();
+    expect(pushCopy("demo").action).toBeNull();
     expect(pushCopy("needs-install").sub).not.toBe(pushCopy("unsupported").sub);
   });
 


### PR DESCRIPTION
## What does this PR do?

Two things shipped onto the **published demo** that should never have reached it. I only found them by driving the demo build itself, served at its real base path, rather than the build I had been testing all along.

The demo is a static site on GitHub Pages with no agentglass behind it. It still mounts the phone shell, and the shell registers the service worker on mount — so **visiting the demo installed a service worker** at `/agentglass/demo/`, for a feature that cannot work there, which outlived the visit with nothing in the UI able to remove it.

And the settings row offered **Turn on**. Pressing it asks a visitor for notification permission — the most intrusive thing this app can do to somebody who is only looking — and then fails on a key no server is there to hand over. That is the same dead button this work removed from every other state.

A sixth state, checked before anything is registered and before permission is requested. Not `unsupported`, which would be false and would blame the browser: the browser is fine, there is no machine to be alerted about one.

## How was it tested?

Against a real `build:demo`, served at `/agentglass/demo/` the way Pages serves it:

```
before   service workers registered: ["http://127.0.0.1:4099/agentglass/demo/"]
         row: "Get held gates on this phone, screen off"   [Turn on]

after    service workers registered: []
         row: "Not in the demo — this needs agentglass running on your machine"   (no button)
```

And the ordinary build re-driven end to end afterwards — on, Test, the device list, forget, off — unchanged.

Six mutations, all red. 170/170 phone audit checks. Suites green: 1111 server, 783 web.

## The two that walked through

Both were in `browserPushEnv` — the wiring that actually reads the flags, and the one part of this module with no test at all, which is precisely where the bug lived.

- `demo = true` as the parameter default: nothing failed.
- The flag dropped on its way into the env: nothing failed.

Either would have silently reintroduced exactly what this PR fixes. It is covered now, asserted *through the answer* rather than by reading the field back, plus that it builds at all where `Notification` and `PushManager` do not exist — which is the desktop cockpit, and where a missing-global read is a `ReferenceError` at import time that would take the app with it.
