### PR TITLE
The demo showed a phone the companion, which sells nothing

### DIFF
--- a/web/src/lib/viewport.ts
+++ b/web/src/lib/viewport.ts
@@ -34,7 +34,8 @@ export function wantsPhoneLayout(
   width: number,
   coarsePointer: boolean,
   override: LayoutOverride = null,
-  remote = false
+  remote = false,
+  demo = false
 ): boolean {
   // Ahead of the override on purpose: the choice a person made about the
   // laptop on their desk is not consent for the cockpit to open on a device
@@ -43,6 +44,21 @@ export function wantsPhoneLayout(
   if (remote) return true;
   if (override === "mobile") return true;
   if (override === "desktop") return false;
+  // The published demo is a different question to everything below it.
+  //
+  // Every rule here is about *capability*: a phone cannot drive a terminal, so
+  // it gets an application that does not have one. The demo has no capability
+  // at all — no terminal, no git, no docker, no server — so the only thing
+  // left is what a stranger should be shown, and that is the cockpit. It is
+  // the part that is hard to describe in words and the reason anyone follows
+  // the link; the companion is already explained on the landing page and in
+  // the README, with real screenshots.
+  //
+  // What a phone visitor got instead was a queue of fabricated approvals,
+  // which without any of that context reads as a to-do list. Below the
+  // override so that anyone who does want to see the companion demo still
+  // can, by setting it by hand.
+  if (demo) return false;
   if (width < 768) return true;
   // A touch device up to 900px is a phone in landscape. Beyond that it is a
   // tablet, which has the room for the real thing.
@@ -94,9 +110,28 @@ export function servedToRemoteDevice(): boolean {
   );
 }
 
-/** The live answer for this browser, right now. */
-export function phoneLayoutNow(): boolean {
+/**
+ * Is this the published demo?
+ *
+ * The same flag `demo.ts` reads, checked here rather than imported from it:
+ * this module is on the path to the first paint, and demo.ts is a thousand
+ * lines of fabricated fleet that a real install must never pull in to answer
+ * one boolean. Vite replaces the expression at build time either way.
+ */
+export const IS_DEMO_BUILD = import.meta.env.VITE_DEMO === "1";
+
+/**
+ * The live answer for this browser, right now.
+ *
+ * `demo` is a parameter with the build-time flag as its default, only so the
+ * threading is checkable: a test cannot observe a constant Vite has already
+ * substituted, and leaving it unreachable is how the flag came to be dropped
+ * here in the first place — a mutation deleting it changed nothing. What no
+ * unit test can cover is the value of the constant itself; that is what the
+ * browser drive against a real `build:demo` is for.
+ */
+export function phoneLayoutNow(demo = IS_DEMO_BUILD): boolean {
   if (typeof window === "undefined") return false;
   const coarse = typeof window.matchMedia === "function" && window.matchMedia("(pointer: coarse)").matches;
-  return wantsPhoneLayout(window.innerWidth, coarse, readOverride(), servedToRemoteDevice());
+  return wantsPhoneLayout(window.innerWidth, coarse, readOverride(), servedToRemoteDevice(), demo);
 }

--- a/web/test/viewport.test.ts
+++ b/web/test/viewport.test.ts
@@ -5,7 +5,7 @@
 // the git panel, and a phone that gets the cockpit has a terminal it cannot
 // type into. The saved override is the escape hatch from either.
 import { describe, expect, test, beforeEach } from "bun:test";
-import { wantsPhoneLayout, readOverride, LAYOUT_KEY } from "../src/lib/viewport.ts";
+import { wantsPhoneLayout, phoneLayoutNow, readOverride, LAYOUT_KEY } from "../src/lib/viewport.ts";
 
 describe("wantsPhoneLayout", () => {
   test("narrow viewports get the phone application", () => {
@@ -78,5 +78,68 @@ describe("readOverride", () => {
   test("survives storage that throws (private mode, blocked cookies)", () => {
     expect(readOverride({ getItem: () => { throw new Error("denied"); } })).toBe(null);
     expect(readOverride(null)).toBe(null);
+  });
+});
+
+describe("the published demo", () => {
+  // The demo is on GitHub Pages with nothing behind it, and every rule above
+  // is about capability: a phone gets its own application because it cannot
+  // drive a terminal. The demo has no terminal, no git, no docker and no
+  // server, so the only question left is what a stranger following the link
+  // should be shown — and that is the cockpit, which is the part that is hard
+  // to describe in words. The companion is already covered on the landing page
+  // and in the README, with real screenshots.
+
+  test("shows a phone the cockpit, which is what they came for", () => {
+    expect(wantsPhoneLayout(390, true, null, false, true)).toBe(false);
+    expect(wantsPhoneLayout(360, true, null, false, true)).toBe(false);
+    // And the same viewport off the demo still gets the companion.
+    expect(wantsPhoneLayout(390, true, null, false, false)).toBe(true);
+  });
+
+  test("changes nothing on a desk", () => {
+    expect(wantsPhoneLayout(1440, false, null, false, true)).toBe(false);
+    expect(wantsPhoneLayout(1440, false, null, false, false)).toBe(false);
+  });
+
+  test("still yields to somebody who asked for the companion by hand", () => {
+    // Nothing in the UI writes this, so it is the one way left to look at the
+    // companion demo on purpose. Losing that would make it unreachable.
+    expect(wantsPhoneLayout(390, true, "mobile", false, true)).toBe(true);
+    expect(wantsPhoneLayout(1440, false, "mobile", false, true)).toBe(true);
+  });
+
+  test("never lets the demo flag reach a device that came over the network", () => {
+    // Belt and braces: the demo is never served with the remote marker, but
+    // if the two ever met, the marker is a safety rule and must still win.
+    expect(wantsPhoneLayout(1440, false, null, true, true)).toBe(true);
+  });
+});
+
+describe("phoneLayoutNow, which is the part main.tsx actually calls", () => {
+  // The rule above was covered and the wiring to it was not, which is how the
+  // demo flag came to be dropped here — a mutation deleting it from this call
+  // changed nothing that anything checked.
+  const withWindow = (width: number, fn: () => void) => {
+    const g = globalThis as Record<string, unknown>;
+    const had = "window" in g;
+    const prev = g.window;
+    g.window = { innerWidth: width, matchMedia: () => ({ matches: true }) };
+    try { fn(); } finally { if (had) g.window = prev; else delete g.window; }
+  };
+
+  test("hands the demo flag to the rule", () => {
+    withWindow(390, () => {
+      expect(phoneLayoutNow(true)).toBe(false);   // demo: the cockpit
+      expect(phoneLayoutNow(false)).toBe(true);   // a real install: the companion
+    });
+  });
+
+  test("answers false where there is no browser at all", () => {
+    // Imported before React mounts, and on any server-side or test runtime
+    // `window` is simply absent — a bare read would be a ReferenceError that
+    // takes the whole app down at import time.
+    expect(phoneLayoutNow(true)).toBe(false);
+    expect(phoneLayoutNow(false)).toBe(false);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Nobody decided this. The layout rule was written for the live app and the demo inherited it: width under 768 gets the phone application, so anyone following the demo link **from a phone** landed on the companion.

Every rule in `wantsPhoneLayout` is about **capability**. A phone gets its own application because it cannot drive a terminal, a git panel or a docker table — a real constraint about a real machine. The demo has no capability at all: no terminal, no git, no docker, no server, no machine. So the only question left is what a stranger following the link should be shown, and that is the cockpit — the part that is hard to describe in words and the reason anyone clicks. The companion is already covered on the landing page and in the README, with real screenshots of it.

What a phone visitor got instead was a queue of fabricated approvals, which without any of that context reads as a to-do list.

**The cockpit at 390px turns out to be the easy part.** It reflows to a single column with no horizontal scrolling at all — `scrollWidth 390 = innerWidth 390` — showing spend, tokens, live agents, throughput, and every session grouped by project.

Placed **below the saved override**, so anybody who does want the companion demo can still reach it by hand — nothing in the UI writes that key, so it is the only way left. And **below the remote marker**, which is a safety rule and must keep winning.

The landing's hero iframe is unaffected: it already refuses to load below `980px`, so it was never showing the companion behind the glass.

## How was it tested?

Against real builds, driven in a browser:

```
before   demo at 390px      -> layout "phone",   phone shell present
after    demo at 390px      -> layout "desktop", the cockpit
and      ordinary build 390 -> layout "phone",   unchanged
```

170/170 phone audit checks. Suites green: 1111 server, 789 web.

## Six mutations, all red bar one — and that one is honest

`phoneLayoutNow`'s default is the build-time constant, and a test cannot observe a value Vite has already substituted, so a mutation changing `demo = IS_DEMO_BUILD` to `demo = false` passes.

That is stated rather than hidden. It is also why the flag is a *parameter* now: a mutation dropping it from the call to `wantsPhoneLayout` **did** walk through before, because nothing exercised `phoneLayoutNow` at all — the rule was covered and the wiring to it was not. The threading is pinned now; the constant is covered by driving a real `build:demo`.

That is the third time in this run of work that the untested wiring, rather than the tested logic, was where the bug actually lived.
