### PR TITLE
The tabs now say which agent wants you (#tmux tab flash)

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,6 +196,17 @@ straight to tmux, and the tabs follow. The point is that the window list stops
 being the one strip of the workspace themed by whichever `.tmux.conf` the
 machine happens to carry.
 
+A tab **flashes** when the agent in that window wants you: amber because it
+stopped to ask something, green because its turn ended. Four agents in four
+windows, and the strip says which one, not just that something happened. The
+mark is tmux's own `@ai_state` window option, set by agentglass's `Stop` and
+`Notification` hooks and cleared the moment you switch to the window, so
+anything else can raise it too:
+
+```bash
+tmux set-option -w -t "$TMUX_PANE" @ai_state done   # or: waiting
+```
+
 **If a shell ever renders solid white,** switch **Settings ▸ Preferences ▸
 Terminal renderer** to *Compatibility*. xterm's GPU renderer is fast, but on
 some Linux GPU/compositor stacks it paints the terminal blank with no catchable

--- a/hooks/send_event.py
+++ b/hooks/send_event.py
@@ -15,10 +15,69 @@ Env:
 import argparse
 import json
 import os
+import shutil
+import subprocess
 import sys
 import urllib.request
 
 DEFAULT_SERVER = os.environ.get("AGENTGLASS_SERVER", "http://localhost:4000")
+
+# What each event means to a tmux tab. None clears the mark: the user is driving
+# this window again, so it has nothing to ask for.
+TMUX_STATE = {
+    "Stop": "done",
+    "Notification": "waiting",
+    "UserPromptSubmit": None,
+    "SessionStart": None,
+    "SessionEnd": None,
+}
+
+
+def mark_tmux_window(event_type):
+    """Tell the tmux window this agent runs in what it wants, if anything.
+
+    The terminal panel draws tmux's windows as tabs and flashes the ones with a
+    state set, which is the only way to see which of four agents stopped when
+    all four are off screen. The mark is a plain tmux user option, so tmux is
+    the one holding the state and anything else can read or set it too.
+
+    Best effort throughout: an agent must never fail a turn because a status
+    colour could not be set.
+    """
+    if event_type not in TMUX_STATE:
+        return
+    pane = os.environ.get("TMUX_PANE")
+    if not pane or not os.environ.get("TMUX"):
+        return
+    tmux = shutil.which("tmux")
+    if not tmux:
+        return
+    state = TMUX_STATE[event_type]
+    try:
+        if state is None:
+            subprocess.run([tmux, "set-option", "-w", "-q", "-t", pane, "-u", "@ai_state"],
+                           timeout=2, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+            return
+        # Don't flash the window the user is already looking at, as long as
+        # somebody is there to look: a state set on a detached session still has
+        # to be waiting when its user comes back.
+        #
+        # Two calls rather than one command list. `display-message ; list-clients`
+        # answers only the first half from a hook's context, which is how this
+        # went out flagging the window it was told to leave alone.
+        # (`#{session_attached}` is no use either: it reports 0 whenever the
+        # command has no client of its own, which is always the case here.)
+        current = subprocess.run([tmux, "display-message", "-p", "-t", pane, "#{window_active}"],
+                                 capture_output=True, text=True, timeout=2)
+        if current.stdout.strip() == "1":
+            seen = subprocess.run([tmux, "list-clients", "-F", "c"],
+                                  capture_output=True, text=True, timeout=2)
+            if seen.stdout.strip():
+                return
+        subprocess.run([tmux, "set-option", "-w", "-q", "-t", pane, "@ai_state", state],
+                       timeout=2, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+    except Exception:
+        pass
 
 def _agentglass_local_only(url):
     """Refuse to send transcript/telemetry anywhere but this machine.
@@ -84,6 +143,10 @@ def main():
     session_id = payload.get("session_id") or payload.get("sessionId") or "unknown"
     event_type = args.event_type or payload.get("hook_event_name") or "Unknown"
     model_name = payload.get("model") or payload.get("model_name") or args.model_name
+
+    # Before the POST: the tab should light up the moment the turn ends, not
+    # after a server round trip that may be timing out.
+    mark_tmux_window(event_type)
 
     chat = None
     if args.add_chat:

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -162,6 +162,12 @@ const WINDOW_ID = /^@\d+$/;
  * `#` activity, `Z` zoomed). They are passed through rather than interpreted
  * here: the panel decides what to show, and tmux stays the single source of
  * truth for what is true.
+ *
+ * `@ai_state` is the one field tmux does not set itself: it is a user option on
+ * the window, which an agent's own hooks write when it finishes a turn or stops
+ * to ask something. Unknown values are dropped rather than passed on, because
+ * this ends up choosing a colour and a half-written option should not paint a
+ * tab a colour nothing else in the app uses.
  */
 export function parseWindows(out: string): TmuxWindow[] {
   const windows: TmuxWindow[] = [];
@@ -169,10 +175,18 @@ export function parseWindows(out: string): TmuxWindow[] {
     if (!line.trim()) continue;
     // Tab-separated, because window names routinely contain spaces and a
     // space-separated format would split "npm run dev" into three windows.
-    const [id, index, name, active, flags] = line.split("\t");
+    const [id, index, name, active, flags, state] = line.split("\t");
     const i = Number(index);
     if (!WINDOW_ID.test(id ?? "") || !Number.isInteger(i)) continue;
-    windows.push({ id: id!, index: i, name: name ?? "", active: active === "1", flags: (flags ?? "").trim() });
+    const attention = state?.trim();
+    windows.push({
+      id: id!,
+      index: i,
+      name: name ?? "",
+      active: active === "1",
+      flags: (flags ?? "").trim(),
+      attention: attention === "waiting" || attention === "done" ? attention : null,
+    });
   }
   return windows;
 }
@@ -210,11 +224,22 @@ export function readFrame(c: TmuxClient): TmuxFrame | null {
     "list-clients", "-F", "c\t#{client_tty}\t#{session_name}\t#{session_id}",
     ";",
     "list-windows", "-a",
-    "-F", "w\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}",
+    "-F", "w\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}\t#{@ai_state}",
   ]);
   if (!out) return null;
   const f = parseFrame(out, c.tty);
-  return f ? { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows } : null;
+  if (!f) return null;
+  // The window you are on cannot be asking for your attention, so a state left
+  // on it is dropped here rather than rendered. `runAction` clears it when the
+  // panel does the switching; this catches the other half, where the user
+  // switched with `^b n` and tmux told nobody. Costs a second spawn only in the
+  // one poll after that happens.
+  const stale = f.windows.find((w) => w.active && w.attention);
+  if (stale) {
+    tmux(c.socket, ["set-option", "-w", "-q", "-t", stale.id, "-u", "@ai_state"]);
+    stale.attention = null;
+  }
+  return { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows };
 }
 
 /**
@@ -300,7 +325,16 @@ export function runAction(t: TmuxTarget, action: TmuxAction, window?: string, na
   const id = WINDOW_ID.test(window ?? "") ? window! : null;
   switch (action) {
     case "select":
-      return id === null ? false : tmux(t.socket, ["select-window", "-t", id]) !== null;
+      // Selecting a window also drops its `@ai_state`, in the same tmux call:
+      // the tab was flashing to get you here, and you are here. tmux clears its
+      // own bell flag on select for the same reason, but it knows nothing about
+      // a user option, and leaving that to a `pane-focus-in` hook in the user's
+      // config would mean the flash only ever stops for people who have one.
+      return id === null ? false : tmux(t.socket, [
+        "select-window", "-t", id,
+        ";",
+        "set-option", "-w", "-q", "-t", id, "-u", "@ai_state",
+      ]) !== null;
     case "new":
       // At the end, which is tmux's default and where the button is.
       //

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -14,8 +14,8 @@ describe("reading tmux's window list", () => {
   test("id, index, name, active flag and tmux's own marks", () => {
     const out = "@0\t1\tAI01\t0\t-\n@4\t2\tlazygit\t1\t*\n";
     expect(parseWindows(out)).toEqual([
-      { id: "@0", index: 1, name: "AI01", active: false, flags: "-" },
-      { id: "@4", index: 2, name: "lazygit", active: true, flags: "*" },
+      { id: "@0", index: 1, name: "AI01", active: false, flags: "-", attention: null },
+      { id: "@4", index: 2, name: "lazygit", active: true, flags: "*", attention: null },
     ]);
   });
 
@@ -29,7 +29,7 @@ describe("reading tmux's window list", () => {
 
   test("a window with no name is not dropped", () => {
     const [w] = parseWindows("@7\t4\t\t0\t\n");
-    expect(w).toEqual({ id: "@7", index: 4, name: "", active: false, flags: "" });
+    expect(w).toEqual({ id: "@7", index: 4, name: "", active: false, flags: "", attention: null });
   });
 
   test("blank lines and unparseable indexes are skipped, not guessed at", () => {
@@ -44,6 +44,21 @@ describe("reading tmux's window list", () => {
     const [bell, activity] = parseWindows("@0\t1\tbuild\t0\t!\n@1\t2\ttest\t0\t#\n");
     expect(bell!.flags).toBe("!");
     expect(activity!.flags).toBe("#");
+  });
+
+  test("an agent's own state comes back as the tab's attention", () => {
+    const [waiting, done] = parseWindows("@0\t1\tAI00\t0\t\twaiting\n@1\t2\tAI01\t0\t\tdone\n");
+    expect(waiting!.attention).toBe("waiting");
+    expect(done!.attention).toBe("done");
+  });
+
+  test("a state nothing recognises is dropped, not passed on", () => {
+    // It picks a colour at the far end. A half-written option, or one somebody
+    // else's tooling set for its own purposes, should leave the tab alone.
+    expect(parseWindows("@0\t1\tAI00\t0\t\tthinking\n")[0]!.attention).toBeNull();
+    expect(parseWindows("@0\t1\tAI00\t0\t\t\n")[0]!.attention).toBeNull();
+    // tmux servers older than the format change answer without the column.
+    expect(parseWindows("@0\t1\tAI00\t0\t-\n")[0]!.attention).toBeNull();
   });
 });
 
@@ -88,11 +103,16 @@ describe("which session the client is on", () => {
     expect(parseFrame("", "/dev/pts/0")).toBeNull();
   });
 
+  test("the agent's state survives the trip through the tagged frame", () => {
+    const f = parseFrame("c\t/dev/pts/0\tmain\t$2\nw\t$2\t@1\t1\tAI00\t0\t\twaiting", "/dev/pts/0");
+    expect(f!.windows[0]!.attention).toBe("waiting");
+  });
+
   test("window names with tabs in them do not smuggle a session id", () => {
     // The name is the last-but-two field and is not re-split, so this is a
     // window called what it says, in $2, and not one in $7.
     const f = parseFrame("c\t/dev/pts/0\tmain\t$2\nw\t$2\t@1\t1\tnpm run dev\t1\t*", "/dev/pts/0");
-    expect(f!.windows).toEqual([{ id: "@1", index: 1, name: "npm run dev", active: true, flags: "*" }]);
+    expect(f!.windows).toEqual([{ id: "@1", index: 1, name: "npm run dev", active: true, flags: "*", attention: null }]);
   });
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -281,6 +281,14 @@ export interface StatsSummary {
   retention_days?: number;
 }
 
+/** What an agent running in a tmux window says it wants from you: `waiting` for
+ *  a question it has asked, `done` for a turn it has finished. Read from the
+ *  window's own `@ai_state` option, which `hooks/send_event.py` sets from the
+ *  agent's Stop and Notification hooks. A plain tmux option rather than
+ *  something of ours, so a build script or another agent can flash a tab with
+ *  one line: `tmux set-option -w -t "$TMUX_PANE" @ai_state done`. */
+export type TmuxAttention = "waiting" | "done" | null;
+
 /** One tmux window, as tmux itself reports it. The panel renders these as its
  *  own tabs; tmux stays the source of truth for which is active. `flags` is
  *  tmux's own marks (`*` current, `-` last, `!` bell, `#` activity, `Z` zoomed),
@@ -294,6 +302,9 @@ export interface TmuxWindow {
   name: string;
   active: boolean;
   flags: string;
+  /** Absent in demo mode's older payloads, and null whenever nothing has
+   *  claimed the window. */
+  attention?: TmuxAttention;
 }
 
 /** A tool call held at the gate, awaiting a remote approve/deny. */

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -1393,16 +1393,43 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       // one pane is filling the window and the others are still
                       // there, which is confusing precisely when it is invisible.
                       const zoomed = w.flags.includes("Z");
+                      // An agent in the window has said what it wants: amber
+                      // because it asked you something, green because its turn
+                      // ended. A dot was not enough here. These tabs are how you
+                      // watch four agents at once, and the thing you need to see
+                      // from across the room is which one of the four, not that
+                      // one of them did something.
+                      //
+                      // Never on the tab you are looking at: whatever it wanted
+                      // to tell you is on screen, and the state is cleared the
+                      // moment the window is selected anyway. Painting it first
+                      // would only flash once on every switch.
+                      const attention = w.id === activeWindow ? null : w.attention ?? null;
+                      const attentionColor = attention === "waiting" ? "var(--warning)" : "var(--success)";
                       return (
                         <div key={w.id}
                           onClick={() => { if (w.id !== activeWindow) { setPendingWindow(w.id); tmuxCmd("select", { window: w.id }); } }}
                           onDoubleClick={() => setRenaming(w.id)}
-                          title={`Window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
+                          title={attention
+                            ? `Window ${w.index}: ${attention === "waiting" ? "asking you something" : "finished its turn"}${w.flags ? ` (${w.flags})` : ""}, double-click to rename`
+                            : `Window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
                           className="group flex items-center gap-1.5 px-2 py-1 rounded-md text-[10.5px] cursor-pointer shrink-0"
+                          // Every branch carries a border, transparent when it
+                          // has nothing to say, so a tab lighting up does not
+                          // shove the strip a pixel sideways.
                           style={w.id === activeWindow
-                            ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)" }
-                            : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)" }}>
-                          <span className="tabular-nums" style={{ color: "var(--text4)" }}>{w.index}</span>
+                            ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)", border: "1px solid transparent" }
+                            : attention
+                              ? {
+                                  background: `color-mix(in srgb, ${attentionColor} 22%, transparent)`,
+                                  color: attentionColor,
+                                  border: `1px solid color-mix(in srgb, ${attentionColor} 60%, transparent)`,
+                                  animation: "agx-attention 1.8s ease-in-out infinite",
+                                }
+                              : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)", border: "1px solid transparent" }}>
+                          {/* The index inherits the tab's colour while it is
+                              flashing; --text4 on an amber pill is unreadable. */}
+                          <span className="tabular-nums" style={attention ? undefined : { color: "var(--text4)" }}>{w.index}</span>
                           {renaming === w.id ? (
                             <input
                               autoFocus
@@ -1428,8 +1455,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                             <span>{w.name || "shell"}</span>
                           )}
                           {zoomed && <span className="text-[9px] font-semibold leading-none" style={{ color: "var(--text4)" }} title="A pane in this window is zoomed">⤢</span>}
-                          {bell && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--error)" }} title="Bell" />}
-                          {!bell && activity && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="Activity" />}
+                          {/* The dots stand down while the whole tab is
+                              flashing: a bell rung by the same turn that set
+                              the state is the same news twice. */}
+                          {!attention && bell && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--error)" }} title="Bell" />}
+                          {!attention && !bell && activity && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="Activity" />}
                           <button onClick={(e) => { e.stopPropagation(); tmuxCmd("kill", { window: w.id }); }}
                             className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="Close window (kill-window)">✕</button>
                         </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -628,10 +628,15 @@
 /* A chat that replied while you were elsewhere. Deliberately a slow, low-
    contrast breath rather than a hard blink: it sits in a header you look at
    all day, and something that flashes urgently for a message that can wait
-   trains you to ignore it. */
+   trains you to ignore it.
+
+   The halo is drawn in currentColor so one keyframe serves every caller: the
+   element already has to set a colour to look like it means anything, and a
+   tmux tab breathing amber for "it asked you something" reads differently from
+   a chat breathing green for "it replied". */
 @keyframes agx-attention {
-  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 40%, transparent); }
-  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, var(--success) 0%, transparent); }
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 40%, transparent); }
+  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 0%, transparent); }
 }
 @media (prefers-reduced-motion: reduce) {
   @keyframes agx-attention { 0%, 100% { box-shadow: none; } }


### PR DESCRIPTION
## What does this PR do?

A tmux tab in the terminal panel now **flashes** when the agent in that window wants you: amber because it stopped to ask something, green because its turn ended. With four agents in four windows, the bell dot said *something happened over there*, but not which of the four, and not whether it needed an answer.

The state is one tmux **window** option, `@ai_state` (`waiting` | `done`):

- `hooks/send_event.py` sets it from the hooks it already runs on: `Notification` asks, `Stop` finishes, `UserPromptSubmit` clears it because you are driving again. It never flags the window you are looking at.
- The panel reads it back with the window list at no extra cost: one more field in a format string the server already sends.
- It clears the moment you reach the window, by `runAction("select")` when the panel did the switching and on the next poll when `^b n` did.

A tab with a state does not get a dot, it becomes the colour, breathing on the same keyframe the chat header uses (now drawn in `currentColor`, so one keyframe serves both). Keeping the state in tmux rather than in our own store means it survives the panel being closed and anything else can raise a tab with one line:

```bash
tmux set-option -w -t "$TMUX_PANE" @ai_state done
```

`shared/types.ts` carries the new `TmuxAttention` type; the README section on the tmux tabs documents the behaviour and the one-liner.

## How was it tested?

- `bunx tsc --noEmit` in `web/` and `server/`, clean.
- `cd web && bun run build`, clean.
- `cd server && bun test --timeout 20000`: 1113 pass, 1 fail. The failure is `webui > resolveDist > blank and unset fall through to the fallback`, which fails identically on unmodified `main` on this machine, so it is pre-existing and unrelated.
- `cd web && bun test`: 789 pass.
- New unit tests for the parse: a state read back as `waiting` / `done`, an unrecognised or empty value dropped rather than passed on, an older format with no column reading as null, and the state surviving the trip through the tagged frame.
- Exercised against a live tmux: the hook flags a background window and leaves the focused one alone, and the desktop app was rebuilt with `electron/install-local.sh` and the tabs watched while agents finished turns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)