### PR TITLE
A branch merged yesterday said "not merged" until a ref happened to move

### DIFF
--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1066,11 +1066,17 @@ function applyMemo(root: string, key: string, set: Set<string>): void {
   }
 }
 
+/** The key every merged-set cache is filed under: one repo, one trunk.
+ *
+ *  `\u0000` rather than a raw NUL byte: written literally it makes the whole
+ *  file `data` to grep, which then skips it silently — you get no matches and
+ *  no warning. Same separator, same keys, still greppable. Written once here
+ *  rather than at each use, so `sweepInFlight` cannot drift from the key the
+ *  sweep is actually filed under and answer "no sweep is running" forever. */
+const mergedKey = (root: string, ref: string) => `${root}\u0000${ref}`;
+
 async function mergedInto(root: string, ref: string): Promise<Set<string>> {
-  // \u0000 rather than a raw NUL byte: written literally it makes the whole
-  // file `data` to grep, which then skips it silently — you get no matches
-  // and no warning. Same separator, same keys, still greppable.
-  const key = `${root}\u0000${ref}`;
+  const key = mergedKey(root, ref);
   const hit = mergedCache.get(key);
   if (hit && Date.now() - hit.at < MERGED_TTL_MS) return hit.set;
   // 644ms on a repo with a long history — the single most expensive call in
@@ -1098,9 +1104,22 @@ async function mergedInto(root: string, ref: string): Promise<Set<string>> {
  * absent: the UI reads that as "we don't know" and keeps the delete
  * confirmation, which is the safe direction to be wrong in. So the list goes
  * out immediately and the sweep fills the very Set the cache entry holds, in
- * place, so the next poll serves the fuller answer with no extra request — and
- * records each verdict in probeMemo, which is what carries it past the moment
- * that Set is thrown away and rebuilt.
+ * place, and records each verdict in probeMemo, which is what carries it past
+ * the moment that Set is thrown away and rebuilt.
+ *
+ * Filling the Set is not enough on its own, and that was the bug: the answer
+ * this endpoint serves is a JSON string cached against a fingerprint of every
+ * ref, so it is only rebuilt when a ref MOVES. A sweep moves no refs. On a
+ * repository nobody is committing to, which is exactly the repository you sit
+ * down to tidy, the pre-sweep answer was served forever, and a branch whose PR
+ * was squash-merged read "not merged, kept" until something unrelated happened
+ * to move a ref. Measured on this repo: a branch merged 17 hours earlier, still
+ * reported unmerged, two forced fingerprint changes needed to see the truth.
+ *
+ * So a sweep that changes a verdict says so. The hook clears that cached body
+ * and nudges the clients, which is the one thing the sweep could not do for
+ * itself. Fired once, when the sweep finishes, and only when it actually proved
+ * something: a sweep that learns nothing must not cost a rebuild.
  *
  * Newest first: that's the order for-each-ref gives with this sort, and the
  * order that spends the probe budget where deletes actually happen.
@@ -1123,7 +1142,15 @@ function sweepProbes(root: string, ref: string, key: string, set: Set<string>): 
   let idx = 0;
   let probes = 0;
   let started = false;
+  let proved = 0;
   let all: [string, string][] = [];
+  const finish = () => {
+    probeRunning.delete(key);
+    // Only when the sweep changed the answer. Announcing an empty sweep would
+    // invalidate a cached response and wake every open panel to redraw the
+    // identical list, on a five-minute clock, forever.
+    if (proved) { try { onMergedVerdicts?.(root); } catch { /* a listener must not break the sweep */ } }
+  };
   const step = () => {
     try {
       if (!started) { all = [...branchTips(root)]; started = true; }
@@ -1138,6 +1165,7 @@ function sweepProbes(root: string, ref: string, key: string, set: Set<string>): 
           // sees the fuller answer without another sweep — and the memo keeps
           // it once that Set expires.
           set.add(name);
+          proved++;
           let memo = probeMemo.get(key);
           if (!memo) probeMemo.set(key, (memo = new Map()));
           memo.set(name, sha);
@@ -1146,13 +1174,41 @@ function sweepProbes(root: string, ref: string, key: string, set: Set<string>): 
         return;
       }
       probedAt.set(key, Date.now());
-      probeRunning.delete(key);
+      finish();
     } catch {
       // A failed sweep just leaves the ancestry answer standing.
-      probeRunning.delete(key);
+      finish();
     }
   };
   setTimeout(step, 0);
+}
+
+/**
+ * Told when a sweep proved something ancestry could not see.
+ *
+ * A hook for the same reason `setGitChangeHook` is one: this module must not
+ * import the HTTP layer. What the listener does with it (drop the cached
+ * `/git/branches` body, nudge the clients) is the server's business, and both
+ * of those are things only the server can do.
+ */
+let onMergedVerdicts: ((root: string) => void) | null = null;
+export function setMergedVerdictHook(fn: ((root: string) => void) | null): void { onMergedVerdicts = fn; }
+
+/**
+ * Is a sweep still running for this root's trunk?
+ *
+ * A flag like this was tried once and removed, because it was asked from inside
+ * `branches()`, which is the very call that schedules the sweep, so it always
+ * answered yes and the label it drove never went away. Two things make it
+ * honest now: a completed sweep is remembered for PROBE_TTL_MS, so this reads
+ * false for minutes at a time; and the sweep now announces itself when it ends,
+ * so whatever the flag explains stops being true on screen without a poll.
+ *
+ * The panel uses it for one thing only: not calling a branch "not merged"
+ * while the check that could clear it is still running.
+ */
+export function sweepInFlight(root: string, ref: string): boolean {
+  return probeRunning.has(mergedKey(root, ref));
 }
 
 
@@ -1183,9 +1239,9 @@ export function invalidateMerged(root?: string): void {
 }
 
 
-export async function branches(rootIn: unknown): Promise<{ current: string; branches: GitBranch[]; trunk: string | null }> {
+export async function branches(rootIn: unknown): Promise<{ current: string; branches: GitBranch[]; trunk: string | null; checking: boolean }> {
   const root = repoRoot(rootIn);
-  if (!root) return { current: "", branches: [], trunk: null };
+  if (!root) return { current: "", branches: [], trunk: null, checking: false };
   const fmt = `%(refname:short)${US}%(HEAD)${US}%(upstream:short)${US}%(upstream:track)${US}%(committerdate:relative)${US}%(contents:subject)`;
   // The ref list and the trunk lookup are independent; run them together and
   // off the loop (this recomputes on /git/branches whenever a ref moves).
@@ -1206,13 +1262,19 @@ export async function branches(rootIn: unknown): Promise<{ current: string; bran
       ...(merged ? { mergedIntoTrunk: merged.has(name) } : {}),
     });
   }
-  // No "still sweeping" flag here, deliberately. mergedInto() above is what
-  // schedules the sweep, so asking whether one is running always answered yes:
-  // the sweep is a setTimeout and cannot have run yet within this call. The
-  // flag was a question asked immediately after switching it on. The count
-  // settling a beat later is the honest behaviour, and a permanent label
-  // explaining it was worse than the thing it explained.
-  return { current: await currentBranch(root), branches: list, trunk };
+  // A "still sweeping" flag lived here once and was taken out, because
+  // mergedInto() above is what schedules the sweep: asked immediately after
+  // switching it on, it always answered yes, and the label it drove never went
+  // away. What was missing then was the other half: nothing ever told the
+  // panel the sweep had finished, so the flag had no end and the count it
+  // qualified never settled on screen either.
+  //
+  // Both halves exist now. The sweep announces itself when it proves something
+  // (setMergedVerdictHook), and a finished sweep is remembered for
+  // PROBE_TTL_MS, so this reads false for minutes at a time rather than always.
+  // It says one thing: "not merged" is not the final answer yet. The panel uses
+  // it for exactly that and nothing else.
+  return { current: await currentBranch(root), branches: list, trunk, checking: trunk ? sweepInFlight(root, trunk) : false };
 }
 
 // lazygit-style branch ops

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -42,7 +42,7 @@ import {
   branches as gitBranches, checkout as gitCheckout, createBranch, deleteBranch,
   log as gitLog, commitDiff, stashList, stashPush, stashApply, stashPop, stashDrop,
   applyHunk, logGraph, mergeBranch, rebaseBranch, renameBranch, resetTo,
-  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, rescueLeftovers, fixWorktreeOwnership, startAutoFetch, syncFromBase, setBase, setGitChangeHook,
+  worktreesWithState as gitWorktrees, addWorktree, removeWorktree, worktreeLeftovers, rescueLeftovers, fixWorktreeOwnership, startAutoFetch, syncFromBase, setBase, setGitChangeHook, setMergedVerdictHook,
   conflicts as gitConflicts, resolveWith, conflictBlocks, resolveBlocks, mergeAbort, mergeContinue, baseCandidates, undoMerge,
   remotes as gitRemotes, remoteBranches as gitRemoteBranches, trackRemoteBranch, tags as gitTags, reflog as gitReflog,
 } from "./gitwork.ts";
@@ -323,6 +323,28 @@ const treeCache = new Map<string, { at: number; data: WorkingTree }>();
 const WORKTREES_TTL_MS = 2_500;
 const worktreesCache = new Map<string, { at: number; body: string }>();
 setGitChangeHook(() => { treeCache.clear(); worktreesCache.clear(); broadcast({ type: "git" }); });
+
+/**
+ * The one thing the merged-branch sweep cannot do for itself.
+ *
+ * `whileRefsHoldAsync` above is right about almost everything it caches: if not
+ * one ref has moved, last time's answer is identical, not stale. The sweep that
+ * recognises squash- and rebase-merged branches is the exception, because it
+ * changes the ANSWER without touching a ref, and on the repository you are
+ * actually tidying, nothing else moves a ref either. So the pre-sweep body was
+ * served indefinitely and a branch merged yesterday read "not merged, kept"
+ * until an unrelated commit happened to invalidate the fingerprint.
+ *
+ * Every `branches:` body goes, not just this root's: the cache is keyed by the
+ * QUERY root, which is any worktree of the repo, while the sweep knows only the
+ * repo root. There are at most forty entries and rebuilding one costs a cached
+ * read, so dropping them all is cheaper than being subtly wrong about which
+ * checkout the panel is looking at.
+ */
+setMergedVerdictHook(() => {
+  for (const k of refsCache.keys()) if (k.startsWith("branches:")) refsCache.delete(k);
+  broadcast({ type: "git" });
+});
 // Let the alert path reach a connected client, which raises a native OS
 // notification (cross-platform) instead of the Linux-only notify-send.
 setAlertSink({ broadcast: (a) => broadcast({ type: "alert", data: a }), hasClients: () => clients.size > 0 });

--- a/server/test/branch-merged.test.ts
+++ b/server/test/branch-merged.test.ts
@@ -189,4 +189,71 @@ describe("mergedIntoTrunk", () => {
   });
 });
 
+/**
+ * A verdict nobody can read is not a verdict.
+ *
+ * Everything above proves the sweep reaches the right answer. It reached it in
+ * production too, and no user ever saw it: `/git/branches` serves a JSON body
+ * cached against a fingerprint of every ref, rebuilt only when a ref MOVES, and
+ * a sweep moves no refs. On a repository nobody is committing to, which is the
+ * one you sit down to tidy, the pre-sweep answer was served forever. Measured
+ * on this project: a branch squash-merged 17 hours earlier, still listed as "1
+ * not merged, kept", and two forced ref changes needed to shake it loose.
+ *
+ * So the sweep now says when it proved something, and that announcement is what
+ * drops the cached body and nudges the panel. These pin both halves: that it
+ * fires when there is news, and that it stays quiet when there is not, because
+ * an announcement per sweep would invalidate a good cache and redraw every open
+ * panel on a five-minute clock forever.
+ */
+describe("a proved verdict reaches the panel", () => {
+  const fired: string[] = [];
+  const waitFor = async (want: number, ms = 5000) => {
+    const deadline = Date.now() + ms;
+    while (fired.length < want && Date.now() < deadline) await Bun.sleep(25);
+    return fired.length;
+  };
+
+  test("the sweep announces the repo it proved something in", async () => {
+    gw.setMergedVerdictHook((root) => { fired.push(root); });
+    try {
+      gw.invalidateMerged(REPO);
+      await gw.branches(REPO); // schedules the sweep; answers from ancestry alone
+      expect(await waitFor(1)).toBeGreaterThan(0);
+      expect(fired[0]).toBe(REPO);
+    } finally { gw.setMergedVerdictHook(null); }
+  });
+
+  test("a sweep with nothing new to say stays quiet", async () => {
+    gw.setMergedVerdictHook((root) => { fired.push(root); });
+    try {
+      fired.length = 0;
+      // No invalidation: the sweep ran moments ago and declines to run again,
+      // which is exactly the poll the panel makes every few seconds.
+      for (let i = 0; i < 3; i++) await gw.branches(REPO);
+      await Bun.sleep(200);
+      expect(fired).toEqual([]);
+    } finally { gw.setMergedVerdictHook(null); }
+  });
+});
+
+/**
+ * "Not merged" and "not checked yet" are different things, and the panel now
+ * shows them differently: while a sweep is running it says it is still
+ * checking, instead of stating a false negative as final.
+ *
+ * A flag like this existed once and was removed for answering yes forever, and
+ * it deserved to be: nothing told the panel when the sweep finished, so the
+ * label had no end. Both properties are pinned here, in order.
+ */
+describe("checking", () => {
+  test("is true while the sweep runs, and false once it has", async () => {
+    gw.invalidateMerged(REPO);
+    expect((await gw.branches(REPO)).checking).toBe(true);
+    const deadline = Date.now() + 5000;
+    while ((await gw.branches(REPO)).checking && Date.now() < deadline) await Bun.sleep(25);
+    expect((await gw.branches(REPO)).checking).toBe(false);
+  });
+});
+
 afterAll(() => setSystemTime());

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -7,7 +7,7 @@ import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, FileChange, WalkthroughResult, WalkthroughFile } from "../../../shared/types.ts";
-import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody } from "../lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, forcedDeletePrompt } from "../lib/goneCleanup.ts";
 import { RescueModal } from "./RescueModal.tsx";
 import { useDialogs } from "./ConfirmDialog.tsx";
 import { api } from "../lib/api.ts";
@@ -464,7 +464,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const [repoOpen, setRepoOpen] = useState(false);
   const [repoQuery, setRepoQuery] = useState("");
   // branches / log / stashes / worktrees
-  const [branchData, setBranchData] = useState<{ current: string; branches: GitBranch[]; trunk?: string | null }>({ current: "", branches: [] });
+  const [branchData, setBranchData] = useState<{ current: string; branches: GitBranch[]; trunk?: string | null; checking?: boolean }>({ current: "", branches: [] });
   const [newBranch, setNewBranch] = useState("");
   const [graph, setGraph] = useState<GitGraphLine[]>([]);
   const [stashes, setStashes] = useState<GitStash[]>([]);
@@ -810,10 +810,19 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
    *     kind of thing this panel exists to avoid.
    *   * "not fully merged" — true of every squash-merged branch, which is most
    *     of them here: the PR landed as a new commit, so the branch tip is not
-   *     an ancestor of anything. Only offer the forced retry when we've already
-   *     verified the work is in the trunk (`mergedIntoTrunk`, computed against
-   *     the trunk rather than whatever HEAD happens to be). Without that proof
-   *     the refusal is correct and stands.
+   *     an ancestor of anything. Both answers to "is it really merged?" get a
+   *     way forward, and they are not the same way:
+   *
+   *       - Proven (`mergedIntoTrunk`, computed against the trunk rather than
+   *         whatever HEAD happens to be): git's refusal is the stale one, the
+   *         dialog says so, and the forced retry is a formality.
+   *       - Not proven: the refusal might be right, and it might be one of the
+   *         gaps the server's own probes admit to (a branch whose only commits
+   *         ahead are merges; a repo with more branches than one sweep checks).
+   *         Being unable to tell those apart is not a reason to leave someone
+   *         with a toast that vanishes and no next step, so the delete is still
+   *         offered, named as unproven, with what it would cost and the reflog
+   *         window that can undo it.
    *
    * Deliberately not routed through `act`: it reports failures by flashing the
    * message and returns a bare boolean, and the whole point here is to branch
@@ -840,9 +849,9 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
         reloadWorktrees();
         r = await api.gitBranchDelete(root, b.name, false);
       }
-      if (!r.ok && /not fully merged/i.test(r.error || "") && b.mergedIntoTrunk) {
-        const trunk = branchData.trunk ?? "the trunk";
-        if (await ask({ title: `git says ${b.name} isn't merged`, body: `Its commits are already in ${trunk} — a squash merge rewrites them, so the tip never becomes an ancestor of anything.\n\nDelete it anyway?`, danger: true })) {
+      if (!r.ok && /not fully merged/i.test(r.error || "")) {
+        const q = forcedDeletePrompt(b.name, b.mergedIntoTrunk === true, branchData.trunk ?? "the trunk");
+        if (await ask({ title: q.title, body: q.body, danger: true, confirmLabel: q.confirmLabel })) {
           r = await api.gitBranchDelete(root, b.name, true);
         }
       }
@@ -1961,7 +1970,17 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                           // Joining a list cannot produce that.
                           const parts: ReactNode[] = [];
                           if (goneMerged.length) parts.push(<>{goneMerged.length} already in {branchData.trunk ?? "the trunk"}</>);
-                          if (goneUnmerged.length) parts.push(<span style={{ color: "var(--warning)" }}>{goneUnmerged.length} not merged — kept</span>);
+                          // "Not merged" is a verdict, and while the squash /
+                          // rebase sweep is still running it is not one we have
+                          // yet: those checks are what turn most of these
+                          // green. Saying so beats stating a false negative as
+                          // final, and it clears itself: the sweep pushes the
+                          // moment it proves anything.
+                          if (goneUnmerged.length) parts.push(
+                            branchData.checking
+                              ? <span style={{ color: "var(--text2)" }}>Checking {goneUnmerged.length} more…</span>
+                              : <span style={{ color: "var(--warning)" }}>{goneUnmerged.length} not merged — kept</span>,
+                          );
                           return <span className="text-[9.5px] t-dim2">{parts.map((p, i) => <Fragment key={i}>{i > 0 && " · "}{p}</Fragment>)}</span>;
                         })()}
                       </div>

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -335,7 +335,7 @@ const realApi = {
   gitPush: (root: string) => post<GitActionResult>("/git/push", { root }),
   gitPull: (root: string) => post<GitActionResult>("/git/pull", { root }),
   gitFetch: (root: string) => post<GitActionResult>("/git/fetch", { root }),
-  gitBranches: (root: string) => get<{ current: string; branches: GitBranch[]; trunk?: string | null }>(`/git/branches?root=${encodeURIComponent(root)}`),
+  gitBranches: (root: string) => get<{ current: string; branches: GitBranch[]; trunk?: string | null; checking?: boolean }>(`/git/branches?root=${encodeURIComponent(root)}`),
   gitLog: (root: string, limit = 100) => get<{ commits: GitCommit[] }>(`/git/log?root=${encodeURIComponent(root)}&limit=${limit}`),
   gitCommitDiff: (root: string, hash: string) => get<{ changes: FileChange[] }>(`/git/commit-diff?root=${encodeURIComponent(root)}&hash=${encodeURIComponent(hash)}`),
   gitStashes: (root: string) => get<{ stashes: GitStash[] }>(`/git/stashes?root=${encodeURIComponent(root)}`),

--- a/web/src/lib/goneCleanup.ts
+++ b/web/src/lib/goneCleanup.ts
@@ -105,6 +105,45 @@ export function goneConfirmBody(free: GitBranch[], held: GitBranch[], unmergedCo
 }
 
 /**
+ * What to ask when `git branch -d` answers "not fully merged".
+ *
+ * Two different questions wear the same git error, and collapsing them is how
+ * the panel used to dead-end. Squash and rebase merges make that refusal the
+ * normal case here, so when the trunk demonstrably holds the work the dialog
+ * exists only to say git is looking at the wrong thing.
+ *
+ * When it does NOT hold the work, the honest answer is that we could not tell.
+ * The server's probes have two admitted gaps (a branch whose only commits ahead
+ * are merge commits, and a repository with more branches than one sweep sizes
+ * up), so an unproven branch is not the same as a branch with unlanded work.
+ * Refusing outright left people with a toast that clears itself in 2.6s and no
+ * next step but a terminal. So it is still offered, named as unproven, with the
+ * cost stated and the reflog window that can undo it.
+ *
+ * Lives here rather than in the panel for the reason at the top of this file:
+ * the wording IS the safeguard on an irreversible action, and wording buried in
+ * a component is wording nobody can test.
+ */
+export function forcedDeletePrompt(name: string, proven: boolean, trunk: string): { title: string; body: string; confirmLabel: string } {
+  if (proven) {
+    return {
+      title: `git says ${name} isn't merged`,
+      body: `Its commits are already in ${trunk}. A squash merge rewrites them, so the tip never becomes an ancestor of anything.\n\nDelete it anyway?`,
+      confirmLabel: "Delete",
+    };
+  }
+  return {
+    title: `Delete ${name} without proof it is merged?`,
+    body: [
+      `We could not prove its commits are in ${trunk} either, so this may be work that exists nowhere else.`,
+      `The checks that clear a squash or rebase merge can miss one: a branch whose only commits ahead are merge commits, or a repository with more branches than a single sweep gets through. If ${name} is one of those, deleting costs nothing. If it isn't, this is the last copy.`,
+      "git reflog keeps the tip for about 30 days, so it can still be recovered from this machine.",
+    ].join("\n\n"),
+    confirmLabel: "Delete anyway",
+  };
+}
+
+/**
  * Which leftovers start out ticked in the rescue list.
  *
  * Two rules, and neither one knows what a `.specs` directory is — the repo this

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, preselected, fmtBytes, rescueKey, rescuePicks } from "../src/lib/goneCleanup.ts";
+import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, forcedDeletePrompt, preselected, fmtBytes, rescueKey, rescuePicks } from "../src/lib/goneCleanup.ts";
 import type { GitBranch, WorktreeLeftovers, LeftoverEntry } from "../../shared/types.ts";
 
 /**
@@ -115,6 +115,41 @@ describe("goneConfirmTitle / goneConfirmBody", () => {
     for (const t of [goneConfirmTitle([branch("a")], [branch("b")], trunk), goneConfirmTitle([], [branch("a")], trunk)]) {
       expect(t).not.toContain("\n");
     }
+  });
+});
+
+/**
+ * The single-branch delete, at the moment git refuses it.
+ *
+ * The panel used to offer a way out only when the trunk provably held the work,
+ * and print the raw git error otherwise: a toast that clears itself in 2.6s,
+ * and no next step. But "we could not prove it" is not "it is not merged", and
+ * the difference has to survive in the wording, because the wording is the only
+ * safeguard between a keypress and `branch -D`.
+ */
+describe("forcedDeletePrompt", () => {
+  it("treats git's refusal as the stale answer when the trunk holds the work", () => {
+    const q = forcedDeletePrompt("fix/thing", true, "origin/main");
+    expect(q.title).toBe("git says fix/thing isn't merged");
+    expect(q.body).toContain("already in origin/main");
+    expect(q.confirmLabel).toBe("Delete");
+  });
+
+  it("says plainly that it could not prove it, and never claims the work is safe", () => {
+    const q = forcedDeletePrompt("fix/thing", false, "origin/main");
+    expect(q.title).toBe("Delete fix/thing without proof it is merged?");
+    expect(q.body).toContain("could not prove");
+    expect(q.body).toContain("last copy");
+    expect(q.body).not.toContain("already in origin/main");
+    expect(q.confirmLabel).toBe("Delete anyway");
+  });
+
+  it("still offers the delete when unproven, rather than dead-ending", () => {
+    // The whole point: an unproven branch keeps a way forward, with the reflog
+    // named as the way back.
+    const q = forcedDeletePrompt("fix/thing", false, "origin/main");
+    expect(q.confirmLabel).toMatch(/delete/i);
+    expect(q.body).toContain("reflog");
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Cleaning up gone branches dead-ended on work that was already merged. A branch whose PR was squash-merged the day before showed `1 not merged — kept`, and pressing `d` returned git's raw `not fully merged` with no way forward.

The squash/rebase sweep was right all along; nobody could read its answer. `/git/branches` serves a JSON body cached against a fingerprint of every ref (`whileRefsHoldAsync`), rebuilt only when a ref **moves** — and a sweep moves no refs. On the repository you actually sit down to tidy, nothing else moves one either, so the pre-sweep answer was served indefinitely. Measured on this repo: a branch squash-merged 17 hours earlier still listed as unmerged, and two forced ref changes were needed to shake the truth loose. `invalidateMerged()` compounded it by wiping the memo on every write, so the proof usually died one step before it could be read.

Three changes:

- **The sweep announces itself.** `setMergedVerdictHook` fires once, when a sweep proves something, and the listener drops the cached `branches:` bodies and broadcasts `{type:"git"}` — which the panel already listens for. A sweep that learns nothing stays silent, so a good cache is never invalidated and no panel redraws on a five-minute clock forever.
- **`checking` tells the truth while it runs.** The panel shows `Checking N more…` rather than stating a false negative as final. A flag like this existed once and was removed for answering yes forever; it has an end now, because a finished sweep is remembered and the push above clears the label without a poll.
- **`not fully merged` always offers a way forward.** Proven merged, the dialog says git is comparing against the wrong thing. Unproven, it says so plainly, names what the delete could cost and the ~30 day reflog window that undoes it, and still lets you through. The probes admit two gaps (a branch whose only commits ahead are merge commits; a repository larger than one sweep's budget), and "we could not tell" must not read as "not merged". That wording moved into `lib/goneCleanup.ts` for the reason stated at the top of that file: wording that guards an irreversible action has to be testable.

## How was it tested?

- `bunx tsc --noEmit` clean in `web/` and `server/`; `vite build` via the local desktop package.
- 6 new tests. `server/test/branch-merged.test.ts`: the sweep announces the repo it proved something in, a repeat read stays quiet, and `checking` is true while the sweep runs and false once it has. `web/test/gone-cleanup.test.ts`: `forcedDeletePrompt` never claims work is safe when it could not be proved, and never dead-ends.
- `bun test web/test` 792 pass. `bun test server/test` 1113 pass; the single failure (`webui.test.ts` `resolveDist`) reproduces on `main` on the same machine, where it reads the real installed desktop resources directory.
- Exercised end to end against this repository with **no ref moving**: first read `checking=true` / `mergedIntoTrunk=false`, one `git` frame over the WebSocket, second read `mergedIntoTrunk=true`. Before this change it stayed false indefinitely. Repeated from the packaged desktop app after `electron/install-local.sh`, in Source control → Branches → the gone filter.