### PR TITLE
feat(remote): remember the address, show who is connected, and give the pane room

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,17 +196,6 @@ straight to tmux, and the tabs follow. The point is that the window list stops
 being the one strip of the workspace themed by whichever `.tmux.conf` the
 machine happens to carry.
 
-A tab **flashes** when the agent in that window wants you: amber because it
-stopped to ask something, green because its turn ended. Four agents in four
-windows, and the strip says which one, not just that something happened. The
-mark is tmux's own `@ai_state` window option, set by agentglass's `Stop` and
-`Notification` hooks and cleared the moment you switch to the window, so
-anything else can raise it too:
-
-```bash
-tmux set-option -w -t "$TMUX_PANE" @ai_state done   # or: waiting
-```
-
 **If a shell ever renders solid white,** switch **Settings ▸ Preferences ▸
 Terminal renderer** to *Compatibility*. xterm's GPU renderer is fast, but on
 some Linux GPU/compositor stacks it paints the terminal blank with no catchable

--- a/hooks/send_event.py
+++ b/hooks/send_event.py
@@ -15,69 +15,10 @@ Env:
 import argparse
 import json
 import os
-import shutil
-import subprocess
 import sys
 import urllib.request
 
 DEFAULT_SERVER = os.environ.get("AGENTGLASS_SERVER", "http://localhost:4000")
-
-# What each event means to a tmux tab. None clears the mark: the user is driving
-# this window again, so it has nothing to ask for.
-TMUX_STATE = {
-    "Stop": "done",
-    "Notification": "waiting",
-    "UserPromptSubmit": None,
-    "SessionStart": None,
-    "SessionEnd": None,
-}
-
-
-def mark_tmux_window(event_type):
-    """Tell the tmux window this agent runs in what it wants, if anything.
-
-    The terminal panel draws tmux's windows as tabs and flashes the ones with a
-    state set, which is the only way to see which of four agents stopped when
-    all four are off screen. The mark is a plain tmux user option, so tmux is
-    the one holding the state and anything else can read or set it too.
-
-    Best effort throughout: an agent must never fail a turn because a status
-    colour could not be set.
-    """
-    if event_type not in TMUX_STATE:
-        return
-    pane = os.environ.get("TMUX_PANE")
-    if not pane or not os.environ.get("TMUX"):
-        return
-    tmux = shutil.which("tmux")
-    if not tmux:
-        return
-    state = TMUX_STATE[event_type]
-    try:
-        if state is None:
-            subprocess.run([tmux, "set-option", "-w", "-q", "-t", pane, "-u", "@ai_state"],
-                           timeout=2, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-            return
-        # Don't flash the window the user is already looking at, as long as
-        # somebody is there to look: a state set on a detached session still has
-        # to be waiting when its user comes back.
-        #
-        # Two calls rather than one command list. `display-message ; list-clients`
-        # answers only the first half from a hook's context, which is how this
-        # went out flagging the window it was told to leave alone.
-        # (`#{session_attached}` is no use either: it reports 0 whenever the
-        # command has no client of its own, which is always the case here.)
-        current = subprocess.run([tmux, "display-message", "-p", "-t", pane, "#{window_active}"],
-                                 capture_output=True, text=True, timeout=2)
-        if current.stdout.strip() == "1":
-            seen = subprocess.run([tmux, "list-clients", "-F", "c"],
-                                  capture_output=True, text=True, timeout=2)
-            if seen.stdout.strip():
-                return
-        subprocess.run([tmux, "set-option", "-w", "-q", "-t", pane, "@ai_state", state],
-                       timeout=2, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-    except Exception:
-        pass
 
 def _agentglass_local_only(url):
     """Refuse to send transcript/telemetry anywhere but this machine.
@@ -143,10 +84,6 @@ def main():
     session_id = payload.get("session_id") or payload.get("sessionId") or "unknown"
     event_type = args.event_type or payload.get("hook_event_name") or "Unknown"
     model_name = payload.get("model") or payload.get("model_name") or args.model_name
-
-    # Before the POST: the tab should light up the moment the turn ends, not
-    # after a server round trip that may be timing out.
-    mark_tmux_window(event_type)
 
     chat = None
     if args.add_chat:

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -77,7 +77,7 @@ import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { updateStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
 import { rateOk } from "./ratelimit.ts";
-import { noteClient, isLoopback, remoteStatus } from "./remote.ts";
+import { noteClient, noteSocket, isLoopback, isBlocked, blockDevice, remoteStatus } from "./remote.ts";
 import { parseWindowMs } from "./params.ts";
 import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
 import { notifyCapability, subscribeNotifications, notifyWatching, openNote } from "./notifications.ts";
@@ -115,8 +115,13 @@ const AUTH = resolveToken(LOOPBACK_ONLY && !TRUST_LAN);
 const AUTH_TOKEN = AUTH.token;
 /** One socket, three roles: the live event stream, PTY terminal shells, and
  *  the desktop-notification mirror. */
-type WsData = { kind: "events" } | { kind: "notify" } | PtyWsData;
+/** Every socket carries the address that opened it, so "who is connected right
+ *  now" is answerable, and so a device can be cut off while it is holding one. */
+type WsData = ({ kind: "events" } | { kind: "notify" } | PtyWsData) & { ip?: string | null };
 const clients = new Set<ServerWebSocket<WsData>>();
+/** Every open socket of every kind, which `clients` is not: it holds the event
+ *  streams only, and a device cut off mid-session may be holding a terminal. */
+const sockets = new Set<ServerWebSocket<WsData>>();
 /** Notification sockets, each holding the unsubscribe that keeps the D-Bus
  *  monitor alive. Empty map => no monitor process. */
 const notifySubs = new Map<ServerWebSocket<WsData>, () => void>();
@@ -452,7 +457,16 @@ const server = Bun.serve<WsData>({
     // have actually arrived. Loopback is ignored — it is every call the app
     // makes of itself and says nothing about whether a phone can get in.
     const clientIp = srv.requestIP(req)?.address;
-    noteClient(clientIp);
+    noteClient(clientIp, { agent: req.headers.get("user-agent") });
+    // Cut off on sight. A device the user turned away in the panel is refused
+    // before the token is even considered, because the case this exists for is
+    // "something I do not recognise is holding a terminal on my machine" and
+    // the answer to that has to arrive on the next packet, not the next
+    // restart. It is deliberately above the auth gate: the device already has
+    // the code, which is exactly why it needs to be stopped by address.
+    if (isBlocked(clientIp)) return new Response(JSON.stringify({ ok: false, error: "this device was disconnected from this machine" }), {
+      status: 403, headers: { "content-type": "application/json" },
+    });
     // Same fact, put to a second use: a page served off-box gets the phone
     // application, not the cockpit (see webui.ts). An address we cannot read is
     // treated as local — it means the socket had no peer to report, which on
@@ -519,7 +533,7 @@ const server = Bun.serve<WsData>({
     // stream — a read this feed is not meant to give to the open web.
     if (pathname === "/stream") {
       if (!trustedCaller(req)) return csrfBlocked();
-      if (srv.upgrade(req, { data: { kind: "events" } })) return undefined as unknown as Response;
+      if (srv.upgrade(req, { data: { kind: "events", ip: clientIp ?? null } })) return undefined as unknown as Response;
       return new Response("upgrade failed", { status: 426 });
     }
 
@@ -527,11 +541,12 @@ const server = Bun.serve<WsData>({
     if (pathname === "/terminal/pty") {
       if (!trustedCaller(req)) return csrfBlocked();
       if (!TERMINAL_ENABLED) return json({ error: "terminal is disabled" }, 403);
-      const data: PtyWsData = {
+      const data: PtyWsData & { ip?: string | null } = {
         kind: "pty",
         root: url.searchParams.get("root") || "",
         cols: Number(url.searchParams.get("cols") || 80),
         rows: Number(url.searchParams.get("rows") || 24),
+        ip: clientIp ?? null,
       };
       if (srv.upgrade(req, { data })) return undefined as unknown as Response;
       return new Response("upgrade failed", { status: 426 });
@@ -554,7 +569,7 @@ const server = Bun.serve<WsData>({
       if (!trustedCaller(req)) return csrfBlocked();
       const cap = notifyCapability();
       if (!cap.supported) return json({ error: cap.reason ?? "unsupported" }, 501);
-      if (srv.upgrade(req, { data: { kind: "notify" } })) return undefined as unknown as Response;
+      if (srv.upgrade(req, { data: { kind: "notify", ip: clientIp ?? null } })) return undefined as unknown as Response;
       return new Response("upgrade failed", { status: 426 });
     }
 
@@ -808,6 +823,38 @@ const server = Bun.serve<WsData>({
      * the token is ever set aside. The local UI is the only thing that needs it
      * anyway: it is what draws the QR code.
      */
+    /**
+     * Cut a device off, or let it back in.
+     *
+     * Only from this machine. A phone that already holds the code must not be
+     * able to disconnect the laptop next to it, and an address-level block is
+     * exactly the kind of control that has to stay on the side of the desk the
+     * user is sitting at.
+     *
+     * Blocking closes what it is holding as well as refusing what it sends
+     * next. Half of it — refusing new requests while an open terminal keeps
+     * streaming — would be the worst of both: it looks disconnected in the
+     * panel and is not disconnected on the wire.
+     */
+    if (pathname === "/remote/device" && req.method === "POST") {
+      const ip = srv.requestIP(req)?.address ?? null;
+      if (!ip || !isLoopback(ip)) return json({ ok: false, error: "only this machine can disconnect a device" }, 403);
+      let b: { address?: unknown; blocked?: unknown };
+      try { b = (await req.json()) as { address?: unknown; blocked?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const address = typeof b.address === "string" ? b.address : "";
+      const blocked = b.blocked !== false;
+      if (!address) return json({ ok: false, error: "no address" }, 400);
+      if (!blockDevice(address, blocked)) return json({ ok: false, error: "no such device" }, 404);
+      let closed = 0;
+      if (blocked) {
+        for (const ws of [...sockets]) {
+          if (ws.data?.ip && ws.data.ip.replace(/^::ffff:/, "") === address) {
+            try { ws.close(1008, "disconnected from the host machine"); closed++; } catch { /* already gone */ }
+          }
+        }
+      }
+      return json({ ok: true, address, blocked, closed });
+    }
     if (pathname === "/remote/status") {
       const ip = srv.requestIP(req)?.address ?? null;
       return json(
@@ -1481,6 +1528,11 @@ const server = Bun.serve<WsData>({
 
   websocket: {
     open(ws: ServerWebSocket<WsData>) {
+      // Before the per-kind branches: every socket counts towards "this device
+      // is connected right now", and every socket has to be closable when the
+      // user cuts that device off.
+      sockets.add(ws);
+      noteSocket(ws.data?.ip, 1);
       if (ws.data?.kind === "pty") { ptyOpen(ws); return; }
       if (ws.data?.kind === "notify") {
         notifySubs.set(ws, subscribeNotifications((n) => {
@@ -1499,6 +1551,8 @@ const server = Bun.serve<WsData>({
       ws.send(JSON.stringify(frame));
     },
     close(ws: ServerWebSocket<WsData>) {
+      sockets.delete(ws);
+      noteSocket(ws.data?.ip, -1);
       if (ws.data?.kind === "pty") { ptyClose(ws); return; }
       if (ws.data?.kind === "notify") {
         // Unsubscribing is what stops the monitor process once the last

--- a/server/src/remote.ts
+++ b/server/src/remote.ts
@@ -21,8 +21,35 @@
 // problem is a worse trade than reading one line and pasting it.
 import { networkInterfaces } from "node:os";
 
-/** A non-loopback address that has talked to us, and when it last did. */
-const seen = new Map<string, number>();
+/**
+ * A non-loopback address that has talked to us, and what we know about it.
+ *
+ * The panel used to say "one device has connected, last seen 4m" and that was
+ * the whole story: a number, an age, and no way to tell a phone in your hand
+ * from a phone in a drawer, or either from something on the wifi that is not
+ * yours. What is on the other end of an open port carrying a terminal is not a
+ * detail to summarise. So each address keeps its own record, including whether
+ * a socket from it is open *right now*, which is the only honest answer to
+ * "connected" — an HTTP request proves a device was here a moment ago, and a
+ * held-open WebSocket proves it is here.
+ */
+export interface DeviceRecord {
+  address: string;
+  firstAt: number;
+  lastAt: number;
+  /** Sockets from this address open at this instant. Zero is "was here". */
+  live: number;
+  /** What it calls itself, condensed. See deviceLabel. */
+  label: string;
+  /** The raw User-Agent, for the ones the condenser cannot name. */
+  agent: string;
+  /** Requests seen since it first arrived. */
+  hits: number;
+  /** Turned away at the door until it is let back in, or the server restarts. */
+  blocked: boolean;
+}
+
+const seen = new Map<string, DeviceRecord>();
 
 /** Bun hands v4-mapped v6 back on a dual-stack listener; compare the v4 part. */
 function unmap(ip: string): string {
@@ -42,32 +69,144 @@ export function isLoopback(ip: string): boolean {
  * loopback is every local fetch the app makes of itself, thousands an hour,
  * and it proves nothing about reachability.
  */
-export function noteClient(ip: string | null | undefined, now = Date.now()): void {
+export function noteClient(ip: string | null | undefined, opts: { now?: number; agent?: string | null } = {}): void {
   if (!ip) return;
   const h = unmap(ip);
   if (isLoopback(h)) return;
-  seen.set(h, now);
-  // A cap, because this is fed by unauthenticated connection metadata: without
-  // one, anything that can reach the port can grow this map without limit.
-  if (seen.size > 64) {
-    const oldest = [...seen.entries()].sort((a, b) => a[1] - b[1])[0];
-    if (oldest) seen.delete(oldest[0]);
+  const now = opts.now ?? Date.now();
+  const agent = (opts.agent ?? "").slice(0, 300);
+  const prev = seen.get(h);
+  if (prev) {
+    prev.lastAt = now;
+    prev.hits++;
+    // A device that starts sending a User-Agent (or changes it) renames itself;
+    // a request without one — the phone's own service worker, say — must not
+    // erase the name we already have.
+    if (agent && agent !== prev.agent) { prev.agent = agent; prev.label = deviceLabel(agent); }
+  } else {
+    seen.set(h, {
+      address: h, firstAt: now, lastAt: now, live: 0,
+      label: deviceLabel(agent), agent, hits: 1, blocked: false,
+    });
   }
+  // A cap, because this is fed by unauthenticated connection metadata: without
+  // one, anything that can reach the port can grow this map without limit. A
+  // device with a socket open, or one deliberately blocked, is never the one
+  // dropped: both are answers the user is relying on.
+  if (seen.size > 64) {
+    const evictable = [...seen.values()].filter((d) => d.live === 0 && !d.blocked).sort((a, b) => a.lastAt - b.lastAt)[0];
+    if (evictable) seen.delete(evictable.address);
+  }
+}
+
+/**
+ * A socket from `ip` opened (+1) or closed (-1).
+ *
+ * This is what separates "connected" from "was connected". It is called for
+ * every kind of socket the server holds — the event stream, a terminal, the
+ * notification mirror — because any of them being open means that device is
+ * live on this machine right now.
+ */
+export function noteSocket(ip: string | null | undefined, delta: 1 | -1, now = Date.now()): void {
+  if (!ip) return;
+  const h = unmap(ip);
+  if (isLoopback(h)) return;
+  const d = seen.get(h);
+  if (!d) {
+    if (delta < 0) return; // a close for something we never saw open
+    noteClient(h, { now });
+    const made = seen.get(h);
+    if (made) made.live = 1;
+    return;
+  }
+  // Clamped: a close that arrives twice, or after a reset, must not push this
+  // negative and make a live device look absent forever.
+  d.live = Math.max(0, d.live + delta);
+  d.lastAt = now;
+}
+
+/**
+ * Refuse this address, or let it back in.
+ *
+ * Honest about what it is: an address-level block, held in memory until the
+ * server restarts. It stops a device that is on the network now, which is the
+ * thing you want when you see something you do not recognise holding a
+ * terminal. It is not a replacement for rotating the code — anything that can
+ * pick a new address on the same network can come back — which is why the UI
+ * offers both and says which is which.
+ */
+export function blockDevice(address: string, blocked: boolean): boolean {
+  const d = seen.get(unmap(address));
+  if (!d) return false;
+  d.blocked = blocked;
+  return true;
+}
+
+export function isBlocked(ip: string | null | undefined): boolean {
+  if (!ip) return false;
+  return seen.get(unmap(ip))?.blocked === true;
+}
+
+/** Newest activity first, with anything currently holding a socket on top. */
+export function remoteDevices(): DeviceRecord[] {
+  return [...seen.values()]
+    .sort((a, b) => (b.live > 0 ? 1 : 0) - (a.live > 0 ? 1 : 0) || b.lastAt - a.lastAt)
+    .map((d) => ({ ...d }));
 }
 
 export interface RemoteClients {
   count: number;
   lastAt: number | null;
   addresses: string[];
+  /** How many are holding a socket open at this instant. */
+  liveCount: number;
 }
 
 export function remoteClients(): RemoteClients {
-  const entries = [...seen.entries()].sort((a, b) => b[1] - a[1]);
+  const all = remoteDevices();
   return {
-    count: entries.length,
-    lastAt: entries[0]?.[1] ?? null,
-    addresses: entries.slice(0, 8).map(([ip]) => ip),
+    count: all.length,
+    lastAt: all.reduce<number | null>((n, d) => (n === null || d.lastAt > n ? d.lastAt : n), null),
+    addresses: all.slice(0, 8).map((d) => d.address),
+    liveCount: all.filter((d) => d.live > 0).length,
   };
+}
+
+/**
+ * A User-Agent, reduced to the phrase a person would use for that device.
+ *
+ * Deliberately coarse. The point is telling "my Pixel" apart from "something
+ * else on this wifi", not building a fingerprint: a wrong-but-specific guess
+ * ("Galaxy S22") is worse than a right-and-vague one ("An Android phone"),
+ * because the user acts on this by deciding whether to cut a device off.
+ */
+export function deviceLabel(uaRaw: string | null | undefined): string {
+  const ua = (uaRaw ?? "").trim();
+  if (!ua) return "Unnamed device";
+  if (/^(curl|wget|python-requests|node-fetch|go-http-client|httpie)/i.test(ua)) {
+    return `A script (${ua.split("/")[0]!.toLowerCase()})`;
+  }
+  const browser =
+    /\bEdg\//.test(ua) ? "Edge"
+    : /\bOPR\/|\bOpera\b/.test(ua) ? "Opera"
+    : /\bFirefox\//.test(ua) ? "Firefox"
+    : /\bChrome\//.test(ua) ? "Chrome"
+    : /\bSafari\//.test(ua) ? "Safari"
+    : null;
+  // The model is inside the Android comment, before the build tag. It is the
+  // one place a phone says something a person recognises.
+  const android = ua.match(/Android[^;)]*;\s*([^;)]+?)(?:\s+Build\/[^;)]*)?\s*\)/);
+  const device =
+    /\biPhone\b/.test(ua) ? "iPhone"
+    : /\biPad\b/.test(ua) ? "iPad"
+    : /\bCrOS\b/.test(ua) ? "Chromebook"
+    : android ? (android[1] && !/^wv$/i.test(android[1].trim()) ? android[1].trim() : "An Android device")
+    : /\bMacintosh\b/.test(ua) ? "Mac"
+    : /\bWindows NT\b/.test(ua) ? "Windows PC"
+    : /\bLinux\b/.test(ua) ? "Linux machine"
+    : null;
+  if (device && browser) return `${device} · ${browser}`;
+  return device ?? browser ?? "Unnamed device";
 }
 
 /** Test seam: forget every recorded client. */
@@ -190,6 +329,8 @@ export interface RemoteStatus {
   urls: string[];
   addresses: Reachable[];
   clients: RemoteClients;
+  /** One row per device that has reached this machine, live state included. */
+  devices: DeviceRecord[];
   firewall: FirewallHint | null;
   /** Present only for a local caller — see the gate in index.ts. */
   token?: string;
@@ -219,6 +360,7 @@ export function remoteStatus(opts: {
     urls: addresses.map((a) => `http://${a.address}:${opts.port}${q}`),
     addresses,
     clients: remoteClients(),
+    devices: remoteDevices(),
     firewall: firewallHint(opts.port, addresses[0]?.subnet ?? null, opts.which),
     ...(opts.includeToken && opts.token ? { token: opts.token } : {}),
   };

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -162,12 +162,6 @@ const WINDOW_ID = /^@\d+$/;
  * `#` activity, `Z` zoomed). They are passed through rather than interpreted
  * here: the panel decides what to show, and tmux stays the single source of
  * truth for what is true.
- *
- * `@ai_state` is the one field tmux does not set itself: it is a user option on
- * the window, which an agent's own hooks write when it finishes a turn or stops
- * to ask something. Unknown values are dropped rather than passed on, because
- * this ends up choosing a colour and a half-written option should not paint a
- * tab a colour nothing else in the app uses.
  */
 export function parseWindows(out: string): TmuxWindow[] {
   const windows: TmuxWindow[] = [];
@@ -175,18 +169,10 @@ export function parseWindows(out: string): TmuxWindow[] {
     if (!line.trim()) continue;
     // Tab-separated, because window names routinely contain spaces and a
     // space-separated format would split "npm run dev" into three windows.
-    const [id, index, name, active, flags, state] = line.split("\t");
+    const [id, index, name, active, flags] = line.split("\t");
     const i = Number(index);
     if (!WINDOW_ID.test(id ?? "") || !Number.isInteger(i)) continue;
-    const attention = state?.trim();
-    windows.push({
-      id: id!,
-      index: i,
-      name: name ?? "",
-      active: active === "1",
-      flags: (flags ?? "").trim(),
-      attention: attention === "waiting" || attention === "done" ? attention : null,
-    });
+    windows.push({ id: id!, index: i, name: name ?? "", active: active === "1", flags: (flags ?? "").trim() });
   }
   return windows;
 }
@@ -224,22 +210,11 @@ export function readFrame(c: TmuxClient): TmuxFrame | null {
     "list-clients", "-F", "c\t#{client_tty}\t#{session_name}\t#{session_id}",
     ";",
     "list-windows", "-a",
-    "-F", "w\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}\t#{@ai_state}",
+    "-F", "w\t#{session_id}\t#{window_id}\t#{window_index}\t#{window_name}\t#{window_active}\t#{window_raw_flags}",
   ]);
   if (!out) return null;
   const f = parseFrame(out, c.tty);
-  if (!f) return null;
-  // The window you are on cannot be asking for your attention, so a state left
-  // on it is dropped here rather than rendered. `runAction` clears it when the
-  // panel does the switching; this catches the other half, where the user
-  // switched with `^b n` and tmux told nobody. Costs a second spawn only in the
-  // one poll after that happens.
-  const stale = f.windows.find((w) => w.active && w.attention);
-  if (stale) {
-    tmux(c.socket, ["set-option", "-w", "-q", "-t", stale.id, "-u", "@ai_state"]);
-    stale.attention = null;
-  }
-  return { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows };
+  return f ? { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows } : null;
 }
 
 /**
@@ -325,16 +300,7 @@ export function runAction(t: TmuxTarget, action: TmuxAction, window?: string, na
   const id = WINDOW_ID.test(window ?? "") ? window! : null;
   switch (action) {
     case "select":
-      // Selecting a window also drops its `@ai_state`, in the same tmux call:
-      // the tab was flashing to get you here, and you are here. tmux clears its
-      // own bell flag on select for the same reason, but it knows nothing about
-      // a user option, and leaving that to a `pane-focus-in` hook in the user's
-      // config would mean the flash only ever stops for people who have one.
-      return id === null ? false : tmux(t.socket, [
-        "select-window", "-t", id,
-        ";",
-        "set-option", "-w", "-q", "-t", id, "-u", "@ai_state",
-      ]) !== null;
+      return id === null ? false : tmux(t.socket, ["select-window", "-t", id]) !== null;
     case "new":
       // At the end, which is tmux's default and where the button is.
       //

--- a/server/test/remote.test.ts
+++ b/server/test/remote.test.ts
@@ -6,6 +6,11 @@
 import { describe, expect, test, beforeEach } from "bun:test";
 import {
   noteClient,
+  noteSocket,
+  blockDevice,
+  isBlocked,
+  remoteDevices,
+  deviceLabel,
   remoteClients,
   __resetRemoteClients,
   isLoopback,
@@ -40,33 +45,153 @@ describe("noteClient", () => {
     noteClient(undefined);
     expect(remoteClients().count).toBe(0);
 
-    noteClient("192.168.1.42", 1000);
+    noteClient("192.168.1.42", { now: 1000 });
     expect(remoteClients()).toMatchObject({ count: 1, lastAt: 1000, addresses: ["192.168.1.42"] });
   });
 
   test("one entry per address, keeping the most recent time", () => {
-    noteClient("192.168.1.42", 1000);
-    noteClient("192.168.1.42", 5000);
+    noteClient("192.168.1.42", { now: 1000 });
+    noteClient("192.168.1.42", { now: 5000 });
     expect(remoteClients()).toMatchObject({ count: 1, lastAt: 5000 });
   });
 
   test("newest first, and the address list is capped", () => {
-    noteClient("192.168.1.10", 1000);
-    noteClient("192.168.1.11", 3000);
-    noteClient("192.168.1.12", 2000);
+    noteClient("192.168.1.10", { now: 1000 });
+    noteClient("192.168.1.11", { now: 3000 });
+    noteClient("192.168.1.12", { now: 2000 });
     expect(remoteClients().addresses.slice(0, 2)).toEqual(["192.168.1.11", "192.168.1.12"]);
   });
 
   test("cannot be grown without limit by an unauthenticated caller", () => {
     // This is fed by connection metadata from anything that can reach the port.
-    for (let i = 0; i < 300; i++) noteClient(`10.0.${Math.floor(i / 250)}.${i % 250}`, 1000 + i);
+    for (let i = 0; i < 300; i++) noteClient(`10.0.${Math.floor(i / 250)}.${i % 250}`, { now: 1000 + i });
     expect(remoteClients().count).toBeLessThanOrEqual(64);
   });
 
   test("a v4-mapped address is the same device as its plain form", () => {
-    noteClient("192.168.1.42", 1000);
-    noteClient("::ffff:192.168.1.42", 2000);
+    noteClient("192.168.1.42", { now: 1000 });
+    noteClient("::ffff:192.168.1.42", { now: 2000 });
     expect(remoteClients().count).toBe(1);
+  });
+
+  test("a later request without a User-Agent does not erase the name", () => {
+    // The phone's service worker sends none, and it must not turn a named
+    // device back into "Unnamed device" between two polls.
+    noteClient("192.168.1.42", { now: 1000, agent: "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1" });
+    noteClient("192.168.1.42", { now: 2000, agent: null });
+    expect(remoteDevices()[0]!.label).toBe("iPhone · Safari");
+  });
+});
+
+describe("connected right now", () => {
+  test("a held-open socket is what makes a device live, not its last request", () => {
+    noteClient("192.168.1.42", { now: 1000 });
+    expect(remoteDevices()[0]!.live).toBe(0);
+    noteSocket("192.168.1.42", 1, 2000);
+    expect(remoteDevices()[0]!.live).toBe(1);
+    expect(remoteClients().liveCount).toBe(1);
+    noteSocket("192.168.1.42", -1, 3000);
+    expect(remoteDevices()[0]!.live).toBe(0);
+    expect(remoteClients().liveCount).toBe(0);
+  });
+
+  test("counts several sockets from one device, and never goes negative", () => {
+    // A phone holds the event stream and a terminal at once; a close that
+    // arrives twice must not leave a live device stuck at -1, which would read
+    // as "not connected" forever after.
+    noteSocket("192.168.1.42", 1, 1000);
+    noteSocket("192.168.1.42", 1, 1000);
+    expect(remoteDevices()[0]!.live).toBe(2);
+    noteSocket("192.168.1.42", -1, 2000);
+    noteSocket("192.168.1.42", -1, 2000);
+    noteSocket("192.168.1.42", -1, 2000);
+    expect(remoteDevices()[0]!.live).toBe(0);
+  });
+
+  test("a socket from an address we never saw registers the device", () => {
+    noteSocket("192.168.1.77", 1, 1000);
+    expect(remoteDevices().map((d) => d.address)).toEqual(["192.168.1.77"]);
+    expect(remoteDevices()[0]!.live).toBe(1);
+  });
+
+  test("loopback holds no sockets: the app talking to itself is not a device", () => {
+    noteSocket("127.0.0.1", 1, 1000);
+    noteSocket("::1", 1, 1000);
+    expect(remoteClients().count).toBe(0);
+  });
+
+  test("live devices sort above ones that merely visited", () => {
+    noteClient("192.168.1.10", { now: 9000 });
+    noteClient("192.168.1.11", { now: 1000 });
+    noteSocket("192.168.1.11", 1, 1000);
+    expect(remoteDevices().map((d) => d.address)).toEqual(["192.168.1.11", "192.168.1.10"]);
+  });
+});
+
+describe("disconnecting a device", () => {
+  test("blocks by address and lets it back in", () => {
+    noteClient("192.168.1.42", { now: 1000 });
+    expect(blockDevice("192.168.1.42", true)).toBe(true);
+    expect(isBlocked("192.168.1.42")).toBe(true);
+    // The gate reads whatever the socket reports, which may be v4-mapped.
+    expect(isBlocked("::ffff:192.168.1.42")).toBe(true);
+    expect(blockDevice("192.168.1.42", false)).toBe(true);
+    expect(isBlocked("192.168.1.42")).toBe(false);
+  });
+
+  test("an address that was never seen cannot be blocked into existence", () => {
+    // Otherwise the list becomes writable by anything that can POST a string.
+    expect(blockDevice("8.8.8.8", true)).toBe(false);
+    expect(remoteClients().count).toBe(0);
+  });
+
+  test("nothing and loopback are never blocked", () => {
+    expect(isBlocked(null)).toBe(false);
+    expect(isBlocked("127.0.0.1")).toBe(false);
+  });
+
+  test("the cap never evicts a connected or a blocked device", () => {
+    // The two rows the user is relying on are exactly the two that must not
+    // quietly vanish when 300 strangers touch the port.
+    noteClient("192.168.1.5", { now: 1 });
+    noteSocket("192.168.1.5", 1, 1);
+    noteClient("192.168.1.6", { now: 2 });
+    blockDevice("192.168.1.6", true);
+    for (let i = 0; i < 300; i++) noteClient(`10.0.${Math.floor(i / 250)}.${i % 250}`, { now: 1000 + i });
+    const kept = remoteDevices().map((d) => d.address);
+    expect(kept).toContain("192.168.1.5");
+    expect(kept).toContain("192.168.1.6");
+    expect(remoteDevices().length).toBeLessThanOrEqual(64);
+  });
+});
+
+describe("deviceLabel", () => {
+  test("names the phones a person would recognise", () => {
+    expect(deviceLabel("Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"))
+      .toBe("Pixel 8 Pro · Chrome");
+    expect(deviceLabel("Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"))
+      .toBe("iPhone · Safari");
+    expect(deviceLabel("Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 Safari/604.1")).toBe("iPad · Safari");
+  });
+
+  test("names the machines too, and prefers Edge over the Chrome it also claims", () => {
+    expect(deviceLabel("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36")).toBe("Mac · Chrome");
+    expect(deviceLabel("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36 Edg/120.0.0.0")).toBe("Windows PC · Edge");
+    expect(deviceLabel("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/120.0.0.0 Safari/537.36")).toBe("Linux machine · Chrome");
+  });
+
+  test("says plainly when it is not a browser", () => {
+    expect(deviceLabel("curl/8.4.0")).toBe("A script (curl)");
+    expect(deviceLabel("python-requests/2.31.0")).toBe("A script (python-requests)");
+  });
+
+  test("stays vague rather than guessing", () => {
+    // A wrong-but-specific name is worse than an honest blank: the user acts
+    // on this by deciding whether to cut a device off.
+    expect(deviceLabel("")).toBe("Unnamed device");
+    expect(deviceLabel(null)).toBe("Unnamed device");
+    expect(deviceLabel("Mozilla/5.0 (Linux; Android 14; wv) AppleWebKit/537.36 Version/4.0 Chrome/120.0.0.0 Mobile Safari/537.36"))
+      .toBe("An Android device · Chrome");
   });
 });
 
@@ -162,7 +287,7 @@ describe("remoteStatus", () => {
   });
 
   test("reports the devices that have been seen", () => {
-    noteClient("192.168.1.42", 4242);
+    noteClient("192.168.1.42", { now: 4242 });
     const st = remoteStatus({ ...base, bind: "0.0.0.0", token: null, includeToken: true });
     expect(st.clients).toMatchObject({ count: 1, lastAt: 4242 });
   });

--- a/server/test/tmux-tabs.test.ts
+++ b/server/test/tmux-tabs.test.ts
@@ -14,8 +14,8 @@ describe("reading tmux's window list", () => {
   test("id, index, name, active flag and tmux's own marks", () => {
     const out = "@0\t1\tAI01\t0\t-\n@4\t2\tlazygit\t1\t*\n";
     expect(parseWindows(out)).toEqual([
-      { id: "@0", index: 1, name: "AI01", active: false, flags: "-", attention: null },
-      { id: "@4", index: 2, name: "lazygit", active: true, flags: "*", attention: null },
+      { id: "@0", index: 1, name: "AI01", active: false, flags: "-" },
+      { id: "@4", index: 2, name: "lazygit", active: true, flags: "*" },
     ]);
   });
 
@@ -29,7 +29,7 @@ describe("reading tmux's window list", () => {
 
   test("a window with no name is not dropped", () => {
     const [w] = parseWindows("@7\t4\t\t0\t\n");
-    expect(w).toEqual({ id: "@7", index: 4, name: "", active: false, flags: "", attention: null });
+    expect(w).toEqual({ id: "@7", index: 4, name: "", active: false, flags: "" });
   });
 
   test("blank lines and unparseable indexes are skipped, not guessed at", () => {
@@ -44,21 +44,6 @@ describe("reading tmux's window list", () => {
     const [bell, activity] = parseWindows("@0\t1\tbuild\t0\t!\n@1\t2\ttest\t0\t#\n");
     expect(bell!.flags).toBe("!");
     expect(activity!.flags).toBe("#");
-  });
-
-  test("an agent's own state comes back as the tab's attention", () => {
-    const [waiting, done] = parseWindows("@0\t1\tAI00\t0\t\twaiting\n@1\t2\tAI01\t0\t\tdone\n");
-    expect(waiting!.attention).toBe("waiting");
-    expect(done!.attention).toBe("done");
-  });
-
-  test("a state nothing recognises is dropped, not passed on", () => {
-    // It picks a colour at the far end. A half-written option, or one somebody
-    // else's tooling set for its own purposes, should leave the tab alone.
-    expect(parseWindows("@0\t1\tAI00\t0\t\tthinking\n")[0]!.attention).toBeNull();
-    expect(parseWindows("@0\t1\tAI00\t0\t\t\n")[0]!.attention).toBeNull();
-    // tmux servers older than the format change answer without the column.
-    expect(parseWindows("@0\t1\tAI00\t0\t-\n")[0]!.attention).toBeNull();
   });
 });
 
@@ -103,16 +88,11 @@ describe("which session the client is on", () => {
     expect(parseFrame("", "/dev/pts/0")).toBeNull();
   });
 
-  test("the agent's state survives the trip through the tagged frame", () => {
-    const f = parseFrame("c\t/dev/pts/0\tmain\t$2\nw\t$2\t@1\t1\tAI00\t0\t\twaiting", "/dev/pts/0");
-    expect(f!.windows[0]!.attention).toBe("waiting");
-  });
-
   test("window names with tabs in them do not smuggle a session id", () => {
     // The name is the last-but-two field and is not re-split, so this is a
     // window called what it says, in $2, and not one in $7.
     const f = parseFrame("c\t/dev/pts/0\tmain\t$2\nw\t$2\t@1\t1\tnpm run dev\t1\t*", "/dev/pts/0");
-    expect(f!.windows).toEqual([{ id: "@1", index: 1, name: "npm run dev", active: true, flags: "*", attention: null }]);
+    expect(f!.windows).toEqual([{ id: "@1", index: 1, name: "npm run dev", active: true, flags: "*" }]);
   });
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -281,14 +281,6 @@ export interface StatsSummary {
   retention_days?: number;
 }
 
-/** What an agent running in a tmux window says it wants from you: `waiting` for
- *  a question it has asked, `done` for a turn it has finished. Read from the
- *  window's own `@ai_state` option, which `hooks/send_event.py` sets from the
- *  agent's Stop and Notification hooks. A plain tmux option rather than
- *  something of ours, so a build script or another agent can flash a tab with
- *  one line: `tmux set-option -w -t "$TMUX_PANE" @ai_state done`. */
-export type TmuxAttention = "waiting" | "done" | null;
-
 /** One tmux window, as tmux itself reports it. The panel renders these as its
  *  own tabs; tmux stays the source of truth for which is active. `flags` is
  *  tmux's own marks (`*` current, `-` last, `!` bell, `#` activity, `Z` zoomed),
@@ -302,9 +294,6 @@ export interface TmuxWindow {
   name: string;
   active: boolean;
   flags: string;
-  /** Absent in demo mode's older payloads, and null whenever nothing has
-   *  claimed the window. */
-  attention?: TmuxAttention;
 }
 
 /** A tool call held at the gate, awaiting a remote approve/deny. */
@@ -1526,6 +1515,22 @@ export interface FirewallHint {
   undo: string | null;
 }
 
+/** A device that has reached this machine over the network. */
+export interface RemoteDevice {
+  address: string;
+  firstAt: number;
+  lastAt: number;
+  /** Sockets open from it at this instant: the event stream, a terminal, the
+   *  notification mirror. Above zero means it is connected now. */
+  live: number;
+  /** Its User-Agent, condensed to something a person recognises. */
+  label: string;
+  agent: string;
+  hits: number;
+  /** Refused at the door until it is let back in or the server restarts. */
+  blocked: boolean;
+}
+
 /** Whether another device can reach this server, and whether one ever has. */
 export interface RemoteStatus {
   /** Bound off loopback, so off-box traffic can arrive at all. */
@@ -1540,7 +1545,10 @@ export interface RemoteStatus {
   /** Ready-to-open URLs, token included when the caller is local. */
   urls: string[];
   addresses: ReachableAddress[];
-  clients: { count: number; lastAt: number | null; addresses: string[] };
+  clients: { count: number; lastAt: number | null; addresses: string[]; liveCount: number };
+  /** One row per device that has reached this machine. `live` is sockets held
+   *  open right now, which is the difference between "is here" and "was here". */
+  devices: RemoteDevice[];
   firewall: FirewallHint | null;
   /** Only ever sent to a caller on this machine. */
   token?: string;

--- a/web/src/components/RemoteAccessPane.tsx
+++ b/web/src/components/RemoteAccessPane.tsx
@@ -3,7 +3,8 @@ import { api } from "../lib/api.ts";
 import { IS_DESKTOP, remoteAccessEnabled, setRemoteAccess, revokeRemoteAccess } from "../lib/desktop.ts";
 import { qrMatrix, qrSvgPath } from "../lib/qr.ts";
 import { fmtAgo } from "../lib/format.ts";
-import type { RemoteStatus } from "../../../shared/types.ts";
+import { pickIndex, readPick, writePick, maskToken, type PickedAddress } from "../lib/remoteLink.ts";
+import type { RemoteStatus, RemoteDevice } from "../../../shared/types.ts";
 
 /**
  * Open the dashboard on your phone.
@@ -28,10 +29,15 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
   const [enabled, setEnabled] = useState<boolean | null>(null);
   const [busy, setBusy] = useState(false);
   const [copied, setCopied] = useState<string | null>(null);
-  const [pick, setPick] = useState(0);
+  // The chosen route, not its position in the list: see remotePick.ts for why
+  // an index cannot survive a new DHCP lease or a tailnet that comes up late.
+  const [chosen, setChosen] = useState<PickedAddress | null>(() => readPick());
   // Revoking cannot be undone and cannot be partially done, so it asks once.
   const [confirming, setConfirming] = useState(false);
   const [revokeNote, setRevokeNote] = useState<string | null>(null);
+  // The access code is covered until asked for: this pane is the one that ends
+  // up in screenshots. See maskToken.
+  const [reveal, setReveal] = useState(false);
 
   const load = useCallback(() => {
     api.remoteStatus().then(setSt).catch(() => setSt(null));
@@ -83,19 +89,19 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
   if (!st) return <Wrap><div className="px-3 py-2 text-[11px] t-dim2">Reading network state…</div></Wrap>;
 
   const urls = st.urls;
+  const pick = pickIndex(st.addresses, chosen);
   const url = urls[Math.min(pick, urls.length - 1)] ?? "";
-  const address = st.addresses[Math.min(pick, st.addresses.length - 1)];
+  const address = st.addresses[pick];
   const live = st.exposed && st.trustLan && urls.length > 0;
 
   return (
     <Wrap>
       <div className="px-3 py-2 flex flex-col gap-3">
-        <div className="text-[11.5px]" style={{ color: "var(--text2)" }}>
-          Open agentglass on a phone or tablet on the same network. Monitoring, sessions and gate
-          approvals, from the sofa. A device that connects from off this machine always gets the
-          phone companion, never this dashboard.
-        </div>
-
+        {/* The state of the feature, in the one row the eye lands on: what the
+            server is doing, whether anything is attached to it at this
+            instant, and the switch that changes it. The old pane opened with a
+            paragraph and put the switch under it, which meant the answer to
+            "is this on, and is anyone on it" was two reads away. */}
         {enabled === null ? (
           /* A browser tab cannot rebind the server it is talking to: only the
              process that spawned it can. Rather than a switch that would do
@@ -104,13 +110,30 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
           <Recipe port={st.port} />
         ) : (
           <button onClick={toggle} disabled={busy} role="switch" aria-checked={!!enabled}
-            className="w-full flex items-center gap-3 px-3 py-2.5 rounded-lg text-left hover:bg-white/5">
+            className="tile w-full !flex-row !items-center !gap-3 text-left hover:bg-white/5"
+            style={{ borderColor: enabled ? "color-mix(in srgb, var(--primary) 34%, transparent)" : undefined }}>
+            <StateDot on={!!enabled} live={st.clients.liveCount > 0} />
             <span className="min-w-0 flex-1">
-              <span className="block text-[12.5px]" style={{ color: "var(--text)" }}>Remote access</span>
+              <span className="block text-[13px] font-medium" style={{ color: "var(--text)" }}>
+                {busy ? "Restarting the server…" : enabled ? "Listening on your network" : "Remote access is off"}
+              </span>
               <span className="block text-[10.5px] t-dim2 mt-0.5">
-                {busy ? "Restarting the server…" : enabled ? "The server is listening on your network" : "Off — the server answers this machine only"}
+                {enabled
+                  ? "A phone or tablet can open the companion from the sofa: monitoring, sessions and gate approvals."
+                  : "The server answers this machine only. Nothing off-box can reach it."}
               </span>
             </span>
+            {/* Live count as a chip rather than a sentence: it changes every
+                three seconds, and a number that moves inside prose is noise. */}
+            {enabled && st.clients.liveCount > 0 && (
+              <span className="chip shrink-0 t-mono" style={{
+                color: "var(--success)",
+                background: "color-mix(in srgb, var(--success) 12%, transparent)",
+                borderColor: "color-mix(in srgb, var(--success) 34%, transparent)",
+              }}>
+                {st.clients.liveCount} connected
+              </span>
+            )}
             <span className="shrink-0 relative rounded-full transition-colors" style={{
               width: 34, height: 19, opacity: busy ? 0.5 : 1,
               background: enabled ? "color-mix(in srgb, var(--primary) 55%, transparent)" : "color-mix(in srgb, var(--border) 55%, transparent)",
@@ -124,59 +147,108 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
           </button>
         )}
 
-        {/* Turning it on is a real decision, so the consequence is stated in
-            the words it deserves rather than as "advanced". */}
-        {(enabled || st.exposed) && (
-          <div className="text-[10.5px] px-2.5 py-2 rounded-lg" style={{
-            color: "var(--text2)",
-            background: "color-mix(in srgb, var(--warning) 10%, transparent)",
-            border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)",
-          }}>
-            Anyone on this network who has the link below gets a terminal, git write access and docker
-            control on this machine. Fine at home. Not on café or airport wifi.
-          </div>
-        )}
-
         {live && (
           <>
-            <div className="flex items-start gap-3">
-              <Qr text={url} />
-              <div className="min-w-0 flex-1 flex flex-col gap-1.5">
-                <div className="text-[10.5px] t-dim2">Scan it with the phone's camera</div>
-                <button onClick={() => copy(url)}
-                  className="t-mono text-[10.5px] text-left px-2 py-1.5 rounded-lg break-all hover:opacity-80"
-                  style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg2) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>
-                  {url}
-                </button>
-                <div className="text-[10px] t-dim2">
-                  {copied === url ? "Copied" : "Tap to copy. The link carries the access code once; after that the phone remembers it."}
-                </div>
-                {/* More than one route to this machine is normal (wifi plus a
-                    tailnet). Naming them beats picking one and being wrong. */}
-                {urls.length > 1 && (
-                  <div className="flex flex-wrap gap-1 pt-0.5">
-                    {st.addresses.map((a, i) => (
-                      <button key={a.address} onClick={() => setPick(i)}
-                        className="text-[10px] px-2 py-1 rounded-md"
-                        style={{
-                          color: i === pick ? "var(--primary-hover)" : "var(--text2)",
-                          background: i === pick ? "color-mix(in srgb, var(--primary) 14%, transparent)" : "transparent",
-                          border: `1px solid color-mix(in srgb, var(--border) ${i === pick ? 60 : 30}%, transparent)`,
-                        }}>
-                        {a.tailnet ? "Tailscale" : a.iface} · {a.address}
+            {/* The link, given the room it needs: the code beside the QR
+                rather than under it, and the routes to this machine as a
+                column of real choices instead of a row of small pills. At the
+                old width all of this wrapped into a stack you had to scroll. */}
+            <div className="flex items-start gap-3.5">
+              <div className="shrink-0 flex flex-col items-center gap-1.5">
+                <Qr text={url} />
+                <span className="text-[10px] t-dim2">Scan with the camera</span>
+              </div>
+
+              <div className="min-w-0 flex-1 flex flex-col gap-2.5">
+                <div className="flex flex-col gap-1.5">
+                  <div className="flex items-center gap-2">
+                    <span className="text-[10px] t-dim2 uppercase tracking-wider flex-1">The link</span>
+                    {/* The QR always carries the real code — a masked one would
+                        not scan. This only covers the text a screenshot keeps. */}
+                    {url.includes("token=") && (
+                      <button onClick={(e) => { e.stopPropagation(); setReveal((v) => !v); }}
+                        className="text-[10px] px-2 py-0.5 rounded-md hover:opacity-80"
+                        style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+                        {reveal ? "Hide code" : "Show code"}
                       </button>
-                    ))}
+                    )}
                   </div>
-                )}
-                {address?.tailnet && (
+                  <button onClick={() => copy(url)}
+                    className="t-mono text-[11px] text-left px-2.5 py-2 rounded-lg break-all hover:opacity-80"
+                    style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>
+                    {reveal ? url : maskToken(url)}
+                  </button>
                   <div className="text-[10px] t-dim2">
-                    A tailnet address: reachable from anywhere, but only by devices signed into your Tailscale.
+                    {copied === url
+                      ? "Copied, code included"
+                      : "Click to copy, code included. The phone needs it once and then remembers it."}
+                  </div>
+                </div>
+
+                {/* More than one route to this machine is normal (wifi plus a
+                    tailnet), and they are not equivalent — one crosses a café,
+                    the other does not. Each says what it is rather than making
+                    the user infer it from an address, and the choice is kept
+                    (see remoteLink.ts) because the pane used to forget it. */}
+                {st.addresses.length > 1 && (
+                  <div className="flex flex-col gap-1.5">
+                    <span className="text-[10px] t-dim2 uppercase tracking-wider">Reachable at</span>
+                    <div className="flex flex-col gap-1">
+                      {st.addresses.map((a, i) => {
+                        const on = i === pick;
+                        return (
+                          <button key={a.address} onClick={() => { setChosen(a); writePick(a); }}
+                            className="flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left hover:opacity-90"
+                            style={{
+                              background: on ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+                              border: `1px solid color-mix(in srgb, ${on ? "var(--primary)" : "var(--border)"} ${on ? 45 : 30}%, transparent)`,
+                            }}>
+                            <span className="shrink-0 rounded-full" aria-hidden style={{
+                              width: 6, height: 6,
+                              background: on ? "var(--primary-hover)" : "transparent",
+                              border: on ? "none" : "1px solid var(--text4)",
+                            }} />
+                            <span className="min-w-0 flex-1">
+                              <span className="block text-[11.5px]" style={{ color: on ? "var(--text)" : "var(--text2)" }}>
+                                {a.tailnet ? "Tailscale" : a.iface}
+                                <span className="t-mono text-[10.5px] t-dim2"> {a.address}</span>
+                              </span>
+                              <span className="block text-[10px] t-dim2">
+                                {a.tailnet
+                                  ? "Works from anywhere, for devices signed into your tailnet."
+                                  : "Works for anything on this network, and only there."}
+                              </span>
+                            </span>
+                          </button>
+                        );
+                      })}
+                    </div>
                   </div>
                 )}
               </div>
             </div>
 
-            <Devices st={st} onCopy={copy} copied={copied} />
+            {/* Turning it on is a real decision, so the consequence is stated
+                in the words it deserves rather than as "advanced". The
+                sentence follows the address the user actually chose: a tailnet
+                link is reachable from anywhere and only by devices signed into
+                their own Tailscale, and saying "anyone on this network" over
+                the top of that would be false in the direction that teaches
+                people to stop reading warnings. */}
+            <div className="text-[10.5px] px-2.5 py-2 rounded-lg" style={{
+              color: "var(--text2)",
+              background: "color-mix(in srgb, var(--warning) 10%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)",
+            }}>
+              {address?.tailnet
+                ? <>Whoever holds this link gets a terminal, git write access and docker control on this
+                    machine. Over Tailscale that is limited to devices signed into your tailnet, which is the
+                    safer of the two links on offer. It is still a shell: treat the code like a house key.</>
+                : <>Anyone on this network who has this link gets a terminal, git write access and docker
+                    control on this machine. Fine at home. Not on café or airport wifi.</>}
+            </div>
+
+            <Devices st={st} onCopy={copy} copied={copied} onChanged={load} />
 
             {/* The toggle shuts the port; it does not take back the key. A
                 phone that scanned the code once can still get in the next time
@@ -184,7 +256,7 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
                 Rotating the code is the revoke that reaches devices you no
                 longer have in your hand. */}
             {enabled !== null && st.tokenRequired && (
-              <div className="flex flex-col gap-1.5">
+              <div className="flex flex-col gap-1.5 pt-1.5" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
                 {!confirming ? (
                   <button onClick={() => { setConfirming(true); setRevokeNote(null); }} disabled={busy}
                     className="self-start text-[11px] px-2.5 py-1.5 rounded-lg hover:opacity-80"
@@ -256,19 +328,91 @@ function Wrap({ children }: { children: React.ReactNode }) {
   );
 }
 
-/** Proof, or the reason there is none. */
-function Devices({ st, onCopy, copied }: { st: RemoteStatus; onCopy: (s: string) => void; copied: string | null }) {
-  const { clients, firewall } = st;
-  if (clients.count > 0) {
+/**
+ * Who is on this machine, one row each, and the button that ends it.
+ *
+ * This replaced a single green sentence that counted devices and gave their
+ * age. Counting is the wrong shape for the question being asked: the thing on
+ * the other end of that link holds a terminal, git write access and docker, so
+ * what a person wants to know is which device, whether it is connected *now*,
+ * and how to stop it without getting up. `live` answers the second one
+ * honestly — it is sockets held open at this instant, not a timestamp that
+ * says "4m" whether the phone is in your hand or in a taxi.
+ */
+function Devices({ st, onCopy, copied, onChanged }: {
+  st: RemoteStatus; onCopy: (s: string) => void; copied: string | null; onChanged: () => void;
+}) {
+  const { devices, clients, firewall } = st;
+  const [busy, setBusy] = useState<string | null>(null);
+
+  const setBlocked = async (d: RemoteDevice, blocked: boolean) => {
+    setBusy(d.address);
+    await api.remoteDevice(d.address, blocked).catch(() => null);
+    setBusy(null);
+    onChanged();
+  };
+
+  if (devices.length > 0) {
     return (
-      <div className="text-[11px] px-2.5 py-2 rounded-lg" style={{
-        color: "var(--success)",
-        background: "color-mix(in srgb, var(--success) 10%, transparent)",
-        border: "1px solid color-mix(in srgb, var(--success) 30%, transparent)",
-      }}>
-        {clients.count === 1 ? "One device has connected" : `${clients.count} devices have connected`}
-        {clients.lastAt ? ` — last seen ${fmtAgo(clients.lastAt)}` : ""}.
-        <span className="t-mono t-dim2"> {clients.addresses.slice(0, 3).join(" · ")}</span>
+      <div className="flex flex-col gap-1">
+        <div className="flex items-baseline gap-2 px-0.5">
+          <span className="text-[10px] t-dim2 uppercase tracking-wider flex-1">Devices</span>
+          <span className="text-[10px]" style={{ color: clients.liveCount > 0 ? "var(--success)" : "var(--text4)" }}>
+            {clients.liveCount > 0
+              ? `${clients.liveCount === 1 ? "One device is" : `${clients.liveCount} devices are`} connected right now`
+              : `${devices.length === 1 ? "One device has" : `${devices.length} devices have`} connected before`}
+          </span>
+        </div>
+        {devices.map((d) => {
+          const live = d.live > 0 && !d.blocked;
+          const tint = d.blocked ? "var(--error)" : live ? "var(--success)" : "var(--text3)";
+          return (
+            <div key={d.address} className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg" style={{
+              background: live ? "color-mix(in srgb, var(--success) 8%, transparent)" : "color-mix(in srgb, var(--bg2) 60%, transparent)",
+              border: `1px solid color-mix(in srgb, ${d.blocked ? "var(--error)" : live ? "var(--success)" : "var(--border)"} ${live || d.blocked ? 30 : 40}%, transparent)`,
+            }}>
+              {/* Steady when a socket is open, hollow when the device is only
+                  remembered. It is the fastest read in the row, so it carries
+                  the one fact that decides everything else. */}
+              <span className="shrink-0 rounded-full" aria-hidden style={{
+                width: 7, height: 7, background: live ? "var(--success)" : "transparent",
+                border: live ? "none" : `1px solid ${tint}`,
+                boxShadow: live ? "0 0 0 3px color-mix(in srgb, var(--success) 18%, transparent)" : "none",
+              }} />
+              <div className="min-w-0 flex-1">
+                <div className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>
+                  {d.label}
+                  <span className="t-mono text-[10px] t-dim2"> {d.address}</span>
+                </div>
+                <div className="text-[10px]" style={{ color: tint }}>
+                  {d.blocked
+                    ? "Disconnected. It is refused on every request until you let it back in."
+                    : live
+                      ? `Connected now · ${d.live === 1 ? "one open connection" : `${d.live} open connections`}`
+                      : `Last seen ${fmtAgo(d.lastAt)} · ${d.hits === 1 ? "one request" : `${d.hits} requests`}`}
+                </div>
+              </div>
+              <button onClick={() => setBlocked(d, !d.blocked)} disabled={busy === d.address}
+                className="shrink-0 text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+                style={{
+                  color: d.blocked ? "var(--text2)" : "var(--error)",
+                  background: d.blocked ? "transparent" : "color-mix(in srgb, var(--error) 10%, transparent)",
+                  border: `1px solid color-mix(in srgb, ${d.blocked ? "var(--border)" : "var(--error)"} ${d.blocked ? 45 : 32}%, transparent)`,
+                  opacity: busy === d.address ? 0.5 : 1,
+                }}>
+                {busy === d.address ? "Working…" : d.blocked ? "Let it back in" : "Disconnect"}
+              </button>
+            </div>
+          );
+        })}
+        {/* Said once, under the list, rather than in every row: an address is
+            not an identity. Cutting one off is immediate and it is not the
+            same promise as rotating the code. */}
+        <div className="text-[10px] t-dim2 px-0.5">
+          Disconnecting closes what that device is holding and refuses it by address until this server
+          restarts. A device that can take a new address on your network can come back, so revoke the link
+          below when the answer needs to be permanent.
+        </div>
       </div>
     );
   }
@@ -330,6 +474,25 @@ function Recipe({ port }: { port: number }) {
   );
 }
 
+/**
+ * On, off, and on-with-someone-attached, as one mark.
+ *
+ * Three states rather than two: "listening" and "listening while a phone holds
+ * a socket" are different facts about your machine, and the second is the one
+ * worth noticing from across the room.
+ */
+function StateDot({ on, live }: { on: boolean; live: boolean }) {
+  const tint = !on ? "var(--text4)" : live ? "var(--success)" : "var(--primary-hover)";
+  return (
+    <span className="shrink-0 rounded-full" aria-hidden style={{
+      width: 9, height: 9,
+      background: on ? tint : "transparent",
+      border: on ? "none" : `1px solid ${tint}`,
+      boxShadow: live ? `0 0 0 4px color-mix(in srgb, ${tint} 16%, transparent)` : "none",
+    }} />
+  );
+}
+
 /** The code itself: one SVG path, on a light plate so a dark theme still scans. */
 function Qr({ text }: { text: string }) {
   let path: string;
@@ -345,7 +508,7 @@ function Qr({ text }: { text: string }) {
   const span = size + quiet * 2;
   return (
     <svg
-      width={132} height={132} viewBox={`0 0 ${span} ${span}`} shapeRendering="crispEdges"
+      width={150} height={150} viewBox={`0 0 ${span} ${span}`} shapeRendering="crispEdges"
       role="img" aria-label={`QR code for ${text}`}
       className="shrink-0 rounded-lg"
       style={{ background: "#fff", padding: 0 }}>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -821,12 +821,19 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
               <motion.div
                 initial={{ opacity: 0, scale: 0.96, y: 12 }} animate={{ opacity: 1, scale: 1, y: 0 }} exit={{ opacity: 0, scale: 0.97, y: 8 }}
                 transition={{ type: "spring", stiffness: 340, damping: 30 }}
-                className="w-[820px] max-w-[95vw] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
+                className="w-[1040px] max-w-[95vw] rounded-2xl flex flex-col pointer-events-auto overflow-hidden"
                 // Fixed, not max: with tabs the pane's height would otherwise
                 // change with whichever section you picked, and a dialog that
                 // resizes under the cursor is disorienting in a way a little
                 // empty space never is.
-                                style={{ height: "min(78vh, 620px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
+                //
+                // Grown from 820x620 once Remote became a page rather than a
+                // paragraph: a QR code, a list of addresses and a row per
+                // connected device do not fit a column that narrow without
+                // wrapping into something you have to scroll to read. The vh
+                // caps keep it a dialog on a laptop screen rather than a
+                // full-screen takeover.
+                                style={{ height: "min(86vh, 760px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 60%, transparent)", boxShadow: "0 30px 80px -20px rgba(0,0,0,0.8)" }}>
 
                 <div className="flex items-center gap-3 px-5 py-3 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                   <span className="text-[15px] font-semibold" style={{ color: "var(--text)" }}>Settings</span>
@@ -837,7 +844,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                   {/* One page per concern instead of one long scroll: four
                       sections stacked vertically meant the shortcuts, the part
                       you come here to change, were always below the fold. */}
-                  <div className="shrink-0 w-[168px] py-2 px-2 flex flex-col gap-0.5 border-r" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+                  <div className="shrink-0 w-[186px] py-2 px-2 flex flex-col gap-0.5 border-r" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
                     {TABS.map((t) => (
                       <button key={t.id} onClick={() => setPane(t.id)}
                         className="w-full text-left px-2.5 py-1.5 rounded-lg text-[12px] flex items-center gap-2"

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -1393,43 +1393,16 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       // one pane is filling the window and the others are still
                       // there, which is confusing precisely when it is invisible.
                       const zoomed = w.flags.includes("Z");
-                      // An agent in the window has said what it wants: amber
-                      // because it asked you something, green because its turn
-                      // ended. A dot was not enough here. These tabs are how you
-                      // watch four agents at once, and the thing you need to see
-                      // from across the room is which one of the four, not that
-                      // one of them did something.
-                      //
-                      // Never on the tab you are looking at: whatever it wanted
-                      // to tell you is on screen, and the state is cleared the
-                      // moment the window is selected anyway. Painting it first
-                      // would only flash once on every switch.
-                      const attention = w.id === activeWindow ? null : w.attention ?? null;
-                      const attentionColor = attention === "waiting" ? "var(--warning)" : "var(--success)";
                       return (
                         <div key={w.id}
                           onClick={() => { if (w.id !== activeWindow) { setPendingWindow(w.id); tmuxCmd("select", { window: w.id }); } }}
                           onDoubleClick={() => setRenaming(w.id)}
-                          title={attention
-                            ? `Window ${w.index}: ${attention === "waiting" ? "asking you something" : "finished its turn"}${w.flags ? ` (${w.flags})` : ""}, double-click to rename`
-                            : `Window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
+                          title={`Window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
                           className="group flex items-center gap-1.5 px-2 py-1 rounded-md text-[10.5px] cursor-pointer shrink-0"
-                          // Every branch carries a border, transparent when it
-                          // has nothing to say, so a tab lighting up does not
-                          // shove the strip a pixel sideways.
                           style={w.id === activeWindow
-                            ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)", border: "1px solid transparent" }
-                            : attention
-                              ? {
-                                  background: `color-mix(in srgb, ${attentionColor} 22%, transparent)`,
-                                  color: attentionColor,
-                                  border: `1px solid color-mix(in srgb, ${attentionColor} 60%, transparent)`,
-                                  animation: "agx-attention 1.8s ease-in-out infinite",
-                                }
-                              : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)", border: "1px solid transparent" }}>
-                          {/* The index inherits the tab's colour while it is
-                              flashing; --text4 on an amber pill is unreadable. */}
-                          <span className="tabular-nums" style={attention ? undefined : { color: "var(--text4)" }}>{w.index}</span>
+                            ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--primary-hover)" }
+                            : { background: "color-mix(in srgb, var(--bg3) 55%, transparent)", color: "var(--text2)" }}>
+                          <span className="tabular-nums" style={{ color: "var(--text4)" }}>{w.index}</span>
                           {renaming === w.id ? (
                             <input
                               autoFocus
@@ -1455,11 +1428,8 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                             <span>{w.name || "shell"}</span>
                           )}
                           {zoomed && <span className="text-[9px] font-semibold leading-none" style={{ color: "var(--text4)" }} title="A pane in this window is zoomed">⤢</span>}
-                          {/* The dots stand down while the whole tab is
-                              flashing: a bell rung by the same turn that set
-                              the state is the same news twice. */}
-                          {!attention && bell && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--error)" }} title="Bell" />}
-                          {!attention && !bell && activity && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="Activity" />}
+                          {bell && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--error)" }} title="Bell" />}
+                          {!bell && activity && <span className="w-1.5 h-1.5 rounded-full" style={{ background: "var(--warning)" }} title="Activity" />}
                           <button onClick={(e) => { e.stopPropagation(); tmuxCmd("kill", { window: w.id }); }}
                             className="opacity-0 group-hover:opacity-100 leading-none px-0.5" title="Close window (kill-window)">✕</button>
                         </div>

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -628,15 +628,10 @@
 /* A chat that replied while you were elsewhere. Deliberately a slow, low-
    contrast breath rather than a hard blink: it sits in a header you look at
    all day, and something that flashes urgently for a message that can wait
-   trains you to ignore it.
-
-   The halo is drawn in currentColor so one keyframe serves every caller: the
-   element already has to set a colour to look like it means anything, and a
-   tmux tab breathing amber for "it asked you something" reads differently from
-   a chat breathing green for "it replied". */
+   trains you to ignore it. */
 @keyframes agx-attention {
-  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, currentColor 40%, transparent); }
-  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, currentColor 0%, transparent); }
+  0%, 100% { box-shadow: 0 0 0 0 color-mix(in srgb, var(--success) 40%, transparent); }
+  50%      { box-shadow: 0 0 0 4px color-mix(in srgb, var(--success) 0%, transparent); }
 }
 @media (prefers-reduced-motion: reduce) {
   @keyframes agx-attention { 0%, 100% { box-shadow: none; } }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -414,6 +414,10 @@ const realApi = {
   /** Where this server is reachable from another device, whether one has
    *  arrived, and which firewall is the likely reason if none has. */
   remoteStatus: () => get<RemoteStatus>("/remote/status"),
+  /** Cut one device off (or let it back in). Closes the sockets it is holding
+   *  as well as refusing what it sends next; only this machine may call it. */
+  remoteDevice: (address: string, blocked: boolean) =>
+    post<{ ok: boolean; address?: string; blocked?: boolean; closed?: number; error?: string }>("/remote/device", { address, blocked }),
   updateStatus: () => get<UpdateStatus>("/update/status"),
   // The tag is optional because the automatic modal wants "whatever this build
   // came from", while About asks for a named release — the update it is about
@@ -695,7 +699,8 @@ const demoApi: typeof realApi = {
   dockerStats: () => D(demo.dockerStats()),
   dockerLogs: (id: string, _tail?: number) => D(demo.dockerLogs(id)),
   updateNotes: (_tag?: string) => D({ ok: false, tag: "", notes: "", source: "", error: "not available in the demo" } as ReleaseNotes),
-  remoteStatus: () => D({ exposed: false, bind: "127.0.0.1", port: 4000, trustLan: false, tokenRequired: false, webUi: true, urls: [], addresses: [], clients: { count: 0, lastAt: null, addresses: [] }, firewall: null } as RemoteStatus),
+  remoteStatus: () => D({ exposed: false, bind: "127.0.0.1", port: 4000, trustLan: false, tokenRequired: false, webUi: true, urls: [], addresses: [], clients: { count: 0, lastAt: null, addresses: [], liveCount: 0 }, devices: [], firewall: null } as RemoteStatus),
+  remoteDevice: (_address: string, _blocked: boolean) => D({ ok: false, error: "not available in the demo" }),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),
   updateRun: () => D({ ok: false, error: "not available in the demo" }),
   hooksStatus: () => D({ installed: false, bundled: false, settingsPath: "~/.claude/settings.json", python: "python3" } as HookSetupStatus),

--- a/web/src/lib/remoteLink.ts
+++ b/web/src/lib/remoteLink.ts
@@ -1,0 +1,88 @@
+// Which of this machine's addresses the Remote pane should offer, remembered.
+//
+// A box with Tailscale on it has at least two routes to itself, and the pane
+// listed them with the plain LAN one first because that is the one that needs
+// no software on the phone. Sensible as a default, wrong as a permanent
+// answer: someone who picked the tailnet address picked it for a reason, and
+// the pane forgot on every open, so the QR quietly went back to a URL that
+// only works from the sofa.
+//
+// The saved thing is the address itself, never the index into the list. The
+// list is rebuilt from the live interfaces every three seconds, and it changes
+// shape for ordinary reasons — joining a different wifi, DHCP handing out a new
+// lease, Tailscale coming up late. An index survives none of that and would
+// silently point at a different network than the one that was chosen.
+export interface PickedAddress {
+  address: string;
+  iface: string;
+  tailnet: boolean;
+}
+
+const KEY = "agentglass.remote.address";
+
+export function readPick(store: Pick<Storage, "getItem"> | null = safeStorage()): PickedAddress | null {
+  try {
+    const raw = store?.getItem(KEY);
+    if (!raw) return null;
+    const v = JSON.parse(raw);
+    if (!v || typeof v.address !== "string" || typeof v.iface !== "string") return null;
+    return { address: v.address, iface: v.iface, tailnet: !!v.tailnet };
+  } catch {
+    return null; // private mode, or someone hand-edited it into nonsense
+  }
+}
+
+export function writePick(a: PickedAddress, store: Pick<Storage, "setItem"> | null = safeStorage()): void {
+  try {
+    store?.setItem(KEY, JSON.stringify({ address: a.address, iface: a.iface, tailnet: a.tailnet }));
+  } catch {
+    /* private mode — the choice just lasts as long as the pane is open */
+  }
+}
+
+function safeStorage(): Storage | null {
+  try { return typeof localStorage === "undefined" ? null : localStorage; } catch { return null; }
+}
+
+/**
+ * The index to select, given what is reachable now and what was chosen before.
+ *
+ * Three steps down, because the address that was saved may genuinely be gone:
+ *
+ *   1. the same address, which is the normal case and the only exact answer;
+ *   2. the same interface, for a laptop whose DHCP lease moved it from
+ *      192.168.1.131 to .140 on the same wifi — same route, new number;
+ *   3. the same kind, tailnet or not, which is what carries the intent across
+ *      a change of network entirely. "I want the address that works from
+ *      anywhere" is still answerable on a different wifi; the number is not.
+ *
+ * Nothing saved, or nothing that matches, falls back to 0 — the list already
+ * arrives with the no-extra-software address first.
+ */
+export function pickIndex(addresses: readonly PickedAddress[], saved: PickedAddress | null): number {
+  if (!addresses.length) return 0;
+  if (!saved) return 0;
+  const exact = addresses.findIndex((a) => a.address === saved.address);
+  if (exact >= 0) return exact;
+  const sameIface = addresses.findIndex((a) => a.iface === saved.iface);
+  if (sameIface >= 0) return sameIface;
+  const sameKind = addresses.findIndex((a) => a.tailnet === saved.tailnet);
+  return sameKind >= 0 ? sameKind : 0;
+}
+
+/**
+ * The same link with the access code covered up.
+ *
+ * This pane is the one people screenshot — it is where the QR code is, so it
+ * is what gets sent to a colleague or pasted into an issue to ask why the
+ * phone will not connect. The code in that URL is a working key to a terminal
+ * on this machine, and it is legible in the picture. Covering it by default
+ * costs a click on the rare occasion someone wants to read it out, and saves
+ * the one occasion that matters.
+ *
+ * The QR itself still carries the real URL: a masked code would not scan, and
+ * a photograph of a screen is a far smaller audience than a screenshot.
+ */
+export function maskToken(url: string): string {
+  return url.replace(/([?&]token=)([^&#]+)/i, (_m, lead: string, secret: string) => `${lead}${"•".repeat(Math.min(12, Math.max(6, secret.length)))}`);
+}

--- a/web/test/remote-link.test.ts
+++ b/web/test/remote-link.test.ts
@@ -1,0 +1,100 @@
+// The Remote pane's two pure decisions: which address to offer back, and how
+// much of the link to put on screen. Both exist because of something that
+// happened rather than something imagined — a chosen tailnet address that
+// reverted to the LAN on every open, and an access code legible in a
+// screenshot.
+import { describe, expect, test } from "bun:test";
+import { pickIndex, readPick, writePick, maskToken, type PickedAddress } from "../src/lib/remoteLink.ts";
+
+const lan: PickedAddress = { address: "192.168.1.131", iface: "enp42s0", tailnet: false };
+const tail: PickedAddress = { address: "100.85.155.119", iface: "tailscale0", tailnet: true };
+
+describe("which address to offer", () => {
+  test("nothing saved falls back to the first, which is the no-extra-software one", () => {
+    expect(pickIndex([lan, tail], null)).toBe(0);
+    expect(pickIndex([], tail)).toBe(0);
+  });
+
+  test("the saved address wins, wherever the list puts it now", () => {
+    expect(pickIndex([lan, tail], tail)).toBe(1);
+    // reachableAddresses() sorts tailnet last, so the index is not stable
+    // between reads; the address is what was chosen.
+    expect(pickIndex([tail, lan], tail)).toBe(0);
+  });
+
+  test("a new DHCP lease on the same interface keeps the choice", () => {
+    const moved: PickedAddress = { address: "192.168.1.140", iface: "enp42s0", tailnet: false };
+    expect(pickIndex([moved, tail], lan)).toBe(0);
+  });
+
+  test("on a different network entirely, the kind of address carries the intent", () => {
+    // Saved a tailnet address, now on café wifi with a tailnet that came up
+    // under a different name: "the one that works from anywhere" is still
+    // answerable even though neither the address nor the interface matches.
+    const otherTail: PickedAddress = { address: "100.99.1.2", iface: "tailscale1", tailnet: true };
+    const otherLan: PickedAddress = { address: "10.0.0.9", iface: "wlan0", tailnet: false };
+    expect(pickIndex([otherLan, otherTail], tail)).toBe(1);
+  });
+
+  test("a saved address that has no counterpart at all falls back to the first", () => {
+    expect(pickIndex([lan], tail)).toBe(0);
+  });
+});
+
+describe("remembering it", () => {
+  const fake = () => {
+    const map = new Map<string, string>();
+    return {
+      getItem: (k: string) => map.get(k) ?? null,
+      setItem: (k: string, v: string) => { map.set(k, v); },
+    };
+  };
+
+  test("round-trips the choice", () => {
+    const store = fake();
+    writePick(tail, store);
+    expect(readPick(store)).toEqual(tail);
+  });
+
+  test("survives a hand-edited or absent value without throwing", () => {
+    const store = fake();
+    expect(readPick(store)).toBeNull();
+    store.setItem("agentglass.remote.address", "{not json");
+    expect(readPick(store)).toBeNull();
+    store.setItem("agentglass.remote.address", JSON.stringify({ nope: true }));
+    expect(readPick(store)).toBeNull();
+  });
+
+  test("a storage that refuses to write is not fatal", () => {
+    // Private mode: the choice lasts as long as the pane is open, and nothing
+    // in the pane breaks.
+    const throwing = { setItem: () => { throw new Error("denied"); } };
+    expect(() => writePick(tail, throwing)).not.toThrow();
+  });
+});
+
+describe("masking the access code", () => {
+  test("covers the code and nothing else", () => {
+    // An obviously fake code on purpose: this file is public, and a realistic
+    // one is the kind of string that gets copied out of a test into a shell.
+    const masked = maskToken("http://192.168.1.131:4000/?token=EXAMPLE-not-a-real-access-code-0000");
+    expect(masked).toStartWith("http://192.168.1.131:4000/?token=");
+    expect(masked).not.toContain("EXAMPLE-not-a-real");
+    expect(masked).toMatch(/token=•+$/);
+  });
+
+  test("leaves a link that carries no code alone", () => {
+    expect(maskToken("http://192.168.1.131:4000/")).toBe("http://192.168.1.131:4000/");
+  });
+
+  test("keeps whatever follows the code", () => {
+    expect(maskToken("http://x:4000/?token=abc123&view=fleet")).toBe("http://x:4000/?token=••••••&view=fleet");
+  });
+
+  test("the mask length does not leak the code length", () => {
+    const short = maskToken("http://x:4000/?token=ab");
+    const long = maskToken("http://x:4000/?token=" + "a".repeat(64));
+    expect(short.split("=")[1]).toBe("••••••");
+    expect(long.split("=")[1]).toBe("••••••••••••");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Three things the Remote pane could not do, and the dialog size that was in the way.

**It forgot which address you chose.** A machine on a tailnet has at least two routes to itself. The list puts the plain LAN address first, because that is the one that needs no software on the phone, and the pane read index 0 on every open. Anyone who picked the tailnet address got the LAN one back a minute later, in a QR code, silently. The choice is now saved by address rather than by position: the list is rebuilt from live interfaces every three seconds and changes shape for ordinary reasons, so an index points at a different network than the one that was chosen. Matching steps down from the exact address, to the same interface (a new DHCP lease on the same wifi), to the same kind of address (which is what carries "the one that works from anywhere" onto a different network).

**It could not say who is connected.** "One device has connected, last seen 4m" is a count and an age, and on the other end of that link is a terminal, git write access and docker control. Every device now has a row: the name its User-Agent implies, its address, how many requests it has made, and live state that means what it says. Live is sockets held open at this instant, counted across the event stream, terminals and the notification mirror, rather than a timestamp that reads the same whether the phone is in your hand or in a taxi.

**It offered no way to end a session.** Each row has Disconnect. It closes the sockets that device is holding and refuses it by address from the next packet on, checked above the token gate, because the case this exists for is a device that already has the code. The UI is honest about what that is: an in-memory address block, undone by a restart or by "Let it back in", and not a substitute for rotating the link, which is offered right below it.

Two smaller things. The access code is masked until you ask for it, because this is the pane people screenshot to ask why a phone will not connect, and the code in that URL is a working key to a shell (the QR still carries the real link). And the warning follows the address that is actually selected: on a tailnet link, "anyone on this network" was false in the calm direction, which is how people learn to stop reading warnings.

The Settings dialog goes from 820x620 to 1040x760, capped in vh so it stays a dialog rather than a takeover. Remote had outgrown the old width: a QR code, the addresses this machine answers on, and a row per device wrapped into a stack you scrolled. The pane is rebuilt for the room, opening with the state (a mark that is hollow when off, filled when listening, haloed when something is attached) instead of a paragraph, with the link beside the QR and the routes as a column of choices that each say what they are.

## How was it tested?

- `bun test`: 1925 pass. 44 of them cover this work: address memory and code masking in `web/test/remote-link.test.ts`, and live socket counting, the block list, the eviction cap and the User-Agent condenser in `server/test/remote.test.ts`.
- `bunx tsc --noEmit` in `web/` and `server/`: clean.
- Desktop app rebuilt from this branch and installed locally, and the pane exercised with a phone on the tailnet.

One pre-existing failure is unrelated and also fails on `main`: `server/test/webui.test.ts > resolveDist > blank and unset fall through to the fallback` picks up the real installed app under `~/.local/share/agentglass-desktop`. Same "tests read the machine they run on" pattern as #315, fixed separately.