### PR TITLE
The phone's tab bar floats now, and settings rides on it (#425)

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -258,6 +258,23 @@ async function main() {
     const nowText = await cdp.ev(`document.querySelector("main")?.textContent?.trim()?.length || 0`);
     note("now", "renders something", nowText > 20, `main had ${nowText} chars`);
 
+    // The tab bar floats over the queue, so the queue has to end above it. A
+    // last card parked permanently under the pill is the one way this shape is
+    // worse than the bar it replaced, and it is invisible until you scroll to
+    // the bottom of a list — so scroll to the bottom of the list.
+    await cdp.ev(`scrollTo(0, document.body.scrollHeight)`);
+    await Bun.sleep(900);
+    note("now", "the last card ends above the tab bar",
+      await cdp.ev(`(()=>{const c=[...document.querySelectorAll("main .mb-item")].pop();
+        const n=document.querySelector("nav"); if(!c||!n) return true;
+        return c.getBoundingClientRect().bottom <= n.getBoundingClientRect().top + 1;})()`),
+      await cdp.ev(`(()=>{const c=[...document.querySelectorAll("main .mb-item")].pop();
+        const n=document.querySelector("nav"); if(!c||!n) return "nothing to measure";
+        return "card ends at " + Math.round(c.getBoundingClientRect().bottom)
+          + ", bar starts at " + Math.round(n.getBoundingClientRect().top);})()`));
+    await cdp.ev(`scrollTo(0, 0)`);
+    await Bun.sleep(500);
+
     // ---- Chats -------------------------------------------------------
     note("chats", "tab opens", await tap(cdp, "nav button", "Chats"));
     await Bun.sleep(900);
@@ -710,7 +727,12 @@ async function main() {
     }
 
     // ---- settings ----------------------------------------------------
-    if (await tap(cdp, "header button[aria-label='Settings']")) {
+    // The way in is the key on the tab bar now, not a gear in a header. When
+    // that entry point moves again, this has to fail rather than quietly skip
+    // the thirteen checks behind it, which is what it did the first time.
+    const intoSettings = await tap(cdp, "nav .mb-navkey");
+    note("settings", "the way in is on the tab bar", intoSettings);
+    if (intoSettings) {
       await Bun.sleep(900);
       note("settings", "sheet opens", await cdp.ev(`!!document.querySelector(".mb-sheet.on")`));
       note("settings", "reports what this machine spent",
@@ -815,7 +837,7 @@ async function main() {
 
       // The count the Settings row shows has to be the store's, not a list in
       // memory that a reload has already thrown away.
-      await tap(cdp, "header button", "⚙");
+      await tap(cdp, "nav .mb-navkey");
       await Bun.sleep(700);
       note("later", "Settings counts it as hidden",
         await cdp.ev(`/1 hidden until they change/.test(document.body.textContent)`),
@@ -873,15 +895,29 @@ async function main() {
     // ---- the server going away ---------------------------------------
     // A companion that silently shows stale numbers when the machine it is
     // watching has gone is worse than one that says so.
+    // The state of the link lives on the settings key: a coloured dot, and the
+    // word in the key's own accessible name, which is what a screen reader
+    // announces and what the sheet behind it prints. Reading the name rather
+    // than a header's text is the stronger check of the two — a header can say
+    // "Offline" while the control the person can actually reach says nothing.
+    const linkName = `(document.querySelector("nav .mb-navkey")?.getAttribute("aria-label") || "").toLowerCase()`;
+    const linkDot = `getComputedStyle(document.querySelector("nav .mb-navkey .lk") || document.body).backgroundColor`;
+    // Read while the machine is still there, so the comparison below is against
+    // a colour that actually meant "live".
+    const liveDot = await cdp.ev(linkDot);
+
     await cdp.ev(`window.__origFetch = window.fetch; window.fetch = () => Promise.reject(new Error("offline"))`);
     await Bun.sleep(6000);
-    note("offline", "says the connection is gone",
-      await cdp.ev(`(document.querySelector("header")?.textContent || "").includes("Offline")`));
+    note("offline", "says the connection is gone", await cdp.ev(`${linkName}.includes("offline")`),
+      await cdp.ev(linkName));
+    note("offline", "and the dot stops claiming otherwise",
+      (await cdp.ev(linkDot)) !== liveDot
+      && await cdp.ev(`getComputedStyle(document.querySelector("nav .mb-navkey .lk")).animationName === "none"`));
     await shot(cdp, "12-offline");
     await cdp.ev(`window.fetch = window.__origFetch; window.__audit = { errors: [], net: [] }`);
     await Bun.sleep(5000);
-    note("offline", "comes back on its own",
-      await cdp.ev(`(document.querySelector("header")?.textContent || "").includes("Live")`));
+    note("offline", "comes back on its own", await cdp.ev(`${linkName}.includes("live")`),
+      await cdp.ev(linkName));
     await drain(cdp, "offline");
 
     // ---- landscape ----------------------------------------------------

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -734,33 +734,28 @@ export function MobileApp() {
       {askDialog}
       <div className="mb-sky" />
 
-      {!immersive && <header className="sticky top-0 z-40 flex items-center gap-2 px-4"
-        style={{
-          paddingTop: "calc(env(safe-area-inset-top) + 11px)", paddingBottom: 10,
-          background: "color-mix(in srgb, var(--bg) 80%, transparent)", backdropFilter: "blur(16px) saturate(1.4)",
-          borderBottom: "1px solid var(--mb-line)",
-        }}>
-        <span className="text-[17.5px] font-bold tracking-tight">
-          agent<span style={{ color: "var(--primary-hover)" }}>glass</span>
-        </span>
-        <span className="flex-1" />
-        {/* What this said before was that one four-second poll had succeeded,
-            on an app with no live connection — "Live" meant "the last request
-            came back". It is the socket now, so it can mean what it says. */}
-        <span className="flex items-center gap-1.5 text-[11px]" style={{ color: LINK_TONE[link] }}>
-          <span className="mb-dot pulse" style={{ background: "currentColor", color: "currentColor" }} />
-          {LINK_WORD[link]}
-        </span>
-        <button className="mb-press grid place-items-center" aria-label="Settings"
-          style={{ minHeight: 40, minWidth: 40, borderRadius: 11, fontSize: 15, color: "var(--text3)", background: "transparent" }}
-          onClick={() => setSettings(true)}>⚙</button>
-      </header>}
+      {/* Two permanent bands out of 844px was the complaint, and this is the
+          one that earned its height least: a wordmark the person installed, a
+          word for the link, and a way into settings. The last two moved onto
+          the tab bar, which was going to be there anyway; the wordmark did not
+          survive the move, and nothing is worse for it. What is left of it is
+          the veil over the status bar, which occupies space the layout could
+          never use. */}
+      {!immersive && <div className="mb-veil" />}
 
       {/* No padding while a conversation owns the screen: it is a fixed
           full-height surface of its own, and the reserve for a tab bar that is
           not being drawn would only push its composer off the bottom. */}
       <main className="flex-1 relative"
-        style={{ zIndex: 1, padding: immersive ? 0 : "14px 15px calc(var(--nav) + env(safe-area-inset-bottom) + 22px)" }}>
+        style={{
+          zIndex: 1,
+          padding: immersive
+            ? 0
+            // Top: what the header used to hold clear. Bottom: the pill's top
+            // edge and a breath, so the last card ends above it rather than
+            // under it.
+            : "calc(env(safe-area-inset-top) + 14px) 15px calc(var(--nav-space) + 12px)",
+        }}>
         {tab === "now" && (
           <>
             <NowHero
@@ -785,12 +780,7 @@ export function MobileApp() {
           }} />}
       </main>
 
-      {!immersive && <nav className="fixed left-0 right-0 bottom-0 z-40 flex"
-        style={{
-          background: "color-mix(in srgb, var(--bg2) 84%, transparent)", backdropFilter: "blur(20px) saturate(1.5)",
-          borderTop: "1px solid color-mix(in srgb, var(--border) 48%, transparent)",
-          paddingBottom: "env(safe-area-inset-bottom)",
-        }}>
+      {!immersive && <nav className="mb-nav">
         <TabBtn id="now" tab={tab} onPick={setTab} glyph="◎" label="Now" badge={queue.length} />
         <TabBtn id="chats" tab={tab} onPick={setTab} glyph="▤" label="Chats" />
         <TabBtn id="repos" tab={tab} onPick={setTab} glyph="◇" label="Repos" />
@@ -798,6 +788,17 @@ export function MobileApp() {
             and had no route to a phone. The badge is what is misbehaving. */}
         <TabBtn id="fleet" tab={tab} onPick={setTab} glyph="◈" label="Fleet"
           badge={insights.filter((i) => i.severity === "bad").length} />
+        {/* The state of the link is better off here than it was in the header:
+            a conversation used to hide the header and take the indicator with
+            it, and this is on screen on every tab at every scroll position.
+            The colour is the whole message, so the word it stands for is the
+            first row of the sheet it opens. */}
+        <button className="mb-navkey mb-press" onClick={() => setSettings(true)}
+          aria-label={`Settings · ${LINK_WORD[link].toLowerCase()}`}>
+          ⚙
+          <span className={`lk${link === "offline" ? " dead" : ""}`}
+            style={{ background: LINK_TONE[link], color: LINK_TONE[link] }} />
+        </button>
       </nav>}
 
       <RepoScreen open={!!openRepo && !openPr} repo={openRepo}
@@ -817,6 +818,13 @@ export function MobileApp() {
 
       <Sheet open={settings} title="Settings" sub="This device only." onClose={() => setSettings(false)}>
         <div className="flex flex-col gap-2.5">
+          {/* The word the header used to print, in the place the dot on the
+              settings key sends you. A colour says something is wrong; only
+              this says what. */}
+          <Row tint={LINK_TONE[link]} pulse={link !== "offline"} title={LINK_WORD[link]}
+            sub={link === "live" ? "Streaming from your machine"
+              : link === "slow" ? "Reachable, but not streaming right now"
+              : "Nothing is answering on this address"} />
           <Row title="Spend today" sub={stats?.totals ? `${fmtTokens(stats.totals.input_tokens + stats.totals.output_tokens)} tokens` : "—"} right={spend} />
           <Row title="Sessions" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.sessions) : "—"} />
           <Row title="Tool errors" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.errors) : "—"} />
@@ -887,19 +895,10 @@ function TabBtn({ id, tab, onPick, glyph, label, badge }: {
 }) {
   const on = tab === id;
   return (
-    <button onClick={() => onPick(id)} aria-current={on}
-      className="flex-1 flex flex-col items-center justify-center gap-1 relative"
-      style={{ minHeight: "var(--nav)", fontSize: 10.5, color: on ? "var(--primary-hover)" : "var(--text3)", background: "transparent" }}>
-      <span style={{ fontSize: 17, lineHeight: 1, transform: on ? "translateY(-2px) scale(1.12)" : undefined, transition: "transform .3s cubic-bezier(.3,1.4,.5,1)" }}>{glyph}</span>
+    <button className="mb-tab mb-press" onClick={() => onPick(id)} aria-current={on}>
+      <span className="g">{glyph}</span>
       {label}
-      {on && <span style={{ position: "absolute", top: 0, width: 30, height: 2, borderRadius: "0 0 3px 3px", background: "var(--primary-hover)", boxShadow: "0 0 12px var(--primary)" }} />}
-      {!!badge && (
-        <span className="mb-tnum" style={{
-          position: "absolute", top: 10, right: "calc(50% - 23px)", minWidth: 17, height: 17, borderRadius: 9,
-          fontSize: 9.5, display: "grid", placeItems: "center", padding: "0 5px", fontWeight: 700,
-          background: "var(--warning)", color: "#2a1d02", boxShadow: "0 0 0 2px color-mix(in srgb, var(--bg2) 88%, transparent)",
-        }}>{badge}</span>
-      )}
+      {!!badge && <span className="b">{badge}</span>}
     </button>
   );
 }

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -18,7 +18,16 @@ import type { ConfirmSpec } from "../components/ConfirmDialog.tsx";
 export const MOBILE_CSS = `
 .mb{
   --tap:44px;
-  --nav:64px;
+  /* The tab bar floats, so it is described by three numbers rather than one:
+     how tall the pill is, how far it keeps off the home indicator, and how far
+     it is inset from the sides. --nav-space is where its top edge lands, and
+     that is the reserve everything else measures from — the queue pads by it so
+     the last card is never stranded under the glass, and toasts sit on top of
+     it. Resize the pill here and both follow. */
+  --nav:54px;
+  --nav-gap:10px;
+  --nav-side:14px;
+  --nav-space:calc(var(--nav) + var(--nav-gap) + env(safe-area-inset-bottom));
   --mb-line:color-mix(in srgb,var(--border) 34%,transparent);
   --mb-card:color-mix(in srgb,var(--bg2) 70%,transparent);
   /* A raised surface catches light along its top edge and drops a shadow
@@ -182,9 +191,61 @@ export const MOBILE_CSS = `
   min-height:0;flex:1;overscroll-behavior:contain}
 .mb-sheet h3{font-size:16px;font-weight:600}
 
+/* ── the tab bar ──────────────────────────────────────────────────── */
+/**
+ * A pill that floats, rather than a bar welded to the bottom edge.
+ *
+ * Docked, the bar was 84% translucent, which means its contrast was whatever
+ * happened to be scrolling underneath it: a number that moves is not a contrast
+ * ratio, and at the bottom of a dark queue in daylight four grey labels is what
+ * it came to. On its own surface it has contrast of its own, and the same
+ * change buys the second complaint back for free — the queue visibly continues
+ * past the pill instead of stopping dead above a hard edge, so the reserved
+ * band reads as less of a small screen than it did.
+ *
+ * Labels went from 10.5px regular to 11.5px semibold at the same time. The
+ * translucency was only half of why they were hard to read.
+ */
+.mb-nav{position:fixed;z-index:40;display:flex;gap:2px;padding:5px;
+  left:var(--nav-side);right:var(--nav-side);bottom:calc(env(safe-area-inset-bottom) + var(--nav-gap));
+  border-radius:22px;
+  background:linear-gradient(180deg,color-mix(in srgb,var(--bg3) 62%,var(--bg2)),var(--bg2));
+  border:1px solid color-mix(in srgb,var(--primary) 34%,transparent);
+  box-shadow:0 18px 40px -14px rgba(0,0,0,.92),var(--mb-edge)}
+.mb-tab{flex:1;min-height:var(--nav);border-radius:17px;position:relative;background:transparent;
+  display:flex;flex-direction:column;align-items:center;justify-content:center;gap:3px;
+  font-size:11.5px;font-weight:600;color:var(--text3);transition:background .16s,color .16s}
+.mb-tab .g{font-size:17px;line-height:1}
+/* The active tab is a filled slab. Docked, it was a 2px hairline along the top
+   edge of the bar; on a pill there is no shared edge to draw it on, and a slab
+   says the same thing without one. */
+.mb-tab[aria-current="true"]{color:var(--text);background:color-mix(in srgb,var(--primary) 20%,transparent)}
+.mb-tab .b{position:absolute;top:4px;right:calc(50% - 24px);min-width:17px;height:17px;border-radius:9px;
+  font-size:9.5px;font-weight:700;display:grid;place-items:center;padding:0 5px;
+  background:var(--warning);color:#2a1d02;font-variant-numeric:tabular-nums;
+  box-shadow:0 0 0 2px color-mix(in srgb,var(--bg3) 62%,var(--bg2))}
+/* Settings, and the state of the link as the dot on it. Deliberately not a
+   fifth tab: it does not navigate, so it is narrower than one, it sits behind a
+   hairline, and it never takes the active fill. */
+.mb-navkey{flex:none;width:48px;min-height:var(--nav);border-radius:17px;position:relative;
+  display:grid;place-items:center;font-size:16px;color:var(--text3);background:transparent;
+  transition:background .16s,color .16s}
+.mb-navkey::before{content:"";position:absolute;left:-3px;top:13px;bottom:13px;width:1px;border-radius:1px;
+  background:color-mix(in srgb,var(--primary) 26%,transparent)}
+.mb-navkey .lk{position:absolute;top:12px;right:9px;width:7px;height:7px;border-radius:50%;
+  box-shadow:0 0 0 2px color-mix(in srgb,var(--bg3) 62%,var(--bg2));animation:mb-dp 2s ease-out infinite}
+/* Nothing is answering: a dot that keeps pulsing is claiming otherwise. */
+.mb-navkey .lk.dead{animation:none}
+
+/* The status bar area, now that the app has nothing pinned under it. It costs
+   no layout height — the inset is unusable either way — and it keeps the clock
+   legible over a queue scrolling past underneath. */
+.mb-veil{position:fixed;top:0;left:0;right:0;height:env(safe-area-inset-top);z-index:35;pointer-events:none;
+  background:color-mix(in srgb,var(--bg) 82%,transparent);backdrop-filter:blur(12px)}
+
 /* ── toasts ───────────────────────────────────────────────────────── */
 .mb-toasts{position:fixed;left:14px;right:14px;z-index:90;display:flex;flex-direction:column;gap:9px;
-  pointer-events:none;bottom:calc(var(--nav) + env(safe-area-inset-bottom) + 14px)}
+  pointer-events:none;bottom:calc(var(--nav-space) + 14px)}
 .mb-toasts.raised{bottom:calc(env(safe-area-inset-bottom) + 112px)}
 .mb-toast{border-radius:14px;padding:12px 15px;font-size:12.5px;display:flex;align-items:center;gap:10px;
   background:linear-gradient(180deg,color-mix(in srgb,var(--bg3) 80%,var(--bg2)),var(--bg2));


### PR DESCRIPTION
## What does this PR do?

Fixes #425.

The companion's bottom bar was docked to the bottom edge and 84% translucent, so its contrast was whatever happened to be scrolling underneath it, and its 10.5px labels came to four grey smudges on a real phone. Above the queue sat a second permanent band carrying a wordmark, a word for the link, and a gear.

The bar is now a floating pill: inset from the sides, clear of the home indicator, on its own surface with a shadow, with the queue visibly continuing underneath it rather than stopping dead above a hard edge. Labels are 11.5px semibold, and the active tab is a filled slab rather than a hairline drawn along an edge the pill no longer has.

The header is gone. What it carried that mattered moved onto the pill: a settings key behind a hairline, narrower than a tab because it does not navigate, with the state of the link as the dot on it. That state is permanent for the first time, since the old indicator vanished with the header whenever a conversation was open, and the word it stands for is the first row of the sheet the key opens.

Permanent chrome goes from 218px to 110px on a 390x844 screen.

Two notes on the issue as filed, from measuring it rather than reading it:

- The contrast claim does not hold on this palette. `--text3` over the docked bar composites to 9.8:1 against the darkest ground and 10.1:1 against a critical card. The fault was size and weight, plus a ratio that moved with the content rather than one that was low. Both are fixed; only the diagnosis changed.
- Floating on its own buys almost nothing back: the pill reserves 110px where the docked bar reserved 120px. All the height came from deleting the header, which is why this PR does that rather than only rounding the bar's corners.

`--nav` is still the single number the layout reads, now alongside the gap and the inset the pill needs. `--nav-space` is where its top edge lands, and the queue pads by it so the last card is never stranded under the glass.

## How was it tested?

`bunx tsc --noEmit` in `web/`, clean.

`scripts/phone-audit.ts` against a real server on both sides of the change, headless Chrome at 412x915, with a copy of a real database so the screens have something in them:

- main: 147/147
- this branch: 150/150

Three of the harness's own checks were rewired, because they asserted on a header this PR deletes:

- The way into settings is now `nav .mb-navkey`, and a failure to find it is reported instead of silently skipping the thirteen checks behind it, which is what happened the first time this ran.
- The offline and recovery checks read the link state off the settings key's accessible name and the colour of its dot, rather than a header's text. That is what a screen reader announces, so it is the stronger of the two assertions.

One check was added, for the rule the issue calls load-bearing: scroll the queue to the bottom and assert the last card ends above the tab bar. A card parked permanently under the pill is the one way this shape would be worse than the bar it replaces, and it is invisible until you reach the end of a list.

Exercised by hand on the phone application: Now, Chats, Repos, Fleet, a pushed screen over the pill, an open conversation with the bar gone, the settings sheet, and a toast sitting on top of the reserve.
