### PR TITLE
fix(remote): stop listing this machine as a stranger, and name a Pixel

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -77,7 +77,7 @@ import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
 import { updateStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
 import { rateOk } from "./ratelimit.ts";
-import { noteClient, noteSocket, isLoopback, isBlocked, blockDevice, remoteStatus } from "./remote.ts";
+import { noteClient, noteSocket, isLoopback, isSelf, isBlocked, blockDevice, remoteStatus } from "./remote.ts";
 import { parseWindowMs } from "./params.ts";
 import { serveWeb, serveIndex, WEB_UI_ENABLED } from "./webui.ts";
 import { notifyCapability, subscribeNotifications, notifyWatching, openNote } from "./notifications.ts";
@@ -866,6 +866,10 @@ const server = Bun.serve<WsData>({
       const address = typeof b.address === "string" ? b.address : "";
       const blocked = b.blocked !== false;
       if (!address) return json({ ok: false, error: "no address" }, 400);
+      // Said before the store is asked, so the message names the real reason
+      // rather than "no such device": blocking an address this machine answers
+      // on would cut off the window the button was pressed in.
+      if (blocked && isSelf(address)) return json({ ok: false, error: "that address is this machine" }, 400);
       if (!blockDevice(address, blocked)) return json({ ok: false, error: "no such device" }, 404);
       let closed = 0;
       if (blocked) {

--- a/server/src/remote.ts
+++ b/server/src/remote.ts
@@ -47,6 +47,9 @@ export interface DeviceRecord {
   hits: number;
   /** Turned away at the door until it is let back in, or the server restarts. */
   blocked: boolean;
+  /** This machine, reaching itself through one of its own addresses rather
+   *  than through loopback. Never a device to cut off. */
+  self?: boolean;
 }
 
 const seen = new Map<string, DeviceRecord>();
@@ -135,9 +138,13 @@ export function noteSocket(ip: string | null | undefined, delta: 1 | -1, now = D
  * pick a new address on the same network can come back — which is why the UI
  * offers both and says which is which.
  */
-export function blockDevice(address: string, blocked: boolean): boolean {
+export function blockDevice(address: string, blocked: boolean, own: Iterable<string> = ownAddresses()): boolean {
   const d = seen.get(unmap(address));
   if (!d) return false;
+  // Never this machine. Blocking an address the dashboard itself arrives on
+  // would lock the user out of the window they pressed the button in, and
+  // there is no undo from a page that can no longer talk to its server.
+  if (blocked && isSelf(address, own)) return false;
   d.blocked = blocked;
   return true;
 }
@@ -147,11 +154,35 @@ export function isBlocked(ip: string | null | undefined): boolean {
   return seen.get(unmap(ip))?.blocked === true;
 }
 
-/** Newest activity first, with anything currently holding a socket on top. */
-export function remoteDevices(): DeviceRecord[] {
+/**
+ * Newest activity first, with anything currently holding a socket on top.
+ *
+ * `own` is the set of addresses this machine answers on. Anything arriving
+ * from one of them is this machine talking to itself the long way round — the
+ * app opened at its own tailnet address rather than at loopback, a browser
+ * tab on the same box — and the panel listed it as a stranger with a
+ * Disconnect button beside it. Pressing that would have blocked the address
+ * the dashboard itself was arriving on. Marking it is what lets the UI
+ * suppress the button, and the block route refuse it outright.
+ */
+export function remoteDevices(own: Iterable<string> = ownAddresses()): DeviceRecord[] {
+  const mine = new Set([...own].map(unmap));
   return [...seen.values()]
     .sort((a, b) => (b.live > 0 ? 1 : 0) - (a.live > 0 ? 1 : 0) || b.lastAt - a.lastAt)
-    .map((d) => ({ ...d }));
+    .map((d) => ({ ...d, self: mine.has(d.address) }));
+}
+
+/** Every address this machine answers on, from the live interfaces. */
+export function ownAddresses(): string[] {
+  return reachableAddresses().map((a) => a.address);
+}
+
+/** Whether an address belongs to this machine (loopback included). */
+export function isSelf(ip: string | null | undefined, own: Iterable<string> = ownAddresses()): boolean {
+  if (!ip) return false;
+  const h = unmap(ip);
+  if (isLoopback(h)) return true;
+  return [...own].map(unmap).includes(h);
 }
 
 export interface RemoteClients {
@@ -163,7 +194,10 @@ export interface RemoteClients {
 }
 
 export function remoteClients(): RemoteClients {
-  const all = remoteDevices();
+  // This machine does not count as a device that reached us: "one device is
+  // connected" meaning the window you are reading it in is a lie of the kind
+  // that makes the number useless. The row still appears in the list, named.
+  const all = remoteDevices().filter((d) => !d.self);
   return {
     count: all.length,
     lastAt: all.reduce<number | null>((n, d) => (n === null || d.lastAt > n ? d.lastAt : n), null),
@@ -186,6 +220,10 @@ export function deviceLabel(uaRaw: string | null | undefined): string {
   if (/^(curl|wget|python-requests|node-fetch|go-http-client|httpie)/i.test(ua)) {
     return `A script (${ua.split("/")[0]!.toLowerCase()})`;
   }
+  // Electron says Chrome as well, and on this server the Electron in question
+  // is almost always agentglass itself talking to its own sidecar over a real
+  // address rather than loopback. Naming it beats calling the cockpit "Chrome".
+  if (/\bElectron\//.test(ua)) return "The agentglass app";
   const browser =
     /\bEdg\//.test(ua) ? "Edge"
     : /\bOPR\/|\bOpera\b/.test(ua) ? "Opera"
@@ -194,13 +232,20 @@ export function deviceLabel(uaRaw: string | null | undefined): string {
     : /\bSafari\//.test(ua) ? "Safari"
     : null;
   // The model is inside the Android comment, before the build tag. It is the
-  // one place a phone says something a person recognises.
+  // one place a phone says something a person recognises — when it says
+  // anything at all. Chrome on Android 13 and later freezes the model to the
+  // literal "K" for privacy, and `wv` means a WebView rather than a device, so
+  // both are placeholders to see through. A row reading "K · Chrome" is what
+  // this pane looked like on a Pixel, which is worse than admitting the phone
+  // did not say.
   const android = ua.match(/Android[^;)]*;\s*([^;)]+?)(?:\s+Build\/[^;)]*)?\s*\)/);
+  const model = android?.[1]?.trim() ?? "";
+  const namedModel = model && !/^(k|wv)$/i.test(model) ? model : "";
   const device =
     /\biPhone\b/.test(ua) ? "iPhone"
     : /\biPad\b/.test(ua) ? "iPad"
     : /\bCrOS\b/.test(ua) ? "Chromebook"
-    : android ? (android[1] && !/^wv$/i.test(android[1].trim()) ? android[1].trim() : "An Android device")
+    : android ? (namedModel || "An Android device")
     : /\bMacintosh\b/.test(ua) ? "Mac"
     : /\bWindows NT\b/.test(ua) ? "Windows PC"
     : /\bLinux\b/.test(ua) ? "Linux machine"
@@ -360,7 +405,7 @@ export function remoteStatus(opts: {
     urls: addresses.map((a) => `http://${a.address}:${opts.port}${q}`),
     addresses,
     clients: remoteClients(),
-    devices: remoteDevices(),
+    devices: remoteDevices(addresses.map((a) => a.address)),
     firewall: firewallHint(opts.port, addresses[0]?.subnet ?? null, opts.which),
     ...(opts.includeToken && opts.token ? { token: opts.token } : {}),
   };

--- a/server/test/remote.test.ts
+++ b/server/test/remote.test.ts
@@ -9,6 +9,7 @@ import {
   noteSocket,
   blockDevice,
   isBlocked,
+  isSelf,
   remoteDevices,
   deviceLabel,
   remoteClients,
@@ -165,6 +166,50 @@ describe("disconnecting a device", () => {
   });
 });
 
+describe("this machine is not a device to cut off", () => {
+  test("a connection from one of our own addresses is marked as self", () => {
+    // What the panel showed on a machine with Tailscale: the app reaching its
+    // own sidecar at 100.85.155.119 instead of localhost, listed as a stranger
+    // with a Disconnect button next to it.
+    noteClient("100.85.155.119", { now: 1000 });
+    noteClient("192.168.1.50", { now: 1000 });
+    const devices = remoteDevices(["100.85.155.119", "192.168.1.131"]);
+    expect(devices.find((d) => d.address === "100.85.155.119")?.self).toBe(true);
+    expect(devices.find((d) => d.address === "192.168.1.50")?.self).toBe(false);
+  });
+
+  test("it cannot be blocked, because there is no undo from a dead page", () => {
+    noteClient("192.168.1.50", { now: 1000 });
+    // Same address, once as a stranger and once as one of ours: only the
+    // second is refused, and the refusal is what stops the button blacking
+    // out the window it was pressed in.
+    expect(blockDevice("192.168.1.50", true, ["192.168.1.131"])).toBe(true);
+    expect(blockDevice("192.168.1.50", false, ["192.168.1.131"])).toBe(true);
+    expect(blockDevice("192.168.1.50", true, ["192.168.1.50"])).toBe(false);
+    expect(isBlocked("192.168.1.50")).toBe(false);
+    // Letting a device back in is never refused: it cannot lock anyone out.
+    expect(blockDevice("192.168.1.50", false, ["192.168.1.50"])).toBe(true);
+  });
+
+  test("isSelf covers loopback, v4-mapped forms and nothing else", () => {
+    expect(isSelf("127.0.0.1")).toBe(true);
+    expect(isSelf(null)).toBe(false);
+    expect(isSelf("8.8.8.8", ["192.168.1.131"])).toBe(false);
+    expect(isSelf("192.168.1.131", ["192.168.1.131"])).toBe(true);
+    expect(isSelf("::ffff:192.168.1.131", ["192.168.1.131"])).toBe(true);
+  });
+
+  test("the counts leave this machine out, while the list keeps it", () => {
+    // A number that says "one device is connected" about the window you are
+    // reading it in is worse than no number.
+    noteClient("100.85.155.119", { now: 1000 });
+    noteSocket("100.85.155.119", 1, 1000);
+    const own = ["100.85.155.119"];
+    expect(remoteDevices(own).length).toBe(1);
+    expect(remoteDevices(own)[0]!.self).toBe(true);
+  });
+});
+
 describe("deviceLabel", () => {
   test("names the phones a person would recognise", () => {
     expect(deviceLabel("Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"))
@@ -183,6 +228,22 @@ describe("deviceLabel", () => {
   test("says plainly when it is not a browser", () => {
     expect(deviceLabel("curl/8.4.0")).toBe("A script (curl)");
     expect(deviceLabel("python-requests/2.31.0")).toBe("A script (python-requests)");
+  });
+
+  test("sees through Android's frozen model string", () => {
+    // Chrome on Android 13+ reports the model as the literal "K" for privacy.
+    // A Pixel showed up in the panel as "K · Chrome", which reads like a
+    // stranger's device rather than the phone in your pocket.
+    expect(deviceLabel("Mozilla/5.0 (Linux; Android 13; K) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Mobile Safari/537.36"))
+      .toBe("An Android device · Chrome");
+    // A phone that does name itself is still named.
+    expect(deviceLabel("Mozilla/5.0 (Linux; Android 14; Pixel 8 Pro) AppleWebKit/537.36 Chrome/120.0.0.0 Mobile Safari/537.36"))
+      .toBe("Pixel 8 Pro · Chrome");
+  });
+
+  test("names the cockpit rather than calling it Chrome", () => {
+    expect(deviceLabel("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) agentglass/0.6.0 Chrome/130.0.0.0 Electron/33.4.11 Safari/537.36"))
+      .toBe("The agentglass app");
   });
 
   test("stays vague rather than guessing", () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1529,6 +1529,9 @@ export interface RemoteDevice {
   hits: number;
   /** Refused at the door until it is let back in or the server restarts. */
   blocked: boolean;
+  /** This machine reaching itself through one of its own addresses rather than
+   *  loopback. Shown, named, and never offered a Disconnect. */
+  self?: boolean;
 }
 
 /** Whether another device can reach this server, and whether one ever has. */

--- a/web/src/components/RemoteAccessPane.tsx
+++ b/web/src/components/RemoteAccessPane.tsx
@@ -76,7 +76,13 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
     // the server again is what puts it in the QR.
     if (ok) load();
     // The messages below are for the two cases where the shell declines.
-    if (ok === false) setRevokeNote("AGENTGLASS_TOKEN is set in this app's environment, so the app cannot rotate it. Change it where it is set.");
+    // "Change it where it is set" was true and useless: the variable is
+    // inherited, so the place it is set is somewhere the person has to go
+    // looking — a shell profile, a tmux server's environment, a launcher. Say
+    // what to do instead, and what happens once it is done: with nothing in
+    // the environment the app keeps its own code in ~/.config/agentglass/token
+    // and this button starts working.
+    if (ok === false) setRevokeNote("AGENTGLASS_TOKEN is set in the environment this app was started from, so rotating a file the server does not read would report a revoke that did not happen. Unset it where it is exported (a shell profile, or `tmux setenv -gu AGENTGLASS_TOKEN` if you start the app from tmux), then start agentglass again. The app will keep its own code from then on, and this button will rotate it.");
     else if (ok === null) setRevokeNote("This shell cannot rotate the access code.");
   };
 
@@ -357,51 +363,66 @@ function Devices({ st, onCopy, copied, onChanged }: {
       <div className="flex flex-col gap-1">
         <div className="flex items-baseline gap-2 px-0.5">
           <span className="text-[10px] t-dim2 uppercase tracking-wider flex-1">Devices</span>
+          {/* Counts exclude this machine, which is in the list but is not a
+              device that reached us: "one device is connected" meaning the
+              window you are reading it in is worse than no number at all. */}
           <span className="text-[10px]" style={{ color: clients.liveCount > 0 ? "var(--success)" : "var(--text4)" }}>
             {clients.liveCount > 0
               ? `${clients.liveCount === 1 ? "One device is" : `${clients.liveCount} devices are`} connected right now`
-              : `${devices.length === 1 ? "One device has" : `${devices.length} devices have`} connected before`}
+              : clients.count > 0
+                ? `${clients.count === 1 ? "One device has" : `${clients.count} devices have`} connected before`
+                : "Nothing else has connected yet"}
           </span>
         </div>
         {devices.map((d) => {
           const live = d.live > 0 && !d.blocked;
-          const tint = d.blocked ? "var(--error)" : live ? "var(--success)" : "var(--text3)";
+          // This machine, reaching its own server through a real address
+          // instead of loopback. It is shown because a row that vanishes is
+          // its own kind of confusing, but it is named for what it is and the
+          // button is gone: cutting it off would black out this window.
+          const self = !!d.self;
+          const tint = d.blocked ? "var(--error)" : self ? "var(--text3)" : live ? "var(--success)" : "var(--text3)";
           return (
             <div key={d.address} className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg" style={{
-              background: live ? "color-mix(in srgb, var(--success) 8%, transparent)" : "color-mix(in srgb, var(--bg2) 60%, transparent)",
-              border: `1px solid color-mix(in srgb, ${d.blocked ? "var(--error)" : live ? "var(--success)" : "var(--border)"} ${live || d.blocked ? 30 : 40}%, transparent)`,
+              background: live && !self ? "color-mix(in srgb, var(--success) 8%, transparent)" : "color-mix(in srgb, var(--bg2) 60%, transparent)",
+              border: `1px solid color-mix(in srgb, ${d.blocked ? "var(--error)" : live && !self ? "var(--success)" : "var(--border)"} ${(live && !self) || d.blocked ? 30 : 40}%, transparent)`,
             }}>
               {/* Steady when a socket is open, hollow when the device is only
                   remembered. It is the fastest read in the row, so it carries
                   the one fact that decides everything else. */}
               <span className="shrink-0 rounded-full" aria-hidden style={{
-                width: 7, height: 7, background: live ? "var(--success)" : "transparent",
-                border: live ? "none" : `1px solid ${tint}`,
-                boxShadow: live ? "0 0 0 3px color-mix(in srgb, var(--success) 18%, transparent)" : "none",
+                width: 7, height: 7, background: live && !self ? "var(--success)" : "transparent",
+                border: live && !self ? "none" : `1px solid ${tint}`,
+                boxShadow: live && !self ? "0 0 0 3px color-mix(in srgb, var(--success) 18%, transparent)" : "none",
               }} />
               <div className="min-w-0 flex-1">
-                <div className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>
-                  {d.label}
-                  <span className="t-mono text-[10px] t-dim2"> {d.address}</span>
+                <div className="text-[11.5px] truncate flex items-center gap-1.5" style={{ color: "var(--text)" }}>
+                  <span className="truncate">{d.label}</span>
+                  <span className="t-mono text-[10px] t-dim2">{d.address}</span>
+                  {self && <span className="chip shrink-0 t-dim2">This machine</span>}
                 </div>
                 <div className="text-[10px]" style={{ color: tint }}>
-                  {d.blocked
-                    ? "Disconnected. It is refused on every request until you let it back in."
-                    : live
-                      ? `Connected now · ${d.live === 1 ? "one open connection" : `${d.live} open connections`}`
-                      : `Last seen ${fmtAgo(d.lastAt)} · ${d.hits === 1 ? "one request" : `${d.hits} requests`}`}
+                  {self
+                    ? "This machine, reaching its own server through one of its addresses rather than through localhost."
+                    : d.blocked
+                      ? "Disconnected. It is refused on every request until you let it back in."
+                      : live
+                        ? `Connected now · ${d.live === 1 ? "one open connection" : `${d.live} open connections`}`
+                        : `Last seen ${fmtAgo(d.lastAt)} · ${d.hits === 1 ? "one request" : `${d.hits} requests`}`}
                 </div>
               </div>
-              <button onClick={() => setBlocked(d, !d.blocked)} disabled={busy === d.address}
-                className="shrink-0 text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
-                style={{
-                  color: d.blocked ? "var(--text2)" : "var(--error)",
-                  background: d.blocked ? "transparent" : "color-mix(in srgb, var(--error) 10%, transparent)",
-                  border: `1px solid color-mix(in srgb, ${d.blocked ? "var(--border)" : "var(--error)"} ${d.blocked ? 45 : 32}%, transparent)`,
-                  opacity: busy === d.address ? 0.5 : 1,
-                }}>
-                {busy === d.address ? "Working…" : d.blocked ? "Let it back in" : "Disconnect"}
-              </button>
+              {!self && (
+                <button onClick={() => setBlocked(d, !d.blocked)} disabled={busy === d.address}
+                  className="shrink-0 text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+                  style={{
+                    color: d.blocked ? "var(--text2)" : "var(--error)",
+                    background: d.blocked ? "transparent" : "color-mix(in srgb, var(--error) 10%, transparent)",
+                    border: `1px solid color-mix(in srgb, ${d.blocked ? "var(--border)" : "var(--error)"} ${d.blocked ? 45 : 32}%, transparent)`,
+                    opacity: busy === d.address ? 0.5 : 1,
+                  }}>
+                  {busy === d.address ? "Working…" : d.blocked ? "Let it back in" : "Disconnect"}
+                </button>
+              )}
             </div>
           );
         })}


### PR DESCRIPTION
## What does this PR do?

Two bugs the device list in #428 showed the moment it ran on a real machine, both visible in one screenshot of the pane.

**It offered to disconnect the user from their own dashboard.** The app reaches its sidecar at whichever address it was opened on, and on a box with Tailscale that is the tailnet address rather than loopback. So this machine appeared in the list as a device like any other, with a Disconnect button beside it. Pressing that would have blocked the address the page itself was arriving on, and there is no undo from a window that can no longer talk to its server. Any address this machine answers on is now marked as `self`: the row stays, named "This machine" and without the button, `POST /remote/device` refuses it before the store is touched, and the connected counts exclude it, because "one device is connected" meaning the window you are reading it in is worse than no number at all.

**A Pixel showed up as "K".** Chrome on Android 13 and later freezes the model string to that single letter for privacy, and the User-Agent condenser printed it faithfully. It reads like a stranger's device rather than the phone in your pocket. It is a placeholder exactly like `wv` and is now treated as one, so the row says "An Android device · Chrome" while a phone that does name itself still gets its name. While in there: Electron reports Chrome too, so the cockpit was labelling itself "Linux machine · Chrome"; it now says "The agentglass app".

One copy fix comes with them. When the access code comes from the environment the app cannot rotate it, and the pane said "Change it where it is set", which is true and sends the reader hunting for an inherited variable. It now names the usual places, gives `tmux setenv -gu AGENTGLASS_TOKEN` for the case where the app was started from tmux, and says what changes once it is gone: the app keeps its own code in `~/.config/agentglass/token` and the button starts working.

## How was it tested?

- `bun test`: 1937 pass. Six new cases in `server/test/remote.test.ts` cover self-marking from a supplied address set, the block route refusing self while still allowing "let it back in", `isSelf` over loopback and v4-mapped forms, the frozen `K` model, and the Electron label. `blockDevice` and `remoteDevices` take the address set as a parameter so the tests do not depend on the interfaces of the machine running them.
- `bunx tsc --noEmit` in `web/` and `server/`: clean.

The one pre-existing failure is unrelated and also fails on `main`: `server/test/webui.test.ts > resolveDist > blank and unset fall through to the fallback` reads the real installed app under `~/.local/share/agentglass-desktop`.