### PR TITLE
A closed sheet was painting a black band on the floor of the phone

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -258,6 +258,23 @@ async function main() {
     const nowText = await cdp.ev(`document.querySelector("main")?.textContent?.trim()?.length || 0`);
     note("now", "renders something", nowText > 20, `main had ${nowText} chars`);
 
+    // Fifteen sheets are mounted on this tab and every one of them is closed.
+    // A closed sheet is parked below the viewport, which hides the sheet and
+    // not its shadow — that one points upward, so it landed back on the page
+    // and fifteen of them stacked into a black band along the bottom edge.
+    // Invisible for as long as the tab bar was docked over that strip, which is
+    // exactly why it is worth asserting rather than looking for.
+    note("now", "a closed sheet paints nothing",
+      await cdp.ev(`[...document.querySelectorAll(".mb-sheet:not(.on)")].every(s=>{
+        const c=getComputedStyle(s);
+        return c.visibility === "hidden" && (c.boxShadow === "none" || c.boxShadow === "");
+      })`),
+      await cdp.ev(`(()=>{const b=[...document.querySelectorAll(".mb-sheet:not(.on)")]
+        .filter(s=>{const c=getComputedStyle(s);
+          return c.visibility!=="hidden" || (c.boxShadow!=="none" && c.boxShadow!=="")});
+        return b.length + " of " + document.querySelectorAll(".mb-sheet:not(.on)").length
+          + " closed sheets still paint";})()`));
+
     // The tab bar floats over the queue, so the queue has to end above it. A
     // last card parked permanently under the pill is the one way this shape is
     // worse than the bar it replaced, and it is invisible until you scroll to

--- a/web/src/mobile/mobileUi.tsx
+++ b/web/src/mobile/mobileUi.tsx
@@ -173,12 +173,32 @@ export const MOBILE_CSS = `
 .mb-scrim{position:fixed;inset:0;z-index:70;background:rgba(4,1,10,.66);opacity:0;pointer-events:none;
   transition:opacity .24s;backdrop-filter:blur(3px)}
 .mb-scrim.on{opacity:1;pointer-events:auto}
+/* A closed sheet must paint nothing at all.
+
+   It is parked one screen-height below the viewport, which hides the sheet but
+   not its shadow: that shadow points upward, 0 -20px 50px of black, so it
+   landed back inside the visible page as a band along the bottom edge. Fifteen
+   of these are mounted at once on the Now tab (Settings, the confirmation, the
+   permission modes, one per screen), and fifteen stacked black shadows took the
+   bottom 65px of a magenta test page from 249 down to 93.
+
+   Nobody could see it while the tab bar was docked, because a full-bleed bar
+   was painted over exactly that strip. The bar floated, the strip appeared, and
+   it read as the app going dark towards the floor.
+
+   So the shadow belongs to the open state, and a closed sheet is hidden
+   outright, which is the general form of the same bug: it costs a closed sheet
+   the ability to paint anything at all. Hiding is delayed by the length of the
+   slide, so the sheet is still there to watch on the way out. */
 .mb-sheet{position:fixed;left:0;right:0;bottom:0;z-index:71;border-radius:24px 24px 0 0;
   background:linear-gradient(180deg,color-mix(in srgb,var(--bg3) 50%,var(--bg2)),var(--bg2));
   border-top:1px solid color-mix(in srgb,var(--primary) 38%,transparent);transform:translateY(100%);
-  transition:transform .3s cubic-bezier(.32,.72,0,1);max-height:88dvh;display:flex;flex-direction:column;
+  visibility:hidden;
+  transition:transform .3s cubic-bezier(.32,.72,0,1),visibility 0s linear .3s;
+  max-height:88dvh;display:flex;flex-direction:column}
+.mb-sheet.on{transform:none;visibility:visible;
+  transition:transform .3s cubic-bezier(.32,.72,0,1),visibility 0s;
   box-shadow:0 -20px 50px -20px #000}
-.mb-sheet.on{transform:none}
 .mb-sheet .grab{width:40px;height:4px;border-radius:3px;flex:none;margin:10px auto 5px;
   background:color-mix(in srgb,var(--border) 72%,transparent)}
 /* min-height:0 is what lets this scroll. A flex child will not shrink below its


### PR DESCRIPTION
## What does this PR do?

Follow-up to #429. The bottom of the phone read as a dark hole with the tab bar sitting in it.

It is not the tab bar. Removing the pill's shadow, then the cards' shadows, then the ambient wash, then the entire `<nav>` element, left the band exactly as dark. A control page in the same capture harness came back clean, so it was not the screenshot either.

Every `Sheet` is mounted whether or not it is open, parked one screen-height below the viewport with `translateY(100%)`. That hides the sheet. It does not hide its shadow, which points **upward**, `0 -20px 50px` of black, and so lands back inside the visible page as a band along the bottom edge. Fifteen sheets are mounted on the Now tab: Settings, the confirmation, the permission modes, and one per screen.

Measured on a magenta test page, toggling only `.mb-sheet`'s `box-shadow`, same frame:

| CSS px above the bottom edge | 2 | 5 | 10 | 20 | 32 | 45 | 65 |
|---|---|---|---|---|---|---|---|
| before | 93 | 104 | 119 | 155 | 201 | 233 | 249 |
| after | 243 | 242 | 241 | 239 | 239 | 242 | 249 |

On the real screen the bottom gutter goes from 9 to 24 against a page background of 26.

This has been there for as long as the sheets have. A full-bleed tab bar was painted over precisely that strip, so it could not be seen until the bar floated in #429.

The shadow now belongs to the open state, and a closed sheet is `visibility:hidden` outright. That is the general form of the same bug: it costs a closed sheet the ability to paint anything at all, not just this one shadow. Hiding is delayed by the length of the slide so the sheet is still there to watch on the way out.

## How was it tested?

`bunx tsc --noEmit` in `web/`, clean.

`scripts/phone-audit.ts` against a real server, headless Chrome at 412x915: **138/138**, including the new check.

One check added, and it is the point of the PR: every closed sheet must be hidden and must carry no shadow. This defect was invisible for months and would be invisible again, so it is asserted rather than looked for.

Also verified by capture at 336x705 at device pixel ratio 2, which is the viewport the report came from: the bottom band now matches the page background instead of falling to a third of it, and the bar's own labels read brighter, since those stacked shadows were dimming the bar as well.