### PR TITLE
Eleven code-scanning alerts, three of them worth acting on

### DIFF
--- a/scripts/capture-live.ts
+++ b/scripts/capture-live.ts
@@ -31,7 +31,7 @@ const PANEL_H = 1080;
 
 /** Chrome and the protocol — the same helpers capture.ts and capture-phone.ts
  *  drive, so a fix to the connect retry loop reaches all three. */
-import { connect, findChrome, key, until } from "./cdp.ts";
+import { connect, findChrome, key, lit, until } from "./cdp.ts";
 
 async function main() {
   if (!existsSync(join(REPO, ".git"))) { console.error(`no scratch repo at ${REPO}`); process.exit(1); }
@@ -113,7 +113,7 @@ async function main() {
     for (const line of lines) {
       await cdp.ev(`(()=>{const t=document.querySelector('.xterm-helper-textarea');
         if(!t) return 0;
-        for (const ch of ${JSON.stringify(line + "\r")}) {
+        for (const ch of ${lit(line + "\r")}) {
           t.dispatchEvent(new InputEvent('input',{data:ch,inputType:'insertText',bubbles:true}));
         }
         return 1})()`);

--- a/scripts/capture.ts
+++ b/scripts/capture.ts
@@ -54,7 +54,7 @@ const GIF_W = 1100, GIF_FPS = 12;
  *  see scripts/still.ts for why that step exists at all. */
 import { finishStill, STILL_W, THEME_W } from "./still.ts";
 /** Chrome, the protocol and the static server for the demo build. */
-import { connect, findChrome, key, serveDist, until, DEMO_BASE } from "./cdp.ts";
+import { connect, findChrome, key, lit, serveDist, until, DEMO_BASE } from "./cdp.ts";
 
 async function main() {
   if (!existsSync(join(DIST, "index.html"))) {
@@ -145,7 +145,7 @@ async function main() {
     await Bun.sleep(1200);
 
     for (const id of views) {
-      const ok = await cdp.ev(`(()=>{const b=document.querySelector('[data-view=${JSON.stringify(id)}]');b?.click();return !!b})()`);
+      const ok = await cdp.ev(`(()=>{const b=document.querySelector('[data-view=${lit(id)}]');b?.click();return !!b})()`);
       if (!ok) { console.warn(`  ! no "${id}" view in the rail — skipped`); continue; }
       await Bun.sleep(1600);
       // The PR panel opens on Overview; Files is the view worth showing, and
@@ -176,7 +176,7 @@ async function main() {
       ["forest", THEME_W], ["ember", THEME_W], ["deep-sea", THEME_W], ["light", STILL_W],
     ];
     for (const [t, tw] of themes) {
-      const ok = await cdp.ev(`(()=>{try{localStorage.setItem('agentglass.theme',${JSON.stringify(t)});window.dispatchEvent(new StorageEvent('storage',{key:'agentglass.theme'}));return 1}catch{return 0}})()`);
+      const ok = await cdp.ev(`(()=>{try{localStorage.setItem('agentglass.theme',${lit(t)});window.dispatchEvent(new StorageEvent('storage',{key:'agentglass.theme'}));return 1}catch{return 0}})()`);
       if (!ok) continue;
       await cdp.ev(`location.reload()`);
       await until(cdp, `document.querySelector('#root')?.children.length`, `the ${t} theme`);

--- a/scripts/cdp.ts
+++ b/scripts/cdp.ts
@@ -31,7 +31,10 @@ export function findChrome(): string {
 export async function connect(port: number, tries = 80): Promise<CDP> {
   let targets: any[] = [];
   for (let i = 0; i < tries; i++) {
-    try { targets = await (await fetch(`http://127.0.0.1:${port}/json/list`)).json(); if (targets.length) break; }
+    // Cast, because `.json()` is `unknown` and this file is typechecked now:
+    // the CDP target list has no schema we control, and the shape we need is
+    // asserted a line later by the `find` below.
+    try { targets = (await (await fetch(`http://127.0.0.1:${port}/json/list`)).json()) as any[]; if (targets.length) break; }
     catch { /* not up yet */ }
     await Bun.sleep(250);
   }
@@ -68,15 +71,42 @@ export async function until(cdp: CDP, expr: string, what: string, ms = 15_000) {
   throw new Error(`timed out waiting for ${what}`);
 }
 
+/**
+ * A value as a JavaScript literal, safe to paste into source we are about to
+ * evaluate in the page.
+ *
+ * Every helper here builds a snippet of JS as a string and hands it to
+ * `Runtime.evaluate`, and the values pasted into it are selectors, key names
+ * and label fragments. `JSON.stringify` alone is the obvious way to quote them
+ * and it is not quite enough: JSON is not a subset of JavaScript. U+2028 and
+ * U+2029 pass through it unescaped and were line terminators to a JS parser,
+ * which ends the string mid-expression and leaves whatever follows as code. The
+ * same value reaching an inline `<script>` would end it at a literal
+ * `</script>`.
+ *
+ * Neither is exotic once a value stops being a literal in this file. Some of
+ * them already do not come from here: `AUDIT_REPO` is read from the
+ * environment, and label fragments are chosen to match text the app rendered.
+ * So the quoting is done once, correctly, in the one place all of it passes
+ * through, instead of being a property of who happened to call it.
+ */
+export const lit = (v: unknown): string =>
+  JSON.stringify(v)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+    // `\x3c` is the same character to a JS parser and cannot close a script
+    // element, so a snippet stays inert wherever it is eventually placed.
+    .replace(/</g, "\\x3c");
+
 export const key = (cdp: CDP, k: string, mods: Record<string, boolean> = {}) =>
-  cdp.ev(`(()=>{window.dispatchEvent(new KeyboardEvent("keydown",Object.assign({key:${JSON.stringify(k)},bubbles:true,cancelable:true},${JSON.stringify(mods)})));return 1})()`);
+  cdp.ev(`(()=>{window.dispatchEvent(new KeyboardEvent("keydown",Object.assign({key:${lit(k)},bubbles:true,cancelable:true},${lit(mods)})));return 1})()`);
 
 /** Click the first element matching a predicate over its trimmed text.
  *  Returns false rather than throwing, so a caller can report which step of a
  *  capture went missing instead of dying with a selector error. */
 export const clickByText = (cdp: CDP, selector: string, needle: string) =>
-  cdp.ev(`(()=>{const el=[...document.querySelectorAll(${JSON.stringify(selector)})]
-    .find(e=>e.textContent.includes(${JSON.stringify(needle)}));el?.click();return !!el})()`);
+  cdp.ev(`(()=>{const el=[...document.querySelectorAll(${lit(selector)})]
+    .find(e=>e.textContent.includes(${lit(needle)}));el?.click();return !!el})()`);
 
 /** The demo build is based at /agentglass/demo/ so it can be served from
  *  GitHub Pages, so its asset URLs carry that prefix. Serving it at the root

--- a/scripts/logo.mjs
+++ b/scripts/logo.mjs
@@ -110,11 +110,16 @@ function small({ base, ok }) {
   ].join("");
 }
 
-/** Same markup, JSX attribute casing. */
+/** Same markup, JSX attribute casing.
+ *
+ *  One rule, and only one is needed: the hyphenated SVG attributes this mark
+ *  uses (`stop-color`, `stop-opacity`, `stroke-width`, `stroke-linecap`,
+ *  `fill-opacity`) become camelCase. The element names carry over untouched,
+ *  `<stop>` included, which is why the second pass that used to sit here
+ *  replaced `<stop ` with `<stop ` and did nothing at all. */
 const jsx = (s) => s
   .replace(/\b(stroke|fill|stop)-(width|opacity|linecap|color)="/g,
-    (_, a, b) => `${a}${b[0].toUpperCase()}${b.slice(1)}="`)
-  .replace(/<stop /g, "<stop ");
+    (_, a, b) => `${a}${b[0].toUpperCase()}${b.slice(1)}="`);
 
 // ── the copies ──────────────────────────────────────────────────────────
 /** One tag per line, indented — these files get read and reviewed by hand. */

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -24,7 +24,7 @@ import { spawn } from "bun";
 import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
-import { connect, findChrome, until, type CDP } from "./cdp.ts";
+import { connect, findChrome, lit, until, type CDP } from "./cdp.ts";
 
 const ORIGIN = process.env.AUDIT_ORIGIN || "http://127.0.0.1:4055";
 const SHOTS = process.env.AUDIT_SHOTS || join(tmpdir(), "agentglass-phone-audit");
@@ -157,7 +157,7 @@ const shot = async (cdp: CDP, name: string) => {
 
 /** Text of everything matching a selector, for eyeballing a list in one read. */
 const texts = (cdp: CDP, sel: string) =>
-  cdp.ev(`JSON.stringify([...document.querySelectorAll(${JSON.stringify(sel)})].map(e=>e.textContent.trim()).slice(0,40))`)
+  cdp.ev(`JSON.stringify([...document.querySelectorAll(${lit(sel)})].map(e=>e.textContent.trim()).slice(0,40))`)
     .then((s: string) => JSON.parse(s || "[]") as string[]);
 
 /**
@@ -177,8 +177,8 @@ const closeTop = (cdp: CDP) => cdp.ev(`(()=>{const b=${TOP}?.querySelector(".hd 
 /** Click inside the topmost screen only. */
 const tapTop = async (cdp: CDP, sel: string, needle?: string) => {
   const hit = await cdp.ev(`(()=>{const s=${TOP}; if(!s) return false;
-    const els=[...s.querySelectorAll(${JSON.stringify(sel)})];
-    const el = ${needle ? `els.find(e=>e.textContent.includes(${JSON.stringify(needle)}))` : "els[0]"};
+    const els=[...s.querySelectorAll(${lit(sel)})];
+    const el = ${needle ? `els.find(e=>e.textContent.includes(${lit(needle)}))` : "els[0]"};
     if(!el) return false; el.click(); return true;})()`);
   await Bun.sleep(700);
   return !!hit;
@@ -187,8 +187,8 @@ const tapTop = async (cdp: CDP, sel: string, needle?: string) => {
 const topTitle = (cdp: CDP) => cdp.ev(`(${TOP})?.querySelector(".hd .t b")?.textContent || ""`);
 
 const tap = async (cdp: CDP, sel: string, needle?: string) => {
-  const hit = await cdp.ev(`(()=>{const els=[...document.querySelectorAll(${JSON.stringify(sel)})];
-    const el = ${needle ? `els.find(e=>e.textContent.includes(${JSON.stringify(needle)}))` : "els[0]"};
+  const hit = await cdp.ev(`(()=>{const els=[...document.querySelectorAll(${lit(sel)})];
+    const el = ${needle ? `els.find(e=>e.textContent.includes(${lit(needle)}))` : "els[0]"};
     if(!el) return false; el.click(); return true;})()`);
   await Bun.sleep(700);
   return !!hit;
@@ -832,7 +832,7 @@ async function main() {
       await tap(cdp, "nav button", "Now");
       await Bun.sleep(1600);
       note("later", "and stays gone across a reload",
-        !(await cdp.ev(`document.body.textContent.includes(${JSON.stringify(String(gone).slice(0, 40))})`)),
+        !(await cdp.ev(`document.body.textContent.includes(${lit(String(gone).slice(0, 40))})`)),
         `card was: ${gone}`);
 
       // The count the Settings row shows has to be the store's, not a list in

--- a/server/test/cdp-literal.test.ts
+++ b/server/test/cdp-literal.test.ts
@@ -1,0 +1,53 @@
+// Values pasted into JavaScript that is about to be evaluated in a page.
+//
+// The capture and audit scripts build snippets of JS as strings and hand them
+// to `Runtime.evaluate`. Quoting those values with `JSON.stringify` is the
+// obvious move and is not quite right, because JSON is not a subset of
+// JavaScript: U+2028 and U+2029 survive it unescaped and were line terminators
+// to a JS parser, so a value carrying one ends the string early and everything
+// after it is parsed as code. `</script>` is the same hole in an HTML context.
+//
+// Neither is theoretical here. `AUDIT_REPO` comes from the environment, and the
+// label fragments are chosen to match text the app rendered, so these values
+// have already stopped being literals written in the script.
+//
+// It lives in the server suite because that is a place CI runs; the helper it
+// tests is shared by every script under scripts/.
+import { describe, expect, test } from "bun:test";
+import { lit } from "../../scripts/cdp.ts";
+
+/** What a JS engine gets back when it evaluates the literal we produced. The
+ *  real question is never "how is it spelled" but "does it round-trip". */
+const evaluated = (v: unknown) => new Function(`return ${lit(v)}`)();
+
+describe("lit", () => {
+  test("round-trips ordinary selectors and labels", () => {
+    for (const v of ['nav button', '.mb-screen.on .mb-row', 'Files', '\\', "it's", 'a "quoted" label']) {
+      expect(evaluated(v)).toBe(v);
+    }
+  });
+
+  test("round-trips the objects the key helper passes", () => {
+    expect(evaluated({ ctrlKey: true })).toEqual({ ctrlKey: true });
+  });
+
+  test("escapes the line separators JSON leaves bare", () => {
+    // The bug: `JSON.stringify` returns these raw, and a JS parser of the era
+    // that matters here ends the string on them.
+    expect(lit("a\u2028b")).not.toContain("\u2028");
+    expect(lit("a\u2029b")).not.toContain("\u2029");
+    expect(evaluated("a\u2028b")).toBe("a\u2028b");
+    expect(evaluated("a\u2029b")).toBe("a\u2029b");
+  });
+
+  test("a value cannot close a script element", () => {
+    const out = lit("</script><script>alert(1)</script>");
+    expect(out).not.toContain("<");
+    expect(evaluated("</script><script>alert(1)</script>")).toBe("</script><script>alert(1)</script>");
+  });
+
+  test("a quote in the value cannot end the literal early", () => {
+    const hostile = '";window.pwned=1;"';
+    expect(evaluated(hostile)).toBe(hostile);
+  });
+});

--- a/web/src/lib/markdown.tsx
+++ b/web/src/lib/markdown.tsx
@@ -15,6 +15,7 @@
 // contain anything a model or a tool emitted), so it must never be able to
 // become markup.
 import { memo, type ReactNode } from "react";
+import { externalUrl } from "./externalUrl.ts";
 
 const CODE_BG = "color-mix(in srgb, var(--bg3) 55%, transparent)";
 
@@ -41,9 +42,16 @@ function inline(text: string, keyBase: string): ReactNode[] {
       const label = tok.slice(1, sep);
       const href = tok.slice(sep + 2, -1);
       // Only http(s): a message could otherwise carry javascript: or data:.
-      const safe = /^https?:\/\//i.test(href);
+      //
+      // Asked of the URL parser rather than of a regexp, and asked through the
+      // helper the pull request panel already uses, so there is one answer to
+      // "is this safe to hand a browser" in the app instead of two that can
+      // drift. The parser is also the stricter reader: it normalises away the
+      // tab and newline tricks that hide a scheme from a pattern match, and it
+      // refuses anything that is not an absolute URL at all.
+      const safe = externalUrl(href);
       out.push(safe
-        ? <a key={k} href={href} target="_blank" rel="noreferrer noopener" style={{ color: "var(--primary-hover)", textDecoration: "underline" }}>{label}</a>
+        ? <a key={k} href={safe} target="_blank" rel="noreferrer noopener" style={{ color: "var(--primary-hover)", textDecoration: "underline" }}>{label}</a>
         : <span key={k}>{label}</span>);
     }
     last = m.index + tok.length;

--- a/web/test/markdown-safety.test.ts
+++ b/web/test/markdown-safety.test.ts
@@ -6,12 +6,23 @@
 // possible, but an href is still attacker-controlled: `javascript:` and `data:`
 // URLs execute on click.
 //
-// Kept as a plain predicate test rather than a DOM render because the server
-// suite has no React test environment; the renderer imports this same rule.
+// Kept as a plain predicate test rather than a DOM render: the rule is a pure
+// function, and rendering a component to assert one attribute would test React.
+//
+// It lived in the server suite, where the renderer it describes could not be
+// imported at all. That is what made it a copy.
+//
+// It used to restate the rule as its own regexp, with a comment saying it
+// mirrored the renderer. That is a test of a copy: the renderer could change
+// its mind about a scheme and this would keep passing on the old answer. It now
+// imports the very function the renderer calls, so there is one rule with one
+// test — and the renderer no longer pattern-matches the URL at all, it asks the
+// URL parser, which is the stricter reader of the two.
 import { describe, expect, test } from "bun:test";
+import { externalUrl } from "../src/lib/externalUrl.ts";
 
-/** Mirrors the check in web/src/lib/markdown.tsx — only http(s) becomes a link. */
-const isSafeHref = (href: string) => /^https?:\/\//i.test(href);
+/** The renderer's own check: only an absolute http(s) URL becomes a link. */
+const isSafeHref = (href: string) => externalUrl(href) !== undefined;
 
 describe("markdown link hrefs", () => {
   test("allows ordinary web links", () => {
@@ -42,7 +53,16 @@ describe("markdown link hrefs", () => {
 
   test("a leading-whitespace trick doesn't slip through", () => {
     expect(isSafeHref(" javascript:alert(1)")).toBe(false);
-    expect(isSafeHref("\thttps://ok.example.com")).toBe(false);
+    expect(isSafeHref("\tjavascript:alert(1)")).toBe(false);
+    // Whitespace inside the scheme is the sharper version of the same trick,
+    // and it is why this is parsed rather than matched: a pattern anchored on
+    // `https?://` reads this as "not a link" and moves on, while a browser
+    // handed the raw string strips the tab and runs it.
+    expect(isSafeHref("java\tscript:alert(1)")).toBe(false);
+    // Surrounding whitespace on an otherwise ordinary link is not a trick, and
+    // the parser says so: it trims, then judges the scheme. The regexp this
+    // replaced called it unsafe, which cost a real link for no safety.
+    expect(isSafeHref("\thttps://ok.example.com")).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

Clears the 11 open CodeQL alerts on `main`. Read against the code they collapse into three findings, and each fix stands on its own merits rather than being a scanner appeasement.

**1. `js/xss-through-dom`, High, `web/src/lib/markdown.tsx:46`.** The renderer turns `[label](href)` from untrusted message text into an anchor, guarded by `/^https?:\/\//i`. The pull request panel asks the same question through `externalUrl()`, which parses the URL and checks the protocol. Two answers to one question, and the regexp is the weaker reader: it calls `java\tscript:alert(1)` "not a link" and renders it as plain text, while a browser handed that same string strips the tab and runs it. The renderer now calls `externalUrl()` and links the normalised href.

**2. `js/bad-code-sanitization`, Medium, 9 alerts across `scripts/cdp.ts`, `scripts/capture.ts`, `scripts/phone-audit.ts`.** These build a snippet of JavaScript as a string and hand it to `Runtime.evaluate`, quoting the interpolated values with `JSON.stringify`. JSON is not a subset of JavaScript: U+2028 and U+2029 pass through unescaped and were line terminators to a JS parser, so a value carrying one ends the string mid-expression and everything after it is parsed as code. A literal `</script>` closes an inline script wherever the snippet ends up. Not all of these values are literals written in the script either: `AUDIT_REPO` comes from the environment. `scripts/cdp.ts` gains `lit()`, one place that quotes for the JavaScript string context, and every call site uses it.

**3. `js/identity-replacement`, Medium, `scripts/logo.mjs:117`.** `.replace(/<stop /g, "<stop ")` replaced a substring with itself. Only hyphenated SVG attributes need rewriting for JSX; element names carry over untouched. The dead pass is gone and the comment now says why one rule is enough.

Also in here: `scripts/cdp.ts` is typechecked for the first time, because the new test imports it into the server project. It needed one cast to get there.

## How was it tested?

- `bun scripts/logo.mjs --check` reports the mark still in sync everywhere, which is the proof that the removed pass was dead: no generated file changes.
- New `server/test/cdp-literal.test.ts` (5 tests) evaluates what `lit()` produces with `new Function`, so it asserts the round trip rather than the spelling: ordinary selectors and labels, the object the key helper passes, U+2028/U+2029, a value containing `</script>`, and a quote that would otherwise end the literal early.
- `server/test/markdown-safety.test.ts` moves to `web/test/` and imports `externalUrl()` instead of restating it as a regexp. Two cases added: whitespace inside the scheme is rejected, and surrounding whitespace on an ordinary link no longer costs a real link.
- `bunx tsc --noEmit` clean in `web/` and `server/`. `bun test web/test` 812 pass. `bun test server/test` 1124 pass; the one failure (`webui.test.ts` `resolveDist`) reproduces on `main` on the same machine, where it picks up the real installed desktop resources directory.
- The capture and audit scripts were not re-run end to end here (they need a headless Chrome plus a live app); `lit()` is behaviour-identical to `JSON.stringify` for every value they actually pass, and the round-trip test is what pins that.