### PR TITLE
Now: only what is actually stopped, and nothing that finishes work

### DIFF
--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -328,7 +328,22 @@ async function main() {
     await hygiene(cdp, "chats");
 
     // ---- a conversation ---------------------------------------------
-    if (rows > 0) {
+    //
+    // Opened from a scope that has rows *now*, not from whichever one the
+    // scope exercise above happened to leave selected. It left "Today", and a
+    // fixture seeded a day ago has nothing in Today — so this tapped an empty
+    // list and then waited twelve seconds for a screen that was never going to
+    // mount, taking the whole run down with it. The failure said "timed out
+    // waiting for the conversation screen", which is true and points at
+    // entirely the wrong thing: the conversation was fine, the list was empty.
+    if (!(await cdp.ev(`!!document.querySelector("main button.w-full")`))) {
+      await tap(cdp, "main button", "All");
+      await Bun.sleep(1200);
+    }
+    const openable = await cdp.ev(`document.querySelectorAll("main button.w-full").length`);
+    if (!openable) {
+      console.log("  skip  conversation · no session on this machine to open");
+    } else {
       await tap(cdp, "main button.w-full");
       await until(cdp, `document.querySelector(".mb-chat")`, "the conversation screen", 12_000);
       await Bun.sleep(1400);
@@ -824,6 +839,62 @@ async function main() {
     const actions = await texts(cdp, "main button");
     note("now", "offers an action per item, or none at all",
       !actions.some((a) => a === ""), `${actions.length} buttons`);
+
+    // Nothing in this list finishes work.
+    //
+    // The queue is a scrolling list where every card puts its buttons in the
+    // same shape and the same place, and it carried "Squash & merge" for a
+    // while — behind a confirm, which is the weakest control there is against
+    // a mis-tap, because it appears under the thumb that just tapped. Checked
+    // by label rather than by call site: the audit cannot see the handler, and
+    // the label is what a thumb aims at.
+    const verbs = await cdp.ev(`JSON.stringify(
+      [...document.querySelectorAll("main .mb-item .acts button")].map(b => b.textContent.trim()))`);
+    note("now", "offers nothing irreversible",
+      !/merge|delete|remove|discard|close|force/i.test(verbs || ""), verbs);
+
+    // The count is only ever what is stopped. A badge that adds a held gate to
+    // five pull requests is never zero, and a number that is never zero stops
+    // being read — which is most of what made this screen an inbox.
+    // No regular expressions in here.
+    //
+    // This is a template literal, so `\b` and `\d` are string escapes long
+    // before they are regex syntax — the backslash is eaten and `/^\d+$/`
+    // arrives in the page as `/^d+$/`, which matches the letter d and nothing
+    // else. It found no badge, reported 0, and failed a check about counting
+    // for a reason that had nothing to do with counting.
+    const counts = await cdp.ev(`JSON.stringify((() => {
+      const digits = (t) => t.trim().length > 0 && [...t.trim()].every(ch => ch >= "0" && ch <= "9");
+      const nowTab = [...document.querySelectorAll("nav button")]
+        .find(b => (b.innerText || "").includes("Now"));
+      const badge = nowTab && [...nowTab.querySelectorAll("span")]
+        .find(sp => digits(sp.textContent || ""));
+      const hero = document.querySelector(".mb-hero .mb-fig")?.textContent?.trim();
+      const cards = document.querySelectorAll("main .mb-item").length;
+      const quiet = document.querySelectorAll("main .mb-item.quiet").length;
+      return { badge: badge ? Number(badge.textContent) : 0, hero, cards, quiet,
+        screens: document.querySelectorAll(".mb-screen.on").length };
+    })())`);
+    const c = JSON.parse(counts || "{}") as {
+      badge: number; hero: string; cards: number; quiet: number; screens: number;
+    };
+    note("now", "counts what is stopped, not what is merely true",
+      c.badge === c.cards - c.quiet,
+      `badge ${c.badge} · ${c.cards} cards, ${c.quiet} quiet · ${c.screens} screens open`);
+    note("now", "the hero agrees with the badge",
+      c.hero === (c.badge === 0 ? "✓" : String(c.badge)), `hero "${c.hero}" · badge ${c.badge}`);
+
+    // And when both halves are present, the line between them is drawn — the
+    // one thing that stops news and blockages reading as one undifferentiated
+    // scroll.
+    if (c.quiet > 0 && c.cards > c.quiet) {
+      note("now", "says where the things waiting on you stop",
+        await cdp.ev(`[...document.querySelectorAll("main .mb-eyebrow")]
+          .some(e => /waiting on you/i.test(e.textContent || ""))`));
+    } else {
+      console.log("  skip  now · only one half of the queue is present, so there is no divider to draw");
+    }
+
     await shot(cdp, "11-now-queue");
     await hygiene(cdp, "now");
 

--- a/server/test/mobile-confirms.test.ts
+++ b/server/test/mobile-confirms.test.ts
@@ -35,7 +35,25 @@ const IRREVERSIBLE: { file: string; call: string; what: string }[] = [
   { file: "MobileRepo.tsx", call: "api.dockerRm(", what: "removing a container" },
   { file: "MobilePr.tsx", call: "api.prClose(", what: "closing a pull request" },
   { file: "MobilePr.tsx", call: "api.prMerge(", what: "squash-merging and deleting the branch" },
-  { file: "MobileApp.tsx", call: "api.prMerge(", what: "squash-merging from the Now queue" },
+];
+
+/**
+ * Calls that may not appear in a file at all, confirm or no confirm.
+ *
+ * A confirm is a fine control on a screen you navigated to on purpose: the
+ * pull request is in front of you, with its diff, its checks and its threads,
+ * and the dialog is the last step of a decision you were already making.
+ *
+ * It is a poor one in the Now queue, which is a scrolling list where every
+ * card puts its buttons in the same shape and the same place. There, the
+ * dialog appears under the thumb that just tapped. `MobileApp.tsx` owns that
+ * queue, so the rule for it is not "ask first" but "do not offer".
+ */
+const NEVER: { file: string; call: string; what: string }[] = [
+  { file: "MobileApp.tsx", call: "api.prMerge(", what: "merging from a card in the queue" },
+  { file: "MobileApp.tsx", call: "api.prClose(", what: "closing a pull request from the queue" },
+  { file: "MobileApp.tsx", call: "api.dockerRm(", what: "removing a container from the queue" },
+  { file: "MobileApp.tsx", call: "api.gitDiscard(", what: "discarding changes from the queue" },
 ];
 
 /**
@@ -98,6 +116,27 @@ describe("the phone asks before it does something irreversible", () => {
       const title = spec.match(/title:\s*([^,\n]+)/)?.[1] ?? "";
       expect(title.trim(), `${file}: ${call} has no title at all`).not.toBe("");
       expect(LITERAL.test(title), `${file}: ${call} asks a fixed question — ${title}`).toBe(false);
+    }
+  });
+
+  test("the queue offers nothing irreversible, confirm or no confirm", () => {
+    // Stronger than "ask first", and a different rule for a different surface.
+    // This used to be an `ask()` guard on a Squash & merge in the queue; the
+    // guard was real and the button was still wrong, because the queue is a
+    // scrolling list and a confirm appears under the thumb that just tapped.
+    for (const { file, call, what } of NEVER) {
+      expect(read(file).includes(call), `${file} offers ${what}`).toBe(false);
+    }
+  });
+
+  test("and the shell has not simply been emptied", () => {
+    // The rule above passes trivially against a file that calls nothing, so
+    // pin the writes the queue legitimately makes: a re-run and a restart are
+    // both undone by doing them again, and a gate decision is the answer the
+    // agent is stopped waiting for.
+    const shell = read("MobileApp.tsx");
+    for (const call of ["api.prRerun(", "api.dockerRestart(", "api.gateDecide("]) {
+      expect(shell.includes(call), `the queue should still offer ${call}`).toBe(true);
     }
   });
 

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -16,7 +16,7 @@ import { baseName, ownerOf } from "../../../shared/projectKey.ts";
 import { MobilePr, THREAD_CSS } from "./MobilePr.tsx";
 import { MobileFleet, FLEET_CSS } from "./MobileFleet.tsx";
 import { sessionForInsight } from "./fleet.ts";
-import { buildQueue, type NowItem } from "./nowQueue.ts";
+import { buildQueue, waitingItems, type NowItem } from "./nowQueue.ts";
 import { dedupePrs, mainCheckouts } from "./prRows.ts";
 import { deviceStore, restoreAll, snooze, unsnoozed } from "./snooze.ts";
 import {
@@ -480,6 +480,15 @@ export function MobileApp() {
     () => unsnoozed(snoozeStore, pending),
     [pending, snoozeStore, snoozeRev]
   );
+  /**
+   * The ones where something is actually stopped.
+   *
+   * The tab badge and the hero count these and nothing else. A badge that adds
+   * one held gate to five pull requests is never zero, and a number that is
+   * never zero stops being read — which is most of why this screen felt like an
+   * inbox rather than something you could empty.
+   */
+  const stopped = useMemo(() => waitingItems(queue), [queue]);
 
   /**
    * Which checkout each container belongs to, decided once by the rule the
@@ -636,21 +645,22 @@ export function MobileApp() {
           { label: "Later", tight: true, run: () => later(it) },
         ];
       case "pr-ready":
+        // No merge from here.
+        //
+        // This card used to lead with "Squash & merge", which rewrites history
+        // and deletes the head branch. A confirm sat in front of it, and a
+        // confirm is the weakest control there is against a mis-tap: it appears
+        // under the thumb that just tapped, in a list built for fast scrolling,
+        // in the same shape and position as Allow and Later. Every other action
+        // in this queue re-runs, snoozes or opens something; that one finished
+        // work on a shared repository and could not be undone from a phone.
+        //
+        // Merging is a decision you make looking at the change, and the diff,
+        // the checks and the threads are all one screen away. So the card says
+        // the pull request is ready and takes you to where deciding is possible.
         return [
-          {
-            // The one queue action that cannot be undone. Everything else here
-            // re-runs, snoozes or opens something; this rewrites history and
-            // deletes a branch, from a card the thumb is already scrolling past.
-            label: "Squash & merge", kind: "ok",
-            run: async () => {
-              if (!(await ask({
-                title: `Squash & merge #${o.pr.number}?`, danger: true, confirmLabel: "Squash & merge",
-                body: "Every commit becomes one, and the head branch is deleted straight after. Neither step is reversible from here.",
-              }))) return;
-              await settle(`Merged #${o.pr.number}`, () => api.prMerge(o.root, o.pr.number, "squash", { deleteBranch: true }), it.id);
-            },
-          },
-          { label: "Review", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
+          { label: "Open", kind: "acc", run: () => setOpenPr({ root: o.root, number: o.pr.number }) },
+          { label: "Later", tight: true, run: () => later(it) },
         ];
       case "pr-review":
         return [
@@ -759,7 +769,7 @@ export function MobileApp() {
         {tab === "now" && (
           <>
             <NowHero
-              pending={queue.length} working={live.length}
+              pending={stopped.length} news={queue.length - stopped.length} working={live.length}
               live={openCalls}
               spend={spend}
               repos={[...new Set(live.map((s) => (s.project_path || "").split("/").filter(Boolean).pop() || s.source_app))]}
@@ -781,7 +791,7 @@ export function MobileApp() {
       </main>
 
       {!immersive && <nav className="mb-nav">
-        <TabBtn id="now" tab={tab} onPick={setTab} glyph="◎" label="Now" badge={queue.length} />
+        <TabBtn id="now" tab={tab} onPick={setTab} glyph="◎" label="Now" badge={stopped.length} />
         <TabBtn id="chats" tab={tab} onPick={setTab} glyph="▤" label="Chats" />
         <TabBtn id="repos" tab={tab} onPick={setTab} glyph="◇" label="Repos" />
         {/* Everything on this tab was computed and served from the beginning

--- a/web/src/mobile/MobileNow.tsx
+++ b/web/src/mobile/MobileNow.tsx
@@ -1,7 +1,7 @@
 import { Act, Empty } from "./mobileUi.tsx";
 import { fmtAgo } from "../lib/format.ts";
 import { shortTarget } from "./transcript.ts";
-import type { NowItem, NowTone } from "./nowQueue.ts";
+import { waitingItems, newsItems, type NowItem, type NowTone } from "./nowQueue.ts";
 
 /**
  * The queue, and the hero above it.
@@ -78,6 +78,17 @@ export const NOW_CSS = `
    not the same size of decision as re-running it. */
 .mb-item .acts>.tight{flex:none;display:flex}
 .mb-item .acts>.tight>.mb-btn{min-height:50px;border-radius:13px;padding:0 15px}
+
+/* Nothing is waiting on these.
+   They are still worth reading, so they are not hidden and not shrunk — a card
+   you cannot read is not calmer, it is just worse. What they lose is the fight
+   for attention: no coloured stripe, a flatter surface, and a border that does
+   not compete with the one thing above them that is actually stuck. */
+.mb-item.quiet{background:color-mix(in srgb,var(--bg2) 46%,transparent);
+  border-color:color-mix(in srgb,var(--border) 24%,transparent);
+  box-shadow:var(--mb-edge)}
+.mb-item.quiet::before{width:2px;background:color-mix(in srgb,var(--text3) 42%,transparent)}
+.mb-item.quiet .k{color:var(--text3)}
 `;
 
 export interface NowAction {
@@ -102,8 +113,22 @@ export interface NowAction {
  * session last showed evidence of being alive. So the strip is now one row per
  * open call, and when nothing is open it says so instead of pulsing.
  */
-export function NowHero({ pending, working, live, spend, repos }: {
-  pending: number; working: number; live: LiveCall[]; spend: string; repos: string[];
+/**
+ * The count is only ever things that are stopped.
+ *
+ * It used to be every card in the queue, and a number that adds one held gate
+ * to five pull requests is a number nobody can act on: it is never zero, so it
+ * never means anything, and the screen it heads reads as an inbox. Counting
+ * only what is stuck makes the empty state reachable, and reaching it is the
+ * point — a companion whose queue is usually empty and occasionally urgent is
+ * worth more than one that always has six rows.
+ *
+ * `news` is passed only so the calm line can say what is still down there,
+ * rather than claiming the machine is idle when six things are waiting to be
+ * read.
+ */
+export function NowHero({ pending, news = 0, working, live, spend, repos }: {
+  pending: number; news?: number; working: number; live: LiveCall[]; spend: string; repos: string[];
 }) {
   const calm = pending === 0;
   return (
@@ -111,8 +136,12 @@ export function NowHero({ pending, working, live, spend, repos }: {
       <div className="in">
         <span className="mb-fig n">{calm ? "✓" : pending}</span>
         <span className="w">
-          <b>{calm ? "Nothing needs you" : `${pending} thing${pending > 1 ? "s" : ""} want${pending > 1 ? "" : "s"} you`}</b>
-          <span>{calm ? "The fleet is running clean" : "Answer one and it leaves the queue"}</span>
+          <b>{calm
+            ? "Nothing is waiting on you"
+            : `${pending} ${pending > 1 ? "are" : "is"} stopped, waiting on you`}</b>
+          <span>{calm
+            ? (news > 0 ? `Nothing is stopped · ${news} worth reading below` : "Every agent is running")
+            : "Answer one and it starts again"}</span>
         </span>
       </div>
       {live.length > 0 && (
@@ -160,14 +189,34 @@ export function NowStream({ items, actionsFor, onOpen }: {
 }) {
   if (!items.length) {
     return (
-      <Empty glyph="◎" title="The queue is empty"
-        body="You will hear about it when an agent stops, asks permission, turns something red, or opens something worth your eyes." />
+      <Empty glyph="◎" title="Nothing is waiting"
+        body="You will hear about it the moment an agent stops — a permission it cannot grant itself, a question it cannot answer, a checkout it cannot finish." />
     );
   }
+  const stopped = waitingItems(items);
+  const news = newsItems(items);
   return (
     <div className="flex flex-col gap-3">
-      {items.map((it, i) => (
-        <div key={it.id} className={`mb-item ${toneClass(it.tone)}`} style={{ animationDelay: `${i * 55}ms` }}>
+      {render(stopped, 0)}
+      {/* The line between "something is stuck" and "something is true".
+          Without it the two run together in one scroll, and because there is
+          always more news than there are blockages, the news wins — which is
+          how this screen came to read as a notifications inbox. Drawn only
+          when there is something on both sides of it; a divider over an empty
+          half is noise. */}
+      {stopped.length > 0 && news.length > 0 && (
+        <div className="mb-eyebrow" style={{ margin: "6px 0 -4px", opacity: .75 }}>
+          Nothing below is waiting on you
+        </div>
+      )}
+      {render(news, stopped.length)}
+    </div>
+  );
+
+  function render(list: NowItem[], offset: number) {
+    return list.map((it, i) => (
+        <div key={it.id} className={`mb-item ${toneClass(it.tone)}${it.waiting ? "" : " quiet"}`}
+          style={{ animationDelay: `${(offset + i) * 55}ms` }}>
           <div className="ih">
             <span className="k">{it.kind}</span>
             {it.ts != null && <span className="at">{fmtAgo(it.ts)}</span>}
@@ -189,9 +238,8 @@ export function NowStream({ items, actionsFor, onOpen }: {
             ))}
           </div>
         </div>
-      ))}
-    </div>
-  );
+    ));
+  }
 }
 
 const toneClass = (t: NowTone) => (t === "plain" ? "" : t);

--- a/web/src/mobile/nowQueue.ts
+++ b/web/src/mobile/nowQueue.ts
@@ -60,8 +60,32 @@ export interface NowItem {
    * their band and draw no age at all.
    */
   ts?: number;
+  /**
+   * Something is stopped, and only a person can start it again.
+   *
+   * The distinction this whole screen turns on, and the one it did not make
+   * for a long time. An agent held at a gate is *paused* — the hook's request
+   * is open, nothing proceeds, and the only thing in the world that unblocks it
+   * is somebody tapping Allow. A pull request being ready is true, useful, and
+   * waiting on nobody.
+   *
+   * Both were cards in one list, in the same shape, counted by one number. There
+   * is always more news than there are blockages, so the news won, and what was
+   * left read as a notifications inbox — which everybody already has, and which
+   * is why the honest verdict on this screen was that it did not add value. It
+   * is also how an irreversible merge ended up one thumb-length from Allow.
+   *
+   * So it is a field rather than a tone: a tone says how loud, and this says
+   * whether anything is actually stuck.
+   */
+  waiting: boolean;
   origin: NowOrigin;
 }
+
+/** The ones that are stopped. The hero counts these and nothing else. */
+export const waitingItems = (items: NowItem[]): NowItem[] => items.filter((i) => i.waiting);
+/** Everything else: true, worth knowing, waiting on nobody. */
+export const newsItems = (items: NowItem[]): NowItem[] => items.filter((i) => !i.waiting);
 
 /** Blocked first: an agent waiting on a permission is stopped dead, and every
  *  second of that is wasted. Then things that are broken, then things that are
@@ -108,6 +132,8 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
       // three is progress worth being told about; the clock is not in here.
       mark: `halt:${root}:${h.state}:${h.conflicts.length}`,
       tone: "crit",
+      // Nothing in this checkout will move again until somebody decides.
+      waiting: true,
       kind: "Stopped part-way",
       title: `${baseName(root)}: ${h.title.toLowerCase()}`,
       sub: h.sub,
@@ -120,6 +146,8 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
   for (const g of gates) {
     out.push({
       id: `gate:${g.id}`, mark: `gate:${g.id}`, tone: "crit",
+      // The purest case: the hook's own request is open while this sits here.
+      waiting: true,
       kind: "Blocked · waiting on you",
       title: g.summary || g.tool_name,
       sub: `${g.source_app} · the agent is stopped until you answer`,
@@ -137,6 +165,9 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
       // It spoke again: that is the change, even if it has since gone quiet.
       mark: `session:${s.session_id}:${s.last_seen}`,
       tone: "plain",
+      // Quiet for longer than it takes to think. The agent is not working, it
+      // is waiting to be told something.
+      waiting: true,
       kind: "Stopped · wants direction",
       title: sessionTitle(s),
       sub: `${projectName(s)} · idle ${Math.round(quiet / 60_000)}m`,
@@ -158,6 +189,8 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
         // the failing set. Either is worth surfacing again.
         mark: `red:${repo}#${pr.number}:${pr.updatedAt}:${pr.checks.failing.map((f) => f.name).sort().join(",")}`,
         tone: "bad",
+        // The run already finished. Nothing is paused on your answer.
+        waiting: false,
         kind: "CI went red",
         title: `${pr.checks.failing[0]?.name ?? "A check"} is failing on #${pr.number}`,
         sub: `${pr.title} · ${repo}`,
@@ -172,6 +205,7 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
         id: `ready:${repo}#${pr.number}`,
         mark: `ready:${repo}#${pr.number}:${pr.updatedAt}`,
         tone: "good",
+        waiting: false,
         kind: "Ready to merge",
         title: `#${pr.number} ${pr.title}`,
         sub: `Approved · ${pr.checks.total} checks green · ${repo}`,
@@ -185,6 +219,10 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
         id: `review:${repo}#${pr.number}`,
         mark: `review:${repo}#${pr.number}:${pr.updatedAt}`,
         tone: "plain",
+        // A person is waiting, which is real and is not the same as an agent
+        // stopped mid-run. This is the kind there is always most of, and
+        // letting it into the count is what drowned the gates.
+        waiting: false,
         kind: "Review requested",
         title: `#${pr.number} ${pr.title}`,
         sub: `${pr.author} asked you · +${pr.additions} −${pr.deletions} across ${pr.changedFiles} files`,
@@ -202,6 +240,8 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
       // hours ago"), and a mark that ticks is a snooze that never holds.
       mark: `ctr:${c.id}:${c.state}:${exitCode(c) ?? "?"}`,
       tone: "bad",
+      // Misbehaving, not waiting.
+      waiting: false,
       kind: "Container down",
       title: looping ? `${c.name} is restarting in a loop` : `${c.name} is ${c.state}`,
       // Docker's own status carries the age — "Exited (1) 3 hours ago" — and
@@ -212,10 +252,18 @@ export function buildQueue({ gates, sessions, prs, containers, trees, me, now }:
     });
   }
 
-  // Inside a band, newest first — and anything without a real moment after
-  // everything that has one, rather than ahead of all of it.
+  // Anything stopped outranks everything that is merely true, whatever its
+  // tone. A red build is `bad` and a stalled agent is `plain`, and before this
+  // the red build sorted above it — the loudest card in the list was the one
+  // nothing was waiting on.
+  //
+  // Then the old order inside each group: blocked, broken, finished, and
+  // newest first within a band, with items that have no honest moment last
+  // rather than ahead of everything real.
   return out.sort((a, b) =>
-    RANK[a.tone] - RANK[b.tone] || (b.ts ?? -Infinity) - (a.ts ?? -Infinity));
+    Number(b.waiting) - Number(a.waiting)
+    || RANK[a.tone] - RANK[b.tone]
+    || (b.ts ?? -Infinity) - (a.ts ?? -Infinity));
 }
 
 /**

--- a/web/test/now-actions.test.ts
+++ b/web/test/now-actions.test.ts
@@ -1,0 +1,69 @@
+/*
+ * What the Now queue is allowed to do to you.
+ *
+ * The queue is a vertically scrolling list of cards, every one of which puts
+ * its actions in the same shape and the same place. That is the whole point —
+ * you thumb down it and answer things — and it is exactly why an irreversible
+ * action must not be one of them. "Squash & merge" sat there for a while, with
+ * a danger-styled confirm in front of it, and a confirm is the weakest control
+ * there is against a mis-tap: it appears under the thumb that just tapped.
+ *
+ * A rule over the file rather than an assertion about today's switch
+ * statement. `actionsFor` is a closure over component state and cannot be
+ * imported, and pinning the labels it returns would only say what the cards
+ * say today — it would not stop somebody adding a fifth verb tomorrow. What
+ * has to stay true is smaller and more durable: the shell that owns the queue
+ * calls nothing that cannot be taken back.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SHELL = readFileSync(new URL("../src/mobile/MobileApp.tsx", import.meta.url).pathname, "utf8");
+
+/**
+ * Calls that finish, destroy or rewrite something, where the phone is the
+ * worst possible place to be asked.
+ *
+ * Not a list of everything that writes. `prRerun` re-runs checks, `dockerRestart`
+ * restarts a container, and both are recoverable by doing them again. Merging
+ * deletes a branch, closing rejects somebody's work, removing a container takes
+ * its filesystem, and discarding throws away edits nobody has committed.
+ */
+const IRREVERSIBLE = [
+  "prMerge",
+  "prClose",
+  "dockerRm",
+  "gitDiscard",
+  "gitReset",
+];
+
+describe("the phone's queue", () => {
+  it("offers nothing that cannot be taken back", () => {
+    for (const call of IRREVERSIBLE) {
+      expect(SHELL).not.toContain(`api.${call}(`);
+    }
+  });
+
+  it("still offers the ones that are only a repeat", () => {
+    // The rule above has to be a real constraint rather than a description of
+    // an empty file: these are the writes the queue legitimately makes, and if
+    // they vanish this test is passing for the wrong reason.
+    expect(SHELL).toContain("api.prRerun(");
+    expect(SHELL).toContain("api.dockerRestart(");
+    // And the one the queue exists for. A gate decision is not reversible
+    // either, but it is the decision the agent is stopped waiting for — the
+    // queue is the right place to be asked, which is the whole distinction.
+    expect(SHELL).toContain("api.gateDecide(");
+  });
+
+  it("sends a ready pull request to the screen that can show the change", () => {
+    // Merging is a decision you make looking at the diff, the checks and the
+    // threads, all of which are one screen away.
+    const readyCase = SHELL.slice(SHELL.indexOf('case "pr-ready":'), SHELL.indexOf('case "pr-review":'));
+    expect(readyCase).toContain("setOpenPr");
+    // It navigates and snoozes, and calls no server route at all — which is a
+    // stronger thing to say than "it does not merge", and does not go stale
+    // the moment somebody invents a second way to finish a pull request.
+    expect(readyCase).not.toMatch(/\bapi\.\w+\(/);
+  });
+});

--- a/web/test/now-queue.test.ts
+++ b/web/test/now-queue.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { buildQueue, type NowInput } from "../src/mobile/nowQueue.ts";
+import { buildQueue, waitingItems, newsItems, type NowInput } from "../src/mobile/nowQueue.ts";
 import type { PendingGate, SessionRollup, PrSummary, DockerContainer } from "../../shared/types.ts";
 
 const NOW = 1_700_000_000_000;
@@ -177,7 +177,7 @@ describe("buildQueue", () => {
     expect(opaque).toHaveLength(1);
   });
 
-  it("orders blocked, then broken, then finished, then the rest", () => {
+  it("puts everything that is stopped above everything that is merely true", () => {
     const red = rollup({ failure: 1, verdict: "red", failing: [{ name: "e2e", workflow: "CI", state: "failure", done: true }] });
     const q = buildQueue({
       ...base,
@@ -190,6 +190,58 @@ describe("buildQueue", () => {
         { root: "/r", repo: "s", scope: "review", pr: pr({ number: 3, author: "other" }) },
       ],
     });
-    expect(q.map((i) => i.tone)).toEqual(["crit", "bad", "bad", "good", "plain", "plain"]);
+    // The rule that matters, first: anything stopped comes before anything
+    // that is not, whatever its tone. Before this, a red build (`bad`) sorted
+    // above a stalled agent (`plain`) — so the loudest card on the screen was
+    // the one nothing was waiting on, and the one thing only a person could
+    // restart was below it.
+    expect(q.map((i) => i.waiting)).toEqual([true, true, false, false, false, false]);
+    // And the old order still holds inside each half: blocked, broken,
+    // finished, the rest.
+    expect(q.map((i) => i.tone)).toEqual(["crit", "plain", "bad", "bad", "good", "plain"]);
+  });
+
+  it("counts a gate, a stalled agent and a halted checkout as stopped, and nothing else", () => {
+    // The whole screen turns on this split, so it is worth stating flatly
+    // rather than inferring from an order. A pull request needing review is a
+    // person waiting, which is real and is not an agent that cannot continue —
+    // and it is the kind there is always most of, which is what drowned the
+    // gates when one number counted both.
+    const red = rollup({ failure: 1, verdict: "red", failing: [{ name: "e2e", workflow: "CI", state: "failure", done: true }] });
+    const q = buildQueue({
+      ...base,
+      gates: [gate()],
+      sessions: [session()],
+      containers: [ctr({ state: "exited" })],
+      prs: [
+        { root: "/r", repo: "s", scope: "mine", pr: pr({ number: 1, checks: red }) },
+        { root: "/r", repo: "s", scope: "mine", pr: pr({ number: 2, reviewDecision: "APPROVED" }) },
+        { root: "/r", repo: "s", scope: "review", pr: pr({ number: 3, author: "other" }) },
+      ],
+    });
+    const stopped = q.filter((i) => i.waiting).map((i) => i.origin.t).sort();
+    const news = q.filter((i) => !i.waiting).map((i) => i.origin.t).sort();
+    expect(stopped).toEqual(["gate", "session"]);
+    expect(news).toEqual(["container", "pr-ready", "pr-red", "pr-review"]);
+  });
+
+  it("counts a halted checkout as stopped", () => {
+    // Its own case because it needs a tree rather than a session, and because
+    // it is the one kind with no timestamp: nothing in that checkout moves
+    // again until somebody decides, which is the definition being used here.
+    const q = buildQueue({
+      ...base,
+      trees: { "/r": { state: "merging", conflicts: ["a.ts"], dirty: 1, ahead: 0, behind: 0, branch: "main" } },
+    });
+    expect(q).toHaveLength(1);
+    expect(q[0]!.waiting).toBe(true);
+  });
+
+  it("separates the two halves cleanly for the view", () => {
+    const q = buildQueue({ ...base, gates: [gate()], containers: [ctr({ state: "exited" })] });
+    expect(waitingItems(q).map((i) => i.origin.t)).toEqual(["gate"]);
+    expect(newsItems(q).map((i) => i.origin.t)).toEqual(["container"]);
+    // Every item lands in exactly one of them.
+    expect(waitingItems(q).length + newsItems(q).length).toBe(q.length);
   });
 });


### PR DESCRIPTION
Closes #434. Closes #436.

## What does this PR do?

Two faults with one cause, both reported from a phone during a working day, and the verdict that came with them was that the screen is **mediocre and does not add value**.

**The queue mixed two different things.** An agent held at a gate is *stopped* — the hook's request is open, nothing proceeds, and the only thing in the world that unblocks it is a person tapping Allow. A pull request being ready is true, useful, and waiting on nobody. Both were cards in one list, in one shape, counted by one number. There is always more news than there are blockages, so the news won, and what was left reads as a notifications inbox — which everybody already has.

**It is also how an irreversible merge came to sit one thumb-length from Allow.** Squash & merge rewrites history and deletes the head branch. It had a danger-styled confirm in front of it, which is the weakest control there is against a mis-tap: it appears under the thumb that just tapped, in a list built for fast scrolling.

`waiting` is now a field on the item rather than a tone — a tone says how loud, this says whether anything is actually stuck:

| stopped | not stopped |
|---|---|
| a gate held at `PreToolUse` | a red build (the run already finished) |
| an agent quiet past thinking time | a ready pull request |
| a checkout stopped mid-merge | a review request (a person waiting, not an agent) |
| | a container that is down |

- **Everything stopped outranks everything that is not, whatever its tone.** Before this a red build (`bad`) sorted above a stalled agent (`plain`), so the loudest card on screen was the one nothing was waiting on.
- **The hero and the tab badge count only what is stopped.** A badge that adds one held gate to five pull requests is never zero, and a number that is never zero stops being read. Counting only what is stuck makes the empty state reachable, and reaching it is the point.
- **The news keeps its cards** — it is worth reading, and a card you cannot read is not calmer, only worse. What it loses is the fight for attention: a flat surface, no coloured stripe, and a line above it saying *nothing below is waiting on you*.
- **The ready card opens the pull request.** Merging is a decision you make looking at the change, and the diff, checks and threads are one screen away.

## How was it tested?

Fourteen mutations, all red. 178/178 phone audit checks, four of them new and driven with **both halves of the queue genuinely present** — a real held gate above an approved, green pull request, at 390px:

```
hero:    1 is stopped, waiting on you
badge:   1
cards:   [{ Blocked · waiting on you, quiet: false, [Allow, Deny] },
          { Ready to merge,           quiet: true,  [Open,  Later] }]
divider: NOTHING BELOW IS WAITING ON YOU
```

Suites green: 1132 server, 818 web.

## Three harness faults found on the way

Each had made a check say something untrue, which is worse than a check that fails.

**The audit opened a conversation from whichever scope the scope exercise left selected** — Today — and a fixture seeded a day ago has nothing in Today. It tapped an empty list and waited twelve seconds for a screen that was never going to mount, failing the whole run with *"timed out waiting for the conversation screen"*: true, and pointing at entirely the wrong thing.

**The new checks read the badge with regular expressions inside a template literal,** where `\b` and `\d` are string escapes long before they are regex syntax. `/^\d+$/` reached the page as `/^d+$/`, matched nothing, reported a badge of 0, and failed a check about counting for a reason that had nothing to do with counting. There is no regex in there now.

**An existing rule asserted the queue's merge went through `ask()`.** That premise is gone, so the rule is now the stronger one — some calls may not appear in the shell at all, confirm or no confirm — with a companion check that the shell has not simply been emptied, since the first would pass against a file that calls nothing.
