### PR TITLE
Pair a phone as its own device: confirmed, named, revocable

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,14 +288,42 @@ rely on, and for a good number of people it is not a signal at all.
 
 ### Getting it onto your phone
 
-**Settings ▸ Remote access**, one switch. It prints a QR code, because the URL
-is an IP, a port and a 32-character secret and nobody is typing that. Scan it
-and the phone remembers the code; the link only carries it once.
+**Settings ▸ Remote access**, one switch to open the port. Then adding a device
+is its own small handshake, and it is deliberately not one step.
 
-It is **your network only** — the server binds to the LAN, the code is required,
-and a phone that scanned it once keeps working until you rotate it. The same
-pane will tell you when a host firewall is dropping the packets, because
-otherwise the phone shows a white page and nothing anywhere says why.
+The pane shows a **QR code and six digits**. Scan the code, type the digits on
+the phone, and a request appears back at the computer — naming the device, the
+address it came from, and the same six digits — and waits for somebody to
+accept. Nothing exists until they do.
+
+That shape is the point. **The QR is an invitation, not a key.** It used to be
+the machine's own token, which meant a photograph of this screen, a screenshot
+in a chat or a shared window in a call was a working shell on your laptop; there
+is no way to scan a code carefully, and being able to see it was the whole
+authorisation. Now seeing it gets you a form asking for six digits that are not
+in the picture. The credential itself is minted only after a person agrees, and
+it is encrypted to a key the phone generated for that one pairing — so on a
+network without TLS, everything else on the wifi can watch the entire exchange
+and still not have it.
+
+Each device is then **its own thing**: named, at a level you chose while looking
+at the request, and revocable on its own.
+
+- **Look only** — sessions, costs, changes, pull requests. Approves nothing.
+- **Answer things** *(the default)* — the above, plus approving gates and
+  replying to a running session. What a phone is actually for.
+- **Everything** — the terminal, git write, Docker, merging. For a laptop you
+  trust, not a phone.
+
+**Forget** one device and only that one stops working: its credential is
+revoked, the sockets it is holding are closed, and the desk and every other
+phone carry on. Rotating the code is still there for when you have lost the code
+itself, and still kicks everything.
+
+It is **your network only** — the server binds to the LAN. The same pane will
+tell you when a host firewall is dropping the packets, because otherwise the
+phone shows a white page and nothing anywhere says why. Over café wifi, pair on
+the Tailscale address it offers instead: that one is encrypted end to end.
 
 The page ships a web manifest, so **Add to home screen** gives you an icon that
 opens without browser chrome.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -11,9 +11,13 @@ a deliberate three-part act: bind off loopback, set `AGENTGLASS_TRUST_LAN=1`, an
 carry a token. See [Trust model](#trust-model) below.
 
 The desktop app performs all three as one switch (Settings › Remote), which
-mints the token itself and shows the URL as a QR code. It is off by default, it
-states in plain words what turning it on grants to everyone on the network, and
-turning it off closes the port rather than merely hiding the link.
+mints the token itself. It is off by default, it states in plain words what
+turning it on grants, and turning it off closes the port rather than merely
+hiding the link.
+
+Adding a device is a separate, deliberate act — see
+[Pairing a device](#pairing-a-device). The QR code is an *invitation*, not a
+credential: a photograph of the screen does not pair anything.
 
 ## Supported versions
 
@@ -54,11 +58,15 @@ complement, rather than replace, the private reporting path below.
 - **Desktop-only routes.** The self-update route executes arbitrary code and is
   reachable from the packaged shell's own origin and nothing else — not from a
   browser, not from another machine.
-- **The token is never re-served to the network.** `/remote/status` reports where
-  the server is reachable and whether a device has arrived, but includes the
-  token itself only for a caller on this machine (a loopback peer address). A
-  page loaded over the LAN already holds the token; handing it back out would
-  turn one leaked link into a permanent credential for anything on the wifi.
+- **The token is never served over any route, to anyone.** `/remote/status`
+  reports where the server is reachable and whether a device has arrived, and
+  the addresses it returns are addresses — nothing in that answer, or in any
+  other, is a credential. It used to hand the token back to a caller on this
+  machine, because the QR code *was* the token and the pane had to draw it;
+  pairing replaced that, and a URL that grants a shell is exactly what ends up
+  in a screenshot of the pane it is drawn in.
+- **A device holds its own credential, at its own level.** See
+  [Pairing a device](#pairing-a-device).
 - **Tailnet addresses.** CGNAT (`100.64.0.0/10`, what Tailscale assigns) counts
   as private under `AGENTGLASS_TRUST_LAN=1`, alongside RFC1918. It is reachable
   only across an authenticated, encrypted mesh, so it is a narrower grant than
@@ -71,6 +79,71 @@ complement, rather than replace, the private reporting path below.
   out (`AGENTGLASS_GATE_TIMEOUT`, 60s) falls through rather than blocking your
   agents. Set `AGENTGLASS_GATE_FAILCLOSED=1` if you would rather a timeout or an
   unreachable control plane denied the call.
+
+## Pairing a device
+
+Handing a phone the machine's token had three consequences, and all three are
+why this is now a handshake:
+
+* **anyone who could see the screen was paired.** The QR carried the credential,
+  so a photograph, a screenshot in a chat or a shared window in a call was a
+  working key;
+* **a lost phone could not be cut off.** One token meant revoking was rotating,
+  and rotating kicked every device including the desk;
+* **everything could do everything.** A phone that only ever approves gates had
+  a terminal, git write access and Docker control.
+
+The handshake, in `server/src/pairing.ts`:
+
+1. **The machine mints an invitation.** A ticket id goes in the QR; a six-digit
+   code is shown on the screen and nowhere else. Both last two minutes.
+2. **The phone proves it can see that screen.** It scans the QR, generates a
+   P-256 keypair that never leaves the browser, and types the code. Five wrong
+   guesses closes the invitation outright rather than refusing one attempt.
+3. **A person at the machine agrees.** The request appears in the Remote pane
+   naming the device, the address it came from and the same six digits, and
+   waits. Nothing is minted until somebody accepts, and accepting is where the
+   device's level is chosen.
+4. **The credential is delivered to that claimant and nobody else.** It is
+   encrypted to the key from step 2 (ECDH → HKDF → AES-256-GCM, salted with the
+   ticket) and collected exactly once, authorised by a secret only the claimant
+   holds.
+
+What this gives you, and what it does not:
+
+- **The QR is not a credential.** Photographing it, or scanning it from a shared
+  screen, gets a form asking for six digits that are not in the picture.
+- **The credential never travels in the clear.** The server speaks plain HTTP
+  over the LAN, so anything on that network sees the whole exchange — ticket,
+  code, both public keys — and still has no key.
+- **It does not defend against an active on-path attacker.** Someone who can
+  rewrite traffic can substitute their own public key, and no handshake fixes
+  that without an authenticated channel. That is a TLS problem. On a network you
+  do not own, use the Tailscale address, which is encrypted end to end; the pane
+  says so where the choice is made.
+- **Credentials are stored hashed** (`~/.config/agentglass/devices.json`, `0600`)
+  and compared in constant time. A readable file is not a working key.
+
+**Levels.** A paired device is `read`, `answer` or `full`, chosen when the
+request is accepted and defaulting to `answer`:
+
+| Level | What it can do |
+|---|---|
+| `read` | Every GET, plus the POSTs that only read. Approves nothing, sends nothing. |
+| `answer` | The above, plus `/gate/decide` and replying to a session that is already running. |
+| `full` | Everything the machine can do: the terminal, git write, Docker, merging pull requests. |
+
+Enforcement is **deny by default**: anything that changes state and is not named
+as a read or an answer requires `full`, so a route added later is out of a
+paired phone's reach until somebody decides otherwise. `/terminal/pty` is
+explicitly `full` despite arriving as a `GET` — a browser cannot put a header on
+a WebSocket upgrade, and a rule that trusted the method would hand a read-only
+device an interactive shell.
+
+**Revoking one device** (Settings › Remote › Paired devices › Forget) revokes
+that credential and closes the sockets it is holding, and leaves every other
+device — and the desk — alone. Rotating the machine's token is still there for
+the case where you have lost the code itself, and still kicks everything.
 
 ## What agentglass stores, and how to get rid of it
 
@@ -85,6 +158,7 @@ and no menu item that removes recorded data. The `Clear ✕` in the header clear
 |---|---|
 | `~/.local/share/agentglass/agentglass.db`<br><sub>or `$XDG_DATA_HOME/agentglass/`, or `./agentglass.db` if one is already there</sub> | Every event, with its `summary`, its `error_text` and the **raw hook payload** — which for a tool call is the command line, the file path, and the prompt. Plus session totals, the full-text search index, gate decisions, the daily rollup, and the **activity log** — every write the dashboard performed, with the address it came from. |
 | `~/.config/agentglass/token` | The shared secret, `0600`, when one has been minted. |
+| `~/.config/agentglass/devices.json` | One row per paired device, `0600`: its name, its level, when it was added and last used, and a **SHA-256 of its credential** — never the credential. Revoked rows are kept rather than deleted, so "did I definitely cut that phone off" stays answerable. |
 | `~/.config/agentglass/config.json` | The active project scope and the UI switches. |
 
 **One feature does send data off this machine, and it is the only one.** The AI

--- a/scripts/phone-audit.ts
+++ b/scripts/phone-audit.ts
@@ -1008,6 +1008,125 @@ async function main() {
       await cdp.ev(linkName));
     await drain(cdp, "offline");
 
+    // ---- pairing this device -------------------------------------------
+    //
+    // The one part of the companion that runs before the application does, and
+    // the only part that is cryptography. Both are reasons to drive it in a
+    // real browser rather than trust the unit tests: `unseal` uses WebCrypto,
+    // and the two halves of the handshake are written against two entirely
+    // different implementations of the same four steps. A mismatch in any of
+    // them produces a device that pairs, appears in the list, and then cannot
+    // authenticate.
+    //
+    // Skipped when the audit is run against a server with no token, because
+    // then there is no credential to hand out and `/pair/ticket` is not the
+    // thing being exercised.
+    if (token) {
+      const invite = await (await fetch(ORIGIN + "/pair/ticket", {
+        method: "POST",
+        headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+        body: "{}",
+      })).json() as { ok?: boolean; id?: string; code?: string };
+      note("pairing", "the machine can start an invitation", !!invite.ok && !!invite.id && !!invite.code,
+        JSON.stringify(invite).slice(0, 160));
+
+      if (invite.ok && invite.id && invite.code) {
+        // A device with no credential at all: the page has to load, and it has
+        // to be the pairing screen rather than an application failing behind it.
+        await cdp.ev(`try { localStorage.removeItem("agentglass_token"); } catch {}`);
+        await cdp.send("Page.navigate", { url: `${ORIGIN}/?pair=${encodeURIComponent(invite.id)}` });
+        await until(cdp, `document.querySelector(".pair-card")`, "the pairing screen", 20_000);
+        await Bun.sleep(900);
+
+        note("pairing", "asks for a name and a code, and nothing else",
+          await cdp.ev(`!!document.querySelector("#pair-name") && !!document.querySelector("#pair-code")`));
+        note("pairing", "the application is not mounted behind it",
+          await cdp.ev(`!document.querySelector(".mb") && !document.querySelector("nav")`));
+        note("pairing", "says a person still has to accept",
+          await cdp.ev(`(document.body.textContent||"").includes("Nothing is granted yet")`));
+        note("pairing", "the button is dead until six digits are in",
+          await cdp.ev(`document.querySelector(".pair-go")?.disabled === true`));
+        note("pairing", "nothing spills off the side at phone width",
+          await cdp.ev(`document.documentElement.scrollWidth <= innerWidth + 2`));
+        await shot(cdp, "15-pairing");
+
+        // Type the code the way a person does, then watch for the request to
+        // arrive at the machine. Nothing is granted by this step, which is the
+        // property being checked.
+        await cdp.ev(`(()=>{const i=document.querySelector("#pair-name");
+          const set=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,"value").set;
+          set.call(i,"the audit's phone"); i.dispatchEvent(new Event("input",{bubbles:true}));})()`);
+        await cdp.ev(`(()=>{const i=document.querySelector("#pair-code");
+          const set=Object.getOwnPropertyDescriptor(HTMLInputElement.prototype,"value").set;
+          set.call(i,${JSON.stringify(invite.code)}); i.dispatchEvent(new Event("input",{bubbles:true}));})()`);
+        await Bun.sleep(300);
+        note("pairing", "the button wakes up once the code is complete",
+          await cdp.ev(`document.querySelector(".pair-go")?.disabled === false`));
+        await tap(cdp, ".pair-go");
+        await until(cdp, `(document.body.textContent||"").includes("Waiting for someone at the computer")`,
+          "the wait for a person", 12_000);
+        await shot(cdp, "16-pairing-waiting");
+
+        const state = await (await fetch(`${ORIGIN}/pair/state?ticket=${encodeURIComponent(invite.id)}`,
+          { headers: { authorization: `Bearer ${token}` } })).json() as
+          { pending?: { label?: string; code?: string; agent?: string }[] };
+        const req = state.pending?.[0];
+        note("pairing", "the request reaches the machine, named",
+          req?.label === "the audit's phone", JSON.stringify(state.pending ?? []).slice(0, 200));
+        note("pairing", "and carries the same code, for the person to check",
+          req?.code === invite.code);
+
+        // A person accepts, at the narrow level.
+        const accepted = await (await fetch(ORIGIN + "/pair/accept", {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+          body: JSON.stringify({ ticket: invite.id, scope: "answer" }),
+        })).json() as { ok?: boolean; device?: { id?: string; scope?: string } };
+        note("pairing", "accepting mints a device at the scope chosen",
+          !!accepted.ok && accepted.device?.scope === "answer", JSON.stringify(accepted).slice(0, 160));
+
+        // …and the phone, still polling, unwraps it in this browser with this
+        // browser's WebCrypto and mounts the application on it.
+        await until(cdp, `!!document.querySelector(".mb")`, "the companion, now paired", 20_000);
+        await Bun.sleep(1200);
+        note("pairing", "the phone opens the credential and the app comes up",
+          await cdp.ev(`document.documentElement.dataset.layout === "phone" && !!document.querySelector("nav")`));
+        note("pairing", "the invitation is out of the address bar",
+          await cdp.ev(`!location.search.includes("pair=")`));
+        note("pairing", "and it is a working credential, not a page that 401s",
+          await cdp.ev(`(async()=>{const t=localStorage.getItem("agentglass_token");
+            const r=await fetch("${ORIGIN}/gate/pending",{headers:{authorization:"Bearer "+t}});
+            return r.status===200;})()`),
+          await cdp.ev(`String(localStorage.getItem("agentglass_token") || "").slice(0,4)+"…"`));
+        note("pairing", "…at the level it was granted, and no further",
+          await cdp.ev(`(async()=>{const t=localStorage.getItem("agentglass_token");
+            const r=await fetch("${ORIGIN}/prs/merge",{method:"POST",
+              headers:{"content-type":"application/json",authorization:"Bearer "+t},
+              body:JSON.stringify({root:"/",number:1,method:"squash"})});
+            return r.status===403;})()`));
+        await shot(cdp, "17-paired");
+        // That refusal *is* the check above, so it is not a fault for the
+        // hygiene pass to report. Dropped by hand rather than by draining
+        // early, which would also throw away any real failure this section
+        // caused before it.
+        await cdp.ev(`(()=>{const a=window.__audit; if(a) a.net=a.net.filter(
+          n=>!(String(n).startsWith("403 ") && String(n).includes("/prs/merge")));})()`);
+        await drain(cdp, "pairing");
+
+        // Put the audit's own credential back, so everything after this runs as
+        // the machine rather than as a device that cannot do half of it.
+        const forgot = await (await fetch(ORIGIN + "/pair/forget", {
+          method: "POST",
+          headers: { "content-type": "application/json", authorization: `Bearer ${token}` },
+          body: JSON.stringify({ id: accepted.device?.id }),
+        })).json() as { ok?: boolean };
+        note("pairing", "forgetting the device revokes it", !!forgot.ok);
+        await cdp.send("Page.navigate", { url: `${ORIGIN}/?token=${encodeURIComponent(token)}` });
+        await until(cdp, `document.querySelector(".mb")`, "the phone shell", 25_000);
+        await Bun.sleep(1000);
+      }
+    }
+
     // ---- landscape ----------------------------------------------------
     // A phone turned sideways is 915x412: the same app, half the height, and
     // the composer still has to be reachable.

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -17,6 +17,7 @@ import { timingSafeEqual, randomBytes } from "node:crypto";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
 import { homedir } from "node:os";
 import { join, dirname } from "node:path";
+import { deviceFor, scopeAllows, type Device, type Scope } from "./devices.ts";
 
 const TOKEN_PATH = join(
   process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
@@ -42,13 +43,27 @@ const AUTH_EXEMPT = new Set([
   "/otlp/v1/logs",
 ]);
 
+/**
+ * The pairing handshake, which cannot require the credential it hands out.
+ *
+ * Nothing under here is a way in on its own: the machine-side routes refuse
+ * anything but loopback, and the phone-side ones are worth exactly as much as
+ * the ticket and code the person is holding — see pairing.ts. Prefixed rather
+ * than listed because the set is a protocol, and a step added to the protocol
+ * without its exemption fails in a way that looks like a bug in the phone.
+ */
+export const isPairing = (pathname: string) => pathname === "/pair" || pathname.startsWith("/pair/");
+
 /** True for routes that bypass the shared-secret gate even when a token is set. */
-export const isAuthExempt = (pathname: string) => AUTH_EXEMPT.has(pathname);
+export const isAuthExempt = (pathname: string) => AUTH_EXEMPT.has(pathname) || isPairing(pathname);
 
 // Rate-limited intake sinks (flood protection). /gate is included: even though
 // it authenticates when a token is set, a burst of gate posts shouldn't be
 // unbounded. This set governs throttling only, not auth exemption.
-const INTAKE = new Set([...AUTH_EXEMPT, "/gate"]);
+// `/pair/claim` is here for the same reason: it takes no credential, so the
+// only thing standing between it and a script is the five-guess cap on one
+// ticket. That cap is the real defence; this stops the noise before it.
+const INTAKE = new Set([...AUTH_EXEMPT, "/gate", "/pair/claim"]);
 
 export const isIntake = (pathname: string) => INTAKE.has(pathname);
 
@@ -98,8 +113,98 @@ function eq(a: string, b: string): boolean {
  *  fetch, or `?token=<t>` for the URLs a browser can't attach a header to
  *  (WebSocket upgrades, download navigations). */
 export function tokenOk(req: Request, url: URL, token: string): boolean {
+  const provided = presented(req, url);
+  return !!provided && eq(provided, token);
+}
+
+/** The credential this request carries, however it carried it. */
+function presented(req: Request, url: URL): string {
   const auth = req.headers.get("authorization") || "";
   const bearer = auth.startsWith("Bearer ") ? auth.slice(7).trim() : "";
-  const provided = bearer || url.searchParams.get("token") || "";
-  return !!provided && eq(provided, token);
+  return bearer || url.searchParams.get("token") || "";
+}
+
+/**
+ * Who is asking, and how much they are allowed to do.
+ *
+ * Two kinds of credential reach this server now. The machine's own token is
+ * what the desk uses and what a hook carries; it is the whole machine, so it
+ * is `full`. A **device** credential belongs to one paired phone, was minted
+ * with a scope somebody chose while looking at the request, and can be taken
+ * back without touching anything else — see devices.ts.
+ *
+ * Order matters: the machine token is checked first and in constant time, so
+ * the common case never walks the device list at all.
+ */
+export interface Caller {
+  kind: "machine" | "device";
+  scope: Scope;
+  device?: Device;
+}
+
+export function callerFor(req: Request, url: URL, token: string): Caller | null {
+  const provided = presented(req, url);
+  if (!provided) return null;
+  if (eq(provided, token)) return { kind: "machine", scope: "full" };
+  const device = deviceFor(provided);
+  return device ? { kind: "device", scope: device.scope, device } : null;
+}
+
+/**
+ * A phone may answer what is already asked. It may not drive the machine.
+ *
+ * Written as *deny by default* on purpose: anything that changes state and is
+ * not named below needs `full`, so a route added next month is out of a paired
+ * phone's reach until somebody decides otherwise. The reverse default — a list
+ * of forbidden routes — fails open every time the list is not updated, and the
+ * thing it fails open on is a shell.
+ *
+ * That leaves two sets of exceptions, both of which exist because this server's
+ * verbs do not line up neatly with HTTP's:
+ */
+
+/** POSTs that only read. They are POSTs because their argument is a filesystem
+ *  path, which has no business in a URL, not because they change anything. */
+const READ_POST = new Set(["/git/status"]);
+
+/**
+ * GETs that are not reads. `/terminal/pty` is a WebSocket upgrade, and a
+ * browser cannot put a header on one — so it arrives as a GET carrying
+ * `?token=`, and a rule that trusted the method would hand a read-only device
+ * an interactive root shell. This set is the reason `scopeNeeded` cannot be
+ * one line.
+ */
+const FULL_GET = new Set(["/terminal/pty"]);
+
+/**
+ * What a phone is for.
+ *
+ * `/gate/decide` is the reason the companion exists: an agent is stopped and a
+ * person says go. The chat routes are the same act by other means — replying to
+ * a session that is already running, which is what "answer" means. Starting new
+ * sessions, the terminal, git write and docker are not here.
+ *
+ * `/push/*` is a device managing its own notifications, which is the mechanism
+ * that tells it there is something to answer at all.
+ */
+const ANSWER_POST = new Set([
+  "/gate/decide",
+  "/chat/send",
+  "/chat/pane/key",
+  "/push/subscribe",
+  "/push/unsubscribe",
+  "/push/test",
+]);
+
+export function scopeNeeded(method: string, pathname: string): Scope {
+  if (FULL_GET.has(pathname)) return "full";
+  if (method === "GET" || method === "HEAD") return "read";
+  if (READ_POST.has(pathname)) return "read";
+  if (ANSWER_POST.has(pathname)) return "answer";
+  return "full";
+}
+
+/** True when this caller may make this request. */
+export function allowed(caller: Caller, method: string, pathname: string): boolean {
+  return scopeAllows(caller.scope, scopeNeeded(method, pathname));
 }

--- a/server/src/devices.ts
+++ b/server/src/devices.ts
@@ -1,0 +1,206 @@
+import { createHash, randomBytes, timingSafeEqual } from "node:crypto";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, chmodSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { homedir, tmpdir } from "node:os";
+
+/**
+ * A credential per device, instead of one password for the machine.
+ *
+ * What this replaces: scanning the QR in Settings ▸ Remote access handed the
+ * phone `AGENTGLASS_TOKEN` itself — the machine's single shared secret, with
+ * no expiry, no identity and no way to take it back from one device. Three
+ * things followed from that, and all three are the reason this file exists.
+ *
+ * *Anyone who saw the screen was paired.* The QR carried the credential, so a
+ * photograph of it across a room was a working key. It carries a pairing
+ * ticket now (see pairing.ts) and the credential is only ever minted after
+ * somebody at the machine accepts.
+ *
+ * *A lost phone could not be cut off.* One token meant revoking was rotating,
+ * and rotating kicked every device including the desk. Each device has its own
+ * now, and forgetting one leaves the others alone.
+ *
+ * *Everything could do everything.* A phone that only ever answers gates had
+ * git write, docker control and the terminal, because there was only one level
+ * of access and it was "all of it".
+ *
+ * The token itself is never stored. What is on disk is a SHA-256 of it, so a
+ * readable file is not a working key — the same reason a password file holds
+ * hashes. It is checked in constant time, because a comparison that returns
+ * early leaks the prefix.
+ */
+
+export function devicesPath(): string {
+  return join(
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+    "agentglass",
+    "devices.json",
+  );
+}
+
+/**
+ * The same rule the settings and push files follow: under `bun test`, only the
+ * scratch directory is readable or writable. A suite must never read the
+ * developer's real paired devices, and must never overwrite them.
+ */
+const IS_TEST = process.env.NODE_ENV === "test";
+function offLimits(p: string): boolean {
+  const scratch = tmpdir();
+  return IS_TEST && p !== scratch && !p.startsWith(scratch + "/");
+}
+
+/**
+ * What a device is allowed to do.
+ *
+ * Deliberately coarse. A permission system with twenty verbs is one nobody
+ * reads, and the honest split for this application is much simpler: looking at
+ * things, answering the thing an agent is stopped on, and changing the
+ * repository or the machine.
+ *
+ * `answer` is its own level because it is the entire reason the companion
+ * exists, and because it is *narrow*: it decides a gate the agent is already
+ * blocked on, and can start nothing that was not already asked for.
+ */
+export type Scope = "read" | "answer" | "full";
+
+/** Widest first, so a check can ask "is this at least X". */
+const RANK: Record<Scope, number> = { read: 0, answer: 1, full: 2 };
+export function scopeAllows(has: Scope, needs: Scope): boolean {
+  return RANK[has] >= RANK[needs];
+}
+
+export interface Device {
+  id: string;
+  /** Whatever the phone called itself. Free text, only ever shown back. */
+  label: string;
+  /** SHA-256 of the credential, hex. The credential itself is never kept. */
+  hash: string;
+  scope: Scope;
+  createdAt: number;
+  lastSeenAt?: number;
+  /** Set when forgotten. The row is kept so the device list can say a
+   *  credential was revoked rather than silently forgetting it existed. */
+  revokedAt?: number;
+}
+
+interface DeviceFile { devices?: Device[] }
+
+function read(): DeviceFile {
+  const p = devicesPath();
+  if (offLimits(p) || !existsSync(p)) return {};
+  try {
+    const parsed = JSON.parse(readFileSync(p, "utf8")) as DeviceFile;
+    return parsed && typeof parsed === "object" && !Array.isArray(parsed) ? parsed : {};
+  } catch {
+    // A corrupt file must not take the server down on boot. The cost is that
+    // paired devices have to pair again, which is a minute with the phone in
+    // your hand — a server that will not start is not.
+    return {};
+  }
+}
+
+function write(f: DeviceFile): boolean {
+  const p = devicesPath();
+  if (offLimits(p)) return false;
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    writeFileSync(p, JSON.stringify(f, null, 2) + "\n");
+    // It holds credential hashes and the shape of who can reach this machine.
+    try { chmodSync(p, 0o600); } catch { /* not every fs has modes */ }
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+export const hashToken = (t: string): string => createHash("sha256").update(t).digest("hex");
+
+export function devices(): Device[] {
+  return read().devices ?? [];
+}
+
+/** Only the ones that can still be used. */
+export function activeDevices(): Device[] {
+  return devices().filter((d) => !d.revokedAt);
+}
+
+/**
+ * Mint a credential for one device, and hand it back exactly once.
+ *
+ * The only moment the raw token exists outside the phone that will hold it.
+ * Everything stored is derived from it, so it cannot be recovered from this
+ * machine later — losing it means pairing again, which is the correct cost.
+ */
+export function issueDevice(
+  label: string, scope: Scope = "answer", now = Date.now(),
+): { device: Device; token: string } {
+  const token = randomBytes(32).toString("base64url");
+  const device: Device = {
+    id: randomBytes(8).toString("hex"),
+    label: (label || "A device").slice(0, 60),
+    hash: hashToken(token),
+    scope,
+    createdAt: now,
+  };
+  const f = read();
+  write({ ...f, devices: [...(f.devices ?? []), device] });
+  return { device, token };
+}
+
+/**
+ * Which device this credential belongs to, if any.
+ *
+ * Constant-time over the hashes: a comparison that stops at the first wrong
+ * byte tells an attacker how much of a guess was right, which turns an
+ * impossible search into a feasible one. Hashing first also means the length
+ * being compared is always 64 hex characters, so nothing about the token's own
+ * shape leaks either.
+ */
+export function deviceFor(token: string): Device | null {
+  if (!token) return null;
+  const want = Buffer.from(hashToken(token), "hex");
+  for (const d of devices()) {
+    if (d.revokedAt) continue;
+    // `Buffer.from(x, "hex")` does not throw on rubbish — it stops at the first
+    // byte it cannot read and hands back what it got, so a hand-edited row of
+    // "zzzz" arrives here as zero bytes. The length check is what skips it, and
+    // it has to happen before the compare either way: `timingSafeEqual` throws
+    // on mismatched lengths, which would turn one bad row into a 500 on every
+    // authenticated request.
+    const has = Buffer.from(d.hash, "hex");
+    if (has.length !== want.length) continue;
+    if (timingSafeEqual(has, want)) return d;
+  }
+  return null;
+}
+
+/** Note that a device was used, at most once a minute. */
+const MARK_EVERY_MS = 60_000;
+export function markSeen(id: string, now = Date.now()): void {
+  const f = read();
+  const d = (f.devices ?? []).find((x) => x.id === id);
+  // Every request would otherwise rewrite the file, which on a phone polling
+  // four endpoints is a write per second for a field nobody reads that often.
+  if (!d || (d.lastSeenAt && now - d.lastSeenAt < MARK_EVERY_MS)) return;
+  write({ ...f, devices: (f.devices ?? []).map((x) => (x.id === id ? { ...x, lastSeenAt: now } : x)) });
+}
+
+/**
+ * Forget one device, and only that one.
+ *
+ * Kept as a revoked row rather than deleted: "this credential was revoked on
+ * Tuesday" is worth being able to see, and a list that silently loses entries
+ * cannot be used to answer "did I definitely cut that phone off".
+ */
+export function revokeDevice(id: string, now = Date.now()): boolean {
+  const f = read();
+  const found = (f.devices ?? []).some((d) => d.id === id && !d.revokedAt);
+  if (!found) return false;
+  write({ ...f, devices: (f.devices ?? []).map((d) => (d.id === id ? { ...d, revokedAt: now } : d)) });
+  return true;
+}
+
+/** Only for tests, which run several servers against one scratch directory. */
+export function __resetDevices(): void {
+  write({ devices: [] });
+}

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -74,7 +74,9 @@ import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } f
 import { workspaceRoot, setWorkspaceRoot, inScope } from "./config.ts";
 import { hookStatus, applyHooks } from "./hooksetup.ts";
 import { privateHost } from "./net.ts";
-import { resolveToken, tokenOk, isIntake, isAuthExempt } from "./auth.ts";
+import { resolveToken, tokenOk, isIntake, isAuthExempt, callerFor, allowed, scopeNeeded, type Caller } from "./auth.ts";
+import { activeDevices, markSeen, revokeDevice, type Scope } from "./devices.ts";
+import { mintTicket, claimTicket, pending as pendingPairings, acceptTicket, rejectTicket, collect as collectPairing, dropTicket, getTicket, MAX_ATTEMPTS } from "./pairing.ts";
 import { updateStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
 import { rateOk } from "./ratelimit.ts";
 import { noteClient, noteSocket, isLoopback, isSelf, isBlocked, blockDevice, remoteStatus } from "./remote.ts";
@@ -117,7 +119,11 @@ const AUTH_TOKEN = AUTH.token;
  *  the desktop-notification mirror. */
 /** Every socket carries the address that opened it, so "who is connected right
  *  now" is answerable, and so a device can be cut off while it is holding one. */
-type WsData = ({ kind: "events" } | { kind: "notify" } | PtyWsData) & { ip?: string | null };
+// `deviceId` is how a socket remembers which paired device opened it. Without
+// it, forgetting a device revokes its credential and leaves whatever it is
+// already holding — an event stream, a terminal — running until it disconnects
+// on its own, which is a revoke in the list and not on the wire.
+type WsData = ({ kind: "events" } | { kind: "notify" } | PtyWsData) & { ip?: string | null; deviceId?: string | null };
 const clients = new Set<ServerWebSocket<WsData>>();
 /** Every open socket of every kind, which `clients` is not: it holds the event
  *  streams only, and a device cut off mid-session may be holding a terminal. */
@@ -537,8 +543,33 @@ const server = Bun.serve<WsData>({
     // as ?token= (a browser can't set a header on them); fetch uses Bearer.
     // /gate is NOT exempt here: it's the control plane, and its hook carries the
     // token when one is set (see auth.ts / gate_event.py).
-    if (AUTH_TOKEN && !isAuthExempt(pathname) && !tokenOk(req, url, AUTH_TOKEN)) {
-      return json({ ok: false, error: "unauthorized — pass ?token= or Authorization: Bearer" }, 401);
+    //
+    // A paired phone carries its own credential rather than this one (see
+    // devices.ts), so the answer is no longer yes-or-no: it is *who*, and then
+    // whether that caller's scope covers what the request is asking for. The
+    // machine's token is still the machine, and everything below is unchanged
+    // for it.
+    // Held for the WebSocket upgrades below: a socket has to remember which
+    // device opened it, or forgetting that device cannot close what it holds.
+    let caller: Caller | null = null;
+    if (AUTH_TOKEN && !isAuthExempt(pathname)) {
+      caller = callerFor(req, url, AUTH_TOKEN);
+      if (!caller) return json({ ok: false, error: "unauthorized — pass ?token= or Authorization: Bearer" }, 401);
+      if (!allowed(caller, req.method, pathname)) {
+        // 403 rather than 401: the credential is real and was accepted. Saying
+        // "unauthorized" to a device that is correctly paired sends people to
+        // re-scan a QR, which fixes nothing and is the wrong thing to learn.
+        return json({
+          ok: false,
+          error: `this device is paired for "${caller.scope}" access, and ${pathname} needs "${scopeNeeded(req.method, pathname)}"`,
+          scope: caller.scope,
+          needs: scopeNeeded(req.method, pathname),
+        }, 403);
+      }
+      // Cheap enough to do on every request because it is throttled to once a
+      // minute per device — it is what lets the pane say when a phone was last
+      // heard from, which is the difference between a device list and a guess.
+      if (caller.device) markSeen(caller.device.id);
     }
 
     // Throttle the unauthenticated intake sinks so a runaway client can't flood
@@ -555,7 +586,7 @@ const server = Bun.serve<WsData>({
     // stream — a read this feed is not meant to give to the open web.
     if (pathname === "/stream") {
       if (!trustedCaller(req)) return csrfBlocked();
-      if (srv.upgrade(req, { data: { kind: "events", ip: clientIp ?? null } })) return undefined as unknown as Response;
+      if (srv.upgrade(req, { data: { kind: "events", ip: clientIp ?? null, deviceId: caller?.device?.id ?? null } })) return undefined as unknown as Response;
       return new Response("upgrade failed", { status: 426 });
     }
 
@@ -563,8 +594,9 @@ const server = Bun.serve<WsData>({
     if (pathname === "/terminal/pty") {
       if (!trustedCaller(req)) return csrfBlocked();
       if (!TERMINAL_ENABLED) return json({ error: "terminal is disabled" }, 403);
-      const data: PtyWsData & { ip?: string | null } = {
+      const data: PtyWsData & { ip?: string | null; deviceId?: string | null } = {
         kind: "pty",
+        deviceId: caller?.device?.id ?? null,
         root: url.searchParams.get("root") || "",
         cols: Number(url.searchParams.get("cols") || 80),
         rows: Number(url.searchParams.get("rows") || 24),
@@ -591,7 +623,7 @@ const server = Bun.serve<WsData>({
       if (!trustedCaller(req)) return csrfBlocked();
       const cap = notifyCapability();
       if (!cap.supported) return json({ error: cap.reason ?? "unsupported" }, 501);
-      if (srv.upgrade(req, { data: { kind: "notify", ip: clientIp ?? null } })) return undefined as unknown as Response;
+      if (srv.upgrade(req, { data: { kind: "notify", ip: clientIp ?? null, deviceId: caller?.device?.id ?? null } })) return undefined as unknown as Response;
       return new Response("upgrade failed", { status: 426 });
     }
 
@@ -882,7 +914,6 @@ const server = Bun.serve<WsData>({
       return json({ ok: true, address, blocked, closed });
     }
     if (pathname === "/remote/status") {
-      const ip = srv.requestIP(req)?.address ?? null;
       return json(
         remoteStatus({
           bind: BIND,
@@ -890,10 +921,168 @@ const server = Bun.serve<WsData>({
           trustLan: TRUST_LAN,
           token: AUTH_TOKEN,
           webUi: WEB_UI_ENABLED,
-          includeToken: !!ip && isLoopback(ip),
         })
       );
     }
+    /**
+     * --- pairing a device ---
+     *
+     * The protocol is in pairing.ts, including why it has the shape it does.
+     * What lives here is the split it depends on: four routes that only this
+     * machine may call, and three that must work with no credential at all,
+     * because handing one out is the point.
+     *
+     * `atMachine` is the stronger of the two checks the codebase already uses.
+     * Loopback alone would let any other local process start a pairing; the
+     * token alone would let a phone that is already paired invite another one.
+     * Minting an invitation, seeing the code, and accepting a request are the
+     * three things that must happen where the user is sitting.
+     */
+    const atMachine = (): boolean => {
+      const ip = srv.requestIP(req)?.address ?? null;
+      if (!ip || !isLoopback(ip)) return false;
+      return !AUTH_TOKEN || tokenOk(req, url, AUTH_TOKEN);
+    };
+    const notHere = () => json({ ok: false, error: "only this machine can do that" }, 403);
+
+    if (pathname === "/pair/ticket" && req.method === "POST") {
+      if (!atMachine()) return notHere();
+      const t = mintTicket();
+      // Refused rather than queued: several unanswered invitations at once is
+      // not a person adding a phone, and quietly making room by discarding one
+      // somebody is looking at is worse than saying no.
+      if (!t) return json({ ok: false, error: "too many pairings in progress — answer or wait for the ones open" }, 429);
+      return json({ ok: true, id: t.id, code: t.code, expiresAt: t.expiresAt });
+    }
+
+    if (pathname === "/pair/cancel" && req.method === "POST") {
+      if (!atMachine()) return notHere();
+      let b: { ticket?: unknown };
+      try { b = (await req.json()) as { ticket?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      dropTicket(typeof b.ticket === "string" ? b.ticket : "");
+      return json({ ok: true });
+    }
+
+    if (pathname === "/pair/state") {
+      if (!atMachine()) return notHere();
+      // The ticket the pane is showing is identified by the pane, not held as
+      // "the current one": two windows open on the same machine each have
+      // their own invitation, and a server-side notion of *the* ticket would
+      // have one of them drawing a QR for the other one's code.
+      const id = url.searchParams.get("ticket") || "";
+      const t = id ? getTicket(id) : null;
+      return json({
+        ticket: t ? { id: t.id, code: t.code, expiresAt: t.expiresAt } : null,
+        pending: pendingPairings(),
+        devices: activeDevices(),
+      });
+    }
+
+    if (pathname === "/pair/accept" && req.method === "POST") {
+      if (!atMachine()) return notHere();
+      let b: { ticket?: unknown; scope?: unknown };
+      try { b = (await req.json()) as { ticket?: unknown; scope?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      // Anything unrecognised lands on the narrow scope rather than the wide
+      // one. A typo in a scope name must not be how a phone gets a terminal.
+      const asked = b.scope;
+      const scope: Scope = asked === "read" || asked === "full" ? asked : "answer";
+      const r = acceptTicket(typeof b.ticket === "string" ? b.ticket : "", scope);
+      if (!r.ok) return json({ ok: false, error: r.error === "unknown" ? "that request expired" : "that request is not waiting on you" }, 404);
+      return json({ ok: true, device: r.device });
+    }
+
+    if (pathname === "/pair/reject" && req.method === "POST") {
+      if (!atMachine()) return notHere();
+      let b: { ticket?: unknown };
+      try { b = (await req.json()) as { ticket?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      return json({ ok: rejectTicket(typeof b.ticket === "string" ? b.ticket : "") });
+    }
+
+    /**
+     * Cut one device off, and only that one.
+     *
+     * The revoke that already existed rotates the machine's token, which kicks
+     * every device including the desk — the right answer when you have lost
+     * control of the code, and far too big a hammer for "that tablet is in a
+     * drawer". This is the small one.
+     */
+    if (pathname === "/pair/forget" && req.method === "POST") {
+      if (!atMachine()) return notHere();
+      let b: { id?: unknown };
+      try { b = (await req.json()) as { id?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const id = typeof b.id === "string" ? b.id : "";
+      if (!revokeDevice(id)) return json({ ok: false, error: "no such device" }, 404);
+      // Its open sockets go with it. Revoking a credential while the terminal
+      // it opened keeps streaming is the worst of both: the list says gone and
+      // the wire says otherwise.
+      let closed = 0;
+      for (const ws of [...sockets]) {
+        if (ws.data?.deviceId === id) {
+          try { ws.close(1008, "this device was disconnected from the host machine"); closed++; } catch { /* already gone */ }
+        }
+      }
+      return json({ ok: true, closed });
+    }
+
+    // --- the three the phone calls, before it has anything to authenticate with ---
+
+    /** Is this invitation still open? Lets the phone say "that code expired"
+     *  instead of presenting a form that cannot succeed. */
+    if (pathname === "/pair/info") {
+      const t = getTicket(url.searchParams.get("ticket") || "");
+      return json({ ok: !!t && t.state === "waiting", expiresAt: t?.expiresAt ?? null });
+    }
+
+    if (pathname === "/pair/claim" && req.method === "POST") {
+      let b: { ticket?: unknown; code?: unknown; label?: unknown; pub?: unknown };
+      try { b = (await req.json()) as typeof b; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const r = claimTicket(
+        typeof b.ticket === "string" ? b.ticket : "",
+        typeof b.code === "string" ? b.code : "",
+        {
+          label: typeof b.label === "string" ? b.label : "",
+          pub: typeof b.pub === "string" ? b.pub : undefined,
+          agent: req.headers.get("user-agent") ?? "",
+          ip: srv.requestIP(req)?.address ?? "",
+        },
+      );
+      if (r.ok) return json({ ok: true, secret: r.secret });
+      const said =
+        r.error === "unknown" ? "that invitation has expired — start a new one on the computer"
+        : r.error === "taken" ? "another device is already using that invitation"
+        : r.error === "locked" ? `too many wrong codes — the invitation is closed, start a new one on the computer`
+        : r.error === "shape" ? "this browser could not generate a key for the connection"
+        : `that code is wrong — ${r.left} ${r.left === 1 ? "try" : "tries"} left of ${MAX_ATTEMPTS}`;
+      return json({ ok: false, error: said, left: r.left, reason: r.error }, r.error === "code" ? 401 : 410);
+    }
+
+    /**
+     * The phone picks up what it was given.
+     *
+     * Polled, because the thing it is waiting for is a person walking to a
+     * computer. Answers `claimed` until they decide, and hands the sealed
+     * credential over exactly once — see collect().
+     */
+    if (pathname === "/pair/collect") {
+      const r = collectPairing(url.searchParams.get("ticket") || "", url.searchParams.get("secret") || "");
+      return json(r, r.state === "unknown" ? 404 : 200);
+    }
+
+    /** What this device is, as this server sees it. The phone's Settings shows
+     *  it, and a 401 here is how it learns it has been forgotten. */
+    if (pathname === "/pair/whoami") {
+      if (!AUTH_TOKEN) return json({ paired: false, scope: "full", machine: true });
+      const caller = callerFor(req, url, AUTH_TOKEN);
+      if (!caller) return json({ paired: false }, 401);
+      return json({
+        paired: caller.kind === "device",
+        machine: caller.kind === "machine",
+        scope: caller.scope,
+        label: caller.device?.label ?? null,
+        id: caller.device?.id ?? null,
+      });
+    }
+
     if (pathname === "/search") {
       const q = url.searchParams.get("q") || "";
       const limit = Math.min(200, Number(url.searchParams.get("limit") || 60));

--- a/server/src/pairing.ts
+++ b/server/src/pairing.ts
@@ -1,0 +1,365 @@
+import { randomBytes, randomInt, createHash, timingSafeEqual, createECDH, hkdfSync, createCipheriv } from "node:crypto";
+import { issueDevice, type Scope, type Device } from "./devices.ts";
+
+/**
+ * Adding a phone, without ever putting the key on screen.
+ *
+ * The old flow was one step: the Remote pane drew a QR containing
+ * `http://192.168.1.20:5959/?token=<the machine's token>`, the phone scanned
+ * it, and that was pairing. Everything wrong with it follows from the same
+ * fact — **the QR *was* the credential**:
+ *
+ *   * A photograph of the screen paired you. So did a screenshot in a chat, a
+ *     shared window in a call, or standing behind the desk. There is no way to
+ *     scan a code "carefully"; being able to see it is the whole authorisation.
+ *   * The machine never learned that anything had happened. Nothing to accept,
+ *     nothing to name, nothing to take back.
+ *   * What was handed over was the *machine's* token — the same secret the
+ *     desk uses — so the phone got a terminal, git write and docker control,
+ *     and cutting it off meant rotating for everybody.
+ *
+ * So the QR carries a **ticket** now: a public handle that on its own is worth
+ * nothing. Three things have to be true before a credential exists:
+ *
+ *   1. **the scanner can see the screen** — it must type a six-digit code that
+ *      is only ever displayed at the machine, never transmitted in the QR;
+ *   2. **a person at the machine agrees** — the claim shows up in the Remote
+ *      pane naming the device and the address it came from, and waits;
+ *   3. **the credential is delivered to that claimant and nobody else** — it is
+ *      encrypted to a public key the phone generated for this one pairing, and
+ *      collected exactly once.
+ *
+ * (3) is what keeps this honest on a network without TLS, which is the normal
+ * case here: the server speaks plain HTTP over the LAN. Anything on that wifi
+ * running tcpdump sees every byte of this exchange — the ticket, the code, the
+ * public keys — and still cannot read the credential, because it never travels
+ * in the clear and the key that unwraps it never leaves the phone.
+ *
+ * What this does **not** defend against is an active on-path attacker: someone
+ * who can rewrite traffic can substitute their own public key, and no amount of
+ * handshake fixes that without an authenticated channel. That is a TLS problem,
+ * not a pairing problem, and the honest answer is the one the pane already
+ * offers — pair over the Tailscale address, which is encrypted end to end.
+ *
+ * Everything here is in memory. A half-finished pairing that survives a restart
+ * is a pairing nobody is watching, and the cost of losing one is scanning
+ * again.
+ */
+
+/** Two minutes: long enough to walk to the desk, short enough to be worthless
+ *  by the time anyone finds the screenshot. */
+export const TICKET_TTL_MS = 120_000;
+
+/** Wrong codes before the ticket is dead. Six digits with five guesses is a
+ *  1-in-200,000 shot at a target that expires in two minutes; without a cap it
+ *  is a million-request script and a certainty. */
+export const MAX_ATTEMPTS = 5;
+
+/** Concurrent pairings. More than a handful is not a person adding a phone. */
+export const MAX_TICKETS = 4;
+
+export type TicketState = "waiting" | "claimed" | "accepted" | "rejected";
+
+export interface Ticket {
+  /** Public handle, in the QR. Knowing it authorises nothing. */
+  id: string;
+  /** Shown at the machine only. Never in the QR, never in a listing that
+   *  leaves this process except to the local pane. */
+  code: string;
+  createdAt: number;
+  expiresAt: number;
+  state: TicketState;
+  attempts: number;
+  /** What the phone called itself, once it has claimed. */
+  label?: string;
+  /** Its User-Agent and address, so the person accepting knows who is asking. */
+  agent?: string;
+  ip?: string;
+  claimedAt?: number;
+  /** SHA-256 of the secret handed back on a successful claim. Only the holder
+   *  can collect, so a second party who watched the claim cannot race for the
+   *  credential once it is minted. */
+  claimHash?: string;
+  /** The claimant's ECDH public key (P-256, uncompressed, base64url). */
+  pub?: string;
+  /** Set once accepted: the credential, encrypted to `pub`. */
+  wrapped?: Wrapped;
+  device?: Device;
+}
+
+/** A credential sealed to one claimant. See sealTo. */
+export interface Wrapped {
+  /** The server's ephemeral public key for this one delivery, base64url. */
+  pub: string;
+  iv: string;
+  data: string;
+}
+
+/** What the local pane is allowed to see: the code, and who is asking. */
+export interface PendingView {
+  id: string;
+  code: string;
+  label: string;
+  agent: string;
+  ip: string;
+  claimedAt: number;
+  expiresAt: number;
+}
+
+const tickets = new Map<string, Ticket>();
+
+const b64 = (b: Buffer | Uint8Array): string => Buffer.from(b).toString("base64url");
+
+function sweep(now: number): void {
+  for (const [id, t] of tickets) if (t.expiresAt <= now) tickets.delete(id);
+}
+
+/**
+ * A six-digit code, from the CSPRNG rather than from `Math.random`.
+ *
+ * `randomInt` is rejection-sampled, so every code is equally likely — a modulo
+ * of a random byte string is not, and the bias is exactly the thing an attacker
+ * with five guesses would spend them on. Zero-padded: dropping a leading zero
+ * would leave nine in ten codes six digits long and one in ten five, which
+ * leaks a digit before anybody types anything.
+ */
+function sixDigits(): string {
+  return String(randomInt(0, 1_000_000)).padStart(6, "0");
+}
+
+/**
+ * Start a pairing, at the machine.
+ *
+ * Null when too many are already in flight. Unclaimed tickets are recycled
+ * first — those are QR codes nobody scanned — and a pairing that is *waiting
+ * on a person* is never dropped to make room, because that person is looking
+ * at it.
+ */
+export function mintTicket(now = Date.now()): Ticket | null {
+  sweep(now);
+  if (tickets.size >= MAX_TICKETS) {
+    const oldestUnclaimed = [...tickets.values()]
+      .filter((t) => t.state === "waiting")
+      .sort((a, b) => a.createdAt - b.createdAt)[0];
+    if (!oldestUnclaimed) return null;
+    tickets.delete(oldestUnclaimed.id);
+  }
+  const t: Ticket = {
+    id: randomBytes(9).toString("base64url"),
+    code: sixDigits(),
+    createdAt: now,
+    expiresAt: now + TICKET_TTL_MS,
+    state: "waiting",
+    attempts: 0,
+  };
+  tickets.set(t.id, t);
+  return t;
+}
+
+/** The live ticket, if it is still live. Expiry is checked on read as well as
+ *  swept, so nothing can be used in the window between sweeps. */
+export function getTicket(id: string, now = Date.now()): Ticket | null {
+  const t = tickets.get(id);
+  if (!t) return null;
+  if (t.expiresAt <= now) { tickets.delete(id); return null; }
+  return t;
+}
+
+/** Forget a ticket, whatever state it is in. */
+export function dropTicket(id: string): void {
+  tickets.delete(id);
+}
+
+export type ClaimResult =
+  | { ok: true; secret: string }
+  | { ok: false; error: "unknown" | "taken" | "code" | "locked" | "shape"; left?: number };
+
+/**
+ * The phone proves it can see the machine's screen.
+ *
+ * The code is compared in constant time and only ever against a ticket that is
+ * still `waiting`: a claimed ticket is locked to whoever claimed it, so a
+ * second scanner cannot displace the first by guessing faster.
+ *
+ * A wrong code costs an attempt whether or not the guess was close, and running
+ * out kills the ticket outright rather than merely rejecting the guess — a
+ * lockout that leaves the target alive is a rate limit, not a cap.
+ */
+export function claimTicket(
+  id: string,
+  code: string,
+  opts: { label?: string; agent?: string; ip?: string; pub?: string; now?: number } = {},
+): ClaimResult {
+  const now = opts.now ?? Date.now();
+  const t = getTicket(id, now);
+  if (!t) return { ok: false, error: "unknown" };
+  if (t.state !== "waiting") return { ok: false, error: "taken" };
+  // Rejected before the compare: an unusable key means the credential could
+  // not be delivered, and finding that out *after* someone at the desk has
+  // accepted is a pairing that fails in the one place it cannot be retried.
+  if (!validPub(opts.pub)) return { ok: false, error: "shape" };
+
+  if (!codeMatches(t.code, code)) {
+    t.attempts++;
+    if (t.attempts >= MAX_ATTEMPTS) { tickets.delete(id); return { ok: false, error: "locked" }; }
+    return { ok: false, error: "code", left: MAX_ATTEMPTS - t.attempts };
+  }
+
+  const secret = randomBytes(32).toString("base64url");
+  t.state = "claimed";
+  t.claimedAt = now;
+  t.claimHash = createHash("sha256").update(secret).digest("hex");
+  t.pub = opts.pub;
+  t.label = (opts.label || "").trim().slice(0, 60) || "A device";
+  t.agent = (opts.agent || "").slice(0, 300);
+  t.ip = opts.ip || "";
+  return { ok: true, secret };
+}
+
+/** Constant-time over a fixed length, so neither the code nor how much of a
+ *  guess was right is readable from how long the answer took. */
+function codeMatches(want: string, got: string): boolean {
+  const a = Buffer.from(want, "utf8");
+  const b = Buffer.from((got || "").trim(), "utf8");
+  if (a.length !== b.length) return false; // length is not a secret: it is six
+  return timingSafeEqual(a, b);
+}
+
+/**
+ * An uncompressed P-256 point, and nothing else.
+ *
+ * 65 bytes starting with 0x04. Anything else is either a mistake or an attempt
+ * to feed the key agreement something it should not have; either way it stops
+ * here rather than inside a cipher.
+ */
+export function validPub(pub: string | undefined): pub is string {
+  if (!pub) return false;
+  let raw: Buffer;
+  try { raw = Buffer.from(pub, "base64url"); } catch { return false; }
+  return raw.length === 65 && raw[0] === 0x04;
+}
+
+/** Claims waiting on a person, oldest first — the order they should be answered. */
+export function pending(now = Date.now()): PendingView[] {
+  sweep(now);
+  return [...tickets.values()]
+    .filter((t) => t.state === "claimed")
+    .sort((a, b) => (a.claimedAt ?? 0) - (b.claimedAt ?? 0))
+    .map((t) => ({
+      id: t.id, code: t.code, label: t.label ?? "A device", agent: t.agent ?? "",
+      ip: t.ip ?? "", claimedAt: t.claimedAt ?? 0, expiresAt: t.expiresAt,
+    }));
+}
+
+export type DecideResult =
+  | { ok: true; device: Device }
+  | { ok: false; error: "unknown" | "notClaimed" };
+
+/**
+ * A person at the machine says yes.
+ *
+ * This is the only place a device credential is ever created, and the only
+ * moment the raw token exists on this machine — it is sealed to the claimant
+ * immediately and the plaintext is not kept, so nothing else in this process
+ * (or in a heap dump of it) holds a working key afterwards.
+ *
+ * The default scope is deliberately not "everything": see devices.ts. A phone
+ * that answers gates does not need the terminal, and the moment to decide that
+ * is the moment somebody is already looking at the question.
+ */
+export function acceptTicket(id: string, scope: Scope = "answer", now = Date.now()): DecideResult {
+  const t = getTicket(id, now);
+  if (!t) return { ok: false, error: "unknown" };
+  if (t.state !== "claimed" || !validPub(t.pub)) return { ok: false, error: "notClaimed" };
+  const { device, token } = issueDevice(t.label ?? "A device", scope, now);
+  t.wrapped = sealTo(t.pub, t.id, token);
+  t.device = device;
+  t.state = "accepted";
+  return { ok: true, device };
+}
+
+/** A person at the machine says no. The ticket is kept, briefly, so the phone
+ *  can be told it was refused instead of sitting on a spinner until it times
+ *  out — "nothing happened" is the answer that makes people try again. */
+export function rejectTicket(id: string, now = Date.now()): boolean {
+  const t = getTicket(id, now);
+  if (!t || t.state !== "claimed") return false;
+  t.state = "rejected";
+  return true;
+}
+
+export type CollectResult =
+  | { state: "claimed" }
+  | { state: "accepted"; wrapped: Wrapped; scope: Scope; label: string }
+  | { state: "rejected" }
+  | { state: "unknown" };
+
+/**
+ * The phone picks up what it was given, once.
+ *
+ * The secret from the claim is what authorises this, compared in constant time
+ * against its hash — the ticket id is in the QR and therefore not a secret, so
+ * without this anything that saw the QR could poll until a credential appeared
+ * and take it before the phone did.
+ *
+ * A decided ticket is destroyed on collection rather than left to expire. One
+ * delivery is all a pairing needs, and a credential that can be fetched twice
+ * is a credential two devices can hold.
+ */
+export function collect(id: string, secret: string, now = Date.now()): CollectResult {
+  const t = getTicket(id, now);
+  if (!t || !t.claimHash) return { state: "unknown" };
+  if (!secretMatches(t.claimHash, secret)) return { state: "unknown" };
+  if (t.state === "claimed") return { state: "claimed" };
+  if (t.state === "accepted" && t.wrapped && t.device) {
+    const out: CollectResult = {
+      state: "accepted", wrapped: t.wrapped, scope: t.device.scope, label: t.device.label,
+    };
+    tickets.delete(id);
+    return out;
+  }
+  if (t.state === "rejected") { tickets.delete(id); return { state: "rejected" }; }
+  return { state: "unknown" };
+}
+
+function secretMatches(hash: string, secret: string): boolean {
+  if (!secret) return false;
+  const want = Buffer.from(hash, "hex");
+  const got = createHash("sha256").update(secret).digest();
+  if (want.length !== got.length) return false;
+  return timingSafeEqual(want, got);
+}
+
+/**
+ * Seal the credential to the key the claimant generated for this pairing.
+ *
+ * ECDH over P-256 to a key that exists only in that phone, HKDF to a content
+ * key, AES-256-GCM over the token. The ticket id is the HKDF salt so two
+ * pairings never derive the same key from the same pair of keys, and the info
+ * string pins what the key is for — a key derived for one purpose must not be
+ * usable for another.
+ *
+ * The ephemeral server keypair is generated here and dropped when this returns.
+ * Nothing on this machine can decrypt the result afterwards, which is the
+ * property that makes it safe to hold in memory until the phone polls for it.
+ */
+export function sealTo(pub: string, ticketId: string, plaintext: string): Wrapped {
+  const ecdh = createECDH("prime256v1");
+  ecdh.generateKeys();
+  const shared = ecdh.computeSecret(Buffer.from(pub, "base64url"));
+  const key = Buffer.from(
+    hkdfSync("sha256", shared, Buffer.from(ticketId, "utf8"), Buffer.from(INFO, "utf8"), 32),
+  );
+  const iv = randomBytes(12);
+  const c = createCipheriv("aes-256-gcm", key, iv);
+  const body = Buffer.concat([c.update(plaintext, "utf8"), c.final(), c.getAuthTag()]);
+  return { pub: b64(ecdh.getPublicKey()), iv: b64(iv), data: b64(body) };
+}
+
+/** Pins the derived key to this protocol and this version of it. */
+export const INFO = "agentglass-pair-v1";
+
+/** Only for tests, which need a clean slate between cases. */
+export function __resetPairing(): void {
+  tickets.clear();
+}

--- a/server/src/remote.ts
+++ b/server/src/remote.ts
@@ -370,15 +370,22 @@ export interface RemoteStatus {
   tokenRequired: boolean;
   /** This port serves the dashboard itself, not just the API. */
   webUi: boolean;
-  /** URLs to hand another device, token included when we know it. */
+  /**
+   * Where this machine answers. Addresses only — no credential.
+   *
+   * These used to arrive with `?token=` on the end for a local caller, because
+   * the QR was the credential and the pane had to draw it. Pairing replaced
+   * that (see pairing.ts), and once nothing needs the secret in a URL, serving
+   * it in one is a hole with no user left: a link that grants a terminal is
+   * exactly the sort of thing that ends up in a screenshot, a chat, or an
+   * issue about why the phone will not connect.
+   */
   urls: string[];
   addresses: Reachable[];
   clients: RemoteClients;
   /** One row per device that has reached this machine, live state included. */
   devices: DeviceRecord[];
   firewall: FirewallHint | null;
-  /** Present only for a local caller — see the gate in index.ts. */
-  token?: string;
 }
 
 export function remoteStatus(opts: {
@@ -387,14 +394,11 @@ export function remoteStatus(opts: {
   trustLan: boolean;
   token: string | null;
   webUi: boolean;
-  /** Whether to include the token (and tokenised URLs) in the answer. */
-  includeToken: boolean;
   addresses?: Reachable[];
   which?: (cmd: string) => string | null;
 }): RemoteStatus {
   const addresses = opts.addresses ?? reachableAddresses();
   const exposed = !["127.0.0.1", "::1", "localhost"].includes(opts.bind);
-  const q = opts.includeToken && opts.token ? `/?token=${encodeURIComponent(opts.token)}` : "/";
   return {
     exposed,
     bind: opts.bind,
@@ -402,11 +406,10 @@ export function remoteStatus(opts: {
     trustLan: opts.trustLan,
     tokenRequired: opts.token !== null,
     webUi: opts.webUi,
-    urls: addresses.map((a) => `http://${a.address}:${opts.port}${q}`),
+    urls: addresses.map((a) => `http://${a.address}:${opts.port}/`),
     addresses,
     clients: remoteClients(),
     devices: remoteDevices(addresses.map((a) => a.address)),
     firewall: firewallHint(opts.port, addresses[0]?.subnet ?? null, opts.which),
-    ...(opts.includeToken && opts.token ? { token: opts.token } : {}),
   };
 }

--- a/server/test/device-scope.test.ts
+++ b/server/test/device-scope.test.ts
@@ -1,0 +1,207 @@
+/*
+ * What a paired phone is allowed to do, and — the half with teeth — what it is
+ * not allowed to do by default.
+ *
+ * The rule is deny-by-default: anything that changes state and is not named as
+ * an answer is `full`. That is the direction that matters. A list of *forbidden*
+ * routes fails open every time somebody adds a route and does not update it,
+ * and the thing it fails open on is an interactive shell. So most of what is
+ * below is written against the route table in index.ts rather than against a
+ * handful of paths, so it keeps being true as that file grows.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { callerFor, scopeNeeded, allowed, isAuthExempt, isPairing, isIntake } from "../src/auth.ts";
+import { issueDevice, revokeDevice, deviceFor, __resetDevices, type Scope } from "../src/devices.ts";
+
+const src = readFileSync(new URL("../src/index.ts", import.meta.url), "utf8");
+
+/** Every route index.ts dispatches on, as it actually writes them. */
+const ROUTES = [...new Set([...src.matchAll(/pathname === "(\/[^"]*)"/g)].map((m) => m[1]!))];
+
+/** The ones it only reaches by prefix — the git, docker and pull-request
+ *  switches, which is where every write of consequence lives. */
+const SWITCH_CASES = [...new Set([...src.matchAll(/case "(\/(?:git|docker|prs)\/[^"]*)":/g)].map((m) => m[1]!))];
+
+const at = (url: string, headers: Record<string, string> = {}) =>
+  [new Request(url, { headers }), new URL(url)] as const;
+
+beforeEach(() => {
+  process.env.NODE_ENV = "test";
+  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "agx-scope-"));
+  __resetDevices();
+});
+
+describe("who is asking", () => {
+  test("the machine's own token is the machine, and the machine is everything", () => {
+    const [req, url] = at("http://x/anything", { authorization: "Bearer machine-token" });
+    expect(callerFor(req, url, "machine-token")).toEqual({ kind: "machine", scope: "full" });
+  });
+
+  test("a device credential is that device, with the scope it was granted", () => {
+    const { token, device } = issueDevice("iPhone", "answer");
+    const [req, url] = at("http://x/anything", { authorization: `Bearer ${token}` });
+    const c = callerFor(req, url, "machine-token");
+    expect(c).toMatchObject({ kind: "device", scope: "answer" });
+    expect(c!.device!.id).toBe(device.id);
+  });
+
+  test("a credential arriving as ?token= is the same credential", () => {
+    // WebSocket upgrades and download navigations cannot carry a header, so a
+    // rule that only read the header would leave the phone unable to open the
+    // event stream while every fetch worked.
+    const { token } = issueDevice("iPhone", "read");
+    const [req, url] = at(`http://x/stream?token=${encodeURIComponent(token)}`);
+    expect(callerFor(req, url, "machine-token")).toMatchObject({ kind: "device", scope: "read" });
+  });
+
+  test("a revoked device is nobody at all", () => {
+    const { token, device } = issueDevice("iPhone", "answer");
+    revokeDevice(device.id);
+    const [req, url] = at("http://x/anything", { authorization: `Bearer ${token}` });
+    expect(callerFor(req, url, "machine-token")).toBeNull();
+    expect(deviceFor(token)).toBeNull();
+  });
+
+  test("no credential, or a wrong one, is nobody", () => {
+    issueDevice("iPhone", "full");
+    expect(callerFor(...at("http://x/a"), "machine-token")).toBeNull();
+    expect(callerFor(...at("http://x/a", { authorization: "Bearer nope" }), "machine-token")).toBeNull();
+    expect(callerFor(...at("http://x/a", { authorization: "Bearer " }), "machine-token")).toBeNull();
+  });
+});
+
+describe("deny by default", () => {
+  /**
+   * The rule, stated over the tree rather than over today's routes.
+   *
+   * Every POST index.ts dispatches on must resolve to `full` unless it is one
+   * of the handful this file names below as a read or an answer. A route added
+   * next month is therefore out of a paired phone's reach until somebody
+   * decides otherwise, which is the only default that is safe to forget about.
+   */
+  const NAMED_LOWER = new Set([
+    // Reads wearing POST, because their argument is a filesystem path.
+    "/git/status",
+    // What a phone is for: answering something that is already asked.
+    "/gate/decide", "/chat/send", "/chat/pane/key",
+    // A device managing its own notifications — the mechanism that tells it
+    // there is something to answer.
+    "/push/subscribe", "/push/unsubscribe", "/push/test",
+  ]);
+
+  test("every POST route is full access unless it is one of the named few", () => {
+    const surprises = [...ROUTES, ...SWITCH_CASES]
+      .filter((r) => !NAMED_LOWER.has(r) && !isPairing(r))
+      .filter((r) => scopeNeeded("POST", r) !== "full");
+    expect(surprises, "a POST is reachable by a phone without anyone deciding that").toEqual([]);
+  });
+
+  test("a route nobody has written yet is already full access", () => {
+    expect(scopeNeeded("POST", "/some/route/invented/next/month")).toBe("full");
+    expect(scopeNeeded("DELETE", "/anything")).toBe("full");
+    expect(scopeNeeded("PUT", "/anything")).toBe("full");
+  });
+
+  test("the named few really are named — a typo here is a route nobody can reach", () => {
+    // Catches the opposite failure: a name in the list that no longer exists,
+    // which would leave the real route silently at `full` while this file
+    // claims a phone can use it.
+    const known = new Set([...ROUTES, ...SWITCH_CASES]);
+    for (const r of NAMED_LOWER) expect(known.has(r), `${r} is not a route in index.ts`).toBe(true);
+  });
+});
+
+describe("the ones that would be a shell", () => {
+  test("the terminal is full access, even though it arrives as a GET", () => {
+    // A browser cannot put a header on a WebSocket upgrade, so /terminal/pty
+    // arrives as GET ?token=. A rule that trusted the method would hand a
+    // look-only device an interactive shell on this machine.
+    expect(scopeNeeded("GET", "/terminal/pty")).toBe("full");
+    const { token } = issueDevice("iPhone", "answer");
+    const [req, url] = at(`http://x/terminal/pty?token=${encodeURIComponent(token)}`);
+    expect(allowed(callerFor(req, url, "m")!, "GET", "/terminal/pty")).toBe(false);
+  });
+
+  test("every git, docker and pull-request write is full access", () => {
+    // Enumerated from the switch statements themselves, so a case added to any
+    // of them is covered the day it lands.
+    expect(SWITCH_CASES.length).toBeGreaterThan(30);
+    for (const r of SWITCH_CASES) {
+      if (r === "/git/status") continue; // a read; see above
+      expect(scopeNeeded("POST", r), `${r} is not full access`).toBe("full");
+    }
+  });
+
+  test("named individually as well, because these are the ones that hurt", () => {
+    for (const r of ["/git/discard", "/git/reset", "/git/push", "/prs/merge", "/prs/close", "/docker/rm", "/update/run", "/chat/attach", "/control", "/editor/open"]) {
+      expect(scopeNeeded("POST", r), r).toBe("full");
+    }
+  });
+});
+
+describe("what each level can actually do", () => {
+  const caller = (scope: Scope) => {
+    const { token } = issueDevice("d", scope);
+    const [req, url] = at("http://x/", { authorization: `Bearer ${token}` });
+    return callerFor(req, url, "machine-token")!;
+  };
+
+  test("a look-only device looks, and decides nothing", () => {
+    const c = caller("read");
+    expect(allowed(c, "GET", "/sessions")).toBe(true);
+    expect(allowed(c, "GET", "/gate/pending")).toBe(true);
+    expect(allowed(c, "POST", "/git/status")).toBe(true);
+    expect(allowed(c, "POST", "/gate/decide")).toBe(false);
+    expect(allowed(c, "POST", "/chat/send")).toBe(false);
+  });
+
+  test("an answering device unblocks agents, and operates nothing", () => {
+    const c = caller("answer");
+    expect(allowed(c, "POST", "/gate/decide")).toBe(true);
+    expect(allowed(c, "POST", "/chat/send")).toBe(true);
+    expect(allowed(c, "GET", "/sessions")).toBe(true);
+    expect(allowed(c, "POST", "/prs/merge")).toBe(false);
+    expect(allowed(c, "POST", "/git/push")).toBe(false);
+    expect(allowed(c, "POST", "/docker/rm")).toBe(false);
+    expect(allowed(c, "GET", "/terminal/pty")).toBe(false);
+  });
+
+  test("a full device is the machine, which is what makes it a decision", () => {
+    const c = caller("full");
+    for (const r of ["/prs/merge", "/git/reset", "/docker/rm", "/control"]) {
+      expect(allowed(c, "POST", r), r).toBe(true);
+    }
+    expect(allowed(c, "GET", "/terminal/pty")).toBe(true);
+  });
+});
+
+describe("the pairing routes themselves", () => {
+  test("are reachable without a credential, because handing one out is the point", () => {
+    for (const r of ["/pair/info", "/pair/claim", "/pair/collect", "/pair/ticket", "/pair/accept"]) {
+      expect(isAuthExempt(r), r).toBe(true);
+    }
+  });
+
+  test("and nothing else picked up an exemption on the way", () => {
+    // The exemption is a prefix, which is right for a protocol and wrong if it
+    // ever widens. `/paired`, `/pairing-stats` and the like are not the prefix.
+    expect(isPairing("/pair")).toBe(true);
+    expect(isPairing("/pair/anything")).toBe(true);
+    expect(isPairing("/paired")).toBe(false);
+    expect(isPairing("/repair/x")).toBe(false);
+    for (const r of ROUTES.filter((r) => !isPairing(r))) {
+      if (["/health", "/ingest", "/v1/traces", "/otlp/v1/traces", "/v1/logs", "/otlp/v1/logs"].includes(r)) continue;
+      expect(isAuthExempt(r), `${r} no longer needs a credential`).toBe(false);
+    }
+  });
+
+  test("claiming is rate limited, because it is the one with no credential at all", () => {
+    // The five-guess cap on a ticket is the real defence; this stops the noise
+    // before it gets there.
+    expect(isIntake("/pair/claim")).toBe(true);
+  });
+});

--- a/server/test/devices.test.ts
+++ b/server/test/devices.test.ts
@@ -1,0 +1,148 @@
+/*
+ * A credential per device, and what that buys over one password for the machine.
+ *
+ * Three of these are the reasons the file exists: a stored credential is not a
+ * working key, cutting one device off leaves the others alone, and a phone gets
+ * what it was granted rather than everything. The fourth is the boring one that
+ * makes the rest true — a lookup that does not leak how much of a guess was
+ * right.
+ */
+import { beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+import {
+  issueDevice, deviceFor, devices, activeDevices, revokeDevice, markSeen,
+  scopeAllows, hashToken, devicesPath, __resetDevices,
+} from "../src/devices.ts";
+
+beforeEach(() => {
+  process.env.NODE_ENV = "test";
+  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "agx-dev-"));
+  __resetDevices();
+});
+
+describe("what is stored", () => {
+  test("the credential is never on disk — only a hash of it", () => {
+    const { token } = issueDevice("iPhone", "answer");
+    expect(readFileSync(devicesPath(), "utf8")).not.toContain(token);
+    expect(devices()[0]!.hash).toBe(hashToken(token));
+  });
+
+  test("the file is not readable by anyone else", () => {
+    issueDevice("iPhone");
+    // It holds credential hashes and the shape of who can reach this machine.
+    expect(statSync(devicesPath()).mode & 0o077).toBe(0);
+  });
+
+  test("two devices never share a credential", () => {
+    const a = issueDevice("iPhone").token;
+    const b = issueDevice("iPad").token;
+    expect(a).not.toBe(b);
+    expect(deviceFor(a)!.label).toBe("iPhone");
+    expect(deviceFor(b)!.label).toBe("iPad");
+  });
+
+  test("a corrupt file reads as empty rather than taking the server down", () => {
+    // Pairing again is a minute with the phone in your hand. A server that
+    // will not start is not.
+    mkdirSync(dirname(devicesPath()), { recursive: true });
+    writeFileSync(devicesPath(), "{ not json");
+    expect(devices()).toEqual([]);
+    expect(deviceFor("anything")).toBeNull();
+  });
+
+  test("a name is kept short and never empty", () => {
+    expect(issueDevice("").device.label).toBe("A device");
+    expect(issueDevice("x".repeat(400)).device.label).toHaveLength(60);
+  });
+});
+
+describe("looking a credential up", () => {
+  test("the right one resolves, anything else is nobody", () => {
+    const { token } = issueDevice("iPhone");
+    expect(deviceFor(token)!.label).toBe("iPhone");
+    expect(deviceFor("")).toBeNull();
+    expect(deviceFor(token + "x")).toBeNull();
+    expect(deviceFor(token.slice(0, -1))).toBeNull();
+  });
+
+  test("a hash that is not a hash is skipped, not thrown on", () => {
+    // Hand-edited files exist, and `timingSafeEqual` throws when the two sides
+    // are different lengths — so one bad row without a length check is a 500 on
+    // every authenticated request, not a row that quietly does not match.
+    const { token } = issueDevice("iPhone");
+    const f = JSON.parse(readFileSync(devicesPath(), "utf8"));
+    for (const junk of ["zzzz", "", "ab", "f".repeat(200)]) {
+      f.devices.unshift({ id: "x" + junk, label: "junk", hash: junk, scope: "full", createdAt: 0 });
+    }
+    writeFileSync(devicesPath(), JSON.stringify(f));
+    expect(deviceFor(token)!.label).toBe("iPhone");
+    expect(deviceFor("not the token")).toBeNull();
+  });
+});
+
+describe("taking one back", () => {
+  test("a revoked credential stops working, and only that one", () => {
+    const a = issueDevice("iPhone").token;
+    const b = issueDevice("iPad").token;
+    expect(revokeDevice(deviceFor(a)!.id)).toBe(true);
+    expect(deviceFor(a)).toBeNull();
+    expect(deviceFor(b)!.label).toBe("iPad"); // the desk keeps working
+  });
+
+  test("the row stays, so 'did I definitely cut it off' is answerable", () => {
+    const { device } = issueDevice("iPhone");
+    revokeDevice(device.id, 5_000);
+    expect(activeDevices()).toHaveLength(0);
+    expect(devices()).toHaveLength(1);
+    expect(devices()[0]!.revokedAt).toBe(5_000);
+  });
+
+  test("revoking twice, or something that is not there, is not a success", () => {
+    const { device } = issueDevice("iPhone");
+    expect(revokeDevice(device.id)).toBe(true);
+    expect(revokeDevice(device.id)).toBe(false);
+    expect(revokeDevice("never-existed")).toBe(false);
+  });
+});
+
+describe("last seen", () => {
+  test("is recorded, but not on every request", () => {
+    // A phone polling four endpoints would otherwise rewrite this file about
+    // once a second, for a field nobody reads that often.
+    const { device } = issueDevice("iPhone");
+    markSeen(device.id, 100_000);
+    expect(devices()[0]!.lastSeenAt).toBe(100_000);
+    markSeen(device.id, 100_500);
+    expect(devices()[0]!.lastSeenAt).toBe(100_000);
+    markSeen(device.id, 200_000);
+    expect(devices()[0]!.lastSeenAt).toBe(200_000);
+  });
+
+  test("an unknown device is not invented by being seen", () => {
+    markSeen("nobody", 1);
+    expect(devices()).toEqual([]);
+  });
+});
+
+describe("scope", () => {
+  test("is a ladder, widest last", () => {
+    expect(scopeAllows("full", "full")).toBe(true);
+    expect(scopeAllows("full", "answer")).toBe(true);
+    expect(scopeAllows("full", "read")).toBe(true);
+    expect(scopeAllows("answer", "answer")).toBe(true);
+    expect(scopeAllows("answer", "read")).toBe(true);
+    expect(scopeAllows("read", "read")).toBe(true);
+  });
+
+  test("and never grants upward — the whole point of having levels", () => {
+    expect(scopeAllows("answer", "full")).toBe(false);
+    expect(scopeAllows("read", "full")).toBe(false);
+    expect(scopeAllows("read", "answer")).toBe(false);
+  });
+
+  test("a phone is paired narrow unless somebody widens it", () => {
+    expect(issueDevice("iPhone").device.scope).toBe("answer");
+  });
+});

--- a/server/test/pair-routes.test.ts
+++ b/server/test/pair-routes.test.ts
@@ -1,0 +1,274 @@
+/*
+ * Pairing a phone, over HTTP, against a real server with the token gate live.
+ *
+ * The unit tests pin the protocol; this pins the thing the protocol is for —
+ * that at the end of it a device holds a credential the server accepts, that
+ * the credential is bounded by what was granted, and that forgetting the device
+ * ends it. Driven end to end because the interesting failures are at the joins:
+ * an exemption that does not cover a step, a scope checked in the wrong place,
+ * a credential that arrives but is not accepted.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { createECDH, hkdfSync, createDecipheriv } from "node:crypto";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { INFO } from "../src/pairing.ts";
+
+const TOKEN = "test-machine-token-not-a-real-one";
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+
+/** The phone: a keypair that never leaves this closure, and the unwrap. */
+function phone() {
+  const e = createECDH("prime256v1");
+  e.generateKeys();
+  return {
+    pub: e.getPublicKey().toString("base64url"),
+    open(w: { pub: string; iv: string; data: string }, ticket: string): string {
+      const shared = e.computeSecret(Buffer.from(w.pub, "base64url"));
+      const key = Buffer.from(hkdfSync("sha256", shared, Buffer.from(ticket, "utf8"), Buffer.from(INFO, "utf8"), 32));
+      const body = Buffer.from(w.data, "base64url");
+      const d = createDecipheriv("aes-256-gcm", key, Buffer.from(w.iv, "base64url"));
+      d.setAuthTag(body.subarray(body.length - 16));
+      return Buffer.concat([d.update(body.subarray(0, body.length - 16)), d.final()]).toString("utf8");
+    },
+  };
+}
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-pairsrv-"));
+  const port = 4700 + Math.floor(Math.random() * 260);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    // A named environment, never `...process.env`: `bun test` shares one
+    // process across files, so the parent's environment is whatever every
+    // suite before this one happened to leave on it.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+      // The whole point: the gate has to be live, or every request below passes
+      // for the wrong reason.
+      AGENTGLASS_TOKEN: TOKEN,
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+/** Every answer below is JSON this file already knows the shape of; the point
+ *  of each assertion is the value, not the parse. */
+type Json = Record<string, any>;
+const jsonOf = (r: Response): Promise<Json> => r.json() as Promise<Json>;
+
+const post = (path: string, body: unknown, token?: string) =>
+  fetch(base + path, {
+    method: "POST",
+    headers: { "content-type": "application/json", ...(token ? { authorization: `Bearer ${token}` } : {}) },
+    body: JSON.stringify(body),
+  });
+const get = (path: string, token?: string) =>
+  fetch(base + path, { headers: token ? { authorization: `Bearer ${token}` } : {} });
+
+/** Machine ▸ invite, phone ▸ claim, machine ▸ accept, phone ▸ collect. */
+async function pair(scope: "read" | "answer" | "full", label = "iPhone") {
+  const p = phone();
+  const t = await jsonOf(await post("/pair/ticket", {}, TOKEN));
+  const claimed = await jsonOf(await post("/pair/claim", { ticket: t.id, code: t.code, label, pub: p.pub }));
+  expect(claimed.ok).toBe(true);
+  const acc = await jsonOf(await post("/pair/accept", { ticket: t.id, scope }, TOKEN));
+  expect(acc.ok).toBe(true);
+  const got = await jsonOf(await get(`/pair/collect?ticket=${t.id}&secret=${encodeURIComponent(claimed.secret)}`));
+  expect(got.state).toBe("accepted");
+  return { token: p.open(got.wrapped, t.id), ticket: t, deviceId: acc.device.id as string };
+}
+
+describe("starting an invitation", () => {
+  test("needs the machine's own credential — a paired phone cannot invite another", () => {
+    // Otherwise the first device through the door can quietly add the rest,
+    // and the confirmation step that makes this safe happens somewhere nobody
+    // at the machine is looking.
+    return post("/pair/ticket", {}).then(async (r) => {
+      expect(r.status).toBe(403);
+      expect((await jsonOf(r)).ok).toBe(false);
+    });
+  });
+
+  test("the code and the ticket are different things", async () => {
+    const t = await jsonOf(await post("/pair/ticket", {}, TOKEN));
+    expect(t.ok).toBe(true);
+    expect(t.code).toMatch(/^[0-9]{6}$/);
+    expect(t.id).not.toContain(t.code);
+  });
+});
+
+describe("the phone's side, with no credential at all", () => {
+  test("can ask whether an invitation is open, and be told when it is not", async () => {
+    const t = await jsonOf(await post("/pair/ticket", {}, TOKEN));
+    expect((await jsonOf(await get(`/pair/info?ticket=${t.id}`))).ok).toBe(true);
+    expect((await jsonOf(await get("/pair/info?ticket=made-up"))).ok).toBe(false);
+  });
+
+  test("a wrong code is refused and counts against the five", async () => {
+    const t = await jsonOf(await post("/pair/ticket", {}, TOKEN));
+    const wrong = t.code === "000000" ? "111111" : "000000";
+    const r = await post("/pair/claim", { ticket: t.id, code: wrong, label: "x", pub: phone().pub });
+    expect(r.status).toBe(401);
+    const j = await jsonOf(r);
+    expect(j.ok).toBe(false);
+    expect(j.left).toBe(4);
+    expect(j.error).toContain("4 tries left");
+  });
+
+  test("everything else about the surface is still shut to it", async () => {
+    // The exemption is the pairing prefix and nothing more. If it leaked, a
+    // device would not need to pair at all.
+    for (const path of ["/sessions", "/gate/pending", "/remote/status"]) {
+      expect((await get(path)).status, path).toBe(401);
+    }
+  });
+});
+
+describe("what a paired phone can do", () => {
+  test("an answering phone reads, decides gates, and cannot merge or open a shell", async () => {
+    const { token } = await pair("answer", "iPhone");
+
+    // It is a real credential: the gate accepts it where it accepted nothing.
+    expect((await get("/gate/pending", token)).status).toBe(200);
+    expect((await get("/sessions", token)).status).toBe(200);
+
+    // A gate decision reaches the handler — 200 or a 400 about the gate, but
+    // never the 403 that means "your device may not".
+    const decide = await post("/gate/decide", { id: "no-such-gate", decision: "allow" }, token);
+    expect(decide.status).not.toBe(403);
+
+    // And the things a phone has no business doing say so, by name.
+    const merge = await post("/prs/merge", { root: dir, number: 1, method: "squash" }, token);
+    expect(merge.status).toBe(403);
+    const why = await jsonOf(merge);
+    expect(why.scope).toBe("answer");
+    expect(why.needs).toBe("full");
+    expect(why.error).toContain("/prs/merge");
+
+    for (const path of ["/git/push", "/git/reset", "/docker/rm", "/chat/attach"]) {
+      expect((await post(path, { root: dir }, token)).status, path).toBe(403);
+    }
+  });
+
+  test("a look-only phone cannot decide a gate either", async () => {
+    const { token } = await pair("read", "an old tablet");
+    expect((await get("/sessions", token)).status).toBe(200);
+    const r = await post("/gate/decide", { id: "x", decision: "allow" }, token);
+    expect(r.status).toBe(403);
+    expect((await jsonOf(r)).needs).toBe("answer");
+  });
+
+  test("a scope the server does not recognise lands on the narrow one", async () => {
+    // A typo in a scope name must not be how a phone ends up with a terminal.
+    const p = phone();
+    const t = await jsonOf(await post("/pair/ticket", {}, TOKEN));
+    const c = await jsonOf(await post("/pair/claim", { ticket: t.id, code: t.code, label: "typo", pub: p.pub }));
+    const acc = await jsonOf(await post("/pair/accept", { ticket: t.id, scope: "administrator" }, TOKEN));
+    expect(acc.device.scope).toBe("answer");
+    const got = await jsonOf(await get(`/pair/collect?ticket=${t.id}&secret=${encodeURIComponent(c.secret)}`));
+    const token = p.open(got.wrapped, t.id);
+    expect((await post("/prs/merge", { root: dir, number: 1, method: "squash" }, token)).status).toBe(403);
+  });
+
+  test("a full device is the machine", async () => {
+    const { token } = await pair("full", "my laptop");
+    // Reaches the handler rather than the gate: what comes back is about the
+    // pull request, not about the device.
+    expect((await post("/prs/merge", { root: dir, number: 1, method: "squash" }, token)).status).not.toBe(403);
+  });
+
+  test("it knows what it is, which is how it learns it was forgotten", async () => {
+    const { token, deviceId } = await pair("answer", "Pixel");
+    const me = await jsonOf(await get("/pair/whoami", token));
+    expect(me).toMatchObject({ paired: true, machine: false, scope: "answer", label: "Pixel", id: deviceId });
+  });
+});
+
+describe("taking one back", () => {
+  test("forgetting one device stops it, and leaves the others alone", async () => {
+    const a = await pair("answer", "the lost phone");
+    const b = await pair("answer", "the phone in my hand");
+    expect((await get("/sessions", a.token)).status).toBe(200);
+
+    const r = await jsonOf(await post("/pair/forget", { id: a.deviceId }, TOKEN));
+    expect(r.ok).toBe(true);
+
+    expect((await get("/sessions", a.token)).status).toBe(401);
+    expect((await get("/sessions", b.token)).status).toBe(200);
+    // …and the machine itself was never in question.
+    expect((await get("/sessions", TOKEN)).status).toBe(200);
+  });
+
+  test("only from the machine — a phone cannot disconnect the desk", async () => {
+    const { token, deviceId } = await pair("full", "a device with everything");
+    // Even at `full`: this is not a scope, it is a place. The button lives on
+    // the side of the desk the user is sitting at.
+    const r = await post("/pair/forget", { id: deviceId }, token);
+    expect(r.status).toBe(403);
+    expect((await get("/sessions", token)).status).toBe(200);
+  });
+
+  test("the machine's own token is not something pairing can revoke", async () => {
+    const r = await post("/pair/forget", { id: "anything-at-all" }, TOKEN);
+    expect(r.status).toBe(404);
+    expect((await get("/sessions", TOKEN)).status).toBe(200);
+  });
+});
+
+describe("what the machine sees", () => {
+  test("the pending list and the device list are for this machine only", async () => {
+    // The pending list carries the code. Serving it to anything that merely
+    // holds a device credential would hand a paired phone the six digits it is
+    // supposed to have needed a person for.
+    const { token } = await pair("full", "a device with everything");
+    expect((await get("/pair/state?ticket=", token)).status).toBe(403);
+    expect((await get("/pair/state?ticket=", TOKEN)).status).toBe(200);
+  });
+
+  test("names what is paired, and what it may do", async () => {
+    const s = await jsonOf(await get("/pair/state?ticket=", TOKEN));
+    const labels = s.devices.map((d: { label: string }) => d.label);
+    expect(labels).toContain("the phone in my hand");
+    expect(labels).not.toContain("the lost phone"); // revoked
+    expect(s.devices.every((d: { hash?: string }) => !d.hash)).toBe(false); // it is the stored row
+  });
+
+  test("a request waiting on a person shows who is asking and the same code", async () => {
+    const t = await jsonOf(await post("/pair/ticket", {}, TOKEN));
+    await post("/pair/claim", { ticket: t.id, code: t.code, label: "someone's phone", pub: phone().pub });
+    const s = await jsonOf(await get(`/pair/state?ticket=${t.id}`, TOKEN));
+    expect(s.pending).toHaveLength(1);
+    expect(s.pending[0]).toMatchObject({ id: t.id, code: t.code, label: "someone's phone" });
+    // Declining grants nothing.
+    expect((await jsonOf(await post("/pair/reject", { ticket: t.id }, TOKEN))).ok).toBe(true);
+  });
+});
+
+describe("the status pane no longer serves a key", () => {
+  test("nothing in /remote/status is the token, for any caller", async () => {
+    // The QR used to be `?token=<the machine's secret>`, so this answer had to
+    // carry it. Pairing replaced that, and a URL that grants a terminal is
+    // exactly what ends up in a screenshot of this pane.
+    const body = await (await get("/remote/status", TOKEN)).text();
+    expect(body).not.toContain(TOKEN);
+    expect(body).not.toContain("?token=");
+  });
+});

--- a/server/test/pairing.test.ts
+++ b/server/test/pairing.test.ts
@@ -1,0 +1,300 @@
+/*
+ * The pairing handshake, at the level where its security properties live.
+ *
+ * Everything asserted here is a claim the feature makes to the person using
+ * it — that a photograph of the screen is not a key, that guessing the code is
+ * not feasible, that only the device which typed the code can collect what was
+ * granted, and that what it collects cannot be read by anything else on the
+ * network. Each of those is a property of this module, so this is where they
+ * are pinned.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { createECDH, hkdfSync, createDecipheriv } from "node:crypto";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  mintTicket, claimTicket, pending, acceptTicket, rejectTicket, collect,
+  getTicket, dropTicket, validPub, sealTo, __resetPairing,
+  TICKET_TTL_MS, MAX_ATTEMPTS, MAX_TICKETS, INFO,
+} from "../src/pairing.ts";
+import { deviceFor, activeDevices, __resetDevices } from "../src/devices.ts";
+
+/** A phone's keypair, and the half of the exchange only it can do. */
+function phone() {
+  const e = createECDH("prime256v1");
+  e.generateKeys();
+  return {
+    pub: e.getPublicKey().toString("base64url"),
+    open(w: { pub: string; iv: string; data: string }, ticketId: string): string {
+      const shared = e.computeSecret(Buffer.from(w.pub, "base64url"));
+      const key = Buffer.from(hkdfSync("sha256", shared, Buffer.from(ticketId, "utf8"), Buffer.from(INFO, "utf8"), 32));
+      const body = Buffer.from(w.data, "base64url");
+      const d = createDecipheriv("aes-256-gcm", key, Buffer.from(w.iv, "base64url"));
+      d.setAuthTag(body.subarray(body.length - 16));
+      return Buffer.concat([d.update(body.subarray(0, body.length - 16)), d.final()]).toString("utf8");
+    },
+  };
+}
+
+beforeEach(() => {
+  // Devices are written to disk; keep every case inside the scratch directory
+  // the offLimits() guard in devices.ts allows.
+  process.env.NODE_ENV = "test";
+  process.env.XDG_CONFIG_HOME = mkdtempSync(join(tmpdir(), "agx-pair-"));
+  __resetPairing();
+  __resetDevices();
+});
+
+afterEach(() => { __resetPairing(); });
+
+describe("the invitation", () => {
+  test("is a handle, not a credential — nothing in it is the code", () => {
+    // The whole reason the QR is safe to point a camera at across a room. If
+    // the code were derivable from the id, a photograph would be a pairing.
+    const t = mintTicket()!;
+    expect(t.id).not.toContain(t.code);
+    expect(t.code).toHaveLength(6);
+    expect(t.code).toMatch(/^[0-9]{6}$/);
+    expect(t.state).toBe("waiting");
+  });
+
+  test("keeps its leading zeros, so the length never leaks a digit", () => {
+    // A code printed without padding would be six digits nine times in ten and
+    // five the tenth, which tells an attacker something before anyone types.
+    for (let i = 0; i < 200; i++) {
+      __resetPairing();
+      expect(mintTicket()!.code).toHaveLength(6);
+    }
+  });
+
+  test("expires, and is gone the instant it does rather than at the next sweep", () => {
+    const t = mintTicket(1_000)!;
+    expect(getTicket(t.id, 1_000 + TICKET_TTL_MS - 1)).not.toBeNull();
+    expect(getTicket(t.id, 1_000 + TICKET_TTL_MS)).toBeNull();
+  });
+
+  test("a claim against an expired invitation fails, however right the code", () => {
+    const t = mintTicket(1_000)!;
+    const r = claimTicket(t.id, t.code, { pub: phone().pub, now: 1_000 + TICKET_TTL_MS + 1 });
+    expect(r).toEqual({ ok: false, error: "unknown" });
+  });
+
+  test("several at once are capped, and a request waiting on a person is never the one dropped", () => {
+    const live = Array.from({ length: MAX_TICKETS }, () => mintTicket()!);
+    // One of them has somebody standing there with a phone.
+    expect(claimTicket(live[0]!.id, live[0]!.code, { pub: phone().pub }).ok).toBe(true);
+    // The cap recycles an unscanned invitation instead.
+    expect(mintTicket()).not.toBeNull();
+    expect(getTicket(live[0]!.id)).not.toBeNull();
+    // With every slot claimed there is nothing free to recycle, and quietly
+    // discarding a pending request would take it off the screen of the person
+    // deciding it.
+    __resetPairing();
+    const all = Array.from({ length: MAX_TICKETS }, () => mintTicket()!);
+    for (const t of all) claimTicket(t.id, t.code, { pub: phone().pub });
+    expect(mintTicket()).toBeNull();
+  });
+});
+
+describe("typing the code", () => {
+  test("the wrong code is refused and says how many tries are left", () => {
+    const t = mintTicket()!;
+    expect(claimTicket(t.id, "000000" === t.code ? "111111" : "000000", { pub: phone().pub }))
+      .toMatchObject({ ok: false, error: "code", left: MAX_ATTEMPTS - 1 });
+  });
+
+  test("running out of guesses kills the invitation rather than just refusing one", () => {
+    // A lockout that leaves the target alive is a rate limit. Six digits is a
+    // million, and a million requests is minutes — the cap is what makes the
+    // short code safe to type.
+    const t = mintTicket()!;
+    const wrong = t.code === "000000" ? "111111" : "000000";
+    for (let i = 1; i < MAX_ATTEMPTS; i++) expect(claimTicket(t.id, wrong, { pub: phone().pub })).toMatchObject({ ok: false, error: "code" });
+    expect(claimTicket(t.id, wrong, { pub: phone().pub })).toEqual({ ok: false, error: "locked" });
+    // Gone: even the right code cannot revive it.
+    expect(getTicket(t.id)).toBeNull();
+    expect(claimTicket(t.id, t.code, { pub: phone().pub })).toEqual({ ok: false, error: "unknown" });
+  });
+
+  test("the second scanner cannot displace the first by guessing faster", () => {
+    const t = mintTicket()!;
+    expect(claimTicket(t.id, t.code, { pub: phone().pub, label: "iPhone" }).ok).toBe(true);
+    expect(claimTicket(t.id, t.code, { pub: phone().pub, label: "not the iPhone" }))
+      .toEqual({ ok: false, error: "taken" });
+    expect(pending()).toHaveLength(1);
+    expect(pending()[0]!.label).toBe("iPhone");
+  });
+
+  test("a key it cannot deliver to is refused before anyone is asked to decide", () => {
+    // Finding out the credential cannot be sealed *after* somebody accepted is
+    // a failure at the one point in the flow that cannot be retried.
+    const t = mintTicket()!;
+    expect(claimTicket(t.id, t.code, { pub: "not-a-key" })).toEqual({ ok: false, error: "shape" });
+    expect(claimTicket(t.id, t.code, {})).toEqual({ ok: false, error: "shape" });
+    // And a wrong key never cost the person an attempt.
+    expect(claimTicket(t.id, t.code, { pub: phone().pub }).ok).toBe(true);
+  });
+
+  test("only an uncompressed P-256 point is a key", () => {
+    expect(validPub(undefined)).toBe(false);
+    expect(validPub("")).toBe(false);
+    expect(validPub(Buffer.alloc(65).toString("base64url"))).toBe(false); // leading byte 0x00
+    expect(validPub(Buffer.concat([Buffer.from([0x04]), Buffer.alloc(63)]).toString("base64url"))).toBe(false); // short
+    expect(validPub(phone().pub)).toBe(true);
+  });
+
+  test("what the person sees is who is asking, and the same six digits", () => {
+    const t = mintTicket()!;
+    claimTicket(t.id, t.code, { pub: phone().pub, label: "Pixel", agent: "Mozilla/5.0 (Linux; Android 14)", ip: "192.168.1.44" });
+    expect(pending()[0]).toMatchObject({
+      id: t.id, code: t.code, label: "Pixel", ip: "192.168.1.44",
+    });
+  });
+
+  test("a device with no name still has one", () => {
+    const t = mintTicket()!;
+    claimTicket(t.id, t.code, { pub: phone().pub, label: "   " });
+    expect(pending()[0]!.label).toBe("A device");
+  });
+});
+
+describe("the decision", () => {
+  test("nothing is minted until somebody says yes", () => {
+    const t = mintTicket()!;
+    claimTicket(t.id, t.code, { pub: phone().pub, label: "iPhone" });
+    expect(activeDevices()).toHaveLength(0);
+    acceptTicket(t.id, "answer");
+    expect(activeDevices()).toHaveLength(1);
+  });
+
+  test("accepting mints a credential that works, sealed so only the phone can read it", () => {
+    const p = phone();
+    const t = mintTicket()!;
+    const c = claimTicket(t.id, t.code, { pub: p.pub, label: "iPhone" });
+    expect(c.ok).toBe(true);
+    expect(acceptTicket(t.id, "answer").ok).toBe(true);
+
+    const got = collect(t.id, (c as { secret: string }).secret);
+    expect(got.state).toBe("accepted");
+    const w = (got as { wrapped: { pub: string; iv: string; data: string } }).wrapped;
+
+    // The property the whole design rests on: the credential is not on the
+    // wire in the clear, so anything on this network with tcpdump gets the
+    // ticket, the code and both public keys and still has no key. Asserted by
+    // *using* it — a check that the ciphertext merely differs from the token
+    // would pass against a server that sent it in plain text under a different
+    // encoding.
+    const token = p.open(w, t.id);
+    const device = deviceFor(token);
+    expect(device).not.toBeNull();
+    expect(device!.label).toBe("iPhone");
+    expect(device!.scope).toBe("answer");
+
+    // …and nothing recoverable is left lying around.
+    expect(JSON.stringify(w)).not.toContain(token);
+  });
+
+  test("the token never touches disk — what is stored is a hash of it", () => {
+    const p = phone();
+    const t = mintTicket()!;
+    const c = claimTicket(t.id, t.code, { pub: p.pub });
+    acceptTicket(t.id, "answer");
+    const token = p.open((collect(t.id, (c as { secret: string }).secret) as any).wrapped, t.id);
+    // A readable devices.json is not a working key, for the same reason a
+    // password file holds hashes.
+    expect(JSON.stringify(activeDevices())).not.toContain(token);
+  });
+
+  test("the scope granted is the scope the credential has", () => {
+    for (const scope of ["read", "answer", "full"] as const) {
+      __resetPairing();
+      __resetDevices();
+      const p = phone();
+      const t = mintTicket()!;
+      const c = claimTicket(t.id, t.code, { pub: p.pub });
+      acceptTicket(t.id, scope);
+      const token = p.open((collect(t.id, (c as { secret: string }).secret) as any).wrapped, t.id);
+      expect(deviceFor(token)!.scope).toBe(scope);
+    }
+  });
+
+  test("declining grants nothing and says so, instead of leaving a spinner", () => {
+    const t = mintTicket()!;
+    const c = claimTicket(t.id, t.code, { pub: phone().pub });
+    expect(rejectTicket(t.id)).toBe(true);
+    expect(collect(t.id, (c as { secret: string }).secret).state).toBe("rejected");
+    expect(activeDevices()).toHaveLength(0);
+  });
+
+  test("an invitation nobody claimed cannot be accepted", () => {
+    const t = mintTicket()!;
+    expect(acceptTicket(t.id, "full")).toEqual({ ok: false, error: "notClaimed" });
+    expect(activeDevices()).toHaveLength(0);
+  });
+});
+
+describe("collecting it", () => {
+  test("only the device that typed the code can, even knowing the ticket", () => {
+    // The ticket id is in the QR and therefore not a secret. Without this,
+    // anything that saw the QR could poll until a credential appeared and take
+    // it before the phone did.
+    const p = phone();
+    const t = mintTicket()!;
+    claimTicket(t.id, t.code, { pub: p.pub });
+    acceptTicket(t.id, "answer");
+    expect(collect(t.id, "").state).toBe("unknown");
+    expect(collect(t.id, "a-guess").state).toBe("unknown");
+    expect(activeDevices()).toHaveLength(1); // still there, waiting for the right holder
+  });
+
+  test("exactly once — a credential two devices can fetch is a credential two devices hold", () => {
+    const p = phone();
+    const t = mintTicket()!;
+    const c = claimTicket(t.id, t.code, { pub: p.pub });
+    acceptTicket(t.id, "answer");
+    const secret = (c as { secret: string }).secret;
+    expect(collect(t.id, secret).state).toBe("accepted");
+    expect(collect(t.id, secret).state).toBe("unknown");
+  });
+
+  test("says 'still waiting' while a person is deciding, rather than an error", () => {
+    const t = mintTicket()!;
+    const c = claimTicket(t.id, t.code, { pub: phone().pub });
+    expect(collect(t.id, (c as { secret: string }).secret)).toEqual({ state: "claimed" });
+  });
+
+  test("a cancelled invitation is gone for the phone too", () => {
+    const t = mintTicket()!;
+    const c = claimTicket(t.id, t.code, { pub: phone().pub });
+    dropTicket(t.id);
+    expect(collect(t.id, (c as { secret: string }).secret).state).toBe("unknown");
+  });
+});
+
+describe("sealTo", () => {
+  test("two pairings of the same two keys do not produce the same bytes", () => {
+    // The IV is fresh per delivery and the ticket id salts the derivation, so
+    // even an identical plaintext to an identical key looks unrelated.
+    const p = phone();
+    const a = sealTo(p.pub, "ticket-a", "same-token");
+    const b = sealTo(p.pub, "ticket-b", "same-token");
+    expect(a.data).not.toBe(b.data);
+    expect(a.iv).not.toBe(b.iv);
+    expect(a.pub).not.toBe(b.pub); // a fresh ephemeral keypair each time
+  });
+
+  test("a tampered ciphertext fails to open instead of yielding something plausible", () => {
+    const p = phone();
+    const w = sealTo(p.pub, "t", "the-token");
+    const bytes = Buffer.from(w.data, "base64url");
+    bytes[0] = bytes[0]! ^ 0xff;
+    expect(() => p.open({ ...w, data: bytes.toString("base64url") }, "t")).toThrow();
+  });
+
+  test("the salt is the ticket, so opening it as a different pairing fails", () => {
+    const p = phone();
+    const w = sealTo(p.pub, "the-real-ticket", "the-token");
+    expect(() => p.open(w, "another-ticket")).toThrow();
+  });
+});

--- a/server/test/remote.test.ts
+++ b/server/test/remote.test.ts
@@ -326,22 +326,27 @@ describe("remoteStatus", () => {
   const base = { port: 4000, trustLan: true, webUi: true, addresses, which: () => null };
 
   test("a loopback bind is not exposed; 0.0.0.0 is", () => {
-    expect(remoteStatus({ ...base, bind: "127.0.0.1", token: null, includeToken: true }).exposed).toBe(false);
-    expect(remoteStatus({ ...base, bind: "::1", token: null, includeToken: true }).exposed).toBe(false);
-    expect(remoteStatus({ ...base, bind: "0.0.0.0", token: null, includeToken: true }).exposed).toBe(true);
+    expect(remoteStatus({ ...base, bind: "127.0.0.1", token: null }).exposed).toBe(false);
+    expect(remoteStatus({ ...base, bind: "::1", token: null }).exposed).toBe(false);
+    expect(remoteStatus({ ...base, bind: "0.0.0.0", token: null }).exposed).toBe(true);
   });
 
-  test("a local caller gets URLs that carry the token", () => {
-    const st = remoteStatus({ ...base, bind: "0.0.0.0", token: "s3cret", includeToken: true });
-    expect(st.token).toBe("s3cret");
-    expect(st.urls).toEqual(["http://192.168.1.131:4000/?token=s3cret"]);
-  });
-
-  test("a remote caller is never handed the token, in the field or in a URL", () => {
-    // The page on the phone already proved it holds the token to get this far.
-    // Re-serving the credential to whatever else is on the wifi is the risk.
-    const st = remoteStatus({ ...base, bind: "0.0.0.0", token: "s3cret", includeToken: false });
-    expect(st.token).toBeUndefined();
+  /**
+   * The one with teeth, and the reason this answer no longer has a local and a
+   * remote version.
+   *
+   * It used to hand a caller on this machine `http://192.168.1.131:4000/?token=
+   * s3cret`, because the QR *was* the credential and the pane had to draw it.
+   * A device is added by pairing now (server/src/pairing.ts), so nothing needs
+   * the secret in a URL — and a URL that grants a terminal is precisely what
+   * ends up in a screenshot of this pane.
+   *
+   * Asserted over the whole serialised answer rather than over `urls`: the hole
+   * this closes was a *field*, and a check that only reads the field it knows
+   * about would pass against a status that leaked the token somewhere else.
+   */
+  test("the token appears nowhere in the status, for any caller", () => {
+    const st = remoteStatus({ ...base, bind: "0.0.0.0", token: "s3cret" });
     expect(st.tokenRequired).toBe(true);
     expect(st.urls).toEqual(["http://192.168.1.131:4000/"]);
     expect(JSON.stringify(st)).not.toContain("s3cret");
@@ -349,7 +354,7 @@ describe("remoteStatus", () => {
 
   test("reports the devices that have been seen", () => {
     noteClient("192.168.1.42", { now: 4242 });
-    const st = remoteStatus({ ...base, bind: "0.0.0.0", token: null, includeToken: true });
+    const st = remoteStatus({ ...base, bind: "0.0.0.0", token: null });
     expect(st.clients).toMatchObject({ count: 1, lastAt: 4242 });
   });
 });

--- a/server/test/retention-promises.test.ts
+++ b/server/test/retention-promises.test.ts
@@ -56,8 +56,39 @@ describe("the promises SECURITY.md makes about retention", () => {
     // "no route" half of the claim false.
     const idx = read("server/src/index.ts");
     const routes = [...idx.matchAll(/pathname === "(\/[^"]*)"/g)].map((m) => m[1]!);
-    const suspicious = routes.filter((r) => /delete|purge|clear|wipe|forget|reset/i.test(r));
+    const suspicious = routes.filter((r) => /delete|purge|clear|wipe|forget|reset/i.test(r) && !REVIEWED.has(r));
     expect(suspicious, "a route now removes data — say so in SECURITY.md").toEqual([]);
+  });
+
+  /**
+   * The exceptions, and the reason they are not just holes in the rule above.
+   *
+   * This tripwire matches on the *name* of a route, which is cheap and catches
+   * the thing worth catching. It also means an honestly-named route that
+   * removes nothing recorded can trip it: `/pair/forget` revokes one paired
+   * device's credential, and devices.ts deliberately keeps a revoked row rather
+   * than dropping it, precisely so "did I definitely cut that phone off" stays
+   * answerable.
+   *
+   * Renaming it to slip past the regex would leave a heuristic passing for a
+   * reason that has nothing to do with what it is checking, which is how a
+   * tripwire quietly stops being one. So the exception is listed, and the test
+   * below makes it earn its place on every run.
+   */
+  const REVIEWED = new Set(["/pair/forget"]);
+
+  test("the reviewed exceptions still touch no stored data", () => {
+    const idx = read("server/src/index.ts");
+    for (const route of REVIEWED) {
+      const at = idx.indexOf(`pathname === "${route}"`);
+      expect(at, `${route} is no longer a route — take it out of REVIEWED`).toBeGreaterThan(-1);
+      // To the start of the next route, so the check reads the whole handler
+      // and only the handler however long it grows.
+      const rest = idx.slice(at + 1);
+      const next = rest.indexOf('pathname === "');
+      const body = next === -1 ? rest : rest.slice(0, next);
+      expect(body, `${route} now reaches the database`).not.toMatch(/DELETE\s+FROM|pruneOldRows|\bdb\.(run|query|exec|prepare)\b/i);
+    }
   });
 
   test("SECURITY.md still says all three, so the tripwire is wired to something", () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1534,6 +1534,63 @@ export interface RemoteDevice {
   self?: boolean;
 }
 
+/**
+ * What a paired device is allowed to do. See server/src/devices.ts.
+ *
+ * Three levels rather than a permission matrix: looking at things, answering
+ * the thing an agent is stopped on, and operating the machine.
+ */
+export type DeviceScope = "read" | "answer" | "full";
+
+/** A phone (or anything else) that holds its own credential to this machine. */
+export interface PairedDevice {
+  id: string;
+  /** Whatever it called itself when it paired. */
+  label: string;
+  scope: DeviceScope;
+  createdAt: number;
+  /** Last request it made, recorded at most once a minute. */
+  lastSeenAt?: number;
+  /** Set when forgotten. The row stays so "did I definitely cut it off" is
+   *  answerable rather than inferred from an absence. */
+  revokedAt?: number;
+}
+
+/**
+ * A device that has typed the code and is waiting on somebody at the machine.
+ *
+ * Carries the code so the pane can show it beside the request: the person
+ * accepting is meant to check that the six digits on the phone in their hand
+ * are the six digits on the screen, which is the step that makes this more
+ * than a button that says yes.
+ */
+export interface PairRequest {
+  id: string;
+  code: string;
+  label: string;
+  agent: string;
+  ip: string;
+  claimedAt: number;
+  expiresAt: number;
+}
+
+/** The credential, sealed to the key the phone generated for this pairing. */
+export interface PairWrapped {
+  /** The server's ephemeral P-256 public key, base64url. */
+  pub: string;
+  iv: string;
+  data: string;
+}
+
+/** Everything the Remote pane needs about pairing, in one poll. Local only. */
+export interface PairState {
+  /** The live invitation, if the pane has started one. */
+  ticket: { id: string; code: string; expiresAt: number } | null;
+  /** Claims waiting on a decision, oldest first. */
+  pending: PairRequest[];
+  devices: PairedDevice[];
+}
+
 /** Whether another device can reach this server, and whether one ever has. */
 export interface RemoteStatus {
   /** Bound off loopback, so off-box traffic can arrive at all. */
@@ -1545,7 +1602,8 @@ export interface RemoteStatus {
   tokenRequired: boolean;
   /** This port serves the dashboard itself, not only the API. */
   webUi: boolean;
-  /** Ready-to-open URLs, token included when the caller is local. */
+  /** Ready-to-open addresses. Never a credential: a device is added by
+   *  pairing (see PairState), not by being handed a link. */
   urls: string[];
   addresses: ReachableAddress[];
   clients: { count: number; lastAt: number | null; addresses: string[]; liveCount: number };
@@ -1553,6 +1611,4 @@ export interface RemoteStatus {
    *  open right now, which is the difference between "is here" and "was here". */
   devices: RemoteDevice[];
   firewall: FirewallHint | null;
-  /** Only ever sent to a caller on this machine. */
-  token?: string;
 }

--- a/web/src/PairScreen.tsx
+++ b/web/src/PairScreen.tsx
@@ -1,0 +1,165 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { SERVER } from "./lib/api.ts";
+import { claim, collectOnce, guessName, makeKeys, type PairKeys } from "./lib/pairing.ts";
+
+/**
+ * Connecting this phone, on the phone.
+ *
+ * The whole screen exists to make two things unmissable, because they are the
+ * two the old flow did not have:
+ *
+ *   * **you have to be looking at the computer.** The six digits are only on
+ *     that screen. Scanning the QR from a photograph, a shared window or across
+ *     a room gets you this form and no further.
+ *   * **somebody there has to agree.** After the code there is a wait, and what
+ *     it is waiting for is a person — named, with the request in front of them.
+ *
+ * It is deliberately the only thing on the display. A pairing handshake folded
+ * into a settings pane is one people click through; this asks for two actions
+ * and then gets out of the way.
+ */
+export function PairScreen({ ticket, onPaired }: { ticket: string; onPaired: (token: string) => void }) {
+  type Stage = "checking" | "form" | "waiting" | "expired" | "rejected" | "failed";
+  const [stage, setStage] = useState<Stage>("checking");
+  const [name, setName] = useState(() => guessName());
+  const [code, setCode] = useState("");
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const keys = useRef<PairKeys | null>(null);
+  const secret = useRef<string>("");
+
+  // Generated while the person is still typing their device name, so the wait
+  // for key generation lands in a moment nobody is watching rather than between
+  // the last digit and the answer.
+  useEffect(() => {
+    let live = true;
+    makeKeys()
+      .then((k) => { if (live) keys.current = k; })
+      .catch(() => { if (live) { setStage("failed"); setErr("This browser cannot generate the key this connection needs. It has to be a recent Safari, Chrome or Firefox, over the address the QR code pointed at."); } });
+    return () => { live = false; };
+  }, []);
+
+  useEffect(() => {
+    let live = true;
+    fetch(`${SERVER}/pair/info?ticket=${encodeURIComponent(ticket)}`)
+      .then((r) => r.json())
+      .then((j: { ok?: boolean }) => { if (live) setStage(j.ok ? "form" : "expired"); })
+      .catch(() => { if (live) { setStage("failed"); setErr(`Could not reach ${SERVER}. Check the phone is on the same network as the computer.`); } });
+    return () => { live = false; };
+  }, [ticket]);
+
+  const send = useCallback(async () => {
+    if (busy || code.length !== 6) return;
+    const k = keys.current;
+    if (!k) { setErr("Still preparing the connection — try again in a second."); return; }
+    setBusy(true);
+    setErr(null);
+    const r = await claim(ticket, code, name.trim() || guessName(), k.pub);
+    setBusy(false);
+    if (!r.ok) {
+      setErr(r.error);
+      // A dead invitation is not a typo. Sending people back to the computer is
+      // the only thing that can work, so the form goes away rather than sitting
+      // there inviting a seventh attempt at a ticket that no longer exists.
+      if (r.fatal) setStage("expired");
+      else setCode("");
+      return;
+    }
+    secret.current = r.secret;
+    setStage("waiting");
+  }, [busy, code, name, ticket]);
+
+  // Polling, because what it is waiting for is somebody walking to a desk. Two
+  // seconds is fast enough to feel immediate when they are already sitting
+  // there and slow enough not to be a load on anything.
+  useEffect(() => {
+    if (stage !== "waiting") return;
+    let live = true;
+    let timer: ReturnType<typeof setTimeout>;
+    const tick = async () => {
+      const k = keys.current;
+      if (!k || !live) return;
+      const r = await collectOnce(ticket, secret.current, k.priv);
+      if (!live) return;
+      if (r.state === "accepted") { onPaired(r.token); return; }
+      if (r.state === "rejected") { setStage("rejected"); return; }
+      if (r.state === "unknown") { setStage("expired"); return; }
+      timer = setTimeout(tick, 2000);
+    };
+    timer = setTimeout(tick, 700);
+    return () => { live = false; clearTimeout(timer); };
+  }, [stage, ticket, onPaired]);
+
+  return (
+    <div className="pair-wrap">
+      <div className="pair-card">
+        <div className="pair-mark" aria-hidden>🛰</div>
+        <h1 className="pair-h1">Connect this device</h1>
+
+        {stage === "checking" && <p className="pair-p">Checking the invitation…</p>}
+
+        {stage === "form" && (
+          <>
+            <p className="pair-p">
+              The computer is showing a six-digit code. Type it here — it is what proves you are
+              standing in front of that screen.
+            </p>
+            <label className="pair-label" htmlFor="pair-name">Call this device</label>
+            <input id="pair-name" className="pair-input" value={name} maxLength={60}
+              onChange={(e) => setName(e.target.value)} placeholder="iPhone" autoComplete="off" />
+            <div className="pair-hint">This is the name you will see when you want to disconnect it.</div>
+
+            <label className="pair-label" htmlFor="pair-code">Code on the computer</label>
+            <input id="pair-code" className="pair-input pair-code" value={code}
+              // Numeric keypad, no autocorrect, no capitalisation: it is six
+              // digits, and a phone keyboard that guesses at it is a keyboard
+              // fighting the only input on the screen.
+              inputMode="numeric" autoComplete="one-time-code" pattern="[0-9]*" maxLength={6}
+              placeholder="000000"
+              onChange={(e) => setCode(e.target.value.replace(/[^0-9]/g, "").slice(0, 6))}
+              onKeyDown={(e) => { if (e.key === "Enter") void send(); }} />
+
+            {err && <div className="pair-err">{err}</div>}
+
+            <button className="pair-go" disabled={busy || code.length !== 6} onClick={() => void send()}>
+              {busy ? "Sending…" : "Ask to connect"}
+            </button>
+            <div className="pair-hint">
+              Nothing is granted yet. Someone at the computer sees this request and has to accept it.
+            </div>
+          </>
+        )}
+
+        {stage === "waiting" && (
+          <>
+            <div className="pair-spin" aria-hidden />
+            <p className="pair-p">
+              <strong>Waiting for someone at the computer.</strong> The request is on screen there,
+              showing this device’s name and the same code you typed. It has to be accepted before
+              this phone gets access to anything.
+            </p>
+          </>
+        )}
+
+        {stage === "rejected" && (
+          <>
+            <p className="pair-p pair-bad">The request was declined at the computer.</p>
+            <p className="pair-hint">Nothing was granted. If that was a mistake, start a new invitation there and scan again.</p>
+          </>
+        )}
+
+        {stage === "expired" && (
+          <>
+            <p className="pair-p pair-bad">{err ?? "This invitation is no longer open."}</p>
+            <p className="pair-hint">
+              Invitations last two minutes and are good for one device. On the computer, open
+              Settings ▸ Remote access and start a new one.
+            </p>
+          </>
+        )}
+
+        {stage === "failed" && <p className="pair-p pair-bad">{err}</p>}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/PairPanel.tsx
+++ b/web/src/components/PairPanel.tsx
@@ -1,0 +1,343 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { api } from "../lib/api.ts";
+import { qrMatrix, qrSvgPath } from "../lib/qr.ts";
+import { fmtAgo } from "../lib/format.ts";
+import type { DeviceScope, PairedDevice, PairRequest, PairState } from "../../../shared/types.ts";
+
+/**
+ * Adding a phone, from the machine's side.
+ *
+ * This replaced a QR code that *was* the credential. Scanning it handed over
+ * `AGENTGLASS_TOKEN` — the machine's own secret, with no expiry, no identity
+ * and no way to take it back from one device — which meant a photograph of
+ * this pane, a screenshot in a chat or a shared window in a call was a working
+ * key to a terminal. There was no way to scan it carefully; being able to see
+ * it was the whole authorisation.
+ *
+ * The QR now carries an invitation, and an invitation is worth nothing on its
+ * own. Between it and a credential are the two steps this panel exists to
+ * make visible:
+ *
+ *   * **six digits that are only on this screen.** They are not in the QR, so
+ *     scanning it from a picture gets you a form asking for something the
+ *     picture does not contain.
+ *   * **a person here saying yes.** The request arrives named, with the
+ *     address it came from and the same code, and waits.
+ *
+ * The full protocol, and what it does and does not defend against, is in
+ * server/src/pairing.ts.
+ */
+export function PairPanel({ baseUrl }: { baseUrl: string }) {
+  const [ticket, setTicket] = useState<{ id: string; code: string; expiresAt: number } | null>(null);
+  const [state, setState] = useState<PairState>({ ticket: null, pending: [], devices: [] });
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+  const [now, setNow] = useState(() => Date.now());
+  /**
+   * Which invitation is open, as a ref rather than only as state.
+   *
+   * Two things read it outside a render, and both were wrong when it was
+   * derived from `ticket` alone. The unmount cleanup has to cancel whatever is
+   * open *at that moment*, not what was open when the effect ran. And the poll
+   * that `start` fires immediately runs before React has re-rendered, so it
+   * read `null`, asked the server about no ticket, was told there is none, and
+   * cleared the invitation it had just minted — a button that visibly did
+   * nothing. Writing the id here the moment it exists is what makes both
+   * readers see the same answer as the render does.
+   */
+  const live = useRef<string | null>(null);
+  live.current = ticket?.id ?? null;
+
+  const poll = useCallback(async (id?: string) => {
+    const want = id ?? live.current ?? "";
+    try {
+      const s = await api.pairState(want);
+      setState(s);
+      // The server is the authority on whether the invitation is still open —
+      // it expires there. Following its answer is what makes the QR disappear
+      // when the code behind it stops working, instead of leaving one on
+      // screen that leads to "this invitation has expired".
+      setTicket(s.ticket);
+    } catch { /* the sidecar restarts when remote access is toggled */ }
+  }, []);
+
+  useEffect(() => {
+    poll();
+    const t = setInterval(poll, 2000);
+    // A second timer only for the countdown, so the digits tick every second
+    // without asking the server sixty times a minute.
+    const c = setInterval(() => setNow(Date.now()), 1000);
+    return () => { clearInterval(t); clearInterval(c); };
+  }, [poll]);
+
+  // Closing the pane closes the invitation. A QR left live because a window was
+  // shut is exactly the code somebody scans off a screenshot later.
+  useEffect(() => () => { if (live.current) void api.pairCancel(live.current); }, []);
+
+  const start = async () => {
+    setBusy(true);
+    setErr(null);
+    if (live.current) await api.pairCancel(live.current).catch(() => null);
+    const r = await api.pairTicket().catch(() => null);
+    setBusy(false);
+    if (!r?.ok || !r.id || !r.code) { setErr(r?.error ?? "Could not start an invitation."); return; }
+    live.current = r.id; // before anything can poll for it — see the ref above
+    setTicket({ id: r.id, code: r.code, expiresAt: r.expiresAt ?? Date.now() });
+    poll(r.id);
+  };
+
+  const decide = async (req: PairRequest, scope: DeviceScope | null) => {
+    setBusy(true);
+    if (scope) await api.pairAccept(req.id, scope).catch(() => null);
+    else await api.pairReject(req.id).catch(() => null);
+    setBusy(false);
+    poll();
+  };
+
+  const forget = async (d: PairedDevice) => {
+    setBusy(true);
+    await api.pairForget(d.id).catch(() => null);
+    setBusy(false);
+    poll();
+  };
+
+  const left = ticket ? Math.max(0, Math.round((ticket.expiresAt - now) / 1000)) : 0;
+  const pairUrl = ticket ? `${baseUrl.replace(/\/$/, "")}/?pair=${encodeURIComponent(ticket.id)}` : "";
+
+  return (
+    <div className="flex flex-col gap-2.5">
+      <div className="flex items-center gap-2">
+        <span className="text-[10px] t-dim2 uppercase tracking-wider flex-1">Connect a phone</span>
+        {ticket && (
+          <button onClick={start} disabled={busy}
+            className="text-[10px] px-2 py-0.5 rounded-md hover:opacity-80"
+            style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+            New code
+          </button>
+        )}
+      </div>
+
+      {/* Requests come before the invitation. Somebody standing with a phone in
+          their hand waiting to be let in is more urgent than the code, and a
+          decision buried under a QR is one that gets made late or not at all. */}
+      {state.pending.map((req) => (
+        <Request key={req.id} req={req} busy={busy} onDecide={decide} />
+      ))}
+
+      {!ticket ? (
+        <button onClick={start} disabled={busy}
+          className="tile w-full !flex-row !items-center !gap-3 text-left hover:bg-white/5 px-3 py-2.5">
+          <span className="text-[15px]" aria-hidden>📱</span>
+          <span className="min-w-0 flex-1">
+            <span className="block text-[12.5px]" style={{ color: "var(--text)" }}>
+              {busy ? "Starting…" : "Show a pairing code"}
+            </span>
+            <span className="block text-[10.5px] t-dim2 mt-0.5">
+              A QR code and six digits, good for two minutes and one device.
+            </span>
+          </span>
+        </button>
+      ) : (
+        <div className="flex items-start gap-3.5">
+          <div className="shrink-0 flex flex-col items-center gap-1.5">
+            <Qr text={pairUrl} />
+            <span className="text-[10px] t-dim2">Scan with the camera</span>
+          </div>
+          <div className="min-w-0 flex-1 flex flex-col gap-1.5">
+            <span className="text-[10px] t-dim2 uppercase tracking-wider">Then type this on the phone</span>
+            {/* The biggest thing in the pane. It is being read off this screen
+                and copied onto another one, and every point of size is a
+                mis-typed digit that costs one of five attempts. */}
+            <div className="t-mono select-all" style={{
+              fontSize: 30, letterSpacing: "0.24em", color: "var(--text)", lineHeight: 1.15,
+            }}>
+              {ticket.code}
+            </div>
+            <div className="text-[10.5px]" style={{ color: left <= 20 ? "var(--warning)" : "var(--text3)" }}>
+              {left > 0 ? `Expires in ${left}s` : "Expired — start a new one"}
+            </div>
+            <div className="text-[10.5px] t-dim2">
+              The code is not in the QR. Scanning it from a photo or a shared screen gets no further
+              than asking for these six digits.
+            </div>
+          </div>
+        </div>
+      )}
+
+      {err && <div className="text-[10.5px]" style={{ color: "var(--error)" }}>{err}</div>}
+
+      <Paired devices={state.devices} busy={busy} onForget={forget} />
+    </div>
+  );
+}
+
+/**
+ * A phone asking to be let in.
+ *
+ * Everything known about it is on the card, because the decision is "is this
+ * mine" and nothing else can answer that: the name it gave, the address it
+ * came from, and the code — so the person here can check the six digits on the
+ * screen in their hand match the six on this one, which is what makes this a
+ * confirmation rather than a button that says yes.
+ */
+function Request({ req, busy, onDecide }: {
+  req: PairRequest; busy: boolean; onDecide: (r: PairRequest, s: DeviceScope | null) => void;
+}) {
+  const [scope, setScope] = useState<DeviceScope>("answer");
+  return (
+    <div className="flex flex-col gap-2 px-3 py-2.5 rounded-xl" style={{
+      background: "color-mix(in srgb, var(--primary) 9%, transparent)",
+      border: "1px solid color-mix(in srgb, var(--primary) 38%, transparent)",
+    }}>
+      <div className="flex items-center gap-2.5">
+        <span className="min-w-0 flex-1">
+          <span className="block text-[13px] font-medium truncate" style={{ color: "var(--text)" }}>
+            {req.label} wants to connect
+          </span>
+          <span className="block text-[10.5px] t-dim2 truncate">
+            {req.agent ? `${req.agent.slice(0, 80)} · ` : ""}from {req.ip || "an unknown address"}
+          </span>
+        </span>
+        <span className="t-mono shrink-0" style={{ fontSize: 17, letterSpacing: "0.16em", color: "var(--text)" }}>
+          {req.code}
+        </span>
+      </div>
+
+      <div className="text-[10.5px] t-dim2">
+        Check those six digits are the ones on the phone. If they are not, this is not the device you
+        are holding — decline it.
+      </div>
+
+      {/* Chosen here rather than assumed, because this is the one moment
+          somebody is already thinking about what this device is for. The
+          default is the narrow one: a phone that answers gates does not need a
+          terminal, and a default of "everything" is how every device ends up
+          with everything. */}
+      <div className="flex flex-col gap-1">
+        <span className="text-[10px] t-dim2 uppercase tracking-wider">Give it</span>
+        {SCOPES.map((s) => (
+          <label key={s.key} className="flex items-start gap-2 px-2 py-1.5 rounded-lg cursor-pointer" style={{
+            background: scope === s.key ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+            border: `1px solid color-mix(in srgb, ${scope === s.key ? "var(--primary)" : "var(--border)"} ${scope === s.key ? 45 : 28}%, transparent)`,
+          }}>
+            <input type="radio" name={`scope-${req.id}`} checked={scope === s.key}
+              onChange={() => setScope(s.key)} className="mt-0.5" />
+            <span className="min-w-0">
+              <span className="block text-[11.5px]" style={{ color: "var(--text)" }}>{s.title}</span>
+              <span className="block text-[10px] t-dim2">{s.what}</span>
+            </span>
+          </label>
+        ))}
+      </div>
+
+      <div className="flex items-center gap-2">
+        <button onClick={() => onDecide(req, scope)} disabled={busy}
+          className="text-[11.5px] px-3 py-1.5 rounded-lg font-medium"
+          style={{ color: "var(--success)", background: "color-mix(in srgb, var(--success) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--success) 44%, transparent)" }}>
+          Accept
+        </button>
+        <button onClick={() => onDecide(req, null)} disabled={busy}
+          className="text-[11.5px] px-3 py-1.5 rounded-lg hover:opacity-80"
+          style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 38%, transparent)" }}>
+          Decline
+        </button>
+      </div>
+    </div>
+  );
+}
+
+/** The three levels, in the words that say what changes rather than what the
+ *  field is called. See server/src/devices.ts for why there are only three. */
+const SCOPES: { key: DeviceScope; title: string; what: string }[] = [
+  { key: "answer", title: "Answer things", what: "Everything below, plus approving gates and replying to a session that is already running. What a phone is for." },
+  { key: "read", title: "Look only", what: "Sessions, costs, changes, pull requests. It cannot approve anything or send anything." },
+  { key: "full", title: "Everything this machine can do", what: "A terminal, git write access, docker control, merging pull requests. Give this to a laptop you trust, not to a phone." },
+];
+
+const SCOPE_WORD: Record<DeviceScope, string> = {
+  read: "Look only",
+  answer: "Answers gates and replies",
+  full: "Full access — terminal, git, docker",
+};
+
+/**
+ * What is paired, and the button that ends one of them.
+ *
+ * The revoke that already existed rotates the machine's code, which kicks every
+ * device including the desk. Right when you have lost the code; far too big for
+ * "that tablet is in a drawer". Forgetting one device leaves the others alone,
+ * which is the difference between a control people use and one they put off.
+ */
+function Paired({ devices, busy, onForget }: {
+  devices: PairedDevice[]; busy: boolean; onForget: (d: PairedDevice) => void;
+}) {
+  const [confirming, setConfirming] = useState<string | null>(null);
+  if (!devices.length) return null;
+  return (
+    <div className="flex flex-col gap-1">
+      <span className="text-[10px] t-dim2 uppercase tracking-wider px-0.5">Paired devices</span>
+      {devices.map((d) => (
+        <div key={d.id} className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg" style={{
+          background: "color-mix(in srgb, var(--bg2) 60%, transparent)",
+          border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)",
+        }}>
+          <div className="min-w-0 flex-1">
+            <div className="text-[11.5px] truncate" style={{ color: "var(--text)" }}>{d.label}</div>
+            <div className="text-[10px] t-dim2">
+              {SCOPE_WORD[d.scope]} · {d.lastSeenAt ? `last used ${fmtAgo(d.lastSeenAt)}` : "not used yet"}
+            </div>
+          </div>
+          {confirming === d.id ? (
+            <div className="flex items-center gap-1.5 shrink-0">
+              <button onClick={() => { setConfirming(null); onForget(d); }} disabled={busy}
+                className="text-[10.5px] px-2 py-1 rounded-md"
+                style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>
+                Forget it
+              </button>
+              <button onClick={() => setConfirming(null)}
+                className="text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+                style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+                Keep
+              </button>
+            </div>
+          ) : (
+            <button onClick={() => setConfirming(d.id)}
+              className="shrink-0 text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+              style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 10%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 32%, transparent)" }}>
+              Forget
+            </button>
+          )}
+        </div>
+      ))}
+      <div className="text-[10px] t-dim2 px-0.5">
+        Forgetting a device revokes only its own credential and closes what it is holding. The others
+        keep working.
+      </div>
+    </div>
+  );
+}
+
+/** Drawn from the matrix rather than fetched: an image of the way in to this
+ *  machine has no business being a request to a third party. */
+function Qr({ text }: { text: string }) {
+  let path: string;
+  let size: number;
+  try {
+    const m = qrMatrix(text);
+    size = m.length;
+    path = qrSvgPath(m);
+  } catch {
+    return null; // longer than version 9 holds
+  }
+  const quiet = 4; // scanners need the margin, so it is part of the image
+  const span = size + quiet * 2;
+  return (
+    <svg
+      width={140} height={140} viewBox={`0 0 ${span} ${span}`} shapeRendering="crispEdges"
+      role="img" aria-label="QR code for the pairing invitation"
+      className="shrink-0 rounded-lg"
+      style={{ background: "#fff", padding: 0 }}>
+      <path d={path} transform={`translate(${quiet} ${quiet})`} fill="#000" />
+    </svg>
+  );
+}

--- a/web/src/components/RemoteAccessPane.tsx
+++ b/web/src/components/RemoteAccessPane.tsx
@@ -3,7 +3,8 @@ import { api } from "../lib/api.ts";
 import { IS_DESKTOP, remoteAccessEnabled, setRemoteAccess, revokeRemoteAccess } from "../lib/desktop.ts";
 import { qrMatrix, qrSvgPath } from "../lib/qr.ts";
 import { fmtAgo } from "../lib/format.ts";
-import { pickIndex, readPick, writePick, maskToken, type PickedAddress } from "../lib/remoteLink.ts";
+import { pickIndex, readPick, writePick, type PickedAddress } from "../lib/remoteLink.ts";
+import { PairPanel } from "./PairPanel.tsx";
 import type { RemoteStatus, RemoteDevice } from "../../../shared/types.ts";
 
 /**
@@ -35,9 +36,6 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
   // Revoking cannot be undone and cannot be partially done, so it asks once.
   const [confirming, setConfirming] = useState(false);
   const [revokeNote, setRevokeNote] = useState<string | null>(null);
-  // The access code is covered until asked for: this pane is the one that ends
-  // up in screenshots. See maskToken.
-  const [reveal, setReveal] = useState(false);
 
   const load = useCallback(() => {
     api.remoteStatus().then(setSt).catch(() => setSt(null));
@@ -155,84 +153,64 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
 
         {live && (
           <>
-            {/* The link, given the room it needs: the code beside the QR
-                rather than under it, and the routes to this machine as a
-                column of real choices instead of a row of small pills. At the
-                old width all of this wrapped into a stack you had to scroll. */}
-            <div className="flex items-start gap-3.5">
-              <div className="shrink-0 flex flex-col items-center gap-1.5">
-                <Qr text={url} />
-                <span className="text-[10px] t-dim2">Scan with the camera</span>
-              </div>
+            {/* Pairing comes first, because it is what this pane is for. The
+                address below it is a fallback for a device that cannot scan;
+                it is only an address, and on its own it opens a page that asks
+                for a code. */}
+            <PairPanel baseUrl={url} />
 
-              <div className="min-w-0 flex-1 flex flex-col gap-2.5">
-                <div className="flex flex-col gap-1.5">
-                  <div className="flex items-center gap-2">
-                    <span className="text-[10px] t-dim2 uppercase tracking-wider flex-1">The link</span>
-                    {/* The QR always carries the real code — a masked one would
-                        not scan. This only covers the text a screenshot keeps. */}
-                    {url.includes("token=") && (
-                      <button onClick={(e) => { e.stopPropagation(); setReveal((v) => !v); }}
-                        className="text-[10px] px-2 py-0.5 rounded-md hover:opacity-80"
-                        style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
-                        {reveal ? "Hide code" : "Show code"}
-                      </button>
-                    )}
-                  </div>
-                  <button onClick={() => copy(url)}
-                    className="t-mono text-[11px] text-left px-2.5 py-2 rounded-lg break-all hover:opacity-80"
-                    style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>
-                    {reveal ? url : maskToken(url)}
-                  </button>
-                  <div className="text-[10px] t-dim2">
-                    {copied === url
-                      ? "Copied, code included"
-                      : "Click to copy, code included. The phone needs it once and then remembers it."}
-                  </div>
-                </div>
-
-                {/* More than one route to this machine is normal (wifi plus a
-                    tailnet), and they are not equivalent — one crosses a café,
-                    the other does not. Each says what it is rather than making
-                    the user infer it from an address, and the choice is kept
-                    (see remoteLink.ts) because the pane used to forget it. */}
-                {st.addresses.length > 1 && (
-                  <div className="flex flex-col gap-1.5">
-                    <span className="text-[10px] t-dim2 uppercase tracking-wider">Reachable at</span>
-                    <div className="flex flex-col gap-1">
-                      {st.addresses.map((a, i) => {
-                        const on = i === pick;
-                        return (
-                          <button key={a.address} onClick={() => { setChosen(a); writePick(a); }}
-                            className="flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left hover:opacity-90"
-                            style={{
-                              background: on ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
-                              border: `1px solid color-mix(in srgb, ${on ? "var(--primary)" : "var(--border)"} ${on ? 45 : 30}%, transparent)`,
-                            }}>
-                            <span className="shrink-0 rounded-full" aria-hidden style={{
-                              width: 6, height: 6,
-                              background: on ? "var(--primary-hover)" : "transparent",
-                              border: on ? "none" : "1px solid var(--text4)",
-                            }} />
-                            <span className="min-w-0 flex-1">
-                              <span className="block text-[11.5px]" style={{ color: on ? "var(--text)" : "var(--text2)" }}>
-                                {a.tailnet ? "Tailscale" : a.iface}
-                                <span className="t-mono text-[10.5px] t-dim2"> {a.address}</span>
-                              </span>
-                              <span className="block text-[10px] t-dim2">
-                                {a.tailnet
-                                  ? "Works from anywhere, for devices signed into your tailnet."
-                                  : "Works for anything on this network, and only there."}
-                              </span>
-                            </span>
-                          </button>
-                        );
-                      })}
-                    </div>
-                  </div>
-                )}
+            <div className="flex flex-col gap-1.5">
+              <span className="text-[10px] t-dim2 uppercase tracking-wider">Or type this address</span>
+              <button onClick={() => copy(url)}
+                className="t-mono text-[11px] text-left px-2.5 py-2 rounded-lg break-all hover:opacity-80"
+                style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}>
+                {url}
+              </button>
+              <div className="text-[10px] t-dim2">
+                {copied === url ? "Copied" : "Safe to share — it is an address, not a key. Opening it on a device that is not paired gets a page and nothing else."}
               </div>
             </div>
+
+            {/* More than one route to this machine is normal (wifi plus a
+                tailnet), and they are not equivalent — one crosses a café,
+                the other does not. Each says what it is rather than making
+                the user infer it from an address, and the choice is kept
+                (see remoteLink.ts) because the pane used to forget it. */}
+            {st.addresses.length > 1 && (
+              <div className="flex flex-col gap-1.5">
+                <span className="text-[10px] t-dim2 uppercase tracking-wider">Reachable at</span>
+                <div className="flex flex-col gap-1">
+                  {st.addresses.map((a, i) => {
+                    const on = i === pick;
+                    return (
+                      <button key={a.address} onClick={() => { setChosen(a); writePick(a); }}
+                        className="flex items-center gap-2.5 px-2.5 py-1.5 rounded-lg text-left hover:opacity-90"
+                        style={{
+                          background: on ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent",
+                          border: `1px solid color-mix(in srgb, ${on ? "var(--primary)" : "var(--border)"} ${on ? 45 : 30}%, transparent)`,
+                        }}>
+                        <span className="shrink-0 rounded-full" aria-hidden style={{
+                          width: 6, height: 6,
+                          background: on ? "var(--primary-hover)" : "transparent",
+                          border: on ? "none" : "1px solid var(--text4)",
+                        }} />
+                        <span className="min-w-0 flex-1">
+                          <span className="block text-[11.5px]" style={{ color: on ? "var(--text)" : "var(--text2)" }}>
+                            {a.tailnet ? "Tailscale" : a.iface}
+                            <span className="t-mono text-[10.5px] t-dim2"> {a.address}</span>
+                          </span>
+                          <span className="block text-[10px] t-dim2">
+                            {a.tailnet
+                              ? "Works from anywhere, for devices signed into your tailnet. Encrypted end to end, which is the one this pane recommends."
+                              : "Works for anything on this network, and only there. Not encrypted — see below."}
+                          </span>
+                        </span>
+                      </button>
+                    );
+                  })}
+                </div>
+              </div>
+            )}
 
             {/* Turning it on is a real decision, so the consequence is stated
                 in the words it deserves rather than as "advanced". The
@@ -247,11 +225,13 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
               border: "1px solid color-mix(in srgb, var(--warning) 30%, transparent)",
             }}>
               {address?.tailnet
-                ? <>Whoever holds this link gets a terminal, git write access and docker control on this
-                    machine. Over Tailscale that is limited to devices signed into your tailnet, which is the
-                    safer of the two links on offer. It is still a shell: treat the code like a house key.</>
-                : <>Anyone on this network who has this link gets a terminal, git write access and docker
-                    control on this machine. Fine at home. Not on café or airport wifi.</>}
+                ? <>Over Tailscale this is encrypted end to end and reaches only devices signed into your
+                    tailnet, which makes it the safer of the two routes and the one to use on wifi you do not
+                    own. Each paired device still gets exactly what you granted it, and nothing more.</>
+                : <>This runs over plain HTTP, so everything between a phone and this machine is readable by
+                    anything else on the network. Pairing keeps the credential itself out of that — it is
+                    encrypted to the device that asked for it — but what it fetches afterwards is not. Fine
+                    at home. On café or airport wifi, use the Tailscale route instead.</>}
             </div>
 
             <Devices st={st} onCopy={copy} copied={copied} onChanged={load} />

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -636,3 +636,85 @@
 @media (prefers-reduced-motion: reduce) {
   @keyframes agx-attention { 0%, 100% { box-shadow: none; } }
 }
+
+/* --- connecting a device (PairScreen) ---------------------------------------
+
+   Its own small stylesheet rather than the phone's, because it runs before
+   either application does: at this point the page holds no credential, so
+   every fetch the cockpit or the companion would make on mount is a 401. It
+   also runs on a desktop browser when somebody opens the link on a laptop, so
+   it centres rather than filling.
+
+   Sized for a thumb and a numeric keypad. The code field is the largest thing
+   on the screen on purpose — it is the one thing being asked for, and typing
+   six digits into a small box while comparing them to another screen is where
+   this goes wrong. */
+.pair-wrap {
+  min-height: 100dvh;
+  display: flex; align-items: center; justify-content: center;
+  padding: 24px 16px calc(24px + env(safe-area-inset-bottom));
+  background: var(--bg);
+}
+.pair-card {
+  width: 100%; max-width: 380px;
+  display: flex; flex-direction: column; gap: 10px;
+  padding: 22px 20px;
+  border-radius: 16px;
+  background: color-mix(in srgb, var(--panel) 80%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+}
+.pair-mark { font-size: 26px; line-height: 1; }
+.pair-h1 { font-size: 19px; font-weight: 600; color: var(--text); margin: 0; }
+.pair-p { font-size: 13px; line-height: 1.5; color: var(--text2); margin: 0; }
+.pair-bad { color: var(--error); }
+.pair-hint { font-size: 11px; line-height: 1.45; color: var(--text3); }
+.pair-label {
+  font-size: 10px; text-transform: uppercase; letter-spacing: 0.06em;
+  color: var(--text3); margin-top: 6px;
+}
+.pair-input {
+  width: 100%;
+  /* 16px is the threshold below which iOS Safari zooms the viewport on focus,
+     which on this screen scrolls the code you are copying out of view. */
+  font-size: 16px;
+  padding: 11px 12px;
+  border-radius: 10px;
+  color: var(--text);
+  background: color-mix(in srgb, var(--bg) 70%, transparent);
+  border: 1px solid color-mix(in srgb, var(--border) 55%, transparent);
+}
+.pair-input:focus { outline: none; border-color: color-mix(in srgb, var(--primary) 55%, transparent); }
+.pair-code {
+  font-family: var(--font-mono, ui-monospace, monospace);
+  font-size: 30px; letter-spacing: 0.28em; text-align: center;
+  padding: 12px 8px;
+}
+/* At this size the browser's default placeholder contrast is not enough: the
+   hint reads as six digits that are already there, and the first thing anyone
+   does with a filled-looking code field is press the button. */
+.pair-code::placeholder { color: var(--text4); opacity: 0.35; }
+.pair-go {
+  margin-top: 6px;
+  min-height: 46px;
+  border-radius: 12px;
+  font-size: 14px; font-weight: 600;
+  color: var(--primary-contrast, #fff);
+  background: var(--primary);
+  border: 1px solid color-mix(in srgb, var(--primary) 70%, transparent);
+}
+.pair-go:disabled { opacity: 0.45; }
+.pair-err {
+  font-size: 12px; line-height: 1.45;
+  color: var(--error);
+  padding: 8px 10px; border-radius: 9px;
+  background: color-mix(in srgb, var(--error) 10%, transparent);
+  border: 1px solid color-mix(in srgb, var(--error) 30%, transparent);
+}
+@keyframes agx-pair-spin { to { transform: rotate(360deg); } }
+.pair-spin {
+  width: 22px; height: 22px; border-radius: 50%;
+  border: 2px solid color-mix(in srgb, var(--border) 60%, transparent);
+  border-top-color: var(--primary);
+  animation: agx-pair-spin 0.9s linear infinite;
+}
+@media (prefers-reduced-motion: reduce) { .pair-spin { animation: none; } }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -418,6 +418,27 @@ const realApi = {
    *  as well as refusing what it sends next; only this machine may call it. */
   remoteDevice: (address: string, blocked: boolean) =>
     post<{ ok: boolean; address?: string; blocked?: boolean; closed?: number; error?: string }>("/remote/device", { address, blocked }),
+
+  // --- pairing a device: the machine's half. See server/src/pairing.ts.
+  //
+  // Every one of these is refused unless it comes from loopback *and* carries
+  // the machine's token, because the three things they do — start an
+  // invitation, read the code, accept a request — are the three that have to
+  // happen where the user is sitting.
+
+  /** Start an invitation: a ticket for the QR and a code for the screen. */
+  pairTicket: () => post<{ ok: boolean; id?: string; code?: string; expiresAt?: number; error?: string }>("/pair/ticket", {}),
+  /** Close one early — when the pane is shut, or a fresh code is asked for. */
+  pairCancel: (ticket: string) => post<{ ok: boolean }>("/pair/cancel", { ticket }),
+  /** The live invitation, the requests waiting on a decision, and what is
+   *  already paired — one poll, because the pane shows all three at once. */
+  pairState: (ticket: string) => get<PairState>(`/pair/state?ticket=${encodeURIComponent(ticket)}`),
+  pairAccept: (ticket: string, scope: DeviceScope) =>
+    post<{ ok: boolean; device?: PairedDevice; error?: string }>("/pair/accept", { ticket, scope }),
+  pairReject: (ticket: string) => post<{ ok: boolean }>("/pair/reject", { ticket }),
+  /** Revoke one device's credential and close what it is holding. */
+  pairForget: (id: string) => post<{ ok: boolean; closed?: number; error?: string }>("/pair/forget", { id }),
+
   updateStatus: () => get<UpdateStatus>("/update/status"),
   // The tag is optional because the automatic modal wants "whatever this build
   // came from", while About asks for a named release — the update it is about
@@ -701,6 +722,14 @@ const demoApi: typeof realApi = {
   updateNotes: (_tag?: string) => D({ ok: false, tag: "", notes: "", source: "", error: "not available in the demo" } as ReleaseNotes),
   remoteStatus: () => D({ exposed: false, bind: "127.0.0.1", port: 4000, trustLan: false, tokenRequired: false, webUi: true, urls: [], addresses: [], clients: { count: 0, lastAt: null, addresses: [], liveCount: 0 }, devices: [], firewall: null } as RemoteStatus),
   remoteDevice: (_address: string, _blocked: boolean) => D({ ok: false, error: "not available in the demo" }),
+  // Pairing needs a machine on the other end of it. The demo has none, and a
+  // QR that cannot lead anywhere is worse than an absent one.
+  pairTicket: () => D({ ok: false, error: "not available in the demo" }),
+  pairCancel: (_ticket: string) => D({ ok: false }),
+  pairState: (_ticket: string) => D({ ticket: null, pending: [], devices: [] } as PairState),
+  pairAccept: (_ticket: string, _scope: DeviceScope) => D({ ok: false, error: "not available in the demo" }),
+  pairReject: (_ticket: string) => D({ ok: false }),
+  pairForget: (_id: string) => D({ ok: false, error: "not available in the demo" }),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),
   updateRun: () => D({ ok: false, error: "not available in the demo" }),
   hooksStatus: () => D({ installed: false, bundled: false, settingsPath: "~/.claude/settings.json", python: "python3" } as HookSetupStatus),

--- a/web/src/lib/pairing.ts
+++ b/web/src/lib/pairing.ts
@@ -1,0 +1,196 @@
+import { SERVER } from "./api.ts";
+
+/**
+ * The phone's half of pairing. The protocol, and why it has this shape, is in
+ * `server/src/pairing.ts`; this is the side that holds the key.
+ *
+ * The one thing worth repeating here is what this file is for: **the credential
+ * must never exist in a form anything but this browser can read.** The server
+ * seals it to a key generated on this device, for this pairing, and thrown away
+ * afterwards. Everything else — the ticket in the QR, the six digits, the
+ * public keys — can be read off the wire by anything on the network without
+ * getting a working key out of it, which matters because the server speaks
+ * plain HTTP over the LAN.
+ *
+ * So the private key is generated non-extractable and never leaves WebCrypto.
+ * There is no code path in this file that could send it anywhere, because
+ * there is no code path anywhere that could get it out.
+ */
+
+/** Must match INFO in server/src/pairing.ts — a key derived for one purpose
+ *  must not be usable for another, which is what the string is doing. */
+const INFO = "agentglass-pair-v1";
+
+const enc = new TextEncoder();
+const dec = new TextDecoder();
+
+const b64url = (b: ArrayBuffer | Uint8Array): string => {
+  const bytes = b instanceof Uint8Array ? b : new Uint8Array(b);
+  let s = "";
+  for (const x of bytes) s += String.fromCharCode(x);
+  return btoa(s).replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+};
+
+/** Plain `ArrayBuffer`, not a view: every WebCrypto argument below wants a
+ *  `BufferSource`, and a `Uint8Array` over a possibly-shared buffer is not one
+ *  as far as the type system is concerned. */
+const unb64url = (s: string): ArrayBuffer => {
+  const raw = atob(s.replace(/-/g, "+").replace(/_/g, "/"));
+  const out = new Uint8Array(raw.length);
+  for (let i = 0; i < raw.length; i++) out[i] = raw.charCodeAt(i);
+  return out.buffer;
+};
+
+/** The same, for text. */
+const utf8 = (s: string): ArrayBuffer => {
+  const u = enc.encode(s);
+  return u.buffer.slice(u.byteOffset, u.byteOffset + u.byteLength) as ArrayBuffer;
+};
+
+/** The invitation this page was opened with, if any. `?pair=<id>` is what the
+ *  QR on the computer encodes; the id alone authorises nothing. */
+export function ticketFromUrl(href: string): string | null {
+  try {
+    const v = new URL(href).searchParams.get("pair");
+    return v && v.trim() ? v.trim() : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Take `?pair=` back out of the address bar once it has been used, so a
+ *  reload does not restart a handshake that has already finished. */
+export function clearTicketFromUrl(): void {
+  try {
+    const u = new URL(location.href);
+    if (!u.searchParams.has("pair")) return;
+    u.searchParams.delete("pair");
+    history.replaceState(null, "", u.pathname + u.search + u.hash);
+  } catch { /* no history API — the parameter is harmless once spent */ }
+}
+
+export interface PairKeys {
+  /** Uncompressed P-256 point, base64url. Safe to send; it is a public key. */
+  pub: string;
+  /** Non-extractable. This is the only thing that can open the credential. */
+  priv: CryptoKey;
+}
+
+/** A keypair for one pairing, and one pairing only. */
+export async function makeKeys(subtle: SubtleCrypto = crypto.subtle): Promise<PairKeys> {
+  const kp = await subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);
+  const raw = await subtle.exportKey("raw", kp.publicKey);
+  return { pub: b64url(raw), priv: kp.privateKey };
+}
+
+export interface Sealed { pub: string; iv: string; data: string }
+
+/**
+ * Open what the server sealed.
+ *
+ * ECDH against the server's ephemeral key, HKDF to a content key with the
+ * ticket id as salt, AES-256-GCM. Every parameter has to match the server
+ * exactly; GCM's tag means a mismatch throws rather than returning plausible
+ * rubbish, which is the behaviour worth having when the alternative is storing
+ * a corrupt credential and failing later with an unrelated 401.
+ */
+export async function unseal(
+  sealed: Sealed, priv: CryptoKey, ticketId: string, subtle: SubtleCrypto = crypto.subtle,
+): Promise<string> {
+  const serverPub = await subtle.importKey(
+    "raw", unb64url(sealed.pub), { name: "ECDH", namedCurve: "P-256" }, false, [],
+  );
+  const shared = await subtle.deriveBits({ name: "ECDH", public: serverPub }, priv, 256);
+  const ikm = await subtle.importKey("raw", shared, "HKDF", false, ["deriveBits"]);
+  const bits = await subtle.deriveBits(
+    { name: "HKDF", hash: "SHA-256", salt: utf8(ticketId), info: utf8(INFO) },
+    ikm, 256,
+  );
+  const key = await subtle.importKey("raw", bits, { name: "AES-GCM" }, false, ["decrypt"]);
+  const plain = await subtle.decrypt(
+    { name: "AES-GCM", iv: unb64url(sealed.iv) }, key, unb64url(sealed.data),
+  );
+  return dec.decode(plain);
+}
+
+/**
+ * A name for this device, guessed so the field is not empty.
+ *
+ * Only ever a starting point — the field is editable, and the guess is
+ * deliberately the vague kind. "iPhone" is a name somebody will recognise in a
+ * list next week; a browser build string is not, and a confidently wrong model
+ * is worse than either, because the list it lands in is the one used to decide
+ * what to cut off.
+ */
+export function guessName(ua: string = navigator.userAgent): string {
+  if (/\biPhone\b/.test(ua)) return "iPhone";
+  if (/\biPad\b/.test(ua)) return "iPad";
+  if (/\bAndroid\b/.test(ua)) return "Android phone";
+  if (/\bMacintosh\b/.test(ua)) return "Mac";
+  if (/\bWindows NT\b/.test(ua)) return "Windows PC";
+  return "My device";
+}
+
+export type ClaimOutcome =
+  | { ok: true; secret: string }
+  | { ok: false; error: string; fatal: boolean };
+
+/** Type the code. A wrong one is worth retrying; everything else is not, and
+ *  saying so is the difference between "try again" and "go to the computer". */
+export async function claim(
+  ticket: string, code: string, label: string, pub: string,
+): Promise<ClaimOutcome> {
+  let r: Response;
+  try {
+    r = await fetch(SERVER + "/pair/claim", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ ticket, code, label, pub }),
+    });
+  } catch {
+    return { ok: false, error: "Could not reach the computer. Check you are on the same network.", fatal: false };
+  }
+  const j = await r.json().catch(() => ({}) as Record<string, unknown>);
+  if (r.ok && (j as { ok?: boolean }).ok) return { ok: true, secret: String((j as { secret?: string }).secret ?? "") };
+  const reason = String((j as { reason?: string }).reason ?? "");
+  return {
+    ok: false,
+    error: String((j as { error?: string }).error ?? "That did not work."),
+    // Only a wrong code leaves the invitation alive. Everything else has
+    // consumed or closed it, and re-typing into a dead ticket is a loop.
+    fatal: reason !== "code",
+  };
+}
+
+export type CollectOutcome =
+  | { state: "claimed" }
+  | { state: "accepted"; token: string; scope: string; label: string }
+  | { state: "rejected" }
+  | { state: "unknown" };
+
+/** Ask once whether somebody has decided yet, and unwrap if they said yes. */
+export async function collectOnce(
+  ticket: string, secret: string, priv: CryptoKey,
+): Promise<CollectOutcome> {
+  let r: Response;
+  try {
+    r = await fetch(`${SERVER}/pair/collect?ticket=${encodeURIComponent(ticket)}&secret=${encodeURIComponent(secret)}`);
+  } catch {
+    return { state: "claimed" }; // a blip while waiting is not a decision
+  }
+  const j = (await r.json().catch(() => ({}))) as { state?: string; wrapped?: Sealed; scope?: string; label?: string };
+  if (j.state === "accepted" && j.wrapped) {
+    // If this throws, the credential is not recoverable — the server has
+    // already destroyed the ticket. Reported as unknown so the screen offers a
+    // fresh start rather than a retry that cannot succeed.
+    try {
+      const token = await unseal(j.wrapped, priv, ticket);
+      return { state: "accepted", token, scope: j.scope ?? "answer", label: j.label ?? "" };
+    } catch {
+      return { state: "unknown" };
+    }
+  }
+  if (j.state === "rejected") return { state: "rejected" };
+  if (j.state === "claimed") return { state: "claimed" };
+  return { state: "unknown" };
+}

--- a/web/src/lib/remoteLink.ts
+++ b/web/src/lib/remoteLink.ts
@@ -69,20 +69,3 @@ export function pickIndex(addresses: readonly PickedAddress[], saved: PickedAddr
   const sameKind = addresses.findIndex((a) => a.tailnet === saved.tailnet);
   return sameKind >= 0 ? sameKind : 0;
 }
-
-/**
- * The same link with the access code covered up.
- *
- * This pane is the one people screenshot — it is where the QR code is, so it
- * is what gets sent to a colleague or pasted into an issue to ask why the
- * phone will not connect. The code in that URL is a working key to a terminal
- * on this machine, and it is legible in the picture. Covering it by default
- * costs a click on the rare occasion someone wants to read it out, and saves
- * the one occasion that matters.
- *
- * The QR itself still carries the real URL: a masked code would not scan, and
- * a photograph of a screen is a far smaller audience than a screenshot.
- */
-export function maskToken(url: string): string {
-  return url.replace(/([?&]token=)([^&#]+)/i, (_m, lead: string, secret: string) => `${lead}${"•".repeat(Math.min(12, Math.max(6, secret.length)))}`);
-}

--- a/web/src/main.tsx
+++ b/web/src/main.tsx
@@ -2,6 +2,9 @@ import React from "react";
 import ReactDOM from "react-dom/client";
 import App from "./App.tsx";
 import { MobileApp } from "./mobile/MobileApp.tsx";
+import { PairScreen } from "./PairScreen.tsx";
+import { adoptServer } from "./lib/api.ts";
+import { ticketFromUrl, clearTicketFromUrl } from "./lib/pairing.ts";
 import { phoneLayoutNow } from "./lib/viewport.ts";
 import { followServerChanges } from "./lib/desktop.ts";
 import { applyTheme, initialTheme, watchThemeStorage } from "./lib/themes.ts";
@@ -35,8 +38,36 @@ const Root = phone ? MobileApp : App;
 // revoked. Adopt the new origin/token in place rather than reloading the app.
 followServerChanges();
 
-ReactDOM.createRoot(document.getElementById("root")!).render(
-  <React.StrictMode>
-    <Root />
-  </React.StrictMode>
-);
+const root = ReactDOM.createRoot(document.getElementById("root")!);
+
+const mount = (tree: React.ReactNode) => root.render(<React.StrictMode>{tree}</React.StrictMode>);
+
+/**
+ * A page opened from the QR has a handshake to finish before it has an
+ * application.
+ *
+ * Decided out here rather than inside the apps, for the same reason the phone
+ * check is: this device holds no credential yet, so every request either tree
+ * makes on mount would come back 401 and the first thing the user would see is
+ * an app failing to load behind a pairing form.
+ *
+ * Handing the token to `adoptServer` rather than reloading means the app mounts
+ * straight into a working session — a reload here would drop the URL the QR
+ * carried and land somebody on a cold start with no explanation of what just
+ * happened.
+ */
+const invitation = ticketFromUrl(location.href);
+if (invitation) {
+  mount(
+    <PairScreen
+      ticket={invitation}
+      onPaired={(token) => {
+        adoptServer({ token });
+        clearTicketFromUrl();
+        mount(<Root />);
+      }}
+    />
+  );
+} else {
+  mount(<Root />);
+}

--- a/web/test/pairing.test.ts
+++ b/web/test/pairing.test.ts
@@ -1,0 +1,174 @@
+/*
+ * The phone's half of pairing.
+ *
+ * The one that matters is `unseal`: it has to open what the server sealed,
+ * across two entirely separate implementations of the same four steps — Node's
+ * `crypto` on one side, WebCrypto on the other. Every parameter (curve, salt,
+ * info string, tag placement) has to agree, and the failure when one does not
+ * is a device that pairs, appears in the list, and then cannot authenticate,
+ * which is a long way from here.
+ *
+ * So the server's real `sealTo` is imported and driven, rather than a fixture.
+ * A fixture would keep passing after a change to either side.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { sealTo } from "../../server/src/pairing.ts";
+
+// api.ts reads `location` at module scope to work out which server it talks to,
+// and pairing.ts imports its `SERVER`. Stubbed before the import rather than
+// after, because that read happens the moment the module is evaluated.
+(globalThis as any).location = { hostname: "localhost", origin: "http://localhost:4000" };
+
+const { unseal, makeKeys, guessName, ticketFromUrl } = await import("../src/lib/pairing.ts");
+
+const read = (p: string) => readFileSync(new URL("../" + p, import.meta.url), "utf8");
+
+describe("opening what the machine sealed", () => {
+  test("the credential arrives intact", async () => {
+    const k = await makeKeys();
+    const token = "a-credential-that-is-not-real-0000";
+    expect(await unseal(sealTo(k.pub, "ticket-id", token), k.priv, "ticket-id")).toBe(token);
+  });
+
+  test("a credential sealed to another device does not open", async () => {
+    // The property that makes polling with a stolen ticket id worthless: the
+    // wrap is to the key of whoever typed the code, and nobody else has it.
+    const mine = await makeKeys();
+    const theirs = await makeKeys();
+    expect(unseal(sealTo(theirs.pub, "t", "secret"), mine.priv, "t")).rejects.toThrow();
+  });
+
+  test("the ticket is part of the derivation, not just the address", async () => {
+    const k = await makeKeys();
+    expect(unseal(sealTo(k.pub, "the-real-ticket", "secret"), k.priv, "another")).rejects.toThrow();
+  });
+
+  test("tampering fails loudly rather than yielding something plausible", async () => {
+    // A corrupt credential stored and used later fails with an unrelated 401,
+    // a long way from the thing that broke.
+    const k = await makeKeys();
+    const w = sealTo(k.pub, "t", "secret");
+    const bytes = Buffer.from(w.data, "base64url");
+    bytes[0] = bytes[0]! ^ 0xff;
+    expect(unseal({ ...w, data: bytes.toString("base64url") }, k.priv, "t")).rejects.toThrow();
+  });
+
+  test("the key this device generates cannot be read out of it", async () => {
+    // Non-extractable, so there is no code path anywhere — in this file or in
+    // anything that imports it — that could send the private half somewhere.
+    const k = await makeKeys();
+    expect(k.priv.extractable).toBe(false);
+    expect(crypto.subtle.exportKey("raw", k.priv)).rejects.toThrow();
+  });
+
+  test("the public half is an uncompressed P-256 point, which is what the server checks", async () => {
+    const raw = Buffer.from((await makeKeys()).pub, "base64url");
+    expect(raw).toHaveLength(65);
+    expect(raw[0]).toBe(0x04);
+  });
+});
+
+describe("the invitation in the address bar", () => {
+  test("is read from ?pair=", () => {
+    expect(ticketFromUrl("http://192.168.1.20:5959/?pair=abc123")).toBe("abc123");
+    expect(ticketFromUrl("http://192.168.1.20:5959/?view=now&pair=abc123#x")).toBe("abc123");
+  });
+
+  test("and absent means there is no handshake to run", () => {
+    expect(ticketFromUrl("http://192.168.1.20:5959/")).toBeNull();
+    expect(ticketFromUrl("http://192.168.1.20:5959/?pair=")).toBeNull();
+    expect(ticketFromUrl("http://192.168.1.20:5959/?pair=%20%20")).toBeNull();
+    expect(ticketFromUrl("not a url at all")).toBeNull();
+  });
+});
+
+describe("naming this device", () => {
+  test("guesses something a person would recognise in a list next week", () => {
+    expect(guessName("Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) Safari/605")).toBe("iPhone");
+    expect(guessName("Mozilla/5.0 (iPad; CPU OS 17_5) Safari/605")).toBe("iPad");
+    expect(guessName("Mozilla/5.0 (Linux; Android 14; Pixel 8) Chrome/126")).toBe("Android phone");
+    expect(guessName("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) Chrome/126")).toBe("Mac");
+    expect(guessName("Mozilla/5.0 (Windows NT 10.0; Win64) Chrome/126")).toBe("Windows PC");
+  });
+
+  test("and says something rather than nothing when it cannot tell", () => {
+    // The field is editable; an empty one is a device called "" in the list
+    // used to decide what to cut off.
+    expect(guessName("")).toBe("My device");
+    expect(guessName("something nobody has seen")).toBe("My device");
+  });
+});
+
+/**
+ * Rules over the tree rather than about today's call sites.
+ *
+ * The screen exists to make two steps unmissable. A change that quietly drops
+ * one of them would leave every test above passing — they are about the
+ * cryptography, and the cryptography is not what makes this safe on its own.
+ */
+describe("the screen keeps its two steps", () => {
+  const screen = read("src/PairScreen.tsx");
+
+  test("asks for the code, and asks for it as digits", () => {
+    expect(screen).toContain("inputMode=\"numeric\"");
+    expect(screen).toContain("maxLength={6}");
+    // The button stays dead until all six are there, so a short code cannot
+    // spend one of five attempts.
+    expect(screen).toContain("code.length !== 6");
+  });
+
+  test("says a person has to accept, rather than implying the code was enough", () => {
+    expect(screen).toMatch(/Nothing is granted yet/);
+    expect(screen).toMatch(/Waiting for someone at the computer/);
+  });
+
+  test("never writes the credential anywhere itself", () => {
+    // It hands it to adoptServer (see main.tsx) and forgets it. A localStorage
+    // write here would be a second copy nothing else knows how to revoke.
+    expect(screen).not.toContain("localStorage");
+    expect(screen).not.toContain("console.");
+  });
+
+  test("closing the pane closes the invitation", () => {
+    // A QR left live because a window was shut is exactly the code somebody
+    // scans off a screenshot later.
+    const panel = read("src/components/PairPanel.tsx");
+    expect(panel).toMatch(/useEffect\(\(\) => \(\) => \{[^}]*pairCancel/);
+  });
+
+  test("a new invitation is recorded before anything polls for it", () => {
+    // Found by opening the pane: the button did nothing at all. The poll that
+    // `start` fires runs before React has re-rendered, so reading the ref found
+    // the *previous* value — null — asked the server about no invitation, was
+    // told there is none, and cleared the one it had just minted.
+    const panel = read("src/components/PairPanel.tsx");
+    const start = panel.slice(panel.indexOf("const start = async"), panel.indexOf("const decide ="));
+    expect(start).toContain("live.current = r.id");
+    expect(start).toContain("poll(r.id)");
+    expect(start.indexOf("live.current = r.id")).toBeLessThan(start.indexOf("poll(r.id)"));
+  });
+
+  test("the invitation the QR points at carries no code", () => {
+    // The entire reason the QR is safe to photograph. A pairing URL that also
+    // carried the digits would put this straight back where it started.
+    const panel = read("src/components/PairPanel.tsx");
+    const url = panel.match(/const pairUrl = [^;]+;/)?.[0] ?? "";
+    expect(url).toContain("?pair=");
+    expect(url).not.toContain("ticket.code");
+    // …and the QR draws that, rather than anything else on the panel.
+    expect(panel).toContain("<Qr text={pairUrl} />");
+  });
+
+  test("and the app does not mount behind it", () => {
+    // This device holds no credential during the handshake, so mounting either
+    // application would show an app failing to load behind a pairing form.
+    const main = read("src/main.tsx");
+    // The decision itself, not just the order the two branches appear in: a
+    // rule about text order survives `const invitation = null`, which is
+    // exactly the change that would mount the app behind the form.
+    expect(main).toContain("const invitation = ticketFromUrl(location.href);");
+    expect(main).toMatch(/if \(invitation\) \{[\s\S]*<PairScreen[\s\S]*\} else \{[\s\S]*mount\(<Root \/>\)/);
+    expect(main).toContain("adoptServer({ token })");
+  });
+});

--- a/web/test/remote-link.test.ts
+++ b/web/test/remote-link.test.ts
@@ -1,10 +1,14 @@
-// The Remote pane's two pure decisions: which address to offer back, and how
-// much of the link to put on screen. Both exist because of something that
-// happened rather than something imagined — a chosen tailnet address that
-// reverted to the LAN on every open, and an access code legible in a
-// screenshot.
+// The Remote pane's one pure decision: which of this machine's addresses to
+// offer back. It exists because of something that happened rather than
+// something imagined — a chosen tailnet address that reverted to the LAN on
+// every open.
+//
+// There used to be a second: how much of the link to cover up, because the
+// link carried the access code. Nothing hands a credential out in a URL any
+// more (see server/src/pairing.ts), so there is nothing left to mask — what
+// the pane shows is an address and only an address.
 import { describe, expect, test } from "bun:test";
-import { pickIndex, readPick, writePick, maskToken, type PickedAddress } from "../src/lib/remoteLink.ts";
+import { pickIndex, readPick, writePick, type PickedAddress } from "../src/lib/remoteLink.ts";
 
 const lan: PickedAddress = { address: "192.168.1.131", iface: "enp42s0", tailnet: false };
 const tail: PickedAddress = { address: "100.85.155.119", iface: "tailscale0", tailnet: true };
@@ -70,31 +74,5 @@ describe("remembering it", () => {
     // in the pane breaks.
     const throwing = { setItem: () => { throw new Error("denied"); } };
     expect(() => writePick(tail, throwing)).not.toThrow();
-  });
-});
-
-describe("masking the access code", () => {
-  test("covers the code and nothing else", () => {
-    // An obviously fake code on purpose: this file is public, and a realistic
-    // one is the kind of string that gets copied out of a test into a shell.
-    const masked = maskToken("http://192.168.1.131:4000/?token=EXAMPLE-not-a-real-access-code-0000");
-    expect(masked).toStartWith("http://192.168.1.131:4000/?token=");
-    expect(masked).not.toContain("EXAMPLE-not-a-real");
-    expect(masked).toMatch(/token=•+$/);
-  });
-
-  test("leaves a link that carries no code alone", () => {
-    expect(maskToken("http://192.168.1.131:4000/")).toBe("http://192.168.1.131:4000/");
-  });
-
-  test("keeps whatever follows the code", () => {
-    expect(maskToken("http://x:4000/?token=abc123&view=fleet")).toBe("http://x:4000/?token=••••••&view=fleet");
-  });
-
-  test("the mask length does not leak the code length", () => {
-    const short = maskToken("http://x:4000/?token=ab");
-    const long = maskToken("http://x:4000/?token=" + "a".repeat(64));
-    expect(short.split("=")[1]).toBe("••••••");
-    expect(long.split("=")[1]).toBe("••••••••••••");
   });
 });


### PR DESCRIPTION
Closes #435.

## What does this PR do?

Scanning the QR in **Settings ▸ Remote access** handed the phone `AGENTGLASS_TOKEN` itself — the machine's single shared secret, with no expiry, no identity and no way to take it back from one device. Three things followed from that, and all three are what this changes.

**Anyone who could see the screen was paired.** The QR *was* the credential, so a photograph of it, a screenshot in a chat, or a shared window in a call was a working shell on the laptop. There is no way to scan a code carefully — being able to see it was the whole authorisation.

**A lost phone could not be cut off.** One token meant revoking was rotating, and rotating kicked every device including the desk.

**Everything could do everything.** A phone that only ever approves gates had a terminal, git write access and docker control, because there was one level of access and it was "all of it".

### The handshake

The QR carries a **ticket** now: a public handle, worth nothing on its own. Three things have to be true before a credential exists.

| | | |
|---|---|---|
| 1 | **The scanner can see the screen** | It types six digits that are shown only at the machine and never travel in the QR. Five wrong guesses closes the invitation outright rather than refusing one attempt. Invitations last two minutes and are good for one device. |
| 2 | **A person at the machine agrees** | The request arrives in the Remote pane naming the device, the address it came from, and **the same six digits** — so the person accepting checks them against the phone in their hand. Its level is chosen there. |
| 3 | **The credential goes to that claimant and nobody else** | Sealed to a P-256 key the phone generated for this one pairing (ECDH → HKDF → AES-256-GCM, salted with the ticket) and collected exactly once, authorised by a secret only the claimant holds. |

Step 3 is what keeps this honest on a network without TLS, which is the normal case here — the server speaks plain HTTP over the LAN. Anything on that wifi running `tcpdump` sees the whole exchange (ticket, code, both public keys) and still has no key.

It does **not** defend against an active on-path attacker: someone who can rewrite traffic can substitute their own public key, and no handshake fixes that without an authenticated channel. That is a TLS problem, and the pane now says so where the choice between the LAN and the Tailscale address is made.

### Levels, and deny by default

A paired device is `read`, `answer` or `full`, defaulting to `answer`:

| Level | What it can do |
|---|---|
| `read` | Every GET, plus the POSTs that only read. Approves nothing, sends nothing. |
| `answer` | The above, plus `/gate/decide` and replying to a session that is already running. |
| `full` | Everything the machine can do: terminal, git write, docker, merging pull requests. |

Enforcement is **deny by default**: anything that changes state and is not named as a read or an answer needs `full`, so a route added next month is out of a paired phone's reach until somebody decides otherwise. A list of *forbidden* routes fails open every time it is not updated, and the thing it fails open on is a shell.

`/terminal/pty` is explicitly `full` despite arriving as a `GET` — a browser cannot put a header on a WebSocket upgrade, so it comes in as `?token=`, and a rule that trusted the method would hand a look-only device an interactive shell.

**Forget** one device and only that one stops: its credential is revoked, the sockets it is holding are closed, and every other device and the desk carry on. Rotating the machine's token is still there for when the code itself is lost, and still kicks everything.

`/remote/status` no longer carries the token in any field or any URL. It used to serve one to a caller on this machine because the QR *was* the token and the pane had to draw it; a link that grants a shell is exactly what ends up in a screenshot of the pane it is drawn in.

## How was it tested?

**45 mutations, all red.** Every guard broken and confirmed to fail something: any code accepted, the attempt cap off by one, a claimed invitation reclaimable, an unclaimed one acceptable, the credential collectable twice, a fixed HKDF salt, the credential sent in the clear, a revoked credential still resolving, the raw token written to disk, scope granting upward, an unnamed write defaulting to a read, the terminal judged by its method, an unrecognised scope read as full access, the pending list (with its codes) served to any paired device, the phone's private key made exportable, the QR carrying the code.

**195/195 phone-audit checks** against a real server in a real browser, sixteen of them new — the whole handshake driven end to end on the phone side:

```
ok   pairing · the machine can start an invitation
ok   pairing · the application is not mounted behind it
ok   pairing · says a person still has to accept
ok   pairing · the button is dead until six digits are in
ok   pairing · the request reaches the machine, named
ok   pairing · and carries the same code, for the person to check
ok   pairing · the phone opens the credential and the app comes up
ok   pairing · and it is a working credential, not a page that 401s
ok   pairing · …at the level it was granted, and no further
ok   pairing · forgetting the device revokes it
```

That last pair is the point of driving it in a browser: `unseal` runs on WebCrypto while the server seals with Node's `crypto`, and every parameter — curve, salt, info string, tag placement — has to agree. A mismatch produces a device that pairs, appears in the list, and then cannot authenticate.

Suites green: **1206 server, 831 web**.

## Two faults found on the way

**A race in the pane, found by opening it.** "Show a pairing code" did nothing at all. The poll that `start` fires runs before React has re-rendered, so it read the previous ref value, asked the server about no ticket, was told there is none, and cleared the invitation it had just minted. The id is recorded before anything can poll for it now, and there is a rule over the file so it stays that way.

**Dead code in the device lookup**, found by mutation. `Buffer.from(x, "hex")` truncates rather than throwing, so the `try/catch` around it could never fire. What actually skips a corrupt row is the length check — and it has to come first regardless, because `timingSafeEqual` throws on mismatched lengths, which would turn one hand-edited row into a 500 on every authenticated request.

**And one in the harness.** An existing tripwire asserts no route removes recorded data, by matching route *names* against `delete|purge|clear|wipe|forget|reset`. `/pair/forget` trips it and removes nothing recorded — `devices.ts` deliberately keeps a revoked row so "did I definitely cut that phone off" stays answerable. Renaming the route to slip past the regex would leave a tripwire passing for a reason unrelated to what it checks, so the exception is listed and a companion test makes it earn its place on every run: the handler must reach no table.