### PR TITLE
Say how to reach this when you are not on the same wifi

### DIFF
--- a/README.md
+++ b/README.md
@@ -326,7 +326,38 @@ phone shows a white page and nothing anywhere says why. Over café wifi, pair on
 the Tailscale address it offers instead: that one is encrypted end to end.
 
 The page ships a web manifest, so **Add to home screen** gives you an icon that
-opens without browser chrome.
+opens without browser chrome. On an iPhone that is not optional — it is the only
+way Safari will deliver a push.
+
+### Reaching it when you are not on the same wifi
+
+The honest answer is **Tailscale**, and it is the one the Remote pane offers
+beside the LAN address. A tailnet address is reachable from a train, encrypted
+end to end, and limited to devices signed into your own account — which is a
+much narrower grant than a network. Install it on both ends, pair on that
+address, and the sofa and the airport work the same way.
+
+The tempting answer is a tunnel — `cloudflared`, `ngrok`, a reverse proxy — and
+it is worth being plain about what that is. **This server can open a shell, push
+to your repositories and control Docker on the machine it runs on.** Putting a
+public hostname in front of it means the only thing between the internet and
+that is a credential, and credentials leak by being pasted into the wrong
+window. Treat the port the way you treat `sshd`: if you must put a proxy in
+front of it, terminate TLS there, require authentication at the proxy as well,
+and set `AGENTGLASS_ALLOWED_HOSTS` so the DNS-rebinding guard knows the name.
+It is not a configuration this project tests, and it is not one to reach for
+because Tailscale looked like a bigger setup than it is.
+
+Either way, **the tunnel is for the browser, not for the hooks.** Everything
+that reports into agentglass — the Claude Code hooks, the OTel exporters, the
+gate that holds a tool call — posts to the server on the machine it is running
+on, at `http://localhost:4000`. It has to: the hook scripts refuse to send a
+transcript anywhere but this host, precisely because a cloned repository can set
+`AGENTGLASS_SERVER` in its own `settings.json` and would otherwise redirect your
+prompts and file contents to somebody else. Pointing them at a public hostname
+does not make anything work better, and turning off the guard to do it
+(`AGENTGLASS_ALLOW_REMOTE=1`) is for the case where the server genuinely runs on
+another machine — not for the case where you added a tunnel to it.
 
 ### Alerts that reach a locked phone
 

--- a/server/test/readme-remote-claims.test.ts
+++ b/server/test/readme-remote-claims.test.ts
@@ -1,0 +1,70 @@
+/*
+ * The README's remote-access section makes claims about code, and the claims
+ * are the useful part.
+ *
+ * It tells people the hooks post to `http://localhost:4000` whatever a tunnel
+ * is doing, that they refuse to send a transcript anywhere else, that
+ * AGENTGLASS_ALLOW_REMOTE is the deliberate way out of that, and that
+ * AGENTGLASS_ALLOWED_HOSTS is how a reverse-proxy name gets past the
+ * DNS-rebinding guard. Every one of those is a thing somebody will act on while
+ * deciding how to expose a server that can open a shell.
+ *
+ * Documentation naming an environment variable that no longer exists is worse
+ * than none: it is followed confidently and does nothing. So each claim is
+ * checked against the file that would have to change for it to stop being true.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const repo = (p: string) => readFileSync(new URL("../../" + p, import.meta.url), "utf8");
+const README = repo("README.md");
+
+/** The part of the README this file is about, so a mention somewhere else does
+ *  not satisfy a check about what the remote section says. */
+const section = (() => {
+  const from = README.indexOf("### Reaching it when you are not on the same wifi");
+  expect(from, "the remote-access section is gone from the README").toBeGreaterThan(-1);
+  return README.slice(from, README.indexOf("### Alerts that reach a locked phone", from));
+})();
+
+describe("what the README tells people about reaching this from elsewhere", () => {
+  test("the escape hatch it names is the one the hooks actually read", () => {
+    expect(section).toContain("AGENTGLASS_ALLOW_REMOTE");
+    // The *read*, not a mention. Both hooks also name the variable in their
+    // docstrings, so a check for the bare string passes against a hook that
+    // documents it and no longer honours it — which is how mutation testing
+    // found this check was not one.
+    for (const hook of ["hooks/send_event.py", "hooks/gate_event.py"]) {
+      expect(repo(hook), `${hook} no longer reads AGENTGLASS_ALLOW_REMOTE`)
+        .toContain('os.environ.get("AGENTGLASS_ALLOW_REMOTE")');
+    }
+  });
+
+  test("the address it says hooks post to is the address they default to", () => {
+    // Quoted in the README because the mistake it prevents — pointing the hooks
+    // at a public hostname — looks like the obvious thing to do once a tunnel
+    // exists.
+    expect(section).toContain("http://localhost:4000");
+    expect(repo("hooks/send_event.py")).toContain('"http://localhost:4000"');
+    expect(repo("hooks/gate_event.py")).toContain('"http://localhost:4000"');
+  });
+
+  test("the reverse-proxy variable it names is the one the guard reads", () => {
+    expect(section).toContain("AGENTGLASS_ALLOWED_HOSTS");
+    // Same trap: index.ts also names it in the 403 body it returns when the
+    // guard fires, so the bare string survives the variable being renamed.
+    expect(repo("server/src/index.ts")).toContain("process.env.AGENTGLASS_ALLOWED_HOSTS");
+  });
+
+  test("and it still says a tunnel is not the recommended answer", () => {
+    // The section exists to be discouraging in a specific way: this server can
+    // open a shell, so the recommendation is a private network rather than a
+    // public hostname. A rewrite that loses that has lost the point of it.
+    // The recommendation itself, not the word. "Tailscale" appears twice more
+    // in this section — including in the sentence warning people off reaching
+    // for a tunnel because Tailscale looked like more setup — so a check for
+    // the name passes against a section that now recommends the opposite.
+    expect(section).toContain("The honest answer is **Tailscale**");
+    expect(section).toMatch(/open a shell/);
+  });
+});


### PR DESCRIPTION
Closes #333.

## What does this PR do?

The companion's documentation ends at the LAN. Somebody who wants it from a train has to work out on their own whether that is even intended, and the two parts that bite are exactly the two nothing says.

**What the answer is.** Tailscale, which the Remote pane already offers beside the LAN address: reachable from anywhere, encrypted end to end, and limited to devices signed into your own account — a much narrower grant than a network.

**What the tempting answer costs.** This server can open a shell, push to your repositories and control Docker on the machine it runs on. A public hostname in front of that leaves a credential as the only thing between it and the internet, and credentials leak by being pasted into the wrong window. Named as not-tested rather than forbidden, with the three things to get right if somebody does it anyway — TLS at the proxy, authentication at the proxy, and `AGENTGLASS_ALLOWED_HOSTS` so the DNS-rebinding guard knows the name.

**And the mistake a tunnel invites.** Everything that reports into agentglass — the hooks, the OTel exporters, the gate that holds a tool call — posts to `http://localhost:4000` on the machine it is running on, and *has to*: the hook scripts refuse to send a transcript anywhere else, because a cloned repository can set `AGENTGLASS_SERVER` in its own `settings.json` and would otherwise redirect your prompts and file contents to somebody else. Pointing them at a public hostname improves nothing, and `AGENTGLASS_ALLOW_REMOTE=1` is for a server that genuinely runs elsewhere, not for one you put a tunnel in front of.

Also a sentence on the iPhone case, now that #423 makes the home-screen icon the real mark: Add to Home Screen is not optional there, because it is the only way Safari delivers a push.

The issue also asked for pairing and token guidance. That landed in #438 and is already in this section and in `SECURITY.md`.

## How was it tested?

Documentation that names an environment variable which no longer exists is worse than none — it gets followed confidently and does nothing. So every claim is checked against the file that would have to change for it to stop being true: the hooks' read of `AGENTGLASS_ALLOW_REMOTE`, their `http://localhost:4000` default, the guard's read of `AGENTGLASS_ALLOWED_HOSTS`, and that the section still recommends a private network over a hostname.

**Seven mutations, all red** — each variable renamed under the docs, the default address changed, the recommendation inverted, the section deleted.

Three of those only went red *after* the assertions were tightened, and that is the reason for running the pass at all. The first version checked that the hooks **mention** `AGENTGLASS_ALLOW_REMOTE` and that the section **mentions** Tailscale. Both strings survive the behaviour being removed — the hooks name the variable in their docstrings, `index.ts` names it in the 403 body the guard returns, and the section names Tailscale again in the sentence warning people off tunnels. Three checks that would have passed against a README describing something the code no longer does. They assert the read and the recommendation sentence now.

Suites green: **1210 server, 839 web**.