### PR TITLE
Answer a gate from the notification, without opening anything

### DIFF
--- a/server/src/alerts.ts
+++ b/server/src/alerts.ts
@@ -103,8 +103,21 @@ export interface PushFanout {
   pruned: number;
 }
 
+/**
+ * What the phone can do about this without opening the app.
+ *
+ * Only a held gate has one, and only ever the gate's own id. It is not a
+ * credential and it is not a capability: deciding still needs the device's
+ * paired credential, and the id alone is a uuid that names something already
+ * on that person's screen. The worker uses it to put Allow and Deny on the
+ * notification instead of a line of text telling somebody to go and find it.
+ */
+export interface PushAction {
+  gate: string;
+}
+
 export async function pushEveryone(
-  title: string, body: string, reach: Reach,
+  title: string, body: string, reach: Reach, action?: PushAction,
 ): Promise<PushFanout> {
   const subs = subscriptions();
   const out: PushFanout = { sent: 0, failed: 0, pruned: 0 };
@@ -118,7 +131,10 @@ export async function pushEveryone(
   // one of the two can wake the device.
   const wake = reach === "wake";
   const payload = new TextEncoder().encode(
-    JSON.stringify({ title, body, at: Date.now(), urgency: wake ? 2 : 1 }),
+    JSON.stringify({
+      title, body, at: Date.now(), urgency: wake ? 2 : 1,
+      ...(action ? { gate: action.gate } : {}),
+    }),
   );
   await Promise.all(subs.map(async (s) => {
     const r = await sendPush(s, payload, keys, {
@@ -132,7 +148,9 @@ export async function pushEveryone(
   return out;
 }
 
-async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2, reach: Reach = "tell") {
+async function deliver(
+  title: string, body: string, urgency: 0 | 1 | 2 = 2, reach: Reach = "tell", action?: PushAction,
+) {
   if (WEBHOOK && !IS_TEST) {
     try {
       await fetch(WEBHOOK, {
@@ -151,7 +169,7 @@ async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2, reac
   if (!IS_TEST) {
     // Never awaited: an unreachable push service must not hold up the
     // notification that is also going to the desktop.
-    pushEveryone(title, body, reach).catch((e) => console.warn("[alerts] push failed:", e));
+    pushEveryone(title, body, reach, action).catch((e) => console.warn("[alerts] push failed:", e));
   }
 
   if (DESKTOP) {
@@ -183,13 +201,22 @@ async function deliver(title: string, body: string, urgency: 0 | 1 | 2 = 2, reac
 
 let warnedNoNotifySend = false;
 
-/** A tool call is being held at the control-plane gate — ping the human. */
-export function pushGate(agent: string, tool: string, summary: string) {
+/**
+ * A tool call is being held at the control-plane gate — ping the human.
+ *
+ * The id travels with it so a phone can answer from the notification rather
+ * than being told to go and find the app. That changes what the sentence
+ * should say, too: "approve or deny in agentglass" was the only instruction
+ * that made sense when the notification was a dead end, and it is the wrong
+ * one to read above two buttons that do it.
+ */
+export function pushGate(agent: string, tool: string, summary: string, id?: string) {
   if (shouldSend(`gate:${agent}:${summary}`))
     deliver(
       "✋ Approval needed",
-      `${agent} wants to run ${tool}${summary ? `: ${summary.slice(0, 200)}` : ""} — approve or deny in agentglass.`,
+      `${agent} wants to run ${tool}${summary ? `: ${summary.slice(0, 200)}` : ""}`,
       2, "wake",
+      id ? { gate: id } : undefined,
     );
 }
 

--- a/server/src/gate.ts
+++ b/server/src/gate.ts
@@ -109,7 +109,7 @@ export function submitGate(
   recordGate({ id, source_app, session_id, tool_name, summary, created, expires });
   return new Promise((resolve) => {
     waiters.set(id, { id, source_app, session_id, tool_name, summary, created, expires, resolve, timer: arm(id, expires) });
-    pushGate(`${source_app}:${session_id.slice(0, 8)}`, tool_name, summary);
+    pushGate(`${source_app}:${session_id.slice(0, 8)}`, tool_name, summary, id);
     onChange();
   });
 }

--- a/server/test/gate-push-action.test.ts
+++ b/server/test/gate-push-action.test.ts
@@ -1,0 +1,90 @@
+/*
+ * The one field that makes a notification answerable.
+ *
+ * A held gate stops an agent until a person says go, and the push that tells
+ * them was a dead end: it named the tool and then instructed them to go and
+ * find the app. The gate's own id travelling with the push is what lets the
+ * service worker put **Allow** and **Deny** on the notification instead — see
+ * web/public/sw.js.
+ *
+ * It is one string, so the risk is not that it is wrong but that it silently
+ * stops being sent: nothing about a phone with no buttons on its notification
+ * looks broken, and the person it happens to is not at a computer. Hence a
+ * test that reads the bytes actually handed to the encryption.
+ */
+import { afterEach, describe, expect, test } from "bun:test";
+import { pushEveryone, type PushFanout } from "../src/alerts.ts";
+import { readFileSync } from "node:fs";
+
+const src = (p: string) => readFileSync(new URL("../src/" + p, import.meta.url), "utf8");
+
+describe("what rides along with a held gate", () => {
+  /**
+   * `pushEveryone` returns early with nothing sent when no device is
+   * subscribed, which is the state of a test run — so the payload it *would*
+   * have built is not observable from its return value. What is observable is
+   * the source: the field is either in the object being serialised or it is
+   * not, and everything downstream of that is the encryption, which has its own
+   * suite.
+   */
+  test("the payload carries the gate id, and only when there is one", () => {
+    const alerts = src("alerts.ts");
+    const payload = alerts.slice(alerts.indexOf("const payload ="), alerts.indexOf("await Promise.all"));
+    expect(payload).toContain("gate: action.gate");
+    // Conditional: a push about a tool error with a `gate` key on it would give
+    // the worker two buttons that answer nothing.
+    expect(payload).toMatch(/\.\.\.\(action \?/);
+  });
+
+  test("a gate hold passes the id it is holding under", () => {
+    // The alert is raised from inside submitGate, where the id already exists;
+    // dropping it there is the quiet way for this whole feature to stop.
+    // Sliced to the function, so a failure prints the call site rather than
+    // the file — the first version of this asserted over the whole of gate.ts
+    // and printed all of it.
+    const all = src("gate.ts");
+    const submit = all.slice(all.indexOf("export function submitGate"), all.indexOf("export function awaitGate"));
+    expect(submit).toContain("tool_name, summary, id)");
+  });
+
+  test("and the sentence no longer tells people to go somewhere else", () => {
+    // "approve or deny in agentglass" was the right words when the
+    // notification could not be acted on. Above two buttons that do exactly
+    // that, it is an instruction to ignore them.
+    const alerts = src("alerts.ts");
+    const fn = alerts.slice(alerts.indexOf("export function pushGate"), alerts.indexOf("/** Inspect an event"));
+    expect(fn).not.toContain("approve or deny in agentglass");
+  });
+
+  test("nothing that is not a held gate carries one", () => {
+    // Every other `deliver` call in the file is news. A fifth argument on one
+    // of them would put Allow and Deny on a build failure.
+    const alerts = src("alerts.ts");
+    const others = [...alerts.matchAll(/deliver\(\s*\n?\s*"[^"]*"/g)].length;
+    expect(others).toBeGreaterThan(2);
+    expect(alerts.match(/\{ gate: id \}/g) ?? []).toHaveLength(1);
+  });
+
+  test("it is an id and not a credential", () => {
+    // Worth stating, because a field that arrives at a push service and then at
+    // a phone is the wrong place to put anything that grants access. Deciding
+    // still needs the device's own credential; this names a thing already on
+    // that person's screen.
+    expect(src("alerts.ts")).not.toMatch(/token:\s*\w+\s*\}\s*\)?,?\s*\n\s*\);/);
+    const alerts = src("alerts.ts");
+    const payload = alerts.slice(alerts.indexOf("const payload ="), alerts.indexOf("await Promise.all"));
+    for (const leak of ["token", "secret", "AUTH"]) {
+      expect(payload, `the push payload mentions ${leak}`).not.toContain(leak);
+    }
+  });
+});
+
+describe("sending it", () => {
+  afterEach(() => { /* nothing subscribed in a test run; nothing to clean */ });
+
+  test("is a no-op with no devices, action or not", async () => {
+    // The guard that keeps this file from touching the network.
+    const out: PushFanout = await pushEveryone("t", "b", "wake", { gate: "g" });
+    expect(out).toEqual({ sent: 0, failed: 0, pruned: 0 });
+  });
+});

--- a/web/public/sw.js
+++ b/web/public/sw.js
@@ -60,6 +60,10 @@ function toNotification(raw) {
   }
   var title = typeof data.title === "string" && data.title ? data.title : FALLBACK.title;
   var body = typeof data.body === "string" && data.body ? data.body : FALLBACK.body;
+  // A non-empty string, or nothing. An older server sends no `gate` at all and
+  // a newer one could send something unexpected; either way the notification
+  // has to end up showable rather than throwing (see above).
+  var gate = typeof data.gate === "string" && data.gate ? data.gate : null;
   return {
     title: title,
     options: {
@@ -89,6 +93,23 @@ function toNotification(raw) {
       // than "now", which is not.
       timestamp: typeof data.at === "number" ? data.at : undefined,
       renotify: false,
+      // The gate this is about, if it is about one. Carried through so the
+      // click handler knows what it is answering without going back to the
+      // server to ask, and so the buttons below have something to send.
+      data: gate ? { gate: gate } : undefined,
+      // Answer it here, rather than being told where to go and answer it.
+      //
+      // A held gate is the only alert with two obvious replies and an agent
+      // stopped until one of them arrives — so the notification carries them.
+      // Everything else this app sends is news, and news with buttons on it is
+      // a worse notification, not a better one.
+      //
+      // Ignored where they are not supported, which today means iPhone: Safari
+      // draws the notification without them and tapping it opens the queue, as
+      // it did before. Nothing here is required for that path to work.
+      actions: gate
+        ? [{ action: "allow", title: "Allow" }, { action: "deny", title: "Deny" }]
+        : undefined,
     },
   };
 }
@@ -99,6 +120,113 @@ self.addEventListener("push", function (event) {
   // the push arrives, the process is torn down, and nothing appears.
   event.waitUntil(self.registration.showNotification(n.title, n.options));
 });
+
+/**
+ * Where the worker finds out who it is.
+ *
+ * The page holds the credential in `localStorage`, which a service worker
+ * cannot read — it has no `window` and no `localStorage`. IndexedDB is the one
+ * store both halves can reach, so the app mirrors two things into it whenever
+ * push is switched on: the server this device is paired to, and the credential
+ * it was given. See web/src/lib/swAuth.ts, which also clears it.
+ *
+ * It is the same credential the page already holds on the same origin, at the
+ * same level it was paired at — not a wider one minted for the worker. A phone
+ * paired to answer gates can answer a gate from here and can do nothing else,
+ * because the server checks the scope on the route, not on the caller's
+ * politeness. Forgetting the device at the machine kills this copy too.
+ *
+ * Every failure resolves to null rather than throwing: this runs with no UI
+ * anywhere, and a rejection here would turn a tapped button into the browser's
+ * own "site updated in the background" notification.
+ */
+function openDb() {
+  return new Promise(function (resolve) {
+    try {
+      // `self.`-qualified, like everything else this file touches. In a real
+      // worker `self` *is* the global, so it changes nothing there — and it is
+      // what lets the suite run this file against a fake scope instead of
+      // reaching past it to the host's real IndexedDB and its real network.
+      var req = self.indexedDB.open("agentglass", 1);
+      req.onupgradeneeded = function () {
+        try { req.result.createObjectStore("auth"); } catch (e) { /* already there */ }
+      };
+      req.onsuccess = function () { resolve(req.result); };
+      req.onerror = function () { resolve(null); };
+      req.onblocked = function () { resolve(null); };
+    } catch (e) { resolve(null); }
+  });
+}
+
+function readAuth() {
+  return openDb().then(function (db) {
+    if (!db) return null;
+    return new Promise(function (resolve) {
+      try {
+        var r = db.transaction("auth", "readonly").objectStore("auth").get("server");
+        r.onsuccess = function () { resolve(r.result || null); };
+        r.onerror = function () { resolve(null); };
+      } catch (e) { resolve(null); }
+    });
+  });
+}
+
+/**
+ * Answer the gate.
+ *
+ * Every outcome is named, because the phone is about to be told one of them
+ * and "something went wrong" is the answer that makes somebody unlock the
+ * screen and go looking — which is the whole thing this is here to avoid.
+ *
+ * `decideGate` on the server is idempotent: a gate that is already decided, or
+ * that timed out while the phone was in a pocket, comes back not-ok rather
+ * than as a conflict. That is a real answer and is reported as one.
+ */
+function decide(gate, decision) {
+  return readAuth().then(function (auth) {
+    if (!auth || !auth.origin) return { ok: false, why: "unpaired" };
+    var headers = { "content-type": "application/json" };
+    if (auth.token) headers.authorization = "Bearer " + auth.token;
+    return self.fetch(String(auth.origin).replace(/\/$/, "") + "/gate/decide", {
+      method: "POST",
+      headers: headers,
+      credentials: "omit",
+      body: JSON.stringify({ id: gate, decision: decision }),
+    }).then(function (r) {
+      // 401 is a credential that no longer works — the device was forgotten,
+      // or the machine's code was rotated. 403 is a device that works and is
+      // not allowed to decide, which is what a look-only phone gets. Different
+      // sentences, because they need different things done about them.
+      if (r.status === 401) return { ok: false, why: "unpaired" };
+      if (r.status === 403) return { ok: false, why: "notAllowed" };
+      return r.json().then(
+        function (j) { return j && j.ok ? { ok: true, why: "" } : { ok: false, why: "gone" }; },
+        function () { return { ok: false, why: "gone" }; },
+      );
+    }, function () { return { ok: false, why: "offline" }; });
+  });
+}
+
+/** What the tap did, said back. A button that answers silently is a button
+ *  nobody trusts the second time. */
+function report(result, decision, gate) {
+  var text =
+    result.ok ? (decision === "allow" ? "Allowed. The agent is going." : "Denied. The agent has been told why.")
+    : result.why === "gone" ? "Already answered, or it timed out waiting."
+    : result.why === "notAllowed" ? "This device is paired to look, not to answer. Change that on the computer."
+    : result.why === "unpaired" ? "This device is not connected any more. Open agentglass to pair it again."
+    : "Could not reach the computer. It may be asleep, or you may be on another network.";
+  return self.registration.showNotification(result.ok ? "✓ agentglass" : "agentglass", {
+    body: text,
+    icon: "./icon-192.png",
+    badge: "./icon-badge.png",
+    // Same tag as nothing else, and keyed to the gate: the answer to one
+    // approval must not replace the notification for a different one that is
+    // still waiting.
+    tag: "gate-result:" + gate,
+    requireInteraction: false,
+  });
+}
 
 /**
  * Tapping the notification puts the decision in front of you.
@@ -119,6 +247,19 @@ self.addEventListener("push", function (event) {
  */
 self.addEventListener("notificationclick", function (event) {
   event.notification.close();
+
+  // A button, rather than the notification itself. Answer it and stop — the
+  // point of the buttons is that the phone stays locked and the app stays
+  // closed, so opening a window here would undo the whole thing.
+  var gate = event.notification.data && event.notification.data.gate;
+  var action = event.action;
+  if (gate && (action === "allow" || action === "deny")) {
+    event.waitUntil(
+      decide(gate, action).then(function (r) { return report(r, action, gate); }),
+    );
+    return;
+  }
+
   var home = new URL("./", self.registration.scope).href;
   event.waitUntil(
     self.clients.matchAll({ type: "window", includeUncontrolled: true }).then(function (all) {

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -126,6 +126,16 @@ export const withToken = (url: string): string =>
 /** Whether this client has a shared-secret token configured. */
 export const hasToken = (): boolean => !!TOKEN;
 
+/**
+ * The credential itself, for the one caller that cannot use `authHeaders`.
+ *
+ * The service worker answers a gate from a notification while the app is
+ * closed, so it needs the credential in a store it can read — see
+ * lib/swAuth.ts. Everything in the page uses `authHeaders`/`withToken` and
+ * should keep doing so: this exists to be mirrored, once, into IndexedDB.
+ */
+export const authToken = (): string => TOKEN;
+
 /** Why a chat turn ended early.
  *
  *  `refused` — the server answered and declined; `detail` is its reason.

--- a/web/src/lib/swAuth.ts
+++ b/web/src/lib/swAuth.ts
@@ -1,0 +1,96 @@
+/**
+ * The one thing the page has to hand the service worker.
+ *
+ * A held gate now arrives on the phone with **Allow** and **Deny** on it, and
+ * answering has to happen in the worker — that is the whole point, the app is
+ * closed and the screen is locked. The worker cannot read `localStorage`: it
+ * has no `window`, and the credential the page keeps there is invisible to it.
+ * IndexedDB is the one store both halves can reach.
+ *
+ * What is mirrored is deliberately the minimum: which server this device is
+ * paired to, and the credential it was given. Not a second, wider credential
+ * minted for the worker — the same one, at the level it was paired at, on the
+ * same origin the page already keeps it on. A phone paired to answer gates can
+ * answer a gate from a notification and can do nothing else, because the
+ * server checks the scope on the route. Forgetting the device at the machine
+ * revokes this copy in the same breath as the other one.
+ *
+ * It is written when push is switched on and cleared when it is switched off,
+ * so a phone that is not receiving notifications is not holding a credential
+ * for a worker that has nothing to do with it.
+ *
+ * Every operation resolves rather than rejecting. This is a side effect of a
+ * toggle, and a private-mode browser that refuses IndexedDB should cost the
+ * buttons on the notification, not the notification.
+ */
+
+const DB = "agentglass";
+const STORE = "auth";
+const KEY = "server";
+
+export interface SwAuth {
+  /** Where to send the decision. The app and the API are the same origin on a
+   *  phone (the server serves the bundle), but not when a dev build talks to a
+   *  server elsewhere — so it is recorded rather than assumed. */
+  origin: string;
+  /** Empty on a box with no token configured, which is the normal local case. */
+  token: string;
+}
+
+function open(): Promise<IDBDatabase | null> {
+  return new Promise((resolve) => {
+    try {
+      const req = indexedDB.open(DB, 1);
+      req.onupgradeneeded = () => {
+        // Guarded: two tabs can race the upgrade, and the second one throwing
+        // here would reject the open for a store that already exists.
+        try { req.result.createObjectStore(STORE); } catch { /* already there */ }
+      };
+      req.onsuccess = () => resolve(req.result);
+      req.onerror = () => resolve(null);
+      req.onblocked = () => resolve(null);
+    } catch {
+      resolve(null); // private mode, or a browser with it switched off
+    }
+  });
+}
+
+function put(value: SwAuth | null): Promise<boolean> {
+  return open().then((db) => {
+    if (!db) return false;
+    return new Promise<boolean>((resolve) => {
+      try {
+        const store = db.transaction(STORE, "readwrite").objectStore(STORE);
+        const req = value ? store.put(value, KEY) : store.delete(KEY);
+        req.onsuccess = () => resolve(true);
+        req.onerror = () => resolve(false);
+      } catch {
+        resolve(false);
+      }
+    });
+  });
+}
+
+/** Tell the worker where this device is paired, and with what. */
+export const rememberForWorker = (auth: SwAuth): Promise<boolean> => put(auth);
+
+/** Take it back. Called when push is switched off, and on nothing else — a
+ *  worker with no subscription has nothing to answer. */
+export const forgetForWorker = (): Promise<boolean> => put(null);
+
+/** Read it back. Only the tests and the settings pane need this; the worker
+ *  has its own copy of the read, because it cannot import from here. */
+export function readForWorker(): Promise<SwAuth | null> {
+  return open().then((db) => {
+    if (!db) return null;
+    return new Promise<SwAuth | null>((resolve) => {
+      try {
+        const req = db.transaction(STORE, "readonly").objectStore(STORE).get(KEY);
+        req.onsuccess = () => resolve((req.result as SwAuth) ?? null);
+        req.onerror = () => resolve(null);
+      } catch {
+        resolve(null);
+      }
+    });
+  });
+}

--- a/web/src/lib/webpush.ts
+++ b/web/src/lib/webpush.ts
@@ -211,6 +211,18 @@ export interface PushEnv {
   getKey: () => Promise<{ key: string }>;
   subscribe: (sub: unknown, label: string) => Promise<{ ok: boolean; error?: string }>;
   unsubscribe: (endpoint: string) => Promise<{ ok: boolean }>;
+  /**
+   * Put the credential somewhere the service worker can read it, and take it
+   * back. See lib/swAuth.ts for what is mirrored and why.
+   *
+   * Seams like every other side effect in here, so the flow can be driven
+   * whole in a test — and *what* is mirrored is left to the wiring, so this
+   * module keeps knowing nothing about the app's server or its credential.
+   * Optional, because a browser that refuses IndexedDB should cost the buttons
+   * on the notification and not the notification.
+   */
+  remember?: () => Promise<unknown>;
+  forget?: () => Promise<unknown>;
   /** Injected so the timeout above can be exercised without a 20s test. */
   sleep?: (ms: number) => Promise<void>;
   timeoutMs?: number;
@@ -352,6 +364,13 @@ export async function enablePush(env: PushEnv): Promise<PushResult> {
 
     const res = await env.subscribe(sub.toJSON(), deviceLabel(env.ua));
     if (!res.ok) return { ok: false, state: "off", error: res.error || "The server would not take the subscription." };
+    // After the server has accepted it, and never before: a credential mirrored
+    // for a subscription that was refused is a credential in a second place for
+    // no reason. Failing here does not fail the toggle — push still arrives,
+    // and tapping the notification still opens the queue. It is the two buttons
+    // on it that quietly stop working, which is why the worker says "not
+    // connected any more" rather than nothing.
+    await env.remember?.();
     return { ok: true, state: "on" };
   } catch (e) {
     return { ok: false, state: "off", error: String((e as Error)?.message ?? e) };
@@ -371,9 +390,12 @@ export async function disablePush(env: PushEnv): Promise<PushResult> {
   try {
     const reg = await env.sw.ready;
     const sub = await reg.pushManager.getSubscription();
-    if (!sub) return { ok: true, state: "off" };
+    if (!sub) { await env.forget?.(); return { ok: true, state: "off" }; }
     await env.unsubscribe(sub.endpoint);
     await sub.unsubscribe();
+    // A worker with no subscription has nothing to answer, so it has no
+    // business still holding a credential.
+    await env.forget?.();
     return { ok: true, state: "off" };
   } catch (e) {
     return { ok: false, state: "on", error: String((e as Error)?.message ?? e) };
@@ -386,6 +408,10 @@ export function browserPushEnv(api: {
   pushKey: () => Promise<{ key: string }>;
   pushSubscribe: (sub: unknown, label: string) => Promise<{ ok: boolean; error?: string }>;
   pushUnsubscribe: (endpoint: string) => Promise<{ ok: boolean }>;
+  /** Mirror the credential for the service worker, and clear it. Passed in
+   *  rather than imported, so this file still depends on nothing. */
+  remember?: () => Promise<unknown>;
+  forget?: () => Promise<unknown>;
 }, demo = false): PushEnv {
   const nav = typeof navigator === "undefined" ? null : navigator;
   const canNotify = typeof Notification !== "undefined";
@@ -412,6 +438,8 @@ export function browserPushEnv(api: {
     getKey: api.pushKey,
     subscribe: api.pushSubscribe,
     unsubscribe: api.pushUnsubscribe,
+    remember: api.remember,
+    forget: api.forget,
     demo,
   };
 }

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useReducer, useState } from "react";
-import { api, probeServer, IS_DEMO } from "../lib/api.ts";
+import { api, probeServer, IS_DEMO, SERVER, authToken } from "../lib/api.ts";
+import { rememberForWorker, forgetForWorker } from "../lib/swAuth.ts";
 import { useLive } from "../lib/useLive.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { subscribeSessionChanged } from "../lib/sessionBus.ts";
@@ -187,7 +188,21 @@ export function MobileApp() {
   // mount rather than only when the toggle is used: registering an unchanged
   // file is a no-op, and it means the worker that receives the next push is the
   // one that shipped, not one left over from an older build.
-  const pushEnv = useMemo(() => browserPushEnv(api, IS_DEMO), []);
+  /**
+   * The push wiring, including the one thing the service worker needs.
+   *
+   * A held gate arrives with Allow and Deny on it, and answering happens in the
+   * worker while this app is closed — so the credential has to be somewhere the
+   * worker can read, which is neither `localStorage` nor this closure. Read at
+   * call time rather than captured: `SERVER` and the token are live bindings
+   * that `adoptServer` rewrites when remote access is toggled or this device is
+   * paired, and a mirror taken at mount would be whatever was true then.
+   */
+  const pushEnv = useMemo(() => browserPushEnv({
+    ...api,
+    remember: () => rememberForWorker({ origin: SERVER, token: authToken() }),
+    forget: forgetForWorker,
+  }, IS_DEMO), []);
   useEffect(() => {
     let live = true;
     currentPushState(pushEnv).then((s) => { if (live) setPushState(s); });

--- a/web/test/service-worker.test.ts
+++ b/web/test/service-worker.test.ts
@@ -19,7 +19,18 @@ const SRC = readFileSync(new URL("../public/sw.js", import.meta.url).pathname, "
 interface Shown { title: string; options: Record<string, any> }
 
 /** Enough of a ServiceWorkerGlobalScope to run the file and see what it did. */
-function loadWorker(opts: { clients?: any[] } = {}) {
+interface Sent { url: string; init: any }
+
+/**
+ * @param auth what the page mirrored into IndexedDB, or null for a device that
+ *   never did — which is what a worker on a phone that has not paired sees.
+ * @param reply how the server answers /gate/decide.
+ */
+function loadWorker(opts: {
+  clients?: any[];
+  auth?: { origin: string; token: string } | null;
+  reply?: { status?: number; body?: unknown; throws?: boolean };
+} = {}) {
   const listeners = new Map<string, (e: any) => void>();
   const shown: Shown[] = [];
   const opened: string[] = [];
@@ -36,7 +47,44 @@ function loadWorker(opts: { clients?: any[] } = {}) {
     postMessage(data: unknown) { order.push("message"); messaged.push({ url: c.url, data }); },
   }));
 
+  // Enough IndexedDB for the worker's read: an object store with one key in
+  // it, driven by the same onsuccess/onerror callbacks the real thing uses.
+  const sent: Sent[] = [];
+  const store = new Map<string, unknown>();
+  if (opts.auth !== undefined && opts.auth !== null) store.set("server", opts.auth);
+  const settle = <T,>(req: any, ok: boolean, result?: T) => {
+    queueMicrotask(() => {
+      req.result = result;
+      if (ok) req.onsuccess?.({}); else req.onerror?.({});
+    });
+    return req;
+  };
+  const fakeIdb = {
+    open: () => {
+      const req: any = {};
+      const db = {
+        createObjectStore: () => {},
+        transaction: () => ({
+          objectStore: () => ({ get: (k: string) => settle({}, true, store.get(k)) }),
+        }),
+      };
+      return settle(req, true, db);
+    },
+  };
+
   const scope = {
+    indexedDB: fakeIdb,
+    fetch: (url: string, init: any) => {
+      sent.push({ url, init });
+      if (opts.reply?.throws) return Promise.reject(new Error("offline"));
+      const status = opts.reply?.status ?? 200;
+      return Promise.resolve({
+        status,
+        json: () => (opts.reply && "body" in opts.reply
+          ? Promise.resolve(opts.reply.body)
+          : Promise.resolve({ ok: true })),
+      });
+    },
     addEventListener: (type: string, fn: (e: any) => void) => { listeners.set(type, fn); },
     skipWaiting: () => { skipped = true; },
     registration: {
@@ -64,7 +112,7 @@ function loadWorker(opts: { clients?: any[] } = {}) {
     await Promise.all(waits);
   };
 
-  return { fire, shown, opened, focused, messaged, order, listeners, waits,
+  return { fire, shown, opened, focused, messaged, order, listeners, waits, sent,
     get claimed() { return claimed; }, get skipped() { return skipped; } };
 }
 
@@ -247,6 +295,188 @@ describe("tapping it", () => {
     const w = loadWorker({ clients: [{ url: "https://box.local/" }] });
     await w.fire("notificationclick", { notification: { close() { closed = true; } } });
     expect(closed).toBe(true);
+  });
+});
+
+/**
+ * The half that makes the notification worth having.
+ *
+ * A held gate stops an agent until a person answers, and until now the
+ * notification could only say so — the answering was still tied to unlocking
+ * the phone, finding the app and waiting for it to load. These are the buttons
+ * that close that loop, and they run in the one place with no console, no UI
+ * and nobody watching, so every branch is pinned.
+ */
+describe("answering a gate from the notification", () => {
+  const AUTH = { origin: "https://box.local", token: "device-credential" };
+  const gatePush = (gate: unknown = "gate-uuid-1") => ({
+    data: pushData({ title: "✋ Approval needed", body: "claude-code:a1b2 wants to run Bash: rm -rf build", at: 1, urgency: 2, gate }),
+  });
+
+  it("a held gate arrives with Allow and Deny on it", async () => {
+    const w = loadWorker();
+    await w.fire("push", gatePush());
+    expect(w.shown[0]!.options.actions).toEqual([
+      { action: "allow", title: "Allow" },
+      { action: "deny", title: "Deny" },
+    ]);
+    // …and the id it is about, so the click handler does not have to ask.
+    expect(w.shown[0]!.options.data).toEqual({ gate: "gate-uuid-1" });
+  });
+
+  it("news does not", async () => {
+    // Everything this app sends other than a held gate is news, and news with
+    // buttons on it is a worse notification rather than a better one.
+    const w = loadWorker();
+    await w.fire("push", { data: pushData({ title: "❌ Tool error", body: "a tool failed.", urgency: 1 }) });
+    expect(w.shown[0]!.options.actions).toBeUndefined();
+    expect(w.shown[0]!.options.data).toBeUndefined();
+  });
+
+  it("and neither does a gate field that is not an id", async () => {
+    // An older server sends none; a confused one could send anything. Buttons
+    // that post `null` to /gate/decide are worse than no buttons.
+    for (const junk of [null, 42, "", {}, []]) {
+      const w = loadWorker();
+      await w.fire("push", gatePush(junk));
+      expect(w.shown[0]!.options.actions, JSON.stringify(junk)).toBeUndefined();
+    }
+  });
+
+  it("tapping Allow decides it, with the credential the page mirrored", async () => {
+    const w = loadWorker({ auth: AUTH });
+    await w.fire("notificationclick", {
+      action: "allow",
+      notification: { close() {}, data: { gate: "gate-uuid-1" } },
+    });
+    expect(w.sent).toHaveLength(1);
+    expect(w.sent[0]!.url).toBe("https://box.local/gate/decide");
+    expect(w.sent[0]!.init.method).toBe("POST");
+    expect(JSON.parse(w.sent[0]!.init.body)).toEqual({ id: "gate-uuid-1", decision: "allow" });
+    expect(w.sent[0]!.init.headers.authorization).toBe("Bearer device-credential");
+  });
+
+  it("tapping Deny sends deny, not allow", async () => {
+    // The one mistake in here that cannot be undone by tapping again.
+    const w = loadWorker({ auth: AUTH });
+    await w.fire("notificationclick", {
+      action: "deny",
+      notification: { close() {}, data: { gate: "g" } },
+    });
+    expect(JSON.parse(w.sent[0]!.init.body).decision).toBe("deny");
+  });
+
+  it("and does not open the app, which is the entire point", async () => {
+    // If answering raised a window, the buttons would be a slower way to do
+    // what tapping the notification already did.
+    const w = loadWorker({ auth: AUTH, clients: [{ url: "https://box.local/" }] });
+    await w.fire("notificationclick", {
+      action: "allow",
+      notification: { close() {}, data: { gate: "g" } },
+    });
+    expect(w.opened).toEqual([]);
+    expect(w.focused).toEqual([]);
+  });
+
+  it("tapping the notification itself still opens the queue", async () => {
+    // The path every iPhone takes, since Safari draws no action buttons.
+    const w = loadWorker({ auth: AUTH, clients: [{ url: "https://box.local/" }] });
+    await w.fire("notificationclick", { notification: { close() {}, data: { gate: "g" } } });
+    expect(w.sent).toEqual([]);
+    expect(w.focused).toEqual(["https://box.local/"]);
+  });
+
+  it("says what the tap did", async () => {
+    const w = loadWorker({ auth: AUTH });
+    await w.fire("notificationclick", { action: "allow", notification: { close() {}, data: { gate: "g" } } });
+    expect(w.shown).toHaveLength(1);
+    expect(w.shown[0]!.options.body).toContain("Allowed");
+    // Keyed to this gate, so answering one does not replace the notification
+    // for another that is still waiting.
+    expect(w.shown[0]!.options.tag).toBe("gate-result:g");
+    expect(w.shown[0]!.options.requireInteraction).toBe(false);
+  });
+
+  it("a gate that was already answered says so, rather than nothing", async () => {
+    // decideGate is idempotent: a gate decided at the desk, or one that timed
+    // out while the phone was in a pocket, comes back not-ok. That is a real
+    // answer and the person who just tapped is owed it.
+    const w = loadWorker({ auth: AUTH, reply: { body: { ok: false } } });
+    await w.fire("notificationclick", { action: "allow", notification: { close() {}, data: { gate: "g" } } });
+    expect(w.shown[0]!.options.body).toContain("Already answered");
+  });
+
+  it("a device that was forgotten is told to pair again", async () => {
+    const w = loadWorker({ auth: AUTH, reply: { status: 401 } });
+    await w.fire("notificationclick", { action: "allow", notification: { close() {}, data: { gate: "g" } } });
+    expect(w.shown[0]!.options.body).toContain("not connected any more");
+  });
+
+  it("a look-only device is told it is look-only, not that it failed", async () => {
+    // 403 is a working credential that may not decide. Sending somebody to
+    // re-pair a device that is paired fine fixes nothing.
+    const w = loadWorker({ auth: AUTH, reply: { status: 403 } });
+    await w.fire("notificationclick", { action: "allow", notification: { close() {}, data: { gate: "g" } } });
+    expect(w.shown[0]!.options.body).toContain("paired to look, not to answer");
+  });
+
+  it("an unreachable machine says so, rather than claiming it was answered", async () => {
+    const w = loadWorker({ auth: AUTH, reply: { throws: true } });
+    await w.fire("notificationclick", { action: "allow", notification: { close() {}, data: { gate: "g" } } });
+    expect(w.shown[0]!.options.body).toContain("Could not reach the computer");
+    expect(w.shown[0]!.title).not.toContain("✓");
+  });
+
+  it("a worker with nothing mirrored sends no request at all", async () => {
+    // Not a blind POST with no credential, which on a box with a token is a
+    // 401 and on one without is an unauthenticated decision from anything that
+    // can reach the port.
+    const w = loadWorker({ auth: null });
+    await w.fire("notificationclick", { action: "allow", notification: { close() {}, data: { gate: "g" } } });
+    expect(w.sent).toEqual([]);
+    expect(w.shown[0]!.options.body).toContain("not connected any more");
+  });
+});
+
+/**
+ * The two halves have to agree about where the credential is.
+ *
+ * The page writes it (src/lib/swAuth.ts) and the worker reads it (public/sw.js),
+ * and neither can import from the other — a service worker has no module graph
+ * and no build step here. So the database name, the store and the key are
+ * written out twice, and a mutation testing pass cannot see a mismatch: both
+ * files are individually correct and the feature silently does nothing.
+ */
+describe("where the page leaves it and where the worker looks", () => {
+  const page = readFileSync(new URL("../src/lib/swAuth.ts", import.meta.url).pathname, "utf8");
+
+  it("is the same database, store and key on both sides", () => {
+    const names = (src: string) => ({
+      db: src.match(/open\(\s*["'`]([^"'`]+)["'`]\s*,\s*1\s*\)/)?.[1]
+        ?? src.match(/const DB = "([^"]+)"/)?.[1],
+      store: src.match(/createObjectStore\((?:STORE|"([^"]+)")\)/)?.[1]
+        ?? src.match(/const STORE = "([^"]+)"/)?.[1],
+    });
+    const w = names(SRC);
+    expect(w.db, "sw.js does not open a database by a readable name").toBeTruthy();
+    expect(page).toContain(`const DB = "${w.db}"`);
+    // The store and the key are literals in the worker and constants in the
+    // page; check the worker's literals appear as the page's values.
+    const store = SRC.match(/\.transaction\("([^"]+)", "readonly"\)/)?.[1];
+    const key = SRC.match(/\.objectStore\([^)]*\)\.get\("([^"]+)"\)/)?.[1];
+    expect(store, "sw.js reads no object store").toBeTruthy();
+    expect(key, "sw.js reads no key").toBeTruthy();
+    expect(page).toContain(`const STORE = "${store}"`);
+    expect(page).toContain(`const KEY = "${key}"`);
+  });
+
+  it("and the worker reads the two fields the page writes", () => {
+    // `origin` decides where the decision is posted and `token` authorises it.
+    // A rename on either side is a worker that posts to "undefined/gate/decide".
+    expect(SRC).toContain("auth.origin");
+    expect(SRC).toContain("auth.token");
+    expect(page).toContain("origin: string");
+    expect(page).toContain("token: string");
   });
 });
 

--- a/web/test/webpush.test.ts
+++ b/web/test/webpush.test.ts
@@ -38,6 +38,8 @@ interface Calls {
   toldServerToForget: string[];
   browserUnsubscribed: number;
   permissionAsked: number;
+  remembered: number;
+  forgot: number;
   order: string[];
 }
 
@@ -49,7 +51,7 @@ function fakeEnv(over: Partial<PushEnv> & {
 } = {}) {
   const calls: Calls = {
     registered: [], subscribedWith: [], toldServer: [], toldServerToForget: [],
-    browserUnsubscribed: 0, permissionAsked: 0, order: [],
+    browserUnsubscribed: 0, permissionAsked: 0, remembered: 0, forgot: 0, order: [],
   };
   let current = over.existing ?? null;
 
@@ -107,6 +109,12 @@ function fakeEnv(over: Partial<PushEnv> & {
       calls.toldServerToForget.push(endpoint);
       return { ok: true };
     },
+    // The credential mirror the service worker reads (lib/swAuth.ts). Recorded
+    // in `order` alongside everything else, because *when* it happens is the
+    // part worth pinning: before the server has accepted the subscription is
+    // too early, and never is the whole feature quietly gone.
+    remember: async () => { calls.order.push("remember"); calls.remembered++; },
+    forget: async () => { calls.order.push("forget"); calls.forgot++; },
     ...over,
   };
   return { env, calls };
@@ -523,7 +531,10 @@ describe("turning it off", () => {
     const r = await disablePush(env);
     expect(r.ok).toBe(true);
     expect(r.state).toBe("off");
-    expect(calls.order).toEqual(["server-unsubscribe", "browser-unsubscribe"]);
+    // The mirror is cleared last, once the subscription is genuinely gone at
+    // both ends — clearing it first would leave a window where a push already
+    // in flight arrives with buttons the worker can no longer answer.
+    expect(calls.order).toEqual(["server-unsubscribe", "browser-unsubscribe", "forget"]);
     expect(calls.toldServerToForget).toEqual(["https://push.example/old"]);
   });
 
@@ -575,6 +586,57 @@ describe("working out where this device stands", () => {
   it("reports unsupported with no service worker at all", async () => {
     const { env } = fakeEnv({ sw: null });
     expect(await currentPushState(env)).toBe("unsupported");
+  });
+});
+
+/**
+ * The credential the service worker needs, and when it gets it.
+ *
+ * A held gate arrives on the phone with Allow and Deny on it, and the worker
+ * answering has to hold a credential — it cannot read the one the page keeps.
+ * This is the handoff. It is invisible when it breaks: push still arrives, the
+ * notification still opens the app when tapped, and only the two buttons stop
+ * working, on a device nobody is looking at.
+ */
+describe("what the service worker is told", () => {
+  it("is told who we are once the server has taken the subscription", async () => {
+    const { env, calls } = fakeEnv();
+    expect(await enablePush(env)).toEqual({ ok: true, state: "on" });
+    expect(calls.remembered).toBe(1);
+    // After, not before: a credential mirrored for a subscription that was
+    // refused is a credential in a second place for no reason.
+    expect(calls.order.indexOf("remember")).toBeGreaterThan(calls.order.indexOf("server-subscribe"));
+  });
+
+  it("is told nothing when the server refuses the subscription", async () => {
+    const { env, calls } = fakeEnv({ serverTakesIt: { ok: false, error: "no" } });
+    expect((await enablePush(env)).ok).toBe(false);
+    expect(calls.remembered).toBe(0);
+  });
+
+  it("has it taken back when push is switched off", async () => {
+    // A worker with no subscription has nothing to answer, so it has no
+    // business still holding a credential.
+    const { env, calls } = fakeEnv({ existing: { endpoint: "https://push.example/a" } });
+    expect(await disablePush(env)).toEqual({ ok: true, state: "off" });
+    expect(calls.forgot).toBe(1);
+  });
+
+  it("and has it taken back even when there was nothing subscribed", async () => {
+    // The state a phone lands in after the browser drops a subscription on its
+    // own — pressing Off is how somebody tidies up, and the leftover credential
+    // is exactly what they are tidying.
+    const { env, calls } = fakeEnv({ existing: null });
+    expect(await disablePush(env)).toEqual({ ok: true, state: "off" });
+    expect(calls.forgot).toBe(1);
+  });
+
+  it("works on a browser that has no IndexedDB at all", async () => {
+    // Optional on purpose: this should cost the buttons on the notification,
+    // not the notification.
+    const { env } = fakeEnv({ remember: undefined, forget: undefined });
+    expect(await enablePush(env)).toEqual({ ok: true, state: "on" });
+    expect((await disablePush(env)).ok).toBe(true);
   });
 });
 


### PR DESCRIPTION
## What does this PR do?

A held gate stops an agent until a person says go, and the alert that told them was a dead end. It named the tool and then instructed them to *go and find the app* — so the useful half of the loop was still tied to unlocking the phone, opening the companion and waiting for it to load. On a locked phone in a pocket that is most of a minute, for a decision that takes a second.

**A held gate now arrives with Allow and Deny on it**, and both are answered in the service worker. The app is not opened, and that is the point: a button that raised a window would be a slower way to do what tapping the notification already did.

**Nothing else gets buttons.** Everything this app sends other than a held gate is news, and news with buttons on it is a worse notification rather than a better one.

### How the worker knows who it is

The page keeps the credential in `localStorage`, which a service worker cannot read — it has no `window`. IndexedDB is the one store both halves reach, so the app mirrors the server and the credential there when push is switched on and clears them when it is switched off.

Not a second, wider credential minted for the worker: **the same one, at the level it was paired at**, on the same origin the page already keeps it on. A phone paired to *answer* gates can answer a gate from a notification and can do nothing else, because the server checks the scope on the route (#438). Forgetting the device at the machine revokes this copy in the same breath as the other one.

The gate id rides in the push payload to make any of it possible. It is an **id, not a credential**: deciding still needs the device's own, and the id alone names something already on that person's screen.

### Every outcome is said back

A silent button is one nobody trusts the second time, and "something went wrong" is the answer that makes somebody unlock the screen and go looking — the exact thing this exists to avoid.

| what happened | what the phone says |
|---|---|
| decided | *Allowed. The agent is going.* / *Denied. The agent has been told why.* |
| already decided at the desk, or timed out | *Already answered, or it timed out waiting.* |
| device was forgotten (401) | *This device is not connected any more. Open agentglass to pair it again.* |
| device is look-only (403) | *This device is paired to look, not to answer. Change that on the computer.* |
| machine unreachable | *Could not reach the computer. It may be asleep, or you may be on another network.* |

`decideGate` is already idempotent, so a gate answered at the desk while the phone was in a pocket comes back not-ok rather than as a conflict. That is a real answer and the person who just tapped is owed it.

### On iPhone

None of this appears — Safari draws no notification action buttons. Tapping the notification opens the queue exactly as before, and **that path is tested alongside the buttons** rather than assumed.

## How was it tested?

**Twenty-three mutations, all red.** Deny sending allow, buttons on news, buttons gone from a gate, any `gate` field treated as an id, the credential not attached, a POST with no credential at all, a refusal reported as a success, 401 and 403 collapsed into one sentence, an unreachable machine looking like an answer, one answer replacing another gate's notification, answering also opening the app, tapping the notification deciding instead of opening it, the mirror skipped, the mirror left behind after switching off, the id never leaving the server.

**Four of them are about the two halves agreeing where the credential lives.** The database, the store, the key and the field names are written out twice — neither file can import from the other, since a service worker here has no module graph — and a mismatch leaves both files individually correct while the feature silently does nothing. There is a rule that reads the literals out of `sw.js` and checks them against the constants in `swAuth.ts`.

### One harness fault found on the way

`indexedDB` and `fetch` in the worker were **bare global references**. In a real service worker that is fine — `self` *is* the global — but in the suite it meant the fake scope was bypassed entirely: the IndexedDB read silently returned null on every test, and a test that got as far as the fetch would have reached the host's real network. Both are `self.`-qualified now, like the `self.registration.showNotification` beside them, which changes nothing in a browser and makes the file testable against the scope it is given.

Suites green: **1216 server, 859 web**. **195/195 phone audit** after rebuilding the bundle.

## What this does not do

**It does not close #295.** That issue asks for the same outcome through an interactive webhook — a Slack message with Approve and Deny, and a public callback endpoint verifying a signature. That is a different piece of work and a much larger exposure; this one needs nothing reachable from outside the machine, which is the trade the README now argues for explicitly (#440).