### PR TITLE
Say that the notification can be answered, not only received

### DIFF
--- a/README.md
+++ b/README.md
@@ -369,7 +369,18 @@ exists for, you walked away and an agent is now blocked waiting on a person,
 was the one case nothing covered.
 
 **Settings ▸ Push to this phone**, one switch. After that a held gate buzzes the
-phone in your pocket, and tapping it opens the queue with the decision on it.
+phone in your pocket **with Allow and Deny on the notification** — you answer it
+from the lock screen and nothing opens. That is the whole loop: an agent stops,
+your pocket buzzes, you tap Allow, it goes. Tapping the notification itself
+still opens the queue, which is what happens on an iPhone, where Safari draws no
+buttons.
+
+Only a held gate gets them. Everything else this app sends is news, and news
+with buttons on it is a worse notification rather than a better one.
+
+Answering is bounded by what the device was paired for: a phone paired to
+**Look only** is told so rather than silently failing, and the two buttons do
+nothing it was not granted — the check is on the route, not on the notification.
 
 It is end-to-end encrypted by design: the push service relays a blob it cannot
 read (RFC 8291 over RFC 8188, VAPID for the token). Your machine generates its
@@ -384,6 +395,11 @@ ciphertext addressed to your own device.
   receiving until you say otherwise, and the list is where you say it.
 - A held gate stays on the lock screen until you deal with it; anything less
   urgent is allowed to fade.
+- Every tap says what it did — including the ones that are not a clean yes. A
+  gate somebody already answered at the desk, one that timed out while the phone
+  was face-down, a device that has since been forgotten, or a machine that has
+  gone to sleep are four different sentences, because they need four different
+  things done about them.
 - **On iPhone and iPad this needs the Home Screen icon first.** Safari has had
   Web Push since 16.4, but only for an installed site — in a browser tab the
   switch will say so and point at the share sheet.

--- a/server/test/readme-remote-claims.test.ts
+++ b/server/test/readme-remote-claims.test.ts
@@ -27,6 +27,39 @@ const section = (() => {
   return README.slice(from, README.indexOf("### Alerts that reach a locked phone", from));
 })();
 
+/**
+ * The README also promises the notification can be answered from the lock
+ * screen, which is a promise about `web/public/sw.js`. A worker that stops
+ * drawing the buttons is invisible — the alert still arrives, and only the
+ * thing the README says it does is missing.
+ */
+describe("what the README promises about the notification", () => {
+  const alerts = (() => {
+    const from = README.indexOf("### Alerts that reach a locked phone");
+    expect(from, "the alerts section is gone from the README").toBeGreaterThan(-1);
+    return README.slice(from, README.indexOf("Independent of `AGENTGLASS_NOTIFY`", from));
+  })();
+
+  test("the buttons it names are the buttons the worker draws", () => {
+    expect(alerts).toContain("Allow and Deny on the notification");
+    const sw = repo("web/public/sw.js");
+    expect(sw).toContain('{ action: "allow", title: "Allow" }');
+    expect(sw).toContain('{ action: "deny", title: "Deny" }');
+  });
+
+  test("and it still says only a held gate gets them", () => {
+    // The claim that keeps the feature from becoming a notification with
+    // buttons on everything, which is the version nobody wants.
+    expect(alerts).toMatch(/Only a held gate gets them/);
+    expect(repo("web/public/sw.js")).toContain("actions: gate");
+  });
+
+  test("the tap-to-open path it points iPhone users at is still there", () => {
+    expect(alerts).toContain("Safari draws no");
+    expect(repo("web/public/sw.js")).toContain("openWindow");
+  });
+});
+
 describe("what the README tells people about reaching this from elsewhere", () => {
   test("the escape hatch it names is the one the hooks actually read", () => {
     expect(section).toContain("AGENTGLASS_ALLOW_REMOTE");


### PR DESCRIPTION
Follow-up to #441.

## What does this PR do?

The **Alerts that reach a locked phone** section still described the version where a held gate buzzed the phone and *tapping it opened the queue*. That is now the fallback path — the one an iPhone takes, since Safari draws no action buttons — and what actually happens on Android is that **Allow and Deny are on the notification** and the loop closes without unlocking anything.

Worth stating in full rather than as a line item, because the shape of the promise is the part that matters:

- **only a held gate gets buttons** — everything else this app sends is news, and news with buttons on it is a worse notification, not a better one;
- **answering is bounded by what the device was paired for** — a phone paired to Look only is told so rather than silently failing, because the check is on the route and not on the notification;
- **every tap says what it did**, including the four ways it can honestly not be a clean yes: already answered at the desk, timed out while the phone was face-down, the device since forgotten, or the machine asleep.

## How was it tested?

The claims are checked against `sw.js`, the same way the remote section's claims are checked against the hooks and the rebinding guard (#440). Documentation that describes a behaviour the code no longer has is worse than none — and this one is invisible when it breaks, because the alert still arrives and only the thing the README says it does is missing.

**Eight mutations, all red**: each button renamed in the worker, buttons put on every alert rather than only a held gate, the tap-to-open path removed, and each of the three sentences in the README weakened underneath it.

Suite green: **1219 server**.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UnKBseEi7gnE2XCwdzikzY)_