### PR TITLE
Stop promising an OTLP metrics receiver, and say so where it is asked for

### DIFF
--- a/README.md
+++ b/README.md
@@ -839,7 +839,16 @@ agentglass isn't Claude-only. It exposes an **OTLP/HTTP** trace receiver that
 maps OpenTelemetry **GenAI** spans (the `gen_ai.*` semantic conventions) into the
 same events the dashboard already understands — so anything emitting GenAI
 telemetry streams in: the OpenAI / Google / Bedrock SDK instrumentations,
-LangChain, LiteLLM, OpenLLMetry, and Claude Code's own OTel export.
+LangChain, LiteLLM, OpenLLMetry, Arize Phoenix and the other OpenInference
+instrumentors.
+
+**Not Claude Code's own OTel export**, which this used to list. That export is
+*metrics*, and this receiver takes spans and log records — so pointing
+`OTEL_EXPORTER_OTLP_ENDPOINT` at agentglass from Claude Code sends its metrics
+to an endpoint that turns them away and says why. Nothing is lost: Claude Code
+is already covered, at far higher fidelity, by the hooks (`bun run setup`) —
+per-tool timings, the prompt, the arguments, and the gate. Metrics carry totals,
+which is the one thing the dashboard can already compute.
 
 ### Auto-connect installed CLIs — one command, opt-in
 

--- a/server/src/auth.ts
+++ b/server/src/auth.ts
@@ -41,6 +41,12 @@ const AUTH_EXEMPT = new Set([
   "/otlp/v1/traces",
   "/v1/logs",
   "/otlp/v1/logs",
+  // Exempt although it receives nothing: it exists to explain that there is no
+  // metrics receiver here (see index.ts). An exporter cannot carry a token, so
+  // gating it would replace a silent 404 with a silent 401 — the same dead end
+  // wearing a different number.
+  "/v1/metrics",
+  "/otlp/v1/metrics",
 ]);
 
 /**

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -113,6 +113,9 @@ const TRUST_LAN = process.env.AGENTGLASS_TRUST_LAN === "1";
 // writes through the victim's own loopback. Treating TRUST_LAN as "not loopback
 // only" for the token decision forces a token exactly when one is needed; net.ts
 // already documents TRUST_LAN as something used on top of a token.
+/** So a misconfigured exporter explains itself once rather than every batch. */
+let warnedNoMetrics = false;
+
 const AUTH = resolveToken(LOOPBACK_ONLY && !TRUST_LAN);
 const AUTH_TOKEN = AUTH.token;
 /** One socket, three roles: the live event stream, PTY terminal shells, and
@@ -695,6 +698,45 @@ const server = Bun.serve<WsData>({
         if (b.source_app && b.session_id && b.hook_event_type) ingestBody(b);
       }
       return json({}); // ExportLogsServiceResponse: {} = success
+    }
+
+    /**
+     * --- OTLP metrics: refused out loud, rather than 404 ---
+     *
+     * There is no metrics receiver here, on purpose — otlp.ts says why. What
+     * this route fixes is not the absence but the silence: point
+     * `OTEL_EXPORTER_OTLP_ENDPOINT` at agentglass from Claude Code and its
+     * metrics went to a 404, which an exporter swallows into a log nobody is
+     * reading. The person is left watching a dashboard that never fills, with
+     * nothing anywhere saying the endpoint they configured does not exist.
+     *
+     * 501 rather than 404 or 429: it is honest about what happened, and it is
+     * in the class OTel exporters do not retry — so a misconfigured agent says
+     * this once per batch rather than hammering the port forever.
+     *
+     * Registered for GET as well as POST. An exporter only ever POSTs, but the
+     * first thing anybody does when telemetry does not arrive is open the URL
+     * in a browser, and a 404 there is the same dead end by hand.
+     */
+    if (pathname === "/v1/metrics" || pathname === "/otlp/v1/metrics") {
+      // Said once, on the console the operator is actually looking at. The
+      // exporter's own log is the other place this could land, and it is on
+      // the wrong machine's terminal about as often as not.
+      if (!warnedNoMetrics) {
+        warnedNoMetrics = true;
+        console.warn(
+          "[otlp] something POSTed metrics to " + pathname + ". This server receives OpenTelemetry " +
+          "traces (/v1/traces) and logs (/v1/logs), not metrics — see README ▸ OpenTelemetry. " +
+          "If this is Claude Code, it is already covered in full by the hooks (bun run setup) and its " +
+          "OTel export can be left pointed elsewhere.",
+        );
+      }
+      return json({
+        error: "this server has no OpenTelemetry metrics receiver",
+        accepts: ["/v1/traces", "/v1/logs"],
+        why: "agentglass maps GenAI spans and log records into per-call events. Metrics carry totals, which it already computes from those events.",
+        claudeCode: "Claude Code's OTel export is metrics, and it is already covered at higher fidelity by the hooks — run `bun run setup`.",
+      }, 501);
     }
 
     // --- reads ---

--- a/server/src/otlp.ts
+++ b/server/src/otlp.ts
@@ -8,11 +8,24 @@
 // feed the dashboard.
 //
 // NOT Claude Code's own OTel export, which this used to claim. That export is
-// METRICS, and the only OTLP routes registered are /v1/traces and /v1/logs
-// (server/src/index.ts) — point OTEL_EXPORTER_OTLP_ENDPOINT here from Claude
-// Code and its metrics get a 404. Nothing breaks, because Claude Code is
-// already covered properly by the hooks, but the sentence sent anyone
-// extending this mapper looking for a metrics receiver that is not here.
+// METRICS, and there is no metrics receiver here — deliberately, not by
+// omission:
+//
+//   * everything those metrics carry about Claude Code is already in the
+//     database via the hooks, and at far higher fidelity — per-tool timings,
+//     the prompt, the arguments, the gate decision. Metrics carry totals,
+//     which is the one thing this dashboard already computes;
+//   * a second source for the same numbers is a double-counting bug waiting to
+//     happen. Attribution here is already careful work (see the cumulative-usage
+//     handling in ingest.ts and the pricing fallbacks), and feeding it a
+//     parallel stream of the same tokens would quietly inflate every total;
+//   * metrics have no per-call identity, so nothing in them can become an
+//     event. There is no mapping to write, only a sink to throw them into.
+//
+// So /v1/metrics exists and refuses, rather than 404ing. A silent 404 is how
+// somebody spends an afternoon wondering why nothing arrives — see the route
+// in index.ts, which says what this server takes and where Claude Code is
+// already covered.
 //
 // Mapping strategy:
 //   • a TOOL span (operation "execute_tool" or carrying gen_ai.tool.name) becomes
@@ -22,7 +35,9 @@
 //     carries per-call token usage in payload.usage, so cost math just works.
 // Spans with no gen_ai.* signal are ignored (this is not a general trace store).
 //
-// JSON only: point your exporter with OTEL_EXPORTER_OTLP_PROTOCOL=http/json.
+// Both OTLP/HTTP encodings are accepted — JSON and protobuf, the SDK default —
+// so no Collector is needed. (This line said "JSON only" long after the
+// protobuf decoder landed in otlp_pb.ts.)
 import type { IngestBody } from "../../shared/types.ts";
 
 interface AnyVal {

--- a/server/test/device-scope.test.ts
+++ b/server/test/device-scope.test.ts
@@ -193,9 +193,29 @@ describe("the pairing routes themselves", () => {
     expect(isPairing("/pair/anything")).toBe(true);
     expect(isPairing("/paired")).toBe(false);
     expect(isPairing("/repair/x")).toBe(false);
+    // The register of everything reachable with no credential at all, and why
+    // each one is allowed to be. Changing this list is the moment to re-read
+    // it, which is the whole point of writing it out rather than deriving it.
+    const OPEN: Record<string, string> = {
+      "/health": "answers a fixed shape, so a shell can find which server owns the port",
+      "/ingest": "append-only: a local hook has no way to carry a secret",
+      "/v1/traces": "append-only OTel sink, same reason",
+      "/otlp/v1/traces": "append-only OTel sink, same reason",
+      "/v1/logs": "append-only OTel sink, same reason",
+      "/otlp/v1/logs": "append-only OTel sink, same reason",
+      // Receives nothing and stores nothing — it exists to say there is no
+      // metrics receiver here. Gating it would turn a silent 404 into a silent
+      // 401, which is the same dead end.
+      "/v1/metrics": "refuses, and explains; reads and writes nothing",
+      "/otlp/v1/metrics": "refuses, and explains; reads and writes nothing",
+    };
     for (const r of ROUTES.filter((r) => !isPairing(r))) {
-      if (["/health", "/ingest", "/v1/traces", "/otlp/v1/traces", "/v1/logs", "/otlp/v1/logs"].includes(r)) continue;
+      if (r in OPEN) continue;
       expect(isAuthExempt(r), `${r} no longer needs a credential`).toBe(false);
+    }
+    // And nothing on the list has quietly stopped being a route.
+    for (const r of Object.keys(OPEN)) {
+      expect(isAuthExempt(r), `${r} is listed as open but is not exempt`).toBe(true);
     }
   });
 

--- a/server/test/otlp-metrics-refusal.test.ts
+++ b/server/test/otlp-metrics-refusal.test.ts
@@ -1,0 +1,156 @@
+/*
+ * There is no metrics receiver here, and the server says so.
+ *
+ * The absence is deliberate — otlp.ts sets out why — but for a long time the
+ * only way to find out was that nothing arrived. Pointing
+ * `OTEL_EXPORTER_OTLP_ENDPOINT` at agentglass from Claude Code sent its metrics
+ * to a 404, which an exporter swallows into a log on whichever machine the
+ * agent happens to be running on, and the person is left watching a dashboard
+ * that never fills with nothing anywhere telling them why.
+ *
+ * That is the same failure this codebase already refuses to ship elsewhere: the
+ * firewall hint exists because ufw DROPs rather than REJECTs and the phone just
+ * shows a white page. This is the OTel version of it.
+ *
+ * Driven against a real server, because what is being checked is partly the
+ * HTTP: the status code an exporter will not retry, and that the route answers
+ * before the token gate rather than behind it.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TOKEN = "metrics-test-token-not-a-real-one";
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-metrics-"));
+  const port = 4980 + Math.floor(Math.random() * 15);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    // A named environment, never `...process.env` — `bun test` shares one
+    // process across files, so the parent's is whatever ran before this.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+      // Set, so "answers without a credential" is a fact rather than an
+      // artefact of there being no gate to pass.
+      AGENTGLASS_TOKEN: TOKEN,
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+/** What Claude Code's exporter actually POSTs: an OTLP metrics envelope. */
+const METRICS = {
+  resourceMetrics: [{
+    resource: { attributes: [{ key: "service.name", value: { stringValue: "claude-code" } }] },
+    scopeMetrics: [{ metrics: [{ name: "claude_code.token.usage", sum: { dataPoints: [{ asInt: "1200" }] } }] }],
+  }],
+};
+
+const post = (path: string) =>
+  fetch(base + path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(METRICS),
+  });
+
+describe("metrics arriving at a server that does not take them", () => {
+  test("are refused with a status an exporter will not retry", async () => {
+    // 404 was the old answer and it is indistinguishable from a typo in the
+    // endpoint. 429/502/503/504 are the ones OTel exporters retry, and a
+    // misconfigured agent hammering the port forever is worse than a 404.
+    for (const path of ["/v1/metrics", "/otlp/v1/metrics"]) {
+      const r = await post(path);
+      expect(r.status, path).toBe(501);
+    }
+  });
+
+  test("and the refusal says what this server does take", async () => {
+    const j = await (await post("/v1/metrics")).json() as Record<string, unknown>;
+    expect(j.accepts).toEqual(["/v1/traces", "/v1/logs"]);
+    expect(String(j.error)).toContain("no OpenTelemetry metrics receiver");
+  });
+
+  test("and names where Claude Code is already covered", async () => {
+    // The single most likely sender, and the one for whom nothing is actually
+    // missing — so the answer has to say that rather than only "no".
+    const j = await (await post("/v1/metrics")).json() as Record<string, string>;
+    expect(j.claudeCode).toContain("hooks");
+    expect(j.claudeCode).toContain("bun run setup");
+  });
+
+  test("without needing a credential, because an exporter cannot carry one", async () => {
+    // The token is set on this server. If this route were behind the gate, the
+    // silent 404 would have become a silent 401 — the same dead end.
+    const r = await post("/v1/metrics");
+    expect(r.status).not.toBe(401);
+    expect(r.status).toBe(501);
+  });
+
+  test("and answers a browser too, which is what a person tries next", async () => {
+    const r = await fetch(base + "/v1/metrics");
+    expect(r.status).toBe(501);
+    expect(String((await r.json() as Record<string, unknown>).error)).toContain("metrics receiver");
+  });
+
+  test("the receivers that do exist still take what they take", async () => {
+    // The guard against fixing this by turning the OTLP surface off.
+    for (const path of ["/v1/traces", "/v1/logs"]) {
+      const r = await fetch(base + path, {
+        method: "POST",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({}),
+      });
+      expect(r.status, path).toBe(200);
+    }
+  });
+});
+
+describe("what the documentation says about it", () => {
+  const repo = (p: string) => readFileSync(new URL("../../" + p, import.meta.url), "utf8");
+
+  test("the README no longer lists Claude Code as an OTLP source", () => {
+    // The claim was corrected in otlp.ts and left standing in the README, which
+    // is the more widely read of the two.
+    const readme = repo("README.md");
+    const section = readme.slice(readme.indexOf("### OpenTelemetry"), readme.indexOf("### Auto-connect installed CLIs"));
+    expect(section).not.toMatch(/LangChain, LiteLLM, OpenLLMetry, and Claude Code's own OTel export/);
+    expect(section).toContain("Not Claude Code's own OTel export");
+    // …and says where it *is* covered, rather than only that it is not here.
+    expect(section).toContain("bun run setup");
+  });
+
+  test("and the mapper's own header stops claiming JSON only", () => {
+    // Protobuf has been decoded since otlp_pb.ts landed; the header said
+    // otherwise for as long, which is the same kind of stale claim.
+    const otlp = repo("server/src/otlp.ts");
+    expect(otlp).not.toContain("JSON only: point your exporter");
+    expect(otlp).toContain("protobuf");
+  });
+
+  test("the decision not to receive metrics is written down, not implied", () => {
+    // The issue asked for it either way. An absence with no reason attached is
+    // indistinguishable from an oversight, and gets 'fixed' by the next person.
+    const otlp = repo("server/src/otlp.ts");
+    expect(otlp).toContain("deliberately, not by");
+    expect(otlp).toMatch(/double-counting/);
+  });
+});


### PR DESCRIPTION
Closes #365.

## What does this PR do?

The header in `otlp.ts` was corrected in #375. **The README was left claiming it**, and it is the more widely read of the two:

> anything emitting GenAI telemetry streams in: the OpenAI / Google / Bedrock SDK instrumentations, LangChain, LiteLLM, OpenLLMetry, and **Claude Code's own OTel export**.

That export is *metrics*. This receiver takes spans and log records.

### The open question, answered

The issue ended on one — *"worth deciding at the same time whether a metrics receiver is wanted at all"* — so this answers it rather than leaving the absence to look like an oversight somebody will helpfully fix. It is **not** wanted, for three reasons now written into the header:

- everything those metrics carry about Claude Code is **already in the database via the hooks**, at far higher fidelity — per-tool timings, the prompt, the arguments, the gate decision. Metrics carry totals, which is the one thing the dashboard already computes;
- a second source for the same tokens is a **double-counting bug waiting to happen**. Attribution here is already careful work (the cumulative-usage handling in `ingest.ts`, the pricing fallbacks), and a parallel stream of the same numbers would quietly inflate every total;
- metrics have **no per-call identity**, so nothing in them can become an event. There is no mapping to write, only a sink to throw them into.

### What was actually worth fixing

Not the absence — the *silence*. Pointing `OTEL_EXPORTER_OTLP_ENDPOINT` here from Claude Code sent its metrics to a 404, which an exporter swallows into a log on whichever machine the agent happens to be running on. The person is left watching a dashboard that never fills, with nothing anywhere saying the endpoint they configured does not exist.

That is the same shape as a firewall that DROPs instead of REJECTing — which this codebase already refuses to ship, and wrote `firewallHint` to avoid.

So `/v1/metrics` and `/otlp/v1/metrics` exist and refuse:

```json
{
  "error": "this server has no OpenTelemetry metrics receiver",
  "accepts": ["/v1/traces", "/v1/logs"],
  "why": "agentglass maps GenAI spans and log records into per-call events. Metrics carry totals, which it already computes from those events.",
  "claudeCode": "Claude Code's OTel export is metrics, and it is already covered at higher fidelity by the hooks — run `bun run setup`."
}
```

- **501**, not 404 and not 429/502/503/504 — honest about what happened, and in the class OTel exporters do not retry, so a misconfigured agent says this once per batch rather than hammering the port forever.
- **Said once on the server's own console** as well, because that is the terminal the operator is actually looking at.
- **Registered for GET too.** An exporter only POSTs, but opening the URL is the first thing anybody does when telemetry does not arrive, and a 404 there is the same dead end by hand.
- **Auth-exempt**, like the other intake sinks: an exporter cannot carry a token, and gating it would turn a silent 404 into a silent 401. It receives nothing and stores nothing, so it grants nothing — the register of open routes in `device-scope.test.ts` now records *why* each entry is on it instead of listing them bare, and checks nothing has quietly fallen off.

### One more stale claim in the same header

`// JSON only: point your exporter with OTEL_EXPORTER_OTLP_PROTOCOL=http/json` has been wrong since `otlp_pb.ts` landed — both encodings are decoded, as the README already said. Fixed while the file was open.

## How was it tested?

Driven against a real server with a token set, because part of what is being checked is the HTTP itself: the status an exporter will not retry, and that the route answers *before* the gate rather than behind it. The body posted is a real OTLP metrics envelope carrying `claude_code.token.usage`, which is what actually shows up.

**Twelve mutations, all red**: the route back to a 404, a retryable status, the `/otlp` prefix dropped, the body no longer naming the working endpoints or the hooks, the route moved behind the token gate, GET no longer answered, the traces receiver switched off alongside it, and each documentation sentence weakened underneath its own check.

Suites green: **1228 server, 859 web**.