### PR TITLE
Pin a chat's pane, and see what is actually running

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -69,7 +69,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
 import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
-import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane } from "./tmuxpane.ts";
+import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, inScope } from "./config.ts";
 import { hookStatus, applyHooks } from "./hooksetup.ts";
@@ -1569,6 +1569,53 @@ const server = Bun.serve<WsData>({
       forgetPane(id);
       return json({ killed: was });
     }
+    /**
+     * Keep this chat's pane, however long you are away.
+     *
+     * Eviction is right for the common case and wrong for the one conversation
+     * you are living in — see `pinned` in tmuxpane.ts. Only about idleness:
+     * closing the chat still releases the pane, because closing is an explicit
+     * "done".
+     */
+    if (pathname === "/chat/pane/pin" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: any = {};
+      try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
+      const id = typeof b.session === "string" ? b.session : "";
+      if (!validPaneName(id)) return json({ error: "invalid session id" }, 400);
+      const on = b.pinned !== false;
+      pinPane(id, on);
+      return json({ ok: true, session: id, pinned: on });
+    }
+
+    /**
+     * What is actually running, and which of it belongs to nothing.
+     *
+     * Panes outlive the app: quit or crash and the sessions are still there,
+     * each holding several hundred megabytes. The only way to see that was
+     * `tmux -L agentglass ls` in a terminal, and the only way to clean up was
+     * `kill-session` by hand.
+     *
+     * `orphan` is decided here rather than in tmuxpane.ts, because it is a
+     * question about *chats* and that module knows only about panes: a pane is
+     * an orphan when no chat this server is tracking points at it. `open` is
+     * the set the caller says it has on screen — the client knows which chats
+     * are open, and the server does not, so a pane belonging to a chat in
+     * another window must not be reported as abandoned.
+     */
+    if (pathname === "/chat/panes") {
+      const open = (url.searchParams.get("open") || "").split(",").map((s) => s.trim()).filter(Boolean);
+      return json({
+        // The judgement is in tmuxpane.ts and pure — see classifyPanes. It was
+        // three lines here, which made it reachable only through a machine with
+        // tmux genuinely running.
+        panes: classifyPanes(await panes(), open, activeTurns()),
+        // So the UI can say "reclaimed after 30 minutes" rather than guessing,
+        // and can say "eviction is off" when somebody has turned it off.
+        idleEvictMs: idleEvictMs(),
+      });
+    }
+
     // Answer an interactive prompt without leaving the chat. The pane already
     // takes Enter and Escape from us; arrows are the rest of what a picker
     // needs, and sending them here beats telling someone to open a terminal to

--- a/server/src/tmuxpane.ts
+++ b/server/src/tmuxpane.ts
@@ -283,8 +283,102 @@ const lastUsed = new Map<string, number>();
 export const idleEvictMs = (): number =>
   Math.max(0, Number(process.env.AGENTGLASS_TMUX_IDLE_MINUTES ?? 30)) * 60_000;
 
-export function touchPane(name: string): void { lastUsed.set(name, Date.now()); }
-export function forgetPane(name: string): void { lastUsed.delete(name); }
+/** `now` is a parameter for the same reason `evictIdlePanes` takes one: the two
+ *  are judged against each other, and a test that fixes one clock and not the
+ *  other is comparing a made-up timestamp with a real one. */
+export function touchPane(name: string, now = Date.now()): void { lastUsed.set(name, now); }
+export function forgetPane(name: string): void { lastUsed.delete(name); pinned.delete(name); }
+
+/**
+ * Panes the sweeper may not touch.
+ *
+ * Eviction is right for the common case and wrong for the one chat you are
+ * actually living in: step away for lunch and the session you care about is
+ * precisely the one reclaimed, so the turn you come back to is the slow one —
+ * which is the cost the pane engine exists to remove. There was no way to say
+ * "not this one".
+ *
+ * A pin is about *idleness only*. Closing a pinned chat still releases its
+ * pane, because closing is an explicit "done" and pinning is a statement about
+ * a gap in a conversation, not about keeping a process forever.
+ *
+ * Held in memory, alongside `lastUsed`, and dropped when the pane is — a pin on
+ * a process that no longer exists is not a preference anybody holds. A server
+ * restart therefore loses pins while the tmux panes survive it; the sweeper's
+ * own rule covers that, since a pane it has no record of gets a fresh full
+ * interval rather than being reaped immediately.
+ */
+const pinned = new Set<string>();
+
+export function pinPane(name: string, on: boolean): boolean {
+  if (!validPaneName(name)) return false;
+  if (on) pinned.add(name); else pinned.delete(name);
+  return true;
+}
+
+export const isPinned = (name: string): boolean => pinned.has(name);
+
+/**
+ * Every pane on our socket, with what is known about it.
+ *
+ * Panes outlive the app — quit or crash and the sessions are still there — and
+ * until now the only way to see that was `tmux -L agentglass ls` in a terminal,
+ * with `kill-session` by hand as the only cleanup. A person running five chats
+ * and wondering where two gigabytes went had nowhere in the app to look.
+ *
+ * `lastUsedAt` is null for a pane this process has never served a turn for,
+ * which is exactly the shape of an orphan from a previous run. Whether it *is*
+ * one also depends on which chats are open, which this module does not know —
+ * so that judgement is left to the caller (see /chat/panes).
+ */
+export interface PaneInfo {
+  name: string;
+  lastUsedAt: number | null;
+  pinned: boolean;
+}
+
+/** `list` is a parameter for the same reason `reachableAddresses` takes its
+ *  interfaces and `firewallHint` takes its `which`: everything else in this
+ *  module shells out to tmux, and a test that reached a real one would be
+ *  reading the developer's own sessions. */
+/**
+ * A pane, once it is known what is using it.
+ *
+ * Split out from `panes()` and pure, because the judgement needs two things
+ * neither side of the wire holds alone: which chats are on screen, which only
+ * the client knows, and which turns are in flight, which only the server does.
+ * Combining them in the route left it reachable only through a machine with
+ * tmux actually running, which is to say untested.
+ */
+export interface PaneStatus extends PaneInfo {
+  /** Mid-turn at this instant. Never an orphan, and never safe to end. */
+  running: boolean;
+  /** Nothing open and nothing in flight points at it. */
+  orphan: boolean;
+}
+
+export function classifyPanes(
+  rows: PaneInfo[], open: Iterable<string>, running: Iterable<string>,
+): PaneStatus[] {
+  const isOpen = new Set(open);
+  const isRunning = new Set(running);
+  return rows.map((p) => ({
+    ...p,
+    running: isRunning.has(p.name),
+    // A pane serving a turn is never an orphan, whatever anybody has on
+    // screen — the turn is the proof that something is using it, and it is the
+    // one row that must not be offered a one-click end.
+    orphan: !isRunning.has(p.name) && !isOpen.has(p.name),
+  }));
+}
+
+export async function panes(list: () => Promise<string[]> = listPanes): Promise<PaneInfo[]> {
+  return (await list()).map((name) => ({
+    name,
+    lastUsedAt: lastUsed.get(name) ?? null,
+    pinned: pinned.has(name),
+  }));
+}
 
 /** Kill panes idle past the threshold. Returns the names it reclaimed.
  *
@@ -292,16 +386,24 @@ export function forgetPane(name: string): void { lastUsed.delete(name); }
  *  chat from before a server restart or something a human started by hand, and
  *  killing an agent mid-work to save memory it might be actively using is a much
  *  worse failure than holding the memory. It gets a record instead, so it is
- *  eligible for eviction one full interval from now. */
-export async function evictIdlePanes(now = Date.now()): Promise<string[]> {
+ *  eligible for eviction one full interval from now.
+ *
+ *  A pinned pane is skipped entirely — see `pinned`. */
+export async function evictIdlePanes(
+  now = Date.now(),
+  io: { list: () => Promise<string[]>; kill: (n: string) => Promise<void> } = { list: listPanes, kill: killPane },
+): Promise<string[]> {
   const window = idleEvictMs();
   if (!window) return [];
   const evicted: string[] = [];
-  for (const name of await listPanes()) {
+  for (const name of await io.list()) {
+    // Checked before the bookkeeping, so a pinned pane is not silently given a
+    // timestamp it will be judged on the moment it is unpinned.
+    if (pinned.has(name)) continue;
     const seen = lastUsed.get(name);
     if (seen === undefined) { lastUsed.set(name, now); continue; }
     if (now - seen < window) continue;
-    await killPane(name);
+    await io.kill(name);
     lastUsed.delete(name);
     evicted.push(name);
   }
@@ -323,4 +425,4 @@ export function stopPaneSweeper(): void {
 }
 
 /** Test seam: drop the idle bookkeeping without touching any real server. */
-export function __resetPaneState(): void { lastUsed.clear(); }
+export function __resetPaneState(): void { lastUsed.clear(); pinned.clear(); }

--- a/server/test/pane-pin.test.ts
+++ b/server/test/pane-pin.test.ts
@@ -1,0 +1,214 @@
+/*
+ * Saying "not this one" to the sweeper, and being able to see what is running.
+ *
+ * Idle eviction is right for the common case and wrong for the chat you are
+ * actually living in: step away for lunch and the session you care about is
+ * precisely the one reclaimed, so the turn you come back to is the slow one —
+ * the exact cost the pane engine exists to remove.
+ *
+ * `listPanes` and `killPane` shell out to tmux, which is not running here, so
+ * they are injected. What is under test is the *decision* — which panes the
+ * sweeper takes and which it leaves — and that is the part with a several
+ * hundred megabyte process on the other end of it.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import {
+  evictIdlePanes, touchPane, forgetPane, pinPane, isPinned, panes, classifyPanes, __resetPaneState,
+} from "../src/tmuxpane.ts";
+
+/**
+ * tmux, as a parameter.
+ *
+ * A module namespace is frozen, so there is nothing to monkey-patch here — and
+ * that is the better answer anyway: `evictIdlePanes` and `panes` take their
+ * listing and killing the same way `reachableAddresses` takes its interfaces
+ * and `firewallHint` takes its `which`. A test that reached a real tmux would
+ * be reading, and reaping, the developer's own sessions.
+ */
+function fakeTmux(names: string[]) {
+  const killed: string[] = [];
+  const live = new Set(names);
+  return {
+    killed,
+    live,
+    io: {
+      list: async () => [...live],
+      kill: async (n: string) => { killed.push(n); live.delete(n); },
+    },
+  };
+}
+
+beforeEach(() => {
+  process.env.NODE_ENV = "test";
+  process.env.AGENTGLASS_TMUX_IDLE_MINUTES = "30";
+  __resetPaneState();
+});
+
+afterEach(() => { __resetPaneState(); });
+
+const HOUR = 3_600_000;
+
+/**
+ * Pane names are session ids, and the shape is pinned to what a uuid is —
+ * tmux treats `:` and `.` as window/pane separators, so a crafted name could
+ * resolve onto a target nobody meant. Short readable names are refused, which
+ * is correct and is why these are not "chat-a".
+ */
+const A = "6b191fd3-f71e-5010-863d-d32334eaf400";
+const B = "9c2a41ee-0d38-4a17-91bb-6f0e2b7c1d55";
+const STRANGER = "0e77b2c4-3a91-4d60-8f2e-1c5a9b3d7e88";
+
+describe("pinning", () => {
+  test("a pinned pane is not reclaimed, however long it sits", async () => {
+    const t0 = 2_000_000;
+    const t = fakeTmux([A, B]);
+    touchPane(A, t0);
+    touchPane(B, t0);
+    pinPane(A, true);
+    // Both are an hour idle, which is twice the window.
+    expect(await evictIdlePanes(t0 + HOUR, t.io)).toEqual([B]);
+    expect(t.killed).toEqual([B]);
+  });
+
+  test("unpinning puts it straight back under the ordinary rule", async () => {
+    // Judged on when it was last *used*, not on when the pin came off — the pin
+    // suspends the sweeper's interest in a pane, it does not restart its clock.
+    const t0 = 1_000_000;
+    const t = fakeTmux([A]);
+    touchPane(A, t0);
+    pinPane(A, true);
+    expect(await evictIdlePanes(t0 + HOUR, t.io)).toEqual([]);
+    pinPane(A, false);
+    expect(await evictIdlePanes(t0 + HOUR, t.io)).toEqual([A]);
+  });
+
+  test("closing a chat releases its pane, pinned or not", async () => {
+    // Pinning is about idleness. Closing is an explicit "done", and a pin that
+    // survived it would be a memory leak with a switch in front of it.
+    pinPane(A, true);
+    expect(isPinned(A)).toBe(true);
+    forgetPane(A);
+    expect(isPinned(A)).toBe(false);
+  });
+
+  test("a name that is not a pane name is refused", () => {
+    // The name goes to `tmux kill-session -t`, so the same validation the rest
+    // of this module applies to it applies here.
+    expect(pinPane("../../etc/passwd", true)).toBe(false);
+    expect(pinPane("a; rm -rf /", true)).toBe(false);
+    expect(pinPane("sess:0.1", true)).toBe(false); // tmux's window/pane separators
+    expect(pinPane("short", true)).toBe(false);    // a uuid is longer than this
+    expect(isPinned("a; rm -rf /")).toBe(false);
+    expect(pinPane(A, true)).toBe(true);
+  });
+
+  test("pinning does not resurrect the record of a pane nobody has used", async () => {
+    // A pane this process has never served is left alone for one full interval
+    // whether or not it is pinned — the sweeper's existing rule, unchanged.
+    const t = fakeTmux([STRANGER]);
+    pinPane(STRANGER, true);
+    expect(await evictIdlePanes(3_000_000 + HOUR, t.io)).toEqual([]);
+    expect(t.killed).toEqual([]);
+  });
+});
+
+describe("what the sweeper still does", () => {
+  test("reclaims an unpinned pane past the window", async () => {
+    const t0 = 4_000_000;
+    const t = fakeTmux([A]);
+    touchPane(A, t0);
+    expect(await evictIdlePanes(t0 + HOUR, t.io)).toEqual([A]);
+  });
+
+  test("leaves one inside the window alone", async () => {
+    const t0 = 5_000_000;
+    const t = fakeTmux([A]);
+    touchPane(A, t0);
+    expect(await evictIdlePanes(t0, t.io)).toEqual([]);
+  });
+
+  test("leaves a pane it has never seen, and gives it a full interval", async () => {
+    // Unchanged and load-bearing: after a restart every genuinely live chat
+    // looks exactly like an orphan, and killing an agent mid-work to save
+    // memory is a much worse failure than holding the memory.
+    const t0 = 9_000_000;
+    const t = fakeTmux([STRANGER]);
+    expect(await evictIdlePanes(t0, t.io)).toEqual([]);
+    expect(await evictIdlePanes(t0 + HOUR, t.io)).toEqual([STRANGER]);
+  });
+
+  test("does nothing at all when eviction is switched off", async () => {
+    process.env.AGENTGLASS_TMUX_IDLE_MINUTES = "0";
+    const t0 = 6_000_000;
+    const t = fakeTmux([A]);
+    touchPane(A, t0);
+    expect(await evictIdlePanes(t0 + 10 * HOUR, t.io)).toEqual([]);
+    expect(t.killed).toEqual([]);
+  });
+});
+
+describe("seeing what is running", () => {
+  test("reports every pane, with what is known about each", async () => {
+    const t = fakeTmux([A, STRANGER]);
+    touchPane(A, 7_000_000);
+    pinPane(A, true);
+    const rows = await panes(t.io.list);
+    expect(rows).toHaveLength(2);
+    const a = rows.find((r) => r.name === A)!;
+    expect(a.pinned).toBe(true);
+    expect(a.lastUsedAt).toBe(7_000_000);
+    // Null rather than zero: "this server has never run a turn in it" is the
+    // shape of a leftover from a previous run, and 0 would render as 1970.
+    const s = rows.find((r) => r.name === STRANGER)!;
+    expect(s.lastUsedAt).toBeNull();
+    expect(s.pinned).toBe(false);
+  });
+
+  test("is empty when nothing is running, rather than throwing", async () => {
+    const t = fakeTmux([]);
+    expect(await panes(t.io.list)).toEqual([]);
+  });
+});
+
+/**
+ * Which panes belong to nothing.
+ *
+ * Pure, and tested here rather than through the route, because a machine with
+ * no tmux has no panes to classify — which is every test machine, and is how
+ * this judgement went untested when it was three lines inside the handler.
+ */
+describe("deciding what is an orphan", () => {
+  const rows = [A, B, STRANGER].map((name) => ({ name, lastUsedAt: null, pinned: false }));
+
+  test("a pane no open chat and no running turn points at", () => {
+    const out = classifyPanes(rows, [A], [B]);
+    expect(out.find((p) => p.name === STRANGER)!.orphan).toBe(true);
+    expect(out.find((p) => p.name === A)!.orphan).toBe(false);
+    expect(out.find((p) => p.name === B)!.orphan).toBe(false);
+  });
+
+  test("a pane mid-turn is never an orphan, whatever is on screen", () => {
+    // The proof that something is using it, and the one row that must not be
+    // offered a one-click end. A window with no chats open at all — the app
+    // reopened in a second tab — must not mark a working agent abandoned.
+    const out = classifyPanes(rows, [], [B]);
+    expect(out.find((p) => p.name === B)!).toMatchObject({ running: true, orphan: false });
+  });
+
+  test("and a chat open in this window keeps its pane, mid-turn or not", () => {
+    const out = classifyPanes(rows, [A, B, STRANGER], []);
+    expect(out.every((p) => !p.orphan)).toBe(true);
+    expect(out.every((p) => !p.running)).toBe(true);
+  });
+
+  test("with nothing open and nothing running, everything is an orphan", () => {
+    // The state after a crash: the panes are still there and nothing in the app
+    // knows about any of them. Exactly what the panel exists to show.
+    expect(classifyPanes(rows, [], []).every((p) => p.orphan)).toBe(true);
+  });
+
+  test("and what it was told about each pane survives the classification", () => {
+    const out = classifyPanes([{ name: A, lastUsedAt: 7_000_000, pinned: true }], [A], []);
+    expect(out[0]).toMatchObject({ name: A, lastUsedAt: 7_000_000, pinned: true });
+  });
+});

--- a/server/test/pane-routes.test.ts
+++ b/server/test/pane-routes.test.ts
@@ -1,0 +1,194 @@
+/*
+ * The two routes behind "keep this one" and "what is running".
+ *
+ * Driven against a real server, because the interesting half is not the pane
+ * bookkeeping (that has its own suite) but what the HTTP does with it: which
+ * names are refused before they can reach `tmux kill-session -t`, and how the
+ * orphan judgement is put together from two things neither side knows alone.
+ *
+ * Most of it runs against an empty socket, which is exactly the state of a
+ * machine with the pane engine switched off — worth pinning that the panel
+ * answers rather than errors there, since the alternative is a settings tab
+ * that fails to load for everybody not using panes.
+ *
+ * The orphan judgement gets a real tmux session, because it is the one thing
+ * that cannot be observed without a pane to judge. Skipped where tmux is not
+ * installed, and on its own socket with a `sleep` in it — never a `claude`.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+
+const A = "6b191fd3-f71e-5010-863d-d32334eaf400";
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-panes-"));
+  const port = 4930 + Math.floor(Math.random() * 20);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    // A named environment, never `...process.env`.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+      // A socket nothing is listening on, so `tmux list-sessions` fails the way
+      // it does on a machine that has never run a pane: cleanly, with nothing.
+      AGENTGLASS_TMUX_SOCKET: "agentglass-test-nothing-here",
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+type Json = Record<string, any>;
+const jsonOf = (r: Response) => r.json() as Promise<Json>;
+const post = (path: string, body: unknown) =>
+  fetch(base + path, {
+    method: "POST",
+    headers: { "content-type": "application/json" },
+    body: JSON.stringify(body),
+  });
+
+describe("pinning a chat's pane", () => {
+  test("takes a session id and says what it did", async () => {
+    const r = await jsonOf(await post("/chat/pane/pin", { session: A, pinned: true }));
+    expect(r).toEqual({ ok: true, session: A, pinned: true });
+  });
+
+  test("and unpinning is the same route, not a second one", async () => {
+    const r = await jsonOf(await post("/chat/pane/pin", { session: A, pinned: false }));
+    expect(r.pinned).toBe(false);
+  });
+
+  test("refuses a name that is not a session id", async () => {
+    // The name ends up in `tmux kill-session -t`, and tmux reads `:` and `.` as
+    // window and pane separators — a crafted one resolves onto a target nobody
+    // meant. Refused here rather than escaped later.
+    for (const session of ["../../etc/passwd", "a; rm -rf /", "sess:0.1", "short", ""]) {
+      const r = await post("/chat/pane/pin", { session, pinned: true });
+      expect(r.status, session).toBe(400);
+    }
+  });
+
+  test("and a body that is not a body", async () => {
+    const r = await fetch(base + "/chat/pane/pin", {
+      method: "POST", headers: { "content-type": "application/json" }, body: "{",
+    });
+    expect(r.status).toBe(400);
+  });
+
+  test("defaults to pinning when the flag is missing, not to unpinning", async () => {
+    // The route is reached by a toggle; a missing flag is a client that meant
+    // the affirmative, and silently unpinning would be the one direction that
+    // loses a warm CLI somebody asked to keep.
+    const r = await jsonOf(await post("/chat/pane/pin", { session: A }));
+    expect(r.pinned).toBe(true);
+    await post("/chat/pane/pin", { session: A, pinned: false });
+  });
+});
+
+describe("listing what is running", () => {
+  test("answers on a machine with no panes at all", async () => {
+    // Every user who has not switched the pane engine on. A settings tab that
+    // errors for them would be a worse bug than the one this panel fixes.
+    const r = await fetch(base + "/chat/panes?open=");
+    expect(r.status).toBe(200);
+    const j = await jsonOf(r);
+    expect(j.panes).toEqual([]);
+  });
+
+  test("says how long a pane may idle, so the panel need not guess", async () => {
+    const j = await jsonOf(await fetch(base + "/chat/panes?open="));
+    // The default is 30 minutes, and 0 would mean eviction is off — which the
+    // panel has to be able to say out loud rather than imply.
+    expect(j.idleEvictMs).toBe(30 * 60_000);
+  });
+
+  test("takes the open chats from the caller, because the server has no idea", async () => {
+    // Which chats are on screen is known only to the client, and a pane
+    // belonging to a chat open in another window must not be called abandoned.
+    // Nothing is running here, so what is asserted is that the parameter is
+    // accepted and shapes the answer rather than being ignored.
+    const r = await fetch(`${base}/chat/panes?open=${A},${encodeURIComponent("  ")}`);
+    expect(r.status).toBe(200);
+    expect((await jsonOf(r)).panes).toEqual([]);
+  });
+});
+
+/**
+ * With something actually running.
+ *
+ * `sleep` rather than an agent: what is under test is the bookkeeping, and a
+ * suite that started a real CLI would be spending somebody's tokens to check a
+ * boolean. Its own socket, so it cannot see — or reap — the developer's panes.
+ */
+describe("with a pane genuinely running", () => {
+  const SOCK = "agentglass-test-nothing-here";
+  const tmuxOk = Bun.spawnSync(["tmux", "-V"]).exitCode === 0;
+  const tmux = (...args: string[]) => Bun.spawnSync(["tmux", "-L", SOCK, ...args]);
+
+  test.skipIf(!tmuxOk)("a pane no open chat points at is named an orphan", async () => {
+    tmux("new-session", "-d", "-s", A, "sleep", "300");
+    try {
+      // Nothing open: the state after a crash, where the panes are still there
+      // and nothing in the app knows about any of them.
+      const none = await jsonOf(await fetch(base + "/chat/panes?open="));
+      const row = none.panes.find((p: Json) => p.name === A);
+      expect(row, "the running pane was not listed at all").toBeTruthy();
+      expect(row.orphan).toBe(true);
+      expect(row.running).toBe(false);
+
+      // …and the same pane, with its chat open in this window, is not.
+      const open = await jsonOf(await fetch(`${base}/chat/panes?open=${A}`));
+      expect(open.panes.find((p: Json) => p.name === A).orphan).toBe(false);
+    } finally {
+      tmux("kill-session", "-t", "=" + A);
+    }
+  });
+
+  test.skipIf(!tmuxOk)("and a pin shows up in the listing", async () => {
+    tmux("new-session", "-d", "-s", A, "sleep", "300");
+    try {
+      await post("/chat/pane/pin", { session: A, pinned: true });
+      const j = await jsonOf(await fetch(base + "/chat/panes?open="));
+      expect(j.panes.find((p: Json) => p.name === A).pinned).toBe(true);
+      await post("/chat/pane/pin", { session: A, pinned: false });
+      const after = await jsonOf(await fetch(base + "/chat/panes?open="));
+      expect(after.panes.find((p: Json) => p.name === A).pinned).toBe(false);
+    } finally {
+      tmux("kill-session", "-t", "=" + A);
+    }
+  });
+
+  test.skipIf(!tmuxOk)("ending one actually ends it", async () => {
+    tmux("new-session", "-d", "-s", A, "sleep", "300");
+    expect((await jsonOf(await post("/chat/pane/close", { session: A }))).killed).toBe(true);
+    const j = await jsonOf(await fetch(base + "/chat/panes?open="));
+    expect(j.panes.find((p: Json) => p.name === A)).toBeUndefined();
+  });
+});
+
+describe("ending one", () => {
+  test("is the route that already exists, not a new one", async () => {
+    // Ending a pane is ending a pane. A second route that killed panes would be
+    // one more thing able to stop an agent, for no new capability.
+    const r = await jsonOf(await post("/chat/pane/close", { session: A }));
+    expect(r).toHaveProperty("killed");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1591,6 +1591,34 @@ export interface PairState {
   devices: PairedDevice[];
 }
 
+/**
+ * A warm CLI held in a tmux pane, and what is known about it.
+ *
+ * Each is several hundred megabytes — that is the price of skipping the MCP
+ * re-init a fresh turn pays — so "what is running" is a question with a number
+ * attached to it, and until now the only place to ask it was a terminal.
+ */
+export interface ChatPane {
+  /** The chat's session id, which is also the pane's name. */
+  name: string;
+  /** When this server last ran a turn in it. Null for a pane it has never
+   *  served — a leftover from a previous run, or something started by hand. */
+  lastUsedAt: number | null;
+  /** Exempt from idle eviction until unpinned or closed. */
+  pinned: boolean;
+  /** Mid-turn at this instant. Never an orphan, and never safe to end. */
+  running: boolean;
+  /** No chat this client has open, and no turn in flight, points at it. */
+  orphan: boolean;
+}
+
+export interface ChatPaneList {
+  panes: ChatPane[];
+  /** How long a pane may sit unused before it is reclaimed. 0 means eviction
+   *  is switched off, which is a thing the UI has to say rather than imply. */
+  idleEvictMs: number;
+}
+
 /** Whether another device can reach this server, and whether one ever has. */
 export interface RemoteStatus {
   /** Bound off loopback, so off-box traffic can arrive at all. */

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -35,7 +35,7 @@ import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
   engineFor,
   DEFAULT_MODEL, DEFAULT_MODE, addAttachments, answerPane, dropAttachment, renameChat, clearAttention, type Chat,
-  restoredActiveId, setActiveChatId, chatFocusRequest,
+  restoredActiveId, setActiveChatId, chatFocusRequest, setPanePinned, hydratePanePins,
 } from "../lib/chatStore.ts";
 import { peekChatIntent, subscribeChatIntent, takeChatIntent } from "../lib/chatIntent.ts";
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
@@ -695,6 +695,11 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
       .then((r) => setWorkspace(r.workspace))
       .catch(() => {})
       .finally(() => setScopeKnown(true));
+    // Which panes are pinned lives on the server and deliberately does not
+    // persist with the chat — it is a statement about a process running now.
+    // So a reloaded window knows nothing about it, and a Pin button showing
+    // "off" over a pinned pane is the same lie as the reverse.
+    void hydratePanePins();
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [open]);
 
@@ -1176,6 +1181,29 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             className="text-[10px] px-2 py-1 rounded-md shrink-0 disabled:opacity-40"
                             style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}
                           >⚙ Config</button>
+                        )}
+                        {/* Keep this one, however long you are away.
+                            The engine reclaims a warm CLI after half an hour
+                            idle, which is right for the four chats you opened to
+                            ask one question each and wrong for the one you are
+                            living in — step away for lunch and the session you
+                            care about is exactly the one reclaimed, so the turn
+                            you come back to is the slow one. Beside the engine
+                            chip rather than in a menu, because a pin that holds
+                            several hundred megabytes should be something you can
+                            see you switched on. */}
+                        {engineFor(active) === "tmux" && active.sessionId && (
+                          <button
+                            onClick={() => void setPanePinned(active.id, !active.panePinned)}
+                            role="switch" aria-checked={!!active.panePinned}
+                            title={active.panePinned
+                              ? "Pinned: this chat's warm CLI is kept no matter how long it sits idle. Closing the chat still releases it."
+                              : "Pin this chat, so its warm CLI is never reclaimed for being idle. Costs a few hundred megabytes for as long as it is on."}
+                            className="text-[10px] px-2 py-1 rounded-md shrink-0"
+                            style={active.panePinned
+                              ? { color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }
+                              : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}
+                          >{active.panePinned ? "📌 Pinned" : "📌 Pin"}</button>
                         )}
                         {active.sessionId && <span className="text-[9.5px] t-dim2 tabular-nums" title="Resuming this session">↻ {active.sessionId.slice(0, 8)}</span>}
                         {/* Pushed right so the two copy actions sit together at

--- a/web/src/components/RunningPanes.tsx
+++ b/web/src/components/RunningPanes.tsx
@@ -1,0 +1,152 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../lib/api.ts";
+import { fmtAgo } from "../lib/format.ts";
+import { listChats } from "../lib/chatStore.ts";
+import type { ChatPane } from "../../../shared/types.ts";
+
+/**
+ * What is actually running, and what belongs to nothing.
+ *
+ * Panes outlive the app. Quit agentglass, or let it crash, and every warm
+ * `claude` is still there — several hundred megabytes each, growing with use.
+ * The sweeper deliberately leaves any pane it has no record of alone, because
+ * killing an agent mid-work to save memory it might be using is a much worse
+ * failure than holding the memory, so after a restart they get a fresh grace
+ * period each time.
+ *
+ * That is the right behaviour and it left no way to see the consequence. The
+ * only way to find out what was out there was `tmux -L agentglass ls` in a
+ * terminal, and the only way to clean up was `kill-session` by hand — for a
+ * feature whose entire cost is memory, in an app that otherwise makes a point
+ * of showing you what it is doing on your machine.
+ *
+ * An orphan is named rather than guessed at: it is a pane no open chat and no
+ * running turn points at. That judgement needs both halves — which chats this
+ * window has open, which only the client knows, and which turns are in flight,
+ * which only the server does — so the open list is sent and the answer comes
+ * back labelled.
+ */
+export function RunningPanes({ open }: { open: boolean }) {
+  const [panes, setPanes] = useState<ChatPane[] | null>(null);
+  const [evictMs, setEvictMs] = useState(0);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [confirming, setConfirming] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    const ids = listChats().map((c) => c.sessionId).filter(Boolean);
+    api.chatPanes(ids)
+      .then((r) => { setPanes(r.panes); setEvictMs(r.idleEvictMs); })
+      .catch(() => setPanes([]));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    load();
+    // Slow: this is a list of long-lived processes, not a live meter, and the
+    // listing shells out to tmux.
+    const t = setInterval(load, 5000);
+    return () => clearInterval(t);
+  }, [open, load]);
+
+  const end = async (p: ChatPane) => {
+    setBusy(p.name);
+    // The same route the close button uses. Ending a pane is ending a pane —
+    // there is no second kind, and a route that killed panes and nothing else
+    // would be one more thing able to stop an agent.
+    await api.chatPaneClose(p.name).catch(() => null);
+    setBusy(null);
+    setConfirming(null);
+    load();
+  };
+
+  if (!panes) return <div className="text-[11px] t-dim2">Looking…</div>;
+
+  if (!panes.length) {
+    return (
+      <div className="text-[11px] t-dim2">
+        Nothing is running. A chat on the pane engine starts one on its first turn.
+      </div>
+    );
+  }
+
+  const orphans = panes.filter((p) => p.orphan).length;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      <div className="flex items-baseline gap-2">
+        <span className="text-[11px]" style={{ color: "var(--text2)" }}>
+          {panes.length === 1 ? "One warm CLI" : `${panes.length} warm CLIs`}
+          {orphans > 0 && <span style={{ color: "var(--warning)" }}> · {orphans} belonging to nothing</span>}
+        </span>
+        <span className="text-[10px] t-dim2 ml-auto">
+          {/* Said rather than implied: somebody who has switched eviction off
+              is looking at a list that will never shrink on its own, and that
+              is the single most useful thing this panel can tell them. */}
+          {evictMs > 0
+            ? `Reclaimed after ${Math.round(evictMs / 60_000)} idle minutes`
+            : "Idle eviction is off — nothing here is reclaimed on its own"}
+        </span>
+      </div>
+
+      {panes.map((p) => (
+        <div key={p.name} className="flex items-center gap-2.5 px-2.5 py-2 rounded-lg" style={{
+          background: p.orphan ? "color-mix(in srgb, var(--warning) 8%, transparent)" : "color-mix(in srgb, var(--bg2) 60%, transparent)",
+          border: `1px solid color-mix(in srgb, ${p.orphan ? "var(--warning)" : "var(--border)"} ${p.orphan ? 32 : 40}%, transparent)`,
+        }}>
+          <span className="shrink-0 rounded-full" aria-hidden style={{
+            width: 7, height: 7,
+            background: p.running ? "var(--success)" : "transparent",
+            border: p.running ? "none" : "1px solid var(--text4)",
+          }} />
+          <div className="min-w-0 flex-1">
+            <div className="text-[11.5px] t-mono truncate" style={{ color: "var(--text)" }}>
+              {p.name.slice(0, 8)}
+              {p.pinned && <span className="chip ml-1.5" style={{ color: "var(--primary-hover)" }}>pinned</span>}
+              {p.orphan && <span className="chip ml-1.5" style={{ color: "var(--warning)" }}>no chat</span>}
+            </div>
+            <div className="text-[10px] t-dim2">
+              {p.running
+                ? "Working right now"
+                : p.orphan
+                  ? "Left over from a previous run, or started by hand. Nothing in this window is using it."
+                  : p.lastUsedAt
+                    ? `Last turn ${fmtAgo(p.lastUsedAt)}`
+                    : "No turn run from this window yet"}
+            </div>
+          </div>
+          {/* Never for one mid-turn. Ending a pane while the agent is working
+              is the one action here that loses something, and a confirm under
+              the thumb that just clicked is the weakest guard there is. */}
+          {!p.running && (
+            confirming === p.name ? (
+              <div className="flex items-center gap-1.5 shrink-0">
+                <button onClick={() => void end(p)} disabled={busy === p.name}
+                  className="text-[10.5px] px-2 py-1 rounded-md"
+                  style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 14%, transparent)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>
+                  End it
+                </button>
+                <button onClick={() => setConfirming(null)}
+                  className="text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+                  style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+                  Keep
+                </button>
+              </div>
+            ) : (
+              <button onClick={() => setConfirming(p.name)}
+                title="Kill this pane and free its memory. The chat it belongs to, if any, starts a fresh CLI on its next turn."
+                className="shrink-0 text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+                style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+                End
+              </button>
+            )
+          )}
+        </div>
+      ))}
+
+      <div className="text-[10px] t-dim2">
+        Ending one frees its memory and loses nothing: the chat it belongs to resumes in a fresh CLI on
+        its next turn, one slower turn later.
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -19,6 +19,7 @@ import { ReleaseNotesModal } from "./ReleaseNotesModal.tsx";
 import { installedNotes, type NotesTarget } from "../lib/whatsNew.ts";
 import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESKTOP } from "../lib/desktop.ts";
 import { RemoteAccessPane } from "./RemoteAccessPane.tsx";
+import { RunningPanes } from "./RunningPanes.tsx";
 import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRenderer.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
@@ -938,6 +939,17 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         { v: "process", label: "Separate" },
                         { v: "tmux", label: "tmux panes" },
                       ]} />
+                    {/* The consequence of the setting above, made visible.
+                        Panes outlive the app, so "how new chats run" quietly
+                        decides how much memory is resident on this machine an
+                        hour from now, and until this list existed the only
+                        place to see that was a terminal. */}
+                    {tmuxEngine?.available && (
+                      <div className="flex flex-col gap-1.5 pt-1">
+                        <span className="text-[10px] t-dim2 uppercase tracking-wider">Warm CLIs running now</span>
+                        <RunningPanes open={open} />
+                      </div>
+                    )}
                     <Choice<SysNotifyMode>
                       label="Desktop notifications on the notch"
                       hint="Slack and the rest, mirrored onto the strip you can still see in fullscreen"

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -573,6 +573,15 @@ const realApi = {
    *  Only navigation and the two answers a prompt takes — the server keeps its
    *  own allowlist, since this reaches a live terminal running an agent. */
   chatPaneKey: (session: string, key: string) => post<{ screen: string }>("/chat/pane/key", { session, key }),
+  /** Exempt this chat's pane from idle eviction. About idleness only — closing
+   *  the chat still releases the pane. */
+  chatPanePin: (session: string, pinned: boolean) =>
+    post<{ ok: boolean; session: string; pinned: boolean }>("/chat/pane/pin", { session, pinned }),
+  /** Every pane on this machine, with which of them belongs to nothing. `open`
+   *  is the chats this client has on screen — the server does not know, and a
+   *  pane belonging to a chat in another window is not an orphan. */
+  chatPanes: (open: string[]) =>
+    get<ChatPaneList>(`/chat/panes?open=${encodeURIComponent(open.join(","))}`),
   chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine; effort?: ChatEffort }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
     let res: Response;
     // A fetch that throws before a response has arrived never reached the
@@ -753,6 +762,10 @@ const demoApi: typeof realApi = {
   chatAttach: (_session: string) => D({ command: "", live: false }),
   chatPaneClose: (_session: string) => D({ killed: false }),
   chatPaneKey: (_session: string, _key: string) => D({ screen: "" }),
+  chatPanePin: (_session: string, pinned: boolean) => D({ ok: false, session: "", pinned }),
+  // The demo runs no processes, so there is nothing to list and nothing to
+  // reclaim. An empty list is the truth here rather than a placeholder.
+  chatPanes: (_open: string[]) => D({ panes: [], idleEvictMs: 0 } as ChatPaneList),
   chatStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine; effort?: ChatEffort }, onEvent: (o: Record<string, unknown>) => void) => {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -220,6 +220,18 @@ export type Chat = {
    *  `claude` that has never been logged in. Distinct from a failed turn:
    *  retrying changes nothing until the command is run. */
   setupNeeded?: { command: string; why: string };
+  /** Keep this chat's pane through any amount of idleness.
+   *
+   *  The engine reclaims a warm CLI after 30 idle minutes, which is right for
+   *  the four chats you opened to ask one question each and wrong for the one
+   *  you are living in — step away for lunch and the session you care about is
+   *  exactly the one reclaimed. Server-side state (see tmuxpane.ts); this is the
+   *  client's copy of it, so the toggle can render without a round trip.
+   *
+   *  Never persisted with the chat: it is a statement about a process that is
+   *  running now, and a pin restored for a pane that no longer exists is a
+   *  switch that is on and does nothing. */
+  panePinned?: boolean;
   /** An interactive prompt waiting in this chat's pane — a `/model` picker and
    *  the like. Held as state rather than left as text in the reply, because it
    *  is a thing to answer, not a thing to read: the screen redraws as keys are
@@ -631,6 +643,43 @@ export function update(id: string, fn: (c: Chat) => void) {
   if (!c) return;
   fn(c);
   emit();
+}
+
+/**
+ * Pin or unpin a chat's pane, and remember what the server said.
+ *
+ * Optimistic, then corrected: the toggle is the kind of control that has to
+ * move under the thumb, and a pin that fails is a pane that gets reclaimed
+ * half an hour later rather than anything immediate.
+ */
+export async function setPanePinned(id: string, pinned: boolean): Promise<void> {
+  const chat = chats.get(id);
+  if (!chat?.sessionId) return;
+  update(id, (c) => { c.panePinned = pinned; });
+  const r = await api.chatPanePin(chat.sessionId, pinned).catch(() => null);
+  if (!r?.ok) update(id, (c) => { c.panePinned = !pinned; });
+}
+
+/**
+ * Ask the server which panes are actually pinned, and adopt the answer.
+ *
+ * The pin lives on the server, and deliberately does not persist with the chat
+ * — it is a statement about a process that is running now. So after a reload
+ * the client knows nothing about it, and a button showing "not pinned" over a
+ * pane that is pinned is the same lie as the reverse. This is the one read that
+ * makes the toggle tell the truth.
+ */
+export async function hydratePanePins(): Promise<void> {
+  const ids = [...chats.values()].map((c) => c.sessionId).filter(Boolean);
+  if (!ids.length) return;
+  const r = await api.chatPanes(ids).catch(() => null);
+  if (!r) return;
+  const on = new Set(r.panes.filter((p) => p.pinned).map((p) => p.name));
+  for (const c of chats.values()) {
+    if (!c.sessionId) continue;
+    const want = on.has(c.sessionId);
+    if (c.panePinned !== want) update(c.id, (x) => { x.panePinned = want; });
+  }
 }
 
 const titleOf = (s: string) => {

--- a/web/test/running-panes.test.ts
+++ b/web/test/running-panes.test.ts
@@ -1,0 +1,102 @@
+/*
+ * The two controls this adds, and the properties that make them safe to use.
+ *
+ * Both are about several hundred megabytes each and an agent that might be
+ * mid-work, so the interesting assertions are the negative ones: what the panel
+ * refuses to offer, and what the pin deliberately does not survive.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const read = (p: string) => readFileSync(new URL("../" + p, import.meta.url), "utf8");
+const panel = read("src/components/RunningPanes.tsx");
+const store = read("src/lib/chatStore.ts");
+const chat = read("src/components/ChatPanel.tsx");
+
+describe("the list of what is running", () => {
+  test("never offers to end a pane that is mid-turn", () => {
+    // The one action here that loses something. A confirm would not be enough:
+    // it appears under the thumb that just tapped, and the agent is working.
+    expect(panel).toContain("{!p.running && (");
+  });
+
+  test("and asks twice before ending one that is not", () => {
+    expect(panel).toContain("setConfirming(p.name)");
+    expect(panel).toMatch(/confirming === p\.name/);
+  });
+
+  test("says out loud when nothing will ever be reclaimed", () => {
+    // Somebody who has set AGENTGLASS_TMUX_IDLE_MINUTES=0 is looking at a list
+    // that never shrinks on its own, and that is the single most useful thing
+    // this panel can tell them.
+    expect(panel).toContain("Idle eviction is off");
+    expect(panel).toMatch(/evictMs > 0/);
+  });
+
+  test("names an orphan rather than leaving it to be inferred", () => {
+    expect(panel).toContain("no chat");
+    expect(panel).toMatch(/p\.orphan/);
+  });
+
+  test("ends a pane through the route that already kills panes", () => {
+    // A second kill route would be one more thing able to stop an agent, for no
+    // capability that did not already exist.
+    expect(panel).toContain("api.chatPaneClose(p.name)");
+  });
+
+  test("and tells the truth about what ending one costs", () => {
+    // Nothing, except one slower turn — which is worth saying, because "End"
+    // beside a running agent reads like it might lose the conversation.
+    expect(panel).toMatch(/resumes in a fresh CLI/);
+  });
+
+  test("sends the chats this window has open, so they are not called abandoned", () => {
+    // The server knows which turns are in flight and nothing about which tabs
+    // exist. Both halves are needed or every pane in a second window is an
+    // orphan.
+    expect(panel).toContain("listChats()");
+    expect(panel).toContain("api.chatPanes(ids)");
+  });
+});
+
+describe("the pin", () => {
+  test("is offered only where there is a pane to pin", () => {
+    // `claude -p` leaves nothing running between turns, so a pin on it would be
+    // a switch with nothing behind it.
+    const pin = chat.slice(chat.indexOf("Keep this one, however long you are away"), chat.indexOf("Resuming this session"));
+    expect(pin).toContain('engineFor(active) === "tmux"');
+    expect(pin).toContain("active.sessionId");
+  });
+
+  test("says what it costs, where it is switched on", () => {
+    const pin = chat.slice(chat.indexOf("Keep this one, however long you are away"), chat.indexOf("Resuming this session"));
+    expect(pin).toMatch(/hundred megabytes/);
+    // And that closing still releases it, so nobody reads the pin as "forever".
+    expect(pin).toMatch(/Closing the chat still releases it/);
+  });
+
+  test("is not persisted with the chat", () => {
+    // It is a statement about a process running now. Restored for a pane that
+    // no longer exists, it is a switch that is on and does nothing — and the
+    // pane it claims to protect was reclaimed hours ago.
+    const pack = read("src/lib/chatPersist.ts");
+    expect(pack).not.toContain("panePinned");
+    expect(store).toContain("panePinned");
+  });
+
+  test("is read back from the server instead, when the panel opens", () => {
+    // Which follows from not persisting it: without this read, a reloaded
+    // window shows "not pinned" over a pinned pane, which is the same lie as
+    // the reverse.
+    expect(store).toContain("export async function hydratePanePins");
+    expect(chat).toContain("void hydratePanePins();");
+  });
+
+  test("puts itself back if the server would not take it", () => {
+    // Optimistic, because the toggle has to move under the thumb — but a pin
+    // that failed and still reads as on is how a chat gets reclaimed at lunch.
+    const fn = store.slice(store.indexOf("export async function setPanePinned"), store.indexOf("export async function hydratePanePins"));
+    expect(fn).toMatch(/if \(!r\?\.ok\)/);
+    expect(fn).toContain("c.panePinned = !pinned");
+  });
+});


### PR DESCRIPTION
Closes #332.

## What does this PR do?

The engine reclaims a chat's warm CLI after 30 idle minutes, and closing a chat releases it at once. Both are right for the common case — a warm `claude` is ~380MB growing with use, and holding that for a conversation nobody is having is waste.

Neither is right for **the chat you are living in**. Step away for lunch and the one session you care about is the one reclaimed, so the turn you come back to is the slow one — which is the exact cost the pane engine exists to remove.

### Pin

Beside the engine chip, not in a menu: a switch that holds several hundred megabytes should be something you can see is on.

It exempts a chat from **idle eviction and nothing else**. Closing still releases the pane, because closing is an explicit "done" and pinning is a statement about a gap in a conversation.

The pin lives on the server and **deliberately does not persist with the chat**. It is about a process that is running now; one restored for a pane that no longer exists is a switch that is on and does nothing, over a pane reclaimed hours ago. So the panel reads the real state back when it opens — which is what keeps the button honest after a reload, and is the half that would have been easy to leave out.

### What is actually running

The mirror-image gap. Panes outlive the app — quit or crash and the sessions are still there — and the sweeper deliberately leaves any pane it has no record of alone, because after a restart every genuinely live chat looks exactly like an orphan and killing an agent mid-work to save memory is the worse failure. Right, and it left no way to see the consequence: `tmux -L agentglass ls` in a terminal was the only way to find out, and `kill-session` by hand the only cleanup, for a feature whose entire cost is memory.

Settings now lists every warm CLI with its age, whether it is pinned, and whether anything is using it:

- **Never offers to end one mid-turn.** That is the single action here that loses something, and a confirm appears under the thumb that just clicked.
- **Ending goes through the route that already kills panes**, not a new one — a second kill route would be one more thing able to stop an agent, for no capability that did not already exist.
- **Says out loud when eviction is switched off** (`AGENTGLASS_TMUX_IDLE_MINUTES=0`), because that person is looking at a list that will never shrink on its own.
- **Says what ending one costs**: nothing, except one slower turn. "End" beside a running agent reads like it might lose the conversation.

An **orphan is named rather than guessed at**. It needs two things neither side holds alone — which chats are on screen, known only to the client, and which turns are in flight, known only to the server — so the open list is sent and the answer comes back labelled.

## How was it tested?

**26 mutations, all red**: the sweeper ignoring the pin, a pinned pane given a timestamp while exempt, unpinning doing nothing, a pin surviving a close, pinning accepting a name that is not a session id, a missing flag unpinning instead of pinning, a running pane called an orphan, an open chat's pane called an orphan, End offered mid-turn, the confirm removed, the pin persisted with the chat, the read-back dropped, and a failed pin still reading as on.

Route tests drive a **real tmux session** (running `sleep`, on its own socket, never a `claude`) for the parts that cannot be observed without a pane to judge, and skip where tmux is absent. The rest runs against an empty socket, which is the state of every machine with the pane engine switched off — worth pinning that the panel answers rather than errors there.

### Two things the mutation pass changed

**The orphan judgement moved out of the handler.** It was three lines inline, which made it reachable only through a machine with tmux genuinely running — two mutations walked straight through it. It is a pure `classifyPanes(rows, open, running)` in `tmuxpane.ts` now, tested directly, and the route is thinner for it.

**`evictIdlePanes`, `panes` and `touchPane` take their tmux and their clock as parameters** — the same seam `reachableAddresses` and `firewallHint` already use. A module namespace is frozen, so there was nothing to monkey-patch; and a suite that reached a real tmux would be reading, and reaping, the developer's own sessions. `touchPane` needed the clock too: the first version of one test compared a made-up timestamp against a real `Date.now()` and passed for the wrong reason.

Suites green: **1256 server, 871 web**. **178/178 phone audit**.