### PR TITLE
Name what a pane agent has to provide

### DIFF
--- a/server/src/agents/claudecode.ts
+++ b/server/src/agents/claudecode.ts
@@ -1,0 +1,72 @@
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { LaunchSpec, PaneAgent } from "../paneagent.ts";
+
+/**
+ * Claude Code, as a pane agent.
+ *
+ * Everything here was inline in chatpane.ts and is moved unchanged — the paths,
+ * the flags and the end-of-turn marker are all verified against a real session
+ * rather than inferred, and this file exists to hold them in one place rather
+ * than to improve them.
+ *
+ * It is also the reference for what a second agent has to supply. Reading it
+ * top to bottom is the shortest description of the contract in paneagent.ts.
+ */
+
+/** Where Claude Code keeps its transcripts. `CLAUDE_CONFIG_DIR` is the CLI's own
+ *  knob and is honoured for the same reason it exists; the agentglass override
+ *  is so tests can point at a fixture instead of a developer's real history. */
+export function claudeHome(): string {
+  return process.env.AGENTGLASS_CLAUDE_HOME || process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
+}
+
+/**
+ * The directory name Claude Code derives from a working directory.
+ *
+ * Every character that is not a letter or a digit becomes `-`, which is why a
+ * path like `/home/x/code/app/.claude/wt` lands in `-home-x-code-app--claude-wt`
+ * (the separator and the leading dot each contribute one). Verified against a
+ * real session rather than inferred.
+ */
+export function projectSlug(cwd: string): string {
+  return cwd.replace(/[^A-Za-z0-9]/g, "-");
+}
+
+export const claudeCode: PaneAgent = {
+  id: "claude-code",
+  label: "Claude Code",
+
+  bin: () => Bun.which("claude"),
+
+  missingReason: () =>
+    "no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)",
+
+  transcriptFor: (cwd, sessionId) =>
+    join(claudeHome(), "projects", projectSlug(cwd), `${sessionId}.jsonl`),
+
+  argv(spec: LaunchSpec): string[] {
+    const bin = this.bin();
+    const argv = [bin ?? "claude", "--model", spec.model];
+    if (spec.effort) argv.push("--effort", spec.effort);
+    // The distinction that matters: a session id that has never run must be
+    // started with `--session-id`, and one that has must be started with
+    // `--resume`. Reusing `--session-id` on an existing session is a hard error
+    // ("Session ID is already in use"), so getting this backwards does not
+    // degrade, it fails the turn.
+    if (spec.fresh) argv.push("--session-id", spec.sessionId);
+    else argv.push("--resume", spec.sessionId);
+    if (spec.mode === "bypassPermissions") argv.push("--dangerously-skip-permissions");
+    else argv.push("--permission-mode", spec.mode);
+    return argv;
+  },
+
+  /** Deterministic and written by the CLI itself: every completed turn's last
+   *  transcript line is a `system` entry with subtype `turn_duration`. This is
+   *  why the engine never has to guess from a spinner or an idle screen. */
+  isTurnEnd: (o) => o.type === "system" && o.subtype === "turn_duration",
+
+  /** A transcript carries a great deal that is not the conversation — file
+   *  history snapshots, attachment records, the CLI's own title guess. */
+  forwards: (type) => type === "assistant" || type === "user",
+};

--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -18,9 +18,10 @@
 // `tmux -L agentglass attach -t <id>` drops the user into the very chat they
 // were reading in the app and lets them keep typing. That is not something the
 // `-p` engine can ever offer.
-import { homedir } from "node:os";
 import { join } from "node:path";
 import { mkdirSync } from "node:fs";
+import type { PaneAgent } from "./paneagent.ts";
+import { claudeCode, claudeHome, projectSlug } from "./agents/claudecode.ts";
 import { stat } from "node:fs/promises";
 import { costUsd } from "./pricing.ts";
 import {
@@ -28,31 +29,26 @@ import {
   touchPane, forgetPane, tmuxCapability, validPaneName, attachCommand,
 } from "./tmuxpane.ts";
 
-const claudeBin = () => Bun.which("claude");
-
-/** Where Claude Code keeps its transcripts. `CLAUDE_CONFIG_DIR` is the CLI's own
- *  knob and is honoured for the same reason it exists; the agentglass override
- *  is so tests can point at a fixture instead of a developer's real history. */
-function claudeHome(): string {
-  return process.env.AGENTGLASS_CLAUDE_HOME || process.env.CLAUDE_CONFIG_DIR || join(homedir(), ".claude");
-}
-
-/** The directory name Claude Code derives from a working directory.
+/**
+ * Which agent this engine runs.
  *
- *  Every character that is not a letter or a digit becomes `-`, which is why a
- *  path like `/home/x/code/app/.claude/wt` lands in `-home-x-code-app--claude-wt`
- *  (the separator and the leading dot each contribute one). Verified against a
- *  real session rather than inferred. */
-export function projectSlug(cwd: string): string {
-  return cwd.replace(/[^A-Za-z0-9]/g, "-");
-}
+ * One, today. The point of the indirection is not that there are two — it is
+ * that the four things Claude Code's own format decides (where the binary is,
+ * the transcript path, the launch flags, and the line that ends a turn) were
+ * spread through this file, so "run something else in a pane" could not even be
+ * costed. They are named in paneagent.ts and implemented in
+ * agents/claudecode.ts, unchanged.
+ */
+const agent: PaneAgent = claudeCode;
 
 /** Where this session's transcript will be, whether or not it exists yet. The
  *  path has to be computable up front: a brand-new session has no file until it
  *  has answered something, and the turn needs to know where to watch. */
 export function transcriptFor(cwd: string, sessionId: string): string {
-  return join(claudeHome(), "projects", projectSlug(cwd), `${sessionId}.jsonl`);
+  return agent.transcriptFor(cwd, sessionId);
 }
+
+export { projectSlug };
 
 /** Size of a file, or 0 when it does not exist.
  *
@@ -64,8 +60,8 @@ async function sizeOf(path: string): Promise<number> {
 
 // What we launched each pane with. A chat that changes model or permission mode
 // mid-conversation cannot be honoured by an already-running CLI — both are
-// process-level here — so the pane is relaunched with `--resume`, which costs
-// one slow turn and keeps the conversation intact.
+// process-level here — so the pane is taken down and brought back resumed,
+// which costs one slow turn and keeps the conversation intact.
 interface PaneSpec { model: string; mode: string; effort: string; cwd: string }
 const specs = new Map<string, PaneSpec>();
 
@@ -197,15 +193,15 @@ async function submitConfirmed(name: string, pasted: string, deadline: number): 
 
 /** Ensure a live pane for this session, launching or relaunching as needed.
  *
- *  The distinction that matters: a session id that has never run must be started
- *  with `--session-id`, and one that has must be started with `--resume`. Reusing
- *  `--session-id` on an existing session is a hard error ("Session ID is already
- *  in use"), so getting this backwards does not degrade, it fails the turn. */
+ *  Whether the session has ever run is decided here — an empty transcript means
+ *  it has not — and handed to the agent as `fresh`. What that turns into on the
+ *  command line is the agent's business, and it is not a detail to get wrong:
+ *  see agents/claudecode.ts, where getting it backwards fails the turn outright
+ *  rather than degrading. */
 async function ensurePane(
   sessionId: string, cwd: string, model: string, mode: string, effort: string,
 ): Promise<{ ok: true } | { ok: false; error: string }> {
-  const bin = claudeBin();
-  if (!bin) return { ok: false, error: "no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)" };
+  if (!agent.bin()) return { ok: false, error: agent.missingReason() };
 
   const alive = await paneAlive(sessionId);
   const spec = specs.get(sessionId);
@@ -220,12 +216,7 @@ async function ensurePane(
   }
 
   const fresh = (await sizeOf(transcriptFor(cwd, sessionId))) === 0;
-  const argv = [bin, "--model", model];
-  if (effort) argv.push("--effort", effort);
-  if (fresh) argv.push("--session-id", sessionId);
-  else argv.push("--resume", sessionId);
-  if (mode === "bypassPermissions") argv.push("--dangerously-skip-permissions");
-  else argv.push("--permission-mode", mode);
+  const argv = agent.argv({ sessionId, cwd, model, effort, mode, fresh });
 
   const started = await startPane(sessionId, cwd, argv);
   if (!started.ok) return { ok: false, error: started.stderr.trim() || "could not start the tmux pane" };
@@ -253,6 +244,15 @@ const EXT: Record<string, string> = {
   "image/png": "png", "image/jpeg": "jpg", "image/gif": "gif", "image/webp": "webp",
 };
 
+/**
+ * Where a turn's images are written before their paths go into the prompt.
+ *
+ * Under Claude Code's home, which is where it has always been — but note this
+ * is *not* part of the agent contract. Any CLI can read any path; the directory
+ * only has to exist and be readable. It is imported directly rather than added
+ * to `PaneAgent` so the interface stays the four things that genuinely differ
+ * per agent.
+ */
 function attachmentDir(): string {
   const dir = join(claudeHome(), "agentglass-attachments");
   mkdirSync(dir, { recursive: true });
@@ -290,15 +290,12 @@ export function panePrompt(text: string, paths: string[]): string {
  *  history snapshots, attachment records, the CLI's own title guess. None of it
  *  means anything to the chat renderer, and forwarding it would have the browser
  *  parsing shapes no one wrote a case for. */
-const FORWARD = new Set(["assistant", "user"]);
+const FORWARD = (type: string): boolean => agent.forwards(type);
 
-/** The line that ends a turn.
- *
- *  Deterministic and written by the CLI itself: every completed turn's last
- *  transcript line is a `system` entry with subtype `turn_duration`. This is why
- *  the engine never has to guess from a spinner or an idle screen. */
-const isTurnEnd = (o: Record<string, unknown>): boolean =>
-  o.type === "system" && o.subtype === "turn_duration";
+/** The line that ends a turn — an explicit marker the agent itself wrote, never
+ *  a guess from a spinner or an idle screen. See paneagent.ts for why that is
+ *  the load-bearing part of the contract. */
+const isTurnEnd = (o: Record<string, unknown>): boolean => agent.isTurnEnd(o);
 
 export interface PaneTurnOptions {
   cwd: string;
@@ -475,7 +472,7 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
                 controller.close();
                 return;
               }
-              if (!FORWARD.has(String(o.type))) continue;
+              if (!FORWARD(String(o.type))) continue;
               const msg = o.message as Record<string, unknown> | undefined;
               const u = msg?.usage as Record<string, unknown> | undefined;
               if (u) {
@@ -584,7 +581,7 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
 export function paneEngineCapability(): { available: boolean; reason: string } {
   const t = tmuxCapability();
   if (!t.available) return t;
-  if (!claudeBin()) return { available: false, reason: "no local `claude` CLI: install Claude Code to chat (Settings ▸ Requirements lists it, with the install guide)" };
+  if (!agent.bin()) return { available: false, reason: agent.missingReason() };
   return { available: true, reason: "" };
 }
 

--- a/server/src/paneagent.ts
+++ b/server/src/paneagent.ts
@@ -1,0 +1,106 @@
+/**
+ * What the pane engine needs from an agent, named.
+ *
+ * The engine (chatpane.ts) keeps one interactive CLI alive in a tmux pane and
+ * renders the conversation from the structured transcript that CLI writes — not
+ * from the screen. That is why a pane chat renders as a chat rather than as a
+ * wall of terminal output, and it is the decision worth keeping.
+ *
+ * It also pinned the whole engine to one vendor's on-disk format. Four things
+ * were Claude Code's specifically, spread through a 600-line file: where the
+ * binary is, the path shape `~/.claude/projects/<slug>/<id>.jsonl`, the flags
+ * that start or resume a session, and the line that means a turn is over.
+ * Nothing else writes any of that, so "run another agent in a pane" could not
+ * be attempted without first answering what, exactly, an agent has to provide.
+ *
+ * This is that answer. It is deliberately smaller than the file the engine
+ * reads today:
+ *
+ *   * **a turn's events**, appended to a file as they happen, in the shape the
+ *     browser's stream parser already understands — `assistant` / `user`
+ *     entries carrying content blocks;
+ *   * **a definite end of turn.** The load-bearing one. The engine is reliable
+ *     precisely because the CLI writes an explicit marker; anything inferred
+ *     from an idle screen or a stopped spinner is wrong exactly when a tool
+ *     takes four minutes, which is the moment it matters most;
+ *   * **usage**, where the source has it, so the cost frame stays measured
+ *     rather than estimated.
+ *
+ * What is deliberately *not* here: reading the screen. The engine screen-reads
+ * for one thing — deciding the TUI has finished drawing its input box — and
+ * that boundary is the whole reason the rest of this is structured data. An
+ * agent that could only be read by scraping is one this engine should decline
+ * rather than accommodate, because doing so loses tool structure, thinking and
+ * usage, and breaks on the next redraw.
+ *
+ * ---
+ *
+ * On adopting somebody else's protocol instead. Several agent CLIs are
+ * converging on a common client protocol, and implementing one of those would
+ * be the longer-lived move — it would make "a definite end of turn" their
+ * contract to keep rather than ours to infer. That is a real question and it is
+ * not answered here: this names the contract the existing engine already
+ * depends on, so it is visible and testable in one place instead of diffuse.
+ * Swapping the inside of it for a wire protocol later is a smaller change than
+ * finding these four couplings again.
+ */
+
+/** How a turn is launched. `fresh` is the distinction that bites: a session id
+ *  that has never run must be *started*, and one that has must be *resumed*.
+ *  Getting it backwards is a hard error rather than a degradation. */
+export interface LaunchSpec {
+  sessionId: string;
+  cwd: string;
+  model: string;
+  /** Empty means "leave the CLI's own setting alone". */
+  effort: string;
+  mode: string;
+  /** No transcript yet, so this session has never produced a turn. */
+  fresh: boolean;
+}
+
+export interface PaneAgent {
+  /** Stable key, for a spec and for saying which agent a chat is running on. */
+  id: string;
+  /** What a person calls it. */
+  label: string;
+
+  /** The executable, or null when it is not on this machine. */
+  bin(): string | null;
+
+  /** Why it cannot be used, in the words the settings pane will show. Only ever
+   *  read when `bin()` is null, so it can name the install path directly. */
+  missingReason(): string;
+
+  /**
+   * Where this session's turn events will be appended, whether or not the file
+   * exists yet.
+   *
+   * Computable up front, and that is a requirement rather than a convenience: a
+   * brand-new session has no file until it answers something, and the turn has
+   * to know where to watch before it sends anything.
+   */
+  transcriptFor(cwd: string, sessionId: string): string;
+
+  /** The command that starts the CLI in the pane. */
+  argv(spec: LaunchSpec): string[];
+
+  /**
+   * Whether this transcript entry means the turn is finished.
+   *
+   * Must be an explicit marker the agent itself wrote. A reader that returns
+   * true on a guess turns a four-minute tool call into a turn that appears to
+   * end halfway through it.
+   */
+  isTurnEnd(entry: Record<string, unknown>): boolean;
+
+  /**
+   * Which entry types are forwarded to the browser.
+   *
+   * A transcript carries more than a conversation — file-history snapshots,
+   * attachment records, the CLI's own title guess. None of it means anything to
+   * the chat renderer, and forwarding it would have the browser parsing shapes
+   * nobody wrote a case for.
+   */
+  forwards(type: string): boolean;
+}

--- a/server/test/pane-agent-contract.test.ts
+++ b/server/test/pane-agent-contract.test.ts
@@ -1,0 +1,198 @@
+/*
+ * What a pane agent has to provide, checked against the one that exists.
+ *
+ * The engine renders a conversation from the transcript a CLI writes, never
+ * from the screen — that is why a pane chat reads as a chat instead of a wall
+ * of terminal output. The cost was that four of Claude Code's own decisions
+ * were spread through a 600-line file: where the binary is, the transcript
+ * path, the launch flags, and the line that ends a turn.
+ *
+ * They are one interface now, and this is what holds it honest. The important
+ * assertions are not that Claude Code satisfies it — it is the file the
+ * interface was extracted from, so of course it does — but that the *properties
+ * the engine relies on* are stated somewhere a second implementation will be
+ * measured against.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { claudeCode, claudeHome, projectSlug } from "../src/agents/claudecode.ts";
+import { transcriptFor } from "../src/chatpane.ts";
+
+const src = (p: string) => readFileSync(new URL("../src/" + p, import.meta.url), "utf8");
+
+/**
+ * The file with its prose taken out.
+ *
+ * The rules below are about what the engine *builds*, and this codebase's
+ * comments explain the things they no longer do — a paragraph about why
+ * `--session-id` must not be reused belongs next to the code that decides it,
+ * and would otherwise fail a check about hard-coded flags for being an
+ * explanation rather than a coupling.
+ */
+const code = (p: string) => src(p)
+  .replace(/\/\*[\s\S]*?\*\//g, "")
+  .split("\n").filter((l) => !l.trim().startsWith("//")).join("\n");
+
+const spec = (over: Partial<Parameters<typeof claudeCode.argv>[0]> = {}) => ({
+  sessionId: "6b191fd3-f71e-5010-863d-d32334eaf400",
+  cwd: "/home/x/code/app",
+  model: "claude-opus-5",
+  effort: "",
+  mode: "default",
+  fresh: true,
+  ...over,
+});
+
+let saved: string | undefined;
+beforeEach(() => {
+  saved = process.env.AGENTGLASS_CLAUDE_HOME;
+  process.env.AGENTGLASS_CLAUDE_HOME = "/tmp/agx-fixture-home";
+});
+afterEach(() => {
+  if (saved === undefined) delete process.env.AGENTGLASS_CLAUDE_HOME;
+  else process.env.AGENTGLASS_CLAUDE_HOME = saved;
+});
+
+describe("the end of a turn", () => {
+  /**
+   * The load-bearing one, and the reason this engine works at all.
+   *
+   * The transcript is appended to as the turn runs, so "has it finished" cannot
+   * be answered by the file being quiet — a tool call that takes four minutes
+   * looks exactly like a turn that ended. Only a marker the agent itself wrote
+   * is an answer, and that is the property a second agent has to bring.
+   */
+  test("is an explicit marker, not the absence of one", () => {
+    expect(claudeCode.isTurnEnd({ type: "system", subtype: "turn_duration" })).toBe(true);
+  });
+
+  test("and nothing that merely looks like the end is mistaken for it", () => {
+    for (const entry of [
+      { type: "system" },                                    // some other system line
+      { type: "system", subtype: "compact_boundary" },       // a real one that is not the end
+      { type: "assistant", message: { content: [] } },       // an empty reply mid-turn
+      { type: "user" },
+      { type: "result" },                                    // the `-p` engine's shape, not this one
+      {},
+    ]) {
+      expect(claudeCode.isTurnEnd(entry), JSON.stringify(entry)).toBe(false);
+    }
+  });
+
+  test("and the engine asks the agent rather than matching a string itself", () => {
+    // The coupling this whole change exists to remove. A `turn_duration` left
+    // in chatpane.ts would mean a second agent silently never finishes a turn.
+    const engine = code("chatpane.ts");
+    expect(engine).not.toContain("turn_duration");
+    expect(engine).toContain("agent.isTurnEnd(o)");
+  });
+});
+
+describe("starting and resuming", () => {
+  test("a session that has never run is started, one that has is resumed", () => {
+    // Reusing `--session-id` on an existing session is a hard error — "Session
+    // ID is already in use" — so getting this backwards does not degrade, it
+    // fails the turn outright.
+    expect(claudeCode.argv(spec({ fresh: true }))).toContain("--session-id");
+    expect(claudeCode.argv(spec({ fresh: true }))).not.toContain("--resume");
+    expect(claudeCode.argv(spec({ fresh: false }))).toContain("--resume");
+    expect(claudeCode.argv(spec({ fresh: false }))).not.toContain("--session-id");
+  });
+
+  test("the effort flag is omitted rather than sent empty", () => {
+    // Empty means "leave the CLI's own setting alone", and `--effort ""` is not
+    // that — it is a value the CLI has to reject or misread.
+    expect(claudeCode.argv(spec({ effort: "" }))).not.toContain("--effort");
+    expect(claudeCode.argv(spec({ effort: "high" }))).toContain("high");
+  });
+
+  test("bypass is its own flag, not a permission mode", () => {
+    const bypass = claudeCode.argv(spec({ mode: "bypassPermissions" }));
+    expect(bypass).toContain("--dangerously-skip-permissions");
+    expect(bypass).not.toContain("--permission-mode");
+    const normal = claudeCode.argv(spec({ mode: "acceptEdits" }));
+    expect(normal).toContain("--permission-mode");
+    expect(normal).toContain("acceptEdits");
+    expect(normal).not.toContain("--dangerously-skip-permissions");
+  });
+
+  test("and the engine builds no argv of its own", () => {
+    const engine = code("chatpane.ts");
+    expect(engine).toContain("agent.argv({");
+    for (const flag of ["--resume", "--session-id", "--permission-mode", "--dangerously-skip-permissions"]) {
+      expect(engine, `${flag} is still hard-coded in the engine`).not.toContain(flag);
+    }
+  });
+});
+
+describe("where the turn is read from", () => {
+  test("is computable before the session has written anything", () => {
+    // Required, not convenient: a brand-new session has no file until it
+    // answers, and the turn has to know where to watch before it sends.
+    const p = claudeCode.transcriptFor("/home/x/code/app", "abc");
+    expect(p).toBe("/tmp/agx-fixture-home/projects/-home-x-code-app/abc.jsonl");
+  });
+
+  test("the slug is the one Claude Code actually derives, not a guess", () => {
+    // Every non-alphanumeric becomes `-`, so a separator and a leading dot each
+    // contribute one. Verified against a real session rather than inferred.
+    expect(projectSlug("/home/x/code/app/.claude/wt")).toBe("-home-x-code-app--claude-wt");
+    expect(projectSlug("/a_b/c.d")).toBe("-a-b-c-d");
+  });
+
+  test("and the engine goes through the agent to find it", () => {
+    expect(transcriptFor("/home/x/code/app", "abc")).toBe(claudeCode.transcriptFor("/home/x/code/app", "abc"));
+    expect(code("chatpane.ts")).not.toContain('"projects"');
+  });
+
+  test("the home honours the CLI's own knob, and the test override", () => {
+    // AGENTGLASS_CLAUDE_HOME exists so a suite points at a fixture instead of
+    // the developer's real history.
+    expect(claudeHome()).toBe("/tmp/agx-fixture-home");
+    delete process.env.AGENTGLASS_CLAUDE_HOME;
+    process.env.CLAUDE_CONFIG_DIR = "/tmp/agx-cli-knob";
+    expect(claudeHome()).toBe("/tmp/agx-cli-knob");
+    delete process.env.CLAUDE_CONFIG_DIR;
+  });
+});
+
+describe("what reaches the browser", () => {
+  test("is the conversation, and not the rest of the transcript", () => {
+    // A transcript carries file-history snapshots, attachment records and the
+    // CLI's own title guess. Forwarding those would have the browser parsing
+    // shapes nobody wrote a case for.
+    expect(claudeCode.forwards("assistant")).toBe(true);
+    expect(claudeCode.forwards("user")).toBe(true);
+    for (const t of ["system", "summary", "file-history-snapshot", "attachment", "result", ""]) {
+      expect(claudeCode.forwards(t), t).toBe(false);
+    }
+  });
+});
+
+describe("the boundary the engine will not cross", () => {
+  test("nothing in the contract asks an agent to be read off the screen", () => {
+    // The engine screen-reads for exactly one thing — deciding the TUI has
+    // finished drawing its input box — and that boundary is the reason the rest
+    // is structured data. An agent that could only be scraped loses tool
+    // structure, thinking and usage, and breaks on the next redraw.
+    const contract = src("paneagent.ts");
+    const iface = contract.slice(contract.indexOf("export interface PaneAgent"));
+    for (const scrape of ["capture", "screen", "scrape"]) {
+      expect(iface.toLowerCase(), `the contract mentions ${scrape}`).not.toContain(scrape);
+    }
+  });
+
+  test("and the reason it will not is written down, not just absent", () => {
+    // An absence with no reason attached reads as an oversight, and gets
+    // helpfully filled in by the next person.
+    // The comment as prose: leaders stripped, then whitespace collapsed. A
+    // regex over the raw file asserts where the lines happen to break, and the
+    // ` * ` at the start of each one is not part of the sentence.
+    const contract = src("paneagent.ts")
+      .split("\n").map((l) => l.replace(/^\s*\*\s?/, "")).join(" ")
+      .replace(/\s+/g, " ");
+    expect(contract).toMatch(/reading the screen/i);
+    expect(contract).toMatch(/decline rather than accommodate/);
+    expect(contract).toMatch(/loses tool structure, thinking and usage/);
+  });
+});


### PR DESCRIPTION
Closes #330.

## What does this PR do?

The pane engine renders a conversation from the structured transcript a CLI writes, never from the screen. That is why a pane chat reads as a chat instead of a wall of terminal output, and it is the decision worth keeping.

It also pinned the whole engine to one vendor's on-disk format — and not in one place. Four of Claude Code's own decisions were spread through a 600-line file:

| | was |
|---|---|
| where the binary is | `Bun.which("claude")`, inline |
| the transcript path | `~/.claude/projects/<slug>/<id>.jsonl`, built in three functions |
| the launch flags | `--session-id` / `--resume` / `--permission-mode`, built inside `ensurePane` |
| the end of a turn | `o.type === "system" && o.subtype === "turn_duration"`, a const in the middle of the stream reader |

Nothing else writes any of that, so *"run another agent in a pane"* (#329) could not be attempted — or even costed — without first answering what an agent has to provide.

`paneagent.ts` is that answer, and it is deliberately **smaller than the file the engine reads today**: a turn's events in the shape the browser already parses, a definite end of turn, and usage where the source has it.

### The end of turn is the load-bearing part

The engine is reliable precisely because the CLI writes an explicit marker. The transcript is appended to *as the turn runs*, so "has it finished" cannot be answered by the file going quiet — a tool call that takes four minutes looks exactly like a turn that ended. Anything inferred from an idle screen or a stopped spinner is wrong at precisely the moment it matters most.

That property is now stated where a second implementation will be measured against it, rather than implied by a string comparison halfway down a stream reader.

### What is deliberately not in the contract

**Reading the screen.** The engine screen-reads for exactly one thing — deciding the TUI has finished drawing its input box — and that boundary is the whole reason the rest is structured data. An agent that could only be scraped loses tool structure, thinking and usage, and breaks on the next redraw; it is one this engine should *decline rather than accommodate*.

The reason is written into the contract, not just absent from it. An absence with no reason attached reads as an oversight and gets helpfully filled in by the next person — and there are two mutations checking the reason is still there.

### On adopting somebody else's protocol instead

Several agent CLIs are converging on a common client protocol, and implementing one would be the longer-lived move: it makes "a definite end of turn" *their* contract to keep rather than ours to infer. **That question is left open rather than guessed at.** What this does is make the four couplings visible and testable in one file, so swapping the inside of it for a wire protocol later is a much smaller change than finding them again.

`agents/claudecode.ts` is today's code **moved, unchanged**. The paths, flags and marker were verified against a real session rather than inferred, and this does not improve them — it holds them in one place. Reading it top to bottom is the shortest description of the contract.

## How was it tested?

Behaviour is unchanged, and that is checked the boring way: **1256 tests passed before the new ones were added, and after the move**.

**Seventeen mutations, all red.** Roughly half are the contract itself — the end of a turn guessed rather than matched, every `system` line ending it, a fresh session resumed, an existing one started, an empty `--effort` sent as a flag, bypass sent as a permission mode as well, the project slug left unescaped, the `projects` directory dropped, the CLI's own `CLAUDE_CONFIG_DIR` ignored, the whole transcript forwarded to the browser, nothing forwarded at all.

The other half are **the coupling coming back**: the engine matching `turn_duration` itself, building its own argv, building its own transcript path, and the contract growing a `captureScreen` hook.

The rules that check the engine are written against the file **with its comments stripped**, which turned out to matter: the paragraph explaining why `--session-id` must not be reused belongs next to the code that decides it, and a naive substring check failed it for being an explanation rather than a coupling. Two comments that named flags this file no longer builds were stale and are fixed.

Suites green: **1270 server, 871 web**.

## What this does not do

It does not add a second agent. #329 is the issue for that, and this is the thing it was blocked on.