### PR TITLE
Budgets I set, not thresholds this app picked

### DIFF
--- a/README.md
+++ b/README.md
@@ -439,7 +439,8 @@ Most agent dashboards show a live event feed and forget everything on refresh. a
 | 📈 **Anthropic plan usage** | 5-hour + weekly plan-limit meters — shown only when you're viewing Anthropic (the one provider with a usage API), on wide screens. |
 | ⌨ **Command palette + shortcuts** | `Ctrl-K` to filter, switch theme, change window, export; `d` diffs · `g` git · `p` pull requests · `o` Docker · `t` terminal · `c` chat · `k` skills · `s` stats · `/` search; click any event for full details; click an agent to filter to it. |
 | 🎨 **22 themes** | 11 dark palettes (Midnight Purple, Forest, Ember, Nord, …), each with a light twin — instant switch, remembered. |
-| 🔔 **Alerts** | Web Push to a locked phone (end-to-end encrypted, no account anywhere) + webhook (Slack/Discord) + desktop notify + optional in-app chime, on approvals and errors. |
+| 🔔 **Alerts** | Web Push to a locked phone (end-to-end encrypted, no account anywhere) — a held gate arrives with **Allow and Deny on the notification** — plus webhook (Slack/Discord), desktop notify and an optional in-app chime. |
+| 💰 **Budgets** | *"No more than $40 a month on this repository."* Per-project and per-model, warned at 80% rather than only when you cross it, counted from the daily rollup as well as live events so a monthly budget really means a month. Settings ▸ Preferences. |
 | 📤 **Export** | One-click CSV / JSON of all events. |
 
 ### Themes

--- a/server/src/budget.ts
+++ b/server/src/budget.ts
@@ -1,0 +1,110 @@
+import type { Budget, BudgetPeriod, BudgetStatus } from "../../shared/types.ts";
+import { spendBetween } from "./db.ts";
+import { readBudgets } from "./config.ts";
+
+/**
+ * A number you chose, instead of one this app picked.
+ *
+ * The spend insights fired on constants — $15 in fifteen minutes is "burning
+ * fast", $60 an hour is a warning — which means they are noise on a project
+ * that genuinely costs that, and silent on one where a tenth of it would be
+ * alarming. There was no way to say "this should not cost more than X a day"
+ * and be told when it does.
+ *
+ * A budget is deliberately three things: how much, over what period, for what.
+ * Not a rate, not a forecast, not a per-session cap. "£40 a month on this
+ * repository" is a sentence somebody can say about their own work; "$0.94 an
+ * hour averaged over a trailing window" is not, and the second kind of setting
+ * is the kind that gets set once and never understood again.
+ *
+ * Evaluated against the rollup as well as live events, which is what #292 made
+ * possible: on a default install raw events are kept for eight days, so before
+ * that a monthly budget was a weekly budget wearing a monthly label.
+ */
+
+/** Fraction of the limit at which a budget starts warning.
+ *
+ *  Before the limit rather than only at it: a budget you are told about the
+ *  moment you cross it is a receipt, not a control. Four fifths leaves room to
+ *  do something and is late enough not to fire on an ordinary Tuesday. */
+export const WARN_AT = 0.8;
+
+/** A budget with nothing filled in, for a UI that is adding one. */
+export const emptyBudget = (): Budget => ({ root: "", model: "", limit: 0, period: "month" });
+
+/** UTC, and the same UTC the rollup's days are in. A budget evaluated in local
+ *  time against days recorded in UTC would jump at whichever midnight came
+ *  first, which on the last day of a month is a whole period out. */
+const dayOf = (ms: number): string => new Date(ms).toISOString().slice(0, 10);
+
+/**
+ * The window a period covers, ending today.
+ *
+ * Calendar periods, not trailing windows. "This month" is what somebody means
+ * by a monthly budget — it resets, and the reset is the thing that makes the
+ * number feel like a budget rather than a rolling average. A trailing 30 days
+ * never resets, so it can only ever creep towards the limit and stay there.
+ *
+ * The week starts on Monday, which is what most of the world means by a week
+ * and what every calendar the user is also looking at will agree with.
+ */
+export function periodWindow(period: BudgetPeriod, now = Date.now()): { fromDay: string; toDay: string } {
+  const d = new Date(now);
+  const toDay = dayOf(now);
+  if (period === "day") return { fromDay: toDay, toDay };
+  if (period === "week") {
+    // getUTCDay: 0 is Sunday, so Monday-start means Sunday counts as six days in.
+    const back = (d.getUTCDay() + 6) % 7;
+    return { fromDay: dayOf(now - back * 86_400_000), toDay };
+  }
+  return { fromDay: `${toDay.slice(0, 7)}-01`, toDay };
+}
+
+/** Human words for a period, used in the insight's own title. */
+export const periodLabel = (p: BudgetPeriod): string =>
+  p === "day" ? "today" : p === "week" ? "this week" : "this month";
+
+/**
+ * A budget worth acting on.
+ *
+ * Anything without a positive limit is ignored rather than treated as zero: a
+ * half-filled row in the settings pane must not start reporting every project
+ * as infinitely over budget.
+ */
+export const usable = (b: Budget): boolean => Number.isFinite(b.limit) && b.limit > 0;
+
+/**
+ * What each budget has spent, and whether that is a problem yet.
+ *
+ * `spend` is injected so the evaluation can be driven without a database — the
+ * arithmetic and the boundaries are what is worth testing here, and they are
+ * the part that is wrong in ways nobody notices for a month.
+ */
+export function budgetStatus(
+  budgets: Budget[] = readBudgets(),
+  now = Date.now(),
+  spend: typeof spendBetween = spendBetween,
+): BudgetStatus[] {
+  return budgets.filter(usable).map((b) => {
+    const { fromDay, toDay } = periodWindow(b.period, now);
+    const spent = spend({ fromDay, toDay, root: b.root || null, model: b.model || null });
+    // Guarded even though `usable` already rejects a zero limit: this is a
+    // denominator, and the one thing worse than a wrong budget is an Infinity
+    // rendered as a percentage on somebody's dashboard.
+    const pct = b.limit > 0 ? spent / b.limit : 0;
+    return {
+      budget: b,
+      fromDay,
+      toDay,
+      spent,
+      pct,
+      level: pct >= 1 ? "over" : pct >= WARN_AT ? "warn" : "ok",
+    };
+  });
+}
+
+/** What a status is about, in the words the insight will use. */
+export function budgetScopeLabel(b: Budget): string {
+  const where = b.root ? b.root.split("/").filter(Boolean).pop() || b.root : "everything";
+  return b.model ? `${where} · ${b.model}` : where;
+}

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -6,6 +6,7 @@
 // find. Environment variables still win, so a one-off `AGENTGLASS_…=x bun run`
 // overrides the file without editing it.
 
+import type { Budget } from "../../shared/types.ts";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve, dirname, sep, delimiter } from "node:path";
@@ -64,6 +65,9 @@ interface Config {
    *  for a packaged install or a shell-less deployment — exactly the people who
    *  want it off. The env var still wins when set. */
   terminalDisabled?: boolean;
+  /** Spending limits somebody set. See budget.ts. Hand-edited freely like the
+   *  rest of this file, so every field is checked on read. */
+  budgets?: Budget[];
 }
 
 function load(path: string): Config {
@@ -105,6 +109,86 @@ function config(): Config {
 }
 
 const expand = (p: string) => (p.startsWith("~/") ? join(homedir(), p.slice(2)) : p);
+
+/**
+ * The budgets on disk, with anything unusable dropped.
+ *
+ * Checked field by field rather than trusted, for the same reason `root` is:
+ * this file is hand-edited, and a budget is a *denominator*. A limit that
+ * arrives as a string turns every percentage into NaN, and a period nobody
+ * recognises would silently be evaluated as a month. Both are the kind of wrong
+ * that shows up as a number on a dashboard rather than as an error.
+ *
+ * A row that cannot be used is skipped and said about, never coerced into
+ * something plausible — a limit of `"40"` meaning forty is a guess, and
+ * guessing on a spending limit is how somebody finds out at the end of a month.
+ */
+export function readBudgets(): Budget[] {
+  const raw = config().budgets;
+  if (raw === undefined) return [];
+  if (!Array.isArray(raw)) {
+    console.error(`[config] ignoring "budgets" in ${configPath()}: expected an array`);
+    return [];
+  }
+  const out: Budget[] = [];
+  for (const b of raw) {
+    if (!b || typeof b !== "object" || Array.isArray(b)) continue;
+    const r = b as Partial<Budget>;
+    if (typeof r.limit !== "number" || !Number.isFinite(r.limit) || r.limit <= 0) {
+      console.error(`[config] ignoring a budget with a limit that is not a positive number`);
+      continue;
+    }
+    if (r.period !== "day" && r.period !== "week" && r.period !== "month") {
+      console.error(`[config] ignoring a budget with an unknown period: ${String(r.period)}`);
+      continue;
+    }
+    out.push({
+      root: typeof r.root === "string" ? expand(r.root) : "",
+      model: typeof r.model === "string" ? r.model : "",
+      limit: r.limit,
+      period: r.period,
+    });
+  }
+  return out;
+}
+
+/**
+ * Replace the whole set.
+ *
+ * Whole-set rather than per-row: budgets are edited as a list in one pane, and
+ * a partial update needs an identity for a row that has none — two budgets can
+ * differ only by a limit somebody is halfway through typing.
+ *
+ * Written through the same path as the workspace root, and refusing the same
+ * two things: a config file it could not parse, which would be overwritten
+ * wholesale, and any path outside the scratch directory under test.
+ */
+export function writeBudgets(budgets: Budget[]): { ok: boolean; persisted: boolean; error?: string } {
+  const path = configPath();
+  if (realConfigOffLimits(path)) {
+    return { ok: true, persisted: false, error: "not persisted: tests write settings only under os.tmpdir()" };
+  }
+  let existing: Record<string, unknown> = {};
+  try {
+    if (existsSync(path)) {
+      const parsed = JSON.parse(readFileSync(path, "utf8")) as unknown;
+      if (!parsed || typeof parsed !== "object" || Array.isArray(parsed)) {
+        return { ok: false, persisted: false, error: `config file is malformed — fix ${path} to save budgets` };
+      }
+      existing = parsed as Record<string, unknown>;
+    }
+  } catch (e) {
+    return { ok: false, persisted: false, error: `config file is malformed — fix ${path} to save budgets (${e instanceof Error ? e.message : e})` };
+  }
+  try {
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ ...existing, budgets }, null, 2) + "\n");
+    cached = null; // so the next read sees what was just written
+    return { ok: true, persisted: true };
+  } catch (e) {
+    return { ok: false, persisted: false, error: `could not write ${path}: ${e instanceof Error ? e.message : e}` };
+  }
+}
 
 /**
  * Where to look for repos, most explicit source first.

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1039,6 +1039,68 @@ export function dailyUsage(fromDay?: string, toDay?: string): UsageDay[] {
     .all(...rArgs, ...rs.args, ...eArgs, ...es.args);
 }
 
+/**
+ * What was spent, over a window, by one project and optionally one model.
+ *
+ * The same seam dailyUsage() crosses, asked a narrower question. Two things
+ * make it a separate function rather than a filter on that one.
+ *
+ * The scope is *given*, not ambient. Every other metric here answers about the
+ * project the cockpit is currently looking at; a budget answers about the
+ * project it was set for, whatever is on screen. So the scope clauses are
+ * passed a root rather than left to read `workspaceRoot()`.
+ *
+ * And cost is the one column that simply adds. dailyUsage has to count sessions
+ * distinctly because a session running across the cutoff has a row on both
+ * sides — cost does not: the prune folds `timestamp < cutoff`, so every dollar
+ * is on exactly one side of it and summing both is the whole answer. That is
+ * what makes this query short enough to be obviously right, which for the
+ * number a budget fires on is worth more than sharing code.
+ *
+ * Days are UTC, matching what the fold wrote, and `toDay` is inclusive.
+ */
+export function spendBetween(opts: {
+  fromDay: string;
+  toDay: string;
+  /** Project root, or null for the whole machine. */
+  root?: string | null;
+  /** Exact model name, or null for all of them. */
+  model?: string | null;
+}): number {
+  const root = opts.root || null;
+  const rs = rollupScopeClause(root);
+  const es = scopeClause(root);
+  const rModel = opts.model ? " AND model_name = ?" : "";
+  const eModel = opts.model ? " AND model_name = ?" : "";
+  const mArgs = opts.model ? [opts.model] : [];
+  const r = db
+    .query<{ cost: number | null }, any[]>(
+      `SELECT
+         (SELECT COALESCE(SUM(cost_usd), 0) FROM daily_rollup
+           WHERE day >= ? AND day <= ?${rModel}${rs.clause})
+       + (SELECT COALESCE(SUM(cost_usd), 0) FROM events
+           WHERE timestamp >= CAST(strftime('%s', ?) AS INTEGER) * 1000
+             AND timestamp < (CAST(strftime('%s', ?) AS INTEGER) + 86400) * 1000${eModel}${es.clause})
+         AS cost`
+    )
+    .get(opts.fromDay, opts.toDay, ...mArgs, ...rs.args,
+         opts.fromDay, opts.toDay, ...mArgs, ...es.args);
+  return r?.cost ?? 0;
+}
+
+/** Every model that has cost anything, newest activity first — so a budget can
+ *  be attached to one by picking rather than by typing its exact id. */
+export function costedModels(): string[] {
+  const rows = db
+    .query<{ m: string }, []>(
+      `SELECT model_name AS m FROM events WHERE model_name IS NOT NULL AND cost_usd > 0
+       UNION SELECT model_name AS m FROM daily_rollup WHERE cost_usd > 0
+       ORDER BY m`
+    )
+    .all();
+  return rows.map((r) => r.m).filter(Boolean);
+}
+
 /** The oldest day the rollup can speak to, or null when it is empty. Lets a
  *  panel state the real range instead of implying it has everything. */
 export function rollupEarliestDay(): string | null {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -19,6 +19,7 @@ import {
   providerOf,
   gateHistory,
   dailyUsage,
+  costedModels,
   rollupEarliestDay,
   retentionSeamDay,
   getGate,
@@ -71,7 +72,9 @@ import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_D
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
-import { workspaceRoot, setWorkspaceRoot, inScope } from "./config.ts";
+import { workspaceRoot, setWorkspaceRoot, inScope, readBudgets, writeBudgets } from "./config.ts";
+import { budgetStatus } from "./budget.ts";
+import type { Budget } from "../../shared/types.ts";
 import { hookStatus, applyHooks } from "./hooksetup.ts";
 import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt, callerFor, allowed, scopeNeeded, type Caller } from "./auth.ts";
@@ -778,6 +781,49 @@ const server = Bun.serve<WsData>({
     if ((pathname === "/hooks/install" || pathname === "/hooks/uninstall") && req.method === "POST") {
       if (!localOrigin(req)) return csrfBlocked();
       return json(applyHooks(pathname === "/hooks/install" ? "install" : "uninstall"));
+    }
+
+    /**
+     * Budgets: what is set, and where each stands right now.
+     *
+     * Reading is like reading the cost chart beside it — a limit and what has
+     * been spent against it is the same class of fact. Writing is a local
+     * decision like every other setting, so it goes through the origin gate.
+     */
+    if (pathname === "/budgets" && req.method === "GET") {
+      return json({ budgets: readBudgets(), status: budgetStatus(), models: costedModels() });
+    }
+    if (pathname === "/budgets/set" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: { budgets?: unknown };
+      try { b = (await req.json()) as { budgets?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      if (!Array.isArray(b.budgets)) return json({ ok: false, error: "expected a list of budgets" }, 400);
+      // Refused on the way in, not silently dropped. readBudgets() skips what it
+      // cannot use, so a bad row accepted here would vanish on the next read and
+      // look exactly like a save that did nothing.
+      const clean: Budget[] = [];
+      for (const raw of b.budgets as Partial<Budget>[]) {
+        if (!raw || typeof raw !== "object") return json({ ok: false, error: "that is not a budget" }, 400);
+        // A *number*, not something Number() can be talked into. `"40"`
+        // coerces to forty and readBudgets() then refuses it on the next read,
+        // so the save would appear to work and silently do nothing — which is
+        // the exact failure the validation on both sides exists to prevent.
+        const limit = raw.limit;
+        if (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0) {
+          return json({ ok: false, error: "a budget needs a limit above zero" }, 400);
+        }
+        if (raw.period !== "day" && raw.period !== "week" && raw.period !== "month") {
+          return json({ ok: false, error: "a budget needs a period of day, week or month" }, 400);
+        }
+        clean.push({
+          root: typeof raw.root === "string" ? raw.root : "",
+          model: typeof raw.model === "string" ? raw.model : "",
+          limit, period: raw.period,
+        });
+      }
+      const r = writeBudgets(clean);
+      if (!r.ok) return json(r, 400);
+      return json({ ...r, budgets: readBudgets(), status: budgetStatus() });
     }
 
     if (pathname === "/insights") return json({ insights: getInsights() });

--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -3,6 +3,7 @@
 // Computed from the full event history (better than the live buffer for loops).
 import type { Insight } from "../../shared/types.ts";
 import { db, scopeClause } from "./db.ts";
+import { budgetStatus, budgetScopeLabel, periodLabel } from "./budget.ts";
 
 const key = (app: string, sid: string) => `${app}:${sid.slice(0, 8)}`;
 const trim = (s: string, n = 64) => (s.length > n ? s.slice(0, n) + "…" : s);
@@ -93,7 +94,33 @@ export function getInsights(): Insight[] {
     });
   }
 
-  // 4) Spend velocity — overall $/hr over the last hour (context, info-level).
+  // 4) Budgets — a number the user chose, which beats every constant above it.
+  //
+  //    Only when one is set. With none, everything here behaves exactly as it
+  //    did, because a fixed threshold is a reasonable default and taking it
+  //    away from people who never asked for budgets would be a regression
+  //    dressed as a feature.
+  //
+  //    Unscoped by design: a budget names its own project, so it fires whether
+  //    or not the cockpit is currently looking at that one. The whole point is
+  //    to be told about a limit you set, not about the tab you have open.
+  for (const s of budgetStatus(undefined, now)) {
+    if (s.level === "ok") continue;
+    const pct = Math.round(s.pct * 100);
+    out.push({
+      id: `budget:${s.budget.root}:${s.budget.model}:${s.budget.period}`,
+      severity: s.level === "over" ? "bad" : "warn",
+      kind: "spend",
+      title: s.level === "over"
+        ? `Over budget · $${s.spent.toFixed(2)} of $${s.budget.limit.toFixed(2)} ${periodLabel(s.budget.period)}`
+        : `${pct}% of budget · $${s.spent.toFixed(2)} of $${s.budget.limit.toFixed(2)} ${periodLabel(s.budget.period)}`,
+      detail: budgetScopeLabel(s.budget),
+      session: null,
+      ts: now,
+    });
+  }
+
+  // 5) Spend velocity — overall $/hr over the last hour (context, info-level).
   const burn = db
     .query<{ cost: number; toks: number }, any[]>(
       `SELECT SUM(cost_usd) cost, SUM(input_tokens + output_tokens) toks FROM events WHERE timestamp > ?${sc}`

--- a/server/test/budget-routes.test.ts
+++ b/server/test/budget-routes.test.ts
@@ -1,0 +1,163 @@
+/*
+ * Budgets on disk and over the wire.
+ *
+ * `config.json` is hand-edited, and a budget is a *denominator*. A limit that
+ * arrives as the string "40" turns every percentage into NaN; a period nobody
+ * recognises would be evaluated as something. Both are the kind of wrong that
+ * shows up as a plausible number on a dashboard rather than as an error, which
+ * is why every field is checked on the way in and again on the way out.
+ */
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-budget-"));
+  const port = 4870 + Math.floor(Math.random() * 20);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    // A named environment, never `...process.env`.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+type Json = Record<string, any>;
+const jsonOf = (r: Response) => r.json() as Promise<Json>;
+const set = (budgets: unknown) =>
+  fetch(base + "/budgets/set", {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ budgets }),
+  });
+const get = () => fetch(base + "/budgets").then(jsonOf);
+
+const GOOD = { root: "", model: "", limit: 40, period: "month" };
+
+beforeEach(async () => { await set([]); });
+
+describe("saving one", () => {
+  test("round-trips through the config file", async () => {
+    const r = await jsonOf(await set([GOOD]));
+    expect(r.ok).toBe(true);
+    expect(r.persisted).toBe(true);
+    expect((await get()).budgets).toEqual([GOOD]);
+  });
+
+  test("and lands in config.json beside everything else, not in a file of its own", async () => {
+    // One settings file. A second one is a second thing to find, back up and
+    // hand-edit, for four fields.
+    await set([GOOD]);
+    const cfg = JSON.parse(readFileSync(join(dir, "agentglass", "config.json"), "utf8"));
+    expect(cfg.budgets).toEqual([GOOD]);
+  });
+
+  test("without trampling the settings already in there", async () => {
+    // The write is a read-modify-write of a shared file: losing the workspace
+    // root to save a budget would be a spectacularly bad trade.
+    const path = join(dir, "agentglass", "config.json");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ root: "/home/x/keepme", chatBypass: true }));
+    await set([GOOD]);
+    const cfg = JSON.parse(readFileSync(path, "utf8"));
+    expect(cfg.root).toBe("/home/x/keepme");
+    expect(cfg.chatBypass).toBe(true);
+    expect(cfg.budgets).toEqual([GOOD]);
+  });
+
+  test("replacing the whole set, because a row has no identity", async () => {
+    // Two budgets can differ only by a limit somebody is halfway through
+    // typing, so there is nothing to address a partial update at.
+    await set([GOOD, { ...GOOD, root: "/a/b", limit: 10 }]);
+    expect((await get()).budgets).toHaveLength(2);
+    await set([GOOD]);
+    expect((await get()).budgets).toHaveLength(1);
+  });
+});
+
+describe("refusing one that is not a budget", () => {
+  test("a limit that is not a positive number", async () => {
+    for (const limit of [0, -1, "40", null, undefined, NaN]) {
+      const r = await set([{ ...GOOD, limit }]);
+      expect(r.status, String(limit)).toBe(400);
+      expect(String((await jsonOf(r)).error)).toContain("limit above zero");
+    }
+  });
+
+  test("a period nobody recognises", async () => {
+    for (const period of ["year", "fortnight", "", 30, null]) {
+      const r = await set([{ ...GOOD, period }]);
+      expect(r.status, String(period)).toBe(400);
+    }
+  });
+
+  test("and refuses on the way in rather than dropping it quietly", async () => {
+    // readBudgets() skips what it cannot use, so a bad row accepted here would
+    // vanish on the next read and look exactly like a save that did nothing.
+    await set([GOOD]);
+    expect((await set([{ ...GOOD, limit: -1 }])).status).toBe(400);
+    expect((await get()).budgets).toEqual([GOOD]);
+  });
+
+  test("a body that is not a list", async () => {
+    for (const body of [{ budgets: "all of them" }, { budgets: 3 }, {}]) {
+      const r = await fetch(base + "/budgets/set", {
+        method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify(body),
+      });
+      expect(r.status).toBe(400);
+    }
+  });
+
+  test("and a body that is not JSON", async () => {
+    const r = await fetch(base + "/budgets/set", {
+      method: "POST", headers: { "content-type": "application/json" }, body: "{",
+    });
+    expect(r.status).toBe(400);
+  });
+});
+
+describe("what the panel is told", () => {
+  test("every budget comes back with where it stands", async () => {
+    await set([{ ...GOOD, limit: 40 }]);
+    const r = await get();
+    expect(r.status).toHaveLength(1);
+    // Nothing has been spent in this scratch database, so it is under.
+    expect(r.status[0]).toMatchObject({ spent: 0, pct: 0, level: "ok" });
+    // …and it says which days that covers, rather than implying all of them.
+    expect(r.status[0].fromDay).toMatch(/^\d{4}-\d{2}-01$/);
+  });
+
+  test("and the models it could be attached to, so nobody types an id", async () => {
+    const r = await get();
+    expect(Array.isArray(r.models)).toBe(true);
+  });
+
+  test("a budget that is not usable is not given a status", async () => {
+    // It cannot be saved through the route, but it can be hand-edited in, and a
+    // zero limit is a division nobody wants rendered as a percentage.
+    const path = join(dir, "agentglass", "config.json");
+    mkdirSync(dirname(path), { recursive: true });
+    writeFileSync(path, JSON.stringify({ budgets: [{ ...GOOD, limit: 0 }] }));
+    const r = await get();
+    expect(r.status).toEqual([]);
+  });
+});

--- a/server/test/budget.test.ts
+++ b/server/test/budget.test.ts
@@ -1,0 +1,268 @@
+/*
+ * Budgets, and the arithmetic nobody notices is wrong for a month.
+ *
+ * Spend insights fired on constants — $15 in fifteen minutes is "burning fast",
+ * $60 an hour is a warning — which is noise on a project that genuinely costs
+ * that and silence on one where a tenth would be alarming. A budget replaces
+ * the constant with a number somebody chose.
+ *
+ * Which makes the boundaries load-bearing in a way a threshold never was. A
+ * monthly budget that starts on the wrong day, or resets in the wrong timezone,
+ * is not a visible bug: it is a number on a dashboard that is quietly a
+ * different number from the one the user is thinking of, and the first time
+ * anybody finds out is at the end of a month.
+ *
+ * So the window is computed against fixed instants here rather than against
+ * `Date.now()`, and the spend lookup is injected — what is worth pinning is the
+ * decision, not SQLite's ability to add.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  periodWindow, periodLabel, budgetStatus, budgetScopeLabel, usable, emptyBudget, WARN_AT,
+} from "../src/budget.ts";
+import type { Budget } from "../../shared/types.ts";
+import { readBudgets } from "../src/config.ts";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const b = (over: Partial<Budget> = {}): Budget => ({ ...emptyBudget(), limit: 100, ...over });
+
+/** A fixed instant, so "today" is a fact rather than whenever this runs.
+ *  2026-07-15 is a Wednesday; 2026-07-01 is a Wednesday too. */
+const WED = Date.parse("2026-07-15T09:30:00Z");
+
+describe("the window a period covers", () => {
+  test("a day is that day, in UTC", () => {
+    expect(periodWindow("day", WED)).toEqual({ fromDay: "2026-07-15", toDay: "2026-07-15" });
+  });
+
+  test("a week starts on Monday", () => {
+    // What most of the world means by a week, and what every calendar the user
+    // is also looking at will agree with.
+    expect(periodWindow("week", WED)).toEqual({ fromDay: "2026-07-13", toDay: "2026-07-15" });
+  });
+
+  test("and Sunday belongs to the week that is ending, not the one starting", () => {
+    // The off-by-one that a `getUTCDay()` used raw produces: Sunday is 0, so a
+    // naive subtraction makes it the first day of a new week and a Sunday
+    // afternoon silently resets the budget.
+    const sun = Date.parse("2026-07-19T23:00:00Z");
+    expect(periodWindow("week", sun)).toEqual({ fromDay: "2026-07-13", toDay: "2026-07-19" });
+    const mon = Date.parse("2026-07-20T00:30:00Z");
+    expect(periodWindow("week", mon)).toEqual({ fromDay: "2026-07-20", toDay: "2026-07-20" });
+  });
+
+  test("a month starts on the first, and is a calendar month", () => {
+    // Not a trailing thirty days. A trailing window never resets, so it can
+    // only creep towards the limit and stay there — which is an average with a
+    // limit painted on it, not a budget.
+    expect(periodWindow("month", WED)).toEqual({ fromDay: "2026-07-01", toDay: "2026-07-15" });
+    const first = Date.parse("2026-07-01T00:00:01Z");
+    expect(periodWindow("month", first)).toEqual({ fromDay: "2026-07-01", toDay: "2026-07-01" });
+  });
+
+  test("and the year boundary is not special-cased into being wrong", () => {
+    const jan = Date.parse("2027-01-03T12:00:00Z"); // a Sunday
+    expect(periodWindow("month", jan)).toEqual({ fromDay: "2027-01-01", toDay: "2027-01-03" });
+    expect(periodWindow("week", jan)).toEqual({ fromDay: "2026-12-28", toDay: "2027-01-03" });
+  });
+
+  test("late in a day still means the UTC day", () => {
+    expect(periodWindow("day", Date.parse("2026-07-15T23:59:59Z")).toDay).toBe("2026-07-15");
+    expect(periodWindow("day", Date.parse("2026-07-16T00:00:00Z")).toDay).toBe("2026-07-16");
+  });
+
+  /**
+   * …and in a timezone that is not this one.
+   *
+   * The rollup writes UTC days, so a window computed in local time jumps at
+   * whichever midnight arrives first — which on the last day of a month puts a
+   * budget a whole period out. This machine runs in UTC, where that bug is
+   * completely invisible: local and UTC agree on every instant, and a mutation
+   * swapping `toISOString()` for local date parts passed every check above.
+   *
+   * So the property is checked where it can actually fail, in a child process
+   * with TZ set. UTC+14 and UTC-11 straddle the date line, so at 23:30Z on the
+   * 15th one of them is already on the 16th and the other is still on the 15th.
+   */
+  test("and stays the UTC day on a machine that is not in UTC", () => {
+    const budgetSrc = new URL("../src/budget.ts", import.meta.url).pathname;
+    const script = [
+      `const { periodWindow } = await import(${JSON.stringify(budgetSrc)});`,
+      `const now = Date.parse("2026-07-15T23:30:00Z");`,
+      `console.log(JSON.stringify({ local: new Date(now).getDate(),`,
+      `  day: periodWindow("day", now), month: periodWindow("month", now) }));`,
+    ].join("\n");
+    for (const [tz, localDate] of [["Pacific/Kiritimati", 16], ["Pacific/Niue", 15]] as const) {
+      const r = Bun.spawnSync(["bun", "-e", script], {
+        env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", TZ: tz },
+      });
+      const out = JSON.parse(r.stdout.toString().trim() || "{}");
+      // The child really is in that zone — otherwise this test proves nothing.
+      expect(out.local, `${tz} did not take effect`).toBe(localDate);
+      expect(out.day, tz).toEqual({ fromDay: "2026-07-15", toDay: "2026-07-15" });
+      expect(out.month, tz).toEqual({ fromDay: "2026-07-01", toDay: "2026-07-15" });
+    }
+  });
+});
+
+describe("where a budget stands", () => {
+  const spendOf = (amount: number) => () => amount;
+
+  test("under the warn line is nothing to say", () => {
+    const [s] = budgetStatus([b({ limit: 100 })], WED, spendOf(50));
+    expect(s!.level).toBe("ok");
+    expect(s!.pct).toBe(0.5);
+  });
+
+  test("warns before the limit, not at it", () => {
+    // A budget you are told about the moment you cross it is a receipt, not a
+    // control — there is nothing left to do about it.
+    expect(budgetStatus([b({ limit: 100 })], WED, spendOf(100 * WARN_AT))[0]!.level).toBe("warn");
+    expect(budgetStatus([b({ limit: 100 })], WED, spendOf(100 * WARN_AT - 0.01))[0]!.level).toBe("ok");
+    expect(WARN_AT).toBeLessThan(1);
+  });
+
+  test("and over is over, exactly at the limit", () => {
+    expect(budgetStatus([b({ limit: 100 })], WED, spendOf(99.99))[0]!.level).toBe("warn");
+    expect(budgetStatus([b({ limit: 100 })], WED, spendOf(100))[0]!.level).toBe("over");
+  });
+
+  test("the percentage is not capped, because how far over is the point", () => {
+    expect(budgetStatus([b({ limit: 100 })], WED, spendOf(180))[0]!.pct).toBe(1.8);
+  });
+
+  /** Collected into an array rather than a `let`: TypeScript narrows a nullable
+   *  captured by a callback to `null`, so the assertion would be about the type
+   *  rather than the value. */
+  const asksOf = (budgets: Budget[]) => {
+    const seen: { fromDay: string; toDay: string; root?: string | null; model?: string | null }[] = [];
+    budgetStatus(budgets, WED, (o) => { seen.push(o); return 0; });
+    return seen;
+  };
+
+  test("asks about the window the period names", () => {
+    const [asked] = asksOf([b({ period: "month", root: "/home/x/orbit", model: "claude-opus-5" })]);
+    expect(asked).toEqual({
+      fromDay: "2026-07-01", toDay: "2026-07-15",
+      root: "/home/x/orbit", model: "claude-opus-5",
+    });
+  });
+
+  test("and a week or a day asks about that window, not about the month", () => {
+    // The period is the whole setting. Evaluating every budget over a month
+    // makes a daily limit fire once and then stay lit until the first.
+    const asked: Record<string, { fromDay: string; toDay: string }> = {};
+    for (const period of ["day", "week", "month"] as const) {
+      const [o] = asksOf([b({ period })]);
+      asked[period] = { fromDay: o!.fromDay, toDay: o!.toDay };
+    }
+    expect(asked).toEqual({
+      day: { fromDay: "2026-07-15", toDay: "2026-07-15" },
+      week: { fromDay: "2026-07-13", toDay: "2026-07-15" },
+      month: { fromDay: "2026-07-01", toDay: "2026-07-15" },
+    });
+  });
+
+  test("and an unset root or model asks about everything, not about the empty string", () => {
+    expect(asksOf([b()])[0]).toMatchObject({ root: null, model: null });
+  });
+});
+
+describe("a budget that is not one", () => {
+  test("is ignored rather than treated as zero", () => {
+    // A half-filled row in the settings pane must not start reporting every
+    // project as infinitely over budget.
+    expect(usable(b({ limit: 0 }))).toBe(false);
+    expect(usable(b({ limit: -5 }))).toBe(false);
+    expect(usable(b({ limit: NaN }))).toBe(false);
+    expect(usable(b({ limit: Infinity }))).toBe(false);
+    expect(usable(b({ limit: 0.01 }))).toBe(true);
+  });
+
+  test("and never reaches the evaluation at all", () => {
+    let calls = 0;
+    const out = budgetStatus([b({ limit: 0 }), b({ limit: 10 })], WED, () => { calls++; return 1; });
+    expect(out).toHaveLength(1);
+    expect(calls).toBe(1);
+  });
+});
+
+describe("saying what a budget is about", () => {
+  test("names the project by its directory, not its whole path", () => {
+    expect(budgetScopeLabel(b({ root: "/home/x/code/orbit" }))).toBe("orbit");
+    expect(budgetScopeLabel(b({ root: "/home/x/code/orbit/" }))).toBe("orbit");
+  });
+
+  test("says 'everything' rather than nothing when it covers the machine", () => {
+    expect(budgetScopeLabel(b())).toBe("everything");
+  });
+
+  test("and names the model when the budget is about one", () => {
+    expect(budgetScopeLabel(b({ root: "/a/orbit", model: "claude-opus-5" }))).toBe("orbit · claude-opus-5");
+    expect(budgetScopeLabel(b({ model: "claude-opus-5" }))).toBe("everything · claude-opus-5");
+  });
+
+  test("the period reads as a phrase, since it lands mid-sentence", () => {
+    expect(periodLabel("day")).toBe("today");
+    expect(periodLabel("week")).toBe("this week");
+    expect(periodLabel("month")).toBe("this month");
+  });
+});
+
+/**
+ * A config file somebody edited by hand.
+ *
+ * Driven through `readBudgets` rather than through a running server, because
+ * the settings file is read once per resolved path — the same caching every
+ * other setting here uses — so a live process does not see an edit until it
+ * restarts. That is existing behaviour and consistent with `root`; what is
+ * worth pinning is that when the file *is* read, a row it cannot use is
+ * dropped rather than coerced into something plausible.
+ */
+describe("reading budgets off disk", () => {
+  const withConfig = <T,>(budgets: unknown, fn: () => T): T => {
+    // A fresh directory per case, which is also what invalidates the cache.
+    const home = mkdtempSync(join(tmpdir(), "agx-bcfg-"));
+    process.env.XDG_CONFIG_HOME = home;
+    mkdirSync(join(home, "agentglass"), { recursive: true });
+    writeFileSync(join(home, "agentglass", "config.json"), JSON.stringify({ budgets }));
+    return fn();
+  };
+
+  test("keeps the rows it can use and drops the ones it cannot", () => {
+    const out = withConfig(
+      [{ root: "", model: "", limit: 40, period: "month" },
+       { limit: "40", period: "month" },   // a string is a guess, not a limit
+       { limit: 5 },                       // no period
+       { limit: 5, period: "year" },       // not a period this app has
+       null, "a budget", 7,
+       { root: "", model: "", limit: 9, period: "day" }],
+      () => readBudgets(),
+    );
+    expect(out.map((b) => b.limit)).toEqual([40, 9]);
+  });
+
+  test("fills in the parts a hand-edit is allowed to leave out", () => {
+    const [b] = withConfig([{ limit: 12, period: "week" }], () => readBudgets());
+    expect(b).toEqual({ root: "", model: "", limit: 12, period: "week" });
+  });
+
+  test("expands a leading ~ in a root, like every other path in this file", () => {
+    const [b] = withConfig([{ root: "~/code/orbit", limit: 1, period: "day" }], () => readBudgets());
+    expect(b!.root.startsWith("~")).toBe(false);
+    expect(b!.root.endsWith("/code/orbit")).toBe(true);
+  });
+
+  test("a budgets key that is not a list costs the budgets, not the read", () => {
+    expect(withConfig({ nope: true }, () => readBudgets())).toEqual([]);
+    expect(withConfig("all of them", () => readBudgets())).toEqual([]);
+  });
+
+  test("and no budgets key at all is simply none", () => {
+    const home = mkdtempSync(join(tmpdir(), "agx-bcfg-"));
+    process.env.XDG_CONFIG_HOME = home;
+    expect(readBudgets()).toEqual([]);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1591,6 +1591,41 @@ export interface PairState {
   devices: PairedDevice[];
 }
 
+/** How often a budget resets. Calendar periods, not trailing windows — the
+ *  reset is what makes a number feel like a budget rather than an average. */
+export type BudgetPeriod = "day" | "week" | "month";
+
+/**
+ * A spending limit somebody chose.
+ *
+ * The insights used to fire on constants, which makes them noise on a project
+ * that genuinely costs that much and silent on one where a tenth would be
+ * alarming. Three fields, deliberately: how much, over what period, for what.
+ */
+export interface Budget {
+  /** Project root this applies to. Empty means the whole machine. */
+  root: string;
+  /** Exact model name this applies to. Empty means all of them. */
+  model: string;
+  /** In USD, matching every other cost in this app. */
+  limit: number;
+  period: BudgetPeriod;
+}
+
+/** A budget, and where it stands right now. */
+export interface BudgetStatus {
+  budget: Budget;
+  /** The window evaluated, UTC and inclusive — so a panel can say which days
+   *  the number covers rather than implying it covers all of them. */
+  fromDay: string;
+  toDay: string;
+  spent: number;
+  /** Fraction of the limit. Above 1 when over, which is left uncapped: "180%"
+   *  is the useful number and "100%" would hide how far past it went. */
+  pct: number;
+  level: "ok" | "warn" | "over";
+}
+
 /**
  * A warm CLI held in a tmux pane, and what is known about it.
  *

--- a/web/src/components/BudgetsPane.tsx
+++ b/web/src/components/BudgetsPane.tsx
@@ -1,0 +1,159 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../lib/api.ts";
+import { fmtUsd } from "../lib/format.ts";
+import type { Budget, BudgetPeriod, BudgetStatus } from "../../../shared/types.ts";
+
+/**
+ * A number you chose, instead of one this app picked.
+ *
+ * The spend insights fired on constants — $15 in fifteen minutes is "burning
+ * fast" — which is noise on a project that genuinely costs that, and silence on
+ * one where a tenth would be alarming. There was no way to say "this should not
+ * cost more than X a month" and be told when it does.
+ *
+ * Three fields on purpose: how much, over what period, for what. Not a rate,
+ * not a forecast, not a per-session cap. "£40 a month on this repository" is a
+ * sentence somebody can say about their own work, and a setting phrased as one
+ * is a setting that still makes sense a year after it was made.
+ */
+export function BudgetsPane({ open }: { open: boolean }) {
+  const [rows, setRows] = useState<Budget[] | null>(null);
+  const [status, setStatus] = useState<BudgetStatus[]>([]);
+  const [models, setModels] = useState<string[]>([]);
+  const [roots, setRoots] = useState<string[]>([]);
+  const [err, setErr] = useState<string | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const load = useCallback(() => {
+    api.budgets()
+      .then((r) => { setRows(r.budgets); setStatus(r.status); setModels(r.models); })
+      .catch(() => setRows([]));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    load();
+    // The projects this machine has actually worked on, so a budget is attached
+    // by picking rather than by typing a path exactly right.
+    api.gitRepos().then((r) => setRoots(r.repos.map((x) => x.root))).catch(() => setRoots([]));
+  }, [open, load]);
+
+  /** Saved as a set, because a row has no identity: two budgets can differ only
+   *  by a limit somebody is halfway through typing. */
+  const save = async (next: Budget[]) => {
+    setRows(next);
+    setErr(null);
+    // A row being filled in is not an error yet — it is a row being filled in.
+    const ready = next.filter((b) => b.limit > 0);
+    setBusy(true);
+    const r = await api.budgetsSet(ready).catch(() => null);
+    setBusy(false);
+    if (!r?.ok) { setErr(r?.error ?? "Could not save."); return; }
+    if (r.status) setStatus(r.status);
+  };
+
+  const patch = (i: number, over: Partial<Budget>) =>
+    void save((rows ?? []).map((b, n) => (n === i ? { ...b, ...over } : b)));
+
+  if (!rows) return <div className="text-[11px] t-dim2">Reading budgets…</div>;
+
+  const statusFor = (b: Budget) =>
+    status.find((s) => s.budget.root === b.root && s.budget.model === b.model && s.budget.period === b.period);
+
+  return (
+    <div className="flex flex-col gap-2">
+      {rows.length === 0 && (
+        <div className="text-[10.5px] t-dim2">
+          Without one, spend is flagged on fixed thresholds — which is noise on a project that costs
+          that much anyway, and silence on one where a tenth of it would worry you.
+        </div>
+      )}
+
+      {rows.map((b, i) => {
+        const s = statusFor(b);
+        const pct = s ? Math.min(1, s.pct) : 0;
+        const tint = s?.level === "over" ? "var(--error)" : s?.level === "warn" ? "var(--warning)" : "var(--success)";
+        return (
+          <div key={i} className="flex flex-col gap-1.5 px-2.5 py-2 rounded-lg" style={{
+            background: "color-mix(in srgb, var(--bg2) 60%, transparent)",
+            border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)",
+          }}>
+            <div className="flex items-center gap-2 flex-wrap">
+              <span className="text-[10.5px] t-dim2">Spend no more than</span>
+              <span className="flex items-center gap-1">
+                <span className="text-[11px] t-dim2">$</span>
+                <input
+                  className="w-16 text-[12px] px-1.5 py-1 rounded-md t-mono"
+                  style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
+                  inputMode="decimal"
+                  value={b.limit || ""}
+                  placeholder="40"
+                  onChange={(e) => patch(i, { limit: Number(e.target.value.replace(/[^0-9.]/g, "")) || 0 })}
+                />
+              </span>
+              <select className="text-[11px] px-1.5 py-1 rounded-md"
+                style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
+                value={b.period} onChange={(e) => patch(i, { period: e.target.value as BudgetPeriod })}>
+                <option value="day">a day</option>
+                <option value="week">a week</option>
+                <option value="month">a month</option>
+              </select>
+              <span className="text-[10.5px] t-dim2">on</span>
+              <select className="text-[11px] px-1.5 py-1 rounded-md min-w-0 max-w-[9rem]"
+                style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
+                value={b.root} onChange={(e) => patch(i, { root: e.target.value })}>
+                <option value="">everything</option>
+                {roots.map((r) => <option key={r} value={r}>{r.split("/").filter(Boolean).pop() || r}</option>)}
+                {b.root && !roots.includes(b.root) && <option value={b.root}>{b.root}</option>}
+              </select>
+              <select className="text-[11px] px-1.5 py-1 rounded-md min-w-0 max-w-[11rem]"
+                style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
+                value={b.model} onChange={(e) => patch(i, { model: e.target.value })}>
+                <option value="">any model</option>
+                {models.map((m) => <option key={m} value={m}>{m}</option>)}
+                {b.model && !models.includes(b.model) && <option value={b.model}>{b.model}</option>}
+              </select>
+              <button onClick={() => void save(rows.filter((_, n) => n !== i))}
+                className="ml-auto text-[10.5px] px-2 py-1 rounded-md hover:opacity-80"
+                style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+                Remove
+              </button>
+            </div>
+
+            {/* The denominator, where the number is. A budget you cannot see
+                yourself approaching is one you only hear about once. */}
+            {s && (
+              <div className="flex flex-col gap-1">
+                <div className="h-1 rounded-full overflow-hidden" style={{ background: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
+                  <div style={{ width: `${pct * 100}%`, height: "100%", background: tint }} />
+                </div>
+                <div className="text-[10px]" style={{ color: s.level === "ok" ? "var(--text3)" : tint }}>
+                  {fmtUsd(s.spent)} of {fmtUsd(s.budget.limit)} · {Math.round(s.pct * 100)}%
+                  <span className="t-dim2"> · {s.fromDay} to {s.toDay}</span>
+                </div>
+              </div>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="flex items-center gap-2">
+        <button
+          onClick={() => setRows([...(rows ?? []), { root: "", model: "", limit: 0, period: "month" }])}
+          disabled={busy}
+          className="self-start text-[11px] px-2.5 py-1.5 rounded-lg hover:opacity-80"
+          style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
+          Add a budget
+        </button>
+        {err && <span className="text-[10.5px]" style={{ color: "var(--error)" }}>{err}</span>}
+      </div>
+
+      <div className="text-[10px] t-dim2">
+        Counted from the daily rollup as well as live events, so a monthly budget really means a month —
+        raw events are only kept for {}
+        <span className="t-mono">AGENTGLASS_RETENTION_DAYS</span> (8 by default). You are warned at 80%
+        rather than only when you cross it.
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -20,6 +20,7 @@ import { installedNotes, type NotesTarget } from "../lib/whatsNew.ts";
 import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESKTOP } from "../lib/desktop.ts";
 import { RemoteAccessPane } from "./RemoteAccessPane.tsx";
 import { RunningPanes } from "./RunningPanes.tsx";
+import { BudgetsPane } from "./BudgetsPane.tsx";
 import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRenderer.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
@@ -939,6 +940,14 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                         { v: "process", label: "Separate" },
                         { v: "tmux", label: "tmux panes" },
                       ]} />
+                    {/* A limit you chose, so the spend insights stop firing on
+                        constants — which are noise on a project that genuinely
+                        costs that and silence on one where a tenth would be
+                        alarming. */}
+                    <div className="flex flex-col gap-1.5 pt-1">
+                      <span className="text-[10px] t-dim2 uppercase tracking-wider">Spending budgets</span>
+                      <BudgetsPane open={open} />
+                    </div>
                     {/* The consequence of the setting above, made visible.
                         Panes outlive the app, so "how new chats run" quietly
                         decides how much memory is resident on this machine an

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -449,6 +449,14 @@ const realApi = {
   /** Revoke one device's credential and close what it is holding. */
   pairForget: (id: string) => post<{ ok: boolean; closed?: number; error?: string }>("/pair/forget", { id }),
 
+  /** Spending limits, and where each stands right now. */
+  budgets: () => get<{ budgets: Budget[]; status: BudgetStatus[]; models: string[] }>("/budgets"),
+  /** Replace the whole set — a budget row has no identity to address a partial
+   *  update at, since two can differ only by a limit being typed. */
+  budgetsSet: (budgets: Budget[]) =>
+    post<{ ok: boolean; persisted?: boolean; error?: string; budgets?: Budget[]; status?: BudgetStatus[] }>(
+      "/budgets/set", { budgets }),
+
   updateStatus: () => get<UpdateStatus>("/update/status"),
   // The tag is optional because the automatic modal wants "whatever this build
   // came from", while About asks for a named release — the update it is about
@@ -749,6 +757,8 @@ const demoApi: typeof realApi = {
   pairAccept: (_ticket: string, _scope: DeviceScope) => D({ ok: false, error: "not available in the demo" }),
   pairReject: (_ticket: string) => D({ ok: false }),
   pairForget: (_id: string) => D({ ok: false, error: "not available in the demo" }),
+  budgets: () => D({ budgets: [], status: [], models: [] }),
+  budgetsSet: (_budgets: Budget[]) => D({ ok: false, error: "not available in the demo" }),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),
   updateRun: () => D({ ok: false, error: "not available in the demo" }),
   hooksStatus: () => D({ installed: false, bundled: false, settingsPath: "~/.claude/settings.json", python: "python3" } as HookSetupStatus),

--- a/web/test/budgets-pane.test.ts
+++ b/web/test/budgets-pane.test.ts
@@ -1,0 +1,73 @@
+/*
+ * The budgets pane, and the properties that keep it from lying about money.
+ *
+ * A budget is a denominator on somebody's dashboard, so the assertions worth
+ * having are about the ways it could show a plausible wrong number: a half-typed
+ * row saved as a real limit, a percentage bar that pretends 180% is 100%, or a
+ * window that does not say which days it covers.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const read = (p: string) => readFileSync(new URL("../" + p, import.meta.url), "utf8");
+const pane = read("src/components/BudgetsPane.tsx");
+
+describe("setting one", () => {
+  test("a row being filled in is not saved as a budget", () => {
+    // Adding a row starts it at zero, and the moment it were sent it would be
+    // either refused by the server or — worse — treated as a limit of nothing.
+    expect(pane).toContain("next.filter((b) => b.limit > 0)");
+  });
+
+  test("the whole set is sent, because a row has no identity", () => {
+    // Two budgets can differ only by a limit somebody is halfway through
+    // typing, so there is nothing for a partial update to address.
+    expect(pane).toContain("api.budgetsSet(ready)");
+  });
+
+  test("the limit field accepts only digits and a point", () => {
+    // It is bound straight to a number. Letters would land as NaN and every
+    // percentage computed from it would render as "NaN%".
+    expect(pane).toMatch(/replace\(\/\[\^0-9\.\]\/g, ""\)/);
+  });
+
+  test("and the projects and models are picked, not typed", () => {
+    // A budget attached to a path with a typo in it silently measures nothing
+    // and reports zero spend forever, which looks exactly like being under.
+    expect(pane).toContain("api.gitRepos()");
+    expect(pane).toContain("setModels(r.models)");
+  });
+
+  test("a project or model that is no longer offered is still shown", () => {
+    // A repo that has moved, or a model that has not been used this month, must
+    // not silently reassign somebody's budget to "everything" on next render.
+    expect(pane).toContain("!roots.includes(b.root)");
+    expect(pane).toContain("!models.includes(b.model)");
+  });
+});
+
+describe("showing where it stands", () => {
+  test("the bar is capped even though the percentage is not", () => {
+    // 180% is the useful number and a bar 1.8× its own width is a layout bug.
+    expect(pane).toContain("Math.min(1, s.pct)");
+    expect(pane).toContain("Math.round(s.pct * 100)");
+  });
+
+  test("says which days it counted, rather than implying all of them", () => {
+    expect(pane).toContain("{s.fromDay} to {s.toDay}");
+  });
+
+  test("and says where the number comes from, since it crosses the retention boundary", () => {
+    // The thing that makes a monthly budget mean a month: raw events are kept
+    // for eight days by default, so without the rollup this would be a weekly
+    // budget wearing a monthly label.
+    expect(pane).toMatch(/rollup as well as live events/);
+    expect(pane).toContain("AGENTGLASS_RETENTION_DAYS");
+  });
+
+  test("and that the warning comes before the limit", () => {
+    // A budget you hear about only once you cross it is a receipt, not a
+    // control — worth saying, because the user cannot see the threshold.
+    expect(pane).toMatch(/warned at 80%/);
+  });
+});


### PR DESCRIPTION
Closes #301.

## What does this PR do?

The spend insights fired on constants — `$15` in fifteen minutes is *"burning fast"*, `$60` an hour is a warning. Which means they are noise on a project that genuinely costs that, and silent on one where a tenth would be alarming. There was no way to say *"this should not cost more than X a month"* and be told when it does.

A budget is **three things on purpose**: how much, over what period, for what. Not a rate, not a forecast, not a per-session cap. *"$40 a month on this repository"* is a sentence somebody can say about their own work, and a setting phrased as one still makes sense a year after it was made. Per-project and per-model, or neither — which is the whole machine.

```
Spend no more than $ 5     a month  on  everything   any model     [Remove]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
$0.555 of $5.00 · 11% · 2026-07-01 to 2026-07-30

Spend no more than $ 0.3   a day    on  root         any model     [Remove]
━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
$0.555 of $0.300 · 185% · 2026-07-30 to 2026-07-30
```

and in the insights, unscoped, because a budget names its own project and should fire whether or not the cockpit is looking at that one:

```
bad   Over budget · $0.55 of $0.30 today   |   root
```

### Three decisions worth stating

**Calendar periods, not trailing windows.** The reset is what makes a number feel like a budget. A trailing thirty days never resets, so it can only creep towards the limit and stay there — an average with a limit painted on it. The week starts on Monday, which is what every calendar the user is also looking at will say.

**Warned at 80%, not only at the limit.** A budget you hear about the moment you cross it is a receipt, not a control — there is nothing left to do about it.

**Counted across the retention boundary**, which is what #292 made possible. Raw events are kept for eight days by default, so before the rollup a monthly budget was a weekly budget wearing a monthly label. The query is its own short function rather than a filter on `dailyUsage`, because cost is the one column that simply **adds** — the prune folds `timestamp < cutoff`, so every dollar is on exactly one side of it — while `dailyUsage` has to count sessions distinctly. For the number a budget fires on, obviously right is worth more than shared.

With **no budgets set, every existing threshold behaves exactly as it did.** Taking fixed thresholds away from people who never asked for budgets would be a regression dressed as a feature.

Validated on the way in *and* on the way out, because `config.json` is hand-edited and a budget is a **denominator**: a limit arriving as `"40"` turns every percentage into NaN, and a period nobody recognises would be evaluated as something. A row that cannot be used is dropped and said about, never coerced into a plausible guess.

## How was it tested?

**25 mutations, all red** — a week starting on Sunday, a month as a trailing thirty days, the warning moved to the limit, the percentage capped, a half-filled row evaluated as zero, an unset root asked about as `""`, the config write throwing away the rest of `config.json`, the cache left stale so a save appears to do nothing, the route coercing a string limit, the pane saving a row being typed, the progress bar uncapped.

**Two only went red after the tests were fixed**, and both were the tests being weak in ways that matter for this feature specifically:

**The window was computed with `toISOString()`, and a mutation replacing it with local date parts passed everything.** This machine runs in UTC, where that bug is completely invisible — local and UTC agree on every instant. It is checked in a child process with `TZ` set to `Pacific/Kiritimati` (UTC+14) and `Pacific/Niue` (UTC−11) now, which straddle the date line: at 23:30Z on the 15th one is already on the 16th and the other is still on the 15th, and the budget has to agree with the UTC days the rollup wrote. On the last day of a month the alternative is a whole period out — the kind of wrong nobody finds out about until the month ends.

**"Asks about the window the period names" used a monthly budget**, so hardcoding `"month"` in the evaluation passed it. All three periods are asserted against their windows now.

Suites green: **1307 server, 880 web**. Driven against a real server with real spend in it — the screenshot above is that, not a mock.