### PR TITLE
Find the agents already on this machine, and offer to wire them

### DIFF
--- a/hooks/connect_otel.py
+++ b/hooks/connect_otel.py
@@ -136,10 +136,19 @@ def wire_codex(undo: bool) -> bool:
     return True
 
 
+# Keyed by the id the app uses for each agent (see server/src/agentprobe.ts), so
+# a button in the settings pane and a flag on this script name the same thing.
+WIRERS = {"gemini": wire_gemini, "codex": wire_codex}
+
+
 def main() -> None:
     ap = argparse.ArgumentParser(description="Connect agent CLIs to agentglass via OpenTelemetry.")
     ap.add_argument("--undo", action="store_true", help="remove the agentglass telemetry wiring")
     ap.add_argument("--postinstall", action="store_true", help="lifecycle mode: honor AGENTGLASS_NO_OTEL, never fail")
+    # One at a time, for the Settings pane: it offers a button per agent, and
+    # wiring all of them because somebody pressed one is not what the button
+    # says it does.
+    ap.add_argument("--only", choices=sorted(WIRERS), help="connect (or unwire) just this agent")
     args = ap.parse_args()
     _agentglass_local_only(SERVER)
 
@@ -147,16 +156,23 @@ def main() -> None:
         print("[agentglass] AGENTGLASS_NO_OTEL set — skipping OTel auto-connect.")
         return
 
+    todo = {args.only: WIRERS[args.only]} if args.only else WIRERS
     any_tool = False
     try:
-        any_tool = wire_gemini(args.undo) or any_tool
-        any_tool = wire_codex(args.undo) or any_tool
+        for wire in todo.values():
+            any_tool = wire(args.undo) or any_tool
     except Exception as e:  # never break `bun install`
         print(f"[agentglass] OTel auto-connect skipped ({e}).")
-        return
+        # A lifecycle run must not fail the install; an explicit --only is
+        # somebody pressing a button and waiting for an answer, so it says so.
+        sys.exit(0 if args.postinstall else 1)
 
-    if not any_tool and not args.postinstall:
-        print("[agentglass] no supported agent CLIs detected (looked for Gemini CLI, Codex CLI).")
+    if not any_tool:
+        if args.only:
+            print(f"[agentglass] {args.only} is not installed on this machine.")
+            sys.exit(1)
+        if not args.postinstall:
+            print("[agentglass] no supported agent CLIs detected (looked for Gemini CLI, Codex CLI).")
 
 
 if __name__ == "__main__":

--- a/server/src/agentprobe.ts
+++ b/server/src/agentprobe.ts
@@ -1,0 +1,158 @@
+import { existsSync, readFileSync } from "node:fs";
+import { homedir } from "node:os";
+import { join } from "node:path";
+import type { AgentProbe, KnownAgent } from "../../shared/types.ts";
+import { db } from "./db.ts";
+import { hookStatus } from "./hooksetup.ts";
+
+/**
+ * The agents this machine already has, and whether any of them is talking.
+ *
+ * Connecting a second agent is the step where people stop. The hooks ship in
+ * the app, but somebody still has to know which harness they have, which config
+ * file it reads, and what to put in it — three questions the cockpit can just
+ * answer by looking.
+ *
+ * Everything not found is listed too, rather than hidden. A list of what is
+ * installed tells you nothing about what is *supported*, and "supported" is the
+ * question somebody has when they are deciding whether to try a second agent at
+ * all.
+ *
+ * The half that matters is the last one. **"Connected" has to mean an event
+ * landed**, not that a file was written — every failure in this area looks like
+ * a successful write: a config in the right shape that the CLI does not read, a
+ * session started before the change, a typo in an endpoint. A green tick over a
+ * file that changed nothing is worse than no tick, because it stops the search.
+ */
+
+/**
+ * The roster, with its paths resolved when they are asked for.
+ *
+ * Not at import: `homedir()` would be captured once, and both the hook
+ * installer's own `CLAUDE_CONFIG_DIR` and a suite pointing `HOME` at a scratch
+ * directory move afterwards. A frozen path here reads a developer's real
+ * config in tests and the wrong one in an app that re-homes itself.
+ */
+type Roster = Omit<KnownAgent, "configPath"> & { configPath: () => string };
+
+/**
+ * The home the *agent CLIs* use, which is not always the one Bun reports.
+ *
+ * `os.homedir()` in Bun resolves from the passwd entry and ignores `$HOME`;
+ * Node prefers `$HOME` on POSIX, and so does Python's `Path.home()` — which is
+ * what `hooks/connect_otel.py` writes through. So on any machine where the two
+ * differ (a container, `sudo -E`, CI) this module would have read a config the
+ * installer never wrote, and reported a correctly connected agent as
+ * unconnected. `$HOME` is also what the CLIs themselves read, which makes it
+ * the right answer rather than merely the consistent one.
+ */
+const agentHome = (): string => process.env.HOME || homedir();
+
+export const ROSTER: Roster[] = [
+  {
+    id: "claude-code",
+    label: "Claude Code",
+    bin: "claude",
+    via: "hooks",
+    // The hook installer decides this one — it honours CLAUDE_CONFIG_DIR.
+    configPath: () => hookStatus().settingsPath,
+    /** Every event this agent produces arrives under this name. */
+    match: "claude",
+    install: "npm i -g @anthropic-ai/claude-code",
+    connects: "hooks that post each event to this server",
+  },
+  {
+    id: "gemini",
+    label: "Gemini CLI",
+    bin: "gemini",
+    via: "otel",
+    configPath: () => join(agentHome(), ".gemini", "settings.json"),
+    match: "gemini",
+    install: "npm i -g @google/gemini-cli",
+    connects: "OpenTelemetry traces → /v1/traces",
+  },
+  {
+    id: "codex",
+    label: "OpenAI Codex CLI",
+    bin: "codex",
+    via: "otel",
+    configPath: () => join(agentHome(), ".codex", "config.toml"),
+    match: "codex",
+    install: "npm i -g @openai/codex",
+    connects: "OpenTelemetry logs → /v1/logs",
+  },
+];
+
+/**
+ * Whether this agent's config currently points at us.
+ *
+ * Read rather than remembered: the file is the truth, and somebody who edited
+ * it by hand — or ran the CLI's own reset — should see that reflected instead
+ * of a state this app wrote down once.
+ */
+function wired(a: Roster, path: string): boolean {
+  if (a.via === "hooks") return hookStatus().installed;
+  if (!existsSync(path)) return false;
+  let text: string;
+  try { text = readFileSync(path, "utf8"); } catch { return false; }
+  // Deliberately loose: what is being asked is "does this point at an
+  // agentglass receiver", and the port can be anything. A stricter match would
+  // report a server on 4001 as unconnected while its events arrived.
+  if (a.id === "gemini") {
+    try {
+      const cfg = JSON.parse(text) as { telemetry?: { otlpEndpoint?: unknown; enabled?: unknown } };
+      const ep = String(cfg.telemetry?.otlpEndpoint ?? "");
+      return !!cfg.telemetry?.enabled && /^https?:\/\/(localhost|127\.0\.0\.1|\[?::1\]?)(:|\/|$)/.test(ep);
+    } catch {
+      return false;
+    }
+  }
+  return /otlp-http\s*=\s*\{[^}]*(localhost|127\.0\.0\.1)/.test(text);
+}
+
+/**
+ * When this agent last actually said something.
+ *
+ * Matched on a name fragment rather than an exact `source_app`, because for the
+ * OTLP agents that field is whatever the CLI puts in its own `service.name` —
+ * this app does not choose it and cannot pin it. The fragment is the part that
+ * does not change.
+ */
+function lastSeen(match: string, q: typeof db = db): number | null {
+  const r = q
+    .query<{ t: number | null }, [string]>(
+      "SELECT MAX(timestamp) AS t FROM events WHERE source_app LIKE '%' || ? || '%'"
+    )
+    .get(match);
+  return r?.t ?? null;
+}
+
+/** Every agent this app knows how to connect, with what is true of it here. */
+export function probeAgents(
+  which: (cmd: string) => string | null = (c) => Bun.which(c),
+  seen: (match: string) => number | null = lastSeen,
+): AgentProbe[] {
+  return ROSTER.map((a) => {
+    const path = a.configPath();
+    const found = which(a.bin);
+    return {
+      ...a,
+      configPath: path,
+      found: !!found,
+      path: found,
+      connected: wired(a, path),
+      // Independent of `connected` on purpose. A config that was written and an
+      // event that arrived are different facts, and the gap between them is
+      // exactly where this feature earns its place: it is the state somebody
+      // sits in for ten minutes wondering what they did wrong.
+      seenAt: seen(a.match),
+    };
+  });
+}
+
+/** The one word for where an agent stands, so a panel is not re-deriving it. */
+export function agentState(p: AgentProbe): "live" | "waiting" | "ready" | "missing" {
+  if (p.seenAt) return "live";
+  if (p.connected) return "waiting";
+  return p.found ? "ready" : "missing";
+}

--- a/server/src/hooksetup.ts
+++ b/server/src/hooksetup.ts
@@ -76,7 +76,7 @@ export function hooksDir(): string | null {
 // _hook_python: python3 everywhere but Windows, where python3 is usually absent
 // and `py`/`python` is what exists. sys.executable is deliberately not used —
 // a venv deleted later would break every hook.
-function hookPython(): string {
+export function hookPython(): string {
   if (process.platform !== "win32") return "python3";
   for (const cand of ["py", "python"]) {
     if (onPath(cand)) return cand;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -75,7 +75,9 @@ import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } f
 import { workspaceRoot, setWorkspaceRoot, inScope, readBudgets, writeBudgets } from "./config.ts";
 import { budgetStatus } from "./budget.ts";
 import type { Budget } from "../../shared/types.ts";
-import { hookStatus, applyHooks } from "./hooksetup.ts";
+import { hookStatus, applyHooks, hooksDir, hookPython } from "./hooksetup.ts";
+import { probeAgents, ROSTER } from "./agentprobe.ts";
+import { join as joinPath } from "node:path";
 import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt, callerFor, allowed, scopeNeeded, type Caller } from "./auth.ts";
 import { activeDevices, markSeen, revokeDevice, type Scope } from "./devices.ts";
@@ -777,6 +779,60 @@ const server = Bun.serve<WsData>({
     // streaming + gating from Settings instead of cloning the repo to run a
     // Python script. GET reports state; POST writes ~/.claude/settings.json with
     // the same idempotent, backup-first merge the CLI installer uses.
+    /**
+     * Which agents are on this machine, and whether any of them is talking.
+     *
+     * Connecting a second agent is where people stop — three questions (which
+     * harness, which file, what to put in it) that the cockpit can answer by
+     * looking. Everything not installed is listed too, because "what is
+     * supported" is the question somebody has before they try.
+     */
+    if (pathname === "/agents") return json({ agents: probeAgents() });
+
+    /**
+     * Wire one, and only the one asked for.
+     *
+     * Claude Code goes through the same hook installer the Hooks pane uses; the
+     * OTel agents go through connect_otel.py, which backs the file up, refuses
+     * to touch a config it cannot parse, and leaves a hand-written `[otel]`
+     * block alone. This route chooses which, and reports what the machine
+     * looks like afterwards — including whether anything has actually arrived,
+     * which a freshly written file never has.
+     */
+    if (pathname === "/agents/connect" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: { id?: unknown; undo?: unknown };
+      try { b = (await req.json()) as { id?: unknown; undo?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const id = typeof b.id === "string" ? b.id : "";
+      const agent = ROSTER.find((a) => a.id === id);
+      if (!agent) return json({ ok: false, error: "no such agent" }, 400);
+      const undo = b.undo === true;
+
+      if (agent.via === "hooks") {
+        const r = applyHooks(undo ? "uninstall" : "install");
+        return json({ ...r, agents: probeAgents() });
+      }
+
+      const dir = hooksDir();
+      if (!dir) return json({ ok: false, error: "the connect script is not bundled with this build" }, 400);
+      const args = [joinPath(dir, "connect_otel.py"), "--only", id, ...(undo ? ["--undo"] : [])];
+      const p = Bun.spawnSync([hookPython(), ...args], {
+        // A named environment. The script refuses any server but this machine
+        // unless told otherwise, and inheriting an AGENTGLASS_ALLOW_REMOTE from
+        // whatever launched the app would quietly widen that.
+        env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "" },
+      });
+      const out = (p.stdout?.toString() ?? "") + (p.stderr?.toString() ?? "");
+      return json({
+        ok: p.exitCode === 0,
+        // The script's own words. It knows things this route does not — that a
+        // config was already pointing here, or that the user has an `[otel]`
+        // block of their own that it will not touch.
+        detail: out.trim().split("\n").filter(Boolean).slice(-4).join("\n"),
+        agents: probeAgents(),
+      }, p.exitCode === 0 ? 200 : 400);
+    }
+
     if (pathname === "/hooks/status") return json(hookStatus());
     if ((pathname === "/hooks/install" || pathname === "/hooks/uninstall") && req.method === "POST") {
       if (!localOrigin(req)) return csrfBlocked();

--- a/server/test/agent-probe.test.ts
+++ b/server/test/agent-probe.test.ts
@@ -1,0 +1,183 @@
+/*
+ * Which agents are here, and — the half that matters — whether one is talking.
+ *
+ * Connecting a second agent is where people stop, and every failure in that
+ * area looks like a successful write: a config in the right shape the CLI does
+ * not read, a session started before the change, a typo in an endpoint. So the
+ * assertion worth having is that "connected" and "an event arrived" stay two
+ * separate facts, and that the pane can tell somebody which one they are in.
+ *
+ * `Bun.which` and the last-seen lookup are injected, because what is under test
+ * is the judgement, not this container's PATH.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { probeAgents, agentState, ROSTER } from "../src/agentprobe.ts";
+import type { AgentProbe } from "../../shared/types.ts";
+
+let home: string;
+let saved: Record<string, string | undefined>;
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agx-agents-"));
+  saved = { HOME: process.env.HOME, CLAUDE: process.env.CLAUDE_CONFIG_DIR };
+  /*
+   * `HOME`, for every agent including Claude Code.
+   *
+   * hooksetup.ts resolves its settings path from `$HOME`, which is the same
+   * thing `agentHome()` follows and the same thing the CLIs themselves read —
+   * so one variable isolates all three. Setting `CLAUDE_CONFIG_DIR` instead
+   * looked right and isolated nothing: `bun test` shares one process, an
+   * earlier suite had left `HOME` pointing at a scratch tree with hooks
+   * installed in it, and this file reported Claude Code as connected on a
+   * machine where it had asserted nothing was.
+   */
+  process.env.HOME = home;
+});
+afterEach(() => {
+  if (saved.HOME === undefined) delete process.env.HOME; else process.env.HOME = saved.HOME;
+  if (saved.CLAUDE === undefined) delete process.env.CLAUDE_CONFIG_DIR; else process.env.CLAUDE_CONFIG_DIR = saved.CLAUDE;
+});
+
+const has = (...bins: string[]) => (c: string) => (bins.includes(c) ? `/usr/bin/${c}` : null);
+const never = () => null;
+const by = (rows: AgentProbe[], id: string) => rows.find((r) => r.id === id)!;
+
+describe("what is on this machine", () => {
+  test("an agent that is not installed is listed anyway, and says how to get it", () => {
+    // A list of what is present says nothing about what is *supported*, which
+    // is the question somebody has before they try a second agent at all.
+    const rows = probeAgents(never, never);
+    expect(rows).toHaveLength(ROSTER.length);
+    for (const r of rows) {
+      expect(r.found).toBe(false);
+      expect(agentState(r)).toBe("missing");
+      expect(r.install.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("one that is installed is found, and where", () => {
+    const rows = probeAgents(has("gemini"), never);
+    expect(by(rows, "gemini")).toMatchObject({ found: true, path: "/usr/bin/gemini" });
+    expect(by(rows, "codex").found).toBe(false);
+  });
+
+  test("looks in the home the CLIs themselves use, not the one Bun reports", () => {
+    /*
+     * A real bug, found by a test that would not pass.
+     *
+     * Bun's `os.homedir()` resolves from the passwd entry and ignores `$HOME`.
+     * Node prefers `$HOME` on POSIX, and so does Python's `Path.home()` — which
+     * is what hooks/connect_otel.py writes through. On any machine where the
+     * two differ (a container, `sudo -E`, CI) this module read a config the
+     * installer had never written, and reported a correctly connected agent as
+     * unconnected. `$HOME` is also what the CLIs read, so it is the right
+     * answer rather than merely the consistent one.
+     */
+    process.env.HOME = home;
+    for (const r of probeAgents(never, never)) {
+      if (r.via !== "otel") continue;
+      expect(r.configPath.startsWith(home + "/"), `${r.id} → ${r.configPath}`).toBe(true);
+    }
+  });
+
+  test("and every entry names the file connecting it would write", () => {
+    // It is a file in somebody's home directory, so it is said rather than
+    // implied — including for Claude Code, whose path comes from the hook
+    // installer rather than from the roster.
+    for (const r of probeAgents(never, never)) {
+      expect(r.configPath, r.id).toBeTruthy();
+      expect(r.configPath.length, r.id).toBeGreaterThan(1);
+    }
+  });
+});
+
+describe("connected, and actually reporting", () => {
+  test("are two different facts", () => {
+    // The state this whole pane exists for: a config was written and nothing
+    // has arrived. Before, that was indistinguishable from working.
+    const rows = probeAgents(has("gemini"), never);
+    const g = by(rows, "gemini");
+    expect(g.seenAt).toBeNull();
+    expect(agentState({ ...g, connected: true })).toBe("waiting");
+    expect(agentState({ ...g, connected: true, seenAt: 1 })).toBe("live");
+  });
+
+  test("an event makes it live even if the config is not recognised", () => {
+    // A hand-written exporter config this app does not know how to read still
+    // produces events, and reporting that agent as unconnected while its data
+    // is on the dashboard would be the more confusing of the two mistakes.
+    const g = by(probeAgents(has("gemini"), () => 1_700_000), "gemini");
+    expect(g.connected).toBe(false);
+    expect(g.seenAt).toBe(1_700_000);
+    expect(agentState(g)).toBe("live");
+  });
+
+  test("installed but unwired is its own state, distinct from missing", () => {
+    const g = by(probeAgents(has("gemini"), never), "gemini");
+    expect(agentState(g)).toBe("ready");
+    expect(agentState({ ...g, found: false })).toBe("missing");
+  });
+
+  test("the last-seen lookup is asked about a fragment, not an exact name", () => {
+    // For an OTel agent, `source_app` is whatever the CLI puts in its own
+    // `service.name` — this app does not choose it and cannot pin it.
+    const asked: string[] = [];
+    probeAgents(never, (m) => { asked.push(m); return null; });
+    expect(asked).toEqual(ROSTER.map((a) => a.match));
+    for (const m of asked) expect(m).not.toContain("/");
+  });
+});
+
+describe("reading a config that already exists", () => {
+  const geminiCfg = (obj: unknown) => {
+    process.env.HOME = home;
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    writeFileSync(join(home, ".gemini", "settings.json"), JSON.stringify(obj));
+  };
+
+  test("a Gemini config pointing here counts as connected", () => {
+    geminiCfg({ telemetry: { enabled: true, traces: true, otlpEndpoint: "http://localhost:4000", otlpProtocol: "http" } });
+    expect(by(probeAgents(has("gemini"), never), "gemini").connected).toBe(true);
+  });
+
+  test("and one on a different port still counts, because the port is not the point", () => {
+    // A stricter match would report a server on 4001 as unconnected while its
+    // events were arriving.
+    geminiCfg({ telemetry: { enabled: true, otlpEndpoint: "http://127.0.0.1:4055" } });
+    expect(by(probeAgents(has("gemini"), never), "gemini").connected).toBe(true);
+  });
+
+  test("one pointing somewhere else is left alone and reported as unconnected", () => {
+    // Somebody's own collector. Claiming it as ours would offer to disconnect
+    // something this app never wired.
+    geminiCfg({ telemetry: { enabled: true, otlpEndpoint: "https://otel.corp.example" } });
+    expect(by(probeAgents(has("gemini"), never), "gemini").connected).toBe(false);
+  });
+
+  test("telemetry switched off is not connected, whatever the endpoint says", () => {
+    geminiCfg({ telemetry: { enabled: false, otlpEndpoint: "http://localhost:4000" } });
+    expect(by(probeAgents(has("gemini"), never), "gemini").connected).toBe(false);
+  });
+
+  test("and a config that is not JSON costs the answer, not the probe", () => {
+    process.env.HOME = home;
+    mkdirSync(join(home, ".gemini"), { recursive: true });
+    writeFileSync(join(home, ".gemini", "settings.json"), "{ not json");
+    const rows = probeAgents(has("gemini"), never);
+    expect(by(rows, "gemini").connected).toBe(false);
+    expect(rows).toHaveLength(ROSTER.length);
+  });
+
+  test("a Codex config pointing here counts, and one that does not, does not", () => {
+    process.env.HOME = home;
+    mkdirSync(join(home, ".codex"), { recursive: true });
+    const path = join(home, ".codex", "config.toml");
+    writeFileSync(path, '[otel]\nexporter = { otlp-http = { endpoint = "http://localhost:4000/v1/logs", protocol = "binary" } }\n');
+    expect(by(probeAgents(has("codex"), never), "codex").connected).toBe(true);
+    writeFileSync(path, '[otel]\nexporter = { otlp-http = { endpoint = "https://otel.corp.example", protocol = "binary" } }\n');
+    expect(by(probeAgents(has("codex"), never), "codex").connected).toBe(false);
+  });
+});

--- a/server/test/agent-routes.test.ts
+++ b/server/test/agent-routes.test.ts
@@ -1,0 +1,225 @@
+/*
+ * Connecting an agent, for real.
+ *
+ * The route shells out to hooks/connect_otel.py, and what makes that script
+ * safe is behaviour a mock cannot have: it backs the file up before touching
+ * it, refuses a config it cannot parse, and leaves a hand-written `[otel]`
+ * block alone. So this drives the real script against a scratch HOME, which is
+ * also the only way to find out that the reader and the writer agree about
+ * where that home is.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, readFileSync, readdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-agentsrv-"));
+  const port = 4820 + Math.floor(Math.random() * 20);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    // A named environment, never `...process.env` — and HOME pointed at a
+    // scratch directory, so nothing here can write a developer's real
+    // ~/.gemini or ~/.codex.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: dir,
+      XDG_CONFIG_HOME: dir,
+      CLAUDE_CONFIG_DIR: join(dir, ".claude"),
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  // `gemini` is not on this PATH, and connect_otel.py treats an existing
+  // ~/.gemini as the other evidence a CLI is installed — which is deliberate,
+  // since a config directory is proof somebody has run it. Creating it is what
+  // makes this machine look like one with Gemini on it, without inventing a
+  // binary. The script refusing an agent that is genuinely absent is correct
+  // behaviour and is asserted separately.
+  mkdirSync(join(dir, ".gemini"), { recursive: true });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+type Json = Record<string, any>;
+const jsonOf = (r: Response) => r.json() as Promise<Json>;
+const agents = () => fetch(base + "/agents").then(jsonOf);
+const connect = (id: unknown, undo = false) =>
+  fetch(base + "/agents/connect", {
+    method: "POST", headers: { "content-type": "application/json" }, body: JSON.stringify({ id, undo }),
+  });
+const by = (rows: Json[], id: string) => rows.find((r) => r.id === id)!;
+
+const GEMINI = () => join(dir, ".gemini", "settings.json");
+
+describe("what the pane is told", () => {
+  test("every known agent, installed or not", async () => {
+    const r = await agents();
+    expect(r.agents.map((a: Json) => a.id).sort()).toEqual(["claude-code", "codex", "gemini"]);
+  });
+
+  test("with the file connecting it would write, under this machine's HOME", async () => {
+    // The bug this catches: the reader used Bun's `os.homedir()`, which ignores
+    // $HOME, while the writer uses Python's Path.home(), which does not. On a
+    // machine where they differ the app read a config the installer never wrote.
+    for (const a of (await agents()).agents as Json[]) {
+      if (a.via !== "otel") continue;
+      expect(String(a.configPath).startsWith(dir + "/"), `${a.id} → ${a.configPath}`).toBe(true);
+    }
+  });
+
+  test("and nothing has been seen from any of them yet", async () => {
+    // A fresh database. This is the state that used to be indistinguishable
+    // from "connected", which is the whole reason the field exists.
+    for (const a of (await agents()).agents as Json[]) expect(a.seenAt, a.id).toBeNull();
+  });
+
+});
+
+describe("connecting one", () => {
+  test("writes the config, and says so in the script's own words", async () => {
+    const r = await jsonOf(await connect("gemini"));
+    expect(r.ok).toBe(true);
+    // The script's own words, kept: it knows things this route does not — that
+    // a config already pointed here, or that the user has an `[otel]` block of
+    // their own it will not touch.
+    expect(String(r.detail)).toContain("connected Gemini CLI");
+    expect(String(r.detail).length).toBeGreaterThan(10);
+    const cfg = JSON.parse(readFileSync(GEMINI(), "utf8"));
+    expect(cfg.telemetry).toMatchObject({ enabled: true, traces: true });
+    expect(String(cfg.telemetry.otlpEndpoint)).toContain("localhost");
+  });
+
+  test("and the probe agrees, without claiming anything has arrived", async () => {
+    // The distinction the whole feature rests on. A file was written; that is
+    // not the same as an event landing, and the pane must be able to say so.
+    const g = by((await agents()).agents, "gemini");
+    expect(g.connected).toBe(true);
+    expect(g.seenAt).toBeNull();
+  });
+
+  test("twice is not an error, and does not write again", async () => {
+    const r = await jsonOf(await connect("gemini"));
+    expect(r.ok).toBe(true);
+    expect(String(r.detail)).toContain("already connected");
+  });
+
+  test("connects only the one asked for", async () => {
+    // The pane offers a button per agent. Wiring all of them because somebody
+    // pressed one is not what the button says it does — and `bun run connect`
+    // with no flag still does all of them, which is the behaviour this must
+    // not have inherited.
+    expect(readdirSync(dir).includes(".codex")).toBe(false);
+  });
+
+  test("and refuses an agent this machine does not have", async () => {
+    // Codex has neither a binary on PATH nor a config directory here. A route
+    // that wrote a config for a CLI nobody has installed would leave a file
+    // that never does anything and a pane claiming it is connected.
+    const r = await connect("codex");
+    expect(r.status).toBe(400);
+    const body = await jsonOf(r);
+    // Both, because they are set from different expressions: a body saying
+    // `ok: true` under a 400 is what a client actually reads.
+    expect(body.ok).toBe(false);
+    expect(String(body.detail)).toContain("not installed");
+    expect(readdirSync(dir).includes(".codex")).toBe(false);
+  });
+
+  test("and disconnecting takes it back out", async () => {
+    const r = await jsonOf(await connect("gemini", true));
+    expect(r.ok).toBe(true);
+    const cfg = JSON.parse(readFileSync(GEMINI(), "utf8"));
+    expect(cfg.telemetry?.otlpEndpoint).toBeUndefined();
+    expect(by((await agents()).agents, "gemini").connected).toBe(false);
+  });
+
+  test("backing the file up before it changes it", async () => {
+    await connect("gemini");
+    const backups = readdirSync(join(dir, ".gemini")).filter((f) => f.includes("bak"));
+    expect(backups.length, "no backup was written").toBeGreaterThan(0);
+    await connect("gemini", true);
+  });
+});
+
+describe("leaving alone what is not ours", () => {
+  test("a config pointing at somebody else's collector is not claimed", async () => {
+    // Reporting it as connected would offer to disconnect something this app
+    // never wired, and taking it out would break their setup.
+    mkdirSync(join(dir, ".gemini"), { recursive: true });
+    writeFileSync(GEMINI(), JSON.stringify({ telemetry: { enabled: true, otlpEndpoint: "https://otel.corp.example" } }));
+    expect(by((await agents()).agents, "gemini").connected).toBe(false);
+  });
+
+  test("and a Codex block the user wrote is reported rather than overwritten", async () => {
+    const codex = join(dir, ".codex", "config.toml");
+    // The directory is what makes it look installed — see the note in beforeAll.
+    mkdirSync(join(dir, ".codex"), { recursive: true });
+    const mine = '[otel]\nexporter = { otlp-http = { endpoint = "https://otel.corp.example" } }\n';
+    writeFileSync(codex, mine);
+    const r = await jsonOf(await connect("codex"));
+    expect(String(r.detail)).toContain("leaving it");
+    expect(readFileSync(codex, "utf8")).toBe(mine);
+  });
+});
+
+describe("refusing what is not an agent", () => {
+  test("an id nobody knows", async () => {
+    const r = await connect("not-an-agent");
+    expect(r.status).toBe(400);
+    expect(String((await jsonOf(r)).error)).toContain("no such agent");
+  });
+
+  test("and an id that is not a string", async () => {
+    for (const id of [null, 42, {}, undefined]) {
+      expect((await connect(id)).status, String(id)).toBe(400);
+    }
+  });
+
+  test("a body that is not JSON", async () => {
+    const r = await fetch(base + "/agents/connect", {
+      method: "POST", headers: { "content-type": "application/json" }, body: "{",
+    });
+    expect(r.status).toBe(400);
+  });
+});
+
+/**
+ * Last, and deliberately.
+ *
+ * Ingesting an event changes what every "nothing has arrived yet" assertion
+ * above is looking at — the first version of this file put it near the top and
+ * quietly broke a test three describes later. A suite whose order matters
+ * should say so rather than be discovered.
+ */
+describe("once something actually reports", () => {
+  test("an event makes its agent live, matched on the part of the name that is fixed", async () => {
+    // Gemini's events arrive under whatever the CLI puts in its own
+    // `service.name` — "gemini-cli" today, and not something this app chooses
+    // or can pin. An exact match on `source_app` would report a reporting agent
+    // as silent, which is the failure this whole pane exists to prevent.
+    await fetch(base + "/ingest", {
+      method: "POST", headers: { "content-type": "application/json" },
+      body: JSON.stringify({
+        source_app: "gemini-cli", session_id: "s-1", hook_event_type: "Stop", timestamp: Date.now(),
+      }),
+    });
+    const g = by((await agents()).agents, "gemini");
+    expect(g.seenAt, "an event under 'gemini-cli' did not match the agent").toBeGreaterThan(0);
+    // …and it did not light up every other agent at the same time.
+    expect(by((await agents()).agents, "codex").seenAt).toBeNull();
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1591,6 +1591,51 @@ export interface PairState {
   devices: PairedDevice[];
 }
 
+/**
+ * An agent CLI this app knows how to connect, and how.
+ *
+ * Everything not installed is listed too, rather than hidden: a list of what is
+ * present says nothing about what is *supported*, and that is the question
+ * somebody has before they decide to try a second agent at all.
+ */
+export interface KnownAgent {
+  id: string;
+  label: string;
+  /** The executable looked for on PATH. */
+  bin: string;
+  /** How it reports: our own hook forwarder, or its OpenTelemetry exporter. */
+  via: "hooks" | "otel";
+  /** The file connecting it writes. Shown, so nobody has to guess. */
+  configPath: string;
+  /** A fragment of the `source_app` its events arrive under. Not the whole
+   *  thing: for an OTel agent that is the CLI's own `service.name`, which this
+   *  app does not choose and cannot pin. */
+  match: string;
+  /** How to get it, for the ones that are not here. */
+  install: string;
+  /** What connecting it actually does, in a few words. */
+  connects: string;
+}
+
+export interface AgentProbe extends KnownAgent {
+  /** On PATH right now. */
+  found: boolean;
+  /** Where, when it was found. */
+  path: string | null;
+  /** Its config currently points at a local agentglass. */
+  connected: boolean;
+  /**
+   * When an event from it last arrived, or null if one never has.
+   *
+   * The half that matters, and deliberately independent of `connected`: a
+   * config that was written and an event that landed are different facts, and
+   * every failure here looks like a successful write — a file in the right
+   * shape the CLI does not read, a session started before the change, a typo in
+   * an endpoint. A tick over a file that changed nothing stops the search.
+   */
+  seenAt: number | null;
+}
+
 /** How often a budget resets. Calendar periods, not trailing windows — the
  *  reset is what makes a number feel like a budget rather than an average. */
 export type BudgetPeriod = "day" | "week" | "month";

--- a/web/src/components/AgentsPane.tsx
+++ b/web/src/components/AgentsPane.tsx
@@ -1,0 +1,129 @@
+import { useCallback, useEffect, useState } from "react";
+import { api } from "../lib/api.ts";
+import { fmtAgo } from "../lib/format.ts";
+import type { AgentProbe } from "../../../shared/types.ts";
+
+/**
+ * The agents already on this machine, and one button each.
+ *
+ * Connecting a second agent is where people stop. The hooks ship in the app,
+ * but somebody still has to know which harness they have, which config file it
+ * reads and what to put in it — and the docs explaining that are a correct
+ * paragraph, which is less convincing than a working install.
+ *
+ * The ones that are not installed stay in the list. Hiding them makes the list
+ * an inventory of this machine, when the question somebody actually has is
+ * *what is supported* — worth answering before they decide to try a second
+ * agent at all.
+ */
+
+/** Four states, in the order somebody moves through them. */
+type State = "live" | "waiting" | "ready" | "missing";
+
+const stateOf = (p: AgentProbe): State =>
+  p.seenAt ? "live" : p.connected ? "waiting" : p.found ? "ready" : "missing";
+
+export function AgentsPane({ open }: { open: boolean }) {
+  const [agents, setAgents] = useState<AgentProbe[] | null>(null);
+  const [busy, setBusy] = useState<string | null>(null);
+  const [note, setNote] = useState<{ id: string; text: string; bad: boolean } | null>(null);
+
+  const load = useCallback(() => {
+    api.agents().then((r) => setAgents(r.agents)).catch(() => setAgents([]));
+  }, []);
+
+  useEffect(() => {
+    if (!open) return;
+    load();
+    // Polled, because the state this pane exists to show is one that changes
+    // without anybody pressing anything: the moment the first event from a
+    // newly wired agent arrives, "waiting" becomes "live".
+    const t = setInterval(load, 4000);
+    return () => clearInterval(t);
+  }, [open, load]);
+
+  const connect = async (p: AgentProbe, undo: boolean) => {
+    setBusy(p.id);
+    setNote(null);
+    const r = await api.agentConnect(p.id, undo).catch(() => null);
+    setBusy(null);
+    if (r?.agents) setAgents(r.agents);
+    // The script's own words when it has some. It knows things this pane does
+    // not — that the config already pointed here, or that the user has an
+    // `[otel]` block of their own it will not touch.
+    const text = r?.detail || r?.error || (r?.ok ? "" : "Could not write the config.");
+    if (text) setNote({ id: p.id, text, bad: !r?.ok });
+    load();
+  };
+
+  if (!agents) return <div className="text-[11px] t-dim2">Looking for agents…</div>;
+
+  return (
+    <div className="flex flex-col gap-1.5">
+      {agents.map((p) => {
+        const state = stateOf(p);
+        const tint = state === "live" ? "var(--success)"
+          : state === "waiting" ? "var(--warning)"
+          : state === "ready" ? "var(--primary-hover)" : "var(--text4)";
+        return (
+          <div key={p.id} className="flex flex-col gap-1 px-2.5 py-2 rounded-lg" style={{
+            background: state === "missing" ? "transparent" : "color-mix(in srgb, var(--bg2) 60%, transparent)",
+            border: `1px solid color-mix(in srgb, ${state === "live" ? "var(--success)" : "var(--border)"} ${state === "live" ? 30 : 40}%, transparent)`,
+            opacity: state === "missing" ? 0.72 : 1,
+          }}>
+            <div className="flex items-center gap-2.5">
+              <span className="shrink-0 rounded-full" aria-hidden style={{
+                width: 7, height: 7,
+                background: state === "live" ? "var(--success)" : "transparent",
+                border: state === "live" ? "none" : `1px solid ${tint}`,
+              }} />
+              <div className="min-w-0 flex-1">
+                <div className="text-[12px]" style={{ color: "var(--text)" }}>{p.label}</div>
+                <div className="text-[10px]" style={{ color: state === "missing" ? "var(--text4)" : tint }}>
+                  {state === "live" && `Reporting · last event ${fmtAgo(p.seenAt!)}`}
+                  {/* The state this pane exists for. A written config and an
+                      arrived event are different facts, and this is the gap
+                      somebody otherwise sits in wondering what they did wrong. */}
+                  {state === "waiting" && "Wired, but nothing has arrived yet — start a new session for it to take effect"}
+                  {state === "ready" && `Installed, not connected · ${p.connects}`}
+                  {state === "missing" && `Not on this machine · ${p.install}`}
+                </div>
+              </div>
+
+              {state === "missing" ? (
+                <span className="chip shrink-0 t-dim2">not found</span>
+              ) : (
+                <button onClick={() => void connect(p, p.connected)} disabled={busy === p.id}
+                  title={p.connected
+                    ? `Remove the agentglass wiring from ${p.configPath}. The file is backed up first.`
+                    : `Write the agentglass wiring into ${p.configPath}. The file is backed up first, and a config we cannot parse is left alone.`}
+                  className="shrink-0 text-[10.5px] px-2.5 py-1 rounded-md hover:opacity-80"
+                  style={p.connected
+                    ? { color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }
+                    : { color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 12%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 42%, transparent)" }}>
+                  {busy === p.id ? "…" : p.connected ? "Disconnect" : "Connect"}
+                </button>
+              )}
+            </div>
+
+            {/* Where the change lands, named rather than implied. It is a file
+                in somebody's home directory. */}
+            {state !== "missing" && (
+              <div className="text-[9.5px] t-dim2 t-mono truncate pl-[17px]">{p.configPath}</div>
+            )}
+            {note?.id === p.id && (
+              <div className="text-[10px] pl-[17px] whitespace-pre-wrap"
+                style={{ color: note.bad ? "var(--error)" : "var(--text3)" }}>{note.text}</div>
+            )}
+          </div>
+        );
+      })}
+
+      <div className="text-[10px] t-dim2">
+        Connected means an event has actually arrived, not that a file was written — every failure here
+        looks like a successful write. Each config is backed up before it is touched, and one this app
+        cannot parse is left alone.
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -21,6 +21,7 @@ import { autostartEnabled, setAutostart, isFullscreen, toggleFullscreen, IS_DESK
 import { RemoteAccessPane } from "./RemoteAccessPane.tsx";
 import { RunningPanes } from "./RunningPanes.tsx";
 import { BudgetsPane } from "./BudgetsPane.tsx";
+import { AgentsPane } from "./AgentsPane.tsx";
 import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRenderer.ts";
 import { canZoomIn, canZoomOut, fmtScale } from "../lib/uiScale.ts";
 import { MOD_KEY } from "../lib/format.ts";
@@ -136,7 +137,7 @@ const TABS: { id: Pane; label: string }[] = [
   { id: "open", label: "Open" },
   { id: "export", label: "Export" },
   { id: "log", label: "Activity" },
-  { id: "hooks", label: "Hooks" },
+  { id: "hooks", label: "Agents" },
   { id: "reqs", label: "Requirements" },
   { id: "remote", label: "Remote" },
   { id: "about", label: "About" },
@@ -571,6 +572,24 @@ function HooksPane({ open }: { open: boolean }) {
             </span>
           </>
         )}
+      </div>
+    </Section>
+  );
+}
+
+/**
+ * Every agent this app can connect, not only the one it ships hooks for.
+ *
+ * Beside the Claude Code section rather than in a tab of its own: they are the
+ * same act — wiring an agent so it reports here — and splitting them would put
+ * the answer to "can I use my other CLI with this" one tab further away than
+ * the question that prompts it.
+ */
+function AgentsSection({ open }: { open: boolean }) {
+  return (
+    <Section title="Other agents on this machine">
+      <div className="px-3 py-2">
+        <AgentsPane open={open} />
       </div>
     </Section>
   );
@@ -1051,7 +1070,7 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                   </Section>
                   )}
 
-                  {pane === "hooks" && <HooksPane open={open} />}
+                  {pane === "hooks" && <><HooksPane open={open} /><AgentsSection open={open} /></>}
 
                   {pane === "reqs" && <RequirementsPane open={open} />}
 

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -449,6 +449,12 @@ const realApi = {
   /** Revoke one device's credential and close what it is holding. */
   pairForget: (id: string) => post<{ ok: boolean; closed?: number; error?: string }>("/pair/forget", { id }),
 
+  /** Which agent CLIs are on this machine, and whether any is reporting. */
+  agents: () => get<{ agents: AgentProbe[] }>("/agents"),
+  /** Wire one — and only the one asked for. */
+  agentConnect: (id: string, undo = false) =>
+    post<{ ok: boolean; detail?: string; error?: string; agents?: AgentProbe[] }>("/agents/connect", { id, undo }),
+
   /** Spending limits, and where each stands right now. */
   budgets: () => get<{ budgets: Budget[]; status: BudgetStatus[]; models: string[] }>("/budgets"),
   /** Replace the whole set — a budget row has no identity to address a partial
@@ -757,6 +763,10 @@ const demoApi: typeof realApi = {
   pairAccept: (_ticket: string, _scope: DeviceScope) => D({ ok: false, error: "not available in the demo" }),
   pairReject: (_ticket: string) => D({ ok: false }),
   pairForget: (_id: string) => D({ ok: false, error: "not available in the demo" }),
+  // The demo runs on a page, not a machine — there is no PATH to probe and
+  // nothing to wire, and an empty list is the truth rather than a placeholder.
+  agents: () => D({ agents: [] as AgentProbe[] }),
+  agentConnect: (_id: string, _undo?: boolean) => D({ ok: false, error: "not available in the demo" }),
   budgets: () => D({ budgets: [], status: [], models: [] }),
   budgetsSet: (_budgets: Budget[]) => D({ ok: false, error: "not available in the demo" }),
   updateStatus: () => D({ ok: true, available: false, info: { version: "demo", commit: "", builtAt: "", source: "", origin: "", baseTag: "", distance: 0 }, branch: "", behind: 0, ahead: 0, incoming: [], blocked: "not available in the demo" } as UpdateStatus),

--- a/web/test/agents-pane.test.ts
+++ b/web/test/agents-pane.test.ts
@@ -1,0 +1,77 @@
+/*
+ * The agents pane, and the one distinction it exists to make.
+ *
+ * A config that was written and an event that arrived are different facts, and
+ * every failure in this area looks like the first: a file in the right shape a
+ * CLI does not read, a session started before the change, a typo in an
+ * endpoint. A tick over a file that changed nothing stops the search, which is
+ * worse than no tick at all.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const pane = readFileSync(new URL("../src/components/AgentsPane.tsx", import.meta.url), "utf8");
+
+describe("the four states", () => {
+  test("live means an event arrived, not that a file was written", () => {
+    expect(pane).toContain('p.seenAt ? "live"');
+    // …and a written config with nothing arrived has its own word, rather than
+    // being rounded up to working or down to nothing.
+    expect(pane).toContain('p.connected ? "waiting"');
+  });
+
+  test("and waiting says what to do about it", () => {
+    // The state somebody otherwise sits in for ten minutes. Almost always the
+    // answer is that the session predates the change.
+    expect(pane).toMatch(/start a new session for it to take effect/);
+  });
+
+  test("installed-but-unwired is distinct from not installed", () => {
+    expect(pane).toContain('p.found ? "ready" : "missing"');
+  });
+});
+
+describe("what is shown", () => {
+  test("everything, including what is not installed", () => {
+    // A list of what is present says nothing about what is *supported*, which
+    // is the question somebody has before they try a second agent at all.
+    expect(pane).toContain("agents.map((p) => {");
+    expect(pane).not.toContain("agents.filter");
+  });
+
+  test("with how to get the ones that are missing", () => {
+    expect(pane).toContain("p.install");
+  });
+
+  test("and the file that connecting would write, on screen rather than in a tooltip", () => {
+    // It is a file in somebody's home directory. A path that only appears in a
+    // `title` is invisible on a touch device and to anybody not hovering — and
+    // a check for the bare `{p.configPath}` passes on the tooltips alone.
+    expect(pane).toMatch(/t-mono truncate[^>]*>\{p\.configPath\}</);
+  });
+
+  test("but no button for something that is not there", () => {
+    // Nothing to wire. A Connect button over an absent CLI writes a config
+    // that never does anything.
+    expect(pane).toContain('{state === "missing" ? (');
+  });
+});
+
+describe("what it says about itself", () => {
+  test("that connected means an event landed", () => {
+    expect(pane).toMatch(/Connected means an event has actually arrived/);
+  });
+
+  test("and that the config is backed up and a bad one left alone", () => {
+    // Both true of connect_otel.py, and both the kind of thing somebody wants
+    // to know before pressing a button that edits a file they did not open.
+    expect(pane).toMatch(/backed up/);
+    expect(pane).toMatch(/cannot parse is left alone/);
+  });
+
+  test("it polls, because the state it shows changes without anybody clicking", () => {
+    // "waiting" becomes "live" the moment the first event arrives, and nobody
+    // is going to press refresh to find that out.
+    expect(pane).toContain("setInterval(load");
+  });
+});


### PR DESCRIPTION
Closes #300.

## What does this PR do?

Connecting a second agent is where people stop. The hooks ship in the app, but somebody still has to know which harness they have, which config file it reads and what to put in it — and the docs explaining that are a correct paragraph, which is less convincing than a working install.

**Settings → Agents** now answers three questions by looking:

- **what is supported** — the whole roster, including agents that are not installed. Hiding those makes the pane an inventory of this machine, when the question somebody actually has is *what would work if I installed it*, which comes before they decide to try a second agent at all. So a missing agent is listed with its install line and no button.
- **what is installed here** — and the exact file connecting it would write, on screen rather than in a tooltip. It is a file in somebody's home directory; a path that only lives in a `title` is invisible on touch and to anybody not hovering.
- **whether it has actually reported** — the half that matters.

### Connected means an event landed, not that a file was written

Every failure in this area looks like a successful write: a config in the right shape the CLI does not read, a session started before the change, a typo in an endpoint. A tick over a file that changed nothing stops the search, which is worse than no tick at all. So "wired" and "reporting" stay two separate facts, and the pane has four states rather than two:

| state | means | shown as |
| --- | --- | --- |
| `live` | an event has arrived | green dot, "Reporting · last event 2h" |
| `waiting` | the config is written, nothing has come through | "Wired, but nothing has arrived yet — start a new session for it to take effect" |
| `ready` | the CLI is installed, not wired | "Installed, not connected · OpenTelemetry traces → /v1/traces" |
| `missing` | not on this machine | "Not on this machine · `npm i -g …`", no button |

`waiting` is the state somebody otherwise sits in for ten minutes, and the cause is almost always the session predating the change — so the pane says that instead of leaving them to guess. It polls every 4s, because `waiting → live` happens without anybody clicking.

Last-seen is matched on a *fragment* of `source_app`, not an exact name: for an OTel agent that field is whatever the CLI puts in its own `service.name` ("gemini-cli" today), which this app neither chooses nor can pin. An exact match would report a reporting agent as silent.

An agent whose config this app cannot recognise but whose events are arriving is still `live` — reporting it as unconnected while its data sits on the dashboard would be the more confusing of the two mistakes.

### One button, one agent

`hooks/connect_otel.py` grows `--only <agent>`, so pressing Connect on Gemini wires Gemini rather than everything on the machine (`bun run connect` with no flag still does all of them). It exits non-zero when asked for an agent that is genuinely not installed, so the route returns 400 rather than leaving a config file that never does anything.

Everything that made the script safe still holds and is now reachable from a button: the config is backed up before it is touched, one that will not parse is left alone, and a hand-written `[otel]` block is reported rather than overwritten. The route keeps the script's **own words** in the response, because it knows things the pane does not — that the config already pointed here, or that there is a block of yours it will not touch.

A config pointing at somebody else's collector is never claimed as ours. Offering to disconnect something this app never wired, and then breaking their setup by doing it, is a worse outcome than showing "not connected".

### A real bug, found by a test that would not pass

Bun's `os.homedir()` resolves from the passwd entry and **ignores `$HOME`**. Node prefers `$HOME` on POSIX, and so does Python's `Path.home()` — which is what `hooks/connect_otel.py` writes through. On any machine where the two differ (a container, `sudo -E`, CI) the reader looked for a config the writer had never put there: a correctly connected agent reported as unconnected, with a Connect button that appeared to do nothing every time it was pressed.

Both sides now agree on `$HOME`, which is also what the CLIs themselves read — the right answer rather than merely the consistent one. Pinned by a test that fails if the reader goes back to `homedir()`.

## How was it tested?

- **1337 server tests, 890 web tests**, all passing. `bunx tsc --noEmit` clean in both trees; `bun run build` succeeds.
- **`server/test/agent-routes.test.ts` drives the real Python script** against a scratch `HOME`, not a mock — what makes that script safe is behaviour a mock cannot have (the backup, the refusal to parse, the untouched `[otel]` block), and driving it for real is also the only way to find out that the reader and the writer agree about where home is. The spawned server gets a *named* environment, never `...process.env`, so nothing here can write a developer's real `~/.gemini`.
- **`server/test/agent-probe.test.ts`** injects `Bun.which` and the last-seen lookup, so what is under test is the judgement rather than this container's PATH.
- **23 mutations, all red.** Each one is a plausible way to get this wrong: `connected` treated as reporting; unwired collapsed into missing; the last-seen lookup switched to an exact match; unfound agents filtered out of the list; the home switched back to Bun's; any endpoint at all counting as connected; telemetry-off counting anyway; an unparseable config treated as connected; the route wiring every agent instead of the one asked for; a failed connect reported as success; `--undo` ignored so Disconnect connects; the pane showing a tick for a written file. None survived.
- **Rendered and inspected**, not just asserted: Claude Code live with a green dot and its settings path, Gemini and Codex listed as not-on-this-machine with their install lines and no buttons.

Two test-isolation findings worth recording, both of which produced a green suite that was asserting nothing:

- **`CLAUDE_CONFIG_DIR` isolates nothing** here — `hooksetup.ts` resolves its settings path from `$HOME`. `bun test` shares one process across files, an earlier suite had left `HOME` pointing at a scratch tree with hooks installed in it, and this file cheerfully reported Claude Code as connected on a machine where it had just asserted nothing was. One `HOME` isolates all three agents, since it is what every one of them reads.
- **The event-ingest test is last in its file, deliberately**, with a comment saying why: ingesting an event changes what every "nothing has arrived yet" assertion above it is looking at. The first version put it near the top and quietly broke a test three describes later. A suite whose order matters should say so rather than be discovered.