### PR TITLE
Keep a record of which human decided what

### DIFF
--- a/server/src/actions.ts
+++ b/server/src/actions.ts
@@ -14,16 +14,52 @@ import { isLoopback } from "./remote.ts";
 import { recordAction } from "./db.ts";
 import { basename } from "node:path";
 
+/** What the actor of a request needs to be nameable: a device that presented
+ *  its own credential, or nothing. Structural rather than importing `Caller`,
+ *  so a test can name an actor without standing up the auth module. */
+export interface ActorSource {
+  kind: "machine" | "device";
+  device?: { id: string; label: string };
+}
+
+/**
+ * A device's name, made unambiguous.
+ *
+ * The label is free text the phone picked for itself at pairing. Two of them
+ * being identical is not a corner case: `issueDevice` defaults an unnamed one
+ * to "A device", so every phone that skipped the field collides with every
+ * other. An audit line reading "A device approved rm -rf build" answers the
+ * question worse than the address it replaced, so the device's own id comes
+ * with it — short, because it only has to separate the handful of phones one
+ * person has paired.
+ *
+ * The id is part of the stored string rather than resolved at read time on
+ * purpose: forgetting a phone must not erase who used it, and a log that turns
+ * into unresolvable ids the moment you revoke a device is exactly wrong.
+ */
+export function deviceActor(d: { id: string; label: string }): string {
+  const short = String(d.id).replace(/[^0-9a-z]/gi, "").slice(0, 6) || "unknown";
+  const label = String(d.label || "").trim().replace(/\s+/g, " ").slice(0, 40);
+  return label ? `${label} · ${short}` : `device · ${short}`;
+}
+
 /**
  * Who did it, as far as the server can honestly tell.
  *
- * There are no accounts here, and the token is shared rather than personal, so
- * a name would be a fiction. What is true is where the request arrived from:
- * `local` for a loopback caller — the dashboard on this machine — and the
- * address for anything else, which is what makes "I approved that from my
- * phone" a question with an answer.
+ * Two answers, and which one applies is a question of what the caller proved.
+ *
+ * A *paired device* has its own credential and the name somebody accepted when
+ * they paired it (devices.ts), so here a name is a fact rather than a fiction —
+ * this is the part the shared token could never support, and the reason the
+ * question in #299 has a real answer now instead of an address.
+ *
+ * Everything else falls back to where the request arrived from: `local` for a
+ * loopback caller — the dashboard on this machine — and the address otherwise,
+ * which is all the machine token can honestly assert, since it is shared.
  */
-export function actorOf(ip: string | null | undefined): string {
+export function actorOf(ip: string | null | undefined, caller?: ActorSource | null): string {
+  const dev = caller?.kind === "device" ? caller.device : null;
+  if (dev) return deviceActor(dev);
   if (!ip) return "local";
   return isLoopback(ip) ? "local" : ip.replace(/^::ffff:/, "");
 }
@@ -88,9 +124,10 @@ export function noteAction(
   pathname: string,
   body: Record<string, unknown>,
   res: { ok?: boolean; error?: string } | null,
+  caller?: ActorSource | null,
 ): void {
   recordAction({
-    actor: actorOf(ip),
+    actor: actorOf(ip, caller),
     action: pathname,
     target: targetOf(pathname, body),
     ok: !!res?.ok,

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -492,6 +492,25 @@ CREATE TABLE IF NOT EXISTS gates (
 CREATE INDEX IF NOT EXISTS idx_gates_pending ON gates(decision, expires);
 CREATE INDEX IF NOT EXISTS idx_gates_created ON gates(created);
 `);
+/**
+ * *Which* human, not just that one of them answered.
+ *
+ * `resolution` already said what kind of thing decided — a person, the clock, a
+ * restart — and that was the whole answer while a cockpit had one door. Now a
+ * paired phone carries its own credential and its own name (devices.ts), so a
+ * gate can be approved by somebody who is not at the machine, and "a human
+ * decided" stops being an answer to "who".
+ *
+ * It lives on the gate row rather than only in `actions` because the two cannot
+ * be joined: an action line records the route and a clipped `tool · summary`,
+ * so two gates on the same tool a second apart are indistinguishable in it. The
+ * column is written by the same UPDATE that resolves the row, which is what
+ * makes it impossible for the actor and the decision to disagree.
+ *
+ * NULL when nobody decided. A timeout is not an actor, and writing "system"
+ * would invent one — the same reason `actorOf` refuses to invent a name.
+ */
+try { db.exec("ALTER TABLE gates ADD COLUMN decided_by TEXT"); } catch { /* already present */ }
 
 export interface GateRow {
   id: string;
@@ -505,6 +524,9 @@ export interface GateRow {
   reason: string | null;
   resolution: "human" | "timeout" | "restart" | null;
   decided_at: number | null;
+  /** Who, when a person decided. NULL for a timeout, a restart, and for every
+   *  row written before this column existed — an absent actor is not `local`. */
+  decided_by: string | null;
 }
 
 const gateInsert = db.query(`
@@ -513,7 +535,8 @@ const gateInsert = db.query(`
 // Only ever resolves a still-pending row: a decision already recorded wins over
 // a late timeout, so a human's approve can't be overwritten by the clock.
 const gateResolve = db.query(`
-  UPDATE gates SET decision = $decision, reason = $reason, resolution = $resolution, decided_at = $decided_at
+  UPDATE gates SET decision = $decision, reason = $reason, resolution = $resolution,
+                   decided_at = $decided_at, decided_by = $decided_by
    WHERE id = $id AND decision IS NULL`);
 const gateById = db.query<GateRow, [string]>(`SELECT * FROM gates WHERE id = ?`);
 const gatesPending = db.query<GateRow, []>(`SELECT * FROM gates WHERE decision IS NULL ORDER BY created ASC`);
@@ -536,8 +559,16 @@ export function resolveGateRow(
   reason: string,
   resolution: "human" | "timeout" | "restart",
   decided_at = Date.now(),
+  /** Only ever set for a human. The clock is not an actor. */
+  decided_by: string | null = null,
 ): void {
-  gateResolve.run({ $id: id, $decision: decision, $reason: reason, $resolution: resolution, $decided_at: decided_at } as any);
+  gateResolve.run({
+    $id: id, $decision: decision, $reason: reason, $resolution: resolution,
+    $decided_at: decided_at,
+    // Belt as well as braces: the callers pass null for a timeout, and so does
+    // this, so an actor cannot arrive attached to an outcome nobody chose.
+    $decided_by: resolution === "human" ? decided_by : null,
+  } as any);
 }
 
 export function getGate(id: string): GateRow | null {

--- a/server/src/gate.ts
+++ b/server/src/gate.ts
@@ -64,13 +64,20 @@ function timeoutOutcome(): GateOutcome {
 const ID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
 export const validGateId = (id: unknown): id is string => typeof id === "string" && ID_RE.test(id);
 
-function finish(id: string, out: GateOutcome, resolution: "human" | "timeout" | "restart"): void {
+function finish(
+  id: string,
+  out: GateOutcome,
+  resolution: "human" | "timeout" | "restart",
+  /** Who, when a person decided. The timeout path leaves this null on purpose:
+   *  an outcome nobody chose must not arrive carrying an actor. */
+  by: string | null = null,
+): void {
   const w = waiters.get(id);
   if (w) {
     clearTimeout(w.timer);
     waiters.delete(id);
   }
-  resolveGateRow(id, out.decision, out.reason, resolution);
+  resolveGateRow(id, out.decision, out.reason, resolution, Date.now(), by);
   w?.resolve?.(out);
   onChange();
 }
@@ -157,13 +164,39 @@ export function defaultReason(decision: GateDecision): string {
     : "A human reviewed this call in agentglass and approved it.";
 }
 
-export function decideGate(id: string, decision: GateDecision, reason: string): boolean {
+/**
+ * `by` is who the server can honestly say answered — a paired device's name, or
+ * the address it came from. It is recorded on the row itself rather than only
+ * in the action log, because the two cannot be joined: an action line carries a
+ * clipped `tool · summary`, so two gates on the same tool a second apart are
+ * indistinguishable in it.
+ */
+export function decideGate(id: string, decision: GateDecision, reason: string, by: string | null = null): boolean {
   const row = getGate(id);
   // Decidable while pending, whether or not a connection is currently held: a
   // restored request has no waiter and must still take the operator's answer.
   if (!row || row.decision) return false;
-  finish(id, { decision, reason: reason || defaultReason(decision) }, "human");
+  finish(id, { decision, reason: reason || defaultReason(decision) }, "human", by);
   return true;
+}
+
+/**
+ * The words a person actually typed, or nothing.
+ *
+ * `decideGate` backfills an empty reason with `defaultReason`, because the
+ * string travels to a model that has just been stopped and needs something it
+ * can act on. That makes the stored reason useless to a *reader*: every gate
+ * anybody waved through carries the same paragraph, and a history quoting it
+ * back would be three lines of boilerplate per row hiding the one row where
+ * somebody explained themselves.
+ *
+ * Compared against the real function rather than a copy of its text, so the two
+ * cannot drift into a history that quotes a default it no longer recognises.
+ */
+export function typedReason(row: { decision: "allow" | "deny" | null; reason: string | null }): string {
+  const r = row.reason || "";
+  if (!r || !row.decision) return "";
+  return r === defaultReason(row.decision) ? "" : r;
 }
 
 export function pendingGates(): PendingGate[] {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -26,12 +26,12 @@ import {
   actionLog,
 } from "./db.ts";
 import { maybeAlert, setAlertSink, pushEveryone } from "./alerts.ts";
-import { noteAction } from "./actions.ts";
+import { noteAction, actorOf } from "./actions.ts";
 import { getSkills, catalogMarkdown, catalogCsv, usageSince } from "./skills.ts";
 import { getInsights } from "./insights.ts";
 import { vapidKeys, addSubscription, removeSubscription, removeDevice, deviceId, subscriptions } from "./pushstore.ts";
 import { getUsage } from "./usage.ts";
-import { submitGate, decideGate, pendingGates, awaitGate, restoreGates, GATE_MAX_MS } from "./gate.ts";
+import { submitGate, decideGate, pendingGates, awaitGate, restoreGates, typedReason, GATE_MAX_MS } from "./gate.ts";
 import { parseControlCmd } from "./control.ts";
 import { otlpTracesToEvents, otlpLogsToEvents } from "./otlp.ts";
 import { decodeOtlpTraces, decodeOtlpLogs } from "./otlp_pb.ts";
@@ -912,7 +912,16 @@ const server = Bun.serve<WsData>({
     if (pathname === "/gate/pending") return json({ gates: pendingGates() });
     // What was decided while you weren't looking — including the requests a
     // timeout or a restart resolved for you.
-    if (pathname === "/gate/history") return json({ gates: gateHistory(Number(url.searchParams.get("limit") || 50)) });
+    if (pathname === "/gate/history") {
+      // `reason` is narrowed to what a person typed. The stored one is
+      // backfilled with a paragraph written for the stopped model, and a
+      // history quoting that back is boilerplate on every row — see
+      // typedReason().
+      return json({
+        gates: gateHistory(Number(url.searchParams.get("limit") || 50))
+          .map((g) => ({ ...g, reason: typedReason(g) || null })),
+      });
+    }
     // ── web push: the only way an alert reaches a locked phone ────────
     //
     // The socket closes with the screen on purpose, so nothing the server
@@ -988,12 +997,35 @@ const server = Bun.serve<WsData>({
       // the line worth keeping is what was held, not the uuid it was held
       // under. "denied Bash · rm -rf build" is an audit line; a uuid is not.
       const held = getGate(String(b.id));
-      const ok = decideGate(String(b.id), decision, String(b.reason || ""));
       // "Who approved that" is the question #299 opens with, and a gate is the
-      // one write with a stopped agent on the other end of it.
+      // one write with a stopped agent on the other end of it. Resolved once
+      // and handed to both writers, so the gate row and the log line cannot
+      // name two different people for one press.
+      const who = actorOf(srv.requestIP(req)?.address, caller);
+      const ok = decideGate(String(b.id), decision, String(b.reason || ""), who);
+      /*
+       * Why it did not take, in words.
+       *
+       * A press only fails for one interesting reason: something already
+       * resolved the request — usually the clock, occasionally somebody else's
+       * phone — and the agent has already been told the other answer. That is
+       * the most confusing thing that can happen in this feature, and it left a
+       * bare ✕ in the log next to a gate row saying the opposite. The line has
+       * to explain itself, because the record of the press that lost is the
+       * only place the two can be reconciled.
+       */
+      // `held` is enough, and re-reading here would be a guard nothing could
+      // ever show working: it and `decideGate` are adjacent *synchronous*
+      // statements, so the expiry timer cannot fire between them. If this ever
+      // grows an `await` in the middle, that stops being true and the row has
+      // to be read again.
+      const error = ok ? undefined
+        : !held?.decision ? "that request is not one this server is holding"
+        : `already ${held.decision === "deny" ? "denied" : "allowed"} by ${
+            held.resolution === "human" ? "somebody else" : "the timeout"} — this answer arrived too late`;
       noteAction(srv.requestIP(req)?.address, `/gate/${decision}`,
-        { tool: held?.tool_name, summary: held?.summary }, { ok });
-      return json({ ok });
+        { tool: held?.tool_name, summary: held?.summary }, { ok, error }, caller);
+      return json({ ok, ...(error ? { error } : {}) });
     }
     // Drive the dashboard's own UI from outside — a Stream Deck, a phone. Unlike
     // every other route this one changes only what is *shown*: it validates a
@@ -1453,7 +1485,7 @@ const server = Bun.serve<WsData>({
       }
       // Every write through this switch is recorded — see actions.ts for why
       // it keeps the small ones too.
-      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res); return json(res, res.ok ? 200 : 400); }
+      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res, caller); return json(res, res.ok ? 200 : 400); }
     }
 
     // --- live docker panel (lazydocker-style) ---
@@ -1508,7 +1540,7 @@ const server = Bun.serve<WsData>({
       }
       // Every write through this switch is recorded — see actions.ts for why
       // it keeps the small ones too.
-      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res); return json(res, res.ok ? 200 : 400); }
+      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res, caller); return json(res, res.ok ? 200 : 400); }
     }
 
     // --- pull requests (gh-backed) ---
@@ -1608,7 +1640,7 @@ const server = Bun.serve<WsData>({
       }
       // Every write through this switch is recorded — see actions.ts for why
       // it keeps the small ones too.
-      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res); return json(res, res.ok ? 200 : 400); }
+      if (res) { noteAction(srv.requestIP(req)?.address, pathname, b, res, caller); return json(res, res.ok ? 200 : 400); }
     }
 
     // --- in-browser terminal: ready-to-run project commands (make + scripts) ---
@@ -1650,7 +1682,7 @@ const server = Bun.serve<WsData>({
       // transcript and in `events`, and a second copy in an append-only table
       // that nothing prunes is a copy nobody asked for.
       noteAction(srv.requestIP(req)?.address, "/chat/send",
-        { root: b.cwd, name: b.model }, { ok: true });
+        { root: b.cwd, name: b.model }, { ok: true }, caller);
       return chatSend(b);
     }
     // The command that hands a chat to the user's own terminal. Server-side

--- a/server/test/gate-actor-route.test.ts
+++ b/server/test/gate-actor-route.test.ts
@@ -1,0 +1,209 @@
+/*
+ * "I approved that from my phone", end to end — #299.
+ *
+ * Everything below goes through a real server with a real paired device rather
+ * than through the functions directly, because the part that was missing is
+ * plumbing: the route has to know which caller presented which credential, and
+ * hand the same answer to the gate row and to the action log. A unit test of
+ * `actorOf` passes just as happily when the route never calls it.
+ *
+ * The gate that nobody decides is here for the same reason. It is the outcome
+ * with no request behind it, so it is the one an audit trail loses first.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const TOKEN = "machine-token-for-this-test";
+let dir: string, base: string, phone = "", proc: ReturnType<typeof Bun.spawn> | null = null;
+let phoneName = "";
+const savedXdg = process.env.XDG_CONFIG_HOME;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-gateactor-"));
+  // Mint the credential into the same store the server will read. `devices.ts`
+  // re-reads the file on every lookup, so there is no ordering trap here beyond
+  // writing it before the first authenticated request.
+  process.env.XDG_CONFIG_HOME = dir;
+  const { issueDevice } = await import("../src/devices.ts");
+  const issued = issueDevice("Pixel 9", "answer");
+  phone = issued.token;
+  phoneName = issued.device.id.slice(0, 6);
+
+  // 4600–4619 is a band no other suite spawns into. Files run sequentially, so
+  // an overlap only bites when a previous server outlives its own file — which
+  // is exactly the failure that looks like a flake and gets re-run rather than
+  // fixed.
+  const port = 4600 + Math.floor(Math.random() * 20);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    // Named, never `...process.env`: a leaked variable here would be a server
+    // reading a developer's real devices file.
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: dir,
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "gate.db"),
+      AGENTGLASS_TOKEN: TOKEN,
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  if (savedXdg === undefined) delete process.env.XDG_CONFIG_HOME; else process.env.XDG_CONFIG_HOME = savedXdg;
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+type Json = Record<string, any>;
+const as = (cred: string) => ({ authorization: `Bearer ${cred}`, "content-type": "application/json" });
+
+let seq = 0;
+const nextId = () => `00000000-0000-4000-8000-${String(++seq).padStart(12, "0")}`;
+
+/** Hold a tool call, the way the hook does. Returns as soon as it is queued;
+ *  the held promise is nobody's business here. */
+async function hold(id: string, timeoutMs = 30_000): Promise<void> {
+  void fetch(base + "/gate", {
+    method: "POST", headers: as(TOKEN),
+    body: JSON.stringify({
+      id, source_app: "claude", session_id: "s-1", tool_name: "Bash",
+      tool_input: { command: "rm -rf build" }, timeout_ms: timeoutMs,
+    }),
+  }).catch(() => {});
+  for (let i = 0; i < 60; i++) {
+    const r = await fetch(base + "/gate/pending", { headers: as(TOKEN) }).then((x) => x.json() as Promise<Json>);
+    if (r.gates.some((g: Json) => g.id === id)) return;
+    await Bun.sleep(50);
+  }
+  throw new Error("the gate never appeared in the pending queue");
+}
+
+const decide = (id: string, cred: string, decision: "allow" | "deny", reason = "") =>
+  fetch(base + "/gate/decide", {
+    method: "POST", headers: as(cred), body: JSON.stringify({ id, decision, reason }),
+  }).then((r) => r.json() as Promise<Json>);
+
+const history = () =>
+  fetch(base + "/gate/history?limit=50", { headers: as(TOKEN) }).then((r) => r.json() as Promise<Json>);
+const seen = async (id: string): Promise<Json> => (await history()).gates.find((g: Json) => g.id === id);
+
+describe("who answered", () => {
+  test("a paired phone is named, not reduced to the address it is on", async () => {
+    // The question #299 opens with. A phone on DHCP is a different address next
+    // week and the same phone; the address was never what anybody wanted.
+    const id = nextId();
+    await hold(id);
+    expect((await decide(id, phone, "deny", "not on prod")).ok).toBe(true);
+    const g = await seen(id);
+    expect(g.resolution).toBe("human");
+    expect(g.decided_by).toContain("Pixel 9");
+    // …and its id, because "A device" is the default label and two of them
+    // would otherwise be one line.
+    expect(g.decided_by).toContain(phoneName);
+  });
+
+  test("and the same press lands in the action log under the same name", async () => {
+    // Two writers, one actor, resolved once. If they could disagree the log
+    // would answer "who" twice and differently, which is worse than not at all.
+    const r = await fetch(base + "/actions?limit=20", { headers: as(TOKEN) }).then((x) => x.json() as Promise<Json>);
+    const line = r.actions.find((a: Json) => a.action === "/gate/deny");
+    expect(line, "the phone's decision is not in the action log").toBeTruthy();
+    expect(line.actor).toContain("Pixel 9");
+  });
+
+  test("the dashboard on this machine is still a place, because its token is shared", async () => {
+    const id = nextId();
+    await hold(id);
+    expect((await decide(id, TOKEN, "allow")).ok).toBe(true);
+    expect((await seen(id)).decided_by).toBe("local");
+  });
+});
+
+describe("what the reader is given", () => {
+  test("the words a person typed", async () => {
+    const g = (await history()).gates.find((x: Json) => x.reason === "not on prod");
+    expect(g, "a typed reason did not survive to the history").toBeTruthy();
+  });
+
+  test("and not the paragraph written for the stopped model", async () => {
+    // Every gate waved through without a comment carries the same three lines,
+    // which as a quotation in a list is boilerplate on every row hiding the one
+    // row where somebody explained themselves.
+    const { defaultReason } = await import("../src/gate.ts");
+    for (const g of (await history()).gates as Json[]) {
+      expect(g.reason ?? "", g.id).not.toBe(defaultReason(g.decision));
+    }
+  });
+});
+
+describe("what nobody answered", () => {
+  test("expires with an outcome and without an actor", async () => {
+    /*
+     * The row this whole column has to get right. A request that ran out while
+     * everybody was at lunch still allowed a tool call — it is a real outcome
+     * with a real consequence — and it has no actor, because nobody looked at
+     * it. `local` here would be the exact lie an audit trail exists to prevent.
+     *
+     * 1s is the floor `submitGate` clamps to.
+     */
+    const id = nextId();
+    await hold(id, 1000);
+    for (let i = 0; i < 40; i++) {
+      const g = await seen(id);
+      if (g) {
+        expect(g.resolution).toBe("timeout");
+        expect(g.decided_by, "a timeout was given an actor").toBeNull();
+        expect(g.decision).toBe("allow");
+        return;
+      }
+      await Bun.sleep(100);
+    }
+    throw new Error("the gate never expired into the history");
+  });
+
+  test("and deciding it afterwards changes nothing and says so", async () => {
+    // Somebody presses deny on their phone on a request the clock already
+    // allowed. The row must keep what the agent was actually told — and the
+    // press that lost must still be recorded, because it is the single most
+    // confusing thing that can happen here and the gates table has no row for
+    // it.
+    const id = nextId();
+    await hold(id, 1000);
+    for (let i = 0; i < 40 && !(await seen(id)); i++) await Bun.sleep(100);
+    const lostPress = await decide(id, phone, "deny", "too late");
+    expect(lostPress.ok).toBe(false);
+    // …and it says why. A bare failure next to a gate row saying the opposite
+    // is the most confusing thing this feature can produce, and the press that
+    // lost is the only place the two can be reconciled.
+    expect(String(lostPress.error)).toContain("the timeout");
+    expect(String(lostPress.error)).toContain("too late");
+
+    const g = await seen(id);
+    expect(g.decision).toBe("allow");
+    expect(g.resolution).toBe("timeout");
+    expect(g.decided_by).toBeNull();
+
+    const r = await fetch(base + "/actions?limit=50", { headers: as(TOKEN) }).then((x) => x.json() as Promise<Json>);
+    const lost = (r.actions as Json[]).find((a) => a.action === "/gate/deny" && !a.ok);
+    expect(lost, "the decision that lost the race left no trace").toBeTruthy();
+    expect(lost!.actor).toContain("Pixel 9");
+    expect(String(lost!.detail), "the failed line does not say why").toContain("too late");
+  });
+
+  test("and an id this server never held says that, rather than blaming the clock", async () => {
+    const r = await decide("00000000-0000-4000-8000-999999999999", phone, "allow");
+    expect(r.ok).toBe(false);
+    expect(String(r.error)).toContain("not one this server is holding");
+  });
+});

--- a/server/test/who-decided.test.ts
+++ b/server/test/who-decided.test.ts
@@ -1,0 +1,203 @@
+/*
+ * Which human, not just that one of them answered — #299.
+ *
+ * The action log (#389) answered "what was done through this cockpit" and
+ * answered "who" with an address, which was the most a shared token could
+ * honestly support. A paired device has its own credential and a name somebody
+ * accepted (devices.ts), so the honest answer got better, and the gate row —
+ * the one write with a stopped agent on the other end of it — now carries it.
+ *
+ * The two facts this file exists to keep apart:
+ *
+ *   - a decision somebody made, and one the clock made. An actor attached to a
+ *     timeout would be a lie about the single outcome nobody chose.
+ *   - two devices with the same name. "A device" is the *default* label, so a
+ *     bare label is a collision waiting to happen rather than a rare one.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { actorOf, deviceActor } from "../src/actions.ts";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-whodecided-"));
+process.env.AGENTGLASS_DB = join(dir, "who.db");
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+let gate: typeof import("../src/gate.ts");
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  gate = await import("../src/gate.ts");
+});
+
+let n = 0;
+/** A gate row, held. Uuid-shaped because gate.ts refuses anything else. */
+function held(): string {
+  const id = `00000000-0000-4000-8000-${String(++n).padStart(12, "0")}`;
+  db.recordGate({
+    id, source_app: "claude", session_id: "s1", tool_name: "Bash",
+    summary: "rm -rf build", created: Date.now(), expires: Date.now() + 60_000,
+  });
+  return id;
+}
+const row = (id: string) => db.getGate(id)!;
+
+describe("naming a device", () => {
+  test("carries its id, because the default label collides with itself", () => {
+    // `issueDevice` names an unlabelled phone "A device". Two of those in a log
+    // are indistinguishable, which answers "who approved that" worse than the
+    // address this replaced.
+    const a = deviceActor({ id: "3f9c21aa11", label: "A device" });
+    const b = deviceActor({ id: "77b40e0022", label: "A device" });
+    expect(a).not.toBe(b);
+    expect(a).toContain("A device");
+    expect(a).toContain("3f9c21");
+  });
+
+  test("and cannot be mistaken for the machine or for an address", () => {
+    // The label is free text the device chose for itself. Its own id riding
+    // along is what keeps a phone that calls itself "local" from producing a
+    // line that reads as this machine's dashboard.
+    expect(deviceActor({ id: "3f9c21aa11", label: "local" })).not.toBe("local");
+    expect(deviceActor({ id: "3f9c21aa11", label: "192.168.1.9" })).not.toBe("192.168.1.9");
+  });
+
+  test("a device with no name at all still has one", () => {
+    expect(deviceActor({ id: "3f9c21aa11", label: "" })).toBe("device · 3f9c21");
+  });
+
+  test("and a long one is cut rather than kept whole", () => {
+    // 60 characters are allowed at pairing; a log line is not the place to
+    // spend them.
+    const long = deviceActor({ id: "3f9c21aa11", label: "x".repeat(200) });
+    expect(long.length).toBeLessThan(60);
+  });
+});
+
+describe("who the server says it was", () => {
+  test("a paired device is its name, not the address it happens to be on", () => {
+    // The whole point. A phone on DHCP is a different address next week and the
+    // same phone, and the address was never the thing anybody wanted to know.
+    const caller = { kind: "device" as const, device: { id: "3f9c21aa11", label: "iPhone" } };
+    expect(actorOf("192.168.1.9", caller)).toBe("iPhone · 3f9c21");
+    // Even from loopback: a device credential identifies a device wherever it is.
+    expect(actorOf("127.0.0.1", caller)).toBe("iPhone · 3f9c21");
+  });
+
+  test("the machine's own token is still a place, because it is shared", () => {
+    // It is one secret for the whole machine. Any name for it would be invented.
+    expect(actorOf("127.0.0.1", { kind: "machine" })).toBe("local");
+    expect(actorOf("192.168.1.9", { kind: "machine" })).toBe("192.168.1.9");
+  });
+
+  test("and with no caller at all it is what it always was", () => {
+    expect(actorOf("127.0.0.1")).toBe("local");
+    expect(actorOf("192.168.1.9")).toBe("192.168.1.9");
+    expect(actorOf(null)).toBe("local");
+  });
+});
+
+describe("the gate row", () => {
+  test("keeps who decided it, in the same write that resolves it", () => {
+    // On the row rather than only in `actions`, because the two cannot be
+    // joined: an action line carries a clipped `tool · summary`, so two gates
+    // on the same tool a second apart are one line each and indistinguishable.
+    const id = held();
+    expect(gate.decideGate(id, "deny", "not on prod", "iPhone · 3f9c21")).toBe(true);
+    expect(row(id)).toMatchObject({
+      decision: "deny", resolution: "human", decided_by: "iPhone · 3f9c21", reason: "not on prod",
+    });
+  });
+
+  test("and nobody, when nobody decided", () => {
+    // The distinction with teeth. A timeout is not an actor, and a row saying
+    // "local allowed this" about a request that expired unread is the exact
+    // lie an audit trail exists to prevent.
+    const id = held();
+    db.resolveGateRow(id, "allow", "", "timeout");
+    expect(row(id)).toMatchObject({ resolution: "timeout", decided_by: null });
+
+    const other = held();
+    db.resolveGateRow(other, "allow", "", "restart", Date.now());
+    expect(row(other).decided_by).toBeNull();
+  });
+
+  test("an actor handed in with a timeout is refused rather than stored", () => {
+    // Defence in depth on the one field whose value is that it cannot be
+    // wrong: the caller passing null is the rule, and this is what happens if
+    // some future path forgets.
+    const id = held();
+    db.resolveGateRow(id, "allow", "", "timeout", Date.now(), "iPhone · 3f9c21");
+    expect(row(id).decided_by).toBeNull();
+  });
+
+  test("a decision that lost the race writes nothing at all", () => {
+    // The clock got there first. The row must keep the outcome the agent was
+    // actually given, and must not acquire an actor who did not produce it.
+    const id = held();
+    db.resolveGateRow(id, "allow", "", "timeout");
+    expect(gate.decideGate(id, "deny", "too late", "iPhone · 3f9c21")).toBe(false);
+    expect(row(id)).toMatchObject({ decision: "allow", resolution: "timeout", decided_by: null });
+  });
+
+  test("and the row itself refuses the second write, not just the caller", () => {
+    /*
+     * `decideGate` reads the row first and returns false, so the guard in the
+     * UPDATE never fires through that path — which is precisely why it is worth
+     * a test of its own. The read and the write are not one transaction: a
+     * timeout firing between them is a real interleaving, and the whole point
+     * of an append-once record is that the winner cannot be edited afterwards
+     * by anything, including this module.
+     */
+    const id = held();
+    db.resolveGateRow(id, "deny", "a person said no", "human", Date.now(), "iPhone · 3f9c21");
+    db.resolveGateRow(id, "allow", "", "timeout");
+    expect(row(id)).toMatchObject({
+      decision: "deny", resolution: "human", decided_by: "iPhone · 3f9c21", reason: "a person said no",
+    });
+  });
+
+  test("it is in the history, which is where anybody would look", () => {
+    const id = held();
+    gate.decideGate(id, "allow", "", "Pixel · aa00bb");
+    const found = db.gateHistory(50).find((g) => g.id === id)!;
+    expect(found.decided_by).toBe("Pixel · aa00bb");
+  });
+});
+
+describe("the reason, as a reader sees it", () => {
+  test("what a person typed comes back", () => {
+    const id = held();
+    gate.decideGate(id, "deny", "we do not run migrations from here", "local");
+    expect(gate.typedReason(row(id))).toBe("we do not run migrations from here");
+  });
+
+  test("and the paragraph written for the model does not", () => {
+    /*
+     * `decideGate` backfills an empty reason, because the string travels to a
+     * model that has just been stopped and needs something it can act on. Every
+     * gate anybody waved through therefore carries the same three lines, and a
+     * history quoting them back is boilerplate on every row hiding the one row
+     * where somebody explained themselves.
+     *
+     * Compared against the real function rather than a copy of its text, so
+     * this cannot pass while the history quotes a default it stopped
+     * recognising.
+     */
+    for (const d of ["allow", "deny"] as const) {
+      const id = held();
+      gate.decideGate(id, d, "");
+      expect(row(id).reason).toBe(gate.defaultReason(d));
+      expect(gate.typedReason(row(id)), d).toBe("");
+    }
+  });
+
+  test("and a timeout's empty reason stays empty", () => {
+    // Empty on purpose: a non-empty reason makes the hook force-allow and skip
+    // Claude Code's own permission prompt, which an auto-allow must not do.
+    const id = held();
+    db.resolveGateRow(id, "allow", "", "timeout");
+    expect(gate.typedReason(row(id))).toBe("");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -316,14 +316,22 @@ export interface GateRecord extends PendingGate {
   reason: string | null;
   resolution: "human" | "timeout" | "restart" | null;
   decided_at: number | null;
+  /** *Which* human — a paired device's name, or the address the answer came
+   *  from. NULL when nobody decided: a timeout is not an actor, and neither is
+   *  a restart. Also NULL on rows written before the column existed, which is
+   *  why an absent value is never read as "this machine". */
+  decided_by: string | null;
 }
 
 /**
  * One write the cockpit performed, kept.
  *
- * `actor` is where the request came from, not who someone is: there are no
- * accounts and the token is shared, so `local` means the loopback caller — this
- * machine's dashboard — and anything else is the address it arrived from.
+ * `actor` is the most the server can honestly assert. A paired device has its
+ * own credential and the name somebody accepted when they paired it, so it is
+ * named — "iPhone · 3f9c21", with the device id because an unnamed phone
+ * defaults to "A device" and two of those must not read as one. Otherwise it is
+ * a place rather than a person: `local` for the loopback caller — this
+ * machine's dashboard — and the address for anything else.
  */
 export interface ActionRecord {
   id: number;

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -13,7 +13,8 @@ import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import { fmtAgo } from "../lib/format.ts";
-import type { ActionRecord } from "../../../shared/types.ts";
+import type { ActionRecord, GateRecord } from "../../../shared/types.ts";
+import { mergeActivity, gateLine, actorLabel, type ActivityRow } from "../lib/activity.ts";
 import { ingestUpdate } from "../lib/updateStore.ts";
 import { ReleaseNotesModal } from "./ReleaseNotesModal.tsx";
 import { installedNotes, type NotesTarget } from "../lib/whatsNew.ts";
@@ -232,18 +233,33 @@ function KeyRow({ id, keyName, capturing, onCapture, error, chord }: {
  * is a live view of the session rather than an audit trail. So "who approved
  * that" and "what happened to my branch while I was at lunch" had no answer.
  *
- * `actor` is deliberately an address rather than a name. There are no accounts
- * here and the token is shared, so a name would be invented; where the request
- * came from is a fact. `local` is this machine's dashboard, and anything else
- * is the device that reached it — which is what makes "I approved that from my
- * phone" answerable.
+ * Who did it is now a name when there is an honest one. A paired phone carries
+ * its own credential and the label somebody accepted when they paired it, so
+ * "iPhone · 3f9c21 approved that" is a fact, not an invention — the id comes
+ * along because an unnamed device defaults to "A device" and two of those must
+ * not read as one. The machine token is still shared and still anonymous, so
+ * anything holding it is a place: `local` for this machine's dashboard, and the
+ * address for anything else.
+ *
+ * Two records feed this list, not one. The action log holds what a person asked
+ * for; the gates table holds the fate of every held tool call, including the
+ * ones a timeout or a restart resolved while nobody was looking. Those changed
+ * what an agent did and appear in no action row, because nobody made a request
+ * for them — and an outcome nobody chose is the one least likely to be
+ * remembered and most worth writing down. See lib/activity.ts for the merge.
  */
 function ActivityPane({ open }: { open: boolean }) {
-  const [rows, setRows] = useState<ActionRecord[] | null>(null);
+  const [rows, setRows] = useState<ActivityRow[] | null>(null);
   useEffect(() => {
     if (!open) return;
     let alive = true;
-    api.actions(200).then((r) => { if (alive) setRows(r.actions); }).catch(() => { if (alive) setRows([]); });
+    // Both records, because neither is the whole story: the action log has only
+    // what a person asked for, and a gate the timeout allowed is something that
+    // happened without anybody asking. See lib/activity.ts.
+    Promise.all([
+      api.actions(200).then((r) => r.actions).catch(() => [] as ActionRecord[]),
+      api.gateHistory(200).then((r) => r.gates).catch(() => [] as GateRecord[]),
+    ]).then(([a, g]) => { if (alive) setRows(mergeActivity(a, g)); });
     return () => { alive = false; };
   }, [open]);
 
@@ -263,29 +279,78 @@ function ActivityPane({ open }: { open: boolean }) {
     <Section title="Activity">
       <div className="px-3 pb-2 text-[10.5px] t-dim2">
         Newest first. Kept indefinitely — these are the changes you made, not telemetry.
+        Held tool calls appear here whoever resolved them, including the ones the timeout
+        decided while nobody was looking.
       </div>
       <div className="flex flex-col">
-        {rows.map((a) => (
-          <div key={a.id} className="grid grid-cols-[auto_minmax(0,1fr)_auto] gap-x-3 items-baseline px-3 py-1.5 rounded-lg hover:bg-white/5">
-            <span
-              className="text-[9.5px] font-semibold tabular-nums shrink-0"
-              style={{ color: a.ok ? "var(--text4)" : "var(--error)" }}
-              title={a.ok ? "succeeded" : a.detail || "failed"}
-            >
-              {a.ok ? "·" : "✕"}
-            </span>
-            <span className="min-w-0">
-              <span className="text-[11.5px]" style={{ color: "var(--text)" }}>{verb(a.action)}</span>
-              {a.target && <span className="text-[11.5px] t-dim"> {a.target}</span>}
-              {!a.ok && a.detail && <span className="block text-[10px] mt-0.5" style={{ color: "var(--error)" }}>{a.detail}</span>}
-            </span>
-            <span className="text-[9.5px] t-dim2 tabular-nums shrink-0 text-right">
-              {a.actor === "local" ? "" : `${a.actor} · `}{fmtAgo(a.at)}
-            </span>
-          </div>
-        ))}
+        {rows.map((r) => (r.kind === "gate" ? <GateLine key={r.key} g={r.row} /> : <ActionLine key={r.key} a={r.row} />))}
       </div>
     </Section>
+  );
+}
+
+/** The right-hand column: who, then how long ago. Shared so a gate line and a
+ *  git line cannot drift into two different ways of saying the same thing. */
+function Who({ actor, at }: { actor: string; at: number }) {
+  return (
+    <span className="text-[9.5px] t-dim2 tabular-nums shrink-0 text-right">
+      {actor && `${actor} · `}{fmtAgo(at)}
+    </span>
+  );
+}
+
+function ActionLine({ a }: { a: ActionRecord }) {
+  return (
+    <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] gap-x-3 items-baseline px-3 py-1.5 rounded-lg hover:bg-white/5">
+      <span
+        className="text-[9.5px] font-semibold tabular-nums shrink-0"
+        style={{ color: a.ok ? "var(--text4)" : "var(--error)" }}
+        title={a.ok ? "succeeded" : a.detail || "failed"}
+      >
+        {a.ok ? "·" : "✕"}
+      </span>
+      <span className="min-w-0">
+        <span className="text-[11.5px]" style={{ color: "var(--text)" }}>{verb(a.action)}</span>
+        {a.target && <span className="text-[11.5px] t-dim"> {a.target}</span>}
+        {!a.ok && a.detail && <span className="block text-[10px] mt-0.5" style={{ color: "var(--error)" }}>{a.detail}</span>}
+      </span>
+      <Who actor={actorLabel({ kind: "action", at: a.at, key: "", row: a })} at={a.at} />
+    </div>
+  );
+}
+
+/**
+ * A held tool call and how it ended.
+ *
+ * The dot is amber for an outcome nobody chose. "approved" for a call somebody
+ * read and "allowed" for one that expired while they were at lunch are opposite
+ * facts about whether anybody looked, and in a list of past tense verbs they
+ * are one glance apart — so the distinction gets a colour as well as a word.
+ */
+function GateLine({ g }: { g: GateRecord }) {
+  const { verb: did, note } = gateLine(g);
+  const nobody = g.resolution !== "human";
+  return (
+    <div className="grid grid-cols-[auto_minmax(0,1fr)_auto] gap-x-3 items-baseline px-3 py-1.5 rounded-lg hover:bg-white/5">
+      <span
+        className="text-[9.5px] font-semibold tabular-nums shrink-0"
+        style={{ color: nobody ? "var(--warning)" : g.decision === "deny" ? "var(--error)" : "var(--text4)" }}
+        title={nobody ? "nobody decided this" : "decided by a person"}
+      >
+        {nobody ? "⏱" : "·"}
+      </span>
+      <span className="min-w-0">
+        <span className="text-[11.5px]" style={{ color: "var(--text)" }}>{did}</span>
+        <span className="text-[11.5px] t-dim"> {g.tool_name}{g.summary ? ` · ${g.summary}` : ""}</span>
+        {note && <span className="block text-[10px] mt-0.5" style={{ color: "var(--warning)" }}>{note}</span>}
+        {/* The reason a person typed, which lives nowhere else: the agent was
+            given it and the action log never carried it. */}
+        {g.resolution === "human" && g.reason && (
+          <span className="block text-[10px] mt-0.5 t-dim2">“{g.reason}”</span>
+        )}
+      </span>
+      <Who actor={actorLabel({ kind: "gate", at: g.decided_at ?? 0, key: "", row: g })} at={g.decided_at ?? 0} />
+    </div>
   );
 }
 

--- a/web/src/lib/activity.ts
+++ b/web/src/lib/activity.ts
@@ -1,0 +1,82 @@
+/**
+ * One list of what was done through this cockpit, from two records.
+ *
+ * The action log keeps every write a *person* made — staging, pushing, merging,
+ * removing a container, answering a gate. The gates table keeps the fate of
+ * every held tool call, which is not the same set: a request the timeout
+ * allowed, or one a restart found already expired, changed what an agent did
+ * and appears in no action row at all, because nobody made a request for it.
+ *
+ * An audit trail with a hole in it is worse than none — you stop looking for
+ * the missing line — and "the outcomes nobody chose" is the hole most worth
+ * closing, since those are exactly the ones nobody remembers.
+ *
+ * Where the two overlap, the gate record wins. It is the same event told
+ * better: the actor is on the row itself, the summary is not clipped to share
+ * 120 characters with the tool name, and the reason a human typed is there,
+ * which the action log never carried.
+ */
+import type { ActionRecord, GateRecord } from "../../../shared/types.ts";
+
+export type ActivityRow =
+  | { kind: "action"; at: number; key: string; row: ActionRecord }
+  | { kind: "gate"; at: number; key: string; row: GateRecord };
+
+/**
+ * Merge, newest first.
+ *
+ * A *successful* `/gate/*` action row is dropped, because the gate record
+ * carries the same press with more of it. A **failed** one is kept: it is an
+ * attempt rather than an outcome — somebody pressed deny on a request the
+ * clock had already allowed — and the gates table has no row for the press
+ * that lost, only for the one that won. Dropping it would quietly delete the
+ * single most confusing thing that can happen here.
+ */
+export function mergeActivity(actions: ActionRecord[], gates: GateRecord[]): ActivityRow[] {
+  const rows: ActivityRow[] = [];
+  for (const a of actions) {
+    if (a.action.startsWith("/gate/") && a.ok) continue;
+    rows.push({ kind: "action", at: a.at, key: `a${a.id}`, row: a });
+  }
+  for (const g of gates) {
+    // A gate still pending has no place in a record of what happened.
+    if (!g.decided_at) continue;
+    rows.push({ kind: "gate", at: g.decided_at, key: `g${g.id}`, row: g });
+  }
+  return rows.sort((x, y) => y.at - x.at || x.key.localeCompare(y.key));
+}
+
+/**
+ * What a resolved gate says, in the words of the thing that resolved it.
+ *
+ * The three cases are genuinely different events and rounding them together is
+ * the mistake this exists to prevent: "allowed" for a request a person read and
+ * approved, and "allowed" for one that expired while they were at lunch, look
+ * identical in a list and mean opposite things about whether anybody looked.
+ */
+export function gateLine(g: GateRecord): { verb: string; note: string } {
+  const did = g.decision === "deny" ? "denied" : "approved";
+  if (g.resolution === "human") return { verb: did, note: "" };
+  const passive = g.decision === "deny" ? "denied" : "allowed";
+  if (g.resolution === "restart")
+    return { verb: passive, note: "the window closed while the server was down — nobody saw this" };
+  return { verb: passive, note: "nobody answered before the timeout" };
+}
+
+/**
+ * The name to show against a row, or nothing.
+ *
+ * Empty for this machine's own dashboard, which is most rows and where a label
+ * would be noise standing in for the only case that needs no name. Also empty
+ * when nobody decided — but that is never read as "local", because the line
+ * itself already says the timeout resolved it.
+ *
+ * A human-decided row with no actor is one written before the column existed.
+ * It shows nothing, which is knowingly lossy for the handful of rows already on
+ * disk when this shipped; the alternative is marking every one of them unknown
+ * forever to describe a gap that stops growing the moment it is deployed.
+ */
+export function actorLabel(row: ActivityRow): string {
+  const who = row.kind === "action" ? row.row.actor : row.row.decided_by;
+  return !who || who === "local" ? "" : who;
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -298,12 +298,15 @@ const realApi = {
   // useful when the answer is somewhere you were not looking.
   actions: (limit = 200, before?: number) =>
     get<{ actions: ActionRecord[] }>(`/actions?limit=${limit}${before ? `&before=${before}` : ""}`),
+  /** `ok: false` is a 200: the request arrived and something else had already
+   *  decided the gate. `error` says what won, and a caller that ignores it
+   *  tells somebody their answer took when it did not. */
   gateDecide: (id: string, decision: "allow" | "deny", reason = "") =>
     fetch(SERVER + "/gate/decide", {
       method: "POST",
       headers: authHeaders({ "content-type": "application/json" }),
       body: JSON.stringify({ id, decision, reason }),
-    }).then((r) => r.json()),
+    }).then((r) => r.json() as Promise<{ ok: boolean; error?: string }>),
   gitStatus: (paths: string[]) =>
     fetch(SERVER + "/git/status", {
       method: "POST",

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -543,12 +543,29 @@ export function MobileApp() {
 
   const decide = async (id: string, d: "allow" | "deny", itemId: string) => {
     try {
-      await api.gateDecide(id, d);
+      const r = await api.gateDecide(id, d);
+      /*
+       * An answer that did not take must not look like one that did.
+       *
+       * A press that lost the race — the timeout got there first, or somebody
+       * else answered from the desk — comes back 200 with `ok: false`, so it
+       * never reached the `catch` and this said "the agent is moving again"
+       * about a request that had already been decided the other way. On the one
+       * surface built for answering gates, that is the worst sentence available.
+       * The server says what actually won; this repeats it.
+       */
+      if (!r.ok) {
+        toast(r.error || "That did not take — the request was already decided", true);
+        // Still dropped: it is genuinely resolved, just not by this press, and
+        // leaving it in the queue invites pressing again to the same effect.
+        drop(itemId);
+        return;
+      }
       drop(itemId);
       toast(d === "allow" ? "Allowed — the agent is moving again" : "Denied — the agent was told no");
     } catch {
-      // An answer that did not arrive must not look like one that did: the
-      // agent is still blocked, and saying otherwise is the worst outcome here.
+      // Nothing reached the server at all. The agent is still blocked, and
+      // saying otherwise is the worse of the two mistakes.
       toast("That did not reach the server — the agent is still waiting", true);
     }
   };

--- a/web/test/activity-merge.test.ts
+++ b/web/test/activity-merge.test.ts
@@ -1,0 +1,123 @@
+/*
+ * One list of what happened, from two records that overlap — #299.
+ *
+ * The action log holds what a *person* asked for. The gates table holds the
+ * fate of every held tool call, which is not the same set: a request the
+ * timeout allowed changed what an agent did and has no action row at all,
+ * because nobody made a request for it.
+ *
+ * The two failures worth guarding are opposite. Drop too little and every gate
+ * appears twice, once with the actor and once without, and a reader has to work
+ * out which line to believe. Drop too much and the presses that *failed*
+ * disappear — and the press that failed is the one somebody is looking for,
+ * because it is the moment they thought they denied something that was already
+ * allowed.
+ */
+import { describe, expect, test } from "bun:test";
+import { mergeActivity, gateLine, actorLabel } from "../src/lib/activity.ts";
+import type { ActionRecord, GateRecord } from "../../shared/types.ts";
+
+const action = (o: Partial<ActionRecord>): ActionRecord => ({
+  id: 1, at: 1_000, actor: "local", action: "/git/push", target: "repo", ok: true, detail: null, ...o,
+});
+
+const gate = (o: Partial<GateRecord>): GateRecord => ({
+  id: "g1", source_app: "claude", session_id: "s", tool_name: "Bash", summary: "rm -rf build",
+  created: 900, expires: 9_000, decision: "allow", reason: null,
+  resolution: "human", decided_at: 1_000, decided_by: "local", ...o,
+});
+
+describe("what ends up in the list", () => {
+  test("a gate the timeout decided, which exists in no action row", () => {
+    // The hole this closes. Nobody made a request, so the log that records
+    // requests has nothing — and the agent was allowed to run the command.
+    const rows = mergeActivity([], [gate({ resolution: "timeout", decided_by: null })]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe("gate");
+  });
+
+  test("a successful gate press once, from the record that knows more", () => {
+    // Both sources have it. The gate row carries the actor, the untruncated
+    // summary and the reason; the action line carries a clipped `tool ·
+    // summary`. Showing both would make a reader pick.
+    const rows = mergeActivity([action({ action: "/gate/allow", target: "Bash · rm -rf build" })], [gate({})]);
+    expect(rows).toHaveLength(1);
+    expect(rows[0]!.kind).toBe("gate");
+  });
+
+  test("but a gate press that FAILED is kept, because nothing else has it", () => {
+    // Somebody pressed deny on a request the clock had already allowed. The
+    // gates table only ever holds the press that won.
+    const rows = mergeActivity(
+      [action({ action: "/gate/deny", ok: false, at: 2_000 })],
+      [gate({ resolution: "timeout", decided_by: null })],
+    );
+    expect(rows.map((r) => r.kind)).toEqual(["action", "gate"]);
+  });
+
+  test("and a gate still being held is not history yet", () => {
+    expect(mergeActivity([], [gate({ decided_at: null })])).toHaveLength(0);
+  });
+
+  test("newest first, across both sources", () => {
+    const rows = mergeActivity(
+      [action({ id: 7, at: 3_000 }), action({ id: 8, at: 1_000 })],
+      [gate({ id: "gx", decided_at: 2_000 })],
+    );
+    expect(rows.map((r) => r.at)).toEqual([3_000, 2_000, 1_000]);
+  });
+
+  test("with keys that cannot collide between the two", () => {
+    // An action id is a number and a gate id is a uuid, so nothing collides
+    // today — but a list keyed on a bare id is one schema change away from
+    // React reusing a row for a different event, and the id chosen here is
+    // exactly the one an un-prefixed key would land on.
+    const rows = mergeActivity([action({ id: 1 })], [gate({ id: "a1" })]);
+    expect(new Set(rows.map((r) => r.key)).size).toBe(2);
+  });
+});
+
+describe("what a resolved gate is called", () => {
+  test("a person approved it; the clock allowed it", () => {
+    /*
+     * The distinction this pane exists for. "allowed" for a call somebody read
+     * and "allowed" for one that expired while they were at lunch are opposite
+     * facts about whether anybody looked, and in a list of past-tense verbs
+     * they are one glance apart.
+     */
+    expect(gateLine(gate({ resolution: "human" })).verb).toBe("approved");
+    expect(gateLine(gate({ resolution: "timeout", decided_by: null })).verb).toBe("allowed");
+  });
+
+  test("and the one nobody saw says so out loud", () => {
+    expect(gateLine(gate({ resolution: "timeout", decided_by: null })).note).toMatch(/nobody answered/);
+    expect(gateLine(gate({ resolution: "restart", decided_by: null })).note).toMatch(/server was down/);
+    // A human decision needs no excuse attached to it.
+    expect(gateLine(gate({ resolution: "human" })).note).toBe("");
+  });
+
+  test("a denial reads as a denial either way", () => {
+    expect(gateLine(gate({ decision: "deny", resolution: "human" })).verb).toBe("denied");
+    // Fail-closed: the timeout blocked it, and nobody chose that either.
+    expect(gateLine(gate({ decision: "deny", resolution: "timeout", decided_by: null })).verb).toBe("denied");
+  });
+});
+
+describe("who it is shown against", () => {
+  test("a phone is named", () => {
+    expect(actorLabel({ kind: "gate", at: 1, key: "g", row: gate({ decided_by: "Pixel 9 · aa00bb" }) }))
+      .toBe("Pixel 9 · aa00bb");
+  });
+
+  test("this machine's own dashboard is not, because it is most of the list", () => {
+    expect(actorLabel({ kind: "gate", at: 1, key: "g", row: gate({ decided_by: "local" }) })).toBe("");
+    expect(actorLabel({ kind: "action", at: 1, key: "a", row: action({ actor: "local" }) })).toBe("");
+  });
+
+  test("and nothing is claimed about an outcome nobody chose", () => {
+    // Rendering "local" over a timeout would put this machine's name on a
+    // decision nobody made.
+    expect(actorLabel({ kind: "gate", at: 1, key: "g", row: gate({ resolution: "timeout", decided_by: null }) }))
+      .toBe("");
+  });
+});

--- a/web/test/activity-pane.test.ts
+++ b/web/test/activity-pane.test.ts
@@ -1,0 +1,71 @@
+/*
+ * The Activity pane, and the two things it must not quietly drop.
+ *
+ * It is the only screen in the app that answers "who did that". Every rule here
+ * is one where the failure is silent: a pane that reads one source instead of
+ * two, or renders a name it was never given, looks exactly like a working one.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const src = readFileSync(new URL("../src/components/SettingsModal.tsx", import.meta.url), "utf8");
+const pane = src.slice(src.indexOf("function ActivityPane"), src.indexOf("const VERBS"));
+
+describe("where it reads from", () => {
+  test("both records, because neither is the whole story", () => {
+    // A gate the timeout allowed is in the gates table and nowhere else: nobody
+    // made a request, so the log of requests has nothing to show.
+    expect(pane).toContain("api.actions(");
+    expect(pane).toContain("api.gateHistory(");
+  });
+
+  test("merged by the rule rather than by whatever order they arrive in", () => {
+    expect(pane).toContain("mergeActivity(");
+  });
+});
+
+describe("what it says about a held tool call", () => {
+  test("an outcome nobody chose is marked as one, not just worded as one", () => {
+    // "approved" and "allowed" are one glance apart in a list of past-tense
+    // verbs, and they mean opposite things about whether anybody looked.
+    expect(pane).toMatch(/resolution !== "human"/);
+    expect(pane).toContain("var(--warning)");
+  });
+
+  test("and the pane says so in the words the rule chose", () => {
+    expect(pane).toContain("gateLine(");
+  });
+
+  test("the reason a person typed is shown, since it is nowhere else", () => {
+    // The agent was given it and the action log never carried it.
+    expect(pane).toMatch(/g\.resolution === "human" && g\.reason/);
+  });
+});
+
+describe("who", () => {
+  test("comes from the rule, not from reading the field in the markup", () => {
+    // `decided_by` is empty on a timeout and on any row older than the column,
+    // so reading it here is how "local" ends up printed over a decision nobody
+    // made. The field belongs to lib/activity.ts and is named nowhere in this
+    // file — including behind a `?? ""`, which is the version that looks safe.
+    expect(pane.match(/actorLabel\(/g) ?? []).toHaveLength(2);
+    expect(pane, "the pane is reading the actor fields itself").not.toContain("decided_by");
+    expect(pane).not.toMatch(/\{a\.actor === "local"/);
+  });
+
+  test("and is rendered the same way for both kinds of row", () => {
+    // Two spellings of the same column is how a git line and a gate line end up
+    // disagreeing about what "no name" looks like.
+    expect(pane.match(/<Who /g) ?? []).toHaveLength(2);
+  });
+});
+
+describe("what it tells you about itself", () => {
+  test("that the timeouts are in here too", () => {
+    // Otherwise the list reads as "things I did", and the rows nobody did
+    // become surprising rather than the point.
+    // Whitespace-loose: the sentence is wrapped in the JSX, and a guard that
+    // breaks when somebody reflows a paragraph teaches people to delete guards.
+    expect(pane).toMatch(/the timeout\s+decided while nobody was looking/);
+  });
+});

--- a/web/test/gate-answer-took.test.ts
+++ b/web/test/gate-answer-took.test.ts
@@ -1,0 +1,57 @@
+/*
+ * "Allowed — the agent is moving again", about an agent that is not moving.
+ *
+ * A press that loses the race — the timeout got there first, or somebody
+ * answered from the desk — comes back **200** with `ok: false`. It is not an
+ * exception, so a `try/catch` around the call never sees it, and the phone said
+ * the agent had been released about a request that was already decided the
+ * other way. On the one surface built for answering gates, that is the worst
+ * sentence available: it is confidently wrong about the exact thing somebody
+ * opened the app to find out.
+ *
+ * Written over the file rather than by driving the component: `decide` is a
+ * closure over queue state and cannot be imported, and what has to stay true is
+ * smaller than any rendering — the response is read before anybody is told what
+ * happened.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+const SHELL = readFileSync(new URL("../src/mobile/MobileApp.tsx", import.meta.url), "utf8");
+const decide = SHELL.slice(SHELL.indexOf("const decide = async"), SHELL.indexOf("const settle = async"));
+
+describe("answering a gate from the phone", () => {
+  test("the answer is read, not assumed from the absence of a throw", () => {
+    expect(decide).toMatch(/const r = await api\.gateDecide\(/);
+    expect(decide, "a 200 that did not take is treated as success").toMatch(/if \(!r\.ok\)/);
+  });
+
+  test("and a press that did not take says so, in the server's words", () => {
+    // The server knows what won — the clock, or another device. Inventing a
+    // vaguer sentence here would throw away the only useful part.
+    expect(decide).toMatch(/r\.error/);
+  });
+
+  test("the failure is toasted as a failure, not as news", () => {
+    // `toast(text, true)` is the error styling. Without the flag this is the
+    // same green note as a successful answer.
+    expect(decide).toMatch(/toast\(r\.error[^)]*, true\)/);
+  });
+
+  test("and nothing that did reach the server is reported as unreachable", () => {
+    // The catch is for a request that never arrived, which is a different
+    // problem with a different answer: there, the agent really is still waiting.
+    expect(decide).toMatch(/still waiting/);
+  });
+});
+
+describe("what the client type admits", () => {
+  const api = readFileSync(new URL("../src/lib/api.ts", import.meta.url), "utf8");
+  const fn = api.slice(api.indexOf("gateDecide: (id: string"), api.indexOf("gitStatus:"));
+
+  test("gateDecide can come back not-ok, and the type says so", () => {
+    // The call used to be typed `any`, which is how every caller came to treat
+    // "it resolved" as "it worked".
+    expect(fn).toMatch(/ok: boolean; error\?: string/);
+  });
+});


### PR DESCRIPTION
Closes #299.

## What does this PR do?

The append-only action log landed in #389 and answered "who did that" with an **address** — which was the most a shared token could honestly support. One secret for the whole machine means a name would have been invented, so `local` or `192.168.1.42` was the truth and nothing better was available.

That changed in #438. A paired device carries its own credential and the name somebody accepted when they paired it, so a name is now a **fact**. This finishes #299 on that footing: the gate — the one write with a stopped agent on the other end of it — records who decided it, and the pane where you would look for that finally shows the outcomes nobody decided at all.

### `decided_by`, on the row itself

On the gate row rather than only in `actions`, because **the two cannot be joined**: an action line keeps a clipped `tool · summary`, so two gates on the same tool a second apart are one line each and indistinguishable. The column is written by the same `UPDATE` that resolves the gate, which is what makes it impossible for the actor and the decision to disagree, and the route resolves the actor **once** and hands it to both writers so they cannot name two different people for one press.

It is `NULL` when nobody decided. A timeout is not an actor and a restart is not an actor, and writing `system` would invent one — the same reason `actorOf` refuses to invent a name. `resolveGateRow` refuses an actor handed in alongside a non-human resolution, so a future path that forgets still cannot produce the lie.

A device is named with its own id: **`Pixel 9 · aa00bb`**. Not decoration — `issueDevice` stores an unlabelled phone as `"A device"`, so every phone that skipped the field collides with every other, and *"A device approved rm -rf build"* answers the question worse than the address it replaced. The id is part of the stored string rather than resolved when the log is read, because forgetting a phone must not erase who used it; a trail that turns into unresolvable ids the moment you revoke a device is exactly backwards.

### The reader: Activity now reads both records

The action log holds what a **person asked for**. The gates table holds the fate of **every held tool call** — and those are not the same set. A request the timeout allowed, or one a restart found already expired, changed what an agent did and appears in no action row at all, because nobody made a request for it. An audit trail with a hole in it is worse than none (you stop looking for the missing line), and "the outcomes nobody chose" is the hole most worth closing, since those are the ones nobody remembers.

Where the two overlap the gate record wins — same press, told better: the actor is on the row, the summary is not clipped to share 120 characters with the tool name, and the reason is there. A gate press that **failed** is kept, because it is an attempt rather than an outcome and the gates table only ever holds the press that won.

Settings ▸ Activity, against a seeded server:

```
·  approved Bash · rm -rf node_modules && bun install                              2m
·  staged agentglass server/src/db.ts                                              3m
·  started a chat in agentglass · opus                       Pixel 9 · aa00bb ·    9m
✕  pushed agentglass                                                              12m
   rejected — remote has commits you do not
·  denied Bash · psql -c 'drop table users'                  iPhone · 3f9c21 ·    25m
   “not against prod — use the staging url”
✕  denied Write · /etc/nginx/sites-enabled/default           iPhone · 3f9c21 ·    32m
   already allowed by the timeout — this answer arrived too late
⏱  allowed Write · /etc/nginx/sites-enabled/default                               33m
   nobody answered before the timeout
⏱  allowed Bash · git push --force origin main                                    47m
   the window closed while the server was down — nobody saw this
```

Those two adjacent rows are the story worth being able to read: somebody tried to deny a write from their phone, and the clock had allowed it a minute earlier. An amber `⏱` as well as a different verb, because *"approved"* for a call somebody read and *"allowed"* for one that expired while they were at lunch are opposite facts about whether anybody looked, and in a list of past-tense verbs they are one glance apart.

### Two things found on the way, both on the surface this is for

**The phone said "Allowed — the agent is moving again" about agents that were not moving.** A press that loses the race comes back **200** with `ok: false` — not an exception, so the `try/catch` around the call never saw it, and the queue item was dropped with a green toast. On the one surface built for answering gates, that is the worst sentence available: confidently wrong about the exact thing somebody opened the app to find out. It now reads the response and repeats what actually won.

**`/gate/decide` had no words to repeat.** It returned a bare `{ ok: false }`, so a lost press left a `✕` in the log with nothing next to it, one row above a gate line saying the opposite. It now says which — `already allowed by the timeout — this answer arrived too late`, or that the id is not one this server is holding. `api.gateDecide` was typed `any`, which is how every caller came to read "it resolved" as "it worked"; it is typed now.

Also: the reason a person **typed** is shown, and the paragraph written for the model is not. An empty reason is backfilled with three lines aimed at an agent that has just been stopped, so quoting the stored reason back would be boilerplate on every row, hiding the one row where somebody explained themselves. `typedReason` compares against the real `defaultReason` rather than a copy of its text, so the two cannot drift into a history quoting a default it stopped recognising.

## How was it tested?

- **1361 server tests, 915 web tests**, all passing. `bunx tsc --noEmit` clean in both trees; `bun run build` succeeds.
- **40 mutations, all red.** Among them: the device reduced back to its address; the id dropped so two phones collide; the machine token given an invented name; the column never written; a timeout allowed to carry an actor; `decideGate` recording a human decision as the clock's; the row's `AND decision IS NULL` removed so a late answer overwrites the one the agent was actually given; gate presses shown twice; the *failed* press dropped in the merge; the gates table left out so timeouts vanish; a timeout credited to this machine; the pane reading `decided_by` itself instead of through the rule; the phone's `if (!r.ok)` removed. None survived.
- **`server/test/gate-actor-route.test.ts` drives a real server with a real paired device** — credential minted into the same store the server reads, then a held tool call answered over HTTP. The gap being closed here is plumbing: the route has to know which caller presented which credential and hand one answer to both writers, and a unit test of `actorOf` passes just as happily when the route never calls it. The gate nobody decides is in there for the same reason — it is the outcome with no request behind it, so it is the one an audit trail loses first.
- **Rendered and inspected** against a seeded server, which is how the bare-`✕` gap was found at all: it is visible in a list and invisible in an assertion. The block above is that run.
- **`scripts/phone-audit.ts`: 115/115** against a live server, since this touches the companion's decide path.

Two notes on judgement calls, in case they are useful later:

- The re-read after a failed `decideGate` was written, then **removed**. `getGate` and `decideGate` are adjacent *synchronous* statements, so the expiry timer cannot interleave and no mutation could show the guard working — which is the definition of a guard worth deleting. A comment marks the condition under which that stops being true.
- The desktop's `Alerts` still swallows a failed press (`.catch(() => {})` after an optimistic forget). It is the same class of bug, but the desktop already surfaces auto-resolved gates in that panel within 30 minutes and has no imperative toast API outside the notch, so fixing it properly is a separate change rather than a line snuck into this one.