### PR TITLE
One comparable number instead of four kinds of token

### DIFF
--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -16,7 +16,7 @@ import type {
   UsageDay,
 } from "../../shared/types.ts";
 import type { NormalizedEvent } from "./ingest.ts";
-import { costUsd, modelLabel, hasPrice } from "./pricing.ts";
+import { costUsd, modelLabel, hasPrice, equivalentTokens } from "./pricing.ts";
 import { providerOf as sharedProviderOf, UNKNOWN as UNKNOWN_MODEL } from "../../shared/models.ts";
 import { workspaceRoot, scopeRoots, isWithin } from "./config.ts";
 
@@ -819,16 +819,39 @@ const eventByExternalId = db.query<any, [string, string, string]>(
 );
 const sessionById = db.query<Record<string, unknown>, [string]>(`SELECT * FROM sessions WHERE session_id = ?`);
 
+/**
+ * The one place an `events` row becomes a `WatchEvent`, which is why the
+ * weighted token figure is attached here.
+ *
+ * The client folds these rows into fleet cards itself and has no price table —
+ * that is deliberate, and it is exactly why `AgentCard.tokens` could only ever
+ * be `input + output`. Carrying the weighted figure on the event is the same
+ * trick `cost_usd` already uses: the arithmetic that needs prices happens where
+ * the prices are.
+ */
 function parseEventRow(r: any): WatchEvent {
   return {
     ...r,
+    equiv_tokens: equivalentTokens(r, r.model_name),
     payload: safeJson(r.payload),
   } as WatchEvent;
 }
 
+/**
+ * Every `SessionRollup` the app produces comes through here — the list, the
+ * socket frame, the fleet's roll-up lookup — which is why the one comparable
+ * token figure is added here rather than at three call sites that would drift.
+ *
+ * It is derived rather than stored. `equiv_tokens` is a pure function of the
+ * four columns and the model, all of which are on the row already, so it is
+ * exact for history written before the idea existed — no column, no migration,
+ * and no backfill that could be interrupted halfway.
+ */
 function parseSessionRow(r: Record<string, unknown>): SessionRollup {
   const { pricing_baseline_usd: _internal, ...session } = r;
-  return session as unknown as SessionRollup;
+  const s = session as unknown as SessionRollup;
+  s.equiv_tokens = equivalentTokens(s, s.model_name);
+  return s;
 }
 
 function safeJson(s: string): Record<string, unknown> {
@@ -1762,7 +1785,7 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
     const e = modelFold.get(label) ?? {
       model_name: label,
       input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0,
-      cost_usd: 0, sessions: 0, unpriced: false,
+      equiv_tokens: 0, cost_usd: 0, sessions: 0, unpriced: false,
     };
     // Any contributing id without a rate makes the whole row's cost partly a
     // fallback — the honest reading, since the row is one number.
@@ -1771,10 +1794,31 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
     e.output_tokens += r.output_tokens ?? 0;
     e.cache_creation_tokens += r.cache_creation_tokens ?? 0;
     e.cache_read_tokens += r.cache_read_tokens ?? 0;
+    /*
+     * Weighted here, inside the loop, against the RAW id.
+     *
+     * Two ids can fold into one label and be priced differently — that is the
+     * whole reason the fold exists — so weighting the folded row would apply
+     * one model's ratios to another's tokens. Per raw id and then summed is
+     * exact, and keeps the identity that makes this number worth leading with:
+     * equivalent tokens times the base input rate is the cost.
+     */
+    e.equiv_tokens = (e.equiv_tokens ?? 0) + equivalentTokens(r, r.model_name);
     e.cost_usd += r.cost_usd ?? 0;
     modelFold.set(label, e);
   }
   for (const [label, e] of modelFold) e.sessions = sessionsByLabel.get(label)?.size ?? 0;
+  /*
+   * The window's one comparable number, summed from the same rows the
+   * breakdown is built from.
+   *
+   * Deliberately not a separate query. The headline and the legend under it are
+   * the two figures somebody checks against each other, and computing them from
+   * two SQL statements is how they come to disagree — `modelRows` has no
+   * `model_name IS NOT NULL` filter, so this covers events with no model too,
+   * which fall to the fallback rate exactly as their cost already does.
+   */
+  const equivTotal = [...modelFold.values()].reduce((n, e) => n + (e.equiv_tokens ?? 0), 0);
   // Ordered on the way out: the query has no ORDER BY, and the panel renders
   // the array in the order it arrives, so without this the donut's slices
   // reshuffle between refreshes for no reason the viewer can see.
@@ -1821,18 +1865,49 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
   const top_skills: SkillUsage[] = skillUsageDetail(since, 12, provider).slice(0, 20);
 
   // Per-app rollup within the window.
-  const by_app: AppUsage[] = db
-    .query<AppUsage, any[]>(
-      `SELECT source_app,
+  /*
+   * Grouped by app AND model, then folded.
+   *
+   * `tokens` used to be `SUM(input_tokens + output_tokens)`, which is not a
+   * quantity: it adds a token that costs five to a token that costs a tenth and
+   * drops the cache classes entirely. Weighting needs the model, and the model
+   * is not in a group keyed on the app alone — so the group carries it and the
+   * fold puts the apps back together. The extra rows are apps × models, which
+   * is single digits times single digits.
+   */
+  const appRows = db
+    .query<any, any[]>(
+      `SELECT source_app, model_name,
               COUNT(*) AS events,
-              COUNT(DISTINCT session_id) AS sessions,
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) AS tool_calls,
               SUM(cost_usd) AS cost_usd,
-              SUM(input_tokens + output_tokens) AS tokens
+              SUM(input_tokens) AS input_tokens,
+              SUM(output_tokens) AS output_tokens,
+              SUM(cache_creation_tokens) AS cache_creation_tokens,
+              SUM(cache_read_tokens) AS cache_read_tokens
        FROM events WHERE timestamp >= ?${pf}
-       GROUP BY source_app ORDER BY cost_usd DESC, events DESC`
+       GROUP BY source_app, model_name`
     )
     .all(...A);
+  // `sessions` is a COUNT(DISTINCT), which does not survive a fold: a session
+  // that used two models would be counted once per model and twice in the sum.
+  const appSessions = db
+    .query<{ source_app: string; sessions: number }, any[]>(
+      `SELECT source_app, COUNT(DISTINCT session_id) AS sessions
+       FROM events WHERE timestamp >= ?${pf} GROUP BY source_app`
+    )
+    .all(...A);
+  const appFold = new Map<string, AppUsage>();
+  for (const r of appRows) {
+    const e = appFold.get(r.source_app) ?? { source_app: r.source_app, events: 0, sessions: 0, tool_calls: 0, cost_usd: 0, tokens: 0 };
+    e.events += r.events ?? 0;
+    e.tool_calls += r.tool_calls ?? 0;
+    e.cost_usd += r.cost_usd ?? 0;
+    e.tokens += equivalentTokens(r, r.model_name);
+    appFold.set(r.source_app, e);
+  }
+  for (const r of appSessions) { const e = appFold.get(r.source_app); if (e) e.sessions = r.sessions ?? 0; }
+  const by_app: AppUsage[] = [...appFold.values()].sort((a, b) => b.cost_usd - a.cost_usd || b.events - a.events);
 
   // Event-type mix within the window.
   const by_type: TypeCount[] = db
@@ -1861,7 +1936,11 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
   }
   const tlRows = db
     .query<any, any[]>(
-      `SELECT timestamp, is_error, cost_usd, input_tokens, output_tokens FROM events WHERE timestamp >= ?${pf}`
+      // model_name and both cache columns come along so the bucket's `tokens`
+      // can be weighted per row — see the fold below and equivalentTokens().
+      `SELECT timestamp, is_error, cost_usd, model_name,
+              input_tokens, output_tokens, cache_creation_tokens, cache_read_tokens
+         FROM events WHERE timestamp >= ?${pf}`
     )
     .all(...A);
   /**
@@ -1904,7 +1983,7 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
       b.events++;
       b.errors += r.is_error;
       b.cost_usd += r.cost_usd ?? 0;
-      b.tokens += (r.input_tokens ?? 0) + (r.output_tokens ?? 0);
+      b.tokens += equivalentTokens(r, r.model_name);
     }
     heatmap[cellOf(r.timestamp)]++;
   }
@@ -1921,6 +2000,7 @@ function computeStatsSummary(windowMs: number, provider?: string, tz?: string): 
       output_tokens: tokTotals.output_tokens ?? 0,
       cache_creation_tokens: tokTotals.cache_creation_tokens ?? 0,
       cache_read_tokens: tokTotals.cache_read_tokens ?? 0,
+      equiv_tokens: equivTotal,
     },
     by_model,
     tool_latency,
@@ -2109,7 +2189,12 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
             COUNT(*) events,
             SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) tools,
             SUM(is_error) errors, SUM(cost_usd) cost_usd,
-            SUM(input_tokens) input_tokens, SUM(output_tokens) output_tokens
+            SUM(input_tokens) input_tokens, SUM(output_tokens) output_tokens,
+            -- Selected so the session's tokens can be weighted. Their absence
+            -- is why this pane's "Tokens" stat was input+output: not a
+            -- decision, just the two columns that happened to be here.
+            SUM(cache_creation_tokens) cache_creation_tokens,
+            SUM(cache_read_tokens) cache_read_tokens
      FROM events WHERE session_id = ?`).get(sessionId);
   if (!agg || !agg.events) return null;
 
@@ -2281,6 +2366,7 @@ export function getSession(sessionId: string): import("../../shared/types.ts").S
     cost_usd: agg.cost_usd ?? 0,
     input_tokens: agg.input_tokens ?? 0,
     output_tokens: agg.output_tokens ?? 0,
+    equiv_tokens: equivalentTokens(agg, agg.model_name),
     summary,
     tool_mix: toolMix,
     subagents: subRows.map((s) => ({ agent_id: s.agent_id, agent_type: s.agent_type || "subagent", events: s.n })),

--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -3,6 +3,7 @@
 // Computed from the full event history (better than the live buffer for loops).
 import type { Insight } from "../../shared/types.ts";
 import { db, scopeClause } from "./db.ts";
+import { equivalentTokens } from "./pricing.ts";
 import { budgetStatus, budgetScopeLabel, periodLabel } from "./budget.ts";
 
 const key = (app: string, sid: string) => `${app}:${sid.slice(0, 8)}`;
@@ -121,18 +122,34 @@ export function getInsights(): Insight[] {
   }
 
   // 5) Spend velocity — overall $/hr over the last hour (context, info-level).
-  const burn = db
-    .query<{ cost: number; toks: number }, any[]>(
-      `SELECT SUM(cost_usd) cost, SUM(input_tokens + output_tokens) toks FROM events WHERE timestamp > ?${sc}`
+  /*
+   * Grouped by model so the token figure can be weighted.
+   *
+   * `SUM(input_tokens + output_tokens)` is not a quantity — it adds a token
+   * that costs five to one that costs a tenth and drops the cache classes — and
+   * this string sits in the same list as the headline, so an unweighted number
+   * here reads as the headline disagreeing with itself.
+   */
+  const burnRows = db
+    .query<{ model_name: string | null; cost: number; input_tokens: number; output_tokens: number;
+             cache_creation_tokens: number; cache_read_tokens: number }, any[]>(
+      `SELECT model_name, SUM(cost_usd) cost,
+              SUM(input_tokens) input_tokens, SUM(output_tokens) output_tokens,
+              SUM(cache_creation_tokens) cache_creation_tokens, SUM(cache_read_tokens) cache_read_tokens
+         FROM events WHERE timestamp > ?${sc} GROUP BY model_name`
     )
-    .get(now - 60 * 60_000, ...sa);
+    .all(now - 60 * 60_000, ...sa);
+  const burn = burnRows.reduce(
+    (a, r) => ({ cost: a.cost + (r.cost ?? 0), toks: a.toks + equivalentTokens(r, r.model_name) }),
+    { cost: 0, toks: 0 },
+  );
   if (burn && burn.cost > 1) {
     out.push({
       id: "burn:hourly",
       severity: burn.cost >= 60 ? "warn" : "info",
       kind: "burn",
       title: `Spend velocity · $${burn.cost.toFixed(2)}/hr`,
-      detail: `${(burn.toks / 1000).toFixed(0)}k tokens in the last hour`,
+      detail: `${(burn.toks / 1000).toFixed(0)}k eq tokens in the last hour`,
       session: null,
       ts: now,
     });

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -185,6 +185,68 @@ export function costUsd(usage: TokenUsage, modelName: string | null | undefined)
 }
 
 /**
+ * What one token of each class costs, in uncached input tokens.
+ *
+ * A token is not a token. On Opus an output token costs five uncached input
+ * tokens, a cache write costs 1.25 and a cache read costs a tenth — a spread of
+ * fifty to one inside a single number the UI has been calling "tokens". Adding
+ * them up produces a figure that is not comparable between two sessions, or
+ * even between two turns of one session, and the direction of the error is not
+ * predictable: a cache-heavy session looks enormous and is cheap.
+ *
+ * Weighting each class by its own price and expressing the result in the
+ * cheapest one gives a number that *is* comparable, and that multiplies by a
+ * single rate to give money — which is what makes it more useful than cost
+ * alone, since cost moves whenever a provider changes its prices and this does
+ * not.
+ *
+ * Input is 1 by definition. Everything else is a ratio, so the unit survives a
+ * price table where every rate is doubled.
+ */
+export interface TokenWeights {
+  output: number;
+  cache_write: number;
+  cache_read: number;
+}
+
+/**
+ * The ratios for one model.
+ *
+ * A model with a free or absent input rate has no base to express anything in:
+ * dividing by it gives Infinity, and a headline of Infinity is worse than the
+ * raw sum it replaced. Those fall back to weights of 1, which is the same as
+ * counting tokens the old way and is the honest answer when there is no price
+ * to weight by — the caller can tell from `hasPrice` that the number is
+ * unweighted.
+ */
+export function weightsFromPrice(p: Omit<ModelPrice, "match" | "label" | "exact">): TokenWeights {
+  if (!(p.input > 0)) return { output: 1, cache_write: 1, cache_read: 1 };
+  return { output: p.output / p.input, cache_write: p.cache_write / p.input, cache_read: p.cache_read / p.input };
+}
+
+export function weightsFor(modelName: string | null | undefined): TokenWeights {
+  return weightsFromPrice(priceFor(modelName) ?? DEFAULT_PRICE);
+}
+
+/**
+ * One comparable number for a usage row.
+ *
+ * `equivalentTokens(u, m) * priceFor(m).input / 1e6` is exactly `costUsd(u, m)`
+ * when the model is priced — that identity is the point, and it is what a test
+ * pins. Rounded, because a fractional token is not a thing and every consumer
+ * formats it as a count.
+ */
+export function equivalentTokens(usage: TokenUsage, modelName: string | null | undefined): number {
+  const w = weightsFor(modelName);
+  return Math.round(
+    (usage.input_tokens ?? 0) +
+    (usage.output_tokens ?? 0) * w.output +
+    (usage.cache_creation_tokens ?? 0) * w.cache_write +
+    (usage.cache_read_tokens ?? 0) * w.cache_read
+  );
+}
+
+/**
  * What to call a model on screen.
  *
  * This used to return `priceFor(m)?.label`, which welded display naming to

--- a/server/test/equivalent-tokens.test.ts
+++ b/server/test/equivalent-tokens.test.ts
@@ -1,0 +1,143 @@
+/*
+ * One comparable number instead of four kinds of token — #298.
+ *
+ * A token is not a token. On Opus an output token costs five uncached input
+ * tokens, a cache write costs 1.25 and a cache read costs a tenth — a spread of
+ * fifty to one inside a single figure the UI has been calling "tokens". Adding
+ * them up gives a number that is not comparable between two sessions, and the
+ * error does not even point one way: a cache-heavy session looks enormous and
+ * is cheap.
+ *
+ * The assertion that matters is the identity — weighted tokens times the base
+ * input rate is exactly the cost — and it is asserted over the whole price
+ * table rather than over the two models somebody thought of, because a row
+ * added next month is where this would quietly stop being true.
+ */
+import { describe, expect, test } from "bun:test";
+import { costUsd, equivalentTokens, weightsFor, weightsFromPrice, priceFor, PRICE_TABLE, DEFAULT_PRICE } from "../src/pricing.ts";
+
+const usage = { input_tokens: 10_000, output_tokens: 2_000, cache_creation_tokens: 5_000, cache_read_tokens: 400_000 };
+
+describe("the weights", () => {
+  test("input is the unit, so it does not appear", () => {
+    // Everything is expressed *in* uncached input tokens. A weight for input
+    // would be 1 by construction and an invitation to set it to something else.
+    expect(Object.keys(weightsFor("claude-opus-4.5")).sort()).toEqual(["cache_read", "cache_write", "output"]);
+  });
+
+  test("are ratios, so they survive a table where every rate is doubled", () => {
+    // The point of the unit: it says something about the *shape* of the usage,
+    // not about what a provider is charging this week. Cost moves with prices;
+    // this does not.
+    const opus = weightsFor("claude-opus-4.5");
+    expect(opus.output).toBe(5);        // $25 output over $5 input
+    expect(opus.cache_write).toBe(1.25);
+    expect(opus.cache_read).toBe(0.1);
+  });
+
+  test("and a cache read really is a tenth, not a tenth of a percent", () => {
+    // The whole reason the raw sum misleads: 400k cache reads are 40k
+    // input-equivalents, so a session that reads a big context every turn is
+    // not the monster the token count makes it look.
+    expect(equivalentTokens({ cache_read_tokens: 400_000 }, "claude-opus-4.5")).toBe(40_000);
+  });
+
+  test("a model with no rate at all is weighted like the fallback, not like nothing", () => {
+    // `costUsd` already falls back to DEFAULT_PRICE for an unknown model, and
+    // the two must agree or the identity below breaks for exactly the rows
+    // where somebody is most likely to be surprised.
+    expect(priceFor("some-model-nobody-has-heard-of")).toBeNull();
+    expect(weightsFor("some-model-nobody-has-heard-of"))
+      .toEqual({ output: DEFAULT_PRICE.output / DEFAULT_PRICE.input,
+                 cache_write: DEFAULT_PRICE.cache_write / DEFAULT_PRICE.input,
+                 cache_read: DEFAULT_PRICE.cache_read / DEFAULT_PRICE.input });
+  });
+});
+
+describe("the identity, over the whole table", () => {
+  test("weighted tokens times the base input rate is the cost", () => {
+    /*
+     * What makes the number worth leading with: it converts to money with one
+     * multiplication, so it is not a second, differently-wrong figure sitting
+     * beside the cost. Asserted for every priced row, because a row added next
+     * month with a rate structure nobody anticipated is exactly where this
+     * would quietly stop holding.
+     */
+    for (const p of PRICE_TABLE) {
+      const model = p.exact?.[0] ?? p.match[0]!;
+      if (!(p.input > 0)) continue; // a free model has no base to express anything in
+      const equiv = equivalentTokens(usage, model);
+      const viaWeights = (equiv * p.input) / 1_000_000;
+      const direct = costUsd(usage, model);
+      // Rounded to whole tokens, so the two agree to within one token's worth
+      // of the base rate rather than exactly.
+      expect(Math.abs(viaWeights - direct), `${p.label} (${model})`).toBeLessThan(p.input / 1_000_000);
+    }
+  });
+
+  test("and it holds for a model the table has never heard of", () => {
+    const equiv = equivalentTokens(usage, "who-knows");
+    expect(Math.abs((equiv * DEFAULT_PRICE.input) / 1_000_000 - costUsd(usage, "who-knows")))
+      .toBeLessThan(DEFAULT_PRICE.input / 1_000_000);
+  });
+});
+
+describe("what it refuses to divide by", () => {
+  test("a model whose input is free gets weights of one, not Infinity", () => {
+    /*
+     * There is no base to express anything in when the base is free. Dividing
+     * anyway gives Infinity, and `fmtTokens(Infinity)` on the headline is worse
+     * than the raw sum this replaces. Falling back to 1 makes the figure the
+     * plain token count, which is the honest answer when there is no price to
+     * weight by.
+     *
+     * Not hypothetical: AGENTGLASS_PRICING takes a whole table from the user,
+     * and a local model behind an OpenAI-shaped endpoint costs nothing to run.
+     */
+    expect(weightsFromPrice({ input: 0, output: 0, cache_write: 0, cache_read: 0 }))
+      .toEqual({ output: 1, cache_write: 1, cache_read: 1 });
+    // …and a hand-written table with a missing or nonsense rate lands here too,
+    // rather than producing NaN that formats as "NaN tokens".
+    for (const bad of [undefined, null, NaN, -3] as unknown as number[]) {
+      const w = weightsFromPrice({ input: bad, output: 15, cache_write: 3.75, cache_read: 0.3 });
+      expect(Number.isFinite(w.output), String(bad)).toBe(true);
+    }
+  });
+
+  test("a zero rate for one class is kept, because only the base is special", () => {
+    // gpt-5.2-pro charges nothing for cache writes or reads. Those weights are
+    // genuinely zero and must not be swept up by the free-input fallback.
+    const w = weightsFor("gpt-5.2-pro");
+    expect(w.cache_write).toBe(0);
+    expect(w.cache_read).toBe(0);
+    expect(w.output).toBeGreaterThan(1);
+  });
+
+  test("so a million free cache writes weigh nothing", () => {
+    // OpenAI did not charge for cache creation before the 5.6 family. Reading
+    // that zero as "unknown, use 1" would invent a million tokens of spend on
+    // every GPT-5.x session in the fleet.
+    expect(equivalentTokens({ cache_creation_tokens: 1_000_000 }, "gpt-5.4")).toBe(0);
+  });
+
+  test("an empty usage is zero, not NaN", () => {
+    expect(equivalentTokens({}, "claude-opus-4.5")).toBe(0);
+    expect(equivalentTokens({}, null)).toBe(0);
+  });
+});
+
+describe("what it is not", () => {
+  test("it is not the raw sum, and the difference is the whole point", () => {
+    // If these ever agree for a cache-heavy usage, the weighting has been
+    // removed and nothing else would notice.
+    const raw = usage.input_tokens + usage.output_tokens + usage.cache_creation_tokens + usage.cache_read_tokens;
+    expect(equivalentTokens(usage, "claude-opus-4.5")).toBeLessThan(raw / 2);
+  });
+
+  test("and it is not input+output, which is what the UI showed instead", () => {
+    // The old headline dropped cache entirely. On a session that reads a large
+    // context every turn, that is most of the money.
+    expect(equivalentTokens(usage, "claude-opus-4.5"))
+      .toBeGreaterThan(usage.input_tokens + usage.output_tokens);
+  });
+});

--- a/server/test/fixtures/eqtok-probe.ts
+++ b/server/test/fixtures/eqtok-probe.ts
@@ -1,0 +1,98 @@
+/**
+ * Insert a few turns and print what every stats fold made of them.
+ *
+ * A child process, because `db.ts` is a singleton and `bun test` shares one
+ * process: which database it talks to, and which workspace scope it filters by,
+ * are decided by whichever suite imported it first. The first version of the
+ * test that uses this ran in-process and found zero of its own rows in a full
+ * run — an earlier suite had left a workspace scope set, and events with no
+ * project path are outside every scoped query.
+ *
+ * The three rows are each chosen to make one specific mistake visible:
+ *
+ *  - two models under ONE session and ONE app, so a per-app session count that
+ *    got summed across the model fold reads 2 where the truth is 1;
+ *  - `gpt-5.6`, whose display label is "GPT-5" and whose rates are NOT the
+ *    GPT-5 row's, so weighting a folded row by its label rather than by the raw
+ *    ids that fed it produces a different number;
+ *  - a large cache read in every turn, which is the class the old figure
+ *    dropped and the one that dominates a real session.
+ *
+ * Argv: a directory to keep the scratch database in.
+ */
+export {};
+
+const dir = process.argv[2]!;
+process.env.AGENTGLASS_DB = `${dir}/eq.db`;
+process.env.XDG_CONFIG_HOME = dir;
+// Deliberately no AGENTGLASS_ROOT: it sets a workspace scope, and a scoped
+// query drops every event with no project path — which is all of these. That
+// is the same filter that made the in-process version of this test find
+// nothing at all, so leaving it out here is the point rather than an oversight.
+
+const db = await import("../../src/db.ts");
+const pricing = await import("../../src/pricing.ts");
+
+const TURN = { input_tokens: 1_000, output_tokens: 500, cache_creation_tokens: 2_000, cache_read_tokens: 200_000 };
+
+/** [app, session, raw model id] */
+const ROWS: [string, string, string][] = [
+  ["eqtok-app-alpha", "eqtok-session-multi", "claude-opus-4.5"],
+  ["eqtok-app-alpha", "eqtok-session-multi", "claude-haiku-4.5"],
+  ["eqtok-app-beta", "eqtok-session-gpt", "gpt-5.6"],
+];
+
+const now = Date.now();
+ROWS.forEach(([app, session, model], i) =>
+  db.insertEvent({
+    source_app: app, session_id: session, event_id: null, hook_event_type: "Stop",
+    tool_name: null, tool_use_id: null, agent_id: null, agent_type: null,
+    model_name: model, is_error: 0, error_text: null,
+    usage: { ...TURN }, usage_is_cumulative: false,
+    timestamp: now - (i + 1) * 1000, payload: {},
+  } as any));
+
+/**
+ * What each folded row SHOULD hold: every contributing raw id weighted by its
+ * own rates, summed. Computed here from the ids actually inserted, so the test
+ * asserts an exact number rather than a range — a range is what let "weighted
+ * by the label" survive the first time.
+ */
+const expectBy = (pick: (r: [string, string, string]) => string): Record<string, number> => {
+  const m: Record<string, number> = {};
+  for (const r of ROWS) m[pick(r)] = (m[pick(r)] ?? 0) + pricing.equivalentTokens(TURN, r[2]);
+  return m;
+};
+
+const s = db.statsSummary(24 * 60 * 60_000);
+console.log(JSON.stringify({
+  turn: TURN,
+  totals: s.totals,
+  expected_total: ROWS.reduce((n, r) => n + pricing.equivalentTokens(TURN, r[2]), 0),
+  expected_by_label: expectBy((r) => pricing.modelLabel(r[2])),
+  expected_by_app: expectBy((r) => r[0]),
+  by_model: s.by_model.map((m) => ({
+    model_name: m.model_name, equiv_tokens: m.equiv_tokens, cost_usd: m.cost_usd,
+  })),
+  by_app: s.by_app,
+  timeline_tokens: s.timeline.reduce((n, b) => n + b.tokens, 0),
+  sessions: db.getSessions(50).map((r) => ({
+    session_id: r.session_id, model_name: r.model_name, equiv_tokens: r.equiv_tokens,
+    input_tokens: r.input_tokens, output_tokens: r.output_tokens,
+    expected: pricing.equivalentTokens(r, r.model_name),
+  })),
+  events: db.getRecent(50).map((e) => ({
+    id: e.id, model_name: e.model_name, equiv_tokens: e.equiv_tokens,
+    expected: pricing.equivalentTokens(e, e.model_name),
+  })),
+  detail: (() => {
+    // The GPT session, whose single turn has a real cache write — so a detail
+    // query that stopped selecting the cache columns is a different number
+    // rather than merely a smaller one.
+    const d = db.getSession("eqtok-session-gpt");
+    return d && {
+      equiv_tokens: d.equiv_tokens, input_tokens: d.input_tokens, output_tokens: d.output_tokens,
+      expected: pricing.equivalentTokens(TURN, "gpt-5.6"),
+    };
+  })(),
+}));

--- a/server/test/stats-equivalent-tokens.test.ts
+++ b/server/test/stats-equivalent-tokens.test.ts
@@ -1,0 +1,163 @@
+/*
+ * The weighted figure, where the panes actually read it — #298.
+ *
+ * `equivalentTokens` being right is one thing; every producer in db.ts calling
+ * it is the thing that was missing, and a unit test of the helper passes just
+ * as happily when no query calls it.
+ *
+ * Two kinds of assertion here, and both are needed:
+ *
+ *  - *agreement*. The headline, the legend beneath it, the per-app table and
+ *    the timeline are four numbers a reader checks against each other, built by
+ *    four separate folds over one set of events. Four folds is how a dashboard
+ *    comes to contradict itself.
+ *  - *exact value*. Agreement alone is satisfied by four folds that are wrong
+ *    the same way — which is exactly what happens when a folded row is weighted
+ *    by its display label instead of by the raw ids that fed it. So every fold
+ *    is compared against a number the fixture computed from those ids.
+ *
+ * Driven through a child process (test/fixtures/eqtok-probe.ts). `db.ts` is a
+ * singleton and `bun test` shares one process, so which database it talks to —
+ * and which workspace scope it filters by — is decided by whichever suite
+ * imported it first. An in-process version of this file found zero of its own
+ * rows in a full run while passing on its own.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { equivalentTokens, priceFor, modelLabel } from "../src/pricing.ts";
+
+type Row = Record<string, any>;
+let out: Row;
+let TURN: Row, RAW: number;
+
+const MODELS = ["claude-opus-4.5", "claude-haiku-4.5", "gpt-5.6"];
+/** input + output for one turn — what every pane used to show. */
+const IN_OUT = 1_500;
+
+beforeAll(() => {
+  const dir = mkdtempSync(join(tmpdir(), "agx-eqstats-"));
+  const p = Bun.spawnSync(["bun", "run", new URL("./fixtures/eqtok-probe.ts", import.meta.url).pathname, dir], {
+    // Named, never `...process.env`: this suite's own AGENTGLASS_DB and
+    // workspace scope are precisely what the child must not inherit.
+    env: { PATH: process.env.PATH ?? "", HOME: dir },
+    stdout: "pipe", stderr: "pipe",
+  });
+  const text = p.stdout.toString().trim();
+  if (p.exitCode !== 0 || !text) {
+    throw new Error(`the probe failed (${p.exitCode}): ${p.stderr.toString().slice(0, 600)}`);
+  }
+  out = JSON.parse(text.split("\n").at(-1)!);
+  TURN = out.turn;
+  RAW = TURN.input_tokens + TURN.output_tokens + TURN.cache_creation_tokens + TURN.cache_read_tokens;
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+describe("what a weighted row says that the old sum did not", () => {
+  test("a cache-heavy turn is a fraction of its raw token count", () => {
+    // 203,500 tokens on Opus is 26,000 input-equivalents: each of the 200k
+    // cache reads is a tenth of an input token. A session that re-reads a large
+    // context every turn — most of them — looked enormous and is cheap.
+    for (const m of MODELS) {
+      const eq = equivalentTokens(TURN, m);
+      expect(eq, m).toBeLessThan(RAW / 3);
+      // …and above input+output, which is what every pane used to show:
+      // dropping the cache classes is not conservative, it is simply wrong.
+      expect(eq, m).toBeGreaterThan(IN_OUT);
+    }
+  });
+});
+
+describe("every fold gets the same, right number", () => {
+  test("the headline", () => {
+    expect(out.totals.equiv_tokens).toBe(out.expected_total);
+    expect(out.totals.equiv_tokens).toBeGreaterThan(0);
+  });
+
+  test("the per-model legend, weighted by the raw ids rather than by the label", () => {
+    /*
+     * `gpt-5.6` is in the fixture for this test alone. Its display label is
+     * "GPT-5" and the GPT-5 price row is NOT its rate — cache writes are free
+     * there and cost 1.25x input on 5.6 — so a fold that weighted itself by the
+     * name it shows lands 1,500 equivalents short and still adds up perfectly
+     * against every other fold. Only an exact expectation catches that.
+     */
+    const got = Object.fromEntries(out.by_model.map((m: Row) => [m.model_name, m.equiv_tokens]));
+    expect(got).toEqual(out.expected_by_label);
+    // Belt and braces on the fixture itself: if a table change made those two
+    // price the same, this test would go on passing while proving nothing.
+    expect(equivalentTokens(TURN, "gpt-5.6"), "the fixture model no longer distinguishes label from rate")
+      .not.toBe(equivalentTokens(TURN, modelLabel("gpt-5.6")));
+  });
+
+  test("the per-app table, which had to be regrouped to be weightable at all", () => {
+    // `by_app` was a GROUP BY on the app alone, which has no model in it. It
+    // groups by both and folds now — this catches a fold that drops or
+    // double-counts a group.
+    const got = Object.fromEntries(out.by_app.map((a: Row) => [a.source_app, a.tokens]));
+    expect(got).toEqual(out.expected_by_app);
+  });
+
+  test("and the timeline buckets", () => {
+    expect(out.timeline_tokens).toBe(out.expected_total);
+  });
+});
+
+describe("the per-app session count", () => {
+  test("survived the regroup", () => {
+    /*
+     * `sessions` is a COUNT(DISTINCT), which does not survive a fold. One app
+     * in the fixture ran two models inside a *single* session, so a count
+     * accumulated across the model rows reads 2 — and a table that doubles its
+     * session count for anybody who switched model mid-run is wrong in a way
+     * that looks entirely plausible.
+     */
+    expect(out.by_app).toHaveLength(2);
+    for (const a of out.by_app as Row[]) expect(Number(a.sessions), a.source_app).toBe(1);
+  });
+});
+
+describe("the shapes the panes read one at a time", () => {
+  test("a session carries its own weighted figure", () => {
+    // Every SessionRollup in the app comes through one parse, so this covers
+    // the list, the socket frame and the fleet's roll-up lookup at once.
+    expect(out.sessions).toHaveLength(2);
+    for (const s of out.sessions as Row[]) {
+      expect(s.equiv_tokens, s.session_id).toBe(s.expected);
+      expect(s.equiv_tokens, s.session_id).toBeGreaterThan(s.input_tokens + s.output_tokens);
+    }
+  });
+
+  test("and so does a single event, which is what the fleet folds", () => {
+    // The client has no price table and never will — this is the same trick
+    // `cost_usd` already uses, and it is what lets a fleet card show a number
+    // that means anything at all.
+    expect(out.events).toHaveLength(MODELS.length);
+    for (const e of out.events as Row[]) {
+      expect(e.equiv_tokens, String(e.id)).toBe(e.expected);
+      expect(e.equiv_tokens, String(e.id)).toBeGreaterThan(0);
+    }
+  });
+
+  test("and a session's detail pane, which never even had the cache columns", () => {
+    /*
+     * `SessionDetail` selected input and output and nothing else, which is why
+     * its "Tokens" stat was those two: not a decision, just what the query
+     * happened to return. Asserted as an exact number — "greater than
+     * input+output" stays true of the un-fixed query, since output alone
+     * outweighs input.
+     */
+    expect(out.detail).toBeTruthy();
+    expect(out.detail.equiv_tokens).toBe(out.detail.expected);
+    expect(out.detail.equiv_tokens).toBeGreaterThan(out.detail.input_tokens + out.detail.output_tokens);
+  });
+});
+
+describe("the price table backs all of it", () => {
+  test("every model used here is priced, so none of the above is a fallback", () => {
+    // If a rename made these unknown, every figure would quietly fall to
+    // DEFAULT_PRICE and the folds would still agree — against the wrong rate.
+    for (const m of MODELS) expect(priceFor(m), m).not.toBeNull();
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -55,6 +55,16 @@ export interface WatchEvent {
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  /**
+   * Every token class weighted by its own price and expressed in uncached input
+   * tokens — one comparable number in place of four kinds of token that differ
+   * by up to fifty times in what they cost.
+   *
+   * Derived on the server, where the price table lives, exactly as `cost_usd`
+   * already is. Optional because an older server does not send it: absent means
+   * unknown, and a reader must fall back to the raw classes rather than to 0.
+   */
+  equiv_tokens?: number;
   cost_usd: number;
   summary: string | null;
   timestamp: number; // ms
@@ -98,6 +108,9 @@ export interface SessionRollup {
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  /** Weighted tokens in uncached-input units — see WatchEvent.equiv_tokens.
+   *  Optional: absent means an older server, not zero. */
+  equiv_tokens?: number;
   cost_usd: number;
 }
 
@@ -114,6 +127,9 @@ export interface CostByModel {
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  /** Weighted tokens in uncached-input units — see WatchEvent.equiv_tokens.
+   *  Optional: absent means an older server, not zero. */
+  equiv_tokens?: number;
   cost_usd: number;
   sessions: number;
 }
@@ -170,6 +186,9 @@ export interface UsageDay {
   output_tokens: number;
   cache_creation_tokens: number;
   cache_read_tokens: number;
+  /** Weighted tokens in uncached-input units — see WatchEvent.equiv_tokens.
+   *  Optional: absent means an older server, not zero. */
+  equiv_tokens?: number;
   cost_usd: number;
   sessions: number;
   /** Mean tool duration, ms. */
@@ -257,6 +276,9 @@ export interface StatsSummary {
     output_tokens: number;
     cache_creation_tokens: number;
     cache_read_tokens: number;
+    /** Weighted tokens in uncached-input units — see WatchEvent.equiv_tokens.
+     *  Optional: absent means an older server, not zero. */
+    equiv_tokens?: number;
   };
   by_model: CostByModel[];
   tool_latency: ToolLatencyStat[];
@@ -447,6 +469,16 @@ export interface SessionDetail {
   cost_usd: number;
   input_tokens: number;
   output_tokens: number;
+  /**
+   * Weighted tokens in uncached-input units — see WatchEvent.equiv_tokens.
+   *
+   * The cache classes are not on this shape and never were, which is the whole
+   * reason this pane's "Tokens" stat was input+output: not a decision, just the
+   * two columns the query happened to select. They are summed in the query now
+   * and weighted into this one figure rather than added to the type, since four
+   * numbers here would only recreate the problem one field along.
+   */
+  equiv_tokens?: number;
   summary: string | null;
   tool_mix: { tool: string; n: number }[];
   subagents: { agent_id: string; agent_type: string; events: number }[];

--- a/web/src/components/CostByModel.tsx
+++ b/web/src/components/CostByModel.tsx
@@ -3,7 +3,7 @@ import { PieChart, Pie, Cell, ResponsiveContainer } from "recharts";
 import { motion } from "motion/react";
 import type { StatsSummary } from "../../../shared/types.ts";
 import { Panel } from "./Panel.tsx";
-import { fmtUsd, fmtTokens, modelColor } from "../lib/format.ts";
+import { fmtUsd, fmtEq, eqTitle, modelColor } from "../lib/format.ts";
 
 export const CostByModel = memo(function CostByModel({ stats }: { stats: StatsSummary | null }) {
   const models = (stats?.by_model ?? []).filter((m) => m.cost_usd > 0 || m.input_tokens > 0);
@@ -89,7 +89,9 @@ export const CostByModel = memo(function CostByModel({ stats }: { stats: StatsSu
                 )}
               </span>
               <span className="flex items-center gap-3 tabular-nums">
-                <span className="t-dim2">{fmtTokens(m.input_tokens + m.output_tokens)} tok</span>
+                <span className="t-dim2" title={eqTitle(m.equiv_tokens ?? m.input_tokens + m.output_tokens)}>
+                  {fmtEq(m.equiv_tokens ?? m.input_tokens + m.output_tokens)}
+                </span>
                 <span style={{ color: "var(--success)" }}>{fmtUsd(m.cost_usd)}</span>
               </span>
             </motion.div>

--- a/web/src/components/EventModal.tsx
+++ b/web/src/components/EventModal.tsx
@@ -2,7 +2,7 @@ import { motion, AnimatePresence } from "motion/react";
 import type { WatchEvent } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
 import { friendly } from "../lib/labels.ts";
-import { fmtTime, fmtMs, fmtUsd, fmtTokens, agentKey, typeColor } from "../lib/format.ts";
+import { fmtTime, fmtMs, fmtUsd, fmtTokens, fmtEq, eqTitle, agentKey, typeColor } from "../lib/format.ts";
 
 function Row({ k, v }: { k: string; v: React.ReactNode }) {
   return (
@@ -51,7 +51,13 @@ export function EventModal({ event, onClose }: { event: WatchEvent | null; onClo
                   <Row k="Model" v={event.model_name ?? "—"} />
                   <Row k="Duration" v={event.duration_ms != null ? fmtMs(event.duration_ms) : "—"} />
                   <Row k="Cost" v={event.cost_usd > 0 ? fmtUsd(event.cost_usd) : "—"} />
-                  <Row k="Tokens" v={event.input_tokens + event.output_tokens > 0 ? `${fmtTokens(event.input_tokens)} in · ${fmtTokens(event.output_tokens)} out` : "—"} />
+                  {/* All four classes, not two.
+                      The old row was `in · out` behind an `input + output > 0`
+                      guard, so an event that only read cache rendered as an em
+                      dash while carrying real tokens and real cost. This is the
+                      breakdown the one number outside is short for, so it shows
+                      every class that is non-zero. */}
+                  <Row k="Tokens" v={<TokenBreakdown e={event} />} />
                   <Row k="Session" v={event.session_id} />
                   <Row k="Error" v={event.is_error ? <span style={{ color: "var(--error)" }}>{event.error_text ?? "Yes"}</span> : "No"} />
                 </div>
@@ -67,5 +73,29 @@ export function EventModal({ event, onClose }: { event: WatchEvent | null; onClo
         )}
       </AnimatePresence>
     </Portal>
+  );
+}
+
+/**
+ * The breakdown, which is the point of being one click deep.
+ *
+ * The lists outside this modal show a single weighted number, because four
+ * numbers cannot be compared or ranked. Here there is room, and the four are
+ * what make a cache problem diagnosable — a session whose cache writes rival
+ * its reads is re-sending a context it should be hitting.
+ */
+function TokenBreakdown({ e }: { e: WatchEvent }) {
+  const parts: string[] = [];
+  if (e.input_tokens) parts.push(`${fmtTokens(e.input_tokens)} in`);
+  if (e.output_tokens) parts.push(`${fmtTokens(e.output_tokens)} out`);
+  if (e.cache_creation_tokens) parts.push(`${fmtTokens(e.cache_creation_tokens)} cache write`);
+  if (e.cache_read_tokens) parts.push(`${fmtTokens(e.cache_read_tokens)} cache read`);
+  if (!parts.length) return <>—</>;
+  const eq = e.equiv_tokens;
+  return (
+    <span title={eq == null ? undefined : eqTitle(eq)}>
+      {eq == null ? null : <span className="tabular-nums">{fmtEq(eq)} · </span>}
+      <span className="t-dim2">{parts.join(" · ")}</span>
+    </span>
   );
 }

--- a/web/src/components/Fleet.tsx
+++ b/web/src/components/Fleet.tsx
@@ -2,7 +2,7 @@ import { useMemo, useState } from "react";
 import { motion, AnimatePresence } from "motion/react";
 import type { AgentCard, AgentOutcome } from "../lib/derive.ts";
 import { Panel } from "./Panel.tsx";
-import { fmtUsd, fmtTokens, fmtAgo, modelLabelOf } from "../lib/format.ts";
+import { fmtUsd, fmtTokens, fmtEq, eqTitle, fmtAgo, modelLabelOf } from "../lib/format.ts";
 
 // "now ago" reads wrong — fmtAgo already returns "now" for the freshest events.
 const ago = (ts: number) => {
@@ -166,7 +166,7 @@ function SessionCard({ a, selected, onSelect }: { a: AgentCard; selected: boolea
       <div className="mt-1.5 flex items-center gap-3 text-[10px] t-dim2 tabular-nums">
         <span>{a.tools} tools</span>
         {a.errors > 0 && <span style={{ color: "var(--error)" }}>{a.errors} err</span>}
-        <span className="t-dim">{fmtTokens(a.tokens)} tok</span>
+        <span className="t-dim" title={eqTitle(a.tokens)}>{fmtEq(a.tokens)}</span>
         <span style={{ color: "var(--success)" }}>{fmtUsd(a.cost)}</span>
         <span className="ml-auto">{ago(a.lastSeen)}</span>
       </div>

--- a/web/src/components/Kpis.tsx
+++ b/web/src/components/Kpis.tsx
@@ -3,7 +3,7 @@ import { motion } from "motion/react";
 import type { StatsSummary } from "../../../shared/types.ts";
 import type { AgentCard } from "../lib/derive.ts";
 import { useTicker, fmtClock } from "../lib/motion.ts";
-import { fmtUsd, usdDigits } from "../lib/format.ts";
+import { fmtUsd, usdDigits, eqTitle } from "../lib/format.ts";
 import { HealthRing } from "./HealthRing.tsx";
 
 const enter = { initial: { opacity: 0, y: 12 }, animate: { opacity: 1, y: 0 } };
@@ -87,7 +87,22 @@ export function Kpis({
   // to the old field so a server that predates tool_errors still renders.
   const toolFailed = t?.tool_errors ?? failed;
   const cost = t?.cost_usd ?? 0;
-  const tokens = (t?.input_tokens ?? 0) + (t?.output_tokens ?? 0);
+  /*
+   * One comparable number, not four kinds of token.
+   *
+   * This was `input + output`: it dropped both cache classes, and added a token
+   * that costs five to one that costs a tenth. On a session that reads a large
+   * context every turn — which is most of them — the figure it produced was
+   * neither the work done nor the money spent, and two sessions could not be
+   * compared by it at all. Every class is weighted by its own price now and the
+   * result expressed in uncached input tokens, which is the unit that converts
+   * to money with a single rate.
+   *
+   * The fallback is the old sum rather than 0: `equiv_tokens` is absent on a
+   * server older than this, and a hero figure of zero next to real spend is a
+   * worse answer than an unweighted count.
+   */
+  const tokens = t?.equiv_tokens ?? (t?.input_tokens ?? 0) + (t?.output_tokens ?? 0);
   const cached = t?.cache_read_tokens ?? 0;
   const health = tools > 0 ? Math.max(0, Math.round((1 - toolFailed / Math.max(tools, 1)) * 100)) : 100;
   const spark = (stats?.timeline ?? []).slice(-24).map((b) => b.cost_usd);
@@ -122,8 +137,11 @@ export function Kpis({
                   minimumFractionDigits: usdDigits(cost), maximumFractionDigits: usdDigits(cost),
                 }} />}
           </div>
-          <div className="text-[11px] t-dim2 mt-1.5 tabular-nums">
-            <NumberFlow value={tokens} /> tokens · {(cached / 1000).toFixed(0)}k cached
+          {/* Spelled out here and abbreviated to `eq` everywhere else: this is
+              the most prominent token figure in the app, so it is where the
+              unit gets introduced rather than assumed. */}
+          <div className="text-[11px] t-dim2 mt-1.5 tabular-nums" title={eqTitle(tokens)}>
+            <NumberFlow value={tokens} /> input-equivalent tokens · {(cached / 1000).toFixed(0)}k cached
           </div>
         </div>
         <Spark values={spark} color="var(--success)" />

--- a/web/src/components/Radar.tsx
+++ b/web/src/components/Radar.tsx
@@ -1,7 +1,7 @@
 import { useEffect, useRef, useState } from "react";
 import { motion } from "motion/react";
 import { Panel } from "./Panel.tsx";
-import { fmtUsd, fmtTokens } from "../lib/format.ts";
+import { fmtUsd, fmtTokens, fmtEq, eqTitle } from "../lib/format.ts";
 import type { AgentCard, AgentStatus } from "../lib/derive.ts";
 
 const STATUS_COLOR: Record<string, string> = {
@@ -319,7 +319,7 @@ function Dossier({ b, wide, auto }: {
         </div>
         <div className="truncate" title={a.key}>{a.session_id}</div>
         {toCompact != null
-          ? <div className="flex items-center gap-2 min-w-0">{meter}<span className="tabular-nums shrink-0">{fmtTokens(a.tokens)}</span></div>
+          ? <div className="flex items-center gap-2 min-w-0">{meter}<span className="tabular-nums shrink-0" title={eqTitle(a.tokens)}>{fmtEq(a.tokens)}</span></div>
           : <div>ctx unknown — placed by recency</div>}
       </div>
     );

--- a/web/src/components/SessionModal.tsx
+++ b/web/src/components/SessionModal.tsx
@@ -6,7 +6,7 @@ import { ChangesModal } from "./ChangesModal.tsx";
 import { api } from "../lib/api.ts";
 import { usePoll } from "../lib/usePoll.ts";
 import { Markdown } from "../lib/markdown.tsx";
-import { fmtUsd, fmtTokens, fmtAgo, fmtTime, modelLabelOf, modelColor, sessionTitle } from "../lib/format.ts";
+import { fmtUsd, fmtTokens, fmtEq, fmtAgo, fmtTime, modelLabelOf, modelColor, sessionTitle } from "../lib/format.ts";
 import { ToolRow } from "./ToolRow.tsx";
 import { buildRows, entryKey, type Row } from "../lib/toolTree.ts";
 import { sessionIsLive } from "../lib/derive.ts";
@@ -215,7 +215,7 @@ export function SessionModal({ sessionId, sourceApp, onClose, onFilter, onResume
                         <Stat k="Tools" v={d.tools.toLocaleString()} />
                         <Stat k="Errors" v={String(d.errors)} color={d.errors ? "var(--error)" : "var(--text3)"} />
                         <Stat k="Subagents" v={String(d.subagents.length)} color="var(--info)" />
-                        <Stat k="Tokens" v={fmtTokens(d.input_tokens + d.output_tokens)} />
+                        <Stat k="Tokens" v={fmtEq(d.equiv_tokens ?? d.input_tokens + d.output_tokens)} />
                         <Stat k="Cost" v={fmtUsd(d.cost_usd)} color="var(--success)" />
                       </div>
                     </div>

--- a/web/src/components/Sessions.tsx
+++ b/web/src/components/Sessions.tsx
@@ -4,7 +4,7 @@ import type { SessionRollup } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { sessionIsLive } from "../lib/derive.ts";
 import { Panel } from "./Panel.tsx";
-import { fmtUsd, fmtMs, fmtTokens, modelColor, modelLabelOf } from "../lib/format.ts";
+import { fmtUsd, fmtMs, fmtEq, modelColor, modelLabelOf } from "../lib/format.ts";
 
 export const Sessions = memo(function Sessions({ provider = "" }: { provider?: string }) {
   const [sessions, setSessions] = useState<SessionRollup[]>([]);
@@ -46,7 +46,7 @@ export const Sessions = memo(function Sessions({ provider = "" }: { provider?: s
                   title={`${model} · ${fmtMs(dur)} · ${s.event_count} events`}
                 >
                   {live && <span className="h-1.5 w-1.5 rounded-full mr-1" style={{ background: "var(--success)", animation: "ping-ring 1.6s ease-out infinite" }} />}
-                  <span className="truncate" style={{ color: "var(--text2)" }}>{fmtTokens(s.input_tokens + s.output_tokens)} tok</span>
+                  <span className="truncate" style={{ color: "var(--text2)" }}>{fmtEq(s.equiv_tokens ?? s.input_tokens + s.output_tokens)}</span>
                 </motion.div>
               </div>
               <div className="w-14 shrink-0 text-right tabular-nums" style={{ color: "var(--success)" }}>{fmtUsd(s.cost_usd)}</div>

--- a/web/src/components/StatsModal.tsx
+++ b/web/src/components/StatsModal.tsx
@@ -3,7 +3,7 @@ import { motion, AnimatePresence } from "motion/react";
 import type { StatsSummary, UsageHistory } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
-import { fmtUsd, fmtTokens, typeColor } from "../lib/format.ts";
+import { fmtUsd, fmtTokens, fmtEq, eqTitle, typeColor } from "../lib/format.ts";
 
 const WINDOW_LABELS: [number, string][] = [
   [15 * 60_000, "last 15m"],
@@ -355,13 +355,13 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                   ) : (
                     <div className="flex flex-col">
                       <div className="grid grid-cols-[minmax(0,1fr)_repeat(3,auto)] gap-x-4 text-[9px] uppercase tracking-wider t-dim2 pb-1">
-                        <span>app</span><span className="text-right">sessions</span><span className="text-right">tokens</span><span className="text-right">cost</span>
+                        <span>app</span><span className="text-right">sessions</span><span className="text-right">tokens (eq)</span><span className="text-right">cost</span>
                       </div>
                       {apps.map((a) => (
                         <div key={a.source_app} className="grid grid-cols-[minmax(0,1fr)_repeat(3,auto)] gap-x-4 items-baseline py-1 border-t" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
                           <span className="truncate text-[11px]" style={{ color: "var(--text2)" }} title={a.source_app}>{a.source_app}</span>
                           <span className="text-[11px] tabular-nums text-right t-dim">{a.sessions}</span>
-                          <span className="text-[11px] tabular-nums text-right t-dim">{fmtTokens(a.tokens)}</span>
+                          <span className="text-[11px] tabular-nums text-right t-dim" title={eqTitle(a.tokens)}>{fmtEq(a.tokens)}</span>
                           <span className="text-[11px] tabular-nums text-right" style={{ color: "var(--success)" }}>{fmtUsd(a.cost_usd)}</span>
                         </div>
                       ))}

--- a/web/src/lib/chatTranscript.ts
+++ b/web/src/lib/chatTranscript.ts
@@ -74,7 +74,18 @@ export function chatToMarkdown(chat: Chat): string {
   if (chat.sessionId) head.push(`- Session: \`${chat.sessionId}\``);
   if (chat.attachCommand) head.push(`- Terminal: \`${chat.attachCommand}\``);
   if (chat.usage) {
-    head.push(`- Tokens: ${chat.usage.input.toLocaleString()} in / ${chat.usage.output.toLocaleString()} out · $${chat.usage.costUsd.toFixed(4)}`);
+    // All four classes. This said `in / out` and dropped both cache figures,
+    // which on a long chat is most of the tokens and most of the money — and a
+    // transcript is something somebody pastes into a report, so a number
+    // missing three quarters of itself travels further than most.
+    const u = chat.usage;
+    const cls = [
+      `${u.input.toLocaleString()} in`,
+      `${u.output.toLocaleString()} out`,
+      u.cacheWrite ? `${u.cacheWrite.toLocaleString()} cache write` : "",
+      u.cacheRead ? `${u.cacheRead.toLocaleString()} cache read` : "",
+    ].filter(Boolean);
+    head.push(`- Tokens: ${cls.join(" / ")} · $${u.costUsd.toFixed(4)}`);
   }
   // A chat with nothing in it still copies, and says so. Returning an empty
   // string would look exactly like the copy having failed.

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -252,13 +252,13 @@ export function stats(windowMs: number, provider?: string): StatsSummary {
     return { t, events: rint(0, Math.round(40 * busy)), errors: random() < 0.1 ? rint(1, 3) : 0, cost_usd: Number(rnd(0, 12 * busy).toFixed(3)), tokens: rint(0, Math.round(60000 * busy)) };
   });
   const summary: StatsSummary = {
-    totals: { events: si(12840) + streamed.events, sessions: si(41), tool_calls: si(6210) + streamed.tools, errors: Math.round(34 * f), cost_usd: Number((sc(4498.08) + streamed.cost).toFixed(2)), input_tokens: Math.round(9_100_000 * f), output_tokens: Math.round(640_000 * f), cache_creation_tokens: Math.round(1_200_000 * f), cache_read_tokens: Math.round(78_000_000 * f) },
+    totals: { events: si(12840) + streamed.events, sessions: si(41), tool_calls: si(6210) + streamed.tools, errors: Math.round(34 * f), cost_usd: Number((sc(4498.08) + streamed.cost).toFixed(2)), input_tokens: Math.round(9_100_000 * f), output_tokens: Math.round(640_000 * f), cache_creation_tokens: Math.round(1_200_000 * f), cache_read_tokens: Math.round(78_000_000 * f), equiv_tokens: Math.round(21_100_000 * f) },
     by_model: [
-      { model_name: "Opus", input_tokens: Math.round(4_100_000 * f), output_tokens: Math.round(300_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(2350.0), sessions: si(14) },
-      { model_name: "GPT-5", input_tokens: Math.round(3_200_000 * f), output_tokens: Math.round(240_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(1180.3), sessions: si(11) },
-      { model_name: "Sonnet", input_tokens: Math.round(900_000 * f), output_tokens: Math.round(80_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(430.2), sessions: si(6) },
-      { model_name: "Gemini Flash", input_tokens: Math.round(2_400_000 * f), output_tokens: Math.round(180_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(320.44), sessions: si(7) },
-      { model_name: "GPT-5 mini", input_tokens: Math.round(1_800_000 * f), output_tokens: Math.round(120_000 * f), cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: sc(217.14), sessions: si(3) },
+      { model_name: "Opus", input_tokens: Math.round(4_100_000 * f), output_tokens: Math.round(300_000 * f), cache_creation_tokens: Math.round(420_000 * f), cache_read_tokens: Math.round(31_000_000 * f), equiv_tokens: Math.round(9_225_000 * f), cost_usd: sc(2350.0), sessions: si(14) },
+      { model_name: "GPT-5", input_tokens: Math.round(3_200_000 * f), output_tokens: Math.round(240_000 * f), cache_creation_tokens: Math.round(300_000 * f), cache_read_tokens: Math.round(24_000_000 * f), equiv_tokens: Math.round(6_320_000 * f), cost_usd: sc(1180.3), sessions: si(11) },
+      { model_name: "Sonnet", input_tokens: Math.round(900_000 * f), output_tokens: Math.round(80_000 * f), cache_creation_tokens: Math.round(160_000 * f), cache_read_tokens: Math.round(11_000_000 * f), equiv_tokens: Math.round(2_600_000 * f), cost_usd: sc(430.2), sessions: si(6) },
+      { model_name: "Gemini Flash", input_tokens: Math.round(2_400_000 * f), output_tokens: Math.round(180_000 * f), cache_creation_tokens: Math.round(220_000 * f), cache_read_tokens: Math.round(8_000_000 * f), equiv_tokens: Math.round(2_075_000 * f), cost_usd: sc(320.44), sessions: si(7) },
+      { model_name: "GPT-5 mini", input_tokens: Math.round(1_800_000 * f), output_tokens: Math.round(120_000 * f), cache_creation_tokens: Math.round(100_000 * f), cache_read_tokens: Math.round(4_000_000 * f), equiv_tokens: Math.round(880_000 * f), cost_usd: sc(217.14), sessions: si(3) },
     ],
     tool_latency: [
       { tool_name: "Bash", calls: si(2179), timed: si(2174), errors: Math.round(22 * f), p50_ms: 186, p95_ms: 8630, max_ms: 21620, avg_ms: 640, total_ms: Math.round(1_394_560 * f) },
@@ -334,7 +334,12 @@ export function sessions(provider?: string): SessionRollup[] {
     started_at: now - rint(20, 180) * 60_000, ended_at: i % 3 === 0 ? null : now - rint(1, 20) * 60_000,
     last_seen: now - rint(0, 10) * 60_000, event_count: rint(20, 900), tool_count: rint(10, 500),
     error_count: rint(0, 6), input_tokens: rint(50_000, 1_500_000), output_tokens: rint(5000, 120_000),
-    cache_creation_tokens: 0, cache_read_tokens: 0, cost_usd: Number(rnd(0, 600).toFixed(2)),
+    // Cache reads dominate a real session by an order of magnitude, and the
+    // weighted figure is what the fleet card shows — a demo with both at zero
+    // would demonstrate the one thing this number exists to make visible by
+    // showing none of it.
+    cache_creation_tokens: rint(20_000, 300_000), cache_read_tokens: rint(2_000_000, 40_000_000),
+    equiv_tokens: rint(400_000, 6_000_000), cost_usd: Number(rnd(0, 600).toFixed(2)),
   }));
 }
 

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -43,6 +43,15 @@ export interface AgentCard {
    *  `tools` is a legitimate denominator for — see the rate rule below. */
   toolErrors: number;
   cost: number;
+  /**
+   * Every token class weighted by its own price, in uncached-input units.
+   *
+   * It used to be `input + output`, which is not a quantity: it adds a token
+   * that costs five to one that costs a tenth and drops the cache classes
+   * entirely — so a session that reads a large context every turn looked
+   * enormous and was cheap. The weighting happens on the server, where the
+   * prices are, and arrives on the event; this side only adds up.
+   */
   tokens: number;
   lastSeen: number;
   lastErrorTs: number;
@@ -163,18 +172,30 @@ export function buildTitles(sessions: { session_id: string; source_app?: string;
  *
  * The sessions poll already runs for the titles; these are the same rows.
  */
-export type RollupLookup = ReadonlyMap<string, Pick<SessionRollup, "cost_usd" | "input_tokens" | "output_tokens" | "tool_count">>;
+type RollupFields = "cost_usd" | "input_tokens" | "output_tokens" | "equiv_tokens" | "tool_count";
+export type RollupLookup = ReadonlyMap<string, Pick<SessionRollup, RollupFields>>;
 
 export function buildRollups(sessions: SessionRollup[]): RollupLookup {
-  const m = new Map<string, Pick<SessionRollup, "cost_usd" | "input_tokens" | "output_tokens" | "tool_count">>();
+  const m = new Map<string, Pick<SessionRollup, RollupFields>>();
   for (const s of sessions) {
     m.set(s.session_id, {
       cost_usd: s.cost_usd, input_tokens: s.input_tokens,
-      output_tokens: s.output_tokens, tool_count: s.tool_count,
+      output_tokens: s.output_tokens, equiv_tokens: s.equiv_tokens, tool_count: s.tool_count,
     });
   }
   return m;
 }
+
+/**
+ * The weighted figure, or the old raw sum when there isn't one.
+ *
+ * `equiv_tokens` is optional because a server older than this does not send it,
+ * and absent has to mean *unknown* rather than zero — a fleet reporting 0
+ * tokens against a real cost is a worse answer than the unweighted count it
+ * replaces, and it is the one a `?? 0` would give.
+ */
+const weighted = (r: { equiv_tokens?: number; input_tokens: number; output_tokens: number }): number =>
+  r.equiv_tokens ?? r.input_tokens + r.output_tokens;
 
 export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [], titles?: TitleLookup, rollups?: RollupLookup): AgentCard[] {
   const now = Date.now();
@@ -236,7 +257,7 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
       if (e.timestamp >= a.lastErrorTs) a.lastErrorTs = e.timestamp;
     }
     a.cost += e.cost_usd;
-    a.tokens += e.input_tokens + e.output_tokens;
+    a.tokens += weighted(e);
     if (e.timestamp >= a.lastSeen) {
       a.lastSeen = e.timestamp;
       a.lastType = e.hook_event_type;
@@ -310,7 +331,7 @@ export function deriveAgents(events: WatchEvent[], openTools: OpenToolCall[] = [
     const r = rollups?.get(a.session_id);
     if (r) {
       a.cost = Math.max(a.cost, r.cost_usd);
-      a.tokens = Math.max(a.tokens, r.input_tokens + r.output_tokens);
+      a.tokens = Math.max(a.tokens, weighted(r));
       a.tools = Math.max(a.tools, r.tool_count);
     }
     const since = now - a.lastSeen;

--- a/web/src/lib/format.ts
+++ b/web/src/lib/format.ts
@@ -38,6 +38,33 @@ export function fmtTokens(n: number | null | undefined): string {
   return String(Math.round(n));
 }
 
+/**
+ * What a weighted token count is called, and what it means, said once.
+ *
+ * A token is not a token: an output token on Opus costs five uncached input
+ * tokens and a cache read costs a tenth, so the "tokens" this app used to show
+ * — `input + output`, cache dropped — was not a quantity you could compare
+ * between two sessions, and the error did not even point one way.
+ *
+ * Everything spend-shaped now shows the same weighted figure, and everything
+ * says `eq` rather than `tok`, because a number that has stopped being a count
+ * of tokens should stop being labelled as one. The suffix is short enough for a
+ * chip; the sentence below is what a reader gets on hover, and it is the same
+ * sentence everywhere — eight call sites each explaining this in their own
+ * words is how three of them end up explaining it wrongly.
+ */
+export const EQ_SUFFIX = "eq";
+
+export function eqTitle(n: number | null | undefined): string {
+  const exact = n == null || !isFinite(n) ? "unknown" : Math.round(n).toLocaleString();
+  return `${exact} input-equivalent tokens — every class weighted by its own price ` +
+    `(on Opus an output token counts as 5, a cache write 1.25, a cache read 0.1), ` +
+    `so this is comparable between sessions and models in a way a raw token count is not.`;
+}
+
+/** The figure and its unit: "4.2M eq". */
+export const fmtEq = (n: number | null | undefined): string => `${fmtTokens(n)} ${EQ_SUFFIX}`;
+
 export function fmtMs(ms: number | null | undefined): string {
   if (ms == null || !isFinite(ms)) return "—";
   if (ms >= 3_600_000) { const h = ms / 3_600_000; return `${h.toFixed(h >= 10 ? 0 : 1)}h`; }

--- a/web/src/mobile/MobileApp.tsx
+++ b/web/src/mobile/MobileApp.tsx
@@ -5,7 +5,7 @@ import { useLive } from "../lib/useLive.ts";
 import { subscribeGitChanged } from "../lib/gitBus.ts";
 import { subscribeSessionChanged } from "../lib/sessionBus.ts";
 import { useStats } from "../lib/useStats.ts";
-import { fmtUsd, fmtTokens, since } from "../lib/format.ts";
+import { fmtUsd, fmtTokens, fmtEq, since } from "../lib/format.ts";
 import { MobileChats, type OpenChat, type Compose } from "./MobileChats.tsx";
 import { MOBILE_CSS, Sheet, Toasts, useToasts, Row, Act, useAsk } from "./mobileUi.tsx";
 import { pollWhileVisible } from "../lib/poll.ts";
@@ -867,7 +867,7 @@ export function MobileApp() {
             sub={link === "live" ? "Streaming from your machine"
               : link === "slow" ? "Reachable, but not streaming right now"
               : "Nothing is answering on this address"} />
-          <Row title="Spend today" sub={stats?.totals ? `${fmtTokens(stats.totals.input_tokens + stats.totals.output_tokens)} tokens` : "—"} right={spend} />
+          <Row title="Spend today" sub={stats?.totals ? `${fmtEq(stats.totals.equiv_tokens ?? stats.totals.input_tokens + stats.totals.output_tokens)}` : "—"} right={spend} />
           <Row title="Sessions" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.sessions) : "—"} />
           <Row title="Tool errors" sub="In the last 24 hours" right={stats?.totals ? String(stats.totals.errors) : "—"} />
         </div>

--- a/web/src/mobile/MobileFleet.tsx
+++ b/web/src/mobile/MobileFleet.tsx
@@ -1,5 +1,5 @@
 import { Empty } from "./mobileUi.tsx";
-import { fmtAgo, fmtUsd, fmtTokens } from "../lib/format.ts";
+import { fmtAgo, fmtUsd, fmtTokens, fmtEq } from "../lib/format.ts";
 import { orderInsights, spendByModel, spendByApp, errorRate, type SpendRow } from "./fleet.ts";
 import type { Insight, StatsSummary } from "../../../shared/types.ts";
 
@@ -102,7 +102,7 @@ export function MobileFleet({ insights, stats, onOpenInsight }: {
         <div className="mb-eyebrow" style={{ marginBottom: 9 }}>Today</div>
         <div className="mb-card p-3 flex flex-col gap-2">
           <Fig label="Spent" value={t ? fmtUsd(t.cost_usd) : "—"} />
-          <Fig label="Tokens" value={t ? fmtTokens(t.input_tokens + t.output_tokens) : "—"} />
+          <Fig label="Tokens" value={t ? fmtEq(t.equiv_tokens ?? t.input_tokens + t.output_tokens) : "—"} />
           <Fig label="Sessions" value={t ? String(t.sessions) : "—"} />
           <Fig label="Tool calls" value={t?.tool_calls != null ? String(t.tool_calls) : "—"} />
           {/* Null rather than a number, when the server did not send the

--- a/web/test/derive-agents.test.ts
+++ b/web/test/derive-agents.test.ts
@@ -184,6 +184,32 @@ test("a server roll-up beats the truncated buffer", () => {
   expect(card.tools).toBe(900);
 });
 
+test("and it carries the server's weighted token figure, not a raw sum", () => {
+  // #298. The client has no price table, so the weighting happens on the server
+  // and rides along on the roll-up. Dropping it here — which is what
+  // `buildRollups` narrowing the row used to do — silently puts the fleet back
+  // on `input + output`: a number that adds a token costing five to one costing
+  // a tenth, and ignores the cache classes entirely.
+  const r = rollup({
+    input_tokens: 900_000, output_tokens: 100_000,
+    cache_creation_tokens: 50_000, cache_read_tokens: 8_000_000,
+    equiv_tokens: 2_262_500,
+  });
+  const card = deriveAgents([ev()], [], undefined, buildRollups([r]))[0];
+  expect(card.tokens).toBe(2_262_500);
+  // Not the sum the pane used to show, and not the raw total either.
+  expect(card.tokens).not.toBe(1_000_000);
+  expect(card.tokens).toBeLessThan(9_050_000);
+});
+
+test("a roll-up from a server too old to weight falls back rather than to zero", () => {
+  // `equiv_tokens` is optional. Absent has to mean *unknown* — a fleet card
+  // reading 0 tokens next to $12.34 of real spend is a worse answer than the
+  // unweighted count it replaces, and it is the one a `?? 0` would produce.
+  const card = deriveAgents([ev()], [], undefined, buildRollups([rollup({ equiv_tokens: undefined })]))[0];
+  expect(card.tokens).toBe(1_000_000);
+});
+
 test("a burst that beat the 30s poll is not rounded back down", () => {
   // The buffer has more than the roll-up knows about yet. A headline number
   // must never read backwards while you are watching it.

--- a/web/test/one-token-number.test.ts
+++ b/web/test/one-token-number.test.ts
@@ -1,0 +1,111 @@
+/*
+ * One comparable number instead of four kinds of token — #298.
+ *
+ * `input_tokens + output_tokens` is not a quantity. It adds a token that costs
+ * five uncached input tokens to one that costs a tenth, and drops the two cache
+ * classes entirely — so a session that reads a large context every turn, which
+ * is most of them, looked enormous and was cheap. It was the expression behind
+ * nine separate figures in this app, every one of them labelled "tokens".
+ *
+ * The rule below is written over the *tree* rather than over those nine sites,
+ * because the failure mode is somebody adding a tenth. A number that is wrong
+ * in a way nothing crashes on is the kind that survives, and this is the only
+ * thing that would notice.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { fmtEq, eqTitle, EQ_SUFFIX } from "../src/lib/format.ts";
+
+const SRC = new URL("../src", import.meta.url).pathname;
+
+function walk(dir: string, out: string[] = []): string[] {
+  for (const name of readdirSync(dir)) {
+    const p = join(dir, name);
+    if (statSync(p).isDirectory()) walk(p, out);
+    else if (/\.tsx?$/.test(name)) out.push(p);
+  }
+  return out;
+}
+const files = walk(SRC);
+const rel = (p: string) => p.slice(SRC.length + 1);
+
+describe("nothing adds up token classes by hand", () => {
+  /**
+   * `demo.ts` is exempt: it fabricates rows to *populate* those fields rather
+   * than reading them, so the string appears there as a key list and an
+   * assignment, never as a figure anybody is shown.
+   */
+  const EXEMPT = new Set(["lib/demo.ts"]);
+
+  test("`input_tokens + output_tokens` appears nowhere it is rendered", () => {
+    const offenders: string[] = [];
+    for (const f of files) {
+      if (EXEMPT.has(rel(f))) continue;
+      const src = readFileSync(f, "utf8");
+      // Both spellings, since `a.input_tokens + a.output_tokens` and the bare
+      // property names are the two shapes this has taken.
+      for (const [i, line] of src.split("\n").entries()) {
+        if (/input_tokens\s*\+\s*[\w.?]*output_tokens/.test(line)) {
+          // The honest fallback for a server too old to send the weighted
+          // figure is exactly this sum, so it is allowed *behind* a `??`.
+          if (/equiv_tokens\s*\?\?/.test(line)) continue;
+          offenders.push(`${rel(f)}:${i + 1}  ${line.trim()}`);
+        }
+      }
+    }
+    expect(offenders, `a spend figure is summing token classes by hand:\n${offenders.join("\n")}`).toEqual([]);
+  });
+
+  test("and the context measures are left alone, because they are not spend", () => {
+    /*
+     * The opposite mistake, and the reason the rule above names one specific
+     * sum rather than banning arithmetic on these fields.
+     *
+     * A context meter counts what is *in the window* — prompt, cache read,
+     * cache write — and excludes output, which has already left. Weighting it
+     * by price would be nonsense: a 200k context is 200k of context whatever it
+     * cost, and dividing it by a limit measured in real tokens would draw the
+     * bar at a tenth of its true length.
+     */
+    const derive = readFileSync(join(SRC, "lib/derive.ts"), "utf8");
+    expect(derive).toContain("e.input_tokens + e.cache_read_tokens + e.cache_creation_tokens");
+    const chat = readFileSync(join(SRC, "lib/chatStore.ts"), "utf8");
+    expect(chat).toMatch(/contextTokens/);
+  });
+});
+
+describe("what a weighted figure is called", () => {
+  test("not `tok`, because it has stopped being a count of tokens", () => {
+    expect(EQ_SUFFIX).not.toBe("tok");
+    expect(fmtEq(4_200_000)).toBe(`4.20M ${EQ_SUFFIX}`);
+  });
+
+  test("and every site says it the same way", () => {
+    // Eight call sites each wording this themselves is how three of them come
+    // to word it wrongly. `tok` may not survive next to a weighted number.
+    const bad: string[] = [];
+    for (const f of files) {
+      const src = readFileSync(f, "utf8");
+      for (const [i, line] of src.split("\n").entries()) {
+        if (/\}\s*tok</.test(line) || /\btok<\/span>/.test(line)) bad.push(`${rel(f)}:${i + 1}  ${line.trim()}`);
+      }
+    }
+    expect(bad, `a weighted figure is still labelled "tok":\n${bad.join("\n")}`).toEqual([]);
+  });
+
+  test("the explanation names the multipliers, not just the idea", () => {
+    // "weighted by price" tells somebody nothing they can check. The numbers
+    // are what make the figure believable when it does not match their
+    // intuition — which is the whole reason it exists.
+    const t = eqTitle(1234);
+    expect(t).toContain("1,234");
+    expect(t).toMatch(/output token counts as 5/);
+    expect(t).toMatch(/cache read 0\.1/);
+  });
+
+  test("and an unknown figure says so rather than reading as zero", () => {
+    expect(eqTitle(null)).toContain("unknown");
+    expect(fmtEq(null)).toContain("—");
+  });
+});


### PR DESCRIPTION
Closes #298.

## What does this PR do?

A token is not a token. On Opus an output token costs **five** uncached input tokens, a cache write 1.25, and a cache read a **tenth** — a spread of fifty to one inside a single figure that nine panes were calling "tokens".

And the figure they showed was `input_tokens + output_tokens`, which drops both cache classes outright. On a seeded fleet costing $22.23:

| | |
| --- | --- |
| what the headline said | **427,400 tokens** |
| raw tokens actually consumed | 39,812,900 |
| weighted (uncached-input units) | **7,020,790** |

The error does not even point one way. A session that re-reads a large context every turn — which is most of them — looks enormous under the raw sum and is cheap; one that writes cache constantly looks small and is not. Two sessions could not be compared by that number at all, which is the only thing a headline figure is for.

### The unit

Every class weighted by its own price and expressed in uncached input tokens. That unit is comparable across sessions and models, it **survives a price change** because it is a ratio rather than a rate, and it converts to money with one multiplication:

```
equivalentTokens(u, m) * priceFor(m).input / 1e6  ===  costUsd(u, m)
```

That identity is the reason this beats showing cost alone, and it is asserted **over the whole price table** rather than over the two models somebody happened to think of — a row added next month with an unanticipated rate structure is exactly where it would quietly stop holding.

A model whose input rate is zero or missing gets weights of 1 rather than `Infinity`: there is no base to express anything in, and `fmtTokens(Infinity)` on the hero is worse than the raw sum it replaces. Not hypothetical — `AGENTGLASS_PRICING` takes a whole table from the user, and a local model behind an OpenAI-shaped endpoint costs nothing to run. A zero rate for *one class* is kept, because that is a fact about the model: OpenAI did not charge for cache creation before the 5.6 family, and reading that zero as "unknown, use 1" would invent a million tokens of spend on every GPT-5.x session.

### No column, no migration, no backfill

`equiv_tokens` is a pure function of four columns that were always there, so it is **exact for history written long before the idea existed**. The arithmetic happens on the server, where the prices are, and rides along on the payload exactly as `cost_usd` already does — which is what lets a fleet card weight itself when the client has no price table and never will.

Weighting needs the model in scope, so two queries changed shape:

- **`by_app`** was a `GROUP BY source_app`, which has no model in it and therefore cannot be weighted at all. It groups by app *and* model and folds — with its `sessions` count queried separately, because a `COUNT(DISTINCT)` does not survive a fold and an app whose session switched model mid-run would otherwise report two.
- **the timeline** carries `model_name` and both cache columns per row.

The per-model legend weights each **raw id** before folding it into its label. Two ids can share a display name and not a rate: `gpt-5.6` shows as "GPT-5", and the GPT-5 price row charges nothing for cache writes where 5.6 charges 1.25× input. Weighting the folded row by the name it displays lands 1,500 equivalents short *and still adds up perfectly against every other fold* — so the fixture carries that model on purpose, and the test asserts an exact number rather than a range.

### What it looks like

```
SPEND · THIS WINDOW
$7.98
2,526,135 input-equivalent tokens · 13836k cached

WHERE THE MONEY GOES          ALERTS
 ● GPT-5     533.3k eq $2.67   ⚡ Spend velocity · $7.98/hr
 ● Opus      516.0k eq $2.58      2526k eq tokens in the last hour
 ● Sonnet    506.4k eq $1.52
 ● Gemini    970.5k eq $1.21
```

Note the hero and the Alerts burn line agree — the spend-velocity insight was `SUM(input_tokens + output_tokens)` and sat in the same viewport as the headline, so an unweighted number there read as the dashboard disagreeing with itself.

Everything says **`eq`** rather than `tok`. A number that has stopped being a count of tokens should stop being labelled as one, and the same sentence appears on hover everywhere — eight call sites each wording it themselves is how three of them come to word it wrongly. The hero spells the unit out, since it is the most prominent token figure in the app and the right place to introduce it once.

**The context meters are deliberately untouched.** A context meter counts what is *in the window* — prompt, cache read, cache write, and not output, which has already left. Weighting it by price would be nonsense: 200k of context is 200k of context whatever it cost, and dividing it by a limit measured in real tokens would draw the bar at a tenth of its true length. That is the opposite mistake, and it is why the guard names one specific sum rather than banning arithmetic on these fields.

### The breakdown stays one interaction away, and got better

The issue asks to keep it, since the breakdown is what makes a cache problem diagnosable. Two things were wrong with it:

- The **event modal** showed `in · out` behind an `input + output > 0` guard — so an event that only read cache rendered as an em dash while carrying real tokens and real cost. It shows every non-zero class now, led by the weighted figure.
- The **exported chat transcript** dropped both cache figures from a line somebody pastes into a report, where a number missing three quarters of itself travels further than most.

## How was it tested?

- **1383 server tests, 923 web tests**, all passing. `bunx tsc --noEmit` clean in both trees; `bun run build` succeeds.
- **24 mutations, all red.** Among them: output weighted like input so a token is a token again; the ratio inverted; a free input rate divided by anyway; a zero *class* rate swept up by the free-input fallback; the cache classes dropped from the sum; an unknown model weighted differently from how its cost is computed; the headline back to a raw sum; the per-app table back to `input + output`; its session count summed across the fold; a folded row weighted by its label instead of its raw ids; a session or an event carrying no weighted figure; the detail query losing its cache columns; the fleet fold reading raw classes; an older server's absent figure read as `0`; **the context measure weighted, which it must not be**; `eq` relabelled `tok`. None survived.
- **The stats assertions run in a child process** (`test/fixtures/eqtok-probe.ts`). `db.ts` is a singleton and `bun test` shares one process, so which database it talks to — and which workspace scope it filters by — is decided by whichever suite imported it first. The in-process version of this file passed alone and found **zero of its own rows** in a full run: an earlier suite had left a workspace scope set, and events with no project path are outside every scoped query. That is the worst way for a test to be wrong, so it is written down where the fixture lives.
- **A rule over the tree, not over the nine call sites**: `web/test/one-token-number.test.ts` fails if `input_tokens + output_tokens` appears anywhere it is rendered (allowed only behind the `equiv_tokens ??` fallback), and if a weighted figure is ever labelled `tok` again. The failure mode here is somebody adding a tenth site — a number that is wrong in a way nothing crashes on is the kind that survives.
- **Rendered and inspected** against a seeded 220-event fleet with realistic cache-heavy turns across four models — that is where the 427k-vs-7.0M figures above come from, and where I checked that the hero, the legend, the radar, the session bars and the burn insight all agree.
- **`scripts/phone-audit.ts`: 115/115** against a live server, since this touches the companion's Fleet and settings figures.

Demo mode got real cache figures and a weighted total too: a demo with both cache classes at zero would demonstrate the one thing this number exists to make visible by showing none of it.

One judgement call worth recording: the `by_model` **identity does not hold per folded row** in general, because a row can fold ids with different rates — its `cost_usd` is already a sum across them. The identity is a per-raw-id property, and the tests assert it that way rather than pretending a folded row has a single rate.