### PR TITLE
Recognize MiniMax as a provider and price M3/M2.7

### DIFF
--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -110,6 +110,13 @@ export const PRICE_TABLE: ModelPrice[] = [
   // Flat across the whole 1M window — there is no long-context tier to add.
   { match: ["kimi-code/k3", "kimi-k3", "moonshot/k3"], exact: ["k3"], label: "K3", input: 3, output: 15, cache_write: 3, cache_read: 0.3 },
 
+  // --- MiniMax ---
+  // M3 keeps cache creation at the input rate (cache_write === input); M2.7
+  // charges cache creation at 1.25x input. Both discount cache reads to a tenth
+  // of input. Order matters: M2.7 is matched before the generic M3 row.
+  { match: ["minimax-m2.7"], exact: ["MiniMax-M2.7"], label: "MiniMax M2.7", input: 0.3, output: 1.2, cache_write: 0.375, cache_read: 0.06 },
+  { match: ["minimax-m3"], exact: ["MiniMax-M3"], label: "MiniMax M3", input: 0.6, output: 2.4, cache_write: 0.6, cache_read: 0.12 },
+
   // --- others (approx) ---
   { match: ["deepseek"], label: "DeepSeek", input: 0.27, output: 1.1, cache_write: 0, cache_read: 0.07 },
   { match: ["grok"], label: "Grok", input: 2, output: 10, cache_write: 0, cache_read: 0 },

--- a/server/test/pricing.test.ts
+++ b/server/test/pricing.test.ts
@@ -100,6 +100,43 @@ describe("costUsd", () => {
     expect(cost).toBe(DEFAULT_PRICE.input);
   });
 
+  test("MiniMax M3 and M2.7 use their own rates instead of the fallback", () => {
+    // The model ids are short and do not share the Gemini/OpenAI collision
+    // problem, but a bare `minimax` substring would otherwise fall through to
+    // DEFAULT_PRICE — the Sonnet-tier $3/$15 — and over-report cost ~5x.
+    expect(priceFor("MiniMax-M3")).toMatchObject({
+      label: "MiniMax M3",
+      input: 0.6,
+      output: 2.4,
+      cache_write: 0.6,
+      cache_read: 0.12,
+    });
+    expect(priceFor("MiniMax-M2.7")).toMatchObject({
+      label: "MiniMax M2.7",
+      input: 0.3,
+      output: 1.2,
+      cache_write: 0.375,
+      cache_read: 0.06,
+    });
+    // M2.7 must be matched before the M3 row — "minimax-m2.7" contains neither
+    // "minimax-m3" nor a context suffix, and a reversed order would price it at
+    // the M3 rate. This is the load-bearing-property assertion for the order.
+    expect(priceFor("MiniMax-M2.7")?.label).not.toBe("MiniMax M3");
+  });
+
+  test("MiniMax cost math sums each token class at its own rate", () => {
+    const cost = costUsd(
+      {
+        input_tokens: 1_000_000,
+        output_tokens: 1_000_000,
+        cache_creation_tokens: 1_000_000,
+        cache_read_tokens: 1_000_000,
+      },
+      "MiniMax-M3",
+    );
+    expect(cost).toBeCloseTo(0.6 + 2.4 + 0.6 + 0.12, 10);
+  });
+
   test("missing usage fields count as zero", () => {
     expect(costUsd({}, "claude-sonnet-4")).toBe(0);
     expect(costUsd({ input_tokens: 0 }, null)).toBe(0);

--- a/server/test/provider-parity.test.ts
+++ b/server/test/provider-parity.test.ts
@@ -37,6 +37,7 @@ const MODELS = [
   "deepseek-chat", "grok-2", "xai/grok", "mistral-large", "mixtral-8x7b", "codestral",
   "llama-3.1-70b", "meta-llama/Llama-3", "command-r-plus", "cohere.command",
   "k3", "kimi-k3", "kimi-code/k3", "moonshot-v1-128k",
+  "MiniMax-M3", "MiniMax-M2.7",
   // fall-through cases — must be the miss bucket on both sides
   "some-unknown-model", "qwen-2.5", "", "   ", "MODEL-WITH-NO-MATCH",
 ];
@@ -61,6 +62,15 @@ describe("providerOf agrees between the server and the web copy", () => {
       expect(webProviderOf(model)).toBe("Moonshot");
       expect(webModelLabelOf(model)).toBe("K3");
     }
+  });
+
+  test("MiniMax ids resolve to the MiniMax provider and display labels", () => {
+    for (const model of ["MiniMax-M3", "MiniMax-M2.7"]) {
+      expect(serverProviderOf(model)).toBe("MiniMax");
+      expect(webProviderOf(model)).toBe("MiniMax");
+    }
+    expect(webModelLabelOf("MiniMax-M3")).toBe("MiniMax M3");
+    expect(webModelLabelOf("MiniMax-M2.7")).toBe("MiniMax M2.7");
   });
 });
 

--- a/shared/models.ts
+++ b/shared/models.ts
@@ -20,6 +20,7 @@
 /** Raw fragment → display label. Order matters: specific before general. */
 const MODEL_LABELS: [string, string][] = [
   ["kimi-code/k3", "K3"], ["kimi-k3", "K3"], ["moonshot/k3", "K3"],
+  ["minimax-m2.7", "MiniMax M2.7"], ["minimax-m3", "MiniMax M3"], ["minimax", "MiniMax"],
   ["opus", "Opus"], ["sonnet", "Sonnet"], ["haiku", "Haiku"], ["fable", "Fable"],
   ["mythos", "Mythos"],
   ["gpt-4o-mini", "GPT-4o mini"], ["gpt-4o", "GPT-4o"],
@@ -63,6 +64,7 @@ export function providerOf(raw: string | null | undefined): string {
   if (/gpt|davinci|openai|\bo1\b|\bo3\b|\bo4\b/.test(m)) return "OpenAI";
   if (/gemini|palm|bison|flash|google|vertex/.test(m)) return "Google";
   if (/kimi|moonshot/.test(m) || m === "k3" || m.startsWith("k3[")) return "Moonshot";
+  if (/minimax/.test(m)) return "MiniMax";
   if (/deepseek/.test(m)) return "DeepSeek";
   if (/grok|xai/.test(m)) return "xAI";
   if (/mistral|mixtral|codestral/.test(m)) return "Mistral";


### PR DESCRIPTION
Reason: MiniMax events fell back to unknown labels and default pricing instead of the current model-specific rates.

providerOf had no rule for minimax, so MiniMax sessions bucketed under the unknown provider; PRICE_TABLE had no MiniMax-M3 or MiniMax-M2.7 entries, so costUsd fell back to DEFAULT_PRICE. This adds:

- a `minimax` provider branch in shared/models.ts (used by both server and web), with MiniMax M3 / MiniMax M2.7 display labels ahead of a generic MiniMax label;
- two PRICE_TABLE rows in server/src/pricing.ts with the current per-MTok input/output/cache-read/cache-write rates for each id (M2.7 ordered before M3);
- tests covering the matched rates, the per-class cost math, the provider/label parity between server and web, and the M2.7-before-M3 ordering.

Checks run: `cd server && bun test pricing.test.ts provider-parity.test.ts` (109 pass, 0 fail).
