### PR TITLE
Say why a phone cannot pair over a plain-HTTP address

### DIFF
--- a/web/src/PairScreen.tsx
+++ b/web/src/PairScreen.tsx
@@ -1,6 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from "react";
 import { SERVER } from "./lib/api.ts";
-import { claim, collectOnce, guessName, makeKeys, type PairKeys } from "./lib/pairing.ts";
+import { claim, collectOnce, guessName, makeKeys, pairingBlocked, type PairKeys } from "./lib/pairing.ts";
 
 /**
  * Connecting this phone, on the phone.
@@ -20,7 +20,21 @@ import { claim, collectOnce, guessName, makeKeys, type PairKeys } from "./lib/pa
  */
 export function PairScreen({ ticket, onPaired }: { ticket: string; onPaired: (token: string) => void }) {
   type Stage = "checking" | "form" | "waiting" | "expired" | "rejected" | "failed";
+  /** Nothing after this can succeed, so nothing after this may overwrite it. */
+  const TERMINAL: Stage[] = ["failed", "expired", "rejected"];
   const [stage, setStage] = useState<Stage>("checking");
+  /*
+   * Settle a stage only if the screen is not already finished.
+   *
+   * Two effects race here — key generation and the `/pair/info` fetch — and the
+   * fetch is a network round-trip behind. Without this, a browser that cannot
+   * do WebCrypto at all failed instantly and then had the form put back on top
+   * of the explanation, leaving somebody tapping a button that told them to try
+   * again in a second about a thing that would never change.
+   */
+  const settle = useCallback((next: Stage) => {
+    setStage((cur) => (TERMINAL.includes(cur) ? cur : next));
+  }, []);
   const [name, setName] = useState(() => guessName());
   const [code, setCode] = useState("");
   const [err, setErr] = useState<string | null>(null);
@@ -33,9 +47,14 @@ export function PairScreen({ ticket, onPaired }: { ticket: string; onPaired: (to
   // the last digit and the answer.
   useEffect(() => {
     let live = true;
+    // Asked before trying, because the answer is a fact about the address this
+    // page was opened at rather than something a retry can change — and saying
+    // so is the difference between a 30-second fix and a mystery.
+    const blocked = pairingBlocked();
+    if (blocked) { settle("failed"); setErr(blocked); return; }
     makeKeys()
       .then((k) => { if (live) keys.current = k; })
-      .catch(() => { if (live) { setStage("failed"); setErr("This browser cannot generate the key this connection needs. It has to be a recent Safari, Chrome or Firefox, over the address the QR code pointed at."); } });
+      .catch(() => { if (live) { settle("failed"); setErr("This browser cannot generate the key this connection needs. It has to be a recent Safari, Chrome or Firefox, over the address the QR code pointed at."); } });
     return () => { live = false; };
   }, []);
 
@@ -43,8 +62,8 @@ export function PairScreen({ ticket, onPaired }: { ticket: string; onPaired: (to
     let live = true;
     fetch(`${SERVER}/pair/info?ticket=${encodeURIComponent(ticket)}`)
       .then((r) => r.json())
-      .then((j: { ok?: boolean }) => { if (live) setStage(j.ok ? "form" : "expired"); })
-      .catch(() => { if (live) { setStage("failed"); setErr(`Could not reach ${SERVER}. Check the phone is on the same network as the computer.`); } });
+      .then((j: { ok?: boolean }) => { if (live) settle(j.ok ? "form" : "expired"); })
+      .catch(() => { if (live) { settle("failed"); setErr((e) => e ?? `Could not reach ${SERVER}. Check the phone is on the same network as the computer.`); } });
     return () => { live = false; };
   }, [ticket]);
 

--- a/web/src/components/PairPanel.tsx
+++ b/web/src/components/PairPanel.tsx
@@ -103,9 +103,38 @@ export function PairPanel({ baseUrl }: { baseUrl: string }) {
 
   const left = ticket ? Math.max(0, Math.round((ticket.expiresAt - now) / 1000)) : 0;
   const pairUrl = ticket ? `${baseUrl.replace(/\/$/, "")}/?pair=${encodeURIComponent(ticket.id)}` : "";
+  /*
+   * An address a phone cannot pair over, said here rather than there.
+   *
+   * `crypto.subtle` exists only in a secure context — HTTPS or localhost — so a
+   * QR pointing at `http://100.64.1.2:4000` sends somebody to a page whose
+   * handshake is impossible before it starts. The phone now says so instead of
+   * failing quietly, but the phone is the wrong place to learn it: by then they
+   * have walked over, scanned, and typed a name. This is the screen where the
+   * address is chosen, so this is where it belongs.
+   */
+  const insecure = /^http:\/\//i.test(baseUrl) && !/^https?:\/\/(localhost|127\.0\.0\.1|\[?::1\]?)([:/]|$)/i.test(baseUrl);
+  const tailnet = /^https?:\/\/100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(baseUrl);
 
   return (
     <div className="flex flex-col gap-2.5">
+      {insecure && (
+        <div className="text-[10.5px] px-2.5 py-2 rounded-lg" style={{
+          color: "var(--text2)",
+          background: "color-mix(in srgb, var(--error) 10%, transparent)",
+          border: "1px solid color-mix(in srgb, var(--error) 35%, transparent)",
+        }}>
+          <span style={{ color: "var(--error)" }}>A phone cannot pair over this address.</span>{" "}
+          Browsers give a page served over plain HTTP no WebCrypto, and pairing has to encrypt the
+          credential to the device asking for it — so the handshake cannot start, however many times
+          the phone tries.{" "}
+          {tailnet
+            ? <>You are on Tailscale already: run <span className="t-mono">tailscale cert</span> on this
+                machine and pick the <span className="t-mono">https://…ts.net</span> name above.</>
+            : <>Serve the cockpit over HTTPS, or forward the port so the phone reaches it as
+                <span className="t-mono"> http://localhost</span>.</>}
+        </div>
+      )}
       <div className="flex items-center gap-2">
         <span className="text-[10px] t-dim2 uppercase tracking-wider flex-1">Connect a phone</span>
         {ticket && (

--- a/web/src/components/RemoteAccessPane.tsx
+++ b/web/src/components/RemoteAccessPane.tsx
@@ -229,9 +229,10 @@ export function RemoteAccessPane({ open }: { open: boolean }) {
                     tailnet, which makes it the safer of the two routes and the one to use on wifi you do not
                     own. Each paired device still gets exactly what you granted it, and nothing more.</>
                 : <>This runs over plain HTTP, so everything between a phone and this machine is readable by
-                    anything else on the network. Pairing keeps the credential itself out of that — it is
-                    encrypted to the device that asked for it — but what it fetches afterwards is not. Fine
-                    at home. On café or airport wifi, use the Tailscale route instead.</>}
+                    anything else on the network — and a phone cannot pair over it at all. Browsers give a
+                    plain-HTTP page no WebCrypto, so the handshake that encrypts the credential to the
+                    device cannot run. Serve this over HTTPS, or forward the port so the phone reaches it
+                    as http://localhost. On café or airport wifi, use the Tailscale route regardless.</>}
             </div>
 
             <Devices st={st} onCopy={copy} copied={copied} onChanged={load} />

--- a/web/src/lib/pairing.ts
+++ b/web/src/lib/pairing.ts
@@ -76,6 +76,49 @@ export interface PairKeys {
   priv: CryptoKey;
 }
 
+/**
+ * Why this browser cannot pair, in words somebody can act on — or null.
+ *
+ * `crypto.subtle` does not exist outside a *secure context*, which means HTTPS
+ * or localhost and nothing else. A phone opening `http://100.64.1.2:4000` from
+ * a QR code therefore has no WebCrypto at all, and the whole handshake — the
+ * ECDH keypair, the sealed credential — is impossible before it starts.
+ *
+ * This shipped without the check, and the way it failed is the reason the check
+ * is phrased as a *diagnosis* rather than a boolean. Key generation rejected
+ * instantly; the `/pair/info` fetch resolved a network round-trip later and put
+ * the form back over the failure; and the button then said "still preparing the
+ * connection — try again in a second", which is an invitation to tap it forever
+ * for a reason that will never change. Every part of that was true-ish and the
+ * whole was useless.
+ *
+ * Not a thing the app can work around. A pure-JS P-256 is not something to
+ * hand-roll for a credential, and dropping the sealing would send the token
+ * over the same plain HTTP in the clear. So the only honest move is to say what
+ * is wrong and what reaches a secure context instead.
+ */
+export function pairingBlocked(
+  ctx: { isSecureContext?: boolean; origin?: string; subtle?: unknown } = {
+    isSecureContext: typeof isSecureContext !== "undefined" ? isSecureContext : undefined,
+    origin: typeof location !== "undefined" ? location.origin : "",
+    subtle: typeof crypto !== "undefined" ? crypto.subtle : undefined,
+  },
+): string | null {
+  if (ctx.subtle) return null;
+  const where = ctx.origin ? ` (${ctx.origin})` : "";
+  // Named separately because the fix is different: a tailnet already has a
+  // certificate available, and a plain LAN address does not.
+  const tailnet = /^https?:\/\/100\.(6[4-9]|[7-9]\d|1[01]\d|12[0-7])\./.test(ctx.origin ?? "");
+  return (
+    `This page is not a secure context${where}, so the browser gives it no WebCrypto — ` +
+    `and pairing cannot encrypt the credential to this device without it. ` +
+    (tailnet
+      ? `You are on Tailscale already: run \`tailscale cert\` on the computer and open the ` +
+        `https://…ts.net name instead of the raw 100.x address.`
+      : `Open the cockpit over HTTPS, or reach it as http://localhost through a forwarded port.`)
+  );
+}
+
 /** A keypair for one pairing, and one pairing only. */
 export async function makeKeys(subtle: SubtleCrypto = crypto.subtle): Promise<PairKeys> {
   const kp = await subtle.generateKey({ name: "ECDH", namedCurve: "P-256" }, false, ["deriveBits"]);

--- a/web/test/pair-secure-context.test.ts
+++ b/web/test/pair-secure-context.test.ts
@@ -1,0 +1,134 @@
+/*
+ * Why a phone could not pair, and why it could not find out.
+ *
+ * Reported from a real phone: the QR opened `http://100.69.209.63:4000/?pair=…`,
+ * the form appeared, "Ask to connect" did nothing — on the phone or on the
+ * desktop — and the only feedback was "Still preparing the connection — try
+ * again in a second."
+ *
+ * The cause is a browser rule, not a bug in the handshake: `crypto.subtle`
+ * exists only in a *secure context*, which is HTTPS or localhost and nothing
+ * else. Over plain HTTP there is no WebCrypto, so the ECDH keypair the pairing
+ * is built on cannot be generated at all.
+ *
+ * What made it a mystery rather than a message is the second half, and it is
+ * the part worth guarding: key generation rejected immediately and set the
+ * screen to `failed`, then the `/pair/info` fetch resolved a network
+ * round-trip later and put the form back over it. The accurate diagnosis was
+ * replaced by an invitation to keep tapping.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+
+// api.ts reads `location` at module scope and pairing.ts imports its `SERVER`.
+// Stubbed before the import, because that read happens on evaluation.
+(globalThis as any).location = { hostname: "localhost", origin: "http://localhost:4000" };
+const { pairingBlocked } = await import("../src/lib/pairing.ts");
+
+const src = (p: string) => readFileSync(new URL(p, import.meta.url), "utf8");
+
+describe("whether this page can pair at all", () => {
+  test("a secure context can, and is not warned about anything", () => {
+    expect(pairingBlocked({ subtle: {}, origin: "https://box.tail1234.ts.net", isSecureContext: true })).toBeNull();
+    // localhost is a secure context too, which is why this never showed up in
+    // development or in any headless run.
+    expect(pairingBlocked({ subtle: {}, origin: "http://localhost:4000", isSecureContext: true })).toBeNull();
+  });
+
+  test("and one without WebCrypto is told what is wrong, not that it should retry", () => {
+    const why = pairingBlocked({ subtle: undefined, origin: "http://192.168.1.9:4000", isSecureContext: false });
+    expect(why).toBeTruthy();
+    // The cause, in terms somebody can check.
+    expect(why!).toMatch(/secure context/i);
+    expect(why!).toContain("http://192.168.1.9:4000");
+    // …and never the word that sent them round the loop.
+    expect(why!, "the message still suggests trying again").not.toMatch(/try again/i);
+  });
+
+  test("a tailnet address gets the advice that actually applies to it", () => {
+    /*
+     * The reported case. 100.64.0.0/10 is what Tailscale hands out, and it is
+     * the route this app *recommends* — so telling somebody there to "use
+     * HTTPS" without saying how is telling them to abandon the thing they
+     * already set up. `tailscale cert` gives them a real certificate for the
+     * MagicDNS name, and that is a secure context.
+     */
+    const why = pairingBlocked({ subtle: undefined, origin: "http://100.69.209.63:4000", isSecureContext: false })!;
+    expect(why).toContain("tailscale cert");
+    expect(why).toMatch(/ts\.net/);
+  });
+
+  test("and a plain LAN address gets the other one", () => {
+    const why = pairingBlocked({ subtle: undefined, origin: "http://192.168.1.9:4000", isSecureContext: false })!;
+    expect(why).not.toContain("tailscale cert");
+    expect(why).toMatch(/localhost/);
+  });
+
+  test("100.x that is not in the tailnet range is not called Tailscale", () => {
+    // 100.128.0.0 is ordinary public space. Telling somebody to run
+    // `tailscale cert` for it sends them somewhere that cannot help.
+    const why = pairingBlocked({ subtle: undefined, origin: "http://100.128.0.5:4000", isSecureContext: false })!;
+    expect(why).not.toContain("tailscale cert");
+  });
+});
+
+describe("the screen that reported it", () => {
+  const screen = src("../src/PairScreen.tsx");
+
+  test("asks before it tries, because a retry cannot change the answer", () => {
+    expect(screen).toContain("pairingBlocked()");
+  });
+
+  test("and nothing finished can be overwritten by something slower", () => {
+    /*
+     * The race that turned a correct diagnosis into a useless one. Two effects
+     * run on mount — key generation and the ticket fetch — and only one of them
+     * involves the network. Any `setStage` that is not guarded is a chance for
+     * the slower one to bury the faster one's verdict.
+     */
+    expect(screen).toContain("TERMINAL.includes(cur)");
+    // Every stage set from an async continuation goes through the guard. A
+    // bare `setStage` in a `.then` is exactly what caused this.
+    const async = screen.split("\n").filter((l) => /\.then\(|\.catch\(/.test(l) && /setStage\(/.test(l));
+    expect(async, `an async path sets the stage directly:\n${async.join("\n")}`).toEqual([]);
+  });
+});
+
+describe("the screen that chose the address", () => {
+  const panel = src("../src/components/PairPanel.tsx");
+
+  test("says so before somebody walks over with a phone", () => {
+    // The phone is the wrong place to learn this: by then they have scanned,
+    // typed a name and read six digits off a screen.
+    expect(panel).toMatch(/A phone cannot pair over this address/);
+    expect(panel).toContain("const insecure =");
+  });
+
+  test("and only for addresses where it is true", () => {
+    // A rule over the expression rather than over a rendered string, because
+    // this has to keep being right for https and for loopback.
+    const m = /const insecure = (.+);/.exec(panel)!;
+    const insecure = (url: string) => eval(m[1]!.replace(/baseUrl/g, JSON.stringify(url)));
+    expect(insecure("http://100.69.209.63:4000")).toBe(true);
+    expect(insecure("http://192.168.1.9:4000")).toBe(true);
+    expect(insecure("https://box.tail1234.ts.net")).toBe(false);
+    expect(insecure("http://localhost:4000")).toBe(false);
+    expect(insecure("http://127.0.0.1:4000")).toBe(false);
+  });
+});
+
+describe("what the app claims about pairing over plain HTTP", () => {
+  const pane = src("../src/components/RemoteAccessPane.tsx");
+
+  test("no longer promises an encryption the browser will not allow", () => {
+    /*
+     * The pane used to say the credential "is encrypted to the device that
+     * asked for it" on exactly the route where the browser withholds the
+     * primitives to do that. A security claim that is false is worse than a
+     * missing one: it is the sentence somebody reads to decide the risk is
+     * handled.
+     */
+    expect(pane, "the false claim is still here").not.toMatch(/encrypted to the device that asked for it/);
+    expect(pane).toMatch(/cannot pair over it at all/);
+  });
+});


### PR DESCRIPTION
Fixes a pairing failure reported from a real phone.

## What does this PR do?

The QR opened `http://100.69.209.63:4000/?pair=…`, the form rendered, **"Ask to connect" did nothing** — on the phone or on the desktop — and the only feedback was *"Still preparing the connection — try again in a second."*

### The cause is a browser rule, not the handshake

`crypto.subtle` exists only in a **secure context**: HTTPS, or localhost, and nothing else. On a plain-HTTP address there is no WebCrypto at all, so the ECDH keypair the pairing is built on cannot be generated. Pairing there was never going to work, in any browser, however many times the button was pressed.

This never showed up before because every context it was developed and tested in is a secure one — `localhost` qualifies.

### Why it was a mystery instead of a message

The screen already had an accurate message for this. It just never survived long enough to be read:

1. `makeKeys()` rejects **immediately** → stage `failed`, with the right explanation.
2. `/pair/info` resolves a **network round-trip later** → `setStage("form")`, straight over the top of it.
3. The user taps → `keys.current` is null → *"Still preparing the connection — try again in a second."*

Every part of that was true-ish and the whole was useless: an invitation to keep tapping, for a reason that would never change. A terminal stage can no longer be overwritten by something slower, and a test asserts that **no** async path sets the stage directly — the bare `setStage` in a `.then` is what caused this, so the rule is written over the file rather than over the two call sites that exist today.

### Three places, because the fix is only useful in the first one

**The desktop, above the QR.** This is where the address is chosen and where somebody can still act on it. Learning it on the phone means having already walked over, scanned, and typed a name.

> **A phone cannot pair over this address.** Browsers give a page served over plain HTTP no WebCrypto, and pairing has to encrypt the credential to the device asking for it — so the handshake cannot start, however many times the phone tries. You are on Tailscale already: run `tailscale cert` on this machine and pick the `https://…ts.net` name above.

The advice branches, because the fix genuinely differs. A **tailnet** address gets `tailscale cert` and the MagicDNS name — telling somebody on Tailscale to "just use HTTPS" is telling them to abandon the thing they already set up, and this is the route the app itself recommends. A **plain LAN** address gets HTTPS or a forwarded port reached as `http://localhost`.

**The phone**, which now asks before it tries — the answer is a fact about the address the page was opened at, not something a retry can change — and never says "try again".

**Remote access**, which used to claim that over plain HTTP *"pairing keeps the credential itself out of that — it is encrypted to the device that asked for it"*. That is exactly what the browser withholds the primitives to do on that route. A security claim that is false is worse than a missing one: it is the sentence somebody reads to decide the risk is handled.

### What this deliberately does not do

Work around it. A pure-JS P-256 is not something to hand-roll for a credential, and dropping the sealing would put the token on the wire in the clear over the same plain HTTP. The honest move is to say what is wrong and what reaches a secure context instead.

## How was it tested?

- **933 web tests** passing, `bunx tsc --noEmit` clean, `bun run build` succeeds.
- `web/test/pair-secure-context.test.ts` covers the diagnosis (secure context → no warning; insecure → a message naming the origin and never saying "try again"; tailnet → `tailscale cert`; plain LAN → the other advice; `100.128.x` is **not** treated as a tailnet, since telling somebody to run `tailscale cert` for ordinary public space sends them nowhere useful).
- The desktop predicate is tested as an **expression** rather than a rendered string, so it keeps being right for `https://`, `localhost` and `127.0.0.1` rather than only for today's markup.
- The false security claim has its own guard: the test fails if *"encrypted to the device that asked for it"* comes back.
- I confirmed on a non-secure origin in headless Chromium that `isSecureContext` and `crypto.subtle` are both undefined there, which is the reproduction.

One thing I could not verify and should flag: in that headless harness the app shell stops at the boot screen on a non-secure origin, so I could not screenshot the new message rendering. I checked `main` at the same origin and it behaves identically, so **this PR is not the cause** — but it means the phone-side copy is covered by tests and by reading, not by a screenshot of a real device. Worth a glance next time you have the phone in hand.