### PR TITLE
Drive Codex and Google Antigravity from the chat panel

### DIFF
--- a/.github/workflows/desktop-binaries.yml
+++ b/.github/workflows/desktop-binaries.yml
@@ -65,6 +65,12 @@ jobs:
           mkdir -p electron/staging
           bun build --compile --target=${{ matrix.bunTarget }} server/src/index.ts \
             --outfile "electron/staging/agentglass-server${ext}"
+          # The Claude model catalogue is read from disk at runtime, not
+          # imported, so --compile does not carry it. It goes beside the sidecar
+          # because that is where claudemodels.ts looks in a packaged app
+          # (dirname(process.execPath)). Without this the desktop build falls
+          # back to a single model id and the dropdown looks broken.
+          cp shared/claude-models.json electron/staging/claude-models.json
 
       # Sync the package version to the tag so a v0.2.0 tag ships v0.2.0 files.
       - name: Sync version to the tag

--- a/README.md
+++ b/README.md
@@ -207,17 +207,46 @@ Electron window compositor rather than xterm.
 
 ![terminal panel](.github/assets/terminal.png)
 
-### 💬 Chat — drive Claude sessions from the browser &nbsp;`c`
+### 💬 Chat — drive Claude and Codex sessions from the browser &nbsp;`c`
 
 Multi-chat against your **local `claude` CLI**: pick a repo/worktree, a model,
 and a permission mode (plan → default / acceptEdits → bypass), then converse —
 replies stream in, tool calls appear as chips, and follow-ups resume the same
 session. Sessions you start here show up in the fleet like any other agent.
 
+#### A second agent: OpenAI Codex
+
+The same panel drives **`codex`** as well. When both CLIs are on the machine an
+agent picker appears next to the repo — it is switchable until the chat has a
+thread, then frozen, because a resume id belongs to the CLI that minted it and
+there is no meaning to handing a live conversation from one to the other.
+
+Codex brings its own vocabulary rather than borrowing Claude's. Its modes are
+filesystem sandboxes (**Read-only**, **Write in this repo**, **⚡ Full access**)
+instead of per-tool permissions, so there is no allowlist box for a Codex chat —
+it decides at the filesystem boundary, not per tool call. The model list is read
+from Codex's own `models_cache.json`, so it follows whatever your CLI currently
+offers instead of a table in this repo that goes stale on every release. Pasted
+and dropped images are Claude-only: `codex exec` takes images as file paths
+rather than content blocks, so the panel says so instead of dropping them
+silently.
+
+Install and authenticate the Codex CLI separately, then make sure the `codex`
+executable is on the server's `PATH` when agentglass starts. The chat panel uses
+`codex exec --json` for new turns and `codex exec resume` for follow-ups; it does
+not replace the CLI's own login or configuration. Set `CODEX_HOME` when Codex
+keeps its state somewhere other than `~/.codex` — the model cache and rollout
+history are read from that location. To turn off the Codex integration while
+leaving Claude chat available, set `AGENTGLASS_CODEX_DISABLED=1` before starting
+the server.
+
 **↩ resume** picks up a session that already exists — including one you started
-in a terminal — with its full context intact. Sessions that are still running
-are listed but can't be picked: a claude session has a single owner, and a
-second writer on the same transcript corrupts its history.
+in a terminal — with its full context intact, and opens it against the CLI that
+created it. Sessions that are still running are listed but can't be picked: a
+session has a single owner, and a second writer on the same transcript corrupts
+its history. For Codex the replayed history comes from its rollout in
+`$CODEX_HOME/sessions` (`~/.codex/sessions` by default), since the OpenTelemetry
+stream that puts Codex on the radar carries tool calls but none of the words.
 
 **What a session shows:** the conversation is a **timeline**, not only a chat
 log. Tool runs interleave with messages, each tool card carries the head of its
@@ -932,6 +961,8 @@ in its own buckets rather than charged again as ordinary input.
 | `AGENTGLASS_GIT_TIMEOUT_SECONDS` | `120` | Ceiling on a single git subprocess. |
 | `AGENTGLASS_FS_BROWSE_DISABLED` | — | `1` → disable directory completion in the project picker (`/fs/complete`). Separate from the terminal switch on purpose: disabling the shell should not leave the directory tree readable. |
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
+| `AGENTGLASS_CODEX_DISABLED` | — | `1` → disable the **Codex** agent in the Chat panel, leaving Claude chat available. Codex is offered whenever a `codex` executable is on the server's `PATH`. |
+| `CODEX_HOME` | `~/.codex` | Codex's own override for where it keeps its state. agentglass reads the model cache and the rollout history (resumed-thread transcripts) from there. |
 | `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's `bypassPermissions` mode (`claude --dangerously-skip-permissions`). Off by default: the mode is downgraded to a prompting default unless you opt in. |
 | `AGENTGLASS_CHAT_ENGINE` | `process` | `tmux` → new chats run as a live `claude` in a pane on agentglass's own tmux server instead of one `claude -p` per turn. Faster per turn (the CLI's session start is paid once, not every message) and the session is attachable from your own terminal; costs a warm CLI (~380MB, growing with use) for as long as the chat is warm. Per-chat in **Settings → Preferences → How new chats run**. |
 | `AGENTGLASS_TMUX_SOCKET` | `agentglass` | Socket name for that server (`tmux -L <name>`). It is always launched with a config of our own (`-f`), never your `~/.tmux.conf` — otherwise tpm/resurrect/continuum would come with it and continuum's autosave would overwrite your own saved layout in the shared `~/.tmux/resurrect/`. |
@@ -996,6 +1027,8 @@ cannot be configured by `export` at all.
 | `GET /terminal/commands?root=` | Ready-to-run project commands: Makefile targets **with descriptions** + `package.json` scripts (runner-aware), from the repo root **and its subfolders** (`make -C …`), grouped by folder. |
 | `GET /chat/enabled` · `POST /chat/send` | Drive a local `claude` session in a repo (streamed JSONL) — gated by `AGENTGLASS_CHAT_DISABLED`. `send` takes an optional `engine` (`process` \| `tmux`). |
 | `GET /chat/attach` | The `tmux attach` command for a chat running on the pane engine, and whether its pane is still up. |
+| `GET /codex/enabled` · `POST /codex/send` | The same, driving a local `codex` session (`codex exec --json`, `codex exec resume` for follow-ups) — gated by `AGENTGLASS_CODEX_DISABLED`. `enabled` carries the model list read from Codex's own cache. |
+| `GET /codex/transcript?id=` | What a Codex thread said, read from its rollout under `$CODEX_HOME/sessions`. The OTel stream carries its tool calls but none of the prose, so this is what a resumed Codex chat replays. |
 | `GET /prs/capability · /prs/list · /prs/detail · /prs/diff · /prs/commit-diff · /prs/branch-url` | Pull requests through the `gh` CLI, per repository: capability probe, the list for a scope tab, one PR's full detail, its diff, a single commit's diff. Cached, with check states filled by a second batched GraphQL pass. |
 | `POST /prs/{review,review-with,comment,reply,thread-resolved,react,edit,labels,reviewers,draft,update-branch,rerun,merge,close}` | Pull-request actions — **gated** by `AGENTGLASS_GIT_WRITE_DISABLED` and by the active scope. |
 | `POST /prs/review-prompt` | The prompt to review a PR with Claude, and the directory to run it in. Reads only, so the write switch does not gate it; the active scope still does. |

--- a/README.md
+++ b/README.md
@@ -214,6 +214,36 @@ a model, and a permission mode (plan → default / acceptEdits → bypass), then
 replies stream in, tool calls appear as chips, and follow-ups resume the same
 session. Sessions you start here show up in the fleet like any other agent.
 
+#### Which models the Chat panel offers
+
+Every list is the CLI's own answer rather than a table in this repo. Codex reads
+its `models_cache.json`; Antigravity answers `agy models`. Claude Code publishes
+no list at all — there is no `claude models` subcommand, no `--list-models`, and
+nothing cached on disk — so its catalogue lives in
+[`shared/claude-models.json`](shared/claude-models.json).
+
+It is **data, not code**: edit that file and the dropdown follows on the next
+request. No rebuild, no restart.
+
+```json
+{ "id": "claude-opus-5", "display_name": "Claude Opus 5", "status": "active",
+  "release_date": "2026-07-24", "scheduled_shutdown_date": "2027-07-24" }
+```
+
+A model is offered until its `scheduled_shutdown_date` has passed — that date is
+the last day it appears, so it drops out the day after, and the panel stops
+offering retired models without anyone editing anything. `status` is recorded for
+the reader and is deliberately *not* a filter: a `superseded` model still answers
+until it is actually retired, and hiding it early would remove a choice that
+works. A row with no shutdown date never expires, which reads as "no retirement
+announced".
+
+To change the list without touching the checkout — a packaged install, or a
+read-only one — put your own copy at `~/.config/agentglass/claude-models.json`,
+or point `AGENTGLASS_CLAUDE_MODELS` at a file. Ids are validated against the same
+expression that guards the spawn, so an entry that could not be sent is never
+offered.
+
 #### A second agent: OpenAI Codex
 
 The same panel drives **`codex`** as well. When both CLIs are on the machine an
@@ -1005,6 +1035,7 @@ in its own buckets rather than charged again as ordinary input.
 | `AGENTGLASS_GIT_TIMEOUT_SECONDS` | `120` | Ceiling on a single git subprocess. |
 | `AGENTGLASS_FS_BROWSE_DISABLED` | — | `1` → disable directory completion in the project picker (`/fs/complete`). Separate from the terminal switch on purpose: disabling the shell should not leave the directory tree readable. |
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
+| `AGENTGLASS_CLAUDE_MODELS` | — | Path to the Claude model catalogue, overriding the copy in the checkout. See **Which models the Chat panel offers**. |
 | `AGENTGLASS_CODEX_DISABLED` | — | `1` → disable the **Codex** agent in the Chat panel, leaving Claude chat available. Codex is offered whenever a `codex` executable is on the server's `PATH`. |
 | `AGENTGLASS_ANTIGRAVITY_DISABLED` | — | `1` → disable the **Antigravity** agent in the Chat panel, leaving the other two available. Antigravity is offered whenever an `agy` executable is on the server's `PATH`. Independent of the Gemini CLI, which is a different product and is not driven from the chat panel at all. |
 | `CODEX_HOME` | `~/.codex` | Codex's own override for where it keeps its state. agentglass reads the model cache and the rollout history (resumed-thread transcripts) from there. |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Point any AI coding agent at agentglass — via Claude Code hooks or any OpenTelemetry GenAI exporter (OpenAI Codex, Gemini CLI, Bedrock, LangChain, LiteLLM…) — and watch every agent, tool call, token, and dollar move in real time. Cost tracking, tool-latency percentiles, error timelines, session lifecycles, one switch that filters the whole cockpit by provider, and 22 themes. It persists across reloads (unlike a pure in-browser stream).
 
-And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **pull-request** panel that reviews and merges without opening a browser, a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Ships as a **native desktop app**, server included.
+And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **pull-request** panel that reviews and merges without opening a browser, a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code *and* Codex sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Ships as a **native desktop app**, server included.
 
 ### ▶ [**Live demo →**](https://sirallap.github.io/agentglass/demo/)
 
@@ -209,8 +209,8 @@ Electron window compositor rather than xterm.
 
 ### 💬 Chat — drive Claude and Codex sessions from the browser &nbsp;`c`
 
-Multi-chat against your **local `claude` CLI**: pick a repo/worktree, a model,
-and a permission mode (plan → default / acceptEdits → bypass), then converse —
+Multi-chat against your **local `claude` or `codex` CLI**: pick a repo/worktree,
+a model, and a permission mode (plan → default / acceptEdits → bypass), then converse —
 replies stream in, tool calls appear as chips, and follow-ups resume the same
 session. Sessions you start here show up in the fleet like any other agent.
 
@@ -230,6 +230,13 @@ offers instead of a table in this repo that goes stale on every release. Pasted
 and dropped images are Claude-only: `codex exec` takes images as file paths
 rather than content blocks, so the panel says so instead of dropping them
 silently.
+
+A Codex chat shows **tokens but no cost and no context meter**. `codex exec`
+reports neither a price nor a per-turn prompt size, and a bar drawn at 0 / 400k
+would be a claim about a session we know nothing about. Its token counts are
+cumulative for the whole thread rather than per turn, so they are assigned
+rather than added up — and its input count includes the cached part, which is
+subtracted back out so the "In" row means the same thing for both agents.
 
 Install and authenticate the Codex CLI separately, then make sure the `codex`
 executable is on the server's `PATH` when agentglass starts. The chat panel uses
@@ -768,8 +775,8 @@ are:
   also have accounts, any of them could reach the server and its shell **as
   your user**. Set `AGENTGLASS_TOKEN` to lock it to you, and/or disable the
   capability surfaces: `AGENTGLASS_TERMINAL_DISABLED=1`, `AGENTGLASS_FS_BROWSE_DISABLED=1`,
-  `AGENTGLASS_CHAT_DISABLED=1`, `AGENTGLASS_GIT_WRITE_DISABLED=1`,
-  `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
+  `AGENTGLASS_CHAT_DISABLED=1`, `AGENTGLASS_CODEX_DISABLED=1`,
+  `AGENTGLASS_GIT_WRITE_DISABLED=1`, `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
 - **⚠️ Exposing it to a network is a three-part deliberate act.** `AGENTGLASS_BIND=0.0.0.0`
   hands the shell, git write and Docker control to that network. Do it only with
   a token set **and** `AGENTGLASS_TRUST_LAN=1` (off by default, LAN browsers are
@@ -779,9 +786,12 @@ are:
   If a device still can't reach it, the host firewall is dropping the packets:
   the panel names it and prints the command that opens the port to your subnet
   only. Tailnet (Tailscale) addresses count as private under `TRUST_LAN` too.
-- **⚠️ Browser-driven autonomy is opt-in.** The Chat panel's `bypassPermissions`
-  mode (`claude --dangerously-skip-permissions`) is honored only when
-  `AGENTGLASS_CHAT_BYPASS=1`; otherwise it's downgraded to a prompting default.
+- **⚠️ Browser-driven autonomy is opt-in.** The Chat panel's unattended modes —
+  `bypassPermissions` for Claude (`claude --dangerously-skip-permissions`) and
+  `full-access` for Codex (`codex --dangerously-bypass-approvals-and-sandbox`) —
+  are honored only when `AGENTGLASS_CHAT_BYPASS=1`. One opt-in covers both, since
+  it is the same decision. Without it Claude is downgraded to a prompting default
+  and Codex to its read-only sandbox.
 - **Your data stays local.** Events live in a local SQLite file, written
   owner-only (`0700` dir, `0600` file) on POSIX; on Windows, which has no POSIX
   mode bits, it falls back to your account's default ACL. Outbound calls are few and all of them are yours to
@@ -963,7 +973,7 @@ in its own buckets rather than charged again as ordinary input.
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
 | `AGENTGLASS_CODEX_DISABLED` | — | `1` → disable the **Codex** agent in the Chat panel, leaving Claude chat available. Codex is offered whenever a `codex` executable is on the server's `PATH`. |
 | `CODEX_HOME` | `~/.codex` | Codex's own override for where it keeps its state. agentglass reads the model cache and the rollout history (resumed-thread transcripts) from there. |
-| `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's `bypassPermissions` mode (`claude --dangerously-skip-permissions`). Off by default: the mode is downgraded to a prompting default unless you opt in. |
+| `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's unattended modes: `bypassPermissions` for Claude (`--dangerously-skip-permissions`) and `full-access` for Codex (`--dangerously-bypass-approvals-and-sandbox`). Off by default; without it Claude is downgraded to a prompting default and Codex to its read-only sandbox. |
 | `AGENTGLASS_CHAT_ENGINE` | `process` | `tmux` → new chats run as a live `claude` in a pane on agentglass's own tmux server instead of one `claude -p` per turn. Faster per turn (the CLI's session start is paid once, not every message) and the session is attachable from your own terminal; costs a warm CLI (~380MB, growing with use) for as long as the chat is warm. Per-chat in **Settings → Preferences → How new chats run**. |
 | `AGENTGLASS_TMUX_SOCKET` | `agentglass` | Socket name for that server (`tmux -L <name>`). It is always launched with a config of our own (`-f`), never your `~/.tmux.conf` — otherwise tpm/resurrect/continuum would come with it and continuum's autosave would overwrite your own saved layout in the shared `~/.tmux/resurrect/`. |
 | `AGENTGLASS_TMUX_IDLE_MINUTES` | `30` | Minutes a chat pane may sit unused before its CLI is reclaimed. The next turn resumes the session transparently (one slower turn). `0` disables eviction and keeps every warm chat resident. |

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 Point any AI coding agent at agentglass — via Claude Code hooks or any OpenTelemetry GenAI exporter (OpenAI Codex, Gemini CLI, Bedrock, LangChain, LiteLLM…) — and watch every agent, tool call, token, and dollar move in real time. Cost tracking, tool-latency percentiles, error timelines, session lifecycles, one switch that filters the whole cockpit by provider, and 22 themes. It persists across reloads (unlike a pure in-browser stream).
 
-And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **pull-request** panel that reviews and merges without opening a browser, a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code *and* Codex sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Ships as a **native desktop app**, server included.
+And it's not just a viewer. agentglass carries a full **workspace** in the same cockpit — the idea is simple: browser, terminal, IDE panels, agent telemetry… all in one place. A syntax-highlighted **diff** viewer for everything the fleet changed, a **lazygit**-style source-control panel (stage, commit, push), a **pull-request** panel that reviews and merges without opening a browser, a **lazydocker**-style Docker panel (containers, logs, stats), a **real terminal** (an actual PTY shell on your machine, not an emulation), and a **chat** panel that drives local Claude Code, Codex *and* Antigravity sessions — all behind one keystroke, under a notch that mirrors your desktop notifications so nothing is lost while you are fullscreen. Ships as a **native desktop app**, server included.
 
 ### ▶ [**Live demo →**](https://sirallap.github.io/agentglass/demo/)
 
@@ -207,9 +207,9 @@ Electron window compositor rather than xterm.
 
 ![terminal panel](.github/assets/terminal.png)
 
-### 💬 Chat — drive Claude and Codex sessions from the browser &nbsp;`c`
+### 💬 Chat — drive Claude, Codex and Antigravity sessions from the browser &nbsp;`c`
 
-Multi-chat against your **local `claude` or `codex` CLI**: pick a repo/worktree,
+Multi-chat against your **local `claude`, `codex` or `agy` CLI**: pick a repo/worktree,
 a model, and a permission mode (plan → default / acceptEdits → bypass), then converse —
 replies stream in, tool calls appear as chips, and follow-ups resume the same
 session. Sessions you start here show up in the fleet like any other agent.
@@ -246,6 +246,38 @@ keeps its state somewhere other than `~/.codex` — the model cache and rollout
 history are read from that location. To turn off the Codex integration while
 leaving Claude chat available, set `AGENTGLASS_CODEX_DISABLED=1` before starting
 the server.
+
+#### A third agent: Google Antigravity
+
+The panel drives **`agy`** as well — Google's agentic CLI, and a **separate
+product from the Gemini CLI**: a separate binary with separate state, whose
+model list spans Anthropic and open-weight models as well as Google's. Wiring
+one does nothing for the other, and the Gemini CLI keeps its own OpenTelemetry
+route onto the radar unchanged.
+
+Its four modes line up with Claude's — **Ask**, **Plan**, **Auto-accept edits**,
+**⚡ Bypass** — because it really does decide per tool call rather than by
+drawing a line around the filesystem. The model list comes from `agy models`, so
+it follows whatever your CLI currently offers. Like Codex, it takes images as
+file paths rather than content blocks, so pasted images are refused with a
+sentence instead of being dropped.
+
+Two honest gaps, both consequences of Antigravity exporting no telemetry of its
+own:
+
+- **Only chats started here appear in the fleet.** Claude reports through hooks
+  and Codex through OpenTelemetry; Antigravity reports through neither, so
+  agentglass turns the frames of the turns *it* runs into events. An `agy` you
+  ran in a terminal stays invisible.
+- **There is no ↩ resume for it, and no cost or context meter.** Antigravity
+  keeps each conversation as a SQLite database of protobuf blobs on an
+  undocumented internal schema, so there is no history to replay; and the stream
+  reports neither a price nor a context window. Tokens are shown, because those
+  it does report.
+
+Install and authenticate the CLI separately, and make sure `agy` is on the
+server's `PATH` when agentglass starts. To turn it off while leaving the other
+two, set `AGENTGLASS_ANTIGRAVITY_DISABLED=1`.
 
 **↩ resume** picks up a session that already exists — including one you started
 in a terminal — with its full context intact, and opens it against the CLI that
@@ -776,7 +808,8 @@ are:
   your user**. Set `AGENTGLASS_TOKEN` to lock it to you, and/or disable the
   capability surfaces: `AGENTGLASS_TERMINAL_DISABLED=1`, `AGENTGLASS_FS_BROWSE_DISABLED=1`,
   `AGENTGLASS_CHAT_DISABLED=1`, `AGENTGLASS_CODEX_DISABLED=1`,
-  `AGENTGLASS_GIT_WRITE_DISABLED=1`, `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
+  `AGENTGLASS_ANTIGRAVITY_DISABLED=1`, `AGENTGLASS_GIT_WRITE_DISABLED=1`,
+  `AGENTGLASS_DOCKER_WRITE_DISABLED=1`.
 - **⚠️ Exposing it to a network is a three-part deliberate act.** `AGENTGLASS_BIND=0.0.0.0`
   hands the shell, git write and Docker control to that network. Do it only with
   a token set **and** `AGENTGLASS_TRUST_LAN=1` (off by default, LAN browsers are
@@ -787,11 +820,12 @@ are:
   the panel names it and prints the command that opens the port to your subnet
   only. Tailnet (Tailscale) addresses count as private under `TRUST_LAN` too.
 - **⚠️ Browser-driven autonomy is opt-in.** The Chat panel's unattended modes —
-  `bypassPermissions` for Claude (`claude --dangerously-skip-permissions`) and
-  `full-access` for Codex (`codex --dangerously-bypass-approvals-and-sandbox`) —
-  are honored only when `AGENTGLASS_CHAT_BYPASS=1`. One opt-in covers both, since
-  it is the same decision. Without it Claude is downgraded to a prompting default
-  and Codex to its read-only sandbox.
+  `bypassPermissions` for Claude (`claude --dangerously-skip-permissions`),
+  `full-access` for Codex (`codex --dangerously-bypass-approvals-and-sandbox`)
+  and `always-proceed` for Antigravity (`agy --dangerously-skip-permissions`) —
+  are honored only when `AGENTGLASS_CHAT_BYPASS=1`. One opt-in covers all three,
+  since it is the same decision. Without it Claude is downgraded to a prompting
+  default, Codex to its read-only sandbox, and Antigravity to asking.
 - **Your data stays local.** Events live in a local SQLite file, written
   owner-only (`0700` dir, `0600` file) on POSIX; on Windows, which has no POSIX
   mode bits, it falls back to your account's default ACL. Outbound calls are few and all of them are yours to
@@ -972,8 +1006,9 @@ in its own buckets rather than charged again as ordinary input.
 | `AGENTGLASS_FS_BROWSE_DISABLED` | — | `1` → disable directory completion in the project picker (`/fs/complete`). Separate from the terminal switch on purpose: disabling the shell should not leave the directory tree readable. |
 | `AGENTGLASS_CHAT_DISABLED` | — | `1` → disable the **Chat** panel (no `claude` sessions can be started from the browser). |
 | `AGENTGLASS_CODEX_DISABLED` | — | `1` → disable the **Codex** agent in the Chat panel, leaving Claude chat available. Codex is offered whenever a `codex` executable is on the server's `PATH`. |
+| `AGENTGLASS_ANTIGRAVITY_DISABLED` | — | `1` → disable the **Antigravity** agent in the Chat panel, leaving the other two available. Antigravity is offered whenever an `agy` executable is on the server's `PATH`. Independent of the Gemini CLI, which is a different product and is not driven from the chat panel at all. |
 | `CODEX_HOME` | `~/.codex` | Codex's own override for where it keeps its state. agentglass reads the model cache and the rollout history (resumed-thread transcripts) from there. |
-| `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's unattended modes: `bypassPermissions` for Claude (`--dangerously-skip-permissions`) and `full-access` for Codex (`--dangerously-bypass-approvals-and-sandbox`). Off by default; without it Claude is downgraded to a prompting default and Codex to its read-only sandbox. |
+| `AGENTGLASS_CHAT_BYPASS` | — | `1` → allow the Chat panel's unattended modes: `bypassPermissions` for Claude (`--dangerously-skip-permissions`), `full-access` for Codex (`--dangerously-bypass-approvals-and-sandbox`) and `always-proceed` for Antigravity (`--dangerously-skip-permissions`). Off by default; one opt-in covers all three, since it is the same decision. |
 | `AGENTGLASS_CHAT_ENGINE` | `process` | `tmux` → new chats run as a live `claude` in a pane on agentglass's own tmux server instead of one `claude -p` per turn. Faster per turn (the CLI's session start is paid once, not every message) and the session is attachable from your own terminal; costs a warm CLI (~380MB, growing with use) for as long as the chat is warm. Per-chat in **Settings → Preferences → How new chats run**. |
 | `AGENTGLASS_TMUX_SOCKET` | `agentglass` | Socket name for that server (`tmux -L <name>`). It is always launched with a config of our own (`-f`), never your `~/.tmux.conf` — otherwise tpm/resurrect/continuum would come with it and continuum's autosave would overwrite your own saved layout in the shared `~/.tmux/resurrect/`. |
 | `AGENTGLASS_TMUX_IDLE_MINUTES` | `30` | Minutes a chat pane may sit unused before its CLI is reclaimed. The next turn resumes the session transparently (one slower turn). `0` disables eviction and keeps every warm chat resident. |
@@ -1039,6 +1074,7 @@ cannot be configured by `export` at all.
 | `GET /chat/attach` | The `tmux attach` command for a chat running on the pane engine, and whether its pane is still up. |
 | `GET /codex/enabled` · `POST /codex/send` | The same, driving a local `codex` session (`codex exec --json`, `codex exec resume` for follow-ups) — gated by `AGENTGLASS_CODEX_DISABLED`. `enabled` carries the model list read from Codex's own cache. |
 | `GET /codex/transcript?id=` | What a Codex thread said, read from its rollout under `$CODEX_HOME/sessions`. The OTel stream carries its tool calls but none of the prose, so this is what a resumed Codex chat replays. |
+| `GET /antigravity/enabled` · `POST /antigravity/send` | The same for a local `agy` session (`agy -p … --output-format stream-json`, `--conversation` for follow-ups) — gated by `AGENTGLASS_ANTIGRAVITY_DISABLED`. `enabled` carries the model list from `agy models`. `send` also turns the turn's own frames into events, since Antigravity reports to nothing else. There is no transcript route: its conversations are protobuf inside SQLite. |
 | `GET /prs/capability · /prs/list · /prs/detail · /prs/diff · /prs/commit-diff · /prs/branch-url` | Pull requests through the `gh` CLI, per repository: capability probe, the list for a scope tab, one PR's full detail, its diff, a single commit's diff. Cached, with check states filled by a second batched GraphQL pass. |
 | `POST /prs/{review,review-with,comment,reply,thread-resolved,react,edit,labels,reviewers,draft,update-branch,rerun,merge,close}` | Pull-request actions — **gated** by `AGENTGLASS_GIT_WRITE_DISABLED` and by the active scope. |
 | `POST /prs/review-prompt` | The prompt to review a PR with Claude, and the directory to run it in. Reads only, so the write switch does not gate it; the active scope still does. |

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -170,9 +170,32 @@ alongside `server/src/chat.ts`. The division that makes it cheap:
   cost and no context window at all. Each of those is a visible difference in
   the panel, not a fabricated equivalence.
 
-A third CLI would repeat that shape: a `<name>.ts` beside those two, a frame
-translator beside `codexFrames.ts`, and `AgentKind` in `chatStore.ts` gaining a
-member.
+A third CLI repeats that shape, and Google Antigravity is the proof it holds:
+`server/src/antigravity.ts` beside the other two, `web/src/lib/antigravityFrames.ts`
+beside `codexFrames.ts`, and `AgentKind` gaining a member. What the third one
+changed is worth knowing before you add a fourth:
+
+- **The per-agent differences moved into a table.** `AGENTS` in
+  `web/src/lib/agents.ts` holds the label, the binary, the defaults, the
+  unattended mode, and whether the CLI takes attachments or has a replayable
+  transcript. Two agents justified `agent === "codex" ? … : …`; three did not,
+  because a missed branch is silent — a Claude default quietly applied to
+  something that is not Claude. Add the entry, not the branches.
+- **An agent may report through the panel itself.** Claude reaches the fleet
+  over hooks and Codex over OpenTelemetry, but Antigravity exports neither, so
+  its own stream is teed into `ingestBody` — `frameToEvent` maps frames to
+  `SessionStart` / `UserPromptSubmit` / `PreToolUse` / `PostToolUse` /
+  `Turn complete`. That is the `via: "chat"` kind in the agent roster. It only
+  covers chats started here, which is said plainly rather than implied.
+- **Check what the usage numbers actually mean before trusting them.** Codex
+  reports cumulative thread totals and Antigravity reports per-turn figures.
+  They look identical on the wire and are assigned in one case and added in the
+  other; getting it backwards over-reports spend severalfold and nothing fails
+  loudly.
+- **A capability the CLI has not got is left off, not faked.** Antigravity has
+  no readable transcript (protobuf inside SQLite), no price, and no context
+  window, so there is no resume route and the cost and context rows stay hidden
+  rather than being filled from a table in this repo.
 
 ## 2. Use the gate in your own harness
 

--- a/docs/EXTENDING.md
+++ b/docs/EXTENDING.md
@@ -148,6 +148,32 @@ Mapping (see `server/src/otlp.ts`):
 One-command CLI wiring (Gemini / Codex) is documented in the README under
 **Any provider — via OpenTelemetry**.
 
+### Adding a CLI you can talk to, not only watch
+
+OpenTelemetry gets a CLI onto the radar. Driving one from the chat panel is a
+separate seam, and Codex is the worked example of it — `server/src/codex.ts`
+alongside `server/src/chat.ts`. The division that makes it cheap:
+
+- **The server spawns and streams, and does not translate.** It runs the binary
+  non-interactively in a scoped git directory and pipes its JSONL back verbatim,
+  plus an `agx_error` frame of its own when the process never got going. Every
+  guard is shared — `safeAbs` / `repoRootOf` / `inScope`, the `setsid` process
+  group so stopping a turn reaches the whole job tree, the keepalive, and the
+  first-run watchdog that names the login command.
+- **One file in the browser knows the vocabulary.** `web/src/lib/codexFrames.ts`
+  turns Codex's `item.completed` frames into the same `ChatMsg` / `ChatTool` /
+  `ChatUsage` the Claude path fills. Nothing below the store branches on which
+  CLI produced a turn, which is what lets one panel render both.
+- **The differences that remain are real ones, and are surfaced rather than
+  papered over.** Codex has a sandbox where Claude has permission modes; it
+  reports cumulative thread tokens where Claude reports per-turn; it reports no
+  cost and no context window at all. Each of those is a visible difference in
+  the panel, not a fabricated equivalence.
+
+A third CLI would repeat that shape: a `<name>.ts` beside those two, a frame
+translator beside `codexFrames.ts`, and `AgentKind` in `chatStore.ts` gaining a
+member.
+
 ## 2. Use the gate in your own harness
 
 `POST /gate` is a generic approval primitive: hold an action until a human
@@ -326,7 +352,8 @@ folder instead.
 ### Auth and write gates
 
 See the README security table (`AGENTGLASS_TOKEN`, `AGENTGLASS_GIT_WRITE_DISABLED`,
-`AGENTGLASS_DOCKER_WRITE_DISABLED`, `AGENTGLASS_CHAT_DISABLED`, …). Intake routes
+`AGENTGLASS_DOCKER_WRITE_DISABLED`, `AGENTGLASS_CHAT_DISABLED`,
+`AGENTGLASS_CODEX_DISABLED`, …). Intake routes
 (`/ingest`, OTLP) stay tokenless on purpose — local hooks and OTel exporters
 have no way to carry a secret — while everything else needs the token when set.
 

--- a/docs/superpowers/specs/2026-07-31-antigravity-agent-design.md
+++ b/docs/superpowers/specs/2026-07-31-antigravity-agent-design.md
@@ -1,0 +1,169 @@
+# Google Antigravity as a third chat agent
+
+**Date:** 2026-07-31
+**Status:** approved
+
+## What this is
+
+The chat panel drives `claude` and `codex`. This adds Google's Antigravity CLI
+(`agy`) as a third peer. It is **not** a replacement for the Gemini CLI: the two
+are separate binaries with separate wiring, and `agy` is a multi-model harness
+that offers `claude-sonnet-4-6` and `gpt-oss-120b-medium` alongside Gemini
+models. Gemini CLI keeps its existing OpenTelemetry route onto the radar and is
+not touched.
+
+## Facts this design rests on
+
+Established against `agy` 1.1.9, not assumed:
+
+| Need | Antigravity |
+|---|---|
+| Non-interactive stream | `agy -p "…" --output-format stream-json` |
+| Resume | `agy --conversation <uuid> -p "…"` |
+| Model list | `agy models` → newline-separated ids |
+| Modes | `--mode accept-edits\|plan`; default `request-review`; `--dangerously-skip-permissions` → `always-proceed` |
+| State dir | `~/.gemini/antigravity-cli` (shared parent with Gemini CLI, distinct subtree) |
+
+Frame envelope — note the discriminator is `event`, not `type`:
+
+```json
+{"event":"init","conversation_id":"…","init":{"model":"…","cwd":"…","permission_mode":"request-review"}}
+{"event":"step_update","step_update":{"step_index":2,"state":"DONE","step_type":"agent_response","text_delta":"…","usage":{…}}}
+{"event":"step_update","step_update":{"step_index":3,"state":"ACTIVE","step_type":"tool","tool_name":"list_dir","tool_info":{"name":"list_dir","parameters":{"DirectoryPath":"…"}}}}
+{"event":"result","result":{"conversation_id":"…","status":"SUCCESS","response":"…","num_turns":2,"usage":{…}}}
+```
+
+`step_type` ∈ `user_input | agent_response | thinking | tool | subagent |
+browser_action | checkpoint | error_message | unknown`. A tool step appears
+twice, `ACTIVE` then `DONE`, the second carrying `tool_info.output` and
+`duration_seconds`.
+
+Usage is `{input,output,thinking,cache_read,total}_tokens`. **`result.usage` is
+per-turn, not thread-cumulative** — measured: turn 1 reported 31789 input,
+turn 2 reported 16609. So it is added across turns (like Claude), not assigned
+(like Codex). Getting this backwards would over-report spend several-fold.
+
+## Architecture
+
+The seam `docs/EXTENDING.md` already describes: the server spawns and streams
+without translating; one browser file knows the vocabulary; real differences are
+surfaced rather than papered over.
+
+### `server/src/antigravity.ts`
+
+Mirrors `codex.ts`.
+
+- `antigravityModels()` — runs `agy models`, splits lines, caches.
+- `antigravityArgs(bin, model, mode, resumeId)` — pure argv builder.
+- `antigravityStream(cwd, message, model, resumeId, mode, emit?)` — spawns,
+  pipes JSONL back verbatim, emits `agx_error` when the process never started.
+- `frameToEvent(frame, ctx)` — pure frame → event mapper, exported for tests.
+
+Shares every guard with the other two: `safeAbs` / `repoRootOf` / `inScope`, the
+`setsid` process group so stopping a turn reaches the whole job tree, the
+keepalive, and `MODEL_RE` / `SESSION_RE` (a conversation id is a UUID, which
+`SESSION_RE` already accepts).
+
+Gated by `AGENTGLASS_ANTIGRAVITY_DISABLED`.
+`ANTIGRAVITY_BYPASS_ALLOWED = chatBypassAllowed()` — the same single operator
+opt-in that already covers Claude's `bypassPermissions` and Codex's
+`full-access`, because it is the same decision.
+
+### Modes
+
+They land almost 1:1 on Claude's four, which is a property of the CLI rather
+than something forced here:
+
+| Panel | Flag |
+|---|---|
+| Ask (default) | *(none)* → `request-review` |
+| Plan (no edits) | `--mode plan` |
+| Auto-accept edits | `--mode accept-edits` |
+| ⚡ Bypass | `--dangerously-skip-permissions` |
+
+### Fleet visibility: frames → events
+
+Antigravity has neither hooks nor an OTel exporter, so without this its chats
+would exist only in the panel and the README's "sessions you start here show up
+in the fleet" would be false for it.
+
+`antigravityStream` takes an injected `emit` callback; `index.ts` passes
+`ingestBody`. That keeps the mapper pure and testable and matches how `otlp.ts`
+already works — the parser returns events, `index.ts` inserts them.
+
+```
+init         → SessionStart      (model, cwd)
+user_input   → UserPromptSubmit  (prompt)
+tool ACTIVE  → PreToolUse        (tool_name, tool_use_id = step_index)
+tool DONE    → PostToolUse       (tool_info.output, duration_seconds, is_error)
+result       → Turn complete     (usage, model)
+```
+
+`source_app` is `"antigravity"`. This is load-bearing rather than cosmetic:
+`agy` can run `claude-opus-4-6-thinking`, so `model_name` is an actively
+misleading signal, and `agentOf` checks `source_app` first. Setting it
+explicitly is what stops an Antigravity session being misfiled as a Claude one.
+
+Only chats started in the panel produce events. A terminal-run `agy` stays
+invisible, and that is stated rather than implied.
+
+### `web/src/lib/antigravityFrames.ts`
+
+The whole translation, beside `codexFrames.ts`, so there is one file to open
+when a frame renders wrong.
+
+- `applyAntigravityFrame(chat, frame)` — fills the same `ChatMsg` / `ChatTool`
+  shapes the other two produce. Nothing below the store branches on which CLI
+  produced a turn.
+- `antigravityUsage(usage, prev)` — **adds**, per the measured per-turn
+  semantics above.
+- `contextTokens` stays 0. `agy` reports no window, and `ctxLimitOf` does not
+  know the Gemini 3.x families, so a meter here would fall back to a default and
+  draw a confident wrong number. The `contextTokens > 0` guard already
+  suppresses it. Tokens and cost still show.
+
+### The refactor this earns
+
+Two agents justified `agent === "codex" ? x : y`. Three do not — there are ~12
+such ternaries across `ChatPanel` and `chatStore`, and each new agent multiplies
+them.
+
+```ts
+const AGENTS: Record<AgentKind, AgentSpec> = { claude, codex, antigravity };
+// label, cli, defaultModel, defaultMode, modes, bypassMode, canAttach, hasTranscript
+```
+
+`modelsFor` / `modesFor` / `bypassMode` / `cliName` / `agentLabel` become
+lookups. In scope because it is the code this feature touches, and it is what
+makes a fourth agent cheap.
+
+Types generalize the same way: `AgentModel` / `AgentCliStatus` become the shared
+shapes, with `CodexModel` / `CodexStatus` kept as aliases so no call site churns.
+
+## Deliberate omissions
+
+**No `/antigravity/transcript`.** Conversations are per-UUID SQLite databases
+whose `step_payload` is binary protobuf on an undocumented internal schema.
+Decoding it would break on any `agy` update. It costs little: panel chats keep
+their history through `chatPersist` plus the `conversation_id`, and there are no
+fleet-listed Antigravity sessions to adopt in the first place.
+
+**No `--effort` dial.** The model ids already encode it
+(`gemini-3.1-pro-high` / `-low`), so a second control would fight the first.
+
+## Testing
+
+- `server/test/antigravity.test.ts` — argv building per mode, model-list
+  parsing, `frameToEvent` mapping, scope refusal, bypass gating when the
+  operator has not opted in.
+- `web/test/antigravity-frames.test.ts` — frame translation, including that
+  usage is added rather than assigned, and that `contextTokens` stays 0.
+- `web/test/chat-agent.test.ts` — extended to three-way `switchAgent`,
+  `agentOf`, and persistence round-trip.
+
+## Docs
+
+README (chat section, env table, endpoint table, security list), the
+`agentprobe` roster so Settings lists Antigravity among agents on the machine,
+and `EXTENDING.md` — where "a third CLI would repeat that shape" stops being a
+prediction.

--- a/server/src/agentprobe.ts
+++ b/server/src/agentprobe.ts
@@ -81,6 +81,22 @@ export const ROSTER: Roster[] = [
     install: "npm i -g @openai/codex",
     connects: "OpenTelemetry logs → /v1/logs",
   },
+  {
+    // Google's agentic CLI, and a separate product from the Gemini CLI above —
+    // separate binary, separate state, and a model list that spans Anthropic
+    // and open-weight models as well as Google's. Wiring one does nothing for
+    // the other.
+    id: "antigravity",
+    label: "Google Antigravity",
+    bin: "agy",
+    via: "chat",
+    // It keeps state under ~/.gemini/antigravity-cli, but nothing there is a
+    // connection this app writes or reads, so there is no path worth showing.
+    configPath: () => "",
+    match: "antigravity",
+    install: "https://antigravity.google/docs/cli",
+    connects: "the chat panel, which turns its own turns into events",
+  },
 ];
 
 /**
@@ -90,8 +106,14 @@ export const ROSTER: Roster[] = [
  * it by hand — or ran the CLI's own reset — should see that reflected instead
  * of a state this app wrote down once.
  */
-function wired(a: Roster, path: string): boolean {
+function wired(a: Roster, path: string, found: boolean): boolean {
   if (a.via === "hooks") return hookStatus().installed;
+  // Nothing to wire and nothing that could be unwired: a `chat` agent reports
+  // because this server is the thing running it, so being installed is the
+  // whole of being connected. It has to be said that way round — answering a
+  // flat `true` here would report a CLI nobody has installed as connected and
+  // waiting for its first event, which is the one state it can never reach.
+  if (a.via === "chat") return found;
   if (!existsSync(path)) return false;
   let text: string;
   try { text = readFileSync(path, "utf8"); } catch { return false; }
@@ -140,7 +162,7 @@ export function probeAgents(
       configPath: path,
       found: !!found,
       path: found,
-      connected: wired(a, path),
+      connected: wired(a, path, !!found),
       // Independent of `connected` on purpose. A config that was written and an
       // event that arrived are different facts, and the gap between them is
       // exactly where this feature earns its place: it is the state somebody

--- a/server/src/antigravity.ts
+++ b/server/src/antigravity.ts
@@ -126,17 +126,53 @@ export function parseModels(raw: string): AgentModel[] {
   return out;
 }
 
+/**
+ * Asked of `agy models`, off the event loop.
+ *
+ * Asynchronous, single-flighted, and memoised on failure as well as success —
+ * each of those is load-bearing rather than tidiness, and this function got all
+ * three wrong on the first pass:
+ *
+ * Bun runs one event loop. `Bun.spawnSync` here stopped the entire server for
+ * as long as the subprocess took — 1.3s to 2.2s cold. Nothing else was served
+ * in that window, so `/health` could not answer inside probeServer's 2.5s
+ * budget, the dashboard concluded it was talking to some other program, and
+ * every panel went empty behind a "Wrong server" banner. `bun --watch` restarts
+ * on every save, so in development that was re-paid constantly.
+ *
+ * Single-flighted because the panel asks on mount, React StrictMode mounts it
+ * twice, and a reconnect asks again — three subprocesses, serialised, for one
+ * answer that does not change.
+ *
+ * Memoised on failure too, with a retry window: an `agy` that is broken or not
+ * yet signed in otherwise paid the full subprocess cost on every request, which
+ * is the case that can least afford it.
+ */
 let modelCache: AgentModel[] | null = null;
-export function antigravityModels(): AgentModel[] {
-  if (modelCache) return modelCache;
+let modelAsk: Promise<AgentModel[]> | null = null;
+let modelAskedAt = 0;
+/** How long a failed lookup stands before it is worth another subprocess. */
+const MODEL_RETRY_MS = 60_000;
+
+export function antigravityModels(): Promise<AgentModel[]> {
+  if (modelCache) return Promise.resolve(modelCache);
+  if (modelAsk) return modelAsk;
+  if (modelAskedAt && Date.now() - modelAskedAt < MODEL_RETRY_MS) return Promise.resolve(FALLBACK_MODELS);
   const bin = agyBin();
-  if (!bin) return FALLBACK_MODELS;
-  try {
-    const r = Bun.spawnSync([bin, "models"], { stdout: "pipe", stderr: "pipe" });
-    const found = r.exitCode === 0 ? parseModels(r.stdout.toString()) : [];
-    if (found.length) { modelCache = found; return found; }
-  } catch { /* not installed, or it refused */ }
-  return FALLBACK_MODELS;
+  if (!bin) return Promise.resolve(FALLBACK_MODELS);
+  modelAsk = (async () => {
+    try {
+      const p = Bun.spawn([bin, "models"], { stdout: "pipe", stderr: "ignore" });
+      const text = await new Response(p.stdout as ReadableStream<Uint8Array>).text();
+      if ((await p.exited) === 0) {
+        const found = parseModels(text);
+        if (found.length) { modelCache = found; return found; }
+      }
+    } catch { /* not installed, or it refused */ }
+    modelAskedAt = Date.now();
+    return FALLBACK_MODELS;
+  })().finally(() => { modelAsk = null; });
+  return modelAsk;
 }
 
 // --- putting a chat on the radar --------------------------------------------
@@ -343,7 +379,11 @@ export function antigravityStream(
   // than an error.
   if (Array.isArray(images) && images.length) return err("antigravity chats cannot take pasted images yet — send the turn without it, or use a Claude chat");
   if (typeof message !== "string" || !message.trim() || message.length > 100_000) return err("invalid message");
-  const m = typeof model === "string" && MODEL_RE.test(model) ? model : (antigravityModels()[0]?.id ?? FALLBACK_MODELS[0].id);
+  // The panel always names a model, so the fallback is for a caller that did
+  // not. Deliberately the static default rather than the first of the live
+  // list: fetching that here would put a subprocess in front of every turn, to
+  // answer a question the request had already answered.
+  const m = typeof model === "string" && MODEL_RE.test(model) ? model : FALLBACK_MODELS[0].id;
   let mo = typeof mode === "string" && MODES.has(mode) ? mode : DEFAULT_MODE;
   if (mo === "always-proceed" && !ANTIGRAVITY_BYPASS_ALLOWED) mo = DEFAULT_MODE; // opt-in only
   const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";

--- a/server/src/antigravity.ts
+++ b/server/src/antigravity.ts
@@ -1,0 +1,462 @@
+// Multi-chat, Google Antigravity — the third agent the chat panel can drive.
+//
+// Same shape as chat.ts and codex.ts: the local server runs the CLI
+// non-interactively in a chosen repo/worktree and streams its JSONL straight
+// back for the web panel to parse. `agy -p <prompt> --output-format stream-json`
+// is Antigravity's equivalent of `claude -p --output-format stream-json`; the
+// first turn mints a conversation (its id arrives in the `init` frame) and
+// follow-ups go through `--conversation <id>`.
+//
+// This is *not* the Gemini CLI. They are separate binaries with separate
+// wiring, they keep separate state, and `agy models` offers Claude and
+// gpt-oss models alongside Gemini ones — it is a multi-model harness that
+// happens to be Google's. Gemini CLI keeps its own OpenTelemetry route onto the
+// radar and is untouched by any of this.
+//
+// Frames are passed through untranslated, exactly as the other two are. The
+// whole translation lives in web/src/lib/antigravityFrames.ts, so there is one
+// place to look when a frame renders wrong.
+//
+// One thing here has no counterpart in the other two: `frameToEvent`. Claude
+// reaches the fleet over hooks and Codex over OpenTelemetry, but Antigravity
+// exports neither, so a chat started here would otherwise never appear on the
+// radar at all. The frames it streams already carry everything an event needs,
+// so they are mapped and handed to the same ingest path — see the comment on
+// frameToEvent for what that does and does not cover.
+//
+// Gated by AGENTGLASS_ANTIGRAVITY_DISABLED; cwd must be a git dir and inside the
+// open project, the same boundary chat.ts, codex.ts and the terminal hold.
+import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
+import { inScope, chatBypassAllowed } from "./config.ts";
+import { startKeepalive, MODEL_RE, SESSION_RE } from "./chat.ts";
+import type { AgentModel, IngestBody } from "../../shared/types.ts";
+
+const agyBin = () => Bun.which("agy");
+export const ANTIGRAVITY_ENABLED = !!agyBin() && process.env.AGENTGLASS_ANTIGRAVITY_DISABLED !== "1";
+
+/** What `source_app` every synthesized event carries.
+ *
+ *  Load-bearing rather than cosmetic. `agy` can run `claude-opus-4-6-thinking`,
+ *  so `model_name` is an actively misleading signal for "which CLI is this?" —
+ *  agentOf() in web/src/lib/derive.ts checks `source_app` first, and this is
+ *  what stops an Antigravity session being misfiled as a Claude one. */
+export const ANTIGRAVITY_APP = "antigravity";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "content-type",
+};
+
+/**
+ * How much the agent may do without being asked.
+ *
+ * Antigravity's own vocabulary. It lands almost exactly on Claude's four, which
+ * is a property of the CLI rather than something forced here: it really does
+ * decide per tool call, and it really does have a plan mode and an
+ * accept-the-edits mode. Where Codex needed its own three because a sandbox is
+ * not a permission policy, these four mean what their Claude-side labels say.
+ *
+ * `request-review` is the default and is spelled by passing no flag at all —
+ * `--mode` only accepts the two middle values.
+ */
+const MODES = new Set(["request-review", "plan", "accept-edits", "always-proceed"]);
+export const DEFAULT_MODE = "request-review";
+
+/**
+ * `always-proceed` runs `--dangerously-skip-permissions`: every tool approved
+ * without asking, driven from a browser request. Same exposure as Claude's
+ * `--dangerously-skip-permissions` and Codex's
+ * `--dangerously-bypass-approvals-and-sandbox`, so it rides the same operator
+ * opt-in rather than minting a third one — someone who has decided how much
+ * autonomy a browser tab may hand out has decided it for all three CLIs.
+ */
+export const ANTIGRAVITY_BYPASS_ALLOWED = chatBypassAllowed();
+
+/** How long a turn may produce nothing before we assume the CLI is stuck on
+ *  something it cannot ask us for. Only ever armed before the first byte. */
+const STARTUP_TIMEOUT_MS = Number(process.env.AGENTGLASS_ANTIGRAVITY_STARTUP_TIMEOUT_MS ?? 30_000);
+
+const err = (msg: string, status = 400) => new Response(msg + "\n", { status, headers: CORS });
+
+// --- the model list ---------------------------------------------------------
+// Asked of the CLI rather than hardcoded here, for the same reason codex.ts
+// reads Codex's cache: a table checked into this repo is wrong the day Google
+// ships anything, and it fails silently by offering an id the CLI will refuse.
+//
+// `agy models` prints one id per line and nothing else, so there is no cache
+// file to find and no JSON to parse — but it is a subprocess rather than a
+// file read, so the answer is memoized for the life of the server.
+
+/**
+ * A last resort, not the source of truth.
+ *
+ * Reached when `agy models` fails — a fresh install that has not authenticated,
+ * or a CLI too old for the subcommand. Offering nothing would make the panel
+ * look broken on a machine where `agy` works fine, so this is deliberately a
+ * short list of ids that have shipped rather than an attempt at completeness.
+ */
+const FALLBACK_MODELS: AgentModel[] = [
+  { id: "gemini-3.6-flash-medium", label: "gemini-3.6-flash-medium" },
+  { id: "gemini-3.1-pro-high", label: "gemini-3.1-pro-high" },
+];
+
+/**
+ * The models the dropdown may offer.
+ *
+ * Exported for tests. Every entry is validated against MODEL_RE before it goes
+ * out, because the same expression guards the spawn below — offering a choice
+ * the send path would then refuse is the one outcome worth ruling out here.
+ *
+ * The id is used as its own label. Antigravity has no display name to offer,
+ * and the ids are already readable (`gemini-3.1-pro-high`); inventing prettier
+ * ones here would be this repo guessing at branding it does not own.
+ */
+export function parseModels(raw: string): AgentModel[] {
+  const out: AgentModel[] = [];
+  const seen = new Set<string>();
+  for (const line of raw.split("\n")) {
+    const id = line.trim();
+    // `agy models` prints a bare list, but a future version adding a header or
+    // a "(default)" marker should narrow the list rather than corrupt it.
+    if (!id || seen.has(id) || !MODEL_RE.test(id)) continue;
+    seen.add(id);
+    out.push({ id, label: id });
+  }
+  return out;
+}
+
+let modelCache: AgentModel[] | null = null;
+export function antigravityModels(): AgentModel[] {
+  if (modelCache) return modelCache;
+  const bin = agyBin();
+  if (!bin) return FALLBACK_MODELS;
+  try {
+    const r = Bun.spawnSync([bin, "models"], { stdout: "pipe", stderr: "pipe" });
+    const found = r.exitCode === 0 ? parseModels(r.stdout.toString()) : [];
+    if (found.length) { modelCache = found; return found; }
+  } catch { /* not installed, or it refused */ }
+  return FALLBACK_MODELS;
+}
+
+// --- putting a chat on the radar --------------------------------------------
+
+/** What a run needs to remember between frames to describe itself. */
+export type FrameContext = {
+  /** Filled from the `init` frame; every event before it has nowhere to go. */
+  sessionId: string;
+  model: string;
+  /** Where the turn ran, and the repo that directory belongs to.
+   *
+   *  On every event rather than only the first, because this is what scopes a
+   *  session to a project: db.ts lifts `project_path` and `cwd_path` out of the
+   *  payload JSON, and the fleet list filters on them. Without these an
+   *  Antigravity chat lands in the store and then shows up nowhere, which is
+   *  indistinguishable from it never having been recorded. */
+  cwd: string;
+  projectPath: string;
+  /** step_index → tool name, so a DONE step can name the tool its ACTIVE half
+   *  opened. The frames carry `tool_name` on both halves today; this keeps the
+   *  pairing correct if a future one carries it only on the first. */
+  tools: Map<number, string>;
+};
+
+export const newFrameContext = (cwd = ""): FrameContext => ({
+  sessionId: "", model: "", cwd, projectPath: cwd ? (repoRootOf(cwd) || cwd) : "", tools: new Map(),
+});
+
+/** The fields every event of this turn carries, whatever else it says. */
+const scope = (ctx: FrameContext) => ({
+  source_app: ANTIGRAVITY_APP,
+  session_id: ctx.sessionId,
+  model_name: ctx.model || undefined,
+});
+const located = (ctx: FrameContext, payload: Record<string, unknown>) => ({
+  ...payload,
+  ...(ctx.cwd ? { cwd: ctx.cwd } : {}),
+  ...(ctx.projectPath ? { project_path: ctx.projectPath } : {}),
+});
+
+/**
+ * One Antigravity frame as an event for the store, or null for the frames that
+ * are not events.
+ *
+ * Pure, and exported for tests: the mapping is the whole of what makes an
+ * Antigravity chat visible in the fleet, and it is much easier to pin down here
+ * than through a spawned CLI.
+ *
+ * What this covers and what it does not:
+ *
+ *  - **Only chats started in this panel.** An `agy` you ran in a terminal emits
+ *    nothing to anyone, so it stays invisible. That is a real gap and is said
+ *    plainly in the README rather than implied away.
+ *  - **The tool pair carries `step_index` as its `tool_use_id`.** Indices are
+ *    unique within a conversation, which is the scope the pairing needs, and
+ *    they are what the ACTIVE and DONE halves already share.
+ *  - **Usage rides on `result`, once per turn.** Measured rather than assumed:
+ *    turn 1 of a conversation reported 31789 input tokens and turn 2 reported
+ *    16609, so these are per-turn figures and adding them across a thread is
+ *    correct. Codex's are cumulative and must be assigned instead — the two
+ *    look alike and mean opposite things.
+ */
+export function frameToEvent(frame: Record<string, unknown>, ctx: FrameContext): IngestBody | null {
+  const kind = frame.event;
+
+  if (kind === "init") {
+    const init = (frame.init ?? {}) as Record<string, unknown>;
+    const id = typeof frame.conversation_id === "string" ? frame.conversation_id : "";
+    if (!id || !SESSION_RE.test(id)) return null;
+    ctx.sessionId = id;
+    if (typeof init.model === "string") ctx.model = init.model;
+    // The CLI reports where it actually ran, which beats what the caller asked
+    // for — `--add-dir` and a workspace can move it.
+    if (typeof init.cwd === "string" && init.cwd) {
+      ctx.cwd = init.cwd;
+      ctx.projectPath = repoRootOf(init.cwd) || init.cwd;
+    }
+    return {
+      ...scope(ctx),
+      hook_event_type: "SessionStart",
+      payload: located(ctx, { message: ctx.cwd }),
+    };
+  }
+
+  if (kind === "result") {
+    if (!ctx.sessionId) return null;
+    const result = (frame.result ?? {}) as Record<string, unknown>;
+    const u = (result.usage ?? {}) as Record<string, unknown>;
+    const n = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+    return {
+      ...scope(ctx),
+      hook_event_type: "Turn complete",
+      payload: located(ctx, {
+        usage: {
+          input_tokens: n(u.input_tokens),
+          output_tokens: n(u.output_tokens),
+          cache_read_tokens: n(u.cache_read_tokens),
+          // Antigravity reports thinking tokens separately and counts them
+          // inside `output_tokens` already, so they are not added again here.
+          cache_creation_tokens: 0,
+        },
+        message: typeof result.status === "string" ? result.status : "",
+      }),
+    };
+  }
+
+  if (kind !== "step_update") return null;
+  const step = (frame.step_update ?? {}) as Record<string, unknown>;
+  if (!ctx.sessionId) return null;
+  const type = step.step_type;
+  const idx = typeof step.step_index === "number" ? step.step_index : -1;
+
+  if (type === "user_input") {
+    return {
+      ...scope(ctx),
+      hook_event_type: "UserPromptSubmit",
+      payload: located(ctx, { prompt: typeof step.text_delta === "string" ? step.text_delta : "" }),
+    };
+  }
+
+  if (type === "tool") {
+    const info = (step.tool_info ?? {}) as Record<string, unknown>;
+    const name = typeof step.tool_name === "string" ? step.tool_name
+      : typeof info.name === "string" ? info.name
+      : ctx.tools.get(idx) ?? "";
+    if (!name) return null;
+    const base = scope(ctx);
+    if (step.state === "ACTIVE") {
+      ctx.tools.set(idx, name);
+      return { ...base, hook_event_type: "PreToolUse", payload: located(ctx, { tool_name: name, tool_use_id: String(idx) }) };
+    }
+    if (step.state === "DONE") {
+      ctx.tools.delete(idx);
+      const out = typeof info.output === "string" ? info.output : "";
+      return {
+        ...base,
+        hook_event_type: "PostToolUse",
+        // No duration is passed: insertEvent derives it from the Pre/Post pair
+        // and ignores anything the payload claims. The two halves arrive
+        // milliseconds apart in real time, so the paired figure is the same
+        // number `duration_seconds` would have given.
+        payload: located(ctx, { tool_name: name, tool_use_id: String(idx), tool_response: out }),
+      };
+    }
+    return null;
+  }
+
+  // agent_response, thinking, checkpoint, subagent, browser_action, unknown:
+  // real frames the panel draws, but not things the fleet counts. An
+  // `error_message` step carries no payload in the stream — the failure it
+  // stands for shows up on the tool that produced it.
+  return null;
+}
+
+// --- driving a turn ---------------------------------------------------------
+
+/**
+ * The command line for one turn.
+ *
+ * Exported for tests, because the mode mapping is the part worth pinning: three
+ * of the four modes are spelled as flags and the default is spelled by their
+ * absence, so a regression here is silent rather than loud.
+ *
+ * The prompt goes in argv rather than on stdin. `--print` takes it as its
+ * value, and there is no stdin form; the 100KB cap in antigravityStream keeps
+ * that well inside ARG_MAX.
+ *
+ * The working directory is set on the spawn rather than with `--add-dir`,
+ * matching chat.ts and codex.ts.
+ */
+export function antigravityArgs(bin: string, model: string, mode: string, resumeId: string, message: string): string[] {
+  const args = [bin, "-p", message, "--output-format", "stream-json", "--model", model];
+  if (resumeId) args.push("--conversation", resumeId);
+  if (mode === "always-proceed") args.push("--dangerously-skip-permissions");
+  else if (mode === "plan" || mode === "accept-edits") args.push("--mode", mode);
+  // `request-review` is the default and has no flag: passing --mode with it is
+  // rejected, since --mode only accepts the two middle values.
+  return args;
+}
+
+export function antigravityStream(
+  cwd: unknown,
+  message: unknown,
+  model: unknown,
+  resumeId: unknown,
+  mode: unknown,
+  images?: unknown,
+  emit?: (body: IngestBody) => void,
+): Response {
+  const bin = agyBin();
+  if (!bin) return err("no local `agy` CLI — install the Antigravity CLI to chat", 403);
+  if (process.env.AGENTGLASS_ANTIGRAVITY_DISABLED === "1") return err("antigravity chat is disabled (AGENTGLASS_ANTIGRAVITY_DISABLED=1)", 403);
+  const dir = safeAbs(cwd);
+  if (!dir || !repoRootOf(dir)) {
+    const cap = gitCapability();
+    return err(cap.available ? "invalid or non-repo directory" : (cap.reason || "git is not installed"));
+  }
+  // An antigravity turn runs real tools in this directory, so it gets the same
+  // scope boundary a claude turn does.
+  if (!inScope(dir)) return err("outside the open project — open the parent folder to work across repos", 403);
+  // `agy` takes images as file paths, not as content blocks — same position
+  // Codex is in, and refused for the same reason: a turn written about a
+  // screenshot, sent without the screenshot, produces a confusing reply rather
+  // than an error.
+  if (Array.isArray(images) && images.length) return err("antigravity chats cannot take pasted images yet — send the turn without it, or use a Claude chat");
+  if (typeof message !== "string" || !message.trim() || message.length > 100_000) return err("invalid message");
+  const m = typeof model === "string" && MODEL_RE.test(model) ? model : (antigravityModels()[0]?.id ?? FALLBACK_MODELS[0].id);
+  let mo = typeof mode === "string" && MODES.has(mode) ? mode : DEFAULT_MODE;
+  if (mo === "always-proceed" && !ANTIGRAVITY_BYPASS_ALLOWED) mo = DEFAULT_MODE; // opt-in only
+  const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";
+
+  const args = antigravityArgs(bin, m, mo, rid, message);
+
+  // Its own process group, so stopping a turn reaches the whole job tree —
+  // `agy` spawns shells of its own, and killing only the direct child would
+  // leave a test run or a dev server behind still working.
+  const setsid = Bun.which("setsid");
+  const proc = Bun.spawn(setsid ? [setsid, ...args] : args, {
+    cwd: dir,
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+  });
+
+  // Drained from the start, not after exit: a full stderr pipe blocks the child
+  // forever.
+  const stderrText = new Response(proc.stderr as ReadableStream<Uint8Array>).text().catch(() => "");
+
+  const enc = new TextEncoder();
+  const dec = new TextDecoder();
+  const ctx = newFrameContext(dir);
+  let cancelled = false;
+
+  /*
+   * Frames go two places at once: out to the browser verbatim, and — split into
+   * whole lines — through frameToEvent into the store.
+   *
+   * The tee is here rather than in the browser because what the fleet knows is
+   * the server's business. A browser that parses its own frames for display is
+   * one thing; a browser trusted to report what ran is another, and it would
+   * put the store behind a client that can be closed, throttled or reloaded
+   * mid-turn.
+   */
+  let pending = "";
+  const feed = (chunk: Uint8Array | null) => {
+    if (!emit) return;
+    pending += chunk ? dec.decode(chunk, { stream: true }) : "\n";
+    for (;;) {
+      const nl = pending.indexOf("\n");
+      if (nl < 0) break;
+      const line = pending.slice(0, nl).trim();
+      pending = pending.slice(nl + 1);
+      if (!line) continue;
+      try {
+        const ev = frameToEvent(JSON.parse(line) as Record<string, unknown>, ctx);
+        if (ev) emit(ev);
+      } catch { /* a partial or non-JSON line is the browser's problem, not the store's */ }
+    }
+  };
+
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+      const stopKeepalive = startKeepalive(controller);
+      /*
+       * A first-run watchdog, for the same failure chat.ts and codex.ts guard
+       * against: an `agy` that has never been logged in waits on an interactive
+       * prompt that can never arrive here, so it emits nothing and never exits,
+       * and the panel sits on a spinner that reads as agentglass having hung.
+       */
+      let firstByte = false;
+      const watchdog = setTimeout(async () => {
+        if (firstByte || cancelled) return;
+        const hint = (await Promise.race([stderrText, Promise.resolve("")])).trim();
+        try {
+          controller.enqueue(enc.encode(JSON.stringify({
+            type: "agx_error",
+            code: null,
+            errorType: "first_run_setup_required",
+            setupCommand: "agy",
+            error: hint
+              || `agy produced no output in ${STARTUP_TIMEOUT_MS / 1000}s — it is probably waiting for a login it can't ask for here. Run \`agy\` in a terminal and sign in, then try again.`,
+          }) + "\n"));
+        } catch { /* the client already went away */ }
+        try {
+          if (setsid) process.kill(-proc.pid, "SIGTERM");
+          else proc.kill();
+        } catch { /* gone */ }
+      }, STARTUP_TIMEOUT_MS);
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) {
+            firstByte = true;
+            clearTimeout(watchdog);
+            feed(value);
+            controller.enqueue(value);
+          }
+        }
+      } catch { /* closed */ }
+      feed(null); // a last line with no trailing newline
+      clearTimeout(watchdog);
+      stopKeepalive();
+      const code = await proc.exited;
+      if (cancelled) return; // a cancelled controller throws on enqueue/close
+      if (code !== 0) {
+        const text = (await stderrText).trim();
+        controller.enqueue(enc.encode(JSON.stringify({ type: "agx_error", code, error: text || `agy exited ${code}` }) + "\n"));
+      }
+      controller.close();
+    },
+    cancel() {
+      cancelled = true;
+      try {
+        if (setsid) process.kill(-proc.pid, "SIGTERM"); // the group, not just agy
+        else proc.kill();
+      } catch { /* gone */ }
+    },
+  });
+
+  return new Response(stream, { headers: { "content-type": "application/x-ndjson; charset=utf-8", "cache-control": "no-cache", "x-accel-buffering": "no", ...CORS } });
+}

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -49,8 +49,14 @@ const STARTUP_TIMEOUT_MS = Number(process.env.AGENTGLASS_CHAT_STARTUP_TIMEOUT_MS
 // gateway, on Bedrock / Vertex / Foundry, and for Opus 4.6 — which is why it
 // survives here rather than being dropped now that `contextWindow.ts` knows
 // the families outright.
-const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}(\[[a-z0-9]{1,8}\])?$/;
-const SESSION_RE = /^[A-Za-z0-9][A-Za-z0-9-]{7,64}$/;
+//
+// Exported because codex.ts validates the same two things for the same reason.
+// The shapes happen to coincide rather than being made to: a Codex model id
+// (`gpt-5.6-luna`) is already inside this alphabet, and a Codex thread id is a
+// UUID, which SESSION_RE already accepts. If the two ever diverge, codex.ts
+// grows its own pair rather than this one being widened to cover both.
+export const MODEL_RE = /^[a-z0-9][a-z0-9.-]{2,48}(\[[a-z0-9]{1,8}\])?$/;
+export const SESSION_RE = /^[A-Za-z0-9][A-Za-z0-9-]{7,64}$/;
 
 // A pre-approved tool spec, e.g. `Read`, `Edit`, `Bash(git status)`,
 // `Bash(gh pr view:*)`. Deliberately narrow: letters for the tool name, and an

--- a/server/src/claudemodels.ts
+++ b/server/src/claudemodels.ts
@@ -1,0 +1,144 @@
+// The models the Chat panel offers for Claude Code.
+//
+// The other two agents are asked: Codex keeps a `models_cache.json` it refreshes
+// itself, and Antigravity answers `agy models`. Claude Code publishes neither —
+// there is no `models` subcommand, no `--list-models`, and nothing on disk — so
+// the list has to be written down somewhere.
+//
+// Written down as *data*, in shared/claude-models.json, rather than as an array
+// in a TypeScript file. The difference is who can fix it and how fast: a table
+// compiled into the bundle is wrong the day Anthropic ships anything and stays
+// wrong until somebody rebuilds and redeploys, while this file can be corrected
+// in place and takes effect on the next request.
+//
+// A model is offered until its shutdown date has passed. That is the whole
+// filter — `status` is recorded for the reader but is deliberately not consulted,
+// because a superseded model still answers until it is actually retired and
+// hiding it early would take away a choice that still works.
+import { readFileSync, existsSync, statSync } from "node:fs";
+import { join, resolve, dirname } from "node:path";
+import { homedir } from "node:os";
+import { MODEL_RE } from "./chat.ts";
+import type { AgentModel } from "../../shared/types.ts";
+
+/** What one row of the catalogue may say. Everything except `id` is optional so
+ *  a hand-edited file that omits a field degrades to a usable entry rather than
+ *  disappearing. */
+type Row = {
+  id?: unknown;
+  display_name?: unknown;
+  status?: unknown;
+  release_date?: unknown;
+  scheduled_shutdown_date?: unknown;
+};
+
+/**
+ * Where the catalogue is read from, most specific first.
+ *
+ * The override paths exist so the list can be corrected on a machine whose
+ * checkout is read-only or packaged — the same reason `hooksDir()` searches
+ * rather than assuming one layout.
+ */
+export function catalogPaths(): string[] {
+  const out: string[] = [];
+  const env = process.env.AGENTGLASS_CLAUDE_MODELS;
+  if (env) out.push(env);
+  out.push(join(process.env.XDG_CONFIG_HOME || join(homedir(), ".config"), "agentglass", "claude-models.json"));
+  // Beside the packaged binary, then the checkout this file lives in.
+  out.push(join(dirname(process.execPath), "claude-models.json"));
+  out.push(resolve(import.meta.dir, "../../shared/claude-models.json"));
+  out.push(resolve(process.cwd(), "shared/claude-models.json"));
+  return out;
+}
+
+/**
+ * A last resort, not the source of truth.
+ *
+ * Reached only when every path above is missing or unreadable — a packaging
+ * mistake, or a file edited into invalid JSON. Offering an empty dropdown would
+ * make the panel look broken when the CLI works fine, so this is one id that is
+ * certain to exist rather than an attempt at the whole list.
+ */
+const FALLBACK: AgentModel[] = [{ id: "claude-opus-5", label: "Claude Opus 5" }];
+
+/**
+ * Whether this model is still worth offering on `today`.
+ *
+ * Exported for tests, and the one rule in this file worth stating precisely:
+ * the shutdown date is the last day the model is offered, so it disappears the
+ * day *after*. Compared as calendar strings rather than as instants — these are
+ * dates without a timezone, and turning them into Date objects would shift the
+ * boundary by up to a day depending on where the server happens to be.
+ *
+ * A row with no shutdown date never expires. That is the useful reading: it
+ * means "no retirement announced", not "retired at the epoch".
+ */
+export function isOffered(row: Row, today: string): boolean {
+  const end = typeof row.scheduled_shutdown_date === "string" ? row.scheduled_shutdown_date.trim() : "";
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(end)) return true;
+  return today <= end;
+}
+
+/** Today as `YYYY-MM-DD` in local time — the same calendar the dates are written in. */
+export function todayStamp(now = new Date()): string {
+  const p = (n: number) => String(n).padStart(2, "0");
+  return `${now.getFullYear()}-${p(now.getMonth() + 1)}-${p(now.getDate())}`;
+}
+
+/**
+ * The catalogue, filtered to what is still offered.
+ *
+ * Exported separately from the file reading so the filtering can be tested
+ * against a fixed date instead of against whatever day the suite runs on.
+ */
+export function parseCatalog(raw: string, today = todayStamp()): AgentModel[] {
+  let doc: unknown;
+  try { doc = JSON.parse(raw); } catch { return []; }
+  const rows = (doc as { models?: unknown })?.models;
+  if (!Array.isArray(rows)) return [];
+  const out: AgentModel[] = [];
+  const seen = new Set<string>();
+  for (const r of rows as Row[]) {
+    if (!r || typeof r !== "object") continue;
+    const id = typeof r.id === "string" ? r.id.trim() : "";
+    // The same expression guards the spawn in chat.ts, so an id that would be
+    // refused there is not offered here — a dropdown entry that cannot be sent
+    // is worse than one that is missing.
+    if (!id || seen.has(id) || !MODEL_RE.test(id)) continue;
+    if (!isOffered(r, today)) continue;
+    seen.add(id);
+    out.push({ id, label: typeof r.display_name === "string" && r.display_name ? r.display_name : id });
+  }
+  return out;
+}
+
+/**
+ * Read, with the file's own mtime as the cache key.
+ *
+ * Re-read when the file changes rather than once per process, because the point
+ * of moving this out of the code was that somebody can fix it without a
+ * restart. Re-read also when the day rolls over, so a model does not linger in
+ * the dropdown until the server happens to be bounced.
+ */
+let cache: { path: string; key: string; day: string; models: AgentModel[] } | null = null;
+
+export function claudeModels(): AgentModel[] {
+  const day = todayStamp();
+  for (const p of catalogPaths()) {
+    let key: string;
+    try {
+      if (!existsSync(p)) continue;
+      const st = statSync(p);
+      // Size as well as mtime: two edits inside the same millisecond are rare
+      // in life and routine in a test, and an mtime-only key serves the first
+      // one twice.
+      key = `${st.mtimeMs}:${st.size}`;
+    } catch { continue; }
+    if (cache && cache.path === p && cache.key === key && cache.day === day) return cache.models;
+    try {
+      const models = parseCatalog(readFileSync(p, "utf8"), day);
+      if (models.length) { cache = { path: p, key, day, models }; return models; }
+    } catch { /* unreadable; try the next candidate */ }
+  }
+  return FALLBACK;
+}

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -1,0 +1,467 @@
+// Multi-chat, OpenAI Codex — the second agent the chat panel can drive.
+//
+// Same shape as chat.ts: the local server runs the CLI non-interactively in a
+// chosen repo/worktree and streams its JSONL straight back for the web panel to
+// parse. `codex exec --json` is Codex's equivalent of
+// `claude -p --output-format stream-json`; the first turn mints a thread (its id
+// arrives in the `thread.started` frame) and follow-ups go through
+// `codex exec resume <thread_id>`.
+//
+// Frames are passed through untranslated, exactly as chat.ts passes Claude's
+// through. Codex speaks a different vocabulary — `item.completed` with a typed
+// item rather than Anthropic content blocks — and translating it here would put
+// half a parser on the server and half in the browser. The whole translation
+// lives in web/src/lib/codexFrames.ts instead, so there is one place to look
+// when a frame renders wrong.
+//
+// Gated by AGENTGLASS_CODEX_DISABLED; cwd must be a git dir and inside the open
+// project, the same boundary chat.ts and the terminal hold.
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { homedir } from "node:os";
+import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
+import { inScope, chatBypassAllowed } from "./config.ts";
+import { startKeepalive, MODEL_RE, SESSION_RE } from "./chat.ts";
+import type { CodexModel, TimelineEntry } from "../../shared/types.ts";
+
+const codexBin = () => Bun.which("codex");
+export const CODEX_ENABLED = !!codexBin() && process.env.AGENTGLASS_CODEX_DISABLED !== "1";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET,POST,OPTIONS",
+  "Access-Control-Allow-Headers": "content-type",
+};
+
+/**
+ * How much the agent may do without being asked.
+ *
+ * Codex's own vocabulary, not Claude's four permission modes, because the two
+ * do genuinely different things and mapping one onto the other would put a
+ * label on this panel that describes a mechanism Codex has not got. Claude's
+ * "Ask (denies un-allowed)" is a statement about an allowlist consulted per
+ * tool call; Codex draws its line around the filesystem instead, so these are
+ * the three lines it can actually draw.
+ */
+const SANDBOXES = new Set(["read-only", "workspace-write", "full-access"]);
+export const DEFAULT_SANDBOX = "read-only";
+
+/**
+ * `full-access` runs `--dangerously-bypass-approvals-and-sandbox`: no sandbox,
+ * no approvals, driven from a browser request. Same exposure as Claude's
+ * `--dangerously-skip-permissions`, so it rides the same operator opt-in rather
+ * than minting a second one — someone who has decided how much autonomy a
+ * browser tab may hand out has decided it for both CLIs.
+ */
+export const CODEX_BYPASS_ALLOWED = chatBypassAllowed();
+
+/** How long a turn may produce nothing before we assume the CLI is stuck on
+ *  something it cannot ask us for. Only ever armed before the first byte. */
+const STARTUP_TIMEOUT_MS = Number(process.env.AGENTGLASS_CODEX_STARTUP_TIMEOUT_MS ?? 20_000);
+
+const err = (msg: string, status = 400) => new Response(msg + "\n", { status, headers: CORS });
+
+// --- the model list ---------------------------------------------------------
+// Read from Codex's own cache rather than hardcoded here.
+//
+// A model table checked into this repo is wrong the day OpenAI ships anything,
+// and the failure is silent: the dropdown keeps offering an id the CLI no
+// longer serves. Codex already maintains the list on disk — it refreshes
+// `models_cache.json` itself — so the honest answer to "what can I pick?" is
+// whatever that file currently says.
+
+/** Where Codex keeps its state. `CODEX_HOME` is Codex's own override and is
+ *  honoured here so an operator who moved it does not silently get an empty
+ *  list. */
+const codexHome = () => process.env.CODEX_HOME || join(homedir(), ".codex");
+
+/**
+ * A last resort, not the source of truth.
+ *
+ * Reached when the cache is missing (a fresh install that has not talked to the
+ * API yet) or unreadable. Offering nothing at all would make the panel look
+ * broken on a machine where Codex works fine, so this is deliberately a short
+ * list of ids that have shipped rather than an attempt at completeness — the
+ * cache takes over the moment it exists.
+ */
+const FALLBACK_MODELS: CodexModel[] = [
+  { id: "gpt-5.6-sol", label: "GPT-5.6-Sol" },
+  { id: "gpt-5.6-luna", label: "GPT-5.6-Luna" },
+  { id: "gpt-5.5", label: "GPT-5.5" },
+];
+
+/**
+ * The models the dropdown may offer.
+ *
+ * Exported for tests. Every entry is validated against MODEL_RE before it goes
+ * out, because the same expression guards the spawn below — offering a choice
+ * the send path would then refuse is the one outcome worth ruling out here.
+ *
+ * The cache is ~37KB, nearly all of it each model's `base_instructions`. Only
+ * the id and the label cross the wire.
+ */
+export function parseModels(raw: string): CodexModel[] {
+  let doc: unknown;
+  try { doc = JSON.parse(raw); } catch { return []; }
+  const models = (doc as { models?: unknown })?.models;
+  if (!Array.isArray(models)) return [];
+  const out: Array<CodexModel & { priority: number }> = [];
+  for (const m of models) {
+    if (!m || typeof m !== "object") continue;
+    const { slug, display_name, visibility, priority } = m as Record<string, unknown>;
+    // `visibility` is Codex's own answer to "should a human be offered this?" —
+    // the cache also carries internal entries (a review model, service tiers)
+    // that are not conversation models at all.
+    if (visibility !== "list") continue;
+    if (typeof slug !== "string" || !MODEL_RE.test(slug)) continue;
+    out.push({
+      id: slug,
+      label: typeof display_name === "string" && display_name ? display_name : slug,
+      priority: typeof priority === "number" ? priority : Number.MAX_SAFE_INTEGER,
+    });
+  }
+  out.sort((a, b) => a.priority - b.priority);
+  return out.map(({ id, label }) => ({ id, label }));
+}
+
+export function codexModels(): CodexModel[] {
+  try {
+    const found = parseModels(readFileSync(join(codexHome(), "models_cache.json"), "utf8"));
+    if (found.length) return found;
+  } catch { /* no cache yet, or unreadable */ }
+  return FALLBACK_MODELS;
+}
+
+// --- replaying a thread -----------------------------------------------------
+// What a Codex session actually said, for a chat that adopted it from the fleet.
+//
+// The fleet knows Codex sessions through OpenTelemetry, and those log records
+// carry the *shape* of a turn but not its words — `logRecordToEvent` in otlp.ts
+// can build a tool call out of them and has nothing to build a prompt or a reply
+// from. So a resumed Codex chat opened as a blank panel while `codex` held the
+// whole conversation, which reads as the resume having silently failed. It is
+// the same problem `hydrate` already solves for Claude by replaying the stored
+// transcript; Codex's equivalent is its own rollout on disk.
+
+/** How much of a rollout is worth reading. These files grow for the life of a
+ *  thread — a resumed turn appends to the same one — and this runs on the
+ *  server's only thread. */
+const MAX_ROLLOUT_BYTES = 16 * 1024 * 1024;
+/** Tool output in a replayed row, matching what the live path keeps. */
+const MAX_TOOL_OUTPUT = 20_000;
+/** Directories under `sessions/` to look through before giving up. The layout
+ *  is `YYYY/MM/DD`, so this is a large multiple of what any real lookup needs;
+ *  it exists so a corrupted or symlinked tree cannot spin. */
+const MAX_ROLLOUT_DIRS = 4_000;
+
+/**
+ * The rollout file for a thread id, if it is still on disk.
+ *
+ * Codex names these `rollout-<ISO timestamp>-<thread id>.jsonl`, so the id is
+ * in the filename and the search is a name match rather than a read of every
+ * file. Sessions older than the user's retention are simply gone, which is a
+ * normal answer and not an error.
+ */
+export function rolloutPath(id: string, root = join(codexHome(), "sessions")): string | null {
+  const suffix = `-${id}.jsonl`;
+  let scanned = 0;
+  const walk = (dir: string, depth: number): string | null => {
+    if (depth > 4 || ++scanned > MAX_ROLLOUT_DIRS) return null;
+    let entries: string[];
+    try { entries = readdirSync(dir); } catch { return null; }
+    // Newest first: the layout is date-partitioned, so the thread being resumed
+    // is far more likely to be in a recent directory than an old one.
+    for (const name of entries.sort().reverse()) {
+      const full = join(dir, name);
+      if (name.endsWith(suffix)) return full;
+      // `statSync` rather than a Dirent type check because it follows symlinks
+      // the same way the read below would, so what is tested is what is read.
+      let dirent: ReturnType<typeof statSync>;
+      try { dirent = statSync(full); } catch { continue; }
+      if (!dirent.isDirectory()) continue;
+      const hit = walk(full, depth + 1);
+      if (hit) return hit;
+    }
+    return null;
+  };
+  return walk(root, 0);
+}
+
+const asMs = (v: unknown): number => {
+  const t = typeof v === "string" ? Date.parse(v) : typeof v === "number" ? v : NaN;
+  return Number.isFinite(t) ? t : 0;
+};
+
+/**
+ * What a tool call acted on.
+ *
+ * Codex's `input` is a JavaScript snippet it wrote for its own sandbox —
+ * `const r = await tools.exec_command({"cmd":"wc -l README.md", …})` — so the
+ * command is in there but only as a JSON field inside a program. Pulling it out
+ * is a best-effort read of generated code, hence the fallback: showing the
+ * snippet is worse than showing the command and much better than showing
+ * nothing.
+ */
+function callTarget(input: unknown): string | null {
+  if (typeof input !== "string" || !input) return null;
+  const cmd = /"cmd"\s*:\s*("(?:[^"\\]|\\.)*")/.exec(input);
+  if (cmd) { try { return JSON.parse(cmd[1]); } catch { /* not the string we hoped for */ } }
+  // An edit arrives as an apply_patch envelope rather than a command, and the
+  // file it touched is the one thing worth reading out of it — otherwise every
+  // edit in a replayed thread shows 200 characters of identical boilerplate.
+  const patch = /\*\*\* (?:Update|Add|Delete) File: ([^\\"\n]+)/.exec(input);
+  if (patch) return patch[1].trim();
+  return input.slice(0, 200);
+}
+
+/**
+ * Whether a replayed tool run actually failed.
+ *
+ * The call's own `status` is "completed" for a script that ran and reported a
+ * failure — true of the call, not of the work — so a rejected patch replayed
+ * looking exactly like an applied one. Codex's exec wrapper opens its report
+ * with a fixed line, so that is what is read, anchored to the start: a command
+ * whose output merely *contains* these words later has not failed, and matching
+ * loosely would mark it as though it had.
+ */
+const outputFailed = (text: string | null): boolean => !!text && /^Script (?:failed|error)\b/.test(text);
+
+/**
+ * What a tool call printed.
+ *
+ * Codex writes a result as content blocks — `[{type:"text",text:"…"}, …]` — and
+ * writes them *as an array*, not as a string holding one. Both are handled
+ * because both turn up: the rollout carries the array inline, while the same
+ * field arrives JSON-encoded elsewhere in Codex's own plumbing. Reading only
+ * the string form is what made every replayed tool row show no output at all
+ * while looking entirely healthy.
+ *
+ * Anything that is neither is stringified rather than dropped: an unfamiliar
+ * shape is still evidence of what happened.
+ */
+function callOutput(output: unknown): string | null {
+  const blocks = (v: unknown): string | null => {
+    if (!Array.isArray(v)) return null;
+    return v.map((b) => (b && typeof b === "object" && typeof (b as Record<string, unknown>).text === "string" ? (b as Record<string, string>).text : "")).join("");
+  };
+  let text = blocks(output);
+  if (text === null) {
+    if (typeof output !== "string" || !output) return null;
+    // A string that is itself an encoded block array, else the text as written.
+    try { text = blocks(JSON.parse(output)) ?? output; } catch { text = output; }
+  }
+  text = text.trimEnd();
+  if (!text) return null;
+  return text.length > MAX_TOOL_OUTPUT ? text.slice(0, MAX_TOOL_OUTPUT) + "\n[trimmed]" : text;
+}
+
+/**
+ * A Codex thread's conversation and tool runs, in the shape the chat panel
+ * already replays.
+ *
+ * Exported and taking the file's text so it can be pinned against a real
+ * rollout in tests without one having to exist on the machine running them.
+ */
+export function parseRollout(text: string): TimelineEntry[] {
+  const out: TimelineEntry[] = [];
+  const byCall = new Map<string, TimelineEntry>();
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    let rec: { type?: unknown; timestamp?: unknown; payload?: unknown };
+    try { rec = JSON.parse(line); } catch { continue; }
+    const p = (rec.payload ?? {}) as Record<string, unknown>;
+    const ts = asMs(rec.timestamp) || asMs(p.timestamp);
+    const kind = typeof p.type === "string" ? p.type : "";
+
+    if (rec.type === "event_msg" && (kind === "user_message" || kind === "agent_message")) {
+      const message = p.message;
+      if (typeof message !== "string" || !message) continue;
+      out.push({ kind: "message", role: kind === "user_message" ? "user" : "assistant", text: message, ts });
+      continue;
+    }
+    if (rec.type !== "response_item") continue;
+    if (kind === "custom_tool_call" || kind === "function_call") {
+      const callId = typeof p.call_id === "string" ? p.call_id : null;
+      const row: TimelineEntry = {
+        kind: "tool",
+        ts,
+        tool: typeof p.name === "string" && p.name ? p.name : "tool",
+        target: callTarget(p.input ?? p.arguments),
+        tool_use_id: callId,
+        is_error: false,
+        output: null,
+      };
+      if (callId) byCall.set(callId, row);
+      out.push(row);
+      continue;
+    }
+    if (kind === "custom_tool_call_output" || kind === "function_call_output") {
+      const callId = typeof p.call_id === "string" ? p.call_id : "";
+      const row = byCall.get(callId);
+      if (!row) continue;
+      row.output = callOutput(p.output);
+      row.is_error = outputFailed(row.output);
+    }
+  }
+  // A rollout is written in order, but a resumed thread appends to the same
+  // file, so sort rather than assume — the panel renders these in array order.
+  return out.sort((a, b) => a.ts - b.ts);
+}
+
+/** The replay for a thread, or an empty timeline when there is nothing on disk.
+ *  Empty is a real answer: rollouts are retained for a while, not forever. */
+export function codexTranscript(id: unknown): TimelineEntry[] {
+  if (typeof id !== "string" || !SESSION_RE.test(id)) return [];
+  const path = rolloutPath(id);
+  if (!path) return [];
+  try {
+    if (statSync(path).size > MAX_ROLLOUT_BYTES) return [];
+    return parseRollout(readFileSync(path, "utf8"));
+  } catch {
+    return [];
+  }
+}
+
+// --- driving a turn ---------------------------------------------------------
+
+/**
+ * The argv for one turn.
+ *
+ * Exported and pure so the flag mapping can be pinned in tests without
+ * spawning a real `codex` — the same reason chat.ts exports `turnEnvelope`.
+ *
+ * Two things about this are worth writing down, because both were found the
+ * hard way rather than read off the help output:
+ *
+ *  - The prompt goes in on stdin, via the trailing `-`. Passing it as an argv
+ *    element would work until someone pastes something long enough to hit
+ *    ARG_MAX, and it puts what the user typed into the process table.
+ *  - The sandbox is set with `-c sandbox_mode=...` rather than `-s`, because
+ *    `codex exec resume` does not accept `-s` at all ("unexpected argument
+ *    '-s' found") while it does accept `-c`. Using the config override on both
+ *    paths keeps one code path instead of a flag that changes shape depending
+ *    on whether this is the first turn.
+ *
+ * The working directory is set on the spawn, not with `-C`, matching chat.ts —
+ * and `codex exec resume` has no `-C` either.
+ */
+export function codexArgs(bin: string, model: string, sandbox: string, resumeId: string): string[] {
+  const args = [bin, "exec"];
+  if (resumeId) args.push("resume", resumeId);
+  args.push("--json", "-m", model);
+  if (sandbox === "full-access") {
+    args.push("--dangerously-bypass-approvals-and-sandbox");
+  } else {
+    args.push("-c", `sandbox_mode=${sandbox}`);
+    // `codex exec` has no channel to ask down, so an approval policy that would
+    // prompt can only stall or deny. Saying "never" up front makes the sandbox
+    // the only thing deciding, which is what the mode label already claims.
+    args.push("-c", "approval_policy=never");
+  }
+  args.push("-"); // read the prompt from stdin
+  return args;
+}
+
+export function codexStream(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, images?: unknown): Response {
+  const bin = codexBin();
+  if (!bin) return err("no local `codex` CLI — install the Codex CLI to chat", 403);
+  if (process.env.AGENTGLASS_CODEX_DISABLED === "1") return err("codex chat is disabled (AGENTGLASS_CODEX_DISABLED=1)", 403);
+  const dir = safeAbs(cwd);
+  if (!dir || !repoRootOf(dir)) {
+    const cap = gitCapability();
+    return err(cap.available ? "invalid or non-repo directory" : (cap.reason || "git is not installed"));
+  }
+  // A codex turn runs real tools in this directory, so it gets the same scope
+  // boundary a claude turn does.
+  if (!inScope(dir)) return err("outside the open project — open the parent folder to work across repos", 403);
+  // `codex exec` attaches images as file paths (`-i <FILE>`), not as content
+  // blocks, so there is nowhere for pasted bytes to go without staging them on
+  // disk first. Refusing is the honest answer: quietly sending a turn written
+  // about a screenshot, minus the screenshot, produces a confusing reply rather
+  // than an error — the same reasoning behind chat.ts rejecting a bad
+  // attachment instead of dropping it.
+  if (Array.isArray(images) && images.length) return err("codex chats cannot take pasted images yet — send the turn without it, or use a Claude chat");
+  if (typeof message !== "string" || !message.trim() || message.length > 100_000) return err("invalid message");
+  const m = typeof model === "string" && MODEL_RE.test(model) ? model : (codexModels()[0]?.id ?? FALLBACK_MODELS[0].id);
+  let sandbox = typeof mode === "string" && SANDBOXES.has(mode) ? mode : DEFAULT_SANDBOX;
+  if (sandbox === "full-access" && !CODEX_BYPASS_ALLOWED) sandbox = DEFAULT_SANDBOX; // opt-in only
+  const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";
+
+  const args = codexArgs(bin, m, sandbox, rid);
+
+  // Its own process group, so stopping a turn reaches the whole job tree —
+  // `codex` spawns shells of its own, and killing only the direct child would
+  // leave a test run or a dev server behind still working.
+  const setsid = Bun.which("setsid");
+  const proc = Bun.spawn(setsid ? [setsid, ...args] : args, {
+    cwd: dir,
+    stdin: new TextEncoder().encode(message),
+    stdout: "pipe",
+    stderr: "pipe",
+    env: { ...process.env },
+  });
+
+  // Drained from the start, not after exit: a full stderr pipe blocks the child
+  // forever, and `codex` is talkative on stderr even on a clean run (it logs a
+  // line per unloadable skill).
+  const stderrText = new Response(proc.stderr as ReadableStream<Uint8Array>).text().catch(() => "");
+
+  const enc = new TextEncoder();
+  let cancelled = false;
+  const stream = new ReadableStream<Uint8Array>({
+    async start(controller) {
+      const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+      const stopKeepalive = startKeepalive(controller);
+      /*
+       * A first-run watchdog, for the same failure chat.ts guards against: a
+       * `codex` that has never been logged in waits on an interactive prompt
+       * that can never arrive here, so it emits nothing and never exits, and
+       * the panel sits on a spinner that reads as agentglass having hung.
+       */
+      let firstByte = false;
+      const watchdog = setTimeout(async () => {
+        if (firstByte || cancelled) return;
+        const hint = (await Promise.race([stderrText, Promise.resolve("")])).trim();
+        try {
+          controller.enqueue(enc.encode(JSON.stringify({
+            type: "agx_error",
+            code: null,
+            errorType: "first_run_setup_required",
+            setupCommand: "codex login",
+            error: hint
+              || `codex produced no output in ${STARTUP_TIMEOUT_MS / 1000}s — it is probably waiting for a login it can't ask for here. Run \`codex login\` in a terminal, then try again.`,
+          }) + "\n"));
+        } catch { /* the client already went away */ }
+        try {
+          if (setsid) process.kill(-proc.pid, "SIGTERM");
+          else proc.kill();
+        } catch { /* gone */ }
+      }, STARTUP_TIMEOUT_MS);
+      try {
+        for (;;) {
+          const { done, value } = await reader.read();
+          if (done) break;
+          if (value) { firstByte = true; clearTimeout(watchdog); controller.enqueue(value); }
+        }
+      } catch { /* closed */ }
+      clearTimeout(watchdog);
+      stopKeepalive();
+      const code = await proc.exited;
+      if (cancelled) return; // a cancelled controller throws on enqueue/close
+      if (code !== 0) {
+        const text = (await stderrText).trim();
+        controller.enqueue(enc.encode(JSON.stringify({ type: "agx_error", code, error: text || `codex exited ${code}` }) + "\n"));
+      }
+      controller.close();
+    },
+    cancel() {
+      cancelled = true;
+      try {
+        if (setsid) process.kill(-proc.pid, "SIGTERM"); // the group, not just codex
+        else proc.kill();
+      } catch { /* gone */ }
+    },
+  });
+
+  return new Response(stream, { headers: { "content-type": "application/x-ndjson; charset=utf-8", "cache-control": "no-cache", "x-accel-buffering": "no", ...CORS } });
+}

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -362,6 +362,44 @@ export function codexArgs(bin: string, model: string, sandbox: string, resumeId:
   return args;
 }
 
+// --- where a codex thread is running -----------------------------------------
+//
+// Codex reaches the fleet over OpenTelemetry, and those records say everything
+// about a turn except *where* it happened: the payload carries `message`,
+// `event`, `prompt`, `tool_name`, `tool_use_id` and `usage`, and no working
+// directory anywhere. So every Codex session landed with a NULL project_path,
+// and a cockpit scoped to one project — which is the default — filtered all of
+// them out. The symptom was that OpenAI never appeared in the provider list
+// while 1225 Codex events sat in the database.
+//
+// The panel knows the directory, because it is the thing that launched the
+// turn. So it is remembered here, keyed by thread, and stamped onto the OTel
+// events as they arrive (see ingestBody in index.ts).
+//
+// Deliberately *not* the same treatment Antigravity gets. That agent reports to
+// nobody, so its frames are turned into events wholesale. Codex already reports
+// its own PreToolUse, PostToolUse and Turn complete — with the tokens — so
+// doing that here would file a second copy of every turn against the same
+// thread id and double the spend it shows.
+const codexCwds = new Map<string, { cwd: string; root: string }>();
+/** Bounded: a long-running server should not accumulate a row per thread it has
+ *  ever driven. Oldest out first — a thread that has not been touched in that
+ *  many turns is not one whose events are still arriving. */
+const MAX_TRACKED_THREADS = 500;
+
+export function noteCodexCwd(threadId: string, dir: string): void {
+  if (!threadId || !SESSION_RE.test(threadId) || !dir) return;
+  if (codexCwds.has(threadId)) return;
+  if (codexCwds.size >= MAX_TRACKED_THREADS) {
+    const oldest = codexCwds.keys().next().value;
+    if (oldest) codexCwds.delete(oldest);
+  }
+  codexCwds.set(threadId, { cwd: dir, root: repoRootOf(dir) || dir });
+}
+
+/** Where this thread was launched from, if this server launched it. */
+export const codexCwd = (sessionId: string) => codexCwds.get(sessionId) ?? null;
+
 export function codexStream(cwd: unknown, message: unknown, model: unknown, resumeId: unknown, mode: unknown, images?: unknown): Response {
   const bin = codexBin();
   if (!bin) return err("no local `codex` CLI — install the Codex CLI to chat", 403);
@@ -388,6 +426,9 @@ export function codexStream(cwd: unknown, message: unknown, model: unknown, resu
   const rid = typeof resumeId === "string" && SESSION_RE.test(resumeId) ? resumeId : "";
 
   const args = codexArgs(bin, m, sandbox, rid);
+  // A resumed thread is already named; a new one names itself in the
+  // `thread.started` frame below.
+  if (rid) noteCodexCwd(rid, dir);
 
   // Its own process group, so stopping a turn reaches the whole job tree —
   // `codex` spawns shells of its own, and killing only the direct child would
@@ -437,11 +478,37 @@ export function codexStream(cwd: unknown, message: unknown, model: unknown, resu
           else proc.kill();
         } catch { /* gone */ }
       }, STARTUP_TIMEOUT_MS);
+      /*
+       * The only thing read out of this stream on the way past: the id Codex
+       * mints for a new thread, so its OTel events can be told where they ran.
+       * Everything else is forwarded untouched — this is not a second parser,
+       * and the frames' meaning still lives entirely in codexFrames.ts.
+       */
+      const dec = new TextDecoder();
+      let head = "";
+      let named = !!rid;
+      const catchThreadId = (chunk: Uint8Array) => {
+        if (named) return;
+        head += dec.decode(chunk, { stream: true });
+        // `thread.started` is the first frame Codex sends, so this reads a line
+        // or two and then stops looking rather than parsing the whole turn.
+        for (const line of head.split("\n")) {
+          if (!line.includes("thread.started")) continue;
+          try {
+            const o = JSON.parse(line) as { type?: string; thread_id?: unknown };
+            if (o.type === "thread.started" && typeof o.thread_id === "string") {
+              noteCodexCwd(o.thread_id, dir);
+              named = true;
+            }
+          } catch { /* a partial line; the next chunk completes it */ }
+        }
+        if (named || head.length > 8192) head = "";
+      };
       try {
         for (;;) {
           const { done, value } = await reader.read();
           if (done) break;
-          if (value) { firstByte = true; clearTimeout(watchdog); controller.enqueue(value); }
+          if (value) { firstByte = true; clearTimeout(watchdog); catchThreadId(value); controller.enqueue(value); }
         }
       } catch { /* closed */ }
       clearTimeout(watchdog);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -70,7 +70,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
 import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
-import { codexStream, codexModels, codexTranscript, CODEX_ENABLED, CODEX_BYPASS_ALLOWED } from "./codex.ts";
+import { codexStream, codexModels, codexTranscript, codexCwd, CODEX_ENABLED, CODEX_BYPASS_ALLOWED } from "./codex.ts";
 import { antigravityStream, antigravityModels, ANTIGRAVITY_ENABLED, ANTIGRAVITY_BYPASS_ALLOWED } from "./antigravity.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
@@ -448,6 +448,18 @@ setInterval(pushOpenTools, OPEN_TOOL_TICK_MS).unref?.();
 
 /** Normalize → persist → broadcast → alert. Shared by /ingest and /v1/traces. */
 function ingestBody(body: IngestBody) {
+  // Codex's OTel records say everything about a turn except where it ran, so a
+  // cockpit scoped to a project — the default — filtered every one of them out
+  // and OpenAI never appeared in the provider list. The panel knows the
+  // directory because it launched the turn; this is where that is handed back.
+  //
+  // Only fills a gap, never overwrites: an agent that reports its own location
+  // is the better source, and this must not relabel it.
+  const payload = (body.payload ?? {}) as Record<string, unknown>;
+  if (!payload.cwd && !payload.project_path && body.session_id) {
+    const known = codexCwd(String(body.session_id));
+    if (known) body = { ...body, payload: { ...payload, cwd: known.cwd, project_path: known.root } };
+  }
   const n = normalize(body);
   // Live seam only: a skewed sender's clock must not decide which time window
   // its events land in. Backfill inserts elsewhere and keeps its real times.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -70,6 +70,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
 import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
+import { codexStream, codexModels, codexTranscript, CODEX_ENABLED, CODEX_BYPASS_ALLOWED } from "./codex.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, inScope, readBudgets, writeBudgets } from "./config.ts";
@@ -1781,6 +1782,32 @@ const server = Bun.serve<WsData>({
       if (!pane.available) return json({ error: pane.reason }, 400);
       if (!validPaneName(id)) return json({ error: "invalid session id" }, 400);
       return json({ command: attachCommand(id), live: await paneAlive(id) });
+    }
+
+    // --- multi-chat: the same panel, driving codex instead ---
+    // `models` comes back with `enabled` rather than from a route of its own:
+    // the panel needs both to draw a single dropdown, and asking twice would
+    // let it render a model picker for a CLI that turns out not to be there.
+    if (pathname === "/codex/enabled") {
+      return json({ enabled: CODEX_ENABLED, bypass: CODEX_BYPASS_ALLOWED, models: CODEX_ENABLED ? codexModels() : [] });
+    }
+    if (pathname === "/codex/send" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: any = {};
+      try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
+      // Same reasoning as /chat/send: the launch is the auditable fact, not the
+      // turn, and the prompt is already in Codex's own rollout.
+      noteAction(srv.requestIP(req)?.address, "/codex/send",
+        { root: b.cwd, name: b.model }, { ok: true }, caller);
+      return codexStream(b.cwd, b.message, b.model, b.resumeId, b.mode, b.images);
+    }
+    // What a Codex thread said, for a chat adopting it from the fleet. The
+    // OTel stream carries tool calls but no prose, so this reads Codex's own
+    // rollout — see codexTranscript(). Single-flighted like /session: several
+    // panels opening the same thread should read the file once.
+    if (pathname === "/codex/transcript") {
+      const id = url.searchParams.get("id") || "";
+      return body(await singleFlight(`codex:${id}`, async () => JSON.stringify({ timeline: codexTranscript(id) })));
     }
 
     // --- LLM walkthrough: AI-authored review itinerary for the changes ---

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1823,7 +1823,7 @@ const server = Bun.serve<WsData>({
     // internal schema, so there is nothing here that could be read without
     // guessing at it — see server/src/antigravity.ts.
     if (pathname === "/antigravity/enabled") {
-      return json({ enabled: ANTIGRAVITY_ENABLED, bypass: ANTIGRAVITY_BYPASS_ALLOWED, models: ANTIGRAVITY_ENABLED ? antigravityModels() : [] });
+      return json({ enabled: ANTIGRAVITY_ENABLED, bypass: ANTIGRAVITY_BYPASS_ALLOWED, models: ANTIGRAVITY_ENABLED ? await antigravityModels() : [] });
     }
     if (pathname === "/antigravity/send" && req.method === "POST") {
       if (!localOrigin(req)) return csrfBlocked();

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -71,6 +71,7 @@ import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERM
 import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
 import { codexStream, codexModels, codexTranscript, CODEX_ENABLED, CODEX_BYPASS_ALLOWED } from "./codex.ts";
+import { antigravityStream, antigravityModels, ANTIGRAVITY_ENABLED, ANTIGRAVITY_BYPASS_ALLOWED } from "./antigravity.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, SCAN_ENABLED } from "./transcripts.ts";
 import { workspaceRoot, setWorkspaceRoot, inScope, readBudgets, writeBudgets } from "./config.ts";
@@ -819,6 +820,12 @@ const server = Bun.serve<WsData>({
       if (agent.via === "hooks") {
         const r = applyHooks(undo ? "uninstall" : "install");
         return json({ ...r, agents: probeAgents() });
+      }
+      // A `chat` agent has no wiring to apply: it reports because this server
+      // runs it. Refusing plainly beats spawning connect_otel.py with an id it
+      // has never heard of and returning whatever that prints.
+      if (agent.via === "chat") {
+        return json({ ok: false, error: `${agent.label} needs no connecting — it reports through the chat panel that runs it`, agents: probeAgents() }, 400);
       }
 
       const dir = hooksDir();
@@ -1808,6 +1815,27 @@ const server = Bun.serve<WsData>({
     if (pathname === "/codex/transcript") {
       const id = url.searchParams.get("id") || "";
       return body(await singleFlight(`codex:${id}`, async () => JSON.stringify({ timeline: codexTranscript(id) })));
+    }
+
+    // --- multi-chat: the same panel, driving google antigravity ---
+    // No /antigravity/transcript to match the two above: Antigravity keeps each
+    // conversation as a SQLite database of protobuf blobs on an undocumented
+    // internal schema, so there is nothing here that could be read without
+    // guessing at it — see server/src/antigravity.ts.
+    if (pathname === "/antigravity/enabled") {
+      return json({ enabled: ANTIGRAVITY_ENABLED, bypass: ANTIGRAVITY_BYPASS_ALLOWED, models: ANTIGRAVITY_ENABLED ? antigravityModels() : [] });
+    }
+    if (pathname === "/antigravity/send" && req.method === "POST") {
+      if (!localOrigin(req)) return csrfBlocked();
+      let b: any = {};
+      try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
+      noteAction(srv.requestIP(req)?.address, "/antigravity/send",
+        { root: b.cwd, name: b.model }, { ok: true }, caller);
+      // `ingestBody` is handed in rather than imported by antigravity.ts, which
+      // would be a cycle. It is also what puts an Antigravity chat on the radar
+      // at all: unlike Claude (hooks) and Codex (OTel), this CLI reports to
+      // nobody, so its own frames are the only source there is.
+      return antigravityStream(b.cwd, b.message, b.model, b.resumeId, b.mode, b.images, ingestBody);
     }
 
     // --- LLM walkthrough: AI-authored review itinerary for the changes ---

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -70,6 +70,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
 import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
 import { paneEngineCapability, attachCommand, validPaneName } from "./chatpane.ts";
+import { claudeModels } from "./claudemodels.ts";
 import { codexStream, codexModels, codexTranscript, codexCwd, CODEX_ENABLED, CODEX_BYPASS_ALLOWED } from "./codex.ts";
 import { antigravityStream, antigravityModels, ANTIGRAVITY_ENABLED, ANTIGRAVITY_BYPASS_ALLOWED } from "./antigravity.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
@@ -1693,6 +1694,11 @@ const server = Bun.serve<WsData>({
       return json({
         enabled: CHAT_ENABLED,
         bypass: CHAT_BYPASS_ALLOWED,
+        // Claude's list now arrives the same way Codex's and Antigravity's do,
+        // so the panel has one path for all three instead of a table compiled
+        // into the bundle for one of them. Read from shared/claude-models.json,
+        // filtered to what has not reached its shutdown date.
+        models: claudeModels(),
         tmuxEngine: { available: pane.available, reason: pane.reason, defaultOn: CHAT_ENGINE_DEFAULT === "tmux" },
       });
     }

--- a/server/test/agent-probe.test.ts
+++ b/server/test/agent-probe.test.ts
@@ -83,11 +83,17 @@ describe("what is on this machine", () => {
     }
   });
 
-  test("and every entry names the file connecting it would write", () => {
+  test("and every entry that writes a config names the file", () => {
     // It is a file in somebody's home directory, so it is said rather than
     // implied — including for Claude Code, whose path comes from the hook
     // installer rather than from the roster.
+    //
+    // A `chat` agent is exempt because there is no such file: it reports by
+    // being run from the chat panel, so connecting it writes nothing anywhere.
+    // An empty path is the honest answer, and inventing one to satisfy this
+    // would put a filename in the UI that nothing ever reads or writes.
     for (const r of probeAgents(never, never)) {
+      if (r.via === "chat") { expect(r.configPath, r.id).toBe(""); continue; }
       expect(r.configPath, r.id).toBeTruthy();
       expect(r.configPath.length, r.id).toBeGreaterThan(1);
     }

--- a/server/test/agent-routes.test.ts
+++ b/server/test/agent-routes.test.ts
@@ -68,7 +68,7 @@ const GEMINI = () => join(dir, ".gemini", "settings.json");
 describe("what the pane is told", () => {
   test("every known agent, installed or not", async () => {
     const r = await agents();
-    expect(r.agents.map((a: Json) => a.id).sort()).toEqual(["claude-code", "codex", "gemini"]);
+    expect(r.agents.map((a: Json) => a.id).sort()).toEqual(["antigravity", "claude-code", "codex", "gemini"]);
   });
 
   test("with the file connecting it would write, under this machine's HOME", async () => {

--- a/server/test/antigravity.test.ts
+++ b/server/test/antigravity.test.ts
@@ -1,0 +1,203 @@
+import { test, expect, describe } from "bun:test";
+import { antigravityArgs, parseModels, frameToEvent, newFrameContext, ANTIGRAVITY_APP } from "../src/antigravity.ts";
+
+// The two halves of driving a third CLI: the command line that starts a turn,
+// and the mapping that turns what it streams back into events. Both are pure,
+// and both are the kind of thing that breaks silently — a mode flag that stops
+// being passed still runs, it just runs with more authority than the label
+// claims.
+
+const BIN = "/usr/bin/agy";
+const UUID = "78126291-f204-4b7a-b218-9a7e7ba9ac9a";
+
+describe("the command line", () => {
+  test("a first turn names the model and asks for the streaming format", () => {
+    const a = antigravityArgs(BIN, "gemini-3.1-pro-high", "request-review", "", "hello");
+    expect(a).toEqual([BIN, "-p", "hello", "--output-format", "stream-json", "--model", "gemini-3.1-pro-high"]);
+  });
+
+  test("the default mode is spelled by passing no flag", () => {
+    // `--mode` only accepts accept-edits and plan; passing it "request-review"
+    // is rejected outright, so the default has to be the absence of the flag.
+    const a = antigravityArgs(BIN, "m", "request-review", "", "hi");
+    expect(a).not.toContain("--mode");
+    expect(a).not.toContain("--dangerously-skip-permissions");
+  });
+
+  test("plan and accept-edits ride --mode", () => {
+    expect(antigravityArgs(BIN, "m", "plan", "", "hi")).toContain("--mode");
+    expect(antigravityArgs(BIN, "m", "plan", "", "hi")).toContain("plan");
+    expect(antigravityArgs(BIN, "m", "accept-edits", "", "hi")).toContain("accept-edits");
+  });
+
+  test("the unattended mode is its own flag, not a --mode value", () => {
+    const a = antigravityArgs(BIN, "m", "always-proceed", "", "hi");
+    expect(a).toContain("--dangerously-skip-permissions");
+    expect(a).not.toContain("--mode");
+  });
+
+  test("a follow-up resumes the conversation it belongs to", () => {
+    const a = antigravityArgs(BIN, "m", "request-review", UUID, "again");
+    expect(a).toContain("--conversation");
+    expect(a[a.indexOf("--conversation") + 1]).toBe(UUID);
+  });
+
+  test("the prompt is one argv element, however odd it looks", () => {
+    // It goes in argv rather than on stdin, so a prompt full of quotes,
+    // newlines and leading dashes must survive as a single value rather than
+    // being read as more flags.
+    const nasty = "--model evil\n'; rm -rf /\n\"quoted\"";
+    const a = antigravityArgs(BIN, "m", "request-review", "", nasty);
+    expect(a[1]).toBe("-p");
+    expect(a[2]).toBe(nasty);
+    expect(a.filter((x) => x === "--model")).toHaveLength(1);
+  });
+});
+
+describe("the model list", () => {
+  test("reads the bare list `agy models` prints", () => {
+    expect(parseModels("gemini-3.6-flash-low\nclaude-sonnet-4-6\ngpt-oss-120b-medium\n"))
+      .toEqual([
+        { id: "gemini-3.6-flash-low", label: "gemini-3.6-flash-low" },
+        { id: "claude-sonnet-4-6", label: "claude-sonnet-4-6" },
+        { id: "gpt-oss-120b-medium", label: "gpt-oss-120b-medium" },
+      ]);
+  });
+
+  test("drops anything the send path would then refuse", () => {
+    // The same MODEL_RE guards the spawn, so offering a choice that cannot be
+    // sent is the one outcome worth ruling out here.
+    const out = parseModels("gemini-3.1-pro-high\nAvailable models:\n  \nnot a model!\n");
+    expect(out.map((m) => m.id)).toEqual(["gemini-3.1-pro-high"]);
+  });
+
+  test("does not repeat itself", () => {
+    expect(parseModels("a-model\na-model\n").length).toBe(1);
+  });
+});
+
+describe("frames as events", () => {
+  const init = {
+    event: "init",
+    conversation_id: UUID,
+    init: { model: "gemini-3.6-flash-low", cwd: "/repo", permission_mode: "request-review" },
+  };
+
+  test("init opens the session and fixes the model", () => {
+    const ctx = newFrameContext();
+    const e = frameToEvent(init, ctx)!;
+    expect(e.hook_event_type).toBe("SessionStart");
+    expect(e.session_id).toBe(UUID);
+    expect(e.model_name).toBe("gemini-3.6-flash-low");
+    // `source_app` is what tells the rest of the app which CLI this was. It has
+    // to be the agent's own name rather than the model's: `agy` runs Claude
+    // models too, so a model-derived answer would file those under Claude.
+    expect(e.source_app).toBe(ANTIGRAVITY_APP);
+  });
+
+  test("every event says where it ran, or the fleet never shows it", () => {
+    // db.ts lifts `project_path` and `cwd_path` straight out of the payload
+    // JSON, and the fleet list filters on them. Events without these land in
+    // the store and then appear nowhere — which looks exactly like the chat
+    // never having been recorded at all. Found by driving a real turn, not by
+    // reading the code.
+    const ctx = newFrameContext("/repo/checkout");
+    for (const f of [
+      init,
+      { event: "step_update", step_update: { step_index: 0, state: "DONE", step_type: "user_input", text_delta: "go" } },
+      { event: "step_update", step_update: { step_index: 1, state: "ACTIVE", step_type: "tool", tool_name: "list_dir" } },
+      { event: "step_update", step_update: { step_index: 1, state: "DONE", step_type: "tool", tool_name: "list_dir", tool_info: { output: "x" } } },
+      { event: "result", result: { status: "SUCCESS", usage: {} } },
+    ]) {
+      const e = frameToEvent(f, ctx);
+      expect(e, JSON.stringify(f).slice(0, 40)).not.toBeNull();
+      expect(e!.payload!.cwd, e!.hook_event_type).toBeTruthy();
+      expect(e!.payload!.project_path, e!.hook_event_type).toBeTruthy();
+    }
+  });
+
+  test("the directory the CLI reports wins over the one we asked for", () => {
+    // `--add-dir` and a workspace can move it, and the init frame is the CLI
+    // saying where it actually ended up.
+    const ctx = newFrameContext("/repo/asked");
+    frameToEvent({ ...init, init: { ...init.init, cwd: "/repo/actual" } }, ctx);
+    expect(ctx.cwd).toBe("/repo/actual");
+  });
+
+  test("nothing is emitted before a conversation exists", () => {
+    // Every event needs a session id, and until `init` there is none. Guessing
+    // one would scatter a turn across sessions nobody can find.
+    const ctx = newFrameContext();
+    const orphan = { event: "step_update", step_update: { step_index: 0, state: "DONE", step_type: "user_input", text_delta: "hi" } };
+    expect(frameToEvent(orphan, ctx)).toBeNull();
+  });
+
+  test("a tool becomes a Pre/Post pair sharing one id", () => {
+    const ctx = newFrameContext();
+    frameToEvent(init, ctx);
+    const pre = frameToEvent({
+      event: "step_update",
+      step_update: { conversation_id: UUID, step_index: 3, state: "ACTIVE", step_type: "tool", tool_name: "list_dir", tool_info: { name: "list_dir" } },
+    }, ctx)!;
+    const post = frameToEvent({
+      event: "step_update",
+      step_update: { conversation_id: UUID, step_index: 3, state: "DONE", step_type: "tool", tool_name: "list_dir", duration_seconds: 0.04, tool_info: { name: "list_dir", output: "a\nb" } },
+    }, ctx)!;
+    expect(pre.hook_event_type).toBe("PreToolUse");
+    expect(post.hook_event_type).toBe("PostToolUse");
+    // The pairing is what produces a latency figure at all, so the two halves
+    // must agree on the id.
+    expect(pre.payload!.tool_use_id).toBe(post.payload!.tool_use_id);
+    expect(post.payload!.tool_name).toBe("list_dir");
+    expect(post.payload!.tool_response).toBe("a\nb");
+  });
+
+  test("a DONE half still names its tool if only the ACTIVE half carried it", () => {
+    const ctx = newFrameContext();
+    frameToEvent(init, ctx);
+    frameToEvent({ event: "step_update", step_update: { step_index: 7, state: "ACTIVE", step_type: "tool", tool_name: "run_command" } }, ctx);
+    const post = frameToEvent({ event: "step_update", step_update: { step_index: 7, state: "DONE", step_type: "tool", tool_info: { output: "ok" } } }, ctx)!;
+    expect(post.payload!.tool_name).toBe("run_command");
+  });
+
+  test("the prompt is kept, the way Claude Code's hooks keep it", () => {
+    const ctx = newFrameContext();
+    frameToEvent(init, ctx);
+    const e = frameToEvent({ event: "step_update", step_update: { step_index: 0, state: "DONE", step_type: "user_input", text_delta: "list the files" } }, ctx)!;
+    expect(e.hook_event_type).toBe("UserPromptSubmit");
+    expect(e.payload!.prompt).toBe("list the files");
+  });
+
+  test("result closes the turn with what it spent", () => {
+    const ctx = newFrameContext();
+    frameToEvent(init, ctx);
+    const e = frameToEvent({
+      event: "result",
+      result: { conversation_id: UUID, status: "SUCCESS", usage: { input_tokens: 16609, output_tokens: 108, thinking_tokens: 40, cache_read_tokens: 61046, total_tokens: 16717 } },
+    }, ctx)!;
+    expect(e.hook_event_type).toBe("Turn complete");
+    const u = e.payload!.usage as Record<string, number>;
+    expect(u.input_tokens).toBe(16609);
+    expect(u.cache_read_tokens).toBe(61046);
+    // Thinking tokens are already counted inside `output_tokens`, so adding
+    // them again would bill every reasoning turn twice.
+    expect(u.output_tokens).toBe(108);
+  });
+
+  test("the frames that are not events say so", () => {
+    const ctx = newFrameContext();
+    frameToEvent(init, ctx);
+    for (const type of ["agent_response", "thinking", "checkpoint", "unknown", "error_message"]) {
+      expect(frameToEvent({ event: "step_update", step_update: { step_index: 1, state: "DONE", step_type: type } }, ctx), type).toBeNull();
+    }
+    expect(frameToEvent({ event: "something_new" }, ctx)).toBeNull();
+  });
+
+  test("a conversation id that is not one is refused", () => {
+    // The id reaches `--conversation` on a command line and is the key every
+    // event for this turn is filed under.
+    const ctx = newFrameContext();
+    expect(frameToEvent({ event: "init", conversation_id: "../../etc/passwd", init: {} }, ctx)).toBeNull();
+    expect(ctx.sessionId).toBe("");
+  });
+});

--- a/server/test/antigravity.test.ts
+++ b/server/test/antigravity.test.ts
@@ -1,5 +1,15 @@
 import { test, expect, describe } from "bun:test";
-import { antigravityArgs, parseModels, frameToEvent, newFrameContext, ANTIGRAVITY_APP } from "../src/antigravity.ts";
+import { antigravityArgs, parseModels, antigravityModels, frameToEvent, newFrameContext, ANTIGRAVITY_APP } from "../src/antigravity.ts";
+
+/** How many subprocesses have been started. Counted rather than mocked, so the
+ *  assertion is about what actually happens on the machine. */
+const spawnCount = () => SPAWNS.n;
+const SPAWNS = { n: 0 };
+const realSpawn = Bun.spawn;
+(Bun as unknown as { spawn: typeof Bun.spawn }).spawn = ((...args: Parameters<typeof Bun.spawn>) => {
+  SPAWNS.n++;
+  return realSpawn(...args);
+}) as typeof Bun.spawn;
 
 // The two halves of driving a third CLI: the command line that starts a turn,
 // and the mapping that turns what it streams back into events. Both are pure,
@@ -51,6 +61,37 @@ describe("the command line", () => {
     expect(a[1]).toBe("-p");
     expect(a[2]).toBe(nasty);
     expect(a.filter((x) => x === "--model")).toHaveLength(1);
+  });
+});
+
+describe("the model list does not stall the server", () => {
+  // Regression. This used Bun.spawnSync, which blocks Bun's single event loop
+  // for as long as `agy models` takes — measured at 1.3–2.2s on a cold run.
+  // Nothing else was served in that window, so /health could not answer inside
+  // probeServer's 2.5s budget, the dashboard decided it was talking to a
+  // stranger, and every panel went empty behind a "Wrong server" banner. With
+  // `bun --watch` the cost is re-paid on every save.
+  test("is asked for asynchronously, never synchronously", async () => {
+    const out = antigravityModels();
+    expect(out, "antigravityModels must return a promise, not a resolved array").toBeInstanceOf(Promise);
+    expect(Array.isArray(await out)).toBe(true);
+  });
+
+  test("concurrent callers share one lookup", async () => {
+    // The panel mounts, React StrictMode mounts it twice, and a reconnect asks
+    // again — three spawns of the same subprocess, serialised, for one answer.
+    const spawns = spawnCount();
+    await Promise.all([antigravityModels(), antigravityModels(), antigravityModels()]);
+    expect(spawnCount() - spawns).toBeLessThanOrEqual(1);
+  });
+
+  test("a CLI that cannot answer is not re-asked on every request", async () => {
+    // Memoising only on success meant a broken or unauthenticated `agy` paid
+    // the full subprocess cost per request, forever.
+    await antigravityModels();
+    const spawns = spawnCount();
+    await antigravityModels();
+    expect(spawnCount()).toBe(spawns);
   });
 });
 

--- a/server/test/claude-models.test.ts
+++ b/server/test/claude-models.test.ts
@@ -1,0 +1,143 @@
+import { test, expect, describe, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import { parseCatalog, isOffered, todayStamp, claudeModels, catalogPaths } from "../src/claudemodels.ts";
+
+// Claude Code publishes no model list — no `models` subcommand, no
+// `--list-models`, no cache on disk — so unlike Codex and Antigravity this one
+// has to be written down. Written down as data, so it can be corrected without
+// a rebuild, which puts the parsing and the expiry rule on this file.
+
+const catalog = (rows: unknown[]) => JSON.stringify({ models: rows });
+const row = (over: Record<string, unknown> = {}) => ({
+  id: "claude-opus-5", display_name: "Claude Opus 5", status: "active",
+  release_date: "2026-07-24", scheduled_shutdown_date: "2027-07-24", ...over,
+});
+
+describe("what is still offered", () => {
+  test("a model is offered up to and including its shutdown date", () => {
+    // The date is the last day it is offered, not the first day it is gone.
+    // Stated here because it is the kind of boundary that is otherwise decided
+    // by accident.
+    expect(isOffered(row({ scheduled_shutdown_date: "2026-08-01" }), "2026-07-31")).toBe(true);
+    expect(isOffered(row({ scheduled_shutdown_date: "2026-08-01" }), "2026-08-01")).toBe(true);
+    expect(isOffered(row({ scheduled_shutdown_date: "2026-08-01" }), "2026-08-02")).toBe(false);
+  });
+
+  test("no shutdown date means no retirement announced, not retired long ago", () => {
+    expect(isOffered({ id: "x" }, "2030-01-01")).toBe(true);
+    expect(isOffered(row({ scheduled_shutdown_date: "" }), "2030-01-01")).toBe(true);
+    expect(isOffered(row({ scheduled_shutdown_date: "soon" }), "2030-01-01")).toBe(true);
+  });
+
+  test("a retired model is dropped from the list", () => {
+    const raw = catalog([
+      row({ id: "claude-opus-5" }),
+      row({ id: "claude-haiku-4-5", scheduled_shutdown_date: "2026-01-01" }),
+    ]);
+    expect(parseCatalog(raw, "2026-07-31").map((m) => m.id)).toEqual(["claude-opus-5"]);
+  });
+
+  test("status is recorded but does not filter", () => {
+    // A superseded model still answers until it is actually retired; hiding it
+    // early would take away a choice that works.
+    const raw = catalog([row({ id: "claude-opus-4-6", status: "superseded", scheduled_shutdown_date: "2027-02-05" })]);
+    expect(parseCatalog(raw, "2026-07-31").map((m) => m.id)).toEqual(["claude-opus-4-6"]);
+  });
+});
+
+describe("reading the file", () => {
+  test("display_name becomes the label, and the id stands in without one", () => {
+    const out = parseCatalog(catalog([row(), row({ id: "claude-sonnet-5", display_name: undefined })]), "2026-07-31");
+    expect(out).toEqual([
+      { id: "claude-opus-5", label: "Claude Opus 5" },
+      { id: "claude-sonnet-5", label: "claude-sonnet-5" },
+    ]);
+  });
+
+  test("the 1M variant is its own entry", () => {
+    // Not a duplicate: the suffix is what `claude` reads to pick a window behind
+    // a gateway or on Bedrock, where the plain id really does mean 200k.
+    const out = parseCatalog(catalog([row({ id: "claude-opus-5[1m]", display_name: "Claude Opus 5 · 1M" })]), "2026-07-31");
+    expect(out.map((m) => m.id)).toEqual(["claude-opus-5[1m]"]);
+  });
+
+  test("an id the send path would refuse is not offered", () => {
+    // The same expression guards the spawn in chat.ts. A dropdown entry that
+    // cannot be sent is worse than one that is missing.
+    const out = parseCatalog(catalog([row({ id: "../../etc/passwd" }), row({ id: "model with spaces" }), row()]), "2026-07-31");
+    expect(out.map((m) => m.id)).toEqual(["claude-opus-5"]);
+  });
+
+  test("a file edited into nonsense yields nothing rather than throwing", () => {
+    // This is hand-edited by definition, so a broken file is a normal state and
+    // must not take the route down with it.
+    expect(parseCatalog("{ not json", "2026-07-31")).toEqual([]);
+    expect(parseCatalog(JSON.stringify({ models: "everything" }), "2026-07-31")).toEqual([]);
+    expect(parseCatalog(JSON.stringify({}), "2026-07-31")).toEqual([]);
+    expect(parseCatalog(catalog([null, 7, "x"]), "2026-07-31")).toEqual([]);
+  });
+
+  test("the same id twice is listed once", () => {
+    expect(parseCatalog(catalog([row(), row()]), "2026-07-31")).toHaveLength(1);
+  });
+});
+
+describe("where it is read from", () => {
+  let dir = "";
+  const saved = process.env.AGENTGLASS_CLAUDE_MODELS;
+  beforeEach(() => { dir = mkdtempSync(join(tmpdir(), "agx-models-")); });
+  afterEach(() => {
+    if (saved === undefined) delete process.env.AGENTGLASS_CLAUDE_MODELS;
+    else process.env.AGENTGLASS_CLAUDE_MODELS = saved;
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("an override wins over the copy in the checkout", () => {
+    // The point of the file being data is that it can be corrected on a machine
+    // whose checkout is packaged or read-only.
+    const p = join(dir, "claude-models.json");
+    writeFileSync(p, catalog([row({ id: "claude-fable-5", display_name: "Only This One" })]));
+    process.env.AGENTGLASS_CLAUDE_MODELS = p;
+    expect(catalogPaths()[0]).toBe(p);
+    expect(claudeModels()).toEqual([{ id: "claude-fable-5", label: "Only This One" }]);
+  });
+
+  test("an edit is picked up without a restart", () => {
+    // Re-read on mtime, because "update the list without redeploying" is the
+    // whole reason this is a file.
+    const p = join(dir, "claude-models.json");
+    process.env.AGENTGLASS_CLAUDE_MODELS = p;
+    writeFileSync(p, catalog([row({ id: "claude-opus-5", display_name: "First" })]));
+    expect(claudeModels()[0].label).toBe("First");
+    writeFileSync(p, catalog([row({ id: "claude-opus-5", display_name: "Second" })]));
+    expect(claudeModels()[0].label).toBe("Second");
+  });
+
+  test("a broken override falls through rather than emptying the dropdown", () => {
+    const p = join(dir, "claude-models.json");
+    writeFileSync(p, "{{{");
+    process.env.AGENTGLASS_CLAUDE_MODELS = p;
+    // The checkout's own catalogue answers instead.
+    expect(claudeModels().length).toBeGreaterThan(0);
+  });
+});
+
+describe("the catalogue this repo ships", () => {
+  test("is readable, and every entry survives its own rules", () => {
+    delete process.env.AGENTGLASS_CLAUDE_MODELS;
+    const out = claudeModels();
+    expect(out.length).toBeGreaterThan(1);
+    // The default a new chat is created with has to be one of the offered ids,
+    // or the picker opens showing a choice it does not list.
+    expect(out.map((m) => m.id)).toContain("claude-opus-5");
+  });
+
+  test("today's stamp is a plain calendar date", () => {
+    expect(todayStamp(new Date(2026, 6, 31))).toBe("2026-07-31");
+    // Zero-padded, or string comparison against the file's dates is wrong for
+    // nine months of the year.
+    expect(todayStamp(new Date(2026, 0, 5))).toBe("2026-01-05");
+  });
+});

--- a/server/test/codex.test.ts
+++ b/server/test/codex.test.ts
@@ -1,0 +1,255 @@
+// The Codex backend's two pure pieces: the argv a turn is spawned with, and the
+// model list the dropdown is offered.
+//
+// Both are worth pinning without a real `codex`. The argv decides how much a
+// browser request may do to the filesystem, and the model list is read off a
+// cache this repo does not control — a shape change there must degrade to the
+// fallback rather than putting a malformed id into the spawn.
+//
+// The third is the rollout reader, which is what gives a resumed Codex chat its
+// history: the telemetry the fleet knows a Codex session by carries the shape of
+// a turn but none of its words (its `UserPromptSubmit` payload is literally
+// `{"prompt":""}`), so this file on disk is the only source for them.
+import { describe, expect, test } from "bun:test";
+import { codexArgs, parseModels, parseRollout, DEFAULT_SANDBOX } from "../src/codex.ts";
+
+const BIN = "/usr/bin/codex";
+
+describe("codexArgs", () => {
+  test("a first turn opens a thread and reads the prompt from stdin", () => {
+    expect(codexArgs(BIN, "gpt-5.6-sol", "read-only", "")).toEqual([
+      BIN, "exec", "--json", "-m", "gpt-5.6-sol",
+      "-c", "sandbox_mode=read-only",
+      "-c", "approval_policy=never",
+      "-",
+    ]);
+  });
+
+  test("a follow-up resumes the thread it was given", () => {
+    const args = codexArgs(BIN, "gpt-5.6-sol", "workspace-write", "019fb8f6-aabc-72e3-80fe-66edcdf559f5");
+    expect(args.slice(0, 4)).toEqual([BIN, "exec", "resume", "019fb8f6-aabc-72e3-80fe-66edcdf559f5"]);
+    expect(args).toContain("--json");
+    expect(args).toContain("sandbox_mode=workspace-write");
+    // `codex exec resume` rejects `-s` outright, which is why the sandbox rides
+    // in as a config override on both paths rather than as the documented flag.
+    expect(args).not.toContain("-s");
+    expect(args[args.length - 1]).toBe("-");
+  });
+
+  test("full-access drops the sandbox instead of narrowing it", () => {
+    const args = codexArgs(BIN, "gpt-5.6-sol", "full-access", "");
+    expect(args).toContain("--dangerously-bypass-approvals-and-sandbox");
+    // No sandbox_mode alongside it: the two would be contradictory, and the
+    // bypass flag already implies the approval policy.
+    expect(args.some((a) => a.startsWith("sandbox_mode="))).toBe(false);
+    expect(args.some((a) => a.startsWith("approval_policy="))).toBe(false);
+  });
+
+  test("the prompt is never an argv element", () => {
+    // It goes in on stdin. A prompt in argv would hit ARG_MAX on a long paste
+    // and would put what the user typed into the process table.
+    const args = codexArgs(BIN, "gpt-5.6-sol", "read-only", "");
+    expect(args.filter((a) => a === "-")).toHaveLength(1);
+    expect(args).not.toContain("hello");
+  });
+
+  test("the default sandbox is the one that cannot write", () => {
+    expect(DEFAULT_SANDBOX).toBe("read-only");
+  });
+});
+
+/** One entry shaped like the real cache, trimmed to the fields that matter. */
+const model = (o: Record<string, unknown>) => ({
+  slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", visibility: "list", priority: 1,
+  description: "…", base_instructions: "…several kilobytes…", ...o,
+});
+
+describe("parseModels", () => {
+  test("keeps listed models, in priority order, as id and label only", () => {
+    const raw = JSON.stringify({
+      models: [
+        model({ slug: "gpt-5.5", display_name: "GPT-5.5", priority: 3 }),
+        model({ slug: "gpt-5.6-sol", display_name: "GPT-5.6-Sol", priority: 1 }),
+        model({ slug: "gpt-5.6-luna", display_name: "GPT-5.6-Luna", priority: 2 }),
+      ],
+    });
+    expect(parseModels(raw)).toEqual([
+      { id: "gpt-5.6-sol", label: "GPT-5.6-Sol" },
+      { id: "gpt-5.6-luna", label: "GPT-5.6-Luna" },
+      { id: "gpt-5.5", label: "GPT-5.5" },
+    ]);
+  });
+
+  test("drops entries Codex does not itself offer to a human", () => {
+    // The cache carries internal entries — a review model, service tiers — that
+    // are not conversation models at all.
+    const raw = JSON.stringify({
+      models: [model({ slug: "codex-auto-review", visibility: "hidden" }), model({})],
+    });
+    expect(parseModels(raw).map((m) => m.id)).toEqual(["gpt-5.6-sol"]);
+  });
+
+  test("drops an id the send path would then refuse", () => {
+    // Offering a choice that fails validation on the way out is the one outcome
+    // worth ruling out here — it would read as the chat being broken.
+    const raw = JSON.stringify({
+      models: [model({ slug: "gpt-5.6 --dangerously-bypass-approvals-and-sandbox" }), model({ slug: "GPT-Upper" }), model({})],
+    });
+    expect(parseModels(raw).map((m) => m.id)).toEqual(["gpt-5.6-sol"]);
+  });
+
+  test("falls back to the slug when there is no display name", () => {
+    expect(parseModels(JSON.stringify({ models: [model({ display_name: null })] })))
+      .toEqual([{ id: "gpt-5.6-sol", label: "gpt-5.6-sol" }]);
+  });
+
+  test("a cache that is missing, malformed or reshaped yields nothing", () => {
+    // Nothing here throws — codexModels() reads the emptiness as "use the
+    // fallback list", which is what keeps a Codex release from emptying the
+    // dropdown on a machine where the CLI works fine.
+    expect(parseModels("")).toEqual([]);
+    expect(parseModels("not json")).toEqual([]);
+    expect(parseModels("{}")).toEqual([]);
+    expect(parseModels(JSON.stringify({ models: "gpt-5.6-sol" }))).toEqual([]);
+    expect(parseModels(JSON.stringify({ models: [null, 42, "x"] }))).toEqual([]);
+  });
+});
+
+// --- the rollout reader ------------------------------------------------------
+// Records shaped exactly as `~/.codex/sessions/**/rollout-*.jsonl` writes them,
+// down to `output` being an inline array rather than a string holding one —
+// which is the detail that matters, since reading only the string form left
+// every replayed tool row showing no output while looking perfectly healthy.
+const line = (o: unknown) => JSON.stringify(o);
+const msg = (kind: string, message: string, timestamp: string) =>
+  line({ type: "event_msg", timestamp, payload: { type: kind, message } });
+const call = (call_id: string, name: string, input: string, timestamp: string) =>
+  line({ type: "response_item", timestamp, payload: { type: "custom_tool_call", call_id, name, input, status: "completed" } });
+const result = (call_id: string, text: string, timestamp: string) =>
+  line({ type: "response_item", timestamp, payload: { type: "custom_tool_call_output", call_id, output: [{ type: "text", text }] } });
+
+describe("parseRollout", () => {
+  const ROLLOUT = [
+    line({ type: "session_meta", timestamp: "2026-07-31T12:31:13.000Z", payload: { id: "019fb903", cwd: "/tmp/repo" } }),
+    msg("user_message", "how many lines is the readme?", "2026-07-31T12:31:14.000Z"),
+    msg("agent_message", "I’ll check.", "2026-07-31T12:31:15.000Z"),
+    call("c1", "exec", '{"cmd":"wc -l README.md","yield_time_ms":10000}', "2026-07-31T12:31:16.000Z"),
+    result("c1", "4 README.md\n", "2026-07-31T12:31:17.000Z"),
+    msg("agent_message", "Four.", "2026-07-31T12:31:18.000Z"),
+  ].join("\n");
+
+  test("gives back the conversation the telemetry could not", () => {
+    expect(parseRollout(ROLLOUT).filter((e) => e.kind === "message").map((e) => [e.role, e.text]))
+      .toEqual([["user", "how many lines is the readme?"], ["assistant", "I’ll check."], ["assistant", "Four."]]);
+  });
+
+  test("a tool call carries the command it ran and what came back", () => {
+    const [tool] = parseRollout(ROLLOUT).filter((e) => e.kind === "tool");
+    // The command is a JSON field inside a snippet Codex wrote for its own
+    // sandbox, so pulling it out is a read of generated code — worth pinning
+    // precisely, because the fallback (showing the snippet) is much worse.
+    expect(tool.target).toBe("wc -l README.md");
+    // `output` arrives as an array of content blocks, not as a string.
+    expect(tool.output).toBe("4 README.md");
+  });
+
+  test("entries come back in the order they happened", () => {
+    // A resumed thread appends to the same file, so this is sorted rather than
+    // assumed — the panel renders the array in order.
+    const ts = parseRollout(ROLLOUT).map((e) => e.ts);
+    expect(ts).toEqual([...ts].sort((a, b) => a - b));
+    expect(ts.every((t) => t > 0)).toBe(true);
+  });
+
+  test("an output with no call to attach to is dropped, not guessed at", () => {
+    const orphan = [msg("user_message", "hi", "2026-07-31T12:31:14.000Z"), result("nope", "stray", "2026-07-31T12:31:15.000Z")].join("\n");
+    expect(parseRollout(orphan).filter((e) => e.kind === "tool")).toHaveLength(0);
+  });
+
+  test("a truncated or corrupt file yields what it can, and never throws", () => {
+    // These files are appended to by a live process, so reading one mid-write is
+    // ordinary rather than exceptional. Losing the last line costs a row; a
+    // throw here would cost the whole replay.
+    const torn = ROLLOUT + '\n{"type":"event_msg","payload":{"type":"agent_m';
+    expect(parseRollout(torn).filter((e) => e.kind === "message")).toHaveLength(3);
+    expect(parseRollout("")).toEqual([]);
+    expect(parseRollout("not json\n\n{}\n[]")).toEqual([]);
+  });
+
+  test("a message with no words is not replayed as an empty bubble", () => {
+    expect(parseRollout(msg("agent_message", "", "2026-07-31T12:31:15.000Z"))).toEqual([]);
+  });
+});
+
+// --- the rollout reader ------------------------------------------------------
+// Lines below are trimmed from a real `~/.codex/sessions/**/rollout-*.jsonl`
+// (CLI 0.146). Only the fields this parser reads are kept; the shapes are
+// verbatim, including the two that were got wrong the first time — the result is
+// an array of content blocks rather than a string holding one, and a call whose
+// script failed still reports `status: "completed"`.
+const roll = (o: Record<string, unknown>) => JSON.stringify(o);
+const ROLLOUT = [
+  roll({ timestamp: "2026-07-31T16:31:12.043Z", type: "session_meta", payload: { id: "019fb903", cwd: "/tmp/repo" } }),
+  roll({ timestamp: "2026-07-31T16:31:12.044Z", type: "event_msg", payload: { type: "task_started" } }),
+  roll({ timestamp: "2026-07-31T16:31:14.110Z", type: "event_msg", payload: { type: "user_message", message: "count the lines" } }),
+  roll({ timestamp: "2026-07-31T16:31:15.671Z", type: "event_msg", payload: { type: "agent_message", message: "I’ll check." } }),
+  roll({ timestamp: "2026-07-31T16:31:16.560Z", type: "response_item", payload: { type: "custom_tool_call", call_id: "call_a", name: "exec", status: "completed", input: 'const r = await tools.exec_command({"cmd":"wc -l README.md","workdir":"/tmp/repo"});' } }),
+  roll({ timestamp: "2026-07-31T16:31:16.640Z", type: "response_item", payload: { type: "custom_tool_call_output", call_id: "call_a", output: [{ type: "input_text", text: "Script completed\nOutput:\n" }, { type: "input_text", text: "4 README.md\n" }] } }),
+  roll({ timestamp: "2026-07-31T16:31:16.641Z", type: "event_msg", payload: { type: "token_count", info: {} } }),
+  roll({ timestamp: "2026-07-31T16:31:18.221Z", type: "event_msg", payload: { type: "agent_message", message: "Four." } }),
+].join("\n");
+
+describe("parseRollout", () => {
+  test("replays the conversation and the tool runs between it", () => {
+    expect(parseRollout(ROLLOUT).map((e) => [e.kind, e.role ?? e.tool, e.text ?? e.target])).toEqual([
+      ["message", "user", "count the lines"],
+      ["message", "assistant", "I’ll check."],
+      // The command, pulled out of the JavaScript Codex wrote around it.
+      ["tool", "exec", "wc -l README.md"],
+      ["message", "assistant", "Four."],
+    ]);
+  });
+
+  test("a result reaches the call that asked for it", () => {
+    // The blocks arrive as a real array. Reading only the string form is what
+    // made every replayed tool row show no output while looking healthy.
+    const tool = parseRollout(ROLLOUT).find((e) => e.kind === "tool")!;
+    expect(tool.output).toBe("Script completed\nOutput:\n4 README.md");
+    expect(tool.is_error).toBe(false);
+  });
+
+  test("an edit names the file, not the patch boilerplate", () => {
+    const line = roll({ timestamp: "2026-07-31T16:31:51.119Z", type: "response_item", payload: { type: "custom_tool_call", call_id: "c", name: "exec", input: 'const patch = "*** Begin Patch\\n*** Update File: /tmp/repo/README.md\\n@@\\n+x\\n*** End Patch";' } });
+    expect(parseRollout(line)[0].target).toBe("/tmp/repo/README.md");
+  });
+
+  test("a script that failed is not replayed as having worked", () => {
+    // `status` says "completed" — that is true of the call, not of the work.
+    const lines = [
+      roll({ timestamp: "2026-07-31T16:31:51.119Z", type: "response_item", payload: { type: "custom_tool_call", call_id: "c", name: "exec", status: "completed", input: "{}" } }),
+      roll({ timestamp: "2026-07-31T16:31:51.161Z", type: "response_item", payload: { type: "custom_tool_call_output", call_id: "c", output: [{ text: "Script failed\nOutput:\npatch rejected: writing is blocked" }] } }),
+    ].join("\n");
+    expect(parseRollout(lines)[0].is_error).toBe(true);
+  });
+
+  test("output that merely mentions failure is not a failure", () => {
+    // Anchored on purpose: a `grep` walking past those words has not failed.
+    const lines = [
+      roll({ timestamp: "2026-07-31T16:31:51.119Z", type: "response_item", payload: { type: "custom_tool_call", call_id: "c", name: "exec", input: "{}" } }),
+      roll({ timestamp: "2026-07-31T16:31:51.161Z", type: "response_item", payload: { type: "custom_tool_call_output", call_id: "c", output: [{ text: "Script completed\nOutput:\ntest.ts: Script failed to load" }] } }),
+    ].join("\n");
+    expect(parseRollout(lines)[0].is_error).toBe(false);
+  });
+
+  test("a truncated, empty or corrupt rollout costs the history, not the app", () => {
+    // A rollout is being appended to while this reads it, so a half-written last
+    // line is normal rather than exceptional.
+    expect(parseRollout("")).toEqual([]);
+    expect(parseRollout("{not json\n{\"type\":\"event_msg\"")).toEqual([]);
+    expect(parseRollout(ROLLOUT + '\n{"timestamp":"2026-07-31T16:31:19Z","type":"event_msg","payl')).toHaveLength(4);
+  });
+
+  test("an orphaned result is dropped rather than inventing a call", () => {
+    expect(parseRollout(roll({ type: "response_item", payload: { type: "custom_tool_call_output", call_id: "nobody", output: [{ text: "x" }] } }))).toEqual([]);
+  });
+});

--- a/server/test/codex.test.ts
+++ b/server/test/codex.test.ts
@@ -11,7 +11,7 @@
 // a turn but none of its words (its `UserPromptSubmit` payload is literally
 // `{"prompt":""}`), so this file on disk is the only source for them.
 import { describe, expect, test } from "bun:test";
-import { codexArgs, parseModels, parseRollout, DEFAULT_SANDBOX } from "../src/codex.ts";
+import { codexArgs, parseModels, parseRollout, noteCodexCwd, codexCwd, DEFAULT_SANDBOX } from "../src/codex.ts";
 
 const BIN = "/usr/bin/codex";
 
@@ -251,5 +251,45 @@ describe("parseRollout", () => {
 
   test("an orphaned result is dropped rather than inventing a call", () => {
     expect(parseRollout(roll({ type: "response_item", payload: { type: "custom_tool_call_output", call_id: "nobody", output: [{ text: "x" }] } }))).toEqual([]);
+  });
+});
+
+// --- where a codex thread ran ------------------------------------------------
+// Codex's OTel records carry no working directory — the payload keys are
+// `message`, `event`, `prompt`, `tool_name`, `tool_use_id` and `usage`, and
+// nothing else. So every Codex session landed with a NULL project_path and a
+// project-scoped cockpit (the default) hid all of them: 1225 Codex events in
+// the database and OpenAI absent from the provider list.
+describe("remembering where a thread was launched", () => {
+  test("a thread is located once its id is known", () => {
+    const id = "019fb8db-e77f-7021-bde5-94acd40dd97f";
+    expect(codexCwd(id)).toBeNull();
+    noteCodexCwd(id, "/repo/checkout");
+    expect(codexCwd(id)?.cwd).toBe("/repo/checkout");
+  });
+
+  test("an id that is not one is refused", () => {
+    // This is keyed on something arriving over OTLP from outside.
+    noteCodexCwd("../../etc", "/repo");
+    expect(codexCwd("../../etc")).toBeNull();
+  });
+
+  test("the first answer stands", () => {
+    // A thread does not move, and a later turn resuming it from a different
+    // checkout must not relabel everything already recorded against it.
+    const id = "019fb8e9-97de-7f60-908c-3c9950e9e443";
+    noteCodexCwd(id, "/repo/first");
+    noteCodexCwd(id, "/repo/second");
+    expect(codexCwd(id)?.cwd).toBe("/repo/first");
+  });
+
+  test("it does not grow without bound", () => {
+    // One row per thread this server has ever driven, on a process that runs
+    // for weeks, is a leak rather than a cache.
+    for (let i = 0; i < 700; i++) {
+      noteCodexCwd(`019fb8db-e77f-7021-bde5-${String(i).padStart(12, "0")}`, `/repo/${i}`);
+    }
+    expect(codexCwd("019fb8db-e77f-7021-bde5-000000000000")).toBeNull();
+    expect(codexCwd("019fb8db-e77f-7021-bde5-000000000699")?.cwd).toBe("/repo/699");
   });
 });

--- a/shared/claude-models.json
+++ b/shared/claude-models.json
@@ -1,0 +1,73 @@
+{
+  "_comment": [
+    "The models the Chat panel offers for Claude Code.",
+    "",
+    "Data, not code: edit this file and the dropdown follows on the next request —",
+    "no rebuild, no restart. Claude Code publishes no model list of its own (there",
+    "is no `claude models` subcommand and no on-disk cache, unlike Codex's",
+    "models_cache.json and `agy models`), so this catalogue is the only source",
+    "there is. Keeping it here rather than in a TypeScript array is what lets it be",
+    "corrected the day Anthropic ships something.",
+    "",
+    "A model is offered until its scheduled_shutdown_date has passed. `status` is",
+    "recorded for the reader and is deliberately NOT a filter: a superseded model",
+    "still answers until it is retired, and hiding it early would take away a",
+    "choice that still works.",
+    "",
+    "To override without editing the checkout, put your own copy at",
+    "$XDG_CONFIG_HOME/agentglass/claude-models.json (~/.config/agentglass/), or",
+    "point AGENTGLASS_CLAUDE_MODELS at a file."
+  ],
+  "models": [
+    {
+      "id": "claude-opus-5",
+      "display_name": "Claude Opus 5",
+      "status": "active",
+      "release_date": "2026-07-24",
+      "scheduled_shutdown_date": "2027-07-24"
+    },
+    {
+      "id": "claude-opus-5[1m]",
+      "display_name": "Claude Opus 5 · 1M",
+      "status": "active",
+      "release_date": "2026-07-24",
+      "scheduled_shutdown_date": "2027-07-24",
+      "_note": "Same model, asking for the 1M context window. Not a duplicate: the suffix is what `claude` reads to pick a window behind an LLM gateway or on Bedrock / Vertex / Foundry, where the plain id really does mean 200k. On the first-party API the two are the same choice."
+    },
+    {
+      "id": "claude-sonnet-5",
+      "display_name": "Claude Sonnet 5",
+      "status": "active",
+      "release_date": "2026-06-30",
+      "scheduled_shutdown_date": "2027-06-30"
+    },
+    {
+      "id": "claude-fable-5",
+      "display_name": "Claude Fable 5",
+      "status": "active",
+      "release_date": "2026-06-09",
+      "scheduled_shutdown_date": "2027-06-09"
+    },
+    {
+      "id": "claude-haiku-4-5",
+      "display_name": "Claude Haiku 4.5",
+      "status": "active",
+      "release_date": "2025-10-15",
+      "scheduled_shutdown_date": "2026-10-15"
+    },
+    {
+      "id": "claude-sonnet-4-6",
+      "display_name": "Claude Sonnet 4.6",
+      "status": "superseded",
+      "release_date": "2026-02-17",
+      "scheduled_shutdown_date": "2027-02-17"
+    },
+    {
+      "id": "claude-opus-4-6",
+      "display_name": "Claude Opus 4.6",
+      "status": "superseded",
+      "release_date": "2026-02-05",
+      "scheduled_shutdown_date": "2027-02-05"
+    }
+  ]
+}

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1135,6 +1135,23 @@ export interface TerminalCommands {
   scripts: ProjectCommand[]; // package.json scripts, runner-aware
 }
 
+/** A model the local Codex CLI currently offers, read off its own
+ *  `models_cache.json` rather than a table in this repo — see codexModels() in
+ *  server/src/codex.ts for why. */
+export interface CodexModel {
+  id: string;    // the slug passed to `codex exec -m`
+  label: string; // Codex's own display name, or the slug when it has none
+}
+
+/** What the chat panel needs to decide whether to offer Codex at all, and what
+ *  to put in its model dropdown if it does. Both travel together because the
+ *  panel cannot usefully draw one without the other. */
+export interface CodexStatus {
+  enabled: boolean;  // a `codex` binary is on PATH
+  bypass?: boolean;  // the operator opted into the no-sandbox mode
+  models: CodexModel[];
+}
+
 /** Whether `git` is on this machine at all. `available: false` is a first-class
  *  UI state — the git/diff/PR panels and the terminal all need git — not an
  *  error to bury behind an empty "no repos found". */

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1135,22 +1135,34 @@ export interface TerminalCommands {
   scripts: ProjectCommand[]; // package.json scripts, runner-aware
 }
 
-/** A model the local Codex CLI currently offers, read off its own
- *  `models_cache.json` rather than a table in this repo — see codexModels() in
- *  server/src/codex.ts for why. */
-export interface CodexModel {
-  id: string;    // the slug passed to `codex exec -m`
-  label: string; // Codex's own display name, or the slug when it has none
+/** A model one of the chat CLIs currently offers.
+ *
+ *  Always read from the CLI itself rather than from a table in this repo —
+ *  Codex from its own `models_cache.json`, Antigravity from `agy models`. A
+ *  list checked in here is wrong the day the vendor ships anything, and the
+ *  failure is silent: the dropdown keeps offering an id the CLI no longer
+ *  serves. */
+export interface AgentModel {
+  id: string;    // the slug passed to the CLI's model flag
+  label: string; // the CLI's own display name, or the slug when it has none
 }
 
-/** What the chat panel needs to decide whether to offer Codex at all, and what
+/** What the chat panel needs to decide whether to offer a CLI at all, and what
  *  to put in its model dropdown if it does. Both travel together because the
  *  panel cannot usefully draw one without the other. */
-export interface CodexStatus {
-  enabled: boolean;  // a `codex` binary is on PATH
-  bypass?: boolean;  // the operator opted into the no-sandbox mode
-  models: CodexModel[];
+export interface AgentCliStatus {
+  enabled: boolean;  // the binary is on PATH and not disabled by env
+  bypass?: boolean;  // the operator opted into the unattended mode
+  models: AgentModel[];
 }
+
+/** Named for the agents that use them. The shapes are identical — what differs
+ *  is where the list comes from, which is each server module's business — so
+ *  these stay aliases rather than three copies drifting apart. */
+export type CodexModel = AgentModel;
+export type CodexStatus = AgentCliStatus;
+export type AntigravityModel = AgentModel;
+export type AntigravityStatus = AgentCliStatus;
 
 /** Whether `git` is on this machine at all. `available: false` is a first-class
  *  UI state — the git/diff/PR panels and the terminal all need git — not an
@@ -1667,8 +1679,12 @@ export interface KnownAgent {
   label: string;
   /** The executable looked for on PATH. */
   bin: string;
-  /** How it reports: our own hook forwarder, or its OpenTelemetry exporter. */
-  via: "hooks" | "otel";
+  /** How it reports: our own hook forwarder, its OpenTelemetry exporter, or —
+   *  for a CLI that exports neither — the chat panel driving it, which turns
+   *  the frames of its own turns into events. `chat` agents have nothing to
+   *  connect and nothing to undo, and are only ever seen while a chat here is
+   *  running them. */
+  via: "hooks" | "otel" | "chat";
   /** The file connecting it writes. Shown, so nobody has to guess. */
   configPath: string;
   /** A fragment of the `source_app` its events arrive under. Not the whole

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import type { WatchEvent, SessionRollup } from "../../shared/types.ts";
 import { useLive } from "./lib/useLive.ts";
 import { useStats } from "./lib/useStats.ts";
-import { deriveAgents, deriveAlerts, buildTitles, buildRollups } from "./lib/derive.ts";
+import { deriveAgents, deriveAlerts, buildTitles, buildRollups, providersSeen } from "./lib/derive.ts";
 import { publishFleet } from "./lib/demoBridge.ts";
 import { providerOf } from "./lib/format.ts";
 import { api, IS_DEMO } from "./lib/api.ts";
@@ -255,22 +255,29 @@ export default function App() {
   const providerSig = useRef("");
   const sessionProvider = useMemo(() => {
     const map = new Map<string, string>();
+    // The session roll-up first, because `events` is a capped window and this
+    // question is not about the last few minutes. A quiet agent — a Codex or
+    // Antigravity chat that ran nine events an hour ago — drops out of that
+    // buffer as soon as a busy Claude session fills it, and every provider it
+    // was the only evidence for silently left the filter with it. The dashboard
+    // then offered "Anthropic" as the only provider ever seen, while the
+    // server's own scoped answer listed three models.
+    for (const s of sessions) if (s.model_name) map.set(s.session_id, providerOf(s.model_name));
+    // Then the live buffer, which is the fresher of the two: a session that
+    // started since the last sessions poll is here and nowhere else, and its
+    // model may have resolved after that roll-up was taken.
     for (const a of agentsAll) if (a.model_name) map.set(a.session_id, providerOf(a.model_name));
     const sig = [...map].map(([k, v]) => k + "\u0000" + v).join("\u0001");
     if (sig === providerSig.current) return providerRef.current;
     providerSig.current = sig;
     providerRef.current = map;
     return map;
-  }, [agentsAll]);
+  }, [agentsAll, sessions]);
   // "unknown" (sessions whose model never resolved) is kept as a real bucket so
   // it can be filtered to and the per-provider views reconcile with the total,
   // but sorted to the end so it never leads the list. Header renders it as
   // "Unknown".
-  const providers = useMemo(() => {
-    const seen = new Set(sessionProvider.values());
-    const known = [...seen].filter((p) => p !== "unknown").sort();
-    return seen.has("unknown") ? [...known, "unknown"] : known;
-  }, [sessionProvider]);
+  const providers = useMemo(() => providersSeen(sessions, agentsAll), [sessions, agentsAll]);
   // The Anthropic plan meters only make sense when Anthropic is what you're
   // looking at (no filter + Anthropic present, or explicitly filtered to it).
   const showUsage = (!filter.provider && providers.includes("Anthropic")) || filter.provider === "Anthropic";

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { ViewHeader } from "./workspace/ViewHeader.tsx";
 import { motion, AnimatePresence } from "motion/react";
 import { CHAT_EFFORTS } from "../../../shared/types.ts";
-import type { GitRepoRef, SessionRollup, ChatEffort } from "../../../shared/types.ts";
+import type { GitRepoRef, SessionRollup, ChatEffort, CodexStatus } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
@@ -27,14 +27,16 @@ import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
 import { fmtAgo, fmtUsd, fmtTokens, modelLabelOf, modelColor, providerOf } from "../lib/format.ts";
-import { sessionIsLive } from "../lib/derive.ts";
+import { sessionIsLive, agentOf } from "../lib/derive.ts";
 import { ctxLimitOf } from "../lib/contextWindow.ts";
 import { worktreeTag, sessionWorktree, sessionCwd } from "../lib/worktree.ts";
 import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
   engineFor,
-  DEFAULT_MODEL, DEFAULT_MODE, addAttachments, answerPane, dropAttachment, renameChat, clearAttention, type Chat,
+  DEFAULT_MODEL, DEFAULT_MODE, DEFAULT_CODEX_MODEL, DEFAULT_CODEX_MODE,
+  isFresh, switchAgent,
+  addAttachments, answerPane, dropAttachment, renameChat, clearAttention, type Chat, type AgentKind,
   restoredActiveId, setActiveChatId, chatFocusRequest, setPanePinned, hydratePanePins,
 } from "../lib/chatStore.ts";
 import { peekChatIntent, subscribeChatIntent, takeChatIntent } from "../lib/chatIntent.ts";
@@ -69,6 +71,34 @@ const MODES = [
   { id: "acceptEdits", label: "Auto-accept edits" },
   { id: "bypassPermissions", label: "⚡ Bypass (runs all)" },
 ];
+
+// Codex draws its line around the filesystem rather than per tool call, so it
+// gets its own three rather than being squeezed into Claude's four. Labelling a
+// sandbox "Ask (denies un-allowed)" would describe a mechanism it has not got.
+// Keep in step with SANDBOXES in server/src/codex.ts.
+const CODEX_MODES = [
+  { id: "read-only", label: "Read-only (no writes)" },
+  { id: "workspace-write", label: "Write in this repo" },
+  { id: "full-access", label: "⚡ Full access (no sandbox)" },
+];
+
+/** The unattended mode for this agent — the one the server refuses to honour
+ *  unless the operator opted in. One name for two spellings, so the mode
+ *  dropdown and the warnings below don't each need the branch. */
+const bypassMode = (agent: AgentKind) => (agent === "codex" ? "full-access" : "bypassPermissions");
+const cliName = (agent: AgentKind) => (agent === "codex" ? "codex" : "claude");
+const agentLabel = (agent: AgentKind) => (agent === "codex" ? "Codex" : "Claude");
+const modesFor = (agent: AgentKind) => (agent === "codex" ? CODEX_MODES : MODES);
+
+/** What the model dropdown may offer. Claude's list is written down here
+ *  because it is a judgement call about which of many ids are worth offering;
+ *  Codex's is whatever its own cache currently says, so it arrives from the
+ *  server. A Codex with an empty list has not been asked yet — fall back rather
+ *  than render an empty dropdown. */
+function modelsFor(agent: AgentKind, codex: CodexStatus): Array<{ id: string; label: string }> {
+  if (agent !== "codex") return MODELS;
+  return codex.models.length ? codex.models : [{ id: DEFAULT_CODEX_MODEL, label: DEFAULT_CODEX_MODEL }];
+}
 const CWD_KEY = "agentglass.chatCwd";
 const ALLOW_KEY = "agentglass.chatAllowedTools";
 // A starting point that covers the reading and inspection an assistant reaches
@@ -601,6 +631,10 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // The server silently downgrades bypassPermissions unless the operator opted
   // in (AGENTGLASS_CHAT_BYPASS=1) — don't offer a mode that wouldn't stick.
   const [bypassAllowed, setBypassAllowed] = useState(false);
+  // Whether a `codex` is on the machine, and which models it currently offers.
+  // The list comes from the server because it is read off Codex's own cache
+  // rather than a table in this repo — see codexModels() in server/src/codex.ts.
+  const [codex, setCodex] = useState<CodexStatus>({ enabled: false, models: [] });
   // Shared by every chat and remembered across launches: the set of tools you
   // trust is a property of how you work, not of one conversation.
   const [allowed, setAllowed] = useState(() => {
@@ -656,6 +690,17 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // moves selection off it.
   const active = chats.find((c) => c.id === activeId);
 
+  // Whether *this* chat can run: `enabled` only ever spoke for `claude`, so on
+  // a machine with Codex installed and Claude not, it would have greyed out a
+  // composer that works perfectly well.
+  const usable = active ? (active.agent === "codex" ? codex.enabled : enabled) : (enabled || codex.enabled);
+  // Pasting and dropping images is a Claude-only affordance. `codex exec` takes
+  // images as file paths rather than as content blocks, so there is nowhere for
+  // pasted bytes to go without staging them on disk first — the server refuses
+  // them outright, and offering the button anyway would just be a slower way to
+  // reach that refusal.
+  const canAttach = usable && active?.agent !== "codex";
+
   // Only while the draft is a bare `/word` on the first line: past the first
   // space it is prose, and a menu stealing Enter there would be maddening.
   const slashQuery = (() => {
@@ -689,6 +734,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
       setDefaultCwd((c) => c || repos[0]?.root || "");
     }).catch(() => {}).finally(() => setReposKnown(true));
     api.chatEnabled().then((r) => { setEnabled(r.enabled); setBypassAllowed(!!r.bypass); }).catch(() => {});
+    api.codexEnabled().then(setCodex).catch(() => {});
     // Which project this instance is scoped to, if any. A failure here means we
     // never learn of a scope, so nothing is hidden, which is the safe direction.
     api.projects()
@@ -784,12 +830,23 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // and looked like new chats were broken. Refuse instead, and say why.
     if (!cwd) { setNoRepo(true); return; }
     setNoRepo(false);
-    const c = newChat(cwd, active?.model ?? DEFAULT_MODEL, active?.mode ?? DEFAULT_MODE);
+    // A new chat inherits the agent you were last using, the same way it
+    // inherits the repo and the model — and falls back to whichever CLI is
+    // actually installed when there is nothing to inherit from.
+    const agent: AgentKind = active?.agent ?? (enabled ? "claude" : codex.enabled ? "codex" : "claude");
+    const sameAgent = active?.agent === agent;
+    const c = newChat(
+      cwd,
+      sameAgent ? active!.model : agent === "codex" ? DEFAULT_CODEX_MODEL : DEFAULT_MODEL,
+      sameAgent ? active!.mode : agent === "codex" ? DEFAULT_CODEX_MODE : DEFAULT_MODE,
+      undefined,
+      agent,
+    );
     if (seed) update(c.id, (x) => { x.draft = seed; });
     setActiveId(c.id);
     if (!seed) requestAnimationFrame(() => inputRef.current?.focus());
     return c;
-  }, [active, defaultCwd, repos, workspace]);
+  }, [active, defaultCwd, repos, workspace, enabled, codex.enabled]);
 
   // Adopt an existing claude session. Focusing an already-open tab rather than
   // opening a second one is not a nicety: two chats resuming one session id
@@ -800,11 +857,21 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // Resume in the checkout it ran in, not the repo it rolls up to.
     const cwd = sessionCwd(s);
     if (!cwd) return;
+    // Which CLI this session belongs to decides which one has to pick it back
+    // up: a thread id is only meaningful to the binary that minted it, so
+    // opening a Codex session as a Claude chat would send `claude --resume` an
+    // id it has never heard of and fail on the first turn.
+    const agent = agentOf(s);
     const chat = chatResuming(s.session_id)
-      ?? newChat(cwd, s.model_name || undefined, active?.mode ?? DEFAULT_MODE, {
-        sessionId: s.session_id,
-        title: `${s.source_app}:${s.session_id.slice(0, 8)}`,
-      });
+      ?? newChat(
+        cwd,
+        s.model_name || (agent === "codex" ? DEFAULT_CODEX_MODEL : DEFAULT_MODEL),
+        // The mode is this agent's vocabulary, so a mode carried over from the
+        // chat you happened to have open only applies when it is the same one.
+        active?.agent === agent ? active.mode : agent === "codex" ? DEFAULT_CODEX_MODE : DEFAULT_MODE,
+        { sessionId: s.session_id, title: `${s.source_app}:${s.session_id.slice(0, 8)}` },
+        agent,
+      );
     setActiveId(chat.id);
     requestAnimationFrame(() => inputRef.current?.focus());
   }, [active]);
@@ -906,6 +973,13 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // it lands as a change event and opens a chat through onChange.
     const chat = active ?? (files.length ? add() ?? null : null);
     if (!chat) return;
+    // `codex exec` takes images as file paths, not content blocks, so there is
+    // nowhere for pasted bytes to go. Say so instead of dropping them silently.
+    if (files.length && chat.agent === "codex") {
+      e.preventDefault();
+      setHint("codex chats can't take pasted images — start a Claude chat for that");
+      return;
+    }
     if (!files.length) {
       // A paste that carried a file which wasn't an image would otherwise look
       // identical to the feature being broken.
@@ -926,7 +1000,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   const [dragOver, setDragOver] = useState(false);
   const dragDepth = useRef(0);
   const onDragOver = (e: React.DragEvent) => {
-    if (!enabled || !active) return;
+    if (!usable || !active) return;
     if (!Array.from(e.dataTransfer.items).some((i) => i.kind === "file")) return;
     // Without this the browser answers the drop itself by navigating to the
     // file, replacing the whole app with the image.
@@ -944,6 +1018,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     e.preventDefault();
     dragDepth.current = 0;
     setDragOver(false);
+    if (!canAttach) { setHint("codex chats can't take dropped files — start a Claude chat for that"); return; }
     // Files, not just images: `addAttachments` quotes a text file into the
     // draft, which is the same thing the picker and the paste path already do.
     const files = Array.from(e.dataTransfer.files);
@@ -1151,12 +1226,36 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                       <>
                         <Select value={active.cwd} onChange={(v) => { update(active.id, (c) => { c.cwd = v; }); setDefaultCwd(v); }}
                           className={selCls} style={selStyle} options={repoOptions} placeholder="Pick a repo" />
+                        {/* Only shown when there is a choice to make: on a
+                            machine with one CLI installed this would be a
+                            control with a single option and nothing to explain.
+
+                            Switchable until the chat has a thread, then frozen.
+                            A resume id belongs to the CLI that minted it, so
+                            there is no meaning to handing a live conversation
+                            from one to the other — but a tab you have not sent
+                            anything from yet is just a blank tab. */}
+                        {enabled && codex.enabled && (
+                          isFresh(active) ? (
+                            <Select value={active.agent} onChange={(v) => switchAgent(active.id, v as AgentKind)}
+                              className={selCls} style={selStyle} title="Which CLI runs this chat"
+                              options={[{ value: "claude", label: "Claude" }, { value: "codex", label: "Codex" }]} />
+                          ) : (
+                            <span className={selCls} title="The CLI behind this chat — settled once it has a thread to resume"
+                              style={{ ...selStyle, color: "var(--text3)" }}>{agentLabel(active.agent)}</span>
+                          )
+                        )}
                         <Select value={active.model} onChange={(v) => update(active.id, (c) => { c.model = v; })}
-                          className={selCls} style={selStyle} options={MODELS.map((m) => ({ value: m.id, label: m.label }))} />
+                          className={selCls} style={selStyle} options={modelsFor(active.agent, codex).map((m) => ({ value: m.id, label: m.label }))} />
                         <Select value={active.mode} onChange={(v) => update(active.id, (c) => { c.mode = v; })}
-                          className={selCls} style={selStyle} title="Permission mode for tool use"
-                          options={MODES.filter((m) => bypassAllowed || m.id !== "bypassPermissions").map((m) => ({ value: m.id, label: m.label }))} />
-                        {active.mode !== "bypassPermissions" && (
+                          className={selCls} style={selStyle} title={active.agent === "codex" ? "How much codex may touch without asking" : "Permission mode for tool use"}
+                          options={modesFor(active.agent)
+                            .filter((m) => (active.agent === "codex" ? codex.bypass : bypassAllowed) || m.id !== bypassMode(active.agent))
+                            .map((m) => ({ value: m.id, label: m.label }))} />
+                        {/* Codex has no allowlist to fill in: it decides per
+                            filesystem boundary, not per tool call, so a box here
+                            would be a control that silently did nothing. */}
+                        {active.agent !== "codex" && active.mode !== "bypassPermissions" && (
                           <input
                             value={allowed}
                             onChange={(e) => setAllowed(e.target.value)}
@@ -1254,9 +1353,9 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                     <div ref={contentRef} className="min-h-full flex flex-col justify-end gap-3">
                       {active && !active.messages.length && (
                         <div className="grid place-items-center text-center t-dim2 text-[12px] py-10">
-                          {enabled
-                            ? <div>Chat with a Claude session in <b style={{ color: "var(--text2)" }}>{repoName(active.cwd) || "a repo"}</b>.<br />It runs there, appears in your fleet, and follow-ups keep the context.</div>
-                            : <div>No local <code>claude</code> CLI found — install Claude Code to chat.</div>}
+                          {usable
+                            ? <div>Chat with a {agentLabel(active.agent)} session in <b style={{ color: "var(--text2)" }}>{repoName(active.cwd) || "a repo"}</b>.<br />It runs there, appears in your fleet, and follow-ups keep the context.</div>
+                            : <div>No local <code>{cliName(active.agent)}</code> CLI found — install it to chat.</div>}
                         </div>
                       )}
                       {active?.messages.map((m, i) => (
@@ -1515,8 +1614,10 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           ev.target.value = ""; // re-picking the same file must still fire
                           if (active && picked.length) setHint(await addAttachments(active.id, picked));
                         }} />
-                      <button onClick={() => fileRef.current?.click()} disabled={!enabled || !active}
-                        title="Attach a file — images are sent as images, text files are quoted into the message"
+                      <button onClick={() => fileRef.current?.click()} disabled={!canAttach || !active}
+                        title={active?.agent === "codex"
+                          ? "codex chats can't take attachments — start a Claude chat for that"
+                          : "Attach a file — images are sent as images, text files are quoted into the message"}
                         aria-label="Attach a file"
                         className="shrink-0 grid place-items-center rounded-lg px-3 self-stretch"
                         style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text3)" }}>
@@ -1529,7 +1630,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                           the empty state said "press + new" and the box said
                           "Message a new session…", and only one of them was
                           telling the truth. */}
-                      <textarea ref={inputRef} aria-label="Chat composer" value={active?.draft ?? ""} disabled={!enabled} rows={2}
+                      <textarea ref={inputRef} aria-label="Chat composer" value={active?.draft ?? ""} disabled={!usable} rows={2}
                         onChange={(e) => {
                           const v = e.target.value;
                           if (active) { update(active.id, (c) => { c.draft = v; }); return; }
@@ -1540,7 +1641,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         }}
                         onKeyDown={onKey}
                         onPaste={onPaste}
-                        placeholder={!enabled ? "Chat unavailable" : active?.sending ? "Still replying — type anyway, Enter queues it for the next turn" : active?.sessionId ? "Reply… (Enter to send, Shift+Enter newline)" : "Message a new session… (Enter to send)"}
+                        placeholder={!usable ? `${agentLabel(active?.agent ?? "claude")} chat unavailable — no local \`${cliName(active?.agent ?? "claude")}\` CLI` : active?.sending ? "Still replying — type anyway, Enter queues it for the next turn" : active?.sessionId ? "Reply… (Enter to send, Shift+Enter newline)" : "Message a new session… (Enter to send)"}
                         className="agx-scroll flex-1 px-3 py-2 rounded-lg text-[12px] outline-none resize-none" style={{ background: "color-mix(in srgb, var(--bg3) 40%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }} />
                       {/* Stop stays reachable while a turn is queueing: the
                           two are different intents — "answer this next" and
@@ -1551,15 +1652,15 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                         <button onClick={() => stop(active.id)} title="Interrupt the turn and clear anything queued"
                           className="shrink-0 px-3.5 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--error)", border: "1px solid color-mix(in srgb, var(--error) 40%, transparent)" }}>■ Stop</button>
                       )}
-                      <button onClick={submit} disabled={!hasTurn || !active?.cwd || !enabled} className="shrink-0 px-4 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!hasTurn || !active?.cwd) ? 0.45 : 1 }}>
+                      <button onClick={submit} disabled={!hasTurn || !active?.cwd || !usable} className="shrink-0 px-4 rounded-lg text-[11.5px] font-semibold self-stretch" style={{ color: "var(--text)", background: "color-mix(in srgb, var(--primary) 22%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)", opacity: (!hasTurn || !active?.cwd) ? 0.45 : 1 }}>
                         {active?.sending ? "Queue ↵" : "Send ↵"}
                       </button>
                     </div>
                     <div className="mt-1.5 text-[9.5px] t-dim2">
                       {hint
                         ? <span style={{ color: "var(--warning)" }}>{hint}</span>
-                        : <>Runs claude in {active ? repoName(active.cwd) || "the repo" : "the repo"} · {MODES.find((x) => x.id === active?.mode)?.label} · tool calls fold away, click to open</>}
-                      {active?.mode === "bypassPermissions" && <span style={{ color: "var(--warning)" }}> · ⚡ runs tools unattended</span>}
+                        : <>Runs {cliName(active?.agent ?? "claude")} in {active ? repoName(active.cwd) || "the repo" : "the repo"} · {modesFor(active?.agent ?? "claude").find((x) => x.id === active?.mode)?.label} · tool calls fold away, click to open</>}
+                      {active && active.mode === bypassMode(active.agent) && <span style={{ color: "var(--warning)" }}> · ⚡ runs tools unattended</span>}
                     </div>
                   </div>
                 </div>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { ViewHeader } from "./workspace/ViewHeader.tsx";
 import { motion, AnimatePresence } from "motion/react";
 import { CHAT_EFFORTS } from "../../../shared/types.ts";
-import type { GitRepoRef, SessionRollup, ChatEffort, CodexStatus } from "../../../shared/types.ts";
+import type { GitRepoRef, SessionRollup, ChatEffort, AgentCliStatus } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
@@ -34,8 +34,7 @@ import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
   engineFor,
-  DEFAULT_MODEL, DEFAULT_MODE, DEFAULT_CODEX_MODEL, DEFAULT_CODEX_MODE,
-  isFresh, switchAgent,
+  AGENTS, isFresh, switchAgent,
   addAttachments, answerPane, dropAttachment, renameChat, clearAttention, type Chat, type AgentKind,
   restoredActiveId, setActiveChatId, chatFocusRequest, setPanePinned, hydratePanePins,
 } from "../lib/chatStore.ts";
@@ -82,22 +81,37 @@ const CODEX_MODES = [
   { id: "full-access", label: "⚡ Full access (no sandbox)" },
 ];
 
-/** The unattended mode for this agent — the one the server refuses to honour
- *  unless the operator opted in. One name for two spellings, so the mode
- *  dropdown and the warnings below don't each need the branch. */
-const bypassMode = (agent: AgentKind) => (agent === "codex" ? "full-access" : "bypassPermissions");
-const cliName = (agent: AgentKind) => (agent === "codex" ? "codex" : "claude");
-const agentLabel = (agent: AgentKind) => (agent === "codex" ? "Codex" : "Claude");
-const modesFor = (agent: AgentKind) => (agent === "codex" ? CODEX_MODES : MODES);
+// Antigravity's four land on Claude's, because it really does decide per tool
+// call and really does have a plan mode — this is the CLI's own shape rather
+// than a mapping forced here. `request-review` is its default and is spelled by
+// passing no flag. Keep in step with MODES in server/src/antigravity.ts.
+const ANTIGRAVITY_MODES = [
+  { id: "request-review", label: "Ask (denies un-allowed)" },
+  { id: "plan", label: "Plan (no edits)" },
+  { id: "accept-edits", label: "Auto-accept edits" },
+  { id: "always-proceed", label: "⚡ Bypass (runs all)" },
+];
+
+/** Before the server has answered, and for a CLI that is not installed. */
+const CLI_OFF: AgentCliStatus = { enabled: false, models: [] };
+
+const MODES_BY_AGENT: Record<AgentKind, Array<{ id: string; label: string }>> = {
+  claude: MODES, codex: CODEX_MODES, antigravity: ANTIGRAVITY_MODES,
+};
+const modesFor = (agent: AgentKind) => MODES_BY_AGENT[agent];
+const bypassMode = (agent: AgentKind) => AGENTS[agent].bypassMode;
+const cliName = (agent: AgentKind) => AGENTS[agent].cli;
+const agentLabel = (agent: AgentKind) => AGENTS[agent].label;
 
 /** What the model dropdown may offer. Claude's list is written down here
  *  because it is a judgement call about which of many ids are worth offering;
- *  Codex's is whatever its own cache currently says, so it arrives from the
- *  server. A Codex with an empty list has not been asked yet — fall back rather
- *  than render an empty dropdown. */
-function modelsFor(agent: AgentKind, codex: CodexStatus): Array<{ id: string; label: string }> {
-  if (agent !== "codex") return MODELS;
-  return codex.models.length ? codex.models : [{ id: DEFAULT_CODEX_MODEL, label: DEFAULT_CODEX_MODEL }];
+ *  the other two report whatever their own CLI currently serves, so those
+ *  arrive from the server. A list that has not been asked for yet falls back to
+ *  that agent's default rather than rendering an empty dropdown. */
+function modelsFor(agent: AgentKind, status: AgentCliStatus): Array<{ id: string; label: string }> {
+  if (agent === "claude") return MODELS;
+  const fallback = AGENTS[agent].defaultModel;
+  return status.models.length ? status.models : [{ id: fallback, label: fallback }];
 }
 const CWD_KEY = "agentglass.chatCwd";
 const ALLOW_KEY = "agentglass.chatAllowedTools";
@@ -638,10 +652,17 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // The server silently downgrades bypassPermissions unless the operator opted
   // in (AGENTGLASS_CHAT_BYPASS=1) — don't offer a mode that wouldn't stick.
   const [bypassAllowed, setBypassAllowed] = useState(false);
-  // Whether a `codex` is on the machine, and which models it currently offers.
-  // The list comes from the server because it is read off Codex's own cache
-  // rather than a table in this repo — see codexModels() in server/src/codex.ts.
-  const [codex, setCodex] = useState<CodexStatus>({ enabled: false, models: [] });
+  // Whether the other two CLIs are on the machine, and which models each
+  // currently offers. Both lists come from the server because each is read off
+  // that CLI's own answer rather than a table in this repo — see codexModels()
+  // and antigravityModels().
+  const [codex, setCodex] = useState<AgentCliStatus>(CLI_OFF);
+  const [antigravity, setAntigravity] = useState<AgentCliStatus>(CLI_OFF);
+  /** One lookup for "what does the server say about this agent?", so the
+   *  dropdowns and the gates below stop naming CLIs one at a time. Claude's
+   *  status is two separate pieces of state for historical reasons. */
+  const statusOf = (a: AgentKind): AgentCliStatus =>
+    a === "codex" ? codex : a === "antigravity" ? antigravity : { enabled, bypass: bypassAllowed, models: MODELS };
   // Shared by every chat and remembered across launches: the set of tools you
   // trust is a property of how you work, not of one conversation.
   const [allowed, setAllowed] = useState(() => {
@@ -697,16 +718,19 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // moves selection off it.
   const active = chats.find((c) => c.id === activeId);
 
+  /** Which CLIs this machine can actually run a chat with. Drives the agent
+   *  picker, and decides what a brand-new chat should be. */
+  const installed = (Object.keys(AGENTS) as AgentKind[]).filter((a) => statusOf(a).enabled);
   // Whether *this* chat can run: `enabled` only ever spoke for `claude`, so on
   // a machine with Codex installed and Claude not, it would have greyed out a
   // composer that works perfectly well.
-  const usable = active ? (active.agent === "codex" ? codex.enabled : enabled) : (enabled || codex.enabled);
-  // Pasting and dropping images is a Claude-only affordance. `codex exec` takes
+  const usable = active ? statusOf(active.agent).enabled : installed.length > 0;
+  // Pasting and dropping images is a Claude-only affordance. The other two take
   // images as file paths rather than as content blocks, so there is nowhere for
   // pasted bytes to go without staging them on disk first — the server refuses
   // them outright, and offering the button anyway would just be a slower way to
   // reach that refusal.
-  const canAttach = usable && active?.agent !== "codex";
+  const canAttach = usable && !!active && AGENTS[active.agent].canAttach;
 
   // Only while the draft is a bare `/word` on the first line: past the first
   // space it is prose, and a menu stealing Enter there would be maddening.
@@ -742,6 +766,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     }).catch(() => {}).finally(() => setReposKnown(true));
     api.chatEnabled().then((r) => { setEnabled(r.enabled); setBypassAllowed(!!r.bypass); }).catch(() => {});
     api.codexEnabled().then(setCodex).catch(() => {});
+    api.antigravityEnabled().then(setAntigravity).catch(() => {});
     // Which project this instance is scoped to, if any. A failure here means we
     // never learn of a scope, so nothing is hidden, which is the safe direction.
     api.projects()
@@ -840,12 +865,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // A new chat inherits the agent you were last using, the same way it
     // inherits the repo and the model — and falls back to whichever CLI is
     // actually installed when there is nothing to inherit from.
-    const agent: AgentKind = active?.agent ?? (enabled ? "claude" : codex.enabled ? "codex" : "claude");
+    const agent: AgentKind = active?.agent ?? installed[0] ?? "claude";
     const sameAgent = active?.agent === agent;
     const c = newChat(
       cwd,
-      sameAgent ? active!.model : agent === "codex" ? DEFAULT_CODEX_MODEL : DEFAULT_MODEL,
-      sameAgent ? active!.mode : agent === "codex" ? DEFAULT_CODEX_MODE : DEFAULT_MODE,
+      sameAgent ? active!.model : AGENTS[agent].defaultModel,
+      sameAgent ? active!.mode : AGENTS[agent].defaultMode,
       undefined,
       agent,
     );
@@ -853,7 +878,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     setActiveId(c.id);
     if (!seed) requestAnimationFrame(() => inputRef.current?.focus());
     return c;
-  }, [active, defaultCwd, repos, workspace, enabled, codex.enabled]);
+  }, [active, defaultCwd, repos, workspace, enabled, codex.enabled, antigravity.enabled]);
 
   // Adopt an existing claude session. Focusing an already-open tab rather than
   // opening a second one is not a nicety: two chats resuming one session id
@@ -872,10 +897,10 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     const chat = chatResuming(s.session_id)
       ?? newChat(
         cwd,
-        s.model_name || (agent === "codex" ? DEFAULT_CODEX_MODEL : DEFAULT_MODEL),
+        s.model_name || AGENTS[agent].defaultModel,
         // The mode is this agent's vocabulary, so a mode carried over from the
         // chat you happened to have open only applies when it is the same one.
-        active?.agent === agent ? active.mode : agent === "codex" ? DEFAULT_CODEX_MODE : DEFAULT_MODE,
+        active?.agent === agent ? active.mode : AGENTS[agent].defaultMode,
         { sessionId: s.session_id, title: `${s.source_app}:${s.session_id.slice(0, 8)}` },
         agent,
       );
@@ -980,11 +1005,12 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // it lands as a change event and opens a chat through onChange.
     const chat = active ?? (files.length ? add() ?? null : null);
     if (!chat) return;
-    // `codex exec` takes images as file paths, not content blocks, so there is
-    // nowhere for pasted bytes to go. Say so instead of dropping them silently.
-    if (files.length && chat.agent === "codex") {
+    // Codex and Antigravity take images as file paths, not content blocks, so
+    // there is nowhere for pasted bytes to go. Say so instead of dropping them
+    // silently.
+    if (files.length && !AGENTS[chat.agent].canAttach) {
       e.preventDefault();
-      setHint("codex chats can't take pasted images — start a Claude chat for that");
+      setHint(`${cliName(chat.agent)} chats can't take pasted images — start a Claude chat for that`);
       return;
     }
     if (!files.length) {
@@ -1242,27 +1268,28 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                             there is no meaning to handing a live conversation
                             from one to the other — but a tab you have not sent
                             anything from yet is just a blank tab. */}
-                        {enabled && codex.enabled && (
+                        {installed.length > 1 && (
                           isFresh(active) ? (
                             <Select value={active.agent} onChange={(v) => switchAgent(active.id, v as AgentKind)}
                               className={selCls} style={selStyle} title="Which CLI runs this chat"
-                              options={[{ value: "claude", label: "Claude" }, { value: "codex", label: "Codex" }]} />
+                              options={installed.map((a) => ({ value: a, label: AGENTS[a].label }))} />
                           ) : (
                             <span className={selCls} title="The CLI behind this chat — settled once it has a thread to resume"
                               style={{ ...selStyle, color: "var(--text3)" }}>{agentLabel(active.agent)}</span>
                           )
                         )}
                         <Select value={active.model} onChange={(v) => update(active.id, (c) => { c.model = v; })}
-                          className={selCls} style={selStyle} options={modelsFor(active.agent, codex).map((m) => ({ value: m.id, label: m.label }))} />
+                          className={selCls} style={selStyle} options={modelsFor(active.agent, statusOf(active.agent)).map((m) => ({ value: m.id, label: m.label }))} />
                         <Select value={active.mode} onChange={(v) => update(active.id, (c) => { c.mode = v; })}
                           className={selCls} style={selStyle} title={active.agent === "codex" ? "How much codex may touch without asking" : "Permission mode for tool use"}
                           options={modesFor(active.agent)
-                            .filter((m) => (active.agent === "codex" ? codex.bypass : bypassAllowed) || m.id !== bypassMode(active.agent))
+                            .filter((m) => statusOf(active.agent).bypass || m.id !== bypassMode(active.agent))
                             .map((m) => ({ value: m.id, label: m.label }))} />
-                        {/* Codex has no allowlist to fill in: it decides per
-                            filesystem boundary, not per tool call, so a box here
-                            would be a control that silently did nothing. */}
-                        {active.agent !== "codex" && active.mode !== "bypassPermissions" && (
+                        {/* Only Claude has an allowlist to fill in. Codex decides
+                            per filesystem boundary and Antigravity per call under
+                            its own modes, so a box here would be a control that
+                            silently did nothing. */}
+                        {active.agent === "claude" && active.mode !== "bypassPermissions" && (
                           <input
                             value={allowed}
                             onChange={(e) => setAllowed(e.target.value)}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -12,7 +12,7 @@ import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore
 import { ViewHeader } from "./workspace/ViewHeader.tsx";
 import { motion, AnimatePresence } from "motion/react";
 import { CHAT_EFFORTS } from "../../../shared/types.ts";
-import type { GitRepoRef, SessionRollup, ChatEffort, AgentCliStatus } from "../../../shared/types.ts";
+import type { GitRepoRef, SessionRollup, ChatEffort, AgentCliStatus, AgentModel } from "../../../shared/types.ts";
 import { api } from "../lib/api.ts";
 import { Markdown } from "../lib/markdown.tsx";
 import { ToolRow } from "./ToolRow.tsx";
@@ -42,23 +42,15 @@ import { peekChatIntent, subscribeChatIntent, takeChatIntent } from "../lib/chat
 import { useSidebarWidth } from "../lib/sidebarWidth.ts";
 import { SidebarGrip } from "./SidebarGrip.tsx";
 
-// Still hand-maintained, and still drifts every release — the runtime-sourced
-// list is its own job.
+// Claude's list arrives from the server, like the other two agents'. It is data
+// there (shared/claude-models.json), filtered to the models whose shutdown date
+// has not passed — Claude Code publishes no list of its own, so a file that can
+// be corrected without a rebuild is the closest thing to asking the CLI.
 //
-// The `· 1M` entry no longer changes what this app measures: `ctxLimitOf`
-// knows Opus 5 is a 1M model, so the plain id and the suffixed one resolve to
-// the same ceiling. It stays because the suffix is not ours to interpret — it
-// is what `claude` reads to pick a window behind an LLM gateway or on Bedrock
-// / Vertex / Foundry, where the plain id really does mean 200k. Locally the
-// two entries are the same choice; for someone pointed at a provider they are
-// not, and only they can tell which.
-const MODELS = [
-  { id: "claude-fable-5", label: "Fable 5" },
-  { id: "claude-opus-5", label: "Opus 5" },
-  { id: "claude-opus-5[1m]", label: "Opus 5 · 1M" },
-  { id: "claude-sonnet-5", label: "Sonnet 5" },
-  { id: "claude-haiku-4-5", label: "Haiku 4.5" },
-];
+// This is only what to draw before that answer arrives, and on a server too old
+// to send one. Deliberately a single certain id rather than a copy of the
+// catalogue: two lists that drift apart is the problem being solved.
+const MODELS_PENDING = [{ id: "claude-opus-5", label: "Claude Opus 5" }];
 // These run through `claude -p`, which has no terminal to prompt from: a tool
 // that would raise a permission dialog is refused outright, and there is no
 // way to grant it mid-chat. "Ask" therefore does not ask — it declines. The
@@ -103,15 +95,19 @@ const bypassMode = (agent: AgentKind) => AGENTS[agent].bypassMode;
 const cliName = (agent: AgentKind) => AGENTS[agent].cli;
 const agentLabel = (agent: AgentKind) => AGENTS[agent].label;
 
-/** What the model dropdown may offer. Claude's list is written down here
- *  because it is a judgement call about which of many ids are worth offering;
- *  the other two report whatever their own CLI currently serves, so those
- *  arrive from the server. A list that has not been asked for yet falls back to
- *  that agent's default rather than rendering an empty dropdown. */
+/** What the model dropdown may offer.
+ *
+ *  One path for all three agents now: every list comes from the server, because
+ *  every list is the answer to "what will this CLI actually accept" and none of
+ *  them is this component's to decide. Claude used to be the exception, with a
+ *  hand-maintained array here that drifted every release.
+ *
+ *  A list that has not arrived yet falls back to that agent's default rather
+ *  than rendering an empty dropdown. */
 function modelsFor(agent: AgentKind, status: AgentCliStatus): Array<{ id: string; label: string }> {
-  if (agent === "claude") return MODELS;
+  if (status.models.length) return status.models;
   const fallback = AGENTS[agent].defaultModel;
-  return status.models.length ? status.models : [{ id: fallback, label: fallback }];
+  return [{ id: fallback, label: fallback }];
 }
 const CWD_KEY = "agentglass.chatCwd";
 const ALLOW_KEY = "agentglass.chatAllowedTools";
@@ -652,17 +648,18 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // The server silently downgrades bypassPermissions unless the operator opted
   // in (AGENTGLASS_CHAT_BYPASS=1) — don't offer a mode that wouldn't stick.
   const [bypassAllowed, setBypassAllowed] = useState(false);
-  // Whether the other two CLIs are on the machine, and which models each
-  // currently offers. Both lists come from the server because each is read off
-  // that CLI's own answer rather than a table in this repo — see codexModels()
-  // and antigravityModels().
+  // Which models each CLI currently offers. Every list comes from the server,
+  // because every one of them is that CLI's own answer rather than a table in
+  // this repo — Codex's cache, `agy models`, and for Claude a catalogue file
+  // the server reads and filters by shutdown date.
+  const [claudeModels, setClaudeModels] = useState<AgentModel[]>(MODELS_PENDING);
   const [codex, setCodex] = useState<AgentCliStatus>(CLI_OFF);
   const [antigravity, setAntigravity] = useState<AgentCliStatus>(CLI_OFF);
   /** One lookup for "what does the server say about this agent?", so the
    *  dropdowns and the gates below stop naming CLIs one at a time. Claude's
-   *  status is two separate pieces of state for historical reasons. */
+   *  enabled/bypass are separate pieces of state for historical reasons. */
   const statusOf = (a: AgentKind): AgentCliStatus =>
-    a === "codex" ? codex : a === "antigravity" ? antigravity : { enabled, bypass: bypassAllowed, models: MODELS };
+    a === "codex" ? codex : a === "antigravity" ? antigravity : { enabled, bypass: bypassAllowed, models: claudeModels };
   // Shared by every chat and remembered across launches: the set of tools you
   // trust is a property of how you work, not of one conversation.
   const [allowed, setAllowed] = useState(() => {
@@ -764,7 +761,13 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
       setRepos(repos);
       setDefaultCwd((c) => c || repos[0]?.root || "");
     }).catch(() => {}).finally(() => setReposKnown(true));
-    api.chatEnabled().then((r) => { setEnabled(r.enabled); setBypassAllowed(!!r.bypass); }).catch(() => {});
+    api.chatEnabled().then((r) => {
+      setEnabled(r.enabled);
+      setBypassAllowed(!!r.bypass);
+      // Absent from a server too old to send it — keep the placeholder rather
+      // than emptying the dropdown.
+      if (r.models?.length) setClaudeModels(r.models);
+    }).catch(() => {});
     api.codexEnabled().then(setCodex).catch(() => {});
     api.antigravityEnabled().then(setAntigravity).catch(() => {});
     // Which project this instance is scoped to, if any. A failure here means we

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -178,14 +178,21 @@ function Inspector({ chat }: { chat: Chat }) {
   return (
     <div className="shrink-0 px-3 py-2 border-t flex flex-col gap-1.5"
       style={{ borderColor: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
-      <div className="flex items-baseline gap-2">
-        <span className="text-[9px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>context</span>
-        <span className="text-[10px] tabular-nums ml-auto" style={{ color: tone }}>{pct.toFixed(0)}%</span>
-        <span className="text-[9px] t-dim2 tabular-nums">{fmtTokens(u.contextTokens)} / {fmtTokens(limit)}</span>
-      </div>
-      <div className="h-1 rounded-full overflow-hidden" style={{ background: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
-        <div className="h-full rounded-full transition-all" style={{ width: `${Math.max(1, pct)}%`, background: tone }} />
-      </div>
+      {/* Only when the CLI told us the prompt size. Codex's exec stream reports
+          no per-turn context and no window, and a bar drawn at 0 / 400k would
+          be a claim about a session we know nothing about. */}
+      {u.contextTokens > 0 && (
+        <>
+          <div className="flex items-baseline gap-2">
+            <span className="text-[9px] uppercase tracking-wider" style={{ color: "var(--text3)" }}>context</span>
+            <span className="text-[10px] tabular-nums ml-auto" style={{ color: tone }}>{pct.toFixed(0)}%</span>
+            <span className="text-[9px] t-dim2 tabular-nums">{fmtTokens(u.contextTokens)} / {fmtTokens(limit)}</span>
+          </div>
+          <div className="h-1 rounded-full overflow-hidden" style={{ background: "color-mix(in srgb, var(--border) 30%, transparent)" }}>
+            <div className="h-full rounded-full transition-all" style={{ width: `${Math.max(1, pct)}%`, background: tone }} />
+          </div>
+        </>
+      )}
       <div className="grid grid-cols-2 gap-x-4 gap-y-0.5 mt-0.5">
         <Row k="In" v={fmtTokens(u.input)} />
         <Row k="Out" v={fmtTokens(u.output)} />
@@ -1018,7 +1025,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     e.preventDefault();
     dragDepth.current = 0;
     setDragOver(false);
-    if (!canAttach) { setHint("codex chats can't take dropped files — start a Claude chat for that"); return; }
+    if (!canAttach) { setHint("codex chats can't take dropped images — start a Claude chat for that"); return; }
     // Files, not just images: `addAttachments` quotes a text file into the
     // draft, which is the same thing the picker and the paste path already do.
     const files = Array.from(e.dataTransfer.files);

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -26,8 +26,8 @@ import { quickSkills, pinnedSkills, togglePinnedSkill } from "../lib/quickSkills
 import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
-import { fmtAgo, fmtUsd, fmtTokens, modelLabelOf, modelColor, providerOf } from "../lib/format.ts";
-import { sessionIsLive, agentOf } from "../lib/derive.ts";
+import { fmtAgo, fmtUsd, fmtTokens, modelLabelOf, modelColor } from "../lib/format.ts";
+import { sessionIsLive, resumableAgent } from "../lib/derive.ts";
 import { ctxLimitOf } from "../lib/contextWindow.ts";
 import { worktreeTag, sessionWorktree, sessionCwd } from "../lib/worktree.ts";
 import { useStuckBottom } from "../lib/useStuckBottom.ts";
@@ -466,6 +466,17 @@ const blockedReason = (s: SessionRollup): Blocked => (sessionCwd(s) ? null : "no
 function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: string; onPick: () => void }) {
   const why = blockedReason(s);
   const model = modelLabelOf(s.model_name);
+  // Which CLI will be handed this session. Worth showing now that three of them
+  // can appear side by side: the row opens a chat bound to that binary for
+  // life, and "Opus 5" alone no longer says which one — `agy` runs Claude
+  // models too.
+  const agent = resumableAgent(s) ?? "claude";
+  // Claude keeps its transcripts in this app's own store and Codex has a
+  // rollout on disk, so both come back with the conversation in front of you.
+  // Antigravity keeps protobuf inside SQLite, so a resumed thread arrives with
+  // the CLI holding the full context and the panel showing none of it. That is
+  // worth saying before the click, not after.
+  const noReplay = !AGENTS[agent].hasTranscript;
   // A resumable session names the worktree it ran in when that isn't the repo
   // itself — resuming lands back in that checkout, so it has to say which.
   const wt = sessionWorktree(s);
@@ -477,7 +488,10 @@ function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: s
     ? "Already open in this panel — picking it focuses that tab."
     : live
     ? `Running now. Opening it shows the conversation; anything you send waits until this turn ends, because a session has one writer.`
-    : `Continue this conversation in ${sessionCwd(s)}`;
+    : `Continue this ${AGENTS[agent].label} conversation in ${sessionCwd(s)}`
+      + (noReplay
+        ? `\n\n${AGENTS[agent].label} keeps no transcript this panel can read, so the reply history won't be shown — ${AGENTS[agent].cli} still has the full context and follow-ups continue the same thread.`
+        : "");
 
   return (
     <button
@@ -495,7 +509,9 @@ function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: s
           <span className="text-[9.5px] tabular-nums t-dim2 shrink-0">{s.session_id.slice(0, 8)}</span>
         </div>
         <div className="flex items-center gap-1.5 text-[9.5px] t-dim2">
-          <span style={{ color: modelColor(model) }}>{model}</span>
+          <span style={{ color: "var(--text3)" }}>{AGENTS[agent].label}</span>
+          <span style={{ color: modelColor(model) }}>· {model}</span>
+          {noReplay && <span title="History is not replayed for this agent">· no replay</span>}
           <span>· {fmtAgo(s.last_seen)} ago</span>
           <span>· {fmtUsd(s.cost_usd)}</span>
         </div>
@@ -512,13 +528,19 @@ function ResumeRow({ s, openChatId, onPick }: { s: SessionRollup; openChatId?: s
 }
 
 /**
- * Pick up a claude session that already exists.
+ * Pick up a session that already exists, whichever CLI made it.
  *
  * The panel could always *start* conversations, but the ones worth continuing
  * are usually the ones started somewhere else — in a terminal, or by an earlier
  * run — and until now there was no way to reach them from here. This lists what
  * the fleet has seen, most recent first, and hands the chosen session to the
  * store to resume.
+ *
+ * All three agents appear, each row naming the CLI that will be handed it,
+ * because the chat it opens is bound to that binary for life and the model name
+ * alone no longer says which — `agy` runs Claude models too. Sessions belonging
+ * to a CLI this panel cannot drive are left out entirely rather than offered and
+ * failing on the first turn.
  *
  * Running sessions are listed rather than hidden: their absence would read as
  * a bug ("I just used that one, where is it?"), where a greyed row that says
@@ -544,16 +566,19 @@ function ResumePicker({ onPick, onClose }: { onPick: (s: SessionRollup) => void;
   }, [onClose]);
 
   const shown = useMemo(() => {
-    // `claude --resume` only knows about claude's own transcripts, so a session
-    // recorded from another vendor's telemetry is not something we could pick
-    // up. Unknown models stay in — early claude rows have no model recorded.
-    const claudeish = (rows ?? []).filter((s) => {
-      const p = providerOf(s.model_name);
-      return p === "Anthropic" || p === "unknown";
-    });
+    // Every CLI this panel drives can pick its own sessions back up, so the
+    // list is no longer Claude's alone — it was, back when Claude was the only
+    // agent, and stayed that way after Codex and Antigravity could both resume.
+    //
+    // Still not "everything the fleet has seen": a session belonging to a CLI
+    // this panel cannot drive — a Gemini CLI run, any other OTel exporter — has
+    // nothing here that could continue it. `resumableAgent` refuses those
+    // rather than guessing, which matters because the guess would be "Claude"
+    // and `claude --resume` would fail on an id it has never seen.
+    const drivable = (rows ?? []).filter((s) => resumableAgent(s) !== null);
     const needle = q.trim().toLowerCase();
-    if (!needle) return claudeish;
-    return claudeish.filter((s) =>
+    if (!needle) return drivable;
+    return drivable.filter((s) =>
       // cwd included: with a worktree per card, the card id is in the checkout
       // path and nowhere else — searching "20343" has to find that session.
       (`${s.project_path ?? ""} ${s.cwd_path ?? ""} ${s.source_app} ${s.session_id}`).toLowerCase().includes(needle));
@@ -883,7 +908,7 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     return c;
   }, [active, defaultCwd, repos, workspace, enabled, codex.enabled, antigravity.enabled]);
 
-  // Adopt an existing claude session. Focusing an already-open tab rather than
+  // Adopt an existing session. Focusing an already-open tab rather than
   // opening a second one is not a nicety: two chats resuming one session id
   // would both write to that transcript, which is the same corruption the live
   // check exists to prevent.
@@ -896,7 +921,13 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
     // up: a thread id is only meaningful to the binary that minted it, so
     // opening a Codex session as a Claude chat would send `claude --resume` an
     // id it has never heard of and fail on the first turn.
-    const agent = agentOf(s);
+    //
+    // The same function the picker filters on, rather than `agentOf` — which
+    // would answer "claude" for a session belonging to no CLI here and hand it
+    // to the wrong binary. Nothing in the list should reach this, but the two
+    // must not be able to disagree.
+    const agent = resumableAgent(s);
+    if (!agent) return;
     const chat = chatResuming(s.session_id)
       ?? newChat(
         cwd,

--- a/web/src/lib/agents.ts
+++ b/web/src/lib/agents.ts
@@ -1,0 +1,89 @@
+// Which CLIs the chat panel can drive, and everything that differs between
+// them.
+//
+// Its own module rather than a corner of chatStore.ts because chatPersist.ts
+// needs it too, and importing it from the store would put a cycle between the
+// two — one that happens to work today only because of the order two lines
+// appear in. This is the thing both of them depend on, so it sits below both.
+
+/**
+ * Which CLI is behind a conversation.
+ *
+ * A chat is bound to one for life. All three are driven the same way — spawn
+ * the binary non-interactively, stream its JSONL back — and all three land in
+ * the same `ChatMsg` / `ChatTool` shapes, which is what lets the panel render
+ * any of them without knowing. What it changes is the endpoint, the model list,
+ * and what the mode dropdown even means, so it is settled when the chat is
+ * opened rather than switchable mid-thread: a resume id belongs to the CLI that
+ * minted it, and there is no such thing as handing a thread from one to
+ * another.
+ */
+export type AgentKind = "claude" | "codex" | "antigravity";
+
+/**
+ * Everything that differs between the CLIs, in one table.
+ *
+ * This was a run of `agent === "codex" ? … : …` ternaries scattered across the
+ * store and the panel, which worked while there were two agents and multiplies
+ * badly at three: each new CLI meant finding every branch again, and a missed
+ * one is silent — a Claude default quietly applied to something that is not
+ * Claude. A lookup makes the next agent an entry rather than a search.
+ */
+export type AgentSpec = {
+  /** What to call it in the UI. */
+  label: string;
+  /** The binary, as it appears in "no local `x` CLI" and the footer line. */
+  cli: string;
+  defaultModel: string;
+  defaultMode: string;
+  /** The unattended mode — the one the server refuses to honour unless the
+   *  operator opted in. One name for three spellings, so the mode dropdown and
+   *  the warnings do not each need the branch. */
+  bypassMode: string;
+  /** Whether this CLI takes pasted or dropped images. Only Claude does: the
+   *  other two take images as file paths, so there is nowhere for pasted bytes
+   *  to go without staging them on disk first. */
+  canAttach: boolean;
+  /** Whether a resumed chat can have its history replayed from disk. Claude's
+   *  is in this app's own store and Codex keeps a JSONL rollout; Antigravity
+   *  keeps protobuf blobs inside SQLite, which is not something to guess at. */
+  hasTranscript: boolean;
+};
+
+export const DEFAULT_MODEL = "claude-opus-5";
+export const DEFAULT_MODE = "default";
+/** Codex's counterparts. The mode is its sandbox rather than a permission
+ *  policy, so the two vocabularies stay apart. Keep in step with
+ *  DEFAULT_SANDBOX in server/src/codex.ts. */
+export const DEFAULT_CODEX_MODEL = "gpt-5.6-sol";
+export const DEFAULT_CODEX_MODE = "read-only";
+/** Antigravity's. Its four modes happen to line up with Claude's, which is a
+ *  property of the CLI rather than a mapping imposed here. Keep in step with
+ *  DEFAULT_MODE in server/src/antigravity.ts. */
+export const DEFAULT_ANTIGRAVITY_MODEL = "gemini-3.6-flash-medium";
+export const DEFAULT_ANTIGRAVITY_MODE = "request-review";
+
+export const AGENTS: Record<AgentKind, AgentSpec> = {
+  claude: {
+    label: "Claude", cli: "claude",
+    defaultModel: DEFAULT_MODEL, defaultMode: DEFAULT_MODE,
+    bypassMode: "bypassPermissions", canAttach: true, hasTranscript: true,
+  },
+  codex: {
+    label: "Codex", cli: "codex",
+    defaultModel: DEFAULT_CODEX_MODEL, defaultMode: DEFAULT_CODEX_MODE,
+    bypassMode: "full-access", canAttach: false, hasTranscript: true,
+  },
+  antigravity: {
+    label: "Antigravity", cli: "agy",
+    defaultModel: DEFAULT_ANTIGRAVITY_MODEL, defaultMode: DEFAULT_ANTIGRAVITY_MODE,
+    bypassMode: "always-proceed", canAttach: false, hasTranscript: false,
+  },
+};
+
+/** Narrow an untrusted string to an agent. Anything unrecognised is Claude:
+ *  everything written down before chats had a second agent was a Claude chat,
+ *  so a missing field is an older payload saying what it knew rather than
+ *  corruption — and it is the recoverable direction either way. */
+export const asAgent = (v: unknown): AgentKind =>
+  v === "codex" || v === "antigravity" ? v : "claude";

--- a/web/src/lib/antigravityFrames.ts
+++ b/web/src/lib/antigravityFrames.ts
@@ -1,0 +1,217 @@
+// Antigravity's wire vocabulary, folded into the same conversation the Claude
+// and Codex paths build.
+//
+// `agy -p … --output-format stream-json` streams a JSONL whose envelope names
+// itself with `event` rather than `type`: an `init` naming the conversation, a
+// run of `step_update` frames each carrying one typed step, and a `result`
+// closing the turn. Nothing about that shape resembles either of the other two,
+// but everything it says maps onto fields `ChatMsg` / `ChatTool` / `ChatUsage`
+// already have — which is what lets one panel render all three without a branch
+// anywhere below the store.
+//
+// This is the whole translation. The server passes the frames through untouched
+// (server/src/antigravity.ts) precisely so it lives in one file.
+import type { Chat, ChatTool, ChatUsage } from "./chatStore.ts";
+
+const strv = (v: unknown) => (typeof v === "string" && v ? v : null);
+const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+
+/** Tool output is rendered in a chip; a `cat` of a large file is not worth
+ *  holding in memory, let alone drawing. Matches codexFrames.ts and the
+ *  transcript clipping in chatPersist.ts. */
+const MAX_OUTPUT = 20_000;
+const clip = (s: string) => (s.length > MAX_OUTPUT ? s.slice(0, MAX_OUTPUT) + "\n[trimmed]" : s);
+
+/**
+ * What to call an Antigravity tool in the tool strip.
+ *
+ * Deliberately Claude's names where one exists, exactly as codexFrames.ts does:
+ * the chip renderer, the tool mix chart and the session timeline all key off
+ * these, and a `view_file` drawing as its own category would split "reads" into
+ * two columns that mean the same thing. Anything without a counterpart keeps
+ * Antigravity's own name rather than being forced into an approximate one.
+ */
+const TOOL_ALIASES: Record<string, string> = {
+  view_file: "Read",
+  read_url_content: "WebFetch",
+  write_to_file: "Write",
+  replace_file_content: "Edit",
+  multi_replace_file_content: "Edit",
+  sed_file: "Edit",
+  run_command: "Bash",
+  grep_search: "Grep",
+  find_by_name: "Glob",
+  list_dir: "Glob",
+  search_web: "WebSearch",
+  manage_task: "TodoWrite",
+  invoke_subagent: "Task",
+  browser_subagent: "Task",
+};
+const toolName = (raw: string): string => TOOL_ALIASES[raw] ?? raw;
+
+/**
+ * What a step acted on — the thing the chip shows next to the name.
+ *
+ * `tool_info.parameters` is Antigravity's argument bag, and its keys are
+ * PascalCase (`DirectoryPath`, `AbsolutePath`). Rather than enumerate every
+ * tool's schema, the first plausibly path-or-command-shaped value wins, which
+ * is what the chip needs and degrades to "no target" rather than to a wrong one.
+ */
+function toolTarget(params: Record<string, unknown>): string | null {
+  const PREFERRED = ["AbsolutePath", "TargetFile", "FilePath", "DirectoryPath", "Command", "Query", "SearchTerm", "Url"];
+  for (const k of PREFERRED) {
+    const v = strv(params[k]);
+    if (v) return v.slice(0, 300);
+  }
+  for (const v of Object.values(params)) {
+    const s = strv(v);
+    if (s) return s.slice(0, 300);
+  }
+  return null;
+}
+
+/**
+ * What the thread has spent.
+ *
+ * The important difference from the Codex path, and the one that bites if you
+ * assume otherwise: **these figures are per turn, not cumulative for the
+ * thread.** Measured rather than inferred — turn 1 of a conversation reported
+ * 31789 input tokens and turn 2 reported 16609, which cannot be a running
+ * total. So they are added, exactly as the Claude path adds, where Codex's
+ * must be assigned. The two streams look alike here and mean opposite things.
+ *
+ * `contextTokens` stays zero, which suppresses the context meter for an
+ * Antigravity chat. The stream reports no window, and `ctxLimitOf` does not
+ * know the Gemini 3.x families — so a bar drawn here would fall back to a
+ * default ceiling and state a fullness nobody measured. contextWindow.ts is
+ * explicit that over-reading is the unrecoverable direction. No meter is better
+ * than a wrong one.
+ */
+export function antigravityUsage(usage: Record<string, unknown>, prev: ChatUsage | undefined): ChatUsage {
+  return {
+    input: (prev?.input ?? 0) + num(usage.input_tokens),
+    // `thinking_tokens` is reported separately but is already counted inside
+    // `output_tokens`, so adding it here would bill reasoning twice.
+    output: (prev?.output ?? 0) + num(usage.output_tokens),
+    cacheRead: (prev?.cacheRead ?? 0) + num(usage.cache_read_tokens),
+    cacheWrite: prev?.cacheWrite ?? 0,
+    contextTokens: 0,
+    // No price on this stream, and no table in this repo for Antigravity's
+    // model mix — which spans Google, Anthropic and open-weight models at
+    // whatever the harness charges. Left at zero, hiding the cost row rather
+    // than filling it with a guess.
+    costUsd: prev?.costUsd ?? 0,
+  };
+}
+
+/** Append to the assistant turn in progress, creating one if a frame somehow
+ *  arrives before it.
+ *
+ *  Antigravity streams prose as `text_delta` on successive `agent_response`
+ *  steps, so unlike the Codex path these really are deltas of one sentence and
+ *  are concatenated bare — inserting paragraph breaks between them would chop
+ *  a reply mid-word. */
+function say(c: Chat, text: string, field: "text" | "thinking") {
+  const last = c.messages[c.messages.length - 1];
+  if (!last || last.role !== "assistant") {
+    c.messages.push({ role: "assistant", text: field === "text" ? text : "", tools: [], ts: Date.now(), ...(field === "thinking" ? { thinking: text } : {}) });
+    return;
+  }
+  if (field === "text") last.text = (last.text ?? "") + text;
+  else last.thinking = (last.thinking ?? "") + text;
+}
+
+/** The tool row for this step index, creating it on the turn in progress if
+ *  this is the first frame to mention it. The ACTIVE and DONE halves carry the
+ *  same `step_index` and describe one call, so this is an upsert — exactly how
+ *  the Claude path keys on `tool_use_id`. */
+function toolRow(c: Chat, id: string): ChatTool {
+  for (let i = c.messages.length - 1; i >= 0; i--) {
+    const found = c.messages[i].tools.find((t) => t.id === id);
+    if (found) return found;
+  }
+  const row: ChatTool = { id, name: "tool", target: null, output: null, error: false, ts: Date.now(), note: null };
+  const last = c.messages[c.messages.length - 1];
+  if (last && last.role === "assistant") last.tools.push(row);
+  else c.messages.push({ role: "assistant", text: "", tools: [row], ts: Date.now() });
+  return row;
+}
+
+/**
+ * Fold one Antigravity frame into the chat it belongs to.
+ *
+ * Mutates `c` in place, because that is the shape `chatStore.update` hands out.
+ * Everything not specific to this vocabulary — `sending`, the queue, unread,
+ * `agx_error`, abort — stays in the store and is shared with the other two.
+ *
+ * Unrecognised frames and step types are ignored rather than surfaced, for the
+ * same reason the Codex path ignores them: a chat that printed `[unknown frame]`
+ * at the user every time the CLI shipped a new step type would be worse than one
+ * that simply does not draw it yet.
+ */
+export function applyAntigravityFrame(c: Chat, frame: Record<string, unknown>): void {
+  switch (frame.event) {
+    case "init": {
+      // The id `--conversation` wants for every turn after this one. Stable
+      // across a resume, like Codex's thread id and unlike `claude --resume`,
+      // which forks a fresh session id each time.
+      const id = strv(frame.conversation_id);
+      if (!id) return;
+      c.sessionId = id;
+      c.liveFrom = Date.now();
+      // Unlike Codex, this stream *does* name the model it actually ran, which
+      // is the better answer than the one we asked for — `agy` resolves aliases
+      // and can fall back.
+      const init = (frame.init ?? {}) as Record<string, unknown>;
+      c.resolvedModel = strv(init.model) ?? c.model;
+      return;
+    }
+    case "step_update": {
+      const step = (frame.step_update ?? {}) as Record<string, unknown>;
+      const type = step.step_type;
+      const delta = strv(step.text_delta);
+
+      if (type === "tool") {
+        const idx = typeof step.step_index === "number" ? String(step.step_index) : null;
+        if (!idx) return;
+        const info = (step.tool_info ?? {}) as Record<string, unknown>;
+        const raw = strv(step.tool_name) ?? strv(info.name);
+        const row = toolRow(c, idx);
+        if (raw) row.name = toolName(raw);
+        const params = (info.parameters ?? {}) as Record<string, unknown>;
+        const target = toolTarget(params);
+        if (target) row.target = target;
+        const out = strv(info.output);
+        if (out) row.output = clip(out.trimEnd());
+        return;
+      }
+
+      // `agent_response` carries the reply, `thinking` the reasoning. Both
+      // arrive as deltas across several steps.
+      if (type === "agent_response" && delta) { say(c, delta, "text"); return; }
+      if (type === "thinking" && delta) { say(c, delta, "thinking"); return; }
+
+      // The stream reports that something went wrong without saying what — the
+      // step carries no message. Rather than print an empty error, mark the tool
+      // it followed as failed, which is where the detail actually is.
+      if (type === "error_message") {
+        for (let i = c.messages.length - 1; i >= 0; i--) {
+          const tools = c.messages[i].tools;
+          if (tools.length) { tools[tools.length - 1].error = true; return; }
+        }
+      }
+      return;
+    }
+    case "result": {
+      const result = (frame.result ?? {}) as Record<string, unknown>;
+      c.usage = antigravityUsage((result.usage ?? {}) as Record<string, unknown>, c.usage);
+      // A turn that ended badly says so. `status` is SUCCESS on a clean run.
+      const status = strv(result.status);
+      if (status && status !== "SUCCESS") {
+        say(c, `\n[error] the turn ended ${status.toLowerCase()}`, "text");
+        c.attention = "blocked";
+      }
+      return;
+    }
+  }
+}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -661,6 +661,13 @@ const realApi = {
   codexStream: (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) =>
     turnStream("/codex/send", payload, onEvent, signal),
 
+  // --- multi-chat: the same panel, driving google antigravity ---
+  // No transcript call to match the other two: Antigravity keeps a conversation
+  // as protobuf inside SQLite, so there is nothing readable to ask for.
+  antigravityEnabled: () => get<AgentCliStatus>("/antigravity/enabled"),
+  antigravityStream: (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) =>
+    turnStream("/antigravity/send", payload, onEvent, signal),
+
   dockerStart: (id: string) => post<DockerActionResult>("/docker/start", { id }),
   dockerStop: (id: string) => post<DockerActionResult>("/docker/stop", { id }),
   dockerRestart: (id: string) => post<DockerActionResult>("/docker/restart", { id }),
@@ -829,6 +836,12 @@ const demoApi: typeof realApi = {
     onEvent({ type: "thread.started", thread_id: "demo" });
     onEvent({ type: "item.completed", item: { id: "item_0", type: "agent_message", text: "(chat is disabled in the demo — run agentglass locally to drive real Codex sessions)" } });
     onEvent({ type: "turn.completed", usage: {} });
+  },
+  antigravityEnabled: () => D({ enabled: false, models: [] } as AgentCliStatus),
+  antigravityStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void) => {
+    onEvent({ event: "init", conversation_id: "demo-0000-0000-0000-demodemodemo", init: { model: "demo" } });
+    onEvent({ event: "step_update", step_update: { step_index: 0, state: "DONE", step_type: "agent_response", text_delta: "(chat is disabled in the demo — run agentglass locally to drive real Antigravity sessions)" } });
+    onEvent({ event: "result", result: { status: "SUCCESS", usage: {} } });
   },
   dockerStart: (_id: string) => D(demo.dockerActionUnavailable()),
   dockerStop: (_id: string) => D(demo.dockerActionUnavailable()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -159,6 +159,54 @@ export class ChatStreamError extends Error {
     );
     this.name = "ChatStreamError";
   }
+}
+
+/**
+ * POST a turn and read the ndjson stream it answers with, a frame at a time.
+ *
+ * Shared by both agents because none of this is agent-specific: the framing,
+ * the three ways a turn can fail, and the reader are properties of how the
+ * server streams a subprocess, not of which subprocess it streamed. What the
+ * frames *mean* diverges completely, and that lives in the two parsers above
+ * the store.
+ */
+async function turnStream(
+  path: string,
+  payload: Record<string, unknown>,
+  onEvent: (o: Record<string, unknown>) => void,
+  signal?: AbortSignal,
+): Promise<void> {
+  let res: Response;
+  // A fetch that throws before a response has arrived never reached the
+  // server, which is a different problem from one that dies mid-turn — the
+  // turn has not started, so there is nothing running to go back to.
+  try {
+    res = await fetch(SERVER + path, { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
+  } catch (e) {
+    if (e instanceof DOMException && e.name === "AbortError") throw e;
+    throw new ChatStreamError("unreachable", "");
+  }
+  // A refusal — chat disabled, out of scope, a bad directory — comes back as
+  // plain text with a 4xx, not ndjson. Without this it fell into the reader
+  // below, failed to parse as JSON, and was skipped line by line, so the user
+  // was told nothing at all about why their turn did not run.
+  if (!res.ok) throw new ChatStreamError("refused", (await res.text().catch(() => "")).trim(), res.status);
+  if (!res.body) { try { onEvent(JSON.parse(await res.text())); } catch { /* non-json */ } return; }
+  const reader = res.body.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+  const flush = (line: string) => { const t = line.trim(); if (t) { try { onEvent(JSON.parse(t)); } catch { /* skip */ } } };
+  try {
+    for (;;) { const { done, value } = await reader.read(); if (done) break; buf += dec.decode(value, { stream: true }); let nl; while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); } }
+  } catch (e) {
+    // The turn was accepted and then the connection died under it. The raw
+    // error is opaque (a bare "TypeError: Load failed" or similar, depending
+    // on the engine) and says nothing about what happened — the cause is
+    // named here instead, where it is known.
+    if (e instanceof DOMException && e.name === "AbortError") throw e;
+    throw new ChatStreamError("dropped", "");
+  }
+  flush(buf);
 }
 
 /** Tell an auth failure apart from a plain outage. A browser WebSocket can't
@@ -599,39 +647,20 @@ const realApi = {
    *  pane belonging to a chat in another window is not an orphan. */
   chatPanes: (open: string[]) =>
     get<ChatPaneList>(`/chat/panes?open=${encodeURIComponent(open.join(","))}`),
-  chatStream: async (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine; effort?: ChatEffort }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) => {
-    let res: Response;
-    // A fetch that throws before a response has arrived never reached the
-    // server, which is a different problem from one that dies mid-turn — the
-    // turn has not started, so there is nothing running to go back to.
-    try {
-      res = await fetch(SERVER + "/chat/send", { method: "POST", headers: authHeaders({ "content-type": "application/json" }), body: JSON.stringify(payload), signal });
-    } catch (e) {
-      if (e instanceof DOMException && e.name === "AbortError") throw e;
-      throw new ChatStreamError("unreachable", "");
-    }
-    // A refusal — chat disabled, out of scope, a bad directory — comes back as
-    // plain text with a 4xx, not ndjson. Without this it fell into the reader
-    // below, failed to parse as JSON, and was skipped line by line, so the user
-    // was told nothing at all about why their turn did not run.
-    if (!res.ok) throw new ChatStreamError("refused", (await res.text().catch(() => "")).trim(), res.status);
-    if (!res.body) { try { onEvent(JSON.parse(await res.text())); } catch { /* non-json */ } return; }
-    const reader = res.body.getReader();
-    const dec = new TextDecoder();
-    let buf = "";
-    const flush = (line: string) => { const t = line.trim(); if (t) { try { onEvent(JSON.parse(t)); } catch { /* skip */ } } };
-    try {
-      for (;;) { const { done, value } = await reader.read(); if (done) break; buf += dec.decode(value, { stream: true }); let nl; while ((nl = buf.indexOf("\n")) >= 0) { flush(buf.slice(0, nl)); buf = buf.slice(nl + 1); } }
-    } catch (e) {
-      // The turn was accepted and then the connection died under it. The raw
-      // error is opaque (a bare "TypeError: Load failed" or similar, depending
-      // on the engine) and says nothing about what happened — the cause is
-      // named here instead, where it is known.
-      if (e instanceof DOMException && e.name === "AbortError") throw e;
-      throw new ChatStreamError("dropped", "");
-    }
-    flush(buf);
-  },
+  chatStream: (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string; allowedTools?: string[]; images?: ChatImage[]; engine?: ChatEngine; effort?: ChatEffort }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) =>
+    turnStream("/chat/send", payload, onEvent, signal),
+
+  // --- multi-chat: the same panel, driving codex instead ---
+  // Codex takes neither an allowlist nor pasted images, so its payload is the
+  // Claude one minus the two things it has no equivalent for.
+  codexEnabled: () => get<CodexStatus>("/codex/enabled"),
+  // What a codex thread said, read from Codex's own rollout on disk. The OTel
+  // stream that puts Codex on the radar carries tool calls but no prose, so this
+  // is the only source for a resumed thread's history — see codexTranscript().
+  codexTranscript: (id: string) => get<{ timeline: SessionDetail["timeline"] }>(`/codex/transcript?id=${encodeURIComponent(id)}`),
+  codexStream: (payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void, signal?: AbortSignal) =>
+    turnStream("/codex/send", payload, onEvent, signal),
+
   dockerStart: (id: string) => post<DockerActionResult>("/docker/start", { id }),
   dockerStop: (id: string) => post<DockerActionResult>("/docker/stop", { id }),
   dockerRestart: (id: string) => post<DockerActionResult>("/docker/restart", { id }),
@@ -793,6 +822,13 @@ const demoApi: typeof realApi = {
     onEvent({ type: "system", subtype: "init", session_id: "demo" });
     onEvent({ type: "assistant", message: { content: [{ type: "text", text: "(chat is disabled in the demo — run agentglass locally to drive real Claude sessions)" }] } });
     onEvent({ type: "result", result: "" });
+  },
+  codexEnabled: () => D({ enabled: false, models: [] } as CodexStatus),
+  codexTranscript: (_id: string) => D({ timeline: [] as SessionDetail["timeline"] }),
+  codexStream: async (_payload: { cwd: string; message: string; model: string; mode: string; resumeId: string }, onEvent: (o: Record<string, unknown>) => void) => {
+    onEvent({ type: "thread.started", thread_id: "demo" });
+    onEvent({ type: "item.completed", item: { id: "item_0", type: "agent_message", text: "(chat is disabled in the demo — run agentglass locally to drive real Codex sessions)" } });
+    onEvent({ type: "turn.completed", usage: {} });
   },
   dockerStart: (_id: string) => D(demo.dockerActionUnavailable()),
   dockerStop: (_id: string) => D(demo.dockerActionUnavailable()),

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,4 +1,4 @@
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, AgentModel, ChatImage, ConflictBlock, BlockChoice, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrActionResult, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord } from "../../../shared/types.ts";
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 
@@ -626,7 +626,12 @@ const realApi = {
   // --- in-browser terminal: ready-to-run project commands (make + scripts) ---
   terminalCommands: (root: string) => get<TerminalCommands>(`/terminal/commands?root=${encodeURIComponent(root)}`),
   // --- multi-chat: drive a claude session from the browser ---
-  chatEnabled: () => get<{ enabled: boolean; bypass?: boolean; tmuxEngine?: TmuxEngineInfo }>("/chat/enabled"),
+  // `models` rides along for the same reason it does on the other two agents:
+  // the panel cannot usefully draw a model picker without knowing what the CLI
+  // will accept, and asking twice would let it render one for a CLI that turns
+  // out not to be there. Claude's list is data on the server
+  // (shared/claude-models.json) rather than a table compiled in here.
+  chatEnabled: () => get<{ enabled: boolean; bypass?: boolean; models?: AgentModel[]; tmuxEngine?: TmuxEngineInfo }>("/chat/enabled"),
   /** The command that hands a chat to the user's own terminal, and whether its
    *  pane is up right now. Assembled server-side so the socket name never has to
    *  be duplicated here. */
@@ -817,7 +822,7 @@ const demoApi: typeof realApi = {
   dockerInspect: (_id: string) => D({ ok: false, env: [] as string[], config: "", error: "not available in the demo" }),
   dockerTop: (_id: string) => D({ ok: false, text: "", error: "not available in the demo" }),
   terminalCommands: (_root: string) => D({ enabled: false, make: [], scripts: [] } as TerminalCommands),
-  chatEnabled: () => D({ enabled: false, tmuxEngine: { available: false, reason: "the demo runs no local processes", defaultOn: false } }),
+  chatEnabled: () => D({ enabled: false, models: [] as AgentModel[], tmuxEngine: { available: false, reason: "the demo runs no local processes", defaultOn: false } }),
   chatAttach: (_session: string) => D({ command: "", live: false }),
   chatPaneClose: (_session: string) => D({ killed: false }),
   chatPaneKey: (_session: string, _key: string) => D({ screen: "" }),

--- a/web/src/lib/chatPersist.ts
+++ b/web/src/lib/chatPersist.ts
@@ -31,7 +31,7 @@ const MAX_BYTES = 2_000_000;
 /** What actually gets written. Everything absent from here is either not
  *  serializable or not true after a reload. */
 type StoredChat = Pick<Chat,
-  | "id" | "cwd" | "model" | "resolvedModel" | "mode" | "title" | "sessionId" | "draft"
+  | "id" | "cwd" | "agent" | "model" | "resolvedModel" | "mode" | "title" | "sessionId" | "draft"
   | "queued" | "createdAt" | "unread" | "renamed" | "attention" | "usage" | "liveFrom"
   | "engine" | "attachCommand" | "effort">
   & { messages: ChatMsg[] };
@@ -69,7 +69,7 @@ function pack(c: Chat): StoredChat {
   if (last && last.role === "assistant" && !last.text && !last.tools.length) messages = messages.slice(0, -1);
 
   return {
-    id: c.id, cwd: c.cwd, model: c.model,
+    id: c.id, cwd: c.cwd, agent: c.agent, model: c.model,
     // The window the CLI actually resolved, which is what the context meter
     // measures against. Without it a restored chat measures a 1M session against
     // the 200k default until its next turn re-reports one.
@@ -93,6 +93,12 @@ function pack(c: Chat): StoredChat {
 function unpack(s: StoredChat): Chat {
   return {
     ...s,
+    // Written down since chats gained a second agent. Everything saved before
+    // that was a Claude chat, so a missing field is not corruption — it is an
+    // older payload saying what it knew. Defaulting it costs nothing and means
+    // the version number does not have to move, which would have thrown those
+    // tabs away instead.
+    agent: s.agent === "codex" ? "codex" : "claude",
     messages: (s.messages ?? []).map((m) => ({ ...m, streaming: undefined })),
     sending: false,
     abort: null,

--- a/web/src/lib/chatPersist.ts
+++ b/web/src/lib/chatPersist.ts
@@ -13,6 +13,7 @@
 // also on disk in claude's own transcript, but the *set of open tabs* is known
 // nowhere but here.
 
+import { asAgent } from "./chatStore.ts";
 import type { Chat, ChatMsg, ChatTool } from "./chatStore.ts";
 
 const KEY = "agentglass.chats.v1";
@@ -98,7 +99,7 @@ function unpack(s: StoredChat): Chat {
     // older payload saying what it knew. Defaulting it costs nothing and means
     // the version number does not have to move, which would have thrown those
     // tabs away instead.
-    agent: s.agent === "codex" ? "codex" : "claude",
+    agent: asAgent(s.agent),
     messages: (s.messages ?? []).map((m) => ({ ...m, streaming: undefined })),
     sending: false,
     abort: null,

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -10,6 +10,7 @@ import { loadChats, saveChats } from "./chatPersist.ts";
 import { chatEnginePref } from "./chatEnginePref.ts";
 import { paneStillAsking } from "./paneScreen.ts";
 import { applyCodexFrame } from "./codexFrames.ts";
+import { applyAntigravityFrame } from "./antigravityFrames.ts";
 import type { ChatImage, WatchEvent, ChatEngine, ChatEffort, SessionDetail } from "../../../shared/types.ts";
 
 /** A pasted image waiting in the composer. `url` is an object URL for the
@@ -115,19 +116,17 @@ export type ChatUsage = {
 /** A message typed during someone else's turn, waiting for its own. */
 export type QueuedTurn = { id: string; text: string; images: ChatImage[] };
 
-/**
- * Which CLI is behind this conversation.
- *
- * A chat is bound to one for life. Both are driven the same way — spawn the
- * binary non-interactively, stream its JSONL back — and both land in the same
- * `ChatMsg` / `ChatTool` shapes, which is what lets the panel render either
- * without knowing. What it changes is the endpoint, the model list, and what
- * the mode dropdown even means, so it is settled when the chat is opened
- * rather than switchable mid-thread: a `--resume` id belongs to the CLI that
- * minted it, and there is no such thing as handing a thread from one to the
- * other.
- */
-export type AgentKind = "claude" | "codex";
+/** The agents this panel can drive, and everything that differs between them.
+ *  Defined in agents.ts so chatPersist.ts can share it without a cycle, and
+ *  re-exported here because this is where the rest of the app already looks. */
+import { AGENTS, DEFAULT_MODEL, DEFAULT_MODE } from "./agents.ts";
+import type { AgentKind } from "./agents.ts";
+export {
+  AGENTS, asAgent,
+  DEFAULT_MODEL, DEFAULT_MODE, DEFAULT_CODEX_MODEL, DEFAULT_CODEX_MODE,
+  DEFAULT_ANTIGRAVITY_MODEL, DEFAULT_ANTIGRAVITY_MODE,
+} from "./agents.ts";
+export type { AgentKind, AgentSpec } from "./agents.ts";
 
 /** Press one key in a chat's pane and take in what it drew next.
  *
@@ -263,14 +262,6 @@ export type Chat = {
 const chats = new Map<string, Chat>();
 const subs = new Set<() => void>();
 let seq = 0;
-
-export const DEFAULT_MODEL = "claude-opus-5";
-export const DEFAULT_MODE = "default";
-/** Codex's counterparts. The mode is its sandbox rather than a permission
- *  policy, so the two vocabularies stay apart — see `AgentKind`. Keep in step
- *  with DEFAULT_SANDBOX in server/src/codex.ts. */
-export const DEFAULT_CODEX_MODEL = "gpt-5.6-sol";
-export const DEFAULT_CODEX_MODE = "read-only";
 
 // A cached snapshot, rebuilt only when something actually changes.
 //
@@ -412,7 +403,14 @@ async function hydrate(chatId: string, sessionId: string) {
     // thread with every sentence missing. Codex keeps its own rollout on disk,
     // which has both, so that is what the server reads for it. Same timeline
     // shape either way, which is why nothing below has to know.
+    //
+    // Antigravity has neither: its conversations are protobuf blobs inside a
+    // SQLite database on an undocumented internal schema, so there is nothing
+    // here to replay from. It never reaches this path in practice — nothing
+    // lists an Antigravity session to adopt — but a chat carrying an id from
+    // somewhere else must not ask Claude's endpoint about it.
     const agent = chats.get(chatId)?.agent ?? "claude";
+    if (!AGENTS[agent].hasTranscript) return;
     const s: { timeline?: SessionDetail["timeline"]; conversation?: SessionDetail["conversation"] } | null =
       agent === "codex" ? await api.codexTranscript(sessionId) : await api.session(sessionId);
     if (!s) return;
@@ -661,8 +659,8 @@ export function switchAgent(id: string, agent: AgentKind) {
   if (!c || c.agent === agent || !isFresh(c)) return;
   update(id, (x) => {
     x.agent = agent;
-    x.model = agent === "codex" ? DEFAULT_CODEX_MODEL : DEFAULT_MODEL;
-    x.mode = agent === "codex" ? DEFAULT_CODEX_MODE : DEFAULT_MODE;
+    x.model = AGENTS[agent].defaultModel;
+    x.mode = AGENTS[agent].defaultMode;
   });
 }
 
@@ -872,16 +870,22 @@ export async function send(id: string, text: string, isActive: () => boolean, al
     });
   };
 
-  /** Codex's frames, whose whole translation lives in codexFrames.ts. Every
-   *  concern around it — the queue, `sending`, abort, attention — is shared
-   *  with the Claude path below and stays here. */
-  const onCodexEvent = (o: Record<string, unknown>) => {
+  /** Codex's and Antigravity's frames, whose whole translations live in
+   *  codexFrames.ts and antigravityFrames.ts. Every concern around them — the
+   *  queue, `sending`, abort, attention — is shared with the Claude path below
+   *  and stays here.
+   *
+   *  `agx_error` is this server's own frame rather than either CLI's, so it is
+   *  peeled off before the translator sees it. */
+  const framed = (apply: (c: Chat, o: Record<string, unknown>) => void) => (o: Record<string, unknown>) => {
     if (o.type === "agx_error") { onAgxError(o); return; }
     update(id, (c) => {
-      applyCodexFrame(c, o);
+      apply(c, o);
       if (!isActive()) c.unread = true;
     });
   };
+  const onCodexEvent = framed(applyCodexFrame);
+  const onAntigravityEvent = framed(applyAntigravityFrame);
 
   const toolNames = new Map<string, string>();
   const onEvent = (o: Record<string, unknown>) => {
@@ -1031,14 +1035,18 @@ export async function send(id: string, text: string, isActive: () => boolean, al
 
   let broke = false;
   try {
-    // Codex takes no allowlist (it draws its line around the filesystem, not
-    // per tool call) and no pasted images (it attaches them as file paths), so
-    // neither is sent rather than being sent and ignored. The pane engine is
-    // Claude's too — a Codex turn is always the streamed subprocess.
+    // Neither of the other two takes an allowlist (Codex draws its line around
+    // the filesystem, Antigravity decides per call with its own modes) or pasted
+    // images (both attach them as file paths), so neither is sent rather than
+    // being sent and ignored. The pane engine is Claude's too — a Codex or
+    // Antigravity turn is always the streamed subprocess.
+    const turn = { cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId };
     if (chat.agent === "codex") {
-      await api.codexStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId }, onCodexEvent, ac.signal);
+      await api.codexStream(turn, onCodexEvent, ac.signal);
+    } else if (chat.agent === "antigravity") {
+      await api.antigravityStream(turn, onAntigravityEvent, ac.signal);
     } else {
-      await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, effort: chat.effort, resumeId: chat.sessionId, allowedTools, images, engine }, onEvent, ac.signal);
+      await api.chatStream({ ...turn, effort: chat.effort, allowedTools, images, engine }, onEvent, ac.signal);
     }
   } catch (e) {
     // A queue must not keep firing into a turn that failed or one you just

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -497,6 +497,20 @@ const APPLIED_MAX = 8000;
  * `UserPromptSubmit` has the prompt, `Stop` the assistant's reply, and the
  * tool pair the call and its output — so this is a matter of routing, not of
  * new plumbing. Called from the one place `useLive` is consumed.
+ *
+ * That last paragraph is true of Claude Code and only partly true of Codex, and
+ * the difference is worth stating rather than discovering. Codex reaches this
+ * app over OpenTelemetry rather than over hooks, and its log records carry the
+ * shape of a turn but not its words: `logRecordToEvent` in server/src/otlp.ts
+ * can build `PreToolUse` / `PostToolUse` / `Turn complete` out of them, and
+ * there is nothing there to build `UserPromptSubmit` or `Stop` from. So a Codex
+ * session watched from here fills in its tool rows and stays silent between
+ * them.
+ *
+ * It matters less than it sounds. A chat's own turns are drawn from the
+ * `/codex/send` response, which carries everything; this path only covers a
+ * session *adopted* from the fleet, and for those the conversation is replayed
+ * from Codex's own rollout on disk when the chat opens (`hydrate`).
  */
 export function applyLiveEvent(ev: WatchEvent) {
   if (applied.has(ev.id)) return;

--- a/web/src/lib/chatStore.ts
+++ b/web/src/lib/chatStore.ts
@@ -9,7 +9,8 @@ import { api, ChatStreamError } from "./api.ts";
 import { loadChats, saveChats } from "./chatPersist.ts";
 import { chatEnginePref } from "./chatEnginePref.ts";
 import { paneStillAsking } from "./paneScreen.ts";
-import type { ChatImage, WatchEvent, ChatEngine, ChatEffort } from "../../../shared/types.ts";
+import { applyCodexFrame } from "./codexFrames.ts";
+import type { ChatImage, WatchEvent, ChatEngine, ChatEffort, SessionDetail } from "../../../shared/types.ts";
 
 /** A pasted image waiting in the composer. `url` is an object URL for the
  *  thumbnail; it is revoked when the attachment is dropped or sent, since
@@ -114,6 +115,20 @@ export type ChatUsage = {
 /** A message typed during someone else's turn, waiting for its own. */
 export type QueuedTurn = { id: string; text: string; images: ChatImage[] };
 
+/**
+ * Which CLI is behind this conversation.
+ *
+ * A chat is bound to one for life. Both are driven the same way — spawn the
+ * binary non-interactively, stream its JSONL back — and both land in the same
+ * `ChatMsg` / `ChatTool` shapes, which is what lets the panel render either
+ * without knowing. What it changes is the endpoint, the model list, and what
+ * the mode dropdown even means, so it is settled when the chat is opened
+ * rather than switchable mid-thread: a `--resume` id belongs to the CLI that
+ * minted it, and there is no such thing as handing a thread from one to the
+ * other.
+ */
+export type AgentKind = "claude" | "codex";
+
 /** Press one key in a chat's pane and take in what it drew next.
  *
  *  Lives here rather than in the panel because two things call it: the buttons
@@ -163,6 +178,7 @@ export function engineFor(chat: Pick<Chat, "sessionId" | "engine">): ChatEngine 
 export type Chat = {
   id: string;
   cwd: string;
+  agent: AgentKind;
   /** What we ask for: the dropdown's pick, sent with every turn. */
   model: string;
   /** What the CLI reported running, off the `init` frame. Differs from `model`
@@ -250,6 +266,11 @@ let seq = 0;
 
 export const DEFAULT_MODEL = "claude-opus-5";
 export const DEFAULT_MODE = "default";
+/** Codex's counterparts. The mode is its sandbox rather than a permission
+ *  policy, so the two vocabularies stay apart — see `AgentKind`. Keep in step
+ *  with DEFAULT_SANDBOX in server/src/codex.ts. */
+export const DEFAULT_CODEX_MODEL = "gpt-5.6-sol";
+export const DEFAULT_CODEX_MODE = "read-only";
 
 // A cached snapshot, rebuilt only when something actually changes.
 //
@@ -347,10 +368,11 @@ export function newChat(
   model = DEFAULT_MODEL,
   mode = DEFAULT_MODE,
   resume?: { sessionId: string; title?: string },
+  agent: AgentKind = "claude",
 ): Chat {
   const id = `c${++seq}-${Date.now().toString(36)}`;
   const chat: Chat = {
-    id, cwd, model, mode,
+    id, cwd, agent, model, mode,
     // Chosen once, at birth. The engine decides where this chat's session lives,
     // so switching it later would either strand a warm CLI or a live turn — the
     // preference is a default for new chats, never a control over old ones.
@@ -383,7 +405,16 @@ export function newChat(
  *  still has the real context either way. */
 async function hydrate(chatId: string, sessionId: string) {
   try {
-    const s = await api.session(sessionId);
+    // Where a resumed thread's history comes from. Claude Code's is in this
+    // app's own store, put there by hooks. Codex reaches the fleet over
+    // OpenTelemetry instead, and those records carry the tool calls but not a
+    // word of the conversation — replaying from them would hand you a resumed
+    // thread with every sentence missing. Codex keeps its own rollout on disk,
+    // which has both, so that is what the server reads for it. Same timeline
+    // shape either way, which is why nothing below has to know.
+    const agent = chats.get(chatId)?.agent ?? "claude";
+    const s: { timeline?: SessionDetail["timeline"]; conversation?: SessionDetail["conversation"] } | null =
+      agent === "codex" ? await api.codexTranscript(sessionId) : await api.session(sessionId);
     if (!s) return;
     /*
      * The same timeline the session modal renders — messages *and* the tools
@@ -598,6 +629,28 @@ export function clearAttention(id: string) {
 export const chatResuming = (sessionId: string): Chat | undefined =>
   [...chats.values()].find((c) => c.sessionId === sessionId);
 
+/** Whether this chat can still change agent: it holds no thread and has said
+ *  nothing, so nothing about it is bound to a particular CLI yet. */
+export const isFresh = (c: Chat): boolean => !c.sessionId && c.messages.length === 0 && !c.sending;
+
+/**
+ * Point a not-yet-started chat at the other CLI.
+ *
+ * The model and the mode go with it. Both are that agent's own vocabulary —
+ * `claude-opus-5` means nothing to `codex exec -m`, and `acceptEdits` is not
+ * one of its sandboxes — so carrying them across would leave the dropdowns
+ * displaying a choice the server would quietly replace with its default. A
+ * control that lies about what is about to run is worse than no control.
+ */
+export function switchAgent(id: string, agent: AgentKind) {
+  const c = chats.get(id);
+  if (!c || c.agent === agent || !isFresh(c)) return;
+  update(id, (x) => {
+    x.agent = agent;
+    x.model = agent === "codex" ? DEFAULT_CODEX_MODEL : DEFAULT_MODEL;
+    x.mode = agent === "codex" ? DEFAULT_CODEX_MODE : DEFAULT_MODE;
+  });
+}
 
 /** Name a chat by hand. The derived title is a fallback for chats you never
  *  named; once you have, nothing should quietly replace it. */
@@ -771,6 +824,51 @@ export async function send(id: string, text: string, isActive: () => boolean, al
   const ac = new AbortController();
   update(id, (c) => { c.abort = ac; });
 
+  /** How a turn that never started, or one the server had to give up on,
+   *  reaches the chat. Shared by both agents: `agx_error` is this server's own
+   *  frame, wrapped around whichever CLI it was driving, so the handling is the
+   *  same on either side. */
+  const onAgxError = (o: Record<string, unknown>) => {
+    update(id, (c) => {
+      const last = c.messages[c.messages.length - 1];
+      if (last?.role === "assistant") { last.text += `\n[error] ${String(o.error)}`; last.streaming = false; }
+      // A setup failure isn't a turn that went wrong — it's a turn that never
+      // started, and it will fail identically every time until you do the one
+      // thing it names. Raise it as attention so the chat says it needs you
+      // rather than just going quiet.
+      // A picker in the pane is answerable from here, so it is raised as
+      // something to act on rather than appended to the reply as prose. The
+      // screen the server sent is the starting frame; each key sent back
+      // returns the next one.
+      if (o.errorType === "pane_needs_you") {
+        const text = String(o.error ?? "");
+        const screen = text.slice(text.indexOf("\n\n") + 2);
+        c.paneNeedsYou = { screen: screen.slice(screen.indexOf("\n\n") + 2) || screen };
+        c.attention = "blocked";
+        const last = c.messages[c.messages.length - 1];
+        // The prose above the screen is worth keeping; the screen itself is
+        // about to be drawn properly, so it does not belong in the text too.
+        if (last?.role === "assistant") last.text = last.text.split("\n\n")[0];
+        return;
+      }
+      if (typeof o.setupCommand === "string") {
+        c.setupNeeded = { command: o.setupCommand, why: String(o.error ?? "") };
+        c.attention = "blocked";
+      }
+    });
+  };
+
+  /** Codex's frames, whose whole translation lives in codexFrames.ts. Every
+   *  concern around it — the queue, `sending`, abort, attention — is shared
+   *  with the Claude path below and stays here. */
+  const onCodexEvent = (o: Record<string, unknown>) => {
+    if (o.type === "agx_error") { onAgxError(o); return; }
+    update(id, (c) => {
+      applyCodexFrame(c, o);
+      if (!isActive()) c.unread = true;
+    });
+  };
+
   const toolNames = new Map<string, string>();
   const onEvent = (o: Record<string, unknown>) => {
     const t = o.type;
@@ -895,33 +993,7 @@ export async function send(id: string, text: string, isActive: () => boolean, al
         if (tool) update(id, (c) => { c.blockedTool = tool; c.attention = "blocked"; });
       }
     } else if (t === "agx_error") {
-      update(id, (c) => {
-        const last = c.messages[c.messages.length - 1];
-        if (last?.role === "assistant") { last.text += `\n[error] ${String(o.error)}`; last.streaming = false; }
-        // A setup failure isn't a turn that went wrong — it's a turn that never
-        // started, and it will fail identically every time until you do the one
-        // thing it names. Raise it as attention so the chat says it needs you
-        // rather than just going quiet.
-        // A picker in the pane is answerable from here, so it is raised as
-        // something to act on rather than appended to the reply as prose. The
-        // screen the server sent is the starting frame; each key sent back
-        // returns the next one.
-        if (o.errorType === "pane_needs_you") {
-          const text = String(o.error ?? "");
-          const screen = text.slice(text.indexOf("\n\n") + 2);
-          c.paneNeedsYou = { screen: screen.slice(screen.indexOf("\n\n") + 2) || screen };
-          c.attention = "blocked";
-          const last = c.messages[c.messages.length - 1];
-          // The prose above the screen is worth keeping; the screen itself is
-          // about to be drawn properly, so it does not belong in the text too.
-          if (last?.role === "assistant") last.text = last.text.split("\n\n")[0];
-          return;
-        }
-        if (typeof o.setupCommand === "string") {
-          c.setupNeeded = { command: o.setupCommand, why: String(o.error ?? "") };
-          c.attention = "blocked";
-        }
-      });
+      onAgxError(o);
     }
   };
 
@@ -945,7 +1017,15 @@ export async function send(id: string, text: string, isActive: () => boolean, al
 
   let broke = false;
   try {
-    await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, effort: chat.effort, resumeId: chat.sessionId, allowedTools, images, engine }, onEvent, ac.signal);
+    // Codex takes no allowlist (it draws its line around the filesystem, not
+    // per tool call) and no pasted images (it attaches them as file paths), so
+    // neither is sent rather than being sent and ignored. The pane engine is
+    // Claude's too — a Codex turn is always the streamed subprocess.
+    if (chat.agent === "codex") {
+      await api.codexStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, resumeId: chat.sessionId }, onCodexEvent, ac.signal);
+    } else {
+      await api.chatStream({ cwd: chat.cwd, message: msg, model: chat.model, mode: chat.mode, effort: chat.effort, resumeId: chat.sessionId, allowedTools, images, engine }, onEvent, ac.signal);
+    }
   } catch (e) {
     // A queue must not keep firing into a turn that failed or one you just
     // interrupted — the rest of it stays put, visible, for you to decide on.

--- a/web/src/lib/codexFrames.ts
+++ b/web/src/lib/codexFrames.ts
@@ -1,0 +1,273 @@
+// Codex's wire vocabulary, folded into the same conversation the Claude path
+// builds.
+//
+// `codex exec --json` streams a typed JSONL: a `thread.started` naming the
+// thread, a `turn.started`, a run of `item.started` / `item.updated` /
+// `item.completed` carrying one typed item each, and a `turn.completed` (or
+// `turn.failed`) closing it out. Nothing about that shape resembles Claude's
+// stream-json, but everything it says maps onto fields `ChatMsg` / `ChatTool` /
+// `ChatUsage` already have — which is what lets one panel render both without
+// a branch anywhere below the store.
+//
+// This is the whole translation. The server passes Codex's frames through
+// untouched (server/src/codex.ts) precisely so it lives in one file.
+import type { Chat, ChatTool, ChatUsage } from "./chatStore.ts";
+
+const strv = (v: unknown) => (typeof v === "string" && v ? v : null);
+const num = (v: unknown) => (typeof v === "number" && Number.isFinite(v) ? v : 0);
+
+/** Tool output is rendered in a chip; a `cat` of a large file is not worth
+ *  holding in memory, let alone drawing. Matches the spirit of the transcript
+ *  clipping in chatPersist.ts. */
+const MAX_OUTPUT = 20_000;
+const clip = (s: string) => (s.length > MAX_OUTPUT ? s.slice(0, MAX_OUTPUT) + "\n[trimmed]" : s);
+
+/** The item types that read as *work done* rather than as speech. Each becomes
+ *  a tool chip, the same as a Claude `tool_use` block. */
+const TOOL_ITEMS = new Set(["command_execution", "file_change", "mcp_tool_call", "web_search", "todo_list"]);
+
+/**
+ * What to call a Codex item in the tool strip.
+ *
+ * Deliberately Claude's names rather than Codex's: the chip renderer, the tool
+ * mix chart and the session timeline all key off these, and a `file_change`
+ * that drew as its own category would split "edits" into two columns that mean
+ * the same thing. The user is looking at what happened, not at which CLI's noun
+ * for it.
+ */
+function toolName(item: Record<string, unknown>): string {
+  switch (item.type) {
+    case "command_execution": return "Bash";
+    case "file_change": return "Edit";
+    case "web_search": return "WebSearch";
+    case "todo_list": return "TodoWrite";
+    case "mcp_tool_call": {
+      // Field names here are the least pinned-down of the set — the item is
+      // rare enough that it did not turn up in the capture this file was
+      // written against, so both plausible spellings are read before falling
+      // back to something that still says what happened.
+      const server = strv(item.server) ?? strv(item.server_name);
+      const tool = strv(item.tool) ?? strv(item.tool_name) ?? strv(item.name);
+      return server && tool ? `${server}.${tool}` : tool ?? "mcp";
+    }
+    default: return String(item.type ?? "tool");
+  }
+}
+
+/** The paths a `file_change` touched, and what it did to them. */
+function fileChange(item: Record<string, unknown>): { target: string | null; note: string | null } {
+  const changes = Array.isArray(item.changes) ? (item.changes as Array<Record<string, unknown>>) : [];
+  const paths = changes.map((c) => strv(c.path)).filter((p): p is string => !!p);
+  const kinds = [...new Set(changes.map((c) => strv(c.kind)).filter((k): k is string => !!k))];
+  return { target: paths.join(", ") || null, note: kinds.join(", ") || null };
+}
+
+/** What a Codex item acted on — the counterpart of `toolTarget` for the Claude
+ *  path, and the thing the chip actually shows next to the name. */
+function toolTarget(item: Record<string, unknown>): { target: string | null; note: string | null } {
+  switch (item.type) {
+    case "command_execution": return { target: strv(item.command), note: null };
+    case "file_change": return fileChange(item);
+    case "web_search": return { target: strv(item.query), note: null };
+    case "todo_list": {
+      const items = Array.isArray(item.items) ? item.items : [];
+      return { target: items.length ? `${items.length} item${items.length > 1 ? "s" : ""}` : null, note: null };
+    }
+    case "mcp_tool_call": {
+      const args = item.arguments;
+      if (typeof args === "string") return { target: args.slice(0, 200), note: null };
+      if (args && typeof args === "object") { try { return { target: JSON.stringify(args).slice(0, 200), note: null }; } catch { /* cyclic */ } }
+      return { target: null, note: null };
+    }
+    default: return { target: null, note: null };
+  }
+}
+
+/** What a Codex item produced, once it has finished producing it. */
+function toolOutput(item: Record<string, unknown>): string | null {
+  const raw = strv(item.aggregated_output) ?? strv(item.result) ?? strv(item.output);
+  return raw ? clip(raw.trimEnd()) : null;
+}
+
+/**
+ * Whether the item failed.
+ *
+ * `exit_code` is only meaningful once the command has finished — it is `null`
+ * while `status` is `in_progress`, and reading that as zero would mark every
+ * running command green before it had done anything.
+ */
+function toolFailed(item: Record<string, unknown>): boolean {
+  if (item.status === "failed") return true;
+  const code = item.exit_code;
+  return typeof code === "number" && code !== 0;
+}
+
+/**
+ * What the thread has spent.
+ *
+ * Two differences from the Claude path, both of which bite if you assume
+ * otherwise:
+ *
+ *  - **The numbers are cumulative for the whole thread, not for the turn.**
+ *    Measured, not guessed: a one-word third turn moved `output_tokens` from
+ *    258 to 263. So these are assigned, never added — summing them would
+ *    report several times what was actually spent within a handful of turns.
+ *  - **`input_tokens` includes the cached part.** Also measured: the rollout's
+ *    own `total_tokens` equals the input and output counts added together, with
+ *    `cached_input_tokens` nowhere in the sum. Claude's `input_tokens` excludes
+ *    its cache, so the cached portion is subtracted out here — otherwise the
+ *    "In" row would mean one thing for a Claude chat and another for a Codex
+ *    one, in the same column of the same panel.
+ *
+ * `contextTokens` stays zero, which is what suppresses the context meter for a
+ * Codex chat. The exec stream reports no per-turn prompt size and no window,
+ * and the cumulative delta is not a stand-in: a turn makes one API call per
+ * tool round-trip, so the delta over-reads a turn that ran three commands.
+ * contextWindow.ts is explicit that over-reading is the unrecoverable
+ * direction — it draws a session as nearly compacted when it has plenty of
+ * room. No meter is better than a wrong one.
+ */
+export function codexUsage(usage: Record<string, unknown>, prev: ChatUsage | undefined): ChatUsage {
+  const input = num(usage.input_tokens);
+  const cacheRead = num(usage.cached_input_tokens);
+  return {
+    input: Math.max(0, input - cacheRead),
+    output: num(usage.output_tokens),
+    cacheRead,
+    cacheWrite: num(usage.cache_write_input_tokens),
+    contextTokens: 0,
+    // Codex reports tokens, never dollars — there is no `total_cost_usd`
+    // equivalent on this stream. Left at zero, which hides the cost row rather
+    // than filling it from a price table in this repo that would drift. The
+    // fleet view prices Codex turns server-side off the OTel stream, where the
+    // table is actually maintained.
+    costUsd: prev?.costUsd ?? 0,
+  };
+}
+
+/** Append to the assistant turn in progress, creating one if a frame somehow
+ *  arrives before it.
+ *
+ *  Codex says a turn's prose in several complete items rather than as deltas of
+ *  one — a preamble naming what it is about to do, then the answer once it has
+ *  done it. Concatenated bare they read as a single sentence that changes tense
+ *  half way through ("I'll check the line count…This is a scratch repository"),
+ *  so they get the paragraph break they were written with. Anything already
+ *  carrying its own newline — the `[error]` lines below — is left alone. */
+function say(c: Chat, text: string, field: "text" | "thinking") {
+  const last = c.messages[c.messages.length - 1];
+  if (!last || last.role !== "assistant") {
+    c.messages.push({ role: "assistant", text: field === "text" ? text : "", tools: [], ts: Date.now(), ...(field === "thinking" ? { thinking: text } : {}) });
+    return;
+  }
+  const prev = (field === "text" ? last.text : last.thinking) ?? "";
+  const sep = prev && !prev.endsWith("\n") && !text.startsWith("\n") ? "\n\n" : "";
+  if (field === "text") last.text = prev + sep + text;
+  else last.thinking = prev + sep + text;
+}
+
+/** The tool row for this item id, creating it on the turn in progress if this
+ *  is the first frame to mention it. `item.started` and `item.completed` carry
+ *  the same id and describe one call, so this is an upsert — exactly how the
+ *  Claude path keys on `tool_use_id`. */
+function toolRow(c: Chat, id: string): ChatTool {
+  for (let i = c.messages.length - 1; i >= 0; i--) {
+    const found = c.messages[i].tools.find((t) => t.id === id);
+    if (found) return found;
+  }
+  const row: ChatTool = { id, name: "tool", target: null, output: null, error: false, ts: Date.now(), note: null };
+  const last = c.messages[c.messages.length - 1];
+  if (last && last.role === "assistant") last.tools.push(row);
+  else c.messages.push({ role: "assistant", text: "", tools: [row], ts: Date.now() });
+  return row;
+}
+
+/**
+ * Fold one Codex frame into the chat it belongs to.
+ *
+ * Mutates `c` in place, because that is the shape `chatStore.update` hands out.
+ * Everything not specific to Codex's vocabulary — `sending`, the queue, unread,
+ * `agx_error`, abort — stays in the store and is shared with the Claude path.
+ *
+ * Unrecognised frames are ignored rather than surfaced. Codex ships new item
+ * types regularly, and a chat that printed `[unknown frame]` at the user every
+ * time one appeared would be worse than one that simply does not draw it yet.
+ */
+export function applyCodexFrame(c: Chat, frame: Record<string, unknown>): void {
+  switch (frame.type) {
+    case "thread.started": {
+      // The id `codex exec resume` wants for every turn after this one. Codex
+      // keeps it stable across a resume — unlike `claude --resume`, which forks
+      // a fresh session id each time — so this normally reports the same value
+      // the chat already had.
+      const id = strv(frame.thread_id);
+      if (!id) return;
+      c.sessionId = id;
+      c.liveFrom = Date.now();
+      // The exec stream never names the model it ran, so the one we asked for
+      // is the best answer there is. Recorded anyway, so a chat restored from
+      // storage measures against something rather than nothing.
+      c.resolvedModel = c.model;
+      return;
+    }
+    case "item.started":
+    case "item.updated":
+    case "item.completed": {
+      const item = (frame.item ?? {}) as Record<string, unknown>;
+      const id = strv(item.id);
+      const kind = strv(item.type);
+      if (!kind) return;
+
+      if (TOOL_ITEMS.has(kind)) {
+        if (!id) return;
+        const row = toolRow(c, id);
+        const { target, note } = toolTarget(item);
+        row.name = toolName(item);
+        if (target) row.target = target;
+        if (note) row.note = note;
+        const out = toolOutput(item);
+        if (out) row.output = out;
+        row.error = toolFailed(item);
+        return;
+      }
+
+      // Speech and reasoning are taken only from the terminal frame. Codex 0.146
+      // emits each exactly once, as `item.completed`; folding `item.updated` in
+      // as well would double the text the day it starts streaming deltas. The
+      // cost of choosing this way round is that a Codex reply lands whole
+      // instead of typing itself out — which is what it does today regardless.
+      if (frame.type !== "item.completed") return;
+
+      if (kind === "agent_message") {
+        const text = strv(item.text) ?? strv(item.message);
+        if (text) say(c, text, "text");
+        return;
+      }
+      if (kind === "reasoning") {
+        const text = strv(item.text) ?? strv(item.summary) ?? strv(item.content);
+        if (text) say(c, text, "thinking");
+        return;
+      }
+      if (kind === "error") {
+        const text = strv(item.message) ?? strv(item.text) ?? "codex reported an error";
+        say(c, `\n[error] ${text}`, "text");
+        c.attention = "blocked";
+      }
+      return;
+    }
+    case "turn.completed": {
+      const usage = (frame.usage ?? {}) as Record<string, unknown>;
+      c.usage = codexUsage(usage, c.usage);
+      return;
+    }
+    case "turn.failed": {
+      const e = frame.error;
+      const text = strv(e) ?? strv((e as Record<string, unknown> | undefined)?.message) ?? "the turn failed";
+      say(c, `\n[error] ${text}`, "text");
+      // A failed turn will fail the same way again until something changes, so
+      // it asks for you by name rather than going quiet.
+      c.attention = "blocked";
+      return;
+    }
+  }
+}

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -2,6 +2,7 @@ import type { WatchEvent, OpenToolCall, Liveness, SessionRollup } from "../../..
 import { agentKey, fmtMs, sessionTitle } from "./format.ts";
 import { sessionWorktree } from "./worktree.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
+import type { AgentKind } from "./agents.ts";
 
 export type AgentStatus = "working" | "waiting" | "errored" | "idle";
 
@@ -514,8 +515,16 @@ export const sessionIsLive = (
  * `codex exec resume` would be asked to continue a conversation it does not
  * have.
  */
-export const agentOf = (s: { source_app?: string | null; model_name?: string | null }): "claude" | "codex" => {
-  if ((s.source_app ?? "").toLowerCase().startsWith("codex")) return "codex";
+export const agentOf = (s: { source_app?: string | null; model_name?: string | null }): AgentKind => {
+  const app = (s.source_app ?? "").toLowerCase();
+  // Antigravity is matched on `source_app` alone, and only on `source_app`.
+  // Its events are minted by this server (server/src/antigravity.ts), which
+  // sets the name, so the signal is exact rather than a guess — and the model
+  // is no help at all here: `agy` runs Claude and open-weight models as
+  // happily as Gemini ones, so a model-name fallback would file half its
+  // sessions under the wrong CLI.
+  if (app.startsWith("antigravity")) return "antigravity";
+  if (app.startsWith("codex")) return "codex";
   if (/^(gpt|o[134])[-.]/i.test(s.model_name ?? "")) return "codex";
   return "claude";
 };

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -1,5 +1,6 @@
 import type { WatchEvent, OpenToolCall, Liveness, SessionRollup } from "../../../shared/types.ts";
 import { agentKey, fmtMs, sessionTitle } from "./format.ts";
+import { providerOf, UNKNOWN } from "../../../shared/models.ts";
 import { sessionWorktree } from "./worktree.ts";
 import { ctxLimitOf } from "./contextWindow.ts";
 import type { AgentKind } from "./agents.ts";
@@ -515,6 +516,31 @@ export const sessionIsLive = (
  * `codex exec resume` would be asked to continue a conversation it does not
  * have.
  */
+/**
+ * Which CLI could pick this session back up, or null if none of them could.
+ *
+ * Deliberately not `agentOf`, and the difference is the whole point of having
+ * both. `agentOf` answers "whose is this?" and falls back to Claude, because
+ * for labelling a session that is the overwhelmingly likely answer and being
+ * wrong costs a wrong icon. Resuming cannot use a fallback: a Gemini CLI
+ * session would be offered as a Claude one and hand `claude --resume` an id it
+ * has never seen, which fails on the first turn with nothing to explain it.
+ *
+ * So Claude is only accepted when something corroborates it. An unresolved
+ * model still counts — early Claude Code rows recorded no model, and those are
+ * exactly the old sessions worth reaching for — but a session positively
+ * identified as somebody else's (Gemini CLI, an OTel exporter this panel cannot
+ * drive) is refused rather than guessed at.
+ */
+export const resumableAgent = (
+  s: { source_app?: string | null; model_name?: string | null },
+): AgentKind | null => {
+  const a = agentOf(s);
+  if (a !== "claude") return a; // named itself; nothing to second-guess
+  const p = providerOf(s.model_name);
+  return p === "Anthropic" || p === UNKNOWN ? "claude" : null;
+};
+
 export const agentOf = (s: { source_app?: string | null; model_name?: string | null }): AgentKind => {
   const app = (s.source_app ?? "").toLowerCase();
   // Antigravity is matched on `source_app` alone, and only on `source_app`.

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -554,3 +554,33 @@ export const agentOf = (s: { source_app?: string | null; model_name?: string | n
   if (/^(gpt|o[134])[-.]/i.test(s.model_name ?? "")) return "codex";
   return "claude";
 };
+
+/**
+ * Every provider the cockpit has seen, for the header's filter.
+ *
+ * Takes both sources on purpose. `agents` is derived from the live event
+ * buffer, which is capped: a quiet agent — a Codex or Antigravity chat that ran
+ * nine events an hour ago — falls out of it as soon as a busy Claude session
+ * fills it, and any provider it was the only evidence for leaves the filter
+ * with it. That is how the dashboard came to offer "Anthropic" as the only
+ * provider ever seen while the server's own scoped answer listed three models.
+ *
+ * `sessions` is the roll-up over the whole retention window, so it carries the
+ * quiet ones; `agents` is the fresher of the two and carries a session that
+ * started since the last poll. Neither alone is right.
+ *
+ * `unknown` — sessions whose model never resolved — is kept as a real bucket so
+ * it can be filtered to and the per-provider views still add up, but sorted
+ * last so it never leads the list.
+ */
+export function providersSeen(
+  sessions: { session_id: string; model_name?: string | null }[],
+  agents: { session_id: string; model_name?: string | null }[],
+): string[] {
+  const bySession = new Map<string, string>();
+  for (const s of sessions) if (s.model_name) bySession.set(s.session_id, providerOf(s.model_name));
+  for (const a of agents) if (a.model_name) bySession.set(a.session_id, providerOf(a.model_name));
+  const seen = new Set(bySession.values());
+  const known = [...seen].filter((p) => p !== UNKNOWN).sort();
+  return seen.has(UNKNOWN) ? [...known, UNKNOWN] : known;
+}

--- a/web/src/lib/derive.ts
+++ b/web/src/lib/derive.ts
@@ -491,3 +491,31 @@ export const sessionIsLive = (
   s: { ended_at?: number | null; last_seen: number },
   now = Date.now(),
 ): boolean => !s.ended_at && now - s.last_seen < SESSION_LIVE_MS;
+
+/**
+ * Which CLI owns a session on the radar.
+ *
+ * The question only has to be answered to resume one: a thread id means
+ * something to the binary that minted it and nothing to the other, so opening a
+ * Codex session as a Claude chat would hand `claude --resume` an id it has
+ * never seen and fail on the first turn.
+ *
+ * `source_app` is the stronger signal and is checked first. It is whatever the
+ * exporter called itself — Codex's OTel records arrive as `codex_exec` from
+ * `codex exec` and `codex_cli_rs` from the TUI, so this matches on the prefix
+ * rather than on either exact name. Claude Code's hooks send the project
+ * directory's name instead, which is why the model is the fallback and not the
+ * primary: it is the only thing a session with an unfamiliar `source_app` has
+ * to go on.
+ *
+ * Defaults to Claude, because that is the overwhelming majority of what this
+ * app sees and because being wrong in that direction is the recoverable one:
+ * `claude --resume` with a stranger's id reports an unknown session, while
+ * `codex exec resume` would be asked to continue a conversation it does not
+ * have.
+ */
+export const agentOf = (s: { source_app?: string | null; model_name?: string | null }): "claude" | "codex" => {
+  if ((s.source_app ?? "").toLowerCase().startsWith("codex")) return "codex";
+  if (/^(gpt|o[134])[-.]/i.test(s.model_name ?? "")) return "codex";
+  return "claude";
+};

--- a/web/src/lib/useLive.ts
+++ b/web/src/lib/useLive.ts
@@ -9,10 +9,38 @@ import { recordNote, fireDesktopAlert } from "./sysNotify.ts";
 
 const MAX_EVENTS = 2000;
 const FLUSH_MS = 220; // coalesce bursts into ~5 renders/sec
-// Stop hammering a server that won't come back. ~2 minutes of failed reconnects
-// (the backoff tops out at 8s) is long enough to ride out a restart but short
-// enough not to loop forever; becoming visible again resets and retries.
+// Stop *hammering* a server that won't come back. ~2 minutes of failed
+// reconnects (the backoff tops out at 8s) is long enough to ride out a restart.
 const GIVE_UP_MS = 120_000;
+/**
+ * What the retry slows to after that, rather than stopping.
+ *
+ * It used to stop outright, and the only way back was `visibilitychange` — which
+ * a tab sitting in the foreground never receives. So a tab left open and watched
+ * through an outage longer than two minutes disconnected permanently: no events,
+ * no chats, nothing, until somebody reloaded it or happened to switch tabs and
+ * back. The comment here claimed "becoming visible again resets and retries",
+ * which was true of every tab except the one being looked at.
+ *
+ * Slow enough that an unreachable server is not being hammered — one attempt a
+ * minute against a socket that fails immediately is nothing — and quick enough
+ * that a server coming back is noticed without the user doing anything.
+ */
+const IDLE_RETRY_MS = 60_000;
+
+/**
+ * How long to wait before the next reconnect attempt.
+ *
+ * Exported because the invariant worth pinning is not a number but the absence
+ * of one: this always returns a delay. It never says "stop", which is what the
+ * old code did once `failingForMs` passed the give-up window — leaving a
+ * foreground tab, the only kind that receives no `visibilitychange`, dead until
+ * it was reloaded.
+ */
+export function reconnectDelay(failingForMs: number, retry: number): number {
+  if (failingForMs > GIVE_UP_MS) return IDLE_RETRY_MS;
+  return Math.min(8000, 500 * 2 ** retry);
+}
 
 export type ConnState = "connecting" | "open" | "closed" | "unauthorized";
 
@@ -142,8 +170,10 @@ export function useLive(paused = false, keepEvents = true): LiveData {
 
       setConn("closed");
       if (!firstFailAt.current) firstFailAt.current = Date.now();
-      if (Date.now() - firstFailAt.current > GIVE_UP_MS) return; // gave up — see visibility reset
-      reconnectTimer.current = setTimeout(connect, Math.min(8000, 500 * 2 ** retry.current++));
+      // Past the give-up window the backoff stops growing and simply goes
+      // quiet — it never stops. A foreground tab has no other way back.
+      const wait = reconnectDelay(Date.now() - firstFailAt.current, retry.current++);
+      reconnectTimer.current = setTimeout(connect, wait);
     };
     ws.onerror = () => ws.close();
     ws.onmessage = (msg) => {
@@ -337,11 +367,28 @@ export function useLive(paused = false, keepEvents = true): LiveData {
       wsRef.current = null;
       connect();
     };
+    /**
+     * The network came back. Don't sit out a slow retry over it.
+     *
+     * Distinct from the visibility path, which covers a tab returning from the
+     * background: this covers a tab nobody has touched — laptop resumed, wifi
+     * reconnected, VPN back — where nothing about the tab has changed and the
+     * only news is that the machine can reach things again.
+     */
+    const onOnline = () => {
+      if (disposed.current || connRef.current === "open" || connRef.current === "unauthorized") return;
+      if (reconnectTimer.current) { clearTimeout(reconnectTimer.current); reconnectTimer.current = null; }
+      retry.current = 0;
+      firstFailAt.current = 0;
+      connect();
+    };
     document.addEventListener("visibilitychange", onVis);
+    window.addEventListener("online", onOnline);
     window.addEventListener("agentglass:server-changed", onServerChanged);
     return () => {
       disposed.current = true;
       document.removeEventListener("visibilitychange", onVis);
+      window.removeEventListener("online", onOnline);
       window.removeEventListener("agentglass:server-changed", onServerChanged);
       if (timer.current) clearTimeout(timer.current);
       if (reconnectTimer.current) clearTimeout(reconnectTimer.current);

--- a/web/test/antigravity-frames.test.ts
+++ b/web/test/antigravity-frames.test.ts
@@ -1,0 +1,135 @@
+import { test, expect, describe, beforeAll } from "bun:test";
+
+// Antigravity's frames, folded into the same conversation the other two build.
+// The interesting cases are the ones where this stream differs from Codex's in
+// a way that looks the same: deltas that must concatenate rather than get
+// paragraph breaks, and usage that must add rather than be assigned.
+
+let frames: typeof import("../src/lib/antigravityFrames.ts");
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  frames = await import("../src/lib/antigravityFrames.ts");
+});
+
+const UUID = "78126291-f204-4b7a-b218-9a7e7ba9ac9a";
+const chat = (over: Record<string, unknown> = {}) => ({
+  id: "c1", cwd: "/repo", agent: "antigravity", model: "gemini-3.6-flash-low",
+  mode: "request-review", title: "t", messages: [], sessionId: "", sending: true,
+  draft: "", attachments: [], queued: [], createdAt: 1, abort: null, unread: false,
+  attention: "none", ...over,
+}) as any;
+
+const step = (o: Record<string, unknown>) => ({ event: "step_update", step_update: o });
+
+describe("init", () => {
+  test("adopts the conversation id and the model actually run", () => {
+    const c = chat();
+    frames.applyAntigravityFrame(c, {
+      event: "init", conversation_id: UUID,
+      init: { model: "gemini-3.1-pro-high", cwd: "/repo" },
+    });
+    expect(c.sessionId).toBe(UUID);
+    // Unlike the Codex stream, this one names the model it resolved — which is
+    // the better answer than the one we asked for, since `agy` can fall back.
+    expect(c.resolvedModel).toBe("gemini-3.1-pro-high");
+  });
+});
+
+describe("prose", () => {
+  test("deltas concatenate rather than getting paragraph breaks", () => {
+    // The Codex path inserts a blank line between blocks, because Codex says a
+    // turn in several complete items. These really are deltas of one sentence,
+    // so the same treatment would chop a reply mid-word.
+    const c = chat();
+    frames.applyAntigravityFrame(c, step({ step_type: "agent_response", text_delta: "Hello, " }));
+    frames.applyAntigravityFrame(c, step({ step_type: "agent_response", text_delta: "world" }));
+    expect(c.messages[c.messages.length - 1].text).toBe("Hello, world");
+  });
+
+  test("thinking is kept apart from the answer", () => {
+    const c = chat();
+    frames.applyAntigravityFrame(c, step({ step_type: "thinking", text_delta: "weighing it up" }));
+    frames.applyAntigravityFrame(c, step({ step_type: "agent_response", text_delta: "done" }));
+    const last = c.messages[c.messages.length - 1];
+    expect(last.thinking).toBe("weighing it up");
+    expect(last.text).toBe("done");
+  });
+});
+
+describe("tools", () => {
+  test("the two halves of one call are one row", () => {
+    const c = chat();
+    frames.applyAntigravityFrame(c, step({ step_index: 3, state: "ACTIVE", step_type: "tool", tool_name: "list_dir", tool_info: { name: "list_dir", parameters: { DirectoryPath: "/repo/src" } } }));
+    frames.applyAntigravityFrame(c, step({ step_index: 3, state: "DONE", step_type: "tool", tool_name: "list_dir", tool_info: { name: "list_dir", output: "a\nb\n" } }));
+    const tools = c.messages.flatMap((m: any) => m.tools);
+    expect(tools).toHaveLength(1);
+    // Claude's name for the same act, so the chip renderer and the tool-mix
+    // chart do not split one category in two.
+    expect(tools[0].name).toBe("Glob");
+    expect(tools[0].target).toBe("/repo/src");
+    expect(tools[0].output).toBe("a\nb");
+  });
+
+  test("a tool without a Claude counterpart keeps its own name", () => {
+    const c = chat();
+    frames.applyAntigravityFrame(c, step({ step_index: 1, state: "ACTIVE", step_type: "tool", tool_name: "generate_image" }));
+    expect(c.messages.flatMap((m: any) => m.tools)[0].name).toBe("generate_image");
+  });
+
+  test("an error step marks the tool it followed, rather than printing nothing", () => {
+    // The stream reports that something failed without saying what — the step
+    // carries no message at all. Printing an empty `[error]` would be worse
+    // than pointing at the call that produced it.
+    const c = chat();
+    frames.applyAntigravityFrame(c, step({ step_index: 2, state: "ACTIVE", step_type: "tool", tool_name: "view_file" }));
+    frames.applyAntigravityFrame(c, step({ step_index: 3, state: "DONE", step_type: "error_message" }));
+    expect(c.messages.flatMap((m: any) => m.tools)[0].error).toBe(true);
+  });
+});
+
+describe("usage", () => {
+  test("adds across turns, because these figures are per turn", () => {
+    // Measured against agy 1.1.9: turn 1 reported 31789 input tokens and turn 2
+    // reported 16609, which cannot be a running total. Codex's are cumulative
+    // and must be assigned instead — the two streams look alike here and mean
+    // opposite things, and getting it backwards over-reports spend severalfold.
+    const c = chat();
+    frames.applyAntigravityFrame(c, { event: "result", result: { status: "SUCCESS", usage: { input_tokens: 31789, output_tokens: 1226, cache_read_tokens: 65081 } } });
+    frames.applyAntigravityFrame(c, { event: "result", result: { status: "SUCCESS", usage: { input_tokens: 16609, output_tokens: 108, cache_read_tokens: 61046 } } });
+    expect(c.usage.input).toBe(31789 + 16609);
+    expect(c.usage.output).toBe(1226 + 108);
+    expect(c.usage.cacheRead).toBe(65081 + 61046);
+  });
+
+  test("no context meter, because nothing here measures one", () => {
+    // `agy` reports no window and ctxLimitOf does not know the Gemini 3.x
+    // families, so a bar drawn here would state a fullness nobody measured.
+    const c = chat();
+    frames.applyAntigravityFrame(c, { event: "result", result: { status: "SUCCESS", usage: { input_tokens: 9000 } } });
+    expect(c.usage.contextTokens).toBe(0);
+    // Nor a cost: there is no price on this stream and no table for a model mix
+    // spanning three vendors.
+    expect(c.usage.costUsd).toBe(0);
+  });
+
+  test("a turn that ended badly asks for you", () => {
+    const c = chat();
+    frames.applyAntigravityFrame(c, { event: "result", result: { status: "ERROR", usage: {} } });
+    expect(c.attention).toBe("blocked");
+    expect(c.messages[c.messages.length - 1].text).toContain("[error]");
+  });
+});
+
+describe("frames it does not know", () => {
+  test("are ignored rather than shown", () => {
+    // The CLI ships new step types; a chat that printed "[unknown frame]" at
+    // the user each time would be worse than one that does not draw it yet.
+    const c = chat();
+    const before = JSON.stringify(c.messages);
+    frames.applyAntigravityFrame(c, step({ step_type: "browser_action", step_index: 9 }));
+    frames.applyAntigravityFrame(c, step({ step_type: "checkpoint", step_index: 10 }));
+    frames.applyAntigravityFrame(c, { event: "something_new_entirely" });
+    expect(JSON.stringify(c.messages)).toBe(before);
+  });
+});

--- a/web/test/chat-agent.test.ts
+++ b/web/test/chat-agent.test.ts
@@ -52,6 +52,44 @@ describe("agentOf", () => {
   });
 });
 
+describe("resumableAgent", () => {
+  // The resume picker used to offer Anthropic sessions only, which was right
+  // when Claude was the one agent and stayed wrong after Codex and Antigravity
+  // could both pick their own threads back up.
+  test("each agent is offered its own sessions", () => {
+    expect(derive.resumableAgent({ source_app: "my-project", model_name: "claude-opus-5" })).toBe("claude");
+    expect(derive.resumableAgent({ source_app: "codex_exec", model_name: "gpt-5.6-sol" })).toBe("codex");
+    expect(derive.resumableAgent({ source_app: "antigravity", model_name: "gemini-3.6-flash-low" })).toBe("antigravity");
+  });
+
+  test("a session no CLI here can drive is refused, not guessed at", () => {
+    // The whole reason this is not `agentOf`. That function falls back to
+    // Claude, which for a label is the likely answer and costs a wrong icon —
+    // but resuming on that guess hands `claude --resume` an id it has never
+    // seen, and the turn fails with nothing on screen to explain it.
+    expect(derive.resumableAgent({ source_app: "gemini-cli", model_name: "gemini-2.5-pro" })).toBeNull();
+    expect(derive.resumableAgent({ source_app: "some-exporter", model_name: "kimi-k2" })).toBeNull();
+    expect(derive.resumableAgent({ source_app: "x", model_name: "deepseek-v3" })).toBeNull();
+    // ...while agentOf still answers "claude" for exactly those, which is what
+    // makes them two functions rather than one.
+    expect(derive.agentOf({ source_app: "gemini-cli", model_name: "gemini-2.5-pro" })).toBe("claude");
+  });
+
+  test("a session with no model recorded is still Claude's", () => {
+    // Early Claude Code rows recorded no model, and those are exactly the old
+    // sessions somebody reaches for. Refusing them would hide the ones the
+    // picker exists for.
+    expect(derive.resumableAgent({ source_app: "my-project", model_name: null })).toBe("claude");
+    expect(derive.resumableAgent({})).toBe("claude");
+  });
+
+  test("an Antigravity session running a Claude model is still Antigravity's", () => {
+    // `agy` runs claude-opus-4-6-thinking, and handing that thread to `claude
+    // --resume` would fail. source_app decides, and it is set by this server.
+    expect(derive.resumableAgent({ source_app: "antigravity", model_name: "claude-opus-4-6-thinking" })).toBe("antigravity");
+  });
+});
+
 describe("switchAgent", () => {
   test("takes the model and the mode with it", () => {
     // Both are the agent's own vocabulary. Carrying `claude-opus-5` across would

--- a/web/test/chat-agent.test.ts
+++ b/web/test/chat-agent.test.ts
@@ -29,6 +29,18 @@ describe("agentOf", () => {
     expect(derive.agentOf({ source_app: "my-project", model_name: "claude-opus-5" })).toBe("claude");
   });
 
+  test("recognises antigravity, and only by its exporter name", () => {
+    // This is the one agent whose events this server mints itself, so the name
+    // is exact rather than a guess. The model is no help at all: `agy` runs
+    // Claude and open-weight models as happily as Gemini ones, so a model-name
+    // fallback would file half its sessions under the wrong CLI.
+    expect(derive.agentOf({ source_app: "antigravity", model_name: "gemini-3.1-pro-high" })).toBe("antigravity");
+    expect(derive.agentOf({ source_app: "antigravity", model_name: "claude-opus-4-6-thinking" })).toBe("antigravity");
+    // And the converse: a Claude model name does not make a Claude session out
+    // of an Antigravity one.
+    expect(derive.agentOf({ source_app: "antigravity", model_name: "gpt-oss-120b-medium" })).toBe("antigravity");
+  });
+
   test("defaults to claude on anything unrecognised", () => {
     // The recoverable direction: `claude --resume` with a stranger's id reports
     // an unknown session, while `codex exec resume` would be asked to continue
@@ -49,6 +61,18 @@ describe("switchAgent", () => {
     store.switchAgent(c.id, "codex");
     const after = store.getChat(c.id)!;
     expect([after.agent, after.model, after.mode]).toEqual(["codex", store.DEFAULT_CODEX_MODEL, store.DEFAULT_CODEX_MODE]);
+    store.closeChat(c.id);
+  });
+
+  test("carries the third agent's own defaults too", () => {
+    const c = store.newChat("/tmp/repo");
+    store.switchAgent(c.id, "antigravity");
+    const after = store.getChat(c.id)!;
+    expect([after.agent, after.model, after.mode])
+      .toEqual(["antigravity", store.DEFAULT_ANTIGRAVITY_MODEL, store.DEFAULT_ANTIGRAVITY_MODE]);
+    // And back again, without keeping a mode the other CLI has never heard of.
+    store.switchAgent(c.id, "codex");
+    expect(store.getChat(c.id)!.mode).toBe(store.DEFAULT_CODEX_MODE);
     store.closeChat(c.id);
   });
 
@@ -95,6 +119,17 @@ describe("persistence", () => {
     // by a version bump.
     const { agent, ...legacy } = chat({});
     cell.set("agentglass.chats.v1", JSON.stringify({ v: 1, activeId: "c1-abc", chats: [legacy] }));
+    expect(persist.loadChats().chats[0].agent).toBe("claude");
+
+    // The third agent survives a reload for the same reason, and this is the
+    // case that matters most for it: an Antigravity chat has no transcript to
+    // replay, so what is written down here *is* its history.
+    persist.saveChats([chat({ agent: "antigravity", model: "gemini-3.6-flash-low", mode: "request-review" })], "c1-abc");
+    expect(persist.loadChats().chats[0].agent).toBe("antigravity");
+
+    // Anything that is not one of the three is Claude, rather than a chat tab
+    // pointed at a CLI this build has never heard of.
+    persist.saveChats([chat({ agent: "gemini" })], "c1-abc");
     expect(persist.loadChats().chats[0].agent).toBe("claude");
   });
 });

--- a/web/test/chat-agent.test.ts
+++ b/web/test/chat-agent.test.ts
@@ -1,0 +1,100 @@
+import { test, expect, beforeAll, describe } from "bun:test";
+
+// A chat is bound to one CLI for its life. These pin the three places that
+// binding has to survive or be enforced: which agent a session on the radar
+// belongs to, that a restored tab comes back pointed at the same CLI, and that
+// the agent can only be changed while there is no thread to strand.
+
+let store: typeof import("../src/lib/chatStore.ts");
+let derive: typeof import("../src/lib/derive.ts");
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  store = await import("../src/lib/chatStore.ts");
+  derive = await import("../src/lib/derive.ts");
+});
+
+describe("agentOf", () => {
+  test("recognises both of Codex's exporter names", () => {
+    // `codex exec` reports codex_exec, the TUI reports codex_cli_rs — matched on
+    // the prefix so a third name does not need a code change.
+    expect(derive.agentOf({ source_app: "codex_exec", model_name: "gpt-5.6-sol" })).toBe("codex");
+    expect(derive.agentOf({ source_app: "codex_cli_rs", model_name: "gpt-5.6-luna" })).toBe("codex");
+  });
+
+  test("falls back to the model when the exporter name says nothing", () => {
+    // Claude Code's hooks send the project directory's name, so `source_app` is
+    // not a reliable positive signal for either side — only for Codex.
+    expect(derive.agentOf({ source_app: "my-project", model_name: "gpt-5.5" })).toBe("codex");
+    expect(derive.agentOf({ source_app: "my-project", model_name: "claude-opus-5" })).toBe("claude");
+  });
+
+  test("defaults to claude on anything unrecognised", () => {
+    // The recoverable direction: `claude --resume` with a stranger's id reports
+    // an unknown session, while `codex exec resume` would be asked to continue
+    // a conversation it does not have.
+    expect(derive.agentOf({ source_app: "", model_name: null })).toBe("claude");
+    expect(derive.agentOf({})).toBe("claude");
+    // Not every `gpt` substring is a model id — the match is anchored.
+    expect(derive.agentOf({ source_app: "gpt-notes-app", model_name: "claude-sonnet-5" })).toBe("claude");
+  });
+});
+
+describe("switchAgent", () => {
+  test("takes the model and the mode with it", () => {
+    // Both are the agent's own vocabulary. Carrying `claude-opus-5` across would
+    // leave the dropdown showing a choice the server replaces with its default.
+    const c = store.newChat("/tmp/repo");
+    expect([c.agent, c.model, c.mode]).toEqual(["claude", store.DEFAULT_MODEL, store.DEFAULT_MODE]);
+    store.switchAgent(c.id, "codex");
+    const after = store.getChat(c.id)!;
+    expect([after.agent, after.model, after.mode]).toEqual(["codex", store.DEFAULT_CODEX_MODEL, store.DEFAULT_CODEX_MODE]);
+    store.closeChat(c.id);
+  });
+
+  test("refuses once the chat holds a thread", () => {
+    // A resume id means something only to the CLI that minted it, so switching
+    // here would strand the conversation rather than move it.
+    const c = store.newChat("/tmp/repo");
+    store.update(c.id, (x) => { x.sessionId = "019fb903-f445-7db2-b314-35995fc1f77f"; });
+    store.switchAgent(c.id, "codex");
+    expect(store.getChat(c.id)!.agent).toBe("claude");
+    store.closeChat(c.id);
+  });
+
+  test("refuses once anything has been said", () => {
+    const c = store.newChat("/tmp/repo");
+    store.update(c.id, (x) => { x.messages.push({ role: "user", text: "go", tools: [], ts: 1 }); });
+    store.switchAgent(c.id, "codex");
+    expect(store.getChat(c.id)!.agent).toBe("claude");
+    store.closeChat(c.id);
+  });
+});
+
+describe("persistence", () => {
+  test("a restored tab comes back pointed at the same CLI", async () => {
+    const persist = await import("../src/lib/chatPersist.ts");
+    const chat = (over: Record<string, unknown>) => ({
+      id: "c1-abc", cwd: "/repo", agent: "codex", model: "gpt-5.6-sol", mode: "read-only",
+      title: "t", messages: [], sessionId: "019fb903-f445-7db2-b314-35995fc1f77f", sending: false,
+      draft: "", attachments: [], queued: [], createdAt: 1000, abort: null, unread: false,
+      attention: "none", ...over,
+    }) as any;
+    const cell = new Map<string, string>();
+    (globalThis as any).localStorage = {
+      getItem: (k: string) => cell.get(k) ?? null,
+      setItem: (k: string, v: string) => { cell.set(k, v); },
+      removeItem: (k: string) => { cell.delete(k); },
+    };
+    persist.saveChats([chat({})], "c1-abc");
+    expect(persist.loadChats().chats[0].agent).toBe("codex");
+
+    // Everything written before chats had a second agent was a Claude chat. A
+    // missing field is an older payload saying what it knew, not corruption —
+    // defaulting it is what lets those tabs survive instead of being thrown out
+    // by a version bump.
+    const { agent, ...legacy } = chat({});
+    cell.set("agentglass.chats.v1", JSON.stringify({ v: 1, activeId: "c1-abc", chats: [legacy] }));
+    expect(persist.loadChats().chats[0].agent).toBe("claude");
+  });
+});

--- a/web/test/codex-frames.test.ts
+++ b/web/test/codex-frames.test.ts
@@ -1,0 +1,192 @@
+// Codex's frames, folded into a chat.
+//
+// The frames below are a real capture from `codex exec --json` (CLI 0.146) —
+// a first turn that ran a command, then a resumed turn that edited a file, then
+// a one-word third turn. They are pasted verbatim rather than hand-written,
+// because every assumption this parser makes about Codex's vocabulary was read
+// off this capture and nothing else documents it.
+import { test, expect, beforeAll, describe } from "bun:test";
+
+let store: typeof import("../src/lib/chatStore.ts");
+let frames: typeof import("../src/lib/codexFrames.ts");
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  store = await import("../src/lib/chatStore.ts");
+  frames = await import("../src/lib/codexFrames.ts");
+});
+
+/** A codex chat mid-turn: the user's message and the empty assistant turn
+ *  `send()` pushes before any frame arrives. */
+function turning() {
+  const c = store.newChat("/tmp/repo", "gpt-5.6-sol", "read-only", undefined, "codex");
+  store.update(c.id, (x) => {
+    x.messages.push({ role: "user", text: "go", tools: [], ts: Date.now() });
+    x.messages.push({ role: "assistant", text: "", tools: [], ts: Date.now(), streaming: true });
+  });
+  return c.id;
+}
+
+const play = (id: string, ...fs: Array<Record<string, unknown>>) => {
+  for (const f of fs) store.update(id, (c) => frames.applyCodexFrame(c, f));
+};
+const chat = (id: string) => store.getChat(id)!;
+/** The assistant turn in progress — index 1, after the user message. */
+const reply = (id: string) => chat(id).messages[1];
+
+// --- the capture -------------------------------------------------------------
+const THREAD = "019fb8f6-aabc-72e3-80fe-66edcdf559f5";
+const TURN_ONE: Array<Record<string, unknown>> = [
+  { type: "thread.started", thread_id: THREAD },
+  { type: "turn.started" },
+  { type: "item.completed", item: { id: "item_0", type: "agent_message", text: "I’ll check the line count, read the README, and summarize." } },
+  { type: "item.started", item: { id: "item_1", type: "command_execution", command: "/usr/bin/bash -lc \"wc -l README.md\"", aggregated_output: "", exit_code: null, status: "in_progress" } },
+  { type: "item.completed", item: { id: "item_1", type: "command_execution", command: "/usr/bin/bash -lc \"wc -l README.md\"", aggregated_output: "3 README.md\n", exit_code: 0, status: "completed" } },
+  { type: "item.completed", item: { id: "item_2", type: "agent_message", text: "This is a scratch repository." } },
+  { type: "turn.completed", usage: { input_tokens: 30377, cached_input_tokens: 24064, cache_write_input_tokens: 0, output_tokens: 132, reasoning_output_tokens: 19 } },
+];
+
+describe("a turn as codex actually reports it", () => {
+  test("the thread id, the reply, and the command that ran all land", () => {
+    const id = turning();
+    play(id, ...TURN_ONE);
+    const c = chat(id);
+    // The id every following turn is resumed with.
+    expect(c.sessionId).toBe(THREAD);
+    const last = c.messages[c.messages.length - 1];
+    // Codex says a turn in several complete items; they read as one reply, but
+    // as separate paragraphs rather than one run-on sentence.
+    expect(last.text).toBe("I’ll check the line count, read the README, and summarize.\n\nThis is a scratch repository.");
+    const [tool] = last.tools;
+    expect([tool.name, tool.target, tool.output, tool.error])
+      .toEqual(["Bash", "/usr/bin/bash -lc \"wc -l README.md\"", "3 README.md", false]);
+  });
+
+  test("item.started and item.completed are one call, not two", () => {
+    const id = turning();
+    play(id, ...TURN_ONE);
+    expect(reply(id).tools).toHaveLength(1);
+  });
+
+  test("a running command is not reported as having succeeded", () => {
+    // `exit_code` is null while status is in_progress. Reading that as zero
+    // would mark every command green before it had done anything.
+    const id = turning();
+    play(id, TURN_ONE[3]);
+    expect(reply(id).tools[0].error).toBe(false);
+    expect(reply(id).tools[0].output).toBe(null);
+  });
+
+  test("prose is taken from the terminal frame only, so it is never drawn twice", () => {
+    // 0.146 emits each agent_message once, as item.completed. Folding
+    // item.updated in as well would double the reply the day Codex starts
+    // streaming deltas — a silent failure that reads as the model stuttering.
+    // The cost of choosing this way round is a reply that lands whole instead
+    // of typing itself out, which is what it does today regardless.
+    const id = turning();
+    play(id,
+      { type: "item.updated", item: { id: "item_0", type: "agent_message", text: "Half a th" } },
+      { type: "item.completed", item: { id: "item_0", type: "agent_message", text: "Half a thought." } },
+    );
+    expect(reply(id).text).toBe("Half a thought.");
+  });
+
+  test("a failed command is marked from its exit code", () => {
+    const id = turning();
+    play(id, { type: "item.completed", item: { id: "i", type: "command_execution", command: "false", aggregated_output: "", exit_code: 1, status: "completed" } });
+    expect(reply(id).tools[0].error).toBe(true);
+  });
+});
+
+describe("usage", () => {
+  test("is assigned, not accumulated — codex reports thread totals", () => {
+    // Measured against the real CLI: a one-word third turn moved output_tokens
+    // from 258 to 263. Summing these would report several times the real spend
+    // within a handful of turns.
+    const id = turning();
+    play(id, ...TURN_ONE);
+    play(id, { type: "turn.completed", usage: { input_tokens: 61749, cached_input_tokens: 49152, cache_write_input_tokens: 0, output_tokens: 258 } });
+    play(id, { type: "turn.completed", usage: { input_tokens: 77692, cached_input_tokens: 64256, cache_write_input_tokens: 0, output_tokens: 263 } });
+    const u = chat(id).usage!;
+    expect(u.output).toBe(263);
+    expect(u.cacheRead).toBe(64256);
+    // input_tokens includes the cached part; Claude's excludes it. The column
+    // has to mean the same thing in both, so the cache is subtracted out.
+    expect(u.input).toBe(77692 - 64256);
+  });
+
+  test("no context meter and no cost, because codex reports neither", () => {
+    // The exec stream carries no per-turn prompt size and no window, and the
+    // cumulative delta over-reads a turn that made several API calls. A missing
+    // meter is better than one drawn nearly full on a session with room.
+    const id = turning();
+    play(id, ...TURN_ONE);
+    expect(chat(id).usage!.contextTokens).toBe(0);
+    expect(chat(id).usage!.costUsd).toBe(0);
+  });
+
+  test("a usage object missing fields does not produce NaN", () => {
+    const id = turning();
+    play(id, { type: "turn.completed", usage: {} });
+    expect(chat(id).usage).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0, contextTokens: 0, costUsd: 0 });
+  });
+});
+
+describe("the other item types", () => {
+  test("a file change names what it touched and what it did", () => {
+    const id = turning();
+    play(id, { type: "item.completed", item: { id: "i", type: "file_change", changes: [{ path: "/tmp/repo/README.md", kind: "update" }], status: "completed" } });
+    const [t] = reply(id).tools;
+    expect([t.name, t.target, t.note]).toEqual(["Edit", "/tmp/repo/README.md", "update"]);
+  });
+
+  test("reasoning is kept apart from the answer", () => {
+    const id = turning();
+    play(id, { type: "item.completed", item: { id: "i", type: "reasoning", text: "thinking out loud" } });
+    const last = reply(id);
+    expect(last.thinking).toBe("thinking out loud");
+    expect(last.text).toBe("");
+  });
+
+  test("a web search shows its query", () => {
+    const id = turning();
+    play(id, { type: "item.completed", item: { id: "i", type: "web_search", query: "bun test timeout" } });
+    const [t] = reply(id).tools;
+    expect([t.name, t.target]).toEqual(["WebSearch", "bun test timeout"]);
+  });
+});
+
+describe("failure", () => {
+  test("a failed turn says so and asks for you", () => {
+    const id = turning();
+    play(id, { type: "turn.failed", error: { message: "rate limit reached" } });
+    expect(reply(id).text).toContain("[error] rate limit reached");
+    expect(chat(id).attention).toBe("blocked");
+  });
+
+  test("an error item is surfaced in the reply", () => {
+    const id = turning();
+    play(id, { type: "item.completed", item: { id: "i", type: "error", message: "the model refused" } });
+    expect(reply(id).text).toContain("[error] the model refused");
+  });
+});
+
+describe("frames we do not understand", () => {
+  test("are ignored rather than drawn", () => {
+    // Codex ships new item types regularly. A chat that printed "[unknown
+    // frame]" every time one appeared would be worse than one that just does
+    // not draw it yet.
+    const id = turning();
+    play(id,
+      { type: "turn.started" },
+      { type: "something.new", payload: { a: 1 } },
+      { type: "item.completed", item: { id: "i", type: "a_type_from_the_future", detail: "x" } },
+      { type: "item.completed", item: {} },
+      {},
+    );
+    const c = chat(id);
+    expect(c.messages).toHaveLength(2);
+    expect(reply(id).text).toBe("");
+    expect(reply(id).tools).toHaveLength(0);
+  });
+});

--- a/web/test/providers-seen.test.ts
+++ b/web/test/providers-seen.test.ts
@@ -1,0 +1,53 @@
+import { test, expect, describe, beforeAll } from "bun:test";
+
+// The header's provider filter, reported wrong twice: once when Codex sessions
+// were invisible for want of a project, and again when a quiet agent aged out
+// of the live event buffer and took its provider with it.
+
+let derive: typeof import("../src/lib/derive.ts");
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  derive = await import("../src/lib/derive.ts");
+});
+
+const s = (session_id: string, model_name: string | null) => ({ session_id, model_name });
+
+describe("providersSeen", () => {
+  test("a quiet agent is not lost when the event buffer moves on", () => {
+    // The actual failure: an Antigravity chat ran nine events an hour ago, a
+    // busy Claude session filled the capped buffer, and the filter then claimed
+    // Anthropic was the only provider this machine had ever seen — while the
+    // server's own scoped answer still listed gemini-3.6-flash-low.
+    const sessions = [s("a", "claude-opus-5"), s("b", "gemini-3.6-flash-low")];
+    const live = [s("a", "claude-opus-5")]; // only the busy one survived
+    expect(derive.providersSeen(sessions, live)).toEqual(["Anthropic", "Google"]);
+  });
+
+  test("a session too new for the roll-up still counts", () => {
+    // The other direction, and why neither source alone is right: /sessions is
+    // polled, so a chat started since the last poll exists only in the buffer.
+    expect(derive.providersSeen([], [s("c", "gpt-5.6-sol")])).toEqual(["OpenAI"]);
+  });
+
+  test("the live buffer wins on a model that resolved later", () => {
+    // A session whose model was unknown at roll-up time and named since.
+    expect(derive.providersSeen([s("d", null)], [s("d", "claude-opus-5")])).toEqual(["Anthropic"]);
+  });
+
+  test("unknown is a real bucket, and always last", () => {
+    // Kept so it can be filtered to and the per-provider views still add up.
+    const out = derive.providersSeen([s("e", "mystery-model-9")], [s("f", "claude-opus-5")]);
+    expect(out).toEqual(["Anthropic", "unknown"]);
+  });
+
+  test("one session counted once, whichever source it came from", () => {
+    expect(derive.providersSeen([s("g", "claude-opus-5")], [s("g", "claude-opus-5")])).toEqual(["Anthropic"]);
+  });
+
+  test("nothing seen yet is an empty list, not a fake default", () => {
+    // The header renders a disabled single-provider chip when there is exactly
+    // one; claiming a provider nobody has used would make that chip a lie.
+    expect(derive.providersSeen([], [])).toEqual([]);
+  });
+});

--- a/web/test/reconnect-delay.test.ts
+++ b/web/test/reconnect-delay.test.ts
@@ -1,0 +1,56 @@
+import { test, expect, describe, beforeAll } from "bun:test";
+
+// A tab that was watched through an outage stopped reconnecting and never
+// started again. The give-up was real and deliberate — don't hammer a server
+// that isn't coming back — but its only recovery was `visibilitychange`, which
+// the foreground tab is precisely the one that never receives. So the tab being
+// looked at was the one that stayed dead.
+
+let live: typeof import("../src/lib/useLive.ts");
+beforeAll(async () => {
+  (globalThis as any).location ??= new URL("http://localhost:5173/");
+  (globalThis as any).localStorage ??= { getItem: () => null, setItem: () => {}, removeItem: () => {} };
+  live = await import("../src/lib/useLive.ts");
+});
+
+const MIN = 60_000;
+
+describe("reconnectDelay", () => {
+  test("backs off fast at first, capped at 8s", () => {
+    expect(live.reconnectDelay(0, 0)).toBe(500);
+    expect(live.reconnectDelay(1_000, 1)).toBe(1000);
+    expect(live.reconnectDelay(5_000, 3)).toBe(4000);
+    // The cap: a restart should be noticed within seconds, not minutes.
+    expect(live.reconnectDelay(30_000, 8)).toBe(8000);
+    expect(live.reconnectDelay(60_000, 40)).toBe(8000);
+  });
+
+  test("slows down past the give-up window instead of stopping", () => {
+    // This is the fix. It used to return nothing and schedule nothing here.
+    expect(live.reconnectDelay(2 * MIN + 1, 50)).toBe(MIN);
+    expect(live.reconnectDelay(60 * MIN, 5000)).toBe(MIN);
+  });
+
+  test("always answers with a delay, however long it has been failing", () => {
+    // The invariant that matters is the absence of a "stop" answer: a tab left
+    // open overnight against a dead server must still be trying in the morning,
+    // because nothing else will restart it.
+    for (const failingFor of [0, 1, MIN, 2 * MIN, 10 * MIN, 24 * 60 * MIN]) {
+      const d = live.reconnectDelay(failingFor, 999);
+      expect(Number.isFinite(d), `no delay at ${failingFor}ms`).toBe(true);
+      expect(d).toBeGreaterThan(0);
+    }
+  });
+
+  test("never retries faster than twice a second, and never slower than a minute", () => {
+    // Two bounds worth holding: the first keeps a broken server from being
+    // hammered, the second keeps a recovered one from going unnoticed.
+    for (let retry = 0; retry < 40; retry++) {
+      for (const failingFor of [0, 30_000, 3 * MIN]) {
+        const d = live.reconnectDelay(failingFor, retry);
+        expect(d).toBeGreaterThanOrEqual(500);
+        expect(d).toBeLessThanOrEqual(MIN);
+      }
+    }
+  });
+});


### PR DESCRIPTION
The chat panel gains two more agents. It drove `claude`; it now also drives **`codex`** and **`agy`** (Google Antigravity).

All three are driven the same way — spawn the CLI non-interactively, stream its JSONL back — and all three land in the same `ChatMsg` / `ChatTool` / `ChatUsage` shapes, which is what lets one panel render any of them without a branch below the store.

> **Antigravity is not the Gemini CLI, and does not replace it.** Separate binary, separate state, and a model list that offers `claude-sonnet-4-6` and `gpt-oss-120b-medium` alongside Google's. Gemini CLI keeps its existing OpenTelemetry route onto the radar, untouched.

## Each CLI keeps its own vocabulary

Rather than being mapped onto Claude's:

- **Codex** modes are filesystem sandboxes (Read-only / Write in this repo / ⚡ Full access). No allowlist box — it decides at the filesystem boundary, not per tool call.
- **Antigravity** modes *do* land on Claude's four (Ask / Plan / Auto-accept edits / ⚡ Bypass), because it really does decide per call and really does have a plan mode. That is the CLI's shape, not a mapping imposed here.
- Model lists come from each CLI — Codex's `models_cache.json`, `agy models` — so they follow the vendor instead of a table here that goes stale on every release.

A chat is bound to one CLI for life: the agent picker is switchable until it holds a thread, then frozen. A resume id means something only to the binary that minted it.

## Antigravity reports to nobody, so the panel reports for it

Claude reaches the fleet through hooks and Codex through OpenTelemetry. Antigravity exports neither, so a chat started here would appear on the radar nowhere at all.

Its frames already carry everything an event needs, so the stream is teed: out to the browser verbatim, and through `frameToEvent` into the same `ingestBody` path the other intakes use.

```
init         → SessionStart      user_input → UserPromptSubmit
tool ACTIVE  → PreToolUse        tool DONE  → PostToolUse
result       → Turn complete
```

`source_app` is `"antigravity"`, which is load-bearing rather than cosmetic: `agy` can run `claude-opus-4-6-thinking`, so the model name is an actively misleading signal for "which CLI is this?"

The tee is server-side because what the fleet knows should not sit behind a tab that can be closed mid-turn. **Only chats started here are covered** — a terminal `agy` stays invisible, and the README says so rather than implying otherwise.

## Capabilities that are absent are left off, not faked

| | Codex | Antigravity |
|---|---|---|
| Resume from disk | ✅ JSONL rollout | ❌ protobuf in SQLite |
| Cost | ✅ priced server-side | ❌ no price on the stream |
| Context meter | ❌ no per-turn prompt size | ❌ no window reported |

Antigravity's conversations are protobuf blobs on an undocumented internal schema; decoding them would break on any CLI update. And `ctxLimitOf` does not know the Gemini 3.x families, so a context bar would fall back to a default ceiling and state a fullness nobody measured.

## Usage semantics differ, and look identical

Codex reports **cumulative thread totals** — assigned. Antigravity reports **per-turn figures** — added. Measured, not inferred: Antigravity's turn 1 reported 31789 input tokens and turn 2 reported 16609, which cannot be a running total. Getting this backwards over-reports spend severalfold and nothing fails loudly.

## The refactor three agents earned

Two agents justified `agent === "codex" ? … : …`; three did not — a missed branch is silent, a Claude default quietly applied to something that is not Claude. `AGENTS` in `web/src/lib/agents.ts` now holds what differs (label, binary, defaults, unattended mode, whether it takes attachments, whether it has a transcript), so a fourth CLI is an entry rather than a search. Its own module because `chatPersist` needs it too, and importing from the store would put a cycle between them.

One operator opt-in (`AGENTGLASS_CHAT_BYPASS`) covers the unattended mode of all three, since it is the same decision — the README previously documented only the Claude half.

## Verification

- **web:** 966 pass, 0 fail · `tsc --noEmit` clean · `vite build` succeeds
- **server:** 1423 pass. The 2 failures are pre-existing on a clean `main` in this environment (one flaky tmux pane test; one test that assumes `codex` is absent from `PATH`, where this machine has it). Verified by stashing and re-running.
- **Driven for real**, not just unit-tested: a live `agy` turn through `POST /antigravity/send`, confirmed landing in the fleet with the right agent, model, tool pairing (`tool_mix: list_dir ×1`) and tokens. That smoke test is what caught the missing `cwd` / `project_path` on synthesized events — without them a chat landed in the store and then showed up nowhere, which is indistinguishable from never having been recorded. Now pinned by a test.

Design notes: `docs/superpowers/specs/2026-07-31-antigravity-agent-design.md`. `docs/EXTENDING.md` gains what the third CLI taught, where "a third CLI would repeat that shape" used to be a prediction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
