### PR TITLE
Fix the About tab, which cannot name its own version outside the desktop app

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -82,7 +82,7 @@ import { privateHost } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt, callerFor, allowed, scopeNeeded, type Caller } from "./auth.ts";
 import { activeDevices, markSeen, revokeDevice, type Scope } from "./devices.ts";
 import { mintTicket, claimTicket, pending as pendingPairings, acceptTicket, rejectTicket, collect as collectPairing, dropTicket, getTicket, MAX_ATTEMPTS } from "./pairing.ts";
-import { updateStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
+import { updateStatus, viewerStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
 import { rateOk } from "./ratelimit.ts";
 import { noteClient, noteSocket, isLoopback, isSelf, isBlocked, blockDevice, remoteStatus, tailnetNames, refreshTailscale } from "./remote.ts";
 import { parseWindowMs } from "./params.ts";
@@ -1381,16 +1381,23 @@ const server = Bun.serve<WsData>({
       const paths = url.searchParams.getAll("path").slice(0, 50);
       return json({ leftovers: await Promise.all(paths.map((p) => worktreeLeftovers(root, p))) });
     }
-    // Update: reads are gated too, since the status alone reveals the source
-    // path on disk.
+    // Update: the full status reveals the source path on disk, the remote it
+    // pulls from and the last run's log tail, so it stays desktop-only. Refusing
+    // everyone else outright was too blunt, though — the About pane reads this
+    // for the version number and nothing else offers one, so every browser tab
+    // showed a pane stuck on "Reading version…". A caller the origin gate above
+    // already admitted gets the build's identity with the provenance stripped.
     if (pathname === "/update/status") {
-      if (!desktopOnly(req)) return csrfBlocked();
-      return json(await updateStatus());
+      return json(desktopOnly(req) ? await updateStatus() : viewerStatus());
     }
-    // What changed in the release this build came from. Same desktop-only gate
-    // as the rest of /update: the build's origin and tag are in the answer.
+    // What changed in the release this build came from. Open to whoever may
+    // read the status above, for the same reason and as its other half: the
+    // About pane offers these notes whenever the build descends from a tag, so
+    // gating them left a browser with a button that could only ever fail. The
+    // answer is a published release's text, its tag, and whether it came from
+    // the clone or from github — the origin URL and the install path are not in
+    // it, and `tag` is refused unless it looks like a release.
     if (pathname === "/update/notes") {
-      if (!desktopOnly(req)) return csrfBlocked();
       return json(await releaseNotes(url.searchParams.get("tag") || undefined));
     }
     if (pathname === "/update/log") {

--- a/server/src/selfupdate.ts
+++ b/server/src/selfupdate.ts
@@ -211,6 +211,44 @@ export async function updateStatus(): Promise<UpdateStatus> {
   return out;
 }
 
+/**
+ * The same question, answered for a caller outside the desktop shell.
+ *
+ * `updateStatus()` is desktop-only for good reasons — it names the clone on
+ * disk, names the remote the updater pulls from, and carries the tail of the
+ * last update log, which is raw script output with paths in it. None of that
+ * should reach a browser tab, and least of all a paired phone.
+ *
+ * But refusing outright cost more than it protected. The About pane is the only
+ * place this build's version is written down, and it reads it from here, so
+ * under `bun run dev`, under single-port mode, and on a phone the pane got a 403
+ * and sat on "Reading version…" for good. The identity of the build — version,
+ * commit, when it was built — is not a secret; the provenance is. So this
+ * answers the first and drops the second.
+ *
+ * No network, either: the update button is not on offer here, so there is
+ * nothing a `git ls-remote` could inform. `blocked` is what the pane renders
+ * instead of the button, and saying where updating does work beats a blank.
+ */
+export function viewerStatus(): UpdateStatus {
+  const info = buildInfo();
+  return {
+    ok: true,
+    available: false,
+    // Rebuilt field by field rather than spread-and-blank: a field added to
+    // BuildInfo later should have to be named here before it can leave the
+    // machine, instead of arriving on a phone because nobody thought about it.
+    info: {
+      version: info.version, commit: info.commit, builtAt: info.builtAt,
+      baseTag: info.baseTag, distance: info.distance,
+      source: "", origin: "",
+    },
+    branch: "", behind: 0, ahead: 0, incoming: [],
+    // `last` is deliberately absent — see above.
+    blocked: "self-update runs from the desktop app — open agentglass there to install a release",
+  };
+}
+
 let running = false;
 
 export async function startUpdate(): Promise<{ ok: boolean; error?: string; log?: string }> {

--- a/server/test/update-status-origin.test.ts
+++ b/server/test/update-status-origin.test.ts
@@ -1,0 +1,146 @@
+/*
+ * Who may read the build's identity, and how much of it.
+ *
+ * `/update/status` was gated to the packaged shell's custom scheme, reads and
+ * all. The reason was sound — the full answer names the clone on disk, names
+ * the remote it pulls from, and carries the tail of the last update log, none
+ * of which a phone on the wifi has any business seeing. The cost was not
+ * noticed: the About pane is the only place the version is written down, and it
+ * asks this endpoint for it. From `bun run dev`, from single-port mode, from a
+ * paired phone — every browser there is — the request came back 403 and the
+ * pane sat on "Reading version…" forever. An About tab that cannot say what
+ * version you are running is the one thing an About tab is for.
+ *
+ * So the gate redacts rather than refuses: identity for anyone the outer origin
+ * gate already let in, provenance and the update button for the desktop shell
+ * alone. These tests pin both halves, because widening this by accident is how
+ * the install path ends up on a phone screen.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync, mkdirSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** Stands in for the developer's home directory in the build record. If this
+ *  string reaches a browser, the redaction failed. */
+const SECRET_SRC = "/home/somebody/src/agentglass-private";
+/** A path, not a URL: `git ls-remote` fails on it instantly, so the desktop
+ *  request below never touches the network. */
+const FAKE_ORIGIN = "/nonexistent/agentglass.git";
+
+let dir: string, base: string, proc: ReturnType<typeof Bun.spawn> | null = null;
+
+beforeAll(async () => {
+  dir = mkdtempSync(join(tmpdir(), "agx-update-origin-"));
+  // buildInfo() prefers a staged build record over asking git, which is what
+  // gives this test a known source path and origin to look for.
+  mkdirSync(join(dir, "electron", "staging"), { recursive: true });
+  writeFileSync(join(dir, "electron", "staging", "build-info.json"), JSON.stringify({
+    version: "9.9.9", commit: "c0ffee1234567890", builtAt: "2026-01-01T00:00:00Z",
+    source: SECRET_SRC, origin: FAKE_ORIGIN, baseTag: "v9.9.9", distance: 0,
+  }));
+  // The stamp from a previous run. Its tail is raw script output — paths and
+  // all — and it is read from $HOME, which is why HOME is redirected here.
+  mkdirSync(join(dir, ".cache", "agentglass"), { recursive: true });
+  writeFileSync(join(dir, ".cache", "agentglass", "last-update.json"), JSON.stringify({
+    at: "2026-01-02T00:00:00Z", ok: false, tail: `fatal: could not read ${SECRET_SRC}`,
+  }));
+
+  const port = 4910 + Math.floor(Math.random() * 20);
+  base = `http://127.0.0.1:${port}`;
+  proc = Bun.spawn(["bun", "run", new URL("../src/index.ts", import.meta.url).pathname], {
+    cwd: dir, // so buildInfo() finds the staged record above
+    env: {
+      PATH: process.env.PATH ?? "",
+      HOME: dir,
+      XDG_CONFIG_HOME: dir,
+      AGENTGLASS_ROOT: dir,
+      AGENTGLASS_DB: join(dir, "f.db"),
+      AGENTGLASS_SCAN_DISABLED: "1",
+      AGENTGLASS_PORT: String(port),
+    },
+    stdout: "ignore", stderr: "pipe",
+  });
+  for (let i = 0; i < 100; i++) {
+    try { if ((await fetch(base + "/health")).ok) return; } catch { /* not up yet */ }
+    await Bun.sleep(100);
+  }
+  throw new Error("the server did not come up: " + (await new Response(proc.stderr as ReadableStream).text()).slice(0, 400));
+});
+
+afterAll(() => {
+  try { proc?.kill(); } catch { /* already gone */ }
+  try { rmSync(dir, { recursive: true, force: true }); } catch { /* fine */ }
+});
+
+type Json = Record<string, any>;
+/** The dev server's origin — and every other browser origin: a page cannot be
+ *  served under the packaged shell's scheme, which is the whole point of it. */
+const status = (origin: string) =>
+  fetch(base + "/update/status", { headers: { Origin: origin } });
+const BROWSER = "http://localhost:5173";
+const DESKTOP = "agentglass://app";
+
+describe("a browser asking for the version", () => {
+  test("is answered, not refused", async () => {
+    const r = await status(BROWSER);
+    expect(r.status).toBe(200);
+    const j = (await r.json()) as Json;
+    expect(j.ok).toBe(true);
+    // The three lines the About pane puts on screen.
+    expect(j.info.version).toBe("9.9.9");
+    expect(j.info.commit).toBe("c0ffee1234567890");
+    expect(j.info.builtAt).toBe("2026-01-01T00:00:00Z");
+  });
+
+  test("is told nothing about where this build lives", async () => {
+    const j = (await status(BROWSER).then((r) => r.json())) as Json;
+    expect(j.info.source).toBe("");
+    expect(j.info.origin).toBe("");
+    // The log tail is unstructured script output; it quotes paths verbatim.
+    expect(j.last).toBeUndefined();
+    // Belt and braces: whatever else the shape grows, the path stays out of it.
+    expect(JSON.stringify(j)).not.toContain(SECRET_SRC);
+    expect(JSON.stringify(j)).not.toContain(FAKE_ORIGIN);
+  });
+
+  test("is not offered an update it could not install anyway", async () => {
+    const j = (await status(BROWSER).then((r) => r.json())) as Json;
+    expect(j.available).toBe(false);
+    expect(j.behind).toBe(0);
+    // Says why the button is missing, rather than leaving a blank pane.
+    expect(j.blocked).toBeTruthy();
+    expect(String(j.blocked)).toMatch(/desktop/i);
+  });
+
+  test("can read the notes for the release it is running", async () => {
+    // The other half of the pane: About offers a "Release notes" button
+    // whenever the build descends from a tag, so refusing this left a browser
+    // with a button that could only ever fail. There is no clone and no
+    // reachable origin here, so the answer is an honest refusal about the
+    // notes — what matters is that it is an answer and not a 403.
+    const r = await fetch(base + "/update/notes?tag=v9.9.9", { headers: { Origin: BROWSER } });
+    expect(r.status).toBe(200);
+    const j = (await r.json()) as Json;
+    expect(j.tag).toBe("v9.9.9");
+    expect(JSON.stringify(j)).not.toContain(SECRET_SRC);
+    expect(JSON.stringify(j)).not.toContain(FAKE_ORIGIN);
+  });
+
+  test("still cannot start one", async () => {
+    // The gate that matters most is untouched: reading is not running.
+    const r = await fetch(base + "/update/run", {
+      method: "POST", headers: { Origin: BROWSER, "content-type": "application/json" }, body: "{}",
+    });
+    expect(r.status).toBe(403);
+  });
+});
+
+describe("the desktop shell asking", () => {
+  test("still gets the whole answer", async () => {
+    const j = (await status(DESKTOP).then((r) => r.json())) as Json;
+    expect(j.info.source).toBe(SECRET_SRC);
+    expect(j.info.origin).toBe(FAKE_ORIGIN);
+    expect(j.last?.tail).toContain(SECRET_SRC);
+  });
+});

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -398,6 +398,11 @@ function AboutPane({ open }: { open: boolean }) {
   const [busy, setBusy] = useState(false);
   const [err, setErr] = useState<string | null>(null);
   const [started, setStarted] = useState(false);
+  /** Why there is no status, as opposed to it not having arrived yet. Without
+   *  this the two are the same state — a failed read left the pane reading
+   *  "Reading version…" forever, which is how a 403 on /update/status went
+   *  unnoticed: it looked like a slow server rather than a refused request. */
+  const [stErr, setStErr] = useState<string | null>(null);
   // Which release's notes are being read, and what came back. Fetched here
   // because the modal is presentational — the automatic caller has to see the
   // answer before it can decide whether to open at all, so neither of them can
@@ -424,8 +429,8 @@ function AboutPane({ open }: { open: boolean }) {
     // the pane refreshes what the background check knows rather than keeping a
     // second, private answer.
     api.updateStatus()
-      .then((r) => { ingestUpdate(r); if (live) setSt(r); })
-      .catch(() => { if (live) setSt(null); });
+      .then((r) => { ingestUpdate(r); if (live) { setSt(r); setStErr(null); } })
+      .catch((e) => { if (live) { setSt(null); setStErr(String(e?.message || e) || "the server did not answer"); } });
     return () => { live = false; };
   }, [open]);
 
@@ -437,6 +442,14 @@ function AboutPane({ open }: { open: boolean }) {
     setStarted(true);
   };
 
+  if (stErr) return (
+    <Section title="About">
+      <div className="px-3 py-2 text-[11px] flex flex-col gap-1" style={{ color: "var(--text2)" }}>
+        <span>Could not read this build's version.</span>
+        <span className="text-[10px] t-dim2 break-all">{stErr}</span>
+      </div>
+    </Section>
+  );
   if (!st) return <Section title="About"><div className="px-3 py-2 text-[11px] t-dim2">Reading version…</div></Section>;
 
   const short = st.info.commit ? st.info.commit.slice(0, 7) : "unknown";

--- a/web/src/lib/updateStore.ts
+++ b/web/src/lib/updateStore.ts
@@ -110,12 +110,13 @@ async function check(): Promise<void> {
  * available for a week can wait another forty seconds.
  */
 export function startUpdateChecks(): () => void {
-  // Only the desktop shell can answer. `/update/*` is gated on the custom
-  // scheme at the server (it reveals the install path and can start an
-  // install), so from a browser tab — and now from a phone on the LAN, which
-  // is a browser tab that someone is looking at — this poll can only ever
-  // produce a 403 in the console every six hours. Not asking is the fix; the
-  // badge it feeds is desktop-only too.
+  // Only the desktop shell can act on the answer. A browser tab — including a
+  // phone on the LAN, which is a browser tab someone is looking at — can now
+  // read the build's identity from `/update/status`, but it gets that with
+  // `available: false` and no release comparison, because installing is gated
+  // on the custom scheme and always will be. Polling it every six hours would
+  // therefore be six-hourly work to learn nothing actionable, and the badge it
+  // feeds is desktop-only too. The About pane asks directly when it opens.
   if (IS_DEMO || !IS_DESKTOP || timer) return () => {};
   const first = setTimeout(check, FIRST_CHECK_MS);
   timer = setInterval(check, EVERY_MS);


### PR DESCRIPTION
The About tab does not load. In a browser it sits on **"Reading version…" forever**.

`/update/status` is gated to the packaged desktop shell's custom scheme, reads included. The reason is sound — the answer names the clone on disk, the remote the updater pulls from, and the tail of the last update log, none of which a phone on the wifi has any business seeing.

The cost went unnoticed: **the About pane is the only place this build's version is written down, and it reads it from there.** Under `bun run dev`, under single-port mode, and on a paired phone, the request comes back 403 and the pane never resolves.

`web/src/lib/updateStore.ts` already knew about the gate — it stops the background poll on `!IS_DESKTOP` precisely because `/update/*` "can only ever produce a 403 in the console every six hours". The About pane never got the same treatment.

## The gate redacts rather than refusing

Identity — version, commit, built-at — goes to anyone the outer origin gate already admitted. Provenance and the update button stay with the desktop shell.

`/update/run` and `/update/log` are untouched: **reading is not running.** The redacted payload blanks `source` and `origin`, omits the `last` stamp entirely (its tail is raw script output that quotes paths verbatim), reports `available: false`, and carries a sentence saying where updating does work. It skips the `git ls-remote` too — there is no update on offer, so there is nothing a network round trip could inform.

`/update/notes` opens on the same terms and for the same reason: About offers a release-notes button whenever the build descends from a tag, so gating it left a browser holding a button that could only ever fail. Its answer is a published release's text, its tag, and whether it came from the clone or from GitHub — no origin URL, no install path, and `tag` is refused unless it matches a release pattern.

Both relaxed routes still sit behind the outer `localOrigin` gate and the token gate, so this only widens the payload for callers that were already admitted.

## The pane's own bug is the general one

```ts
.catch(() => { if (live) setSt(null); });   // …and `!st` renders "Reading version…"
```

A failed read set state to `null`, which is also exactly what "still loading" looks like. So a refused request rendered as a spinner that never resolved — the two states were indistinguishable. Failure now says so, which also covers the 45-second `ls-remote` ceiling nobody would otherwise wait out.

## Verification

- New `server/test/update-status-origin.test.ts` — 6 tests. It **reproduces the 403 first**, then pins both halves: a browser origin gets the version; the install path and remote never appear in the payload; no update is offered; `/update/run` still returns 403; and the desktop origin still gets the full answer including the log tail.
- `server/test/selfupdate*.test.ts` and `release-notes.test.ts` — 30 passing across the four files that cover this area.
- `web/test/update-store.test.ts`, `whats-new.test.ts` — 21 passing.
- `make typecheck` — clean, both halves.

A stale comment in `updateStore.ts` asserting `/update/*` "can only ever produce a 403" from a browser is corrected in the same change; the background poll stays desktop-only, which is still right, because the badge it feeds is about installing an update a browser cannot install.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
