### PR TITLE
Close the two CodeQL threads left open on the 0.8.0 release

### DIFF
--- a/server/src/clickup.ts
+++ b/server/src/clickup.ts
@@ -499,7 +499,9 @@ export function parseViewUrl(raw: string): ParsedViewUrl | null {
     // Not a URL — maybe somebody pasted just the path, or just an id.
   }
   // The domain, not the subdomain. Anything else is not ours to interpret.
-  if (host && !host.endsWith("clickup.com")) return null;
+  // The `.` matters: a bare endsWith("clickup.com") also accepts
+  // `notclickup.com` and `evilclickup.com`, which are somebody else's hosts.
+  if (host && host !== "clickup.com" && !host.endsWith(".clickup.com")) return null;
 
   const m = VIEW_PATH.exec(path);
   if (m) {

--- a/server/src/issues.ts
+++ b/server/src/issues.ts
@@ -108,7 +108,7 @@ export function branchNameFor(number: number, title: string): string {
 export function worktreePathFor(root: string, number: number, title: string): string {
   const parent = dirname(root);
   const name = basename(root).replace(/\.git$/, "");
-  const slug = branchNameFor(number, title).replace(/^issue-/, "issue-");
+  const slug = branchNameFor(number, title);
   return join(parent, `${name}-${slug}`);
 }
 

--- a/server/test/clickup.test.ts
+++ b/server/test/clickup.test.ts
@@ -371,6 +371,17 @@ describe("the address you paste", () => {
     expect(parseViewUrl("https://notclickup.example/1/v/l/6-1-1")).toBe(null);
   });
 
+  it("refuses a host that merely ends in the domain", () => {
+    // `endsWith("clickup.com")` alone accepts these: they are somebody else's
+    // registrable domains, not a ClickUp subdomain.
+    for (const host of ["notclickup.com", "evilclickup.com", "clickup.com.example.net"]) {
+      expect(parseViewUrl(`https://${host}/9000001/v/l/6-901715483311-1`), host).toBe(null);
+    }
+    // The apex and a real subdomain still read.
+    expect(parseViewUrl("https://clickup.com/9000001/v/l/6-901715483311-1")?.kind).toBe("view");
+    expect(parseViewUrl("https://app.clickup.com/9000001/v/l/6-901715483311-1")?.kind).toBe("view");
+  });
+
   it("refuses nothing, and rubbish", () => {
     for (const bad of ["", "   ", "hello", "https://example.clickup.com/", "https://example.clickup.com/9000001"]) {
       expect(parseViewUrl(bad), JSON.stringify(bad)).toBe(null);


### PR DESCRIPTION
Follow-up to #459. Both findings were raised by CodeQL on that PR, were never resolved, and are still open against `main`.

## What does this PR do?

**`server/src/clickup.ts` — incomplete URL substring sanitization** ([alert 28](https://github.com/SirAllap/agentglass/security/code-scanning/28))

A pasted ClickUp address was accepted on `host.endsWith("clickup.com")`, which also matches `notclickup.com`, `evilclickup.com` and any other registrable domain ending in those characters. The comment above the check already said *"the domain, not the subdomain"* — only the code disagreed. Now the apex and real subdomains pass and a lookalike host does not.

Not an SSRF: `parseViewUrl` only lifts ids out of the text, and the API calls that follow go to ClickUp's own base URL. What it let through is a link from somebody else's host being read as ours, with its ids then used against the real API.

**`server/src/issues.ts` — replacement of a substring with itself** ([alert 27](https://github.com/SirAllap/agentglass/security/code-scanning/27))

`branchNameFor(...).replace(/^issue-/, "issue-")` is a no-op — `branchNameFor` already returns the `issue-` prefix. Removed rather than "corrected": `server/test/issue-names.test.ts` pins the worktree path as `<repo>-issue-<n>-<slug>`, so the prefix is wanted and the output is byte-for-byte unchanged.

Nothing about the 0.8.0 release itself needs undoing — its CI was green and every workflow on the `v0.8.0` tag succeeded. These two threads were the only loose ends.

## How was it tested?

- `bunx tsc --noEmit` in `server/` — clean.
- `bun test` in `server/` — 1656 pass, 5 fail. All five failures are in `tmux-bar.test.ts` and `tmux-stale.test.ts`, and they fail identically on an unmodified `main` in the same container (tmux version differences here); they are not touched by this change and pass on CI's runner.
- New case in `server/test/clickup.test.ts` covering `notclickup.com`, `evilclickup.com` and `clickup.com.example.net` as refused, with the apex and `app.clickup.com` still read as views. It fails against the old `endsWith` check.
- `bun scripts/logo.mjs --check` — in sync.

No behavior change for any valid input, no `shared/types.ts` change, no docs affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuvE7wAi9bdkW6wTbDJVWk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuvE7wAi9bdkW6wTbDJVWk)_