### PR TITLE
Price MiniMax at its standard rates, and catch the models the table has not met

### DIFF
--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -111,11 +111,21 @@ export const PRICE_TABLE: ModelPrice[] = [
   { match: ["kimi-code/k3", "kimi-k3", "moonshot/k3"], exact: ["k3"], label: "K3", input: 3, output: 15, cache_write: 3, cache_read: 0.3 },
 
   // --- MiniMax ---
-  // M3 keeps cache creation at the input rate (cache_write === input); M2.7
-  // charges cache creation at 1.25x input. Both discount cache reads to a tenth
-  // of input. Order matters: M2.7 is matched before the generic M3 row.
-  { match: ["minimax-m2.7"], exact: ["MiniMax-M2.7"], label: "MiniMax M2.7", input: 0.3, output: 1.2, cache_write: 0.375, cache_read: 0.06 },
-  { match: ["minimax-m3"], exact: ["MiniMax-M3"], label: "MiniMax M3", input: 0.6, output: 2.4, cache_write: 0.6, cache_read: 0.12 },
+  // Standard rates, like every other row here. M3 doubles the WHOLE request
+  // past 512K input tokens and M2.7 has a `-highspeed` variant at 2x, and both
+  // of those land on $0.60/$2.40 — which is how the long-context number ends up
+  // looking like the headline one. Cache creation is 1.25x input, cache reads a
+  // fifth of it, the same shape on both models.
+  // `exact` is compared against a lower-cased id (see priceFor), so these are
+  // spelled that way — `MiniMax-M2.7` here would simply never fire.
+  { match: ["minimax-m2.7"], exact: ["minimax-m2.7"], label: "MiniMax M2.7", input: 0.3, output: 1.2, cache_write: 0.375, cache_read: 0.06 },
+  { match: ["minimax-m3"], exact: ["minimax-m3"], label: "MiniMax M3", input: 0.3, output: 1.2, cache_write: 0.375, cache_read: 0.06 },
+  // The catch-all, and the reason it is here: shared/models.ts already labels
+  // any `minimax` id "MiniMax", so without a price row to match it a model this
+  // table has not met yet reads as a named MiniMax model billed at
+  // DEFAULT_PRICE — the Sonnet-tier $3/$15, ten times over. Wrong by a little
+  // beats wrong by an order of magnitude, and it must stay last of the three.
+  { match: ["minimax"], label: "MiniMax", input: 0.3, output: 1.2, cache_write: 0.375, cache_read: 0.06 },
 
   // --- others (approx) ---
   { match: ["deepseek"], label: "DeepSeek", input: 0.27, output: 1.1, cache_write: 0, cache_read: 0.07 },

--- a/server/test/pricing.test.ts
+++ b/server/test/pricing.test.ts
@@ -100,28 +100,35 @@ describe("costUsd", () => {
     expect(cost).toBe(DEFAULT_PRICE.input);
   });
 
-  test("MiniMax M3 and M2.7 use their own rates instead of the fallback", () => {
-    // The model ids are short and do not share the Gemini/OpenAI collision
-    // problem, but a bare `minimax` substring would otherwise fall through to
-    // DEFAULT_PRICE — the Sonnet-tier $3/$15 — and over-report cost ~5x.
-    expect(priceFor("MiniMax-M3")).toMatchObject({
-      label: "MiniMax M3",
-      input: 0.6,
-      output: 2.4,
-      cache_write: 0.6,
-      cache_read: 0.12,
-    });
-    expect(priceFor("MiniMax-M2.7")).toMatchObject({
-      label: "MiniMax M2.7",
-      input: 0.3,
-      output: 1.2,
-      cache_write: 0.375,
-      cache_read: 0.06,
-    });
-    // M2.7 must be matched before the M3 row — "minimax-m2.7" contains neither
-    // "minimax-m3" nor a context suffix, and a reversed order would price it at
-    // the M3 rate. This is the load-bearing-property assertion for the order.
-    expect(priceFor("MiniMax-M2.7")?.label).not.toBe("MiniMax M3");
+  test("MiniMax M3 and M2.7 are priced at their standard rates, not the doubled ones", () => {
+    // $0.60/$2.40 is the trap here, and it is a plausible one: it is M3's
+    // long-context rate (the whole request doubles past 512K input tokens) AND
+    // the price of the `-highspeed` M2.7 variant, so it turns up next to these
+    // models often enough to look like the headline number. Every other row in
+    // this table quotes the standard rate, and a table that quoted the ceiling
+    // for one vendor would report twice the real spend on ordinary turns.
+    for (const id of ["MiniMax-M3", "MiniMax-M2.7"]) {
+      expect(priceFor(id), id).toMatchObject({
+        input: 0.3,
+        output: 1.2,
+        cache_write: 0.375,
+        cache_read: 0.06,
+      });
+    }
+    expect(priceFor("MiniMax-M3")?.label).toBe("MiniMax M3");
+    expect(priceFor("MiniMax-M2.7")?.label).toBe("MiniMax M2.7");
+  });
+
+  test("a MiniMax model this table has not met is still priced as MiniMax", () => {
+    // shared/models.ts labels any `minimax` id "MiniMax", so without the
+    // catch-all row the next model out of that vendor would read as a named
+    // MiniMax model charged at DEFAULT_PRICE — $3/$15, ten times over. The
+    // catch-all has to stay LAST of the three, which is what the labels assert:
+    // hoisted above them it would swallow M3 and M2.7 too.
+    expect(priceFor("MiniMax-M4-preview")).toMatchObject({ label: "MiniMax", input: 0.3, output: 1.2 });
+    expect(priceFor("minimax-text-01")?.label).toBe("MiniMax");
+    expect(priceFor("MiniMax-M3")?.label).toBe("MiniMax M3");
+    expect(priceFor("MiniMax-M2.7")?.label).toBe("MiniMax M2.7");
   });
 
   test("MiniMax cost math sums each token class at its own rate", () => {
@@ -134,7 +141,7 @@ describe("costUsd", () => {
       },
       "MiniMax-M3",
     );
-    expect(cost).toBeCloseTo(0.6 + 2.4 + 0.6 + 0.12, 10);
+    expect(cost).toBeCloseTo(0.3 + 1.2 + 0.375 + 0.06, 10);
   });
 
   test("missing usage fields count as zero", () => {


### PR DESCRIPTION
Follow-up to #451, finishing it rather than sending it back.

## What does this PR do?

**M3 was priced at the doubled rate.** #451 shipped `MiniMax-M3` at `$0.60` in / `$2.40` out with a `$0.12` cache read. Those are not the standard rates — M3 bills the *entire* request at 2x once input passes 512K tokens, and `$0.60/$2.40` is separately what MiniMax charges for the `-highspeed` variant of M2.7, so that pair of numbers sits next to these models in enough places to look like the headline price. Standard is `$0.30/$1.20` with a `$0.06` cache read — the same as M2.7, and the same convention every other row in this table follows (the `gpt-5.6-sol` row says as much in its own comment). Left as merged, every ordinary M3 turn reported twice the spend it cost. M2.7's numbers were already right and are untouched.

**`exact` could never fire.** `priceFor` lower-cases the model id before comparing, so the `exact: ["MiniMax-M3"]` / `["MiniMax-M2.7"]` spellings never matched anything. Harmless in practice — the `match` fragments catch the same ids — but it is dead code in the shape of a guard, and the neighbouring `k3` row spells its `exact` lower-case for exactly this reason.

**A missing catch-all row.** `shared/models.ts` labels *any* id containing `minimax` as "MiniMax", while `pricing.ts` knew only two of them. The vendor's next model would therefore have rendered as a confidently-named MiniMax model billed at `DEFAULT_PRICE` — `$3/$15`, ten times over. A catch-all row, kept last of the three, turns that into being wrong by a little instead of by an order of magnitude. #451's own test comment flagged this risk; this is the row that closes it.

## How was it tested?

- `bunx tsc --noEmit` in `server/` — clean.
- `bun test` in `server/` — 1670 pass, 5 fail. The five are `tmux-bar.test.ts` and `tmux-stale.test.ts`, which fail identically on an unmodified `main` in the same container and pass on CI's runner.
- `pricing.test.ts` — the M3 assertions now pin the standard rates and name the trap; a new case covers the catch-all (`MiniMax-M4-preview`, `minimax-text-01`) while asserting the two specific rows still win, which is what keeps the catch-all last.
- `provider-parity.test.ts` — unchanged and still green; `providerOf` and the display labels were correct in #451.

Rates checked against MiniMax's published pricing for both models, standard tier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuvE7wAi9bdkW6wTbDJVWk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuvE7wAi9bdkW6wTbDJVWk)_