### PR TITLE
fix(chat): a prompt queued behind a running turn is accepted, not broken

### DIFF
--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -103,12 +103,36 @@ async function waitReady(name: string, deadline: number): Promise<boolean> {
  *  never accepted, and the engine reported failure on a successful turn. */
 const INPUT_ROWS = /^❯(.*)$/gm;
 
+/** Hint text the TUI draws *inside* the empty input box.
+ *
+ *  A hint sits on the box's own row, behind the box's own glyph, and is not one
+ *  character the user typed — but it is not whitespace either, so a box showing
+ *  one reads as "holding something" unless it is named here.
+ *
+ *  That distinction is load-bearing. When a turn is already running, a newly
+ *  submitted prompt is QUEUED, and the box then hints `Press up to edit queued
+ *  messages`. Read as content, that hint is text which is neither empty nor the
+ *  prompt we pasted, which is precisely the signature of "a picker opened" — so
+ *  a prompt the CLI had accepted was reported to the user as an interactive
+ *  prompt it could not draw. Worse on the next turn: the hint was already there
+ *  before the paste, so `waitPasted` returned it as though it were our text, and
+ *  every Enter afterwards compared the hint against itself and looked swallowed.
+ *  The turn pressed Enter into a live pane until it timed out and then reported
+ *  that the pane would not accept the prompt. Both prompts had in fact been
+ *  queued, and both ran. */
+const BOX_HINTS: RegExp[] = [
+  /^\s*Try "/,                                  // an empty box in a fresh session
+  /^\s*Press up to edit queued messages\s*$/,   // an empty box with prompts queued
+];
+
 /** What is typed in the live input box right now, or `null` if it is not on
  *  screen at all (the TUI redraws while a turn runs). Note the box renders its
- *  empty state with U+00A0, which `\s` covers. */
+ *  empty state with U+00A0, which `\s` covers, and its hinted states with the
+ *  strings above — both of which are empty as far as this engine is concerned. */
 export function inputBox(screen: string): string | null {
   let last: string | null = null;
   for (const m of screen.matchAll(INPUT_ROWS)) last = m[1];
+  if (last !== null && BOX_HINTS.some((re) => re.test(last!))) return "";
   return last;
 }
 
@@ -139,12 +163,14 @@ async function waitPasted(name: string, deadline: number): Promise<string | null
 
 /** What happened to the prompt we submitted.
  *
- *  `sent` — the box emptied, the CLI took it.
+ *  `sent` — the box emptied, the CLI took it and started on it.
+ *  `queued` — the CLI took it but is busy, so it is holding it behind the turn
+ *    already running. Accepted, not started; see QUEUED_RE.
  *  `diverted` — the box holds something that is not our prompt any more. In
  *    practice this means an interactive command opened a picker: `/model`,
  *    `/effort`, `/config` do not run a turn, they draw a menu.
  *  `stuck` — still our text, still not taken, out of time. */
-type SubmitOutcome = "sent" | "diverted" | "stuck";
+type SubmitOutcome = "sent" | "queued" | "diverted" | "stuck";
 
 /** Press Enter until the prompt is actually accepted.
  *
@@ -182,6 +208,10 @@ async function submitConfirmed(name: string, pasted: string, deadline: number): 
      * it was simply thinking.
      */
     if (NEEDS_YOU_RE.test(screen)) return "diverted";
+    // Also before the box check, and for the same reason: a queued prompt has
+    // been ACCEPTED. Pressing again would not resend it — it would append
+    // another copy of it to the queue.
+    if (QUEUED_RE.test(screen)) return "queued";
     const box = inputBox(screen);
     if (!box?.trim()) return "sent";
     // Still our text, nothing opened: the Enter really was swallowed (the TUI
@@ -323,11 +353,53 @@ const NEEDS_YOU_RE = /Esc to cancel|Enter to confirm|to use this session only/;
 export const __needsYou = (screen: string): boolean => NEEDS_YOU_RE.test(screen);
 export const __isRunning = (screen: string): boolean => RUNNING_RE.test(screen);
 
+/** The CLI is holding prompts it has accepted but not started.
+ *
+ *  Typing while a turn is in flight does not interrupt it and does not fail:
+ *  Claude Code queues the prompt, draws it in a box of pending messages, and
+ *  runs it when the current turn ends. That is a third state next to "running"
+ *  and "idle", and the engine had no name for it, so it read as both of the
+ *  wrong ones — as a picker while submitting (see BOX_HINTS) and as an idle
+ *  pane afterwards, which would have ended the turn eight seconds in.
+ *
+ *  Observed on a machine whose network dropped mid-turn: the CLI sat on
+ *  `Unable to connect to API (ENOTIMP) · Retrying in 8s · attempt 5/10`, two
+ *  prompts sent from the chat were queued behind it, and both were reported to
+ *  the user as errors. Both had been accepted, and both ran once the network
+ *  came back.
+ *
+ *  Matched on the input box's own hint rather than on the pending-message box,
+ *  because the hint is one stable line of text and the box is a drawn frame
+ *  whose contents are the user's own prompts. */
+const QUEUED_RE = /Press up to edit queued messages/;
+export const __isQueued = (screen: string): boolean => QUEUED_RE.test(screen);
+
+/** Wait for a queued prompt to reach the front of the CLI's queue.
+ *
+ *  Deliberately without a deadline. The turn ahead of ours may legitimately run
+ *  for minutes — that is why ours was queued — and giving up on a clock would
+ *  report a failure for a prompt that has been accepted and will run. What is
+ *  bounded is liveness: a pane that has *died* is never coming back, and it is
+ *  checked for on the same interval a silent turn is. */
+async function waitDrained(name: string, stop: () => boolean): Promise<"drained" | "cancelled" | "gone"> {
+  let lastAlive = Date.now();
+  for (;;) {
+    if (stop()) return "cancelled";
+    if (!QUEUED_RE.test(await capture(name))) return "drained";
+    if (Date.now() - lastAlive > STALL_CHECK_MS) {
+      if (!(await paneAlive(name))) return "gone";
+      lastAlive = Date.now();
+    }
+    await Bun.sleep(250);
+  }
+}
+
 /** The submit loop's decision for one observed frame, without the tmux round
  *  trip. Exported so the ordering that matters — picker before input box — is
  *  pinned by a test rather than by a comment. */
 export function __submitVerdict(screen: string, pasted: string): SubmitOutcome | "retry" {
   if (NEEDS_YOU_RE.test(screen)) return "diverted";
+  if (QUEUED_RE.test(screen)) return "queued";
   const box = inputBox(screen);
   if (!box?.trim()) return "sent";
   if (box.trim() !== pasted.trim()) return "diverted";
@@ -433,6 +505,39 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
           controller.close();
           return;
         }
+        if (outcome === "queued") {
+          /*
+           * Accepted, but behind a turn that was already running. Wait for it
+           * to come up rather than reporting anything: the prompt is in the
+           * CLI's hands and it will run.
+           */
+          const drained = await waitDrained(sessionId, () => cancelled);
+          if (drained === "cancelled") { controller.close(); return; }
+          if (drained === "gone") {
+            forgetPane(sessionId);
+            specs.delete(sessionId);
+            fail("the chat's pane exited while this prompt was still queued behind another turn");
+            controller.close();
+            return;
+          }
+          /*
+           * Re-take the watermark now that ours is the turn running.
+           *
+           * The turn we were queued behind finished while we waited, and it
+           * wrote its answer AND its end-of-turn line into this same transcript
+           * after our original watermark. Streaming from there would replay
+           * someone else's answer into this chat bubble and then close on their
+           * end marker, ending this turn before it had said anything. Their
+           * output is not lost by skipping it — the dashboard hydrates history
+           * from the transcript, which is where it already is.
+           *
+           * The race this accepts: the CLI writes our own user message ~220ms
+           * after submitting, so a slow poll can put the watermark past it. That
+           * costs the echo of a message the browser is already showing, and
+           * never any of the answer, which is a round trip further out.
+           */
+          offset = await sizeOf(path);
+        }
 
         // Usage accumulates across the turn's assistant frames so the closing
         // cost frame can be priced. The `-p` engine gets this handed to it by
@@ -514,7 +619,11 @@ export function paneTurnStream(opts: PaneTurnOptions): Response {
              * a turn that produced no transcript and left the pane idle is over,
              * whatever it was called.
              */
-            const running = RUNNING_RE.test(screen);
+            // A pane holding queued prompts is neither running nor idle: it is
+            // waiting its turn, and its box reads empty because what it shows
+            // is a hint. Without this clause that is indistinguishable from
+            // `/clear`, and a queued turn would be declared over ~8s in.
+            const running = RUNNING_RE.test(screen) || QUEUED_RE.test(screen);
             const box = inputBox(screen);
             if (!running && !box?.trim()) {
               if (++idleProbes >= IDLE_PROBES_TO_END) {

--- a/server/test/chat-pane.test.ts
+++ b/server/test/chat-pane.test.ts
@@ -303,3 +303,70 @@ test("an argument with a quote in it cannot break out of the command", () => {
   // Single-quoted with the POSIX '\'' escape, so the `;` stays inside the word.
   expect(cmd).toContain(`'it'\\''s; rm -rf /'`);
 });
+
+// --- a prompt sent while the CLI is busy -------------------------------------
+// Typing into Claude Code mid-turn does not fail and does not interrupt: the
+// prompt is queued and runs when the current turn ends. The engine had no name
+// for that state and read it as two different wrong ones, so two prompts that
+// were accepted — and that ran — were both reported to the user as errors.
+
+/** Captured from a live pane whose network had dropped mid-turn. The CLI is
+ *  still working on the first prompt, two prompts sent from the chat since are
+ *  queued behind it, and the input box shows the hint it draws while it holds
+ *  them. Note that the queued prompts carry the box's own `❯` glyph at column
+ *  zero, exactly as the live box does. */
+const QUEUED = [
+  "❯ why does the release build fail on a clean checkout?",
+  "",
+  "✳ Unable to connect to API (ENOTIMP) · Retrying in 8s · attempt 5/10",
+  "",
+  "❯ continue",
+  "❯ continue",
+  "                              ✗ Auto-update failed · Run claude doctor",
+  "",
+  "❯ Press up to edit queued messages",
+].join("\n");
+
+test("the input box's hint is not something the user typed", () => {
+  // The whole bug in one assertion. Read as content, the hint is text that is
+  // neither empty nor the prompt we pasted — which is the exact signature of a
+  // picker having opened, and is what got reported as one.
+  expect(mod.inputBox(QUEUED)?.trim()).toBe("");
+  expect(mod.inputBox('❯ Try "edit config.ts to add a flag"')?.trim()).toBe("");
+});
+
+test("a queued prompt is accepted, not diverted into a picker", () => {
+  // Reported as: "This opened an interactive prompt in the chat's tmux pane."
+  // Nothing had opened. The prompt was queued, and it ran.
+  expect(mod.__submitVerdict(QUEUED, "continue")).toBe("queued");
+  expect(mod.__isQueued(QUEUED)).toBe(true);
+});
+
+test("a second prompt is not compared against the hint left by the first", () => {
+  // Reported as: "the chat pane would not accept the prompt." With the hint
+  // already on screen before the paste, the old box reader handed it back as
+  // though it were our text, and every Enter afterwards compared it against
+  // itself and looked swallowed — so the turn pressed Enter into a live pane
+  // until it timed out. An empty-reading box keeps the paste wait waiting.
+  expect(mod.__submitVerdict(QUEUED, "Press up to edit queued messages")).toBe("queued");
+  expect(mod.inputBox(QUEUED)?.trim()).not.toBe("Press up to edit queued messages");
+});
+
+test("a queued pane is not mistaken for a menu, or for one gone idle", () => {
+  // The two states either side of it. Reading queued as `needsYou` would send
+  // the user to their terminal to finish a prompt that does not exist; reading
+  // it as idle would end the turn ~8s in, because the box reads empty and
+  // nothing says "esc to interrupt" while the CLI waits.
+  expect(mod.__needsYou(QUEUED)).toBe(false);
+  expect(mod.__isRunning(QUEUED)).toBe(false);
+  expect(mod.__isQueued(NORMAL)).toBe(false);
+  expect(mod.__isQueued(IDLE_AFTER_LOCAL_COMMAND)).toBe(false);
+  expect(mod.__isQueued(MODEL_PICKER)).toBe(false);
+});
+
+test("a picker still wins over a queue, so Enter is never pressed into a menu", () => {
+  // Ordering, again: the queue check sits below the picker check. Enter in a
+  // `/model` or `/effort` menu writes the user's real settings.json, and no
+  // other state may be allowed to reach past that guard.
+  expect(mod.__submitVerdict(`${MODEL_PICKER}\n❯ Press up to edit queued messages`, "/model")).toBe("diverted");
+});


### PR DESCRIPTION
## What does this PR do?

Fixes the tmux chat engine reporting an **error** for a prompt the CLI had accepted.

Typing into Claude Code while a turn is in flight does not fail and does not interrupt — the CLI **queues** the prompt and draws `Press up to edit queued messages` in its input box. `chatpane.ts` had no name for that state, so it read it as two different wrong ones:

- `inputBox()` takes the last `^❯` row as the box's contents, and that hint sits on the box's own row behind the box's own glyph. Read as content it is text that is neither empty nor the prompt we pasted — the exact signature of a picker having opened — so the turn reported **"This opened an interactive prompt in the chat's tmux pane"** when nothing had opened.
- On the *next* turn the hint was already on screen before the paste, so `waitPasted()` handed it back as though it were our text. Every Enter afterwards compared it against itself, looked swallowed, and pressed again — into a live pane, for `PASTE_TIMEOUT_MS`, until it gave up with **"the chat pane would not accept the prompt"**.

Both prompts had in fact been accepted, and both ran.

Seen on a machine whose network dropped mid-turn: the CLI sat retrying `Unable to connect to API (ENOTIMP) · Retrying in 8s · attempt 5/10`, two prompts sent from the chat queued behind it, and both came back as errors.

The change:

- **`BOX_HINTS`** — the input box's hint text reads as an empty box, not as typing. Covers the queued hint and the fresh-session `Try "…"`.
- **`QUEUED_RE` and a `queued` submit outcome** — a third state next to running and idle. Deliberately checked *below* the existing picker guard, so Enter still never reaches a `/model` or `/effort` menu, and *above* the box check, so we never press again and append a second copy of the prompt to the queue.
- **`waitDrained()`** — a queued turn waits for the queue rather than reporting anything. No deadline, since the turn ahead may legitimately run for minutes; bounded on pane liveness instead.
- **The transcript watermark is re-taken once the queue drains.** The turn we were queued behind wrote its answer *and* its end-of-turn line past our original watermark, so without this the fix would replay someone else's answer into this chat bubble and then close on their end marker.
- **A queued pane no longer reads as idle.** It says nothing and its box reads empty, which was indistinguishable from `/clear` and would have ended the turn ~8s in via `IDLE_PROBES_TO_END`.

Server-side only — no `shared/types.ts` change, no web change, no config or docs change.

## How was it tested?

Six new cases in `server/test/chat-pane.test.ts`, built on a `QUEUED` fixture transcribed from the pane where this was reported. They were verified to **fail against the current code with exactly the observed verdicts** (`diverted`, and `retry` until it times out to `stuck`), which is what pins them to the real bug rather than to the fix. The additions are purely additive — no existing test changed.

Everything CONTRIBUTING.md lists, run on this branch:

| | |
|---|---|
| `server`: `bunx tsc --noEmit` | pass |
| `server`: `bun test` | 1742 pass, 19 skip, 1 fail — see below |
| `web`: `bunx tsc --noEmit` | pass |
| `web`: `bun test` | 1357 pass, 0 fail |
| `web`: `bunx vite build` | pass |
| `bun scripts/smoke.ts` | pass — app mounted, no console errors |
| `bun scripts/perfbudget.ts` | pass — p99 3ms against a 120ms budget |

The one server failure is **pre-existing and environment-dependent, not from this change** — it reproduces identically on an unmodified checkout of `main`. `agent-routes.test.ts` → *"and refuses an agent this machine does not have"* asserts that Codex has neither a binary on PATH nor a config directory, and my machine happens to have both (`/usr/bin/codex`, `~/.codex`). It should pass on a runner without Codex installed. Happy to send a separate PR seaming that off the host if you'd like it.
