### PR TITLE
Anchor the fresh-session hint, so a prompt that starts like it still sends

### DIFF
--- a/server/src/chatpane.ts
+++ b/server/src/chatpane.ts
@@ -121,7 +121,13 @@ const INPUT_ROWS = /^❯(.*)$/gm;
  *  that the pane would not accept the prompt. Both prompts had in fact been
  *  queued, and both ran. */
 const BOX_HINTS: RegExp[] = [
-  /^\s*Try "/,                                  // an empty box in a fresh session
+  // Anchored at BOTH ends, and that is the whole design of this list: a hint is
+  // the only thing on its row, while a prompt that merely starts the same way
+  // carries on past it. Unanchored, `Try "` also matched a real prompt —
+  // `Try "npm test" first, then look at the failures` — and a box holding one
+  // read as empty, so waitPasted never saw the paste land and the turn was
+  // reported as a pane that would not take it.
+  /^\s*Try ".*"\s*$/,                           // an empty box in a fresh session
   /^\s*Press up to edit queued messages\s*$/,   // an empty box with prompts queued
 ];
 

--- a/server/test/chat-pane.test.ts
+++ b/server/test/chat-pane.test.ts
@@ -335,6 +335,24 @@ test("the input box's hint is not something the user typed", () => {
   expect(mod.inputBox('❯ Try "edit config.ts to add a flag"')?.trim()).toBe("");
 });
 
+test("but a prompt that merely starts like a hint is still a prompt", () => {
+  // The cost of getting this wrong is silent and total: a box holding real text
+  // that reads as empty is one waitPasted never sees the paste land in, so the
+  // turn spends its deadline pressing Enter and then reports a pane that would
+  // not accept the prompt. A hint owns its whole row; a prompt carries on past
+  // it, which is what both anchors are for.
+  for (const typed of [
+    'Try "npm test" first, then look at the failures',
+    'Try "bun run build" and tell me what breaks',
+    "Try the other approach",
+  ]) {
+    expect(mod.inputBox(`❯ ${typed}`)?.trim(), typed).toBe(typed);
+  }
+  // And the same on the other hint, so neither can be loosened alone.
+  expect(mod.inputBox("❯ Press up to edit queued messages, then rerun")?.trim())
+    .toBe("Press up to edit queued messages, then rerun");
+});
+
 test("a queued prompt is accepted, not diverted into a picker", () => {
   // Reported as: "This opened an interactive prompt in the chat's tmux pane."
   // Nothing had opened. The prompt was queued, and it ran.


### PR DESCRIPTION
Follow-up to #467, flagged when that PR was merged.

## What does this PR do?

#467 taught `inputBox()` to read the TUI's own hints as empty — the fix that stopped a queued prompt being reported as an interactive picker. One of its two patterns was anchored at the start only:

```ts
/^\s*Try "/
```

A hint owns its whole row. A prompt that merely begins the same way carries on past it, and `Try "npm test" first, then look at the failures` is a reasonable thing to type at an agent. It matched, so a box holding real text read as empty — and that is worse than it sounds: `waitPasted` waits for the box to be non-empty, so it never saw the paste land. The turn then spent its whole deadline pressing Enter into a live pane and ended by reporting a pane that would not accept the prompt, with the text sitting visibly on screen the entire time.

Anchored at both ends now, matching the queued hint beside it, which never had this edge because it was written `/^\s*Press up to edit queued messages\s*$/` from the start.

## How was it tested?

- `bun test test/chat-pane.test.ts` — 32 pass.
- The new case covers three prompts that begin like the fresh-session hint and one that begins like the queued hint, so neither pattern can be loosened on its own.
- Run against the unanchored version first: it fails there, on the prompt case.

Nothing else changes — the queued-prompt behaviour #467 came for is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TuvE7wAi9bdkW6wTbDJVWk

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuvE7wAi9bdkW6wTbDJVWk)_