### PR TITLE
The panel quotes its selectors where the rest of the repo already does

### DIFF
--- a/scripts/capture-live.ts
+++ b/scripts/capture-live.ts
@@ -34,7 +34,8 @@ const PANEL_H = 1080;
  *  drive, so a fix to the connect retry loop reaches all three.
  *  (capture-phone.ts was the fourth; it photographed the browser companion for
  *  the README and went when that did — mobile/scripts/qa.ts shoots the app.) */
-import { connect, findChrome, key, lit, until } from "./cdp.ts";
+import { connect, findChrome, key, until } from "./cdp.ts";
+import { jsLit } from "../shared/jsLit.ts";
 
 async function main() {
   if (!existsSync(join(REPO, ".git"))) { console.error(`no scratch repo at ${REPO}`); process.exit(1); }
@@ -176,7 +177,7 @@ async function main() {
     for (const line of lines) {
       await cdp.ev(`(()=>{const t=document.querySelector('.xterm-helper-textarea');
         if(!t) return 0;
-        for (const ch of ${lit(line + "\r")}) {
+        for (const ch of ${jsLit(line + "\r")}) {
           t.dispatchEvent(new InputEvent('input',{data:ch,inputType:'insertText',bubbles:true}));
         }
         return 1})()`);

--- a/scripts/capture.ts
+++ b/scripts/capture.ts
@@ -54,7 +54,8 @@ const GIF_W = 1100, GIF_FPS = 12;
  *  see scripts/still.ts for why that step exists at all. */
 import { finishStill, STILL_W } from "./still.ts";
 /** Chrome, the protocol and the static server for the demo build. */
-import { connect, findChrome, key, lit, serveDist, until, DEMO_BASE } from "./cdp.ts";
+import { connect, findChrome, key, serveDist, until, DEMO_BASE } from "./cdp.ts";
+import { jsLit } from "../shared/jsLit.ts";
 
 async function main() {
   if (!existsSync(join(DIST, "index.html"))) {
@@ -97,7 +98,7 @@ async function main() {
     // is `agentglass-theme`, hyphenated; a dotted `agentglass.theme` reaches
     // nobody, and the mode is `agentglass-theme-mode`.)
     const setTheme = (id: string, mode: string) =>
-      cdp.ev(`(()=>{try{localStorage.setItem('agentglass-theme',${lit(id)});localStorage.setItem('agentglass-theme-mode',${lit(mode)});return 1}catch{return 0}})()`);
+      cdp.ev(`(()=>{try{localStorage.setItem('agentglass-theme',${jsLit(id)});localStorage.setItem('agentglass-theme-mode',${jsLit(mode)});return 1}catch{return 0}})()`);
     await setTheme("graphite", "dark");
     await cdp.ev(`location.reload()`);
     await until(cdp, `document.querySelector('#root')?.children.length`, "the graphite theme");
@@ -170,7 +171,7 @@ async function main() {
     await Bun.sleep(1200);
 
     for (const id of views) {
-      const ok = await cdp.ev(`(()=>{const b=document.querySelector('[data-view=${lit(id)}]');b?.click();return !!b})()`);
+      const ok = await cdp.ev(`(()=>{const b=document.querySelector('[data-view=${jsLit(id)}]');b?.click();return !!b})()`);
       if (!ok) { console.warn(`  ! no "${id}" view in the rail — skipped`); continue; }
       await Bun.sleep(1600);
       // The PR panel opens on Overview; Files is the view worth showing, and
@@ -193,7 +194,7 @@ async function main() {
     // Ports and Resources are an overlay, not a rail view — opened from the
     // rail's own buttons (aria-labelled) and dismissed with Escape.
     for (const [label, name] of [["Ports", "ports"], ["Resources", "resources"]] as const) {
-      const ok = await cdp.ev(`(()=>{const b=document.querySelector('button[aria-label=${lit(label)}]');b?.click();return !!b})()`);
+      const ok = await cdp.ev(`(()=>{const b=document.querySelector('button[aria-label=${jsLit(label)}]');b?.click();return !!b})()`);
       if (!ok) { console.warn(`  ! no "${label}" button — skipped`); continue; }
       await Bun.sleep(1600);
       await capture(name, STILLS_ONLY ? 0 : 14);

--- a/scripts/cdp.ts
+++ b/scripts/cdp.ts
@@ -9,6 +9,8 @@
  * two copies already drifting in their retry counts — and a third capture
  * script would have made it three. One copy now.
  */
+import { jsLit } from "../shared/jsLit.ts";
+
 export type CDP = {
   send: (m: string, p?: unknown) => Promise<any>;
   ev: (expr: string) => Promise<any>;
@@ -71,42 +73,16 @@ export async function until(cdp: CDP, expr: string, what: string, ms = 15_000) {
   throw new Error(`timed out waiting for ${what}`);
 }
 
-/**
- * A value as a JavaScript literal, safe to paste into source we are about to
- * evaluate in the page.
- *
- * Every helper here builds a snippet of JS as a string and hands it to
- * `Runtime.evaluate`, and the values pasted into it are selectors, key names
- * and label fragments. `JSON.stringify` alone is the obvious way to quote them
- * and it is not quite enough: JSON is not a subset of JavaScript. U+2028 and
- * U+2029 pass through it unescaped and were line terminators to a JS parser,
- * which ends the string mid-expression and leaves whatever follows as code. The
- * same value reaching an inline `<script>` would end it at a literal
- * `</script>`.
- *
- * Neither is exotic once a value stops being a literal in this file. Some of
- * them already do not come from here: `AUDIT_REPO` is read from the
- * environment, and label fragments are chosen to match text the app rendered.
- * So the quoting is done once, correctly, in the one place all of it passes
- * through, instead of being a property of who happened to call it.
- */
-export const lit = (v: unknown): string =>
-  JSON.stringify(v)
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029")
-    // `\x3c` is the same character to a JS parser and cannot close a script
-    // element, so a snippet stays inert wherever it is eventually placed.
-    .replace(/</g, "\\x3c");
 
 export const key = (cdp: CDP, k: string, mods: Record<string, boolean> = {}) =>
-  cdp.ev(`(()=>{window.dispatchEvent(new KeyboardEvent("keydown",Object.assign({key:${lit(k)},bubbles:true,cancelable:true},${lit(mods)})));return 1})()`);
+  cdp.ev(`(()=>{window.dispatchEvent(new KeyboardEvent("keydown",Object.assign({key:${jsLit(k)},bubbles:true,cancelable:true},${jsLit(mods)})));return 1})()`);
 
 /** Click the first element matching a predicate over its trimmed text.
  *  Returns false rather than throwing, so a caller can report which step of a
  *  capture went missing instead of dying with a selector error. */
 export const clickByText = (cdp: CDP, selector: string, needle: string) =>
-  cdp.ev(`(()=>{const el=[...document.querySelectorAll(${lit(selector)})]
-    .find(e=>e.textContent.includes(${lit(needle)}));el?.click();return !!el})()`);
+  cdp.ev(`(()=>{const el=[...document.querySelectorAll(${jsLit(selector)})]
+    .find(e=>e.textContent.includes(${jsLit(needle)}));el?.click();return !!el})()`);
 
 /** The demo build is based at /agentglass/demo/ so it can be served from
  *  GitHub Pages, so its asset URLs carry that prefix. Serving it at the root

--- a/scripts/conflict-drive.ts
+++ b/scripts/conflict-drive.ts
@@ -27,6 +27,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 import { connect, findChrome, until } from "./cdp.ts";
+import { jsLit } from "../shared/jsLit.ts";
 import { privateTmuxDir } from "./tmuxTmp.ts";
 
 const ROOT = resolve(import.meta.dir, "..");
@@ -164,7 +165,7 @@ const text = (cdp: any) => cdp.ev(`document.body.innerText`) as Promise<string>;
 const clickText = (cdp: any, re: string) =>
   cdp.ev(`(()=>{const b=[...document.querySelectorAll('button')].find(e=>${re}.test(e.textContent));if(!b)return false;b.click();return true})()`);
 const clickExact = (cdp: any, label: string) =>
-  cdp.ev(`(()=>{const b=[...document.querySelectorAll('button')].find(e=>e.textContent.trim()===${JSON.stringify(label)});if(!b)return false;b.click();return true})()`);
+  cdp.ev(`(()=>{const b=[...document.querySelectorAll('button')].find(e=>e.textContent.trim()===${jsLit(label)});if(!b)return false;b.click();return true})()`);
 
 /* ------------------------------------------------------------------ scenario */
 

--- a/server/test/cdp-literal.test.ts
+++ b/server/test/cdp-literal.test.ts
@@ -12,15 +12,16 @@
 // have already stopped being literals written in the script.
 //
 // It lives in the server suite because that is a place CI runs; the helper it
-// tests is shared by every script under scripts/.
+// tests is shared by the scripts under scripts/, the conflict drive and the
+// browser panel, all three of which hand a built string to an engine.
 import { describe, expect, test } from "bun:test";
-import { lit } from "../../scripts/cdp.ts";
+import { jsLit } from "../../shared/jsLit.ts";
 
 /** What a JS engine gets back when it evaluates the literal we produced. The
  *  real question is never "how is it spelled" but "does it round-trip". */
-const evaluated = (v: unknown) => new Function(`return ${lit(v)}`)();
+const evaluated = (v: unknown) => new Function(`return ${jsLit(v)}`)();
 
-describe("lit", () => {
+describe("jsLit", () => {
   test("round-trips ordinary selectors and labels", () => {
     for (const v of ['nav button', '.mb-screen.on .mb-row', 'Files', '\\', "it's", 'a "quoted" label']) {
       expect(evaluated(v)).toBe(v);
@@ -34,14 +35,14 @@ describe("lit", () => {
   test("escapes the line separators JSON leaves bare", () => {
     // The bug: `JSON.stringify` returns these raw, and a JS parser of the era
     // that matters here ends the string on them.
-    expect(lit("a\u2028b")).not.toContain("\u2028");
-    expect(lit("a\u2029b")).not.toContain("\u2029");
+    expect(jsLit("a\u2028b")).not.toContain("\u2028");
+    expect(jsLit("a\u2029b")).not.toContain("\u2029");
     expect(evaluated("a\u2028b")).toBe("a\u2028b");
     expect(evaluated("a\u2029b")).toBe("a\u2029b");
   });
 
   test("a value cannot close a script element", () => {
-    const out = lit("</script><script>alert(1)</script>");
+    const out = jsLit("</script><script>alert(1)</script>");
     expect(out).not.toContain("<");
     expect(evaluated("</script><script>alert(1)</script>")).toBe("</script><script>alert(1)</script>");
   });

--- a/shared/jsLit.ts
+++ b/shared/jsLit.ts
@@ -1,0 +1,44 @@
+/**
+ * A value as a JavaScript literal, safe to paste into source that is about to
+ * be evaluated somewhere else.
+ *
+ * Three places in this repository build a snippet of JavaScript as a string and
+ * hand it to an engine: the capture and audit scripts through CDP
+ * `Runtime.evaluate`, the conflict drive the same way, and the browser panel
+ * through the webview's `executeJavaScript`. The values pasted into them are
+ * selectors, key names, label fragments and typed text.
+ *
+ * `JSON.stringify` alone is the obvious way to quote those and it is not quite
+ * enough, because JSON is not a subset of JavaScript. U+2028 and U+2029 survive
+ * it unescaped and were line terminators to a JS parser, which ends the string
+ * mid-expression and leaves whatever follows as code; the same value reaching an
+ * inline `<script>` would end it at a literal `</script>`.
+ *
+ * Neither is exotic once a value stops being written in the file that uses it.
+ * `AUDIT_REPO` is read from the environment, label fragments are chosen to match
+ * text the app rendered, and the panel's selectors arrive over the wire from an
+ * agent — the server's own gate refuses a newline, a carriage return and a NUL
+ * in a selector and lets U+2028 through, so that shape does reach a literal.
+ *
+ * So the quoting is done once, correctly, in the one place all of it passes
+ * through, instead of being a property of who happened to call it. It lives in
+ * `shared/` rather than beside any one caller because the callers are in
+ * `scripts/`, `web/` and `server/`, and a second copy is where two of them
+ * drift apart.
+ *
+ * It does not change the string the engine ends up with — `\x3c` is `<` to a JS
+ * parser, and `\u2028` is U+2028. What changes is that neither can end anything
+ * early on the way there.
+ *
+ * Note the escapes in the two replacements below: a bare U+2028 in a regular
+ * expression literal is a line terminator in SOURCE, and the file does not
+ * parse. That is the same property this function exists to handle, seen from
+ * the other side.
+ */
+export const jsLit = (v: unknown): string =>
+  JSON.stringify(v)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029")
+    // `\x3c` is the same character to a JS parser and cannot close a script
+    // element, so a snippet stays inert wherever it is eventually placed.
+    .replace(/</g, "\\x3c");

--- a/web/src/lib/browserDrive.ts
+++ b/web/src/lib/browserDrive.ts
@@ -1,4 +1,5 @@
 import type { BrowserAskFrame } from "../../../shared/types.ts";
+import { jsLit } from "../../../shared/jsLit.ts";
 
 /**
  * The window's half of "let an agent drive the browser".
@@ -12,9 +13,14 @@ import type { BrowserAskFrame } from "../../../shared/types.ts";
  * Everything reaches the page through `executeJavaScript`, which is the only
  * door the webview tag offers, and that is exactly why the verbs are a closed
  * set with no `eval` among them: the code below is written here, and a selector
- * arriving from outside is embedded with JSON.stringify rather than pasted into
- * a template. A selector is data. It has been a source of injection everywhere
- * it was ever treated as anything else.
+ * arriving from outside is embedded as a literal rather than pasted into a
+ * template. A selector is data. It has been a source of injection everywhere it
+ * was ever treated as anything else.
+ *
+ * The literal is built by `jsLit`, which is the repository's one answer to
+ * this and not `JSON.stringify` — JSON is not a subset of JavaScript, and the
+ * server's gate on a selector refuses a newline while letting U+2028 through.
+ * See `shared/jsLit.ts`.
  */
 
 /** The slice of Electron's `<webview>` this needs. Narrowed rather than `any`,
@@ -81,7 +87,7 @@ export async function runBrowserAsk(
    *  file whose job is small enough to test without any of them. */
   captureFromShell: () => Promise<string | null> = async () => null,
 ): Promise<{ ok: boolean; value?: unknown; error?: string }> {
-  const sel = JSON.stringify(String(ask.args.selector ?? ""));
+  const sel = jsLit(String(ask.args.selector ?? ""));
   try {
     switch (ask.op) {
       case "open": {
@@ -137,7 +143,7 @@ export async function runBrowserAsk(
       }
 
       case "type": {
-        const text = JSON.stringify(String(ask.args.text ?? ""));
+        const text = jsLit(String(ask.args.text ?? ""));
         const submit = ask.args.submit === true;
         const hit = await el.executeJavaScript(
           `(() => { const e = document.querySelector(${sel});

--- a/web/test/browser-drive.test.ts
+++ b/web/test/browser-drive.test.ts
@@ -221,3 +221,66 @@ describe("driving a page", () => {
     expect(r.error).toContain("Script failed");
   });
 });
+
+/*
+ * The selector and the typed text are the only outside strings that reach a
+ * literal in code this file builds, and they arrive over the wire from an
+ * agent. The server's gate (server/src/browserdrive.ts) refuses a newline, a
+ * carriage return and a NUL in a selector and lets everything else through —
+ * including U+2028 and U+2029, which JSON.stringify leaves bare and which were
+ * line terminators to a JS parser. So the lock is not "we called the right
+ * helper": it runs what the panel built and checks nothing escaped.
+ */
+describe("a hostile selector stays data", () => {
+  const PAYLOADS: Array<[string, string]> = [
+    ["a double quote", 'a"]'],
+    ["a quote break-out", 'x"); globalThis.__canary.hit = 1; ("'],
+    ["a trailing backslash", "a\\"],
+    ["a backslash before a quote", 'a\\"; globalThis.__canary.hit = 1; //'],
+    ["U+2028 and code after it", "a\u2028globalThis.__canary.hit = 1;//"],
+    ["U+2029 and code after it", "a\u2029globalThis.__canary.hit = 1;//"],
+    ["a closing script tag", '</script><img src=x onerror="globalThis.__canary.hit = 1">'],
+    ["a template literal", "a`${globalThis.__canary.hit = 1}`"],
+    ["a comment close", "a*/ globalThis.__canary.hit = 1; /*"],
+    ["a lone surrogate", "a\uD800b"],
+  ];
+  const VERBS = ["click", "type", "wait", "text", "scroll"];
+
+  /** Run the built code for real, with a querySelector that records exactly
+   *  what it was handed. Evaluating it is the point: asserting on the shape of
+   *  the string would pass for any escaping that merely looks careful. */
+  function run(code: string) {
+    const seen: string[] = [];
+    const doc = {
+      querySelector: (s: string) => { seen.push(s); return null; },
+      body: { innerText: "", scrollHeight: 100 },
+      title: "",
+    };
+    const win = { scrollTo: () => {}, scrollBy: () => {}, scrollY: 0, innerHeight: 10 };
+    // `wait` polls on a timer; a no-op setTimeout stops it after one look.
+    new Function("document", "window", "location", "setTimeout", `return ${code}`)(
+      doc, win, { href: "about:blank" }, () => 0,
+    );
+    return seen;
+  }
+
+  for (const [name, payload] of PAYLOADS) {
+    test(`${name} reaches querySelector verbatim and runs nothing`, async () => {
+      for (const op of VERBS) {
+        const el = fakeGuest(() => false);
+        const g = globalThis as unknown as { __canary: { hit: number } };
+        g.__canary = { hit: 0 };
+        await runBrowserAsk(el, ask(op, { selector: payload, text: payload, submit: false }));
+        const code = el.ran.find((c) => c.includes("querySelector"));
+        expect(code, `${op} built no querySelector`).toBeDefined();
+        expect(run(code!), `${op} did not receive the selector whole`).toEqual([payload]);
+        expect(g.__canary.hit, `${op} let the payload execute`).toBe(0);
+        // Nothing that could end a string, a line or a script element survives
+        // into the source — the property `jsLit` exists to hold.
+        expect(code).not.toContain("\u2028");
+        expect(code).not.toContain("\u2029");
+        expect(code!.slice(code!.indexOf("querySelector"))).not.toContain("<");
+      }
+    });
+  }
+});


### PR DESCRIPTION
## What does this PR do?

Closes the seven open `js/bad-code-sanitization` alerts — six in `web/src/lib/browserDrive.ts`, one in `scripts/conflict-drive.ts` — by using the helper this repository already wrote for exactly this, instead of dismissing them.

They are **not** exploitable, and that was measured rather than argued: see below. But they are not a false positive worth dismissing seven times either. `scripts/cdp.ts` already had the answer — `JSON.stringify`, plus the two line separators it leaves bare, plus `<` as `\x3c` — under a comment saying the quoting is done *"once, correctly, in the one place all of it passes through, instead of being a property of who happened to call it"*. CodeQL flags none of its callers. The seven alerts are precisely the two files that reach past it.

So the helper moves to `shared/jsLit.ts` and is called `jsLit`, because its callers are now in `scripts/`, `web/` and `server/`, and re-exporting it from a file about the DevTools protocol is how the second copy starts. `browserDrive.ts` uses it for the selector and the typed text; `clickExact` uses it for its label.

Nothing else changes. The string the engine ends up with is identical — `\x3c` is `<` to a JS parser — measured across ten payloads before a single caller was touched.

Why the query's premise about the *input* is right, and its conclusion about the *sink* is not: `okSelector` in `server/src/browserdrive.ts` refuses a newline, a carriage return and a NUL, and lets U+2028 through, so a raw line separator really does reach a literal — 15 of the 55 scripts below carried one. But U+2028 and U+2029 have been legal inside a string literal since ES2019, and neither of these sinks parses HTML, so `</script>` is inert there.

## How was it tested?

`bun run typecheck` in `web/` and `server/`, both suites, and `make headcheck` on the commit:

```
server            2464 pass / 0 fail   (2465 across 217 files, 191s)
web               1893 pass / 0 fail
typecheck         clean, web/ and server/
make headcheck    "f5da4fb compiles on its own"
```

Before the change, the exploitability claim was measured. Eleven hostile payloads through five verbs, built by the real path — `parseAsk` in the server and `runBrowserAsk` in the panel — gives 55 scripts, and every one of them was run:

```
bun 1.3.9 (JavaScriptCore)                  55 · 0 break-outs · 55 verbatim
node 24.13.1 (V8 13.6)                      55 · 0 · 55
electron 33.4.11 / chromium 130 (V8 13.0)   55 · 0 · 55
Chrome 151 (V8), over CDP Runtime.evaluate  55 · 0 · 55
```

"verbatim" means `document.querySelector` received the payload whole, as one argument. The Chromium run sends the expression *as the expression*, which is what `executeJavaScript` does — wrapping it to get it into the browser would have meant relying on the escaping under test. The published shell is Electron 43 / Chromium 150, between the two ends of that table.

The lock added here runs the built code rather than reading it: a `querySelector` that records what it was handed must receive the payload whole and exactly once, and a canary on `globalThis` must be untouched. An assertion on the *shape* of the string would pass for any escaping that merely looks careful.

And it is proven by removal — with `JSON.stringify` put back, three of the ten payloads go red, and they are the three the query names:

```
(fail) a hostile selector stays data > U+2028 and code after it …
(fail) a hostile selector stays data > U+2029 and code after it …
(fail) a hostile selector stays data > a closing script tag …
```

The commit message carries the detail.
