### PR TITLE
The demo shows the terminal and the browser instead of hiding them

### DIFF
--- a/web/src/components/BrowserPanel.tsx
+++ b/web/src/components/BrowserPanel.tsx
@@ -39,6 +39,9 @@ import { type DrivableWebview } from "../lib/browserDrive.ts";
 import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
 import { PagePicker } from "./browser/PagePicker.tsx";
 import { MarkupLayer } from "./browser/MarkupLayer.tsx";
+import { DemoPage } from "./browser/DemoPage.tsx";
+import { IS_DEMO } from "../lib/demo.ts";
+import { DEMO_BROWSER_TABS } from "../lib/demoBrowser.ts";
 import { ICON } from "../lib/iconSize.ts";
 import { openSettings } from "../lib/openSettings.ts";
 import { suggest, type Suggestion } from "../lib/suggest.ts";
@@ -135,6 +138,13 @@ export function BrowserView(_props: { active: boolean }) {
    */
   const [profile, setProfile] = useState<string>(() => readSession()?.current ?? "");
   const [tabs, setTabs] = useState<BrowserTab[]>(() => {
+    // The demo opens with its own strip rather than whatever a previous visit
+    // left in localStorage: a saved single blank tab would show the empty-state
+    // card, which is exactly the dead panel this exists to stop being.
+    if (IS_DEMO) return DEMO_BROWSER_TABS.map((t, i) => {
+      const tab = sleepingTab(t.url, t.title, null, "");
+      return i === 0 ? { ...tab, asleep: false } : tab;
+    });
     const saved = readSession();
     const set = setFor(saved, saved?.current ?? "");
     if (!set) return [newTab(homePage(), saved?.current ?? "")];
@@ -554,7 +564,9 @@ export function BrowserView(_props: { active: boolean }) {
     if (k === "l") { e.preventDefault(); (document.getElementById("agx-browser-url") as HTMLInputElement | null)?.focus(); }
   };
 
-  if (!HAS_BROWSER) return null;
+  // The demo has no guest to attach and still draws the panel: its pages are
+  // written into the build, and the chrome around them is this component.
+  if (!HAS_BROWSER && !IS_DEMO) return null;
 
   const blank = !active?.url || active.url === BLANK;
   // Only while typing: `typed` is null the moment the bar is not being edited,
@@ -970,13 +982,17 @@ export function BrowserView(_props: { active: boolean }) {
           <div key={t.id} className="absolute inset-0 flex justify-center"
             style={t.id === activeId ? undefined : { visibility: "hidden" }}>
             <div style={{ width: viewport.width ? `${viewport.width}px` : "100%", height: "100%", maxWidth: "100%" }}>
-              <webview
-                ref={bind(t.id) as unknown as React.Ref<HTMLElement>}
-                src={t.url || BLANK}
-                partition={partitionFor(BROWSER_PARTITION, t.profile)}
-                allowpopups={undefined}
-                style={{ width: "100%", height: "100%", background: "var(--bg)" }}
-              />
+              {IS_DEMO ? (
+                <DemoPage url={t.url || BLANK} />
+              ) : (
+                <webview
+                  ref={bind(t.id) as unknown as React.Ref<HTMLElement>}
+                  src={t.url || BLANK}
+                  partition={partitionFor(BROWSER_PARTITION, t.profile)}
+                  allowpopups={undefined}
+                  style={{ width: "100%", height: "100%", background: "var(--bg)" }}
+                />
+              )}
             </div>
           </div>
           )

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -27,6 +27,7 @@ import { answerDecrqm } from "../lib/xtermDecrqm.ts";
 import { openExternal } from "../lib/externalUrl.ts";
 import type { GitRepoRef, GitBranch, TerminalCommands, TmuxWindow, TmuxPane, PtyServerFrame, PtyClientFrame } from "../../../shared/types.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
+import { playDemoSession } from "../lib/demoTerm.ts";
 import { CommandBar, loadCommands } from "./CommandBar.tsx";
 import { SCROLLBAR_CSS } from "./ChangesModal.tsx";
 import { wantsWebgl, wantsCanvas, fallBackToCanvas } from "../lib/termRenderer.ts";
@@ -270,10 +271,30 @@ function evictLru(exceptRoot: string) {
   // An evicted session must not resurrect itself from a pending retry.
   if (lru.retryTimer) { clearTimeout(lru.retryTimer); lru.retryTimer = null; }
   try { ws?.close(); } catch { /* already gone */ }
+  stopDemoFor(lru.id);
   try { lru.term.dispose(); } catch { /* already disposed */ }
   lru.holder.remove();
   sessions.delete(lru.id);
   rosterChanged();
+}
+
+/**
+ * The demo's canned session, and the two things that have to be remembered
+ * about it: which sessions have already played it, and how to stop one.
+ *
+ * Module scope rather than component state, because `sessions` is module scope
+ * too — the panel unmounts and remounts as views are switched while a terminal
+ * outlives it, and a replay tracked in a hook would restart on every remount.
+ * A timer chain that writes into a disposed xterm throws from a callback nobody
+ * is awaiting, so eviction and close both stop it first.
+ */
+const demoPlayed = new Set<string>();
+const stopDemo = new Map<string, () => void>();
+function stopDemoFor(id: string) {
+  const stop = stopDemo.get(id);
+  if (!stop) return;
+  stop();
+  stopDemo.delete(id);
 }
 
 /**
@@ -687,6 +708,7 @@ function killSession(s: Sess) {
   const ws = s.ws;
   s.ws = null; // detach first so the close handler stays quiet
   try { ws?.close(); } catch { /* already gone */ }
+  stopDemoFor(s.id);
   try { s.term.dispose(); } catch { /* already disposed */ }
   s.holder.remove();
   sessions.delete(s.id);
@@ -1337,12 +1359,17 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     return () => { stopped = true; clearInterval(id); };
   }, [open, focusIdx, paneIds, repos, root, here?.worktreeOf, here?.root]);
 
-  const tabs = !IS_DEMO && root ? termSessionsFor(root) : [];
+  const tabs = root ? termSessionsFor(root) : [];
 
   // Every repo opens with a shell, and the panes always name shells that still
   // exist — closing one must not leave an empty frame behind.
+  //
+  // The demo creates them too. `createSession` builds an xterm and touches
+  // nothing else — `connect` is the only step that opens a socket, and it
+  // returns early in a demo build — so what the demo gets is the real terminal
+  // with nothing talking to it, which is what `playDemoSession` then fills.
   useEffect(() => {
-    if (!open || !root || IS_DEMO) return;
+    if (!open || !root) return;
     const live = termSessionsFor(root);
     const first = live[0] ?? createSession(root);
     setPaneIds((prev) => {
@@ -1430,7 +1457,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   }, [ffm, repoOpen, wtOpen, findOpen, active, open, paneIds]);
 
   useEffect(() => {
-    if (!open || IS_DEMO) return;
+    if (!open) return;
     panelClose = () => closeRef.current();
     // Claim the find chord only while this view is on screen and has a pane to
     // search — see `panelFind`.
@@ -1453,6 +1480,13 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
       const fitSoon = () => { if (fitTimer) clearTimeout(fitTimer); fitTimer = setTimeout(doFit, 100); };
       doFit();
       if (s.status === "idle") connect(s);
+      // Once per session, not once per mount: switching views and coming back
+      // would otherwise replay the same test run on top of itself, and the
+      // scrollback would read as a shell stuck in a loop.
+      if (IS_DEMO && !demoPlayed.has(s.id)) {
+        demoPlayed.add(s.id);
+        stopDemo.set(s.id, playDemoSession(s.term));
+      }
       const ro = new ResizeObserver(fitSoon);
       ro.observe(el);
       mounted.push({ s, el, ro, unTheme, stopFit: () => { if (fitTimer) clearTimeout(fitTimer); } });
@@ -1791,7 +1825,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   }, [paneIds, focusIdx]);
 
   const repoRef = repos.find((r) => r.root === root);
-  const disabled = cmds ? !cmds.enabled : false;
+  /* The demo has no server to ask, so `loadCommands` answers with a terminal
+     that is switched off — and the overlay that message drives was covering the
+     canned session. The demo's terminal is not disabled: it has no shell, which
+     is a different thing and is what the status line says. */
+  const disabled = !IS_DEMO && cmds ? !cmds.enabled : false;
 
   const statusDot: Record<SessStatus, { color: string; label: string }> = {
     idle: { color: "var(--text2)", label: "Idle" },
@@ -2340,11 +2378,14 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         }} />
                     ))}
                   </div>
-                  {(IS_DEMO || disabled) && (
+                  {/* Not in the demo any more. The overlay is for a terminal
+                      that cannot draw anything — Windows, or disabled by config
+                      — and in the demo it was covering a terminal that now has
+                      a session in it. What the demo owes a visitor is the note
+                      in the status line below, not a sheet over the feature. */}
+                  {disabled && (
                     <div className="absolute inset-0 flex items-center justify-center text-[12px] t-dim2" style={{ background: "color-mix(in srgb, var(--bg) 80%, transparent)" }}>
-                      {IS_DEMO
-                        ? "The terminal is disabled in the demo — run agentglass locally for a real shell"
-                        : cmds?.reason === "windows"
+                      {cmds?.reason === "windows"
                         ? "The terminal is not available on Windows yet (the PTY backend needs POSIX; ConPTY support is planned)"
                         : cmds?.reason === "config"
                         ? "Terminal disabled (terminalDisabled in config.json)"
@@ -2387,10 +2428,19 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         </Fragment>
                       ))}
                     </span>
-                  ) : IS_DEMO || disabled ? (
-                    // The shell isn't running here (demo, Windows, or disabled by
-                    // env), so promising a real shell with working TUIs would be
-                    // the lie the overlay above just corrected. Say nothing.
+                  ) : IS_DEMO ? (
+                    // The renderer, the theme and the scrollback are real; the
+                    // bytes are written into the build. Said here rather than
+                    // over the pane, because a visitor should be able to read
+                    // the session and be told what it is at the same time.
+                    <span className="flex items-center gap-2">
+                      <span className="px-1.5 rounded" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 14%, transparent)" }}>demo</span>
+                      <span>A canned session — the terminal is real, nothing is running behind it. Run agentglass locally for a shell you can type in.</span>
+                    </span>
+                  ) : disabled ? (
+                    // The shell isn't running here (Windows, or disabled by env),
+                    // so promising a real shell with working TUIs would be the
+                    // lie the overlay above just corrected. Say nothing.
                     <span className="t-dim2">{cmds?.reason === "windows" ? "Terminal not available on Windows yet" : "Terminal unavailable"}</span>
                   ) : (
                     <span>Real shell — Ctrl+C, Ctrl+R, Tab-complete, vim/htop all work · sessions survive closing this panel · Shift+Esc closes it</span>

--- a/web/src/components/browser/DemoPage.tsx
+++ b/web/src/components/browser/DemoPage.tsx
@@ -1,0 +1,121 @@
+/**
+ * A page, drawn rather than embedded — the demo build's stand-in for a guest.
+ *
+ * See `lib/demoBrowser.ts` for why the demo has a browser view at all. This
+ * component only has to be a convincing PAGE: everything that makes it a
+ * browser — the strip, the address bar, find, the profile menu — is the real
+ * panel around it.
+ *
+ * It carries its own light palette on purpose and does NOT follow the app's
+ * theme. A page does not: a real browser showing a real site inside this panel
+ * is a bright rectangle in a dark window, and that contrast is most of what
+ * makes the view read as a browser rather than as another panel.
+ */
+import { DEMO_BASKET, DEMO_DISCOUNT, DEMO_HEALTH, DEMO_SHIPPING, money, subtotal, total } from "../../lib/demoBrowser.ts";
+
+const PAPER = "#fbfaf7";
+const INK = "#1f2328";
+const MUTED = "#6b7280";
+const LINE = "#e6e2da";
+const BRAND = "#1c5b4a";
+
+function Storefront({ checkout }: { checkout: boolean }) {
+  return (
+    <div style={{ minHeight: "100%", background: PAPER, color: INK, fontFamily: "ui-sans-serif, system-ui, sans-serif" }}>
+      <header style={{ display: "flex", alignItems: "center", gap: 16, padding: "14px 28px", borderBottom: `1px solid ${LINE}` }}>
+        <span style={{ fontSize: 17, fontWeight: 600, letterSpacing: "-0.01em", color: BRAND }}>Harbour Goods</span>
+        <nav style={{ display: "flex", gap: 18, fontSize: 13, color: MUTED }}>
+          <span>Rope</span><span>Brass</span><span>Deck</span><span>Charts</span>
+        </nav>
+        <span style={{ marginLeft: "auto", fontSize: 12.5, color: MUTED }}>
+          Basket · {DEMO_BASKET.reduce((n, l) => n + l.qty, 0)} items
+        </span>
+      </header>
+
+      <div style={{ padding: "26px 28px", maxWidth: 760 }}>
+        <h1 style={{ fontSize: 22, fontWeight: 600, margin: "0 0 4px", letterSpacing: "-0.01em" }}>
+          {checkout ? "Checkout" : "Your basket"}
+        </h1>
+        <p style={{ fontSize: 13, color: MUTED, margin: "0 0 22px" }}>
+          {checkout ? "Two of the same line, one discount." : "Nothing here has shipped yet — this is the dev server on :5173."}
+        </p>
+
+        <table style={{ width: "100%", borderCollapse: "collapse", fontSize: 13.5 }}>
+          <thead>
+            <tr style={{ textAlign: "left", color: MUTED, fontSize: 11.5, textTransform: "uppercase", letterSpacing: "0.04em" }}>
+              <th style={{ padding: "0 0 8px" }}>Item</th>
+              <th style={{ padding: "0 0 8px", width: 60, textAlign: "right" }}>Qty</th>
+              <th style={{ padding: "0 0 8px", width: 90, textAlign: "right" }}>Each</th>
+              <th style={{ padding: "0 0 8px", width: 90, textAlign: "right" }}>Line</th>
+            </tr>
+          </thead>
+          <tbody>
+            {DEMO_BASKET.map((l) => (
+              <tr key={l.name} style={{ borderTop: `1px solid ${LINE}` }}>
+                <td style={{ padding: "9px 0" }}>{l.name}</td>
+                <td style={{ padding: "9px 0", textAlign: "right" }}>{l.qty}</td>
+                <td style={{ padding: "9px 0", textAlign: "right", color: MUTED }}>{money(l.each)}</td>
+                <td style={{ padding: "9px 0", textAlign: "right", fontVariantNumeric: "tabular-nums" }}>{money(l.qty * l.each)}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+
+        <div style={{ marginTop: 18, marginLeft: "auto", width: 260, fontSize: 13.5 }}>
+          {[["Subtotal", money(subtotal())], ["Discount HARBOUR5", `−${money(DEMO_DISCOUNT)}`], ["Shipping", money(DEMO_SHIPPING)]].map(([k, v]) => (
+            <div key={k} style={{ display: "flex", justifyContent: "space-between", padding: "5px 0", color: MUTED }}>
+              <span>{k}</span><span style={{ fontVariantNumeric: "tabular-nums" }}>{v}</span>
+            </div>
+          ))}
+          <div style={{ display: "flex", justifyContent: "space-between", padding: "10px 0 0", marginTop: 6, borderTop: `1px solid ${LINE}`, fontWeight: 600 }}>
+            <span>Total</span><span style={{ fontVariantNumeric: "tabular-nums" }}>{money(total())}</span>
+          </div>
+          <button style={{ marginTop: 14, width: "100%", padding: "9px 0", border: "none", borderRadius: 6, background: BRAND, color: "#fff", fontSize: 13.5, fontWeight: 500 }}>
+            {checkout ? "Pay " + money(total()) : "Checkout"}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function Json() {
+  return (
+    <div style={{ minHeight: "100%", background: "#fff", color: INK, padding: "18px 22px", fontFamily: "ui-monospace, SFMono-Regular, Menlo, monospace", fontSize: 12.5, lineHeight: 1.65 }}>
+      <pre style={{ margin: 0, whiteSpace: "pre-wrap" }}>{JSON.stringify(DEMO_HEALTH, null, 2)}</pre>
+    </div>
+  );
+}
+
+/** An address the demo has no page for. Chromium's own wording, because a
+ *  visitor who types something into the bar should get the answer a browser
+ *  gives rather than one this app invented. */
+function NotReached({ url }: { url: string }) {
+  let host = url;
+  try { host = new URL(url).host || url; } catch { /* whatever was typed */ }
+  return (
+    <div style={{ minHeight: "100%", background: "#fff", color: INK, padding: "56px 60px", fontFamily: "ui-sans-serif, system-ui, sans-serif", maxWidth: 620 }}>
+      <div style={{ fontSize: 44, lineHeight: 1, color: "#c9ccd1", marginBottom: 22 }}>⚠</div>
+      <h1 style={{ fontSize: 19, fontWeight: 500, margin: "0 0 10px" }}>This page isn’t in the demo</h1>
+      <p style={{ fontSize: 13.5, color: MUTED, margin: "0 0 6px", lineHeight: 1.6 }}>
+        <b style={{ color: INK, fontWeight: 500 }}>{host}</b> was not fetched. The demo runs entirely in this
+        tab and reaches nothing, so its browser shows pages that were written into it.
+      </p>
+      <p style={{ fontSize: 13.5, color: MUTED, margin: 0, lineHeight: 1.6 }}>
+        Run agentglass locally and this view is a real browser — logged into what you are
+        logged into, and drivable by an agent.
+      </p>
+    </div>
+  );
+}
+
+export function DemoPage({ url }: { url: string }) {
+  const page = url.startsWith("http://localhost:3000")
+    ? <Json />
+    : url.startsWith("http://localhost:5173")
+      ? <Storefront checkout={url.includes("/checkout")} />
+      : <NotReached url={url} />;
+  // Scrolls on its own, like a page. The panel gives it a fixed box and the
+  // real guest scrolls inside one too.
+  return <div style={{ width: "100%", height: "100%", overflow: "auto", background: "#fff" }}>{page}</div>;
+}

--- a/web/src/components/workspace/views.ts
+++ b/web/src/components/workspace/views.ts
@@ -2,6 +2,7 @@ import type { ComponentType } from "react";
 import type { ViewId } from "../../../../shared/types.ts";
 import { GitIcon, DiffIcon, DockerIcon, TerminalIcon, ChatIcon, PrIcon, BrowserIcon, FilesIcon, DashIcon, IssuesIcon } from "./icons.tsx";
 import { HAS_BROWSER } from "../../lib/desktop.ts";
+import { IS_DEMO } from "../../lib/demo.ts";
 
 /** Re-exported from shared so the server (POST /control validation) and the UI
  *  name one set of views. */
@@ -36,7 +37,13 @@ export type ViewDef = {
  *  without renumbering chords people already have in their fingers — and it is
  *  dropped entirely outside the desktop shell, where a `<webview>` does not
  *  exist. A rail entry that opens an empty pane on a phone would be worse than
- *  no entry at all. */
+ *  no entry at all.
+ *
+ *  The demo is the exception, and it is not a phone: it has pages written into
+ *  it (see lib/demoBrowser.ts), so the entry opens something. Dropping it there
+ *  meant the browser did not exist for anybody evaluating the app from the
+ *  landing page, which is a worse outcome than the empty pane this guard is
+ *  about. */
 export const VIEWS: ViewDef[] = [
   // First, and it leads for a reason: this is the app's own screen — the fleet,
   // the spend, the history — and it used to BE the app. It is a view now, but a
@@ -49,7 +56,7 @@ export const VIEWS: ViewDef[] = [
   { id: "docker", label: "Docker", key: "o", icon: DockerIcon, hint: "Containers, logs, stats & actions" },
   { id: "term", label: "Term", key: "t", icon: TerminalIcon, hint: "A real shell in any repo/worktree" },
   { id: "chat", label: "Chat", key: "c", icon: ChatIcon, hint: "Drive a Claude session in any repo/worktree", group: "utility" },
-  ...(HAS_BROWSER
+  ...(HAS_BROWSER || IS_DEMO
     ? [{ id: "browser" as const, label: "Browser", key: "b", icon: BrowserIcon, hint: "A page, without leaving the app", group: "utility" as const }]
     : []),
   // Appended, for the same reason Browser was: ⌘1..⌘N index into this order,

--- a/web/src/lib/demoBrowser.ts
+++ b/web/src/lib/demoBrowser.ts
@@ -1,0 +1,72 @@
+/**
+ * The pages the demo's built-in browser is showing, for the demo build only.
+ *
+ * The browser view was dropped from the rail entirely outside the desktop shell
+ * (`workspace/views.ts`), because a `<webview>` does not exist in a browser tab
+ * and an entry that opens an empty pane is worse than no entry. True on a
+ * phone; wrong for the demo the landing page links to, where the effect was
+ * that the feature simply did not exist for anybody evaluating the app.
+ *
+ * A demo cannot embed a live page — there is no guest to attach — so these are
+ * drawn as ordinary DOM by `components/browser/DemoPage.tsx`. Everything around
+ * them is the real panel: the strip, the address bar with its suggestions, the
+ * find bar, the profile menu.
+ *
+ * The addresses are the demo's own machine, and they agree with the rest of it:
+ * the ports panel lists vite on 5173 in `shop-web` and bun on 3000 in
+ * `shop-api`, and the cart below adds up the way the checkout test in
+ * `demoTerm.ts` says it should. Nothing here names a real company or borrows a
+ * real site's interface — a fabricated page wearing somebody's brand is a
+ * forgery, however small, and this one only has to look like a page.
+ */
+
+export interface DemoTabSeed {
+  url: string;
+  title: string;
+}
+
+/** What the strip opens with. Three, because one tab hides the strip. */
+export const DEMO_BROWSER_TABS: DemoTabSeed[] = [
+  { url: "http://localhost:5173/", title: "Harbour Goods — dev" },
+  { url: "http://localhost:3000/health", title: "shop-api · health" },
+  { url: "http://localhost:5173/checkout", title: "Checkout — Harbour Goods" },
+];
+
+export interface DemoLine {
+  name: string;
+  qty: number;
+  /** Pence, so the arithmetic on screen is the arithmetic in the test. */
+  each: number;
+}
+
+/** The basket the checkout test is about: two of one line, and a discount that
+ *  applies once rather than per unit. */
+export const DEMO_BASKET: DemoLine[] = [
+  { name: "Deck brush, stiff", qty: 2, each: 1_150 },
+  { name: "Cotton rope, 8mm — 10m", qty: 1, each: 2_400 },
+  { name: "Brass cleat", qty: 4, each: 890 },
+];
+
+export const DEMO_DISCOUNT = 500;
+export const DEMO_SHIPPING = 450;
+
+export const subtotal = (lines: DemoLine[] = DEMO_BASKET) =>
+  lines.reduce((n, l) => n + l.qty * l.each, 0);
+
+/** Shipping is not discounted — the third passing assertion in the canned test
+ *  run, and the reason this is a function rather than a written-down number. */
+export const total = (lines: DemoLine[] = DEMO_BASKET) =>
+  subtotal(lines) - DEMO_DISCOUNT + DEMO_SHIPPING;
+
+export const money = (pence: number) =>
+  `£${(pence / 100).toFixed(2)}`;
+
+/** The JSON the api tab is showing. A real `/health` answer, shaped like the
+ *  server's own. */
+export const DEMO_HEALTH = {
+  ok: true,
+  service: "shop-api",
+  version: "2.4.1",
+  uptime_s: 5_412,
+  checks: { db: "ok", cache: "ok", queue: "ok" },
+};

--- a/web/src/lib/demoTerm.ts
+++ b/web/src/lib/demoTerm.ts
@@ -1,0 +1,122 @@
+/**
+ * A canned shell session, for the demo build only.
+ *
+ * The terminal is the panel this app is most often described by, and in the
+ * demo it was a black rectangle with one line of grey text in the middle of it
+ * — "the terminal is disabled in the demo". Someone who clicked through from
+ * the landing page to see the shell found the one view that shows nothing.
+ * `web/src/lib/demo.ts` already had to learn this lesson once, for the
+ * pull-request panel, and the note there says it plainly: a dead panel is worse
+ * than no panel.
+ *
+ * So the demo gets a real terminal with fabricated bytes rather than a fake
+ * terminal. The renderer, the fonts, the theme, the colours, the reflow on
+ * resize and the scrollback are the product's own — the only thing that is not
+ * real is what a shell said, and there is no shell to say it. Nothing here
+ * reaches the network: the demo build never opens the PTY socket.
+ *
+ * Written as ANSI rather than as styled markup for the same reason: `\x1b[32m`
+ * is what a test runner actually emits, so the colours a visitor sees are the
+ * ones the palette assigns to green, and a theme switch repaints them.
+ *
+ * The repositories, ports and branch names match the rest of the demo — the
+ * ports panel lists vite on 5173 in `shop-web` and bun on 3000 in `shop-api`,
+ * and the git panel is on `feat/git-panel`. Two fabrications that disagree read
+ * as one of them being broken.
+ */
+
+/** One write, and how long to wait after it. */
+export type DemoChunk = [text: string, delayMs: number];
+
+const DIM = "\x1b[2m";
+const OFF = "\x1b[0m";
+const GREEN = "\x1b[32m";
+const RED = "\x1b[31m";
+const YELLOW = "\x1b[33m";
+const CYAN = "\x1b[36m";
+const BOLD = "\x1b[1m";
+
+const prompt = (dir: string) => `${CYAN}~/code/${dir}${OFF} ${DIM}$${OFF} `;
+
+/**
+ * What the pane has already been through when you arrive, and then a few
+ * seconds of it still working.
+ *
+ * The scrollback is painted at once and the tail is typed, because a terminal
+ * that is entirely still is indistinguishable from a screenshot of one, and a
+ * terminal that types its whole history from scratch keeps a visitor waiting to
+ * read something that was supposed to be already there.
+ */
+export function demoTermScript(): DemoChunk[] {
+  const past = [
+    `${prompt("shop-api")}bun test test/checkout.test.ts`,
+    ``,
+    `${DIM}bun test v1.3.9${OFF}`,
+    ``,
+    `test/checkout.test.ts:`,
+    `${GREEN}(pass)${OFF} totals are quantity-aware ${DIM}> two of the same line item${OFF} ${DIM}[3.10ms]${OFF}`,
+    `${GREEN}(pass)${OFF} totals are quantity-aware ${DIM}> a discount applies once${OFF} ${DIM}[1.44ms]${OFF}`,
+    `${GREEN}(pass)${OFF} totals are quantity-aware ${DIM}> shipping is not discounted${OFF} ${DIM}[0.98ms]${OFF}`,
+    `${RED}(fail)${OFF} refunds ${DIM}> a partial refund leaves the order payable${OFF}`,
+    ``,
+    `  ${RED}error${OFF}: expected ${GREEN}1240${OFF} to be ${RED}1200${OFF}`,
+    `      at ${CYAN}test/checkout.test.ts${OFF}:64:5`,
+    ``,
+    ` ${GREEN}3 pass${OFF}`,
+    ` ${RED}1 fail${OFF}`,
+    ` ${DIM}12 expect() calls${OFF}`,
+    `${DIM}Ran 4 tests across 1 file. [214.00ms]${OFF}`,
+    ``,
+    `${prompt("shop-api")}git log --oneline -3`,
+    `${YELLOW}9f2c1a7${OFF} checkout hardening: qty-aware totals`,
+    `${YELLOW}4a1e08b${OFF} refunds: keep the payable amount on a partial`,
+    `${YELLOW}2d77c31${OFF} test: a partial refund is not a full one`,
+    ``,
+  ];
+
+  const tail: DemoChunk[] = [
+    [`${prompt("shop-api")}`, 900],
+    [`bun test`, 700],
+    [`\r\n\r\n${DIM}bun test v1.3.9${OFF}\r\n\r\n`, 500],
+    [`test/checkout.test.ts:\r\n`, 260],
+    [`${GREEN}(pass)${OFF} totals are quantity-aware ${DIM}> two of the same line item${OFF}\r\n`, 200],
+    [`${GREEN}(pass)${OFF} totals are quantity-aware ${DIM}> a discount applies once${OFF}\r\n`, 200],
+    [`${GREEN}(pass)${OFF} totals are quantity-aware ${DIM}> shipping is not discounted${OFF}\r\n`, 240],
+    [`${GREEN}(pass)${OFF} refunds ${DIM}> a partial refund leaves the order payable${OFF}\r\n`, 420],
+    [`\r\n ${GREEN}${BOLD}4 pass${OFF}\r\n ${DIM}0 fail${OFF}\r\n`, 300],
+    [`${DIM}Ran 4 tests across 1 file. [198.00ms]${OFF}\r\n\r\n`, 400],
+    [`${prompt("shop-api")}`, 0],
+  ];
+
+  return [[past.join("\r\n") + "\r\n", 1200], ...tail];
+}
+
+/** Anything a Terminal can be asked to do here. Narrowed so a test can drive
+ *  the player with a recorder instead of a real xterm and a canvas. */
+export interface DemoWritable {
+  write(data: string): void;
+}
+
+/**
+ * Play the canned session into a terminal. Returns a stop function.
+ *
+ * Stopping matters: the panel mounts and unmounts as views are switched, and a
+ * timer chain that outlives its terminal writes into a disposed one — which
+ * xterm answers by throwing, from a callback nobody is awaiting.
+ */
+export function playDemoSession(term: DemoWritable, script: DemoChunk[] = demoTermScript()): () => void {
+  let i = 0;
+  let timer: ReturnType<typeof setTimeout> | null = null;
+  let stopped = false;
+  const step = () => {
+    if (stopped || i >= script.length) return;
+    const [text, delay] = script[i++]!;
+    term.write(text);
+    timer = setTimeout(step, delay);
+  };
+  step();
+  return () => {
+    stopped = true;
+    if (timer) clearTimeout(timer);
+  };
+}

--- a/web/test/demo-term-browser.test.ts
+++ b/web/test/demo-term-browser.test.ts
@@ -1,0 +1,101 @@
+/*
+ * The demo's terminal and browser.
+ *
+ * Both exist because the demo the landing page links to was showing nothing for
+ * either: the terminal was a black rectangle with "disabled in the demo"
+ * written across it, and the browser had been dropped from the rail entirely.
+ * What is locked here is the part a build cannot tell you about — that the
+ * replay stops when it is told to, and that the two fabrications agree with the
+ * rest of the demo rather than each inventing their own numbers.
+ */
+import { describe, expect, test } from "bun:test";
+import { renderToStaticMarkup } from "react-dom/server";
+import { createElement } from "react";
+import { demoTermScript, playDemoSession, type DemoChunk } from "../src/lib/demoTerm.ts";
+import { DEMO_BASKET, DEMO_BROWSER_TABS, DEMO_DISCOUNT, DEMO_SHIPPING, money, subtotal, total } from "../src/lib/demoBrowser.ts";
+import { DemoPage } from "../src/components/browser/DemoPage.tsx";
+
+const sleep = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("the canned terminal session", () => {
+  test("arrives with scrollback already in it", () => {
+    const script = demoTermScript();
+    // The first write is the history: a terminal that types its whole past from
+    // scratch keeps a visitor waiting to read what was supposed to be there
+    // when they arrived.
+    expect(script.length).toBeGreaterThan(5);
+    expect(script[0]![0].split("\r\n").length).toBeGreaterThan(15);
+  });
+
+  test("leaves a prompt, not a half-finished line", () => {
+    const script = demoTermScript();
+    expect(script.at(-1)![0]).toContain("$");
+  });
+
+  test("writes in order and stops when told", async () => {
+    const wrote: string[] = [];
+    const script: DemoChunk[] = [["one", 1], ["two", 1], ["three", 1], ["four", 1]];
+    const stop = playDemoSession({ write: (d) => wrote.push(d) }, script);
+    // First chunk is synchronous — the pane is never briefly empty.
+    expect(wrote).toEqual(["one"]);
+    await sleep(15);
+    stop();
+    const atStop = wrote.length;
+    await sleep(30);
+    // The reason this matters: the panel unmounts as views are switched while a
+    // terminal outlives it, and a timer chain that survives its xterm writes
+    // into a disposed one, which throws from a callback nobody is awaiting.
+    expect(wrote.length).toBe(atStop);
+  });
+
+  test("stopping before the first timer fires is safe", async () => {
+    const wrote: string[] = [];
+    const stop = playDemoSession({ write: (d) => wrote.push(d) }, [["a", 5], ["b", 5]]);
+    stop();
+    await sleep(25);
+    expect(wrote).toEqual(["a"]);
+  });
+});
+
+describe("the demo browser's pages", () => {
+  test("adds up the way the canned test run says it does", () => {
+    // Quantity-aware: two of a line is twice the line, not once.
+    expect(subtotal()).toBe(2 * 1_150 + 2_400 + 4 * 890);
+    // The discount applies once, and shipping is not discounted — the other two
+    // passing assertions in demoTerm's test output. Written as arithmetic rather
+    // than as a number so a change to the basket cannot quietly disagree with
+    // the terminal next to it.
+    expect(total()).toBe(subtotal() - DEMO_DISCOUNT + DEMO_SHIPPING);
+    expect(money(total())).toBe("£82.10");
+  });
+
+  test("browses this demo's own machine", () => {
+    // The ports panel fabricates vite on 5173 and bun on 3000. A browser tab
+    // pointing anywhere else would be a third opinion about one machine.
+    for (const t of DEMO_BROWSER_TABS) {
+      expect(t.url).toMatch(/^http:\/\/localhost:(5173|3000)\//);
+      expect(t.title.length).toBeGreaterThan(0);
+    }
+  });
+
+  test("draws the storefront, the api and an address it has no page for", () => {
+    const shop = renderToStaticMarkup(createElement(DemoPage, { url: "http://localhost:5173/" }));
+    expect(shop).toContain("Harbour Goods");
+    expect(shop).toContain(money(total()));
+
+    const api = renderToStaticMarkup(createElement(DemoPage, { url: "http://localhost:3000/health" }));
+    expect(api).toContain("shop-api");
+    expect(api).toContain("uptime_s");
+
+    // Typing an address has to answer something. It used to be a black
+    // rectangle, which is the failure this whole change is about.
+    const other = renderToStaticMarkup(createElement(DemoPage, { url: "https://example.invalid/thing" }));
+    expect(other).toContain("example.invalid");
+    expect(other).toContain("isn’t in the demo");
+  });
+
+  test("every basket line is drawn", () => {
+    const shop = renderToStaticMarkup(createElement(DemoPage, { url: "http://localhost:5173/checkout" }));
+    for (const l of DEMO_BASKET) expect(shop).toContain(l.name);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Two of the views this app is most often described by showed nothing in the demo the landing page links to. Measured before touching anything, by serving the demo build into a real Chromium and reading it over CDP:

```
rail draws:  git diff pr tasks docker term files dash chat
term:        canvas=0  .xterm=0  — "The terminal is disabled in the demo"
browser:     NO RAIL BUTTON
```

So somebody evaluating the app could not see the shell, and did not learn the built-in browser exists. `demo.ts` already had to learn this once, for the pull-request panel, and the note there says it plainly: a dead panel is worse than no panel.

**The terminal is real; only the bytes are written down.** `createSession` builds an xterm and touches nothing else — `connect` is the only step that opens a socket, and it already returned early in a demo build. So the demo stops skipping session creation and mounting, and `lib/demoTerm.ts` writes a canned session into one: the product's own renderer, fonts, theme, colours, reflow and scrollback, with nothing behind it. Written as ANSI rather than as styled markup, because `\x1b[32m` is what a test runner emits — the green a visitor sees is the green this palette assigns, and a theme switch repaints it. The scrollback is painted at once and only the tail is typed: a terminal that is entirely still is a screenshot of one, and a terminal that types its whole history keeps a visitor waiting to read what should already have been there.

The full-pane overlay is gone from the demo — it was covering the session — and what it said moves to the status line, where it can be read at the same time as the session it is about. The overlay stays for the cases it was written for: no PTY on Windows, or disabled by config. `disabled` also stops being true in the demo, because `loadCommands` has no server to ask and answered "switched off"; the demo's terminal is not disabled, it has no shell, which is a different thing and is what the status line says.

**The browser draws its pages rather than embedding them.** The rail dropped the view wherever there is no `<webview>`. Right on a phone, wrong here: the guard exists to avoid an entry that opens an empty pane, and in the demo it produced a feature that did not exist at all. `lib/demoBrowser.ts` holds the pages and `components/browser/DemoPage.tsx` draws them; everything around them is the real panel — the strip, the address bar and its suggestions, find, the profile menu. The pages carry their own light palette and deliberately do **not** follow the app's theme, because a page does not: a bright rectangle inside a dark window is most of what makes the view read as a browser. An address the demo has no page for answers instead of going black.

Nothing in those pages names a real company or borrows a real site's interface. A fabricated page wearing somebody's brand is a forgery however small, and this one only has to look like a page.

Both fabrications agree with the rest of the demo, which is the part a test can hold: the addresses are the ports panel's own vite on 5173 and bun on 3000, and the basket adds up the way the canned test run beside it says it should — two of a line is twice the line, the discount applies once, shipping is not discounted.

## How was it tested?

`bun run typecheck` and `bun test` in `web/` — **1901 pass / 0 fail** — plus both builds (`build` and `build:demo`), and then the same CDP probe run again against the rebuilt demo:

```
rail draws:  git diff pr tasks docker term files dash chat browser
term:        canvas=4  .xterm=1   status line: "demo · A canned session…"
browser:     3 tabs, localhost:5173, storefront drawn, total £82.10
```

Screenshots were read, not just the DOM: the terminal shows the canned run with its colours and a cursor mid-replay, and the browser shows a light page inside the dark window with the strip and address bar above it.

Eight new tests, holding the parts a build cannot tell you about:

- **The replay stops when it is told to**, including before its first timer fires. This is not hypothetical: the panel unmounts as views are switched while a terminal outlives it, and a timer chain that survives its xterm writes into a disposed one — which throws from a callback nobody is awaiting. Eviction and close both stop it first.
- **The first chunk is synchronous**, so the pane is never briefly empty, and the script ends on a prompt rather than a half-finished line.
- **The arithmetic is asserted as arithmetic**, not as a copied number, so a change to the basket cannot quietly disagree with the terminal next to it.
- **Every tab points at this demo's own machine** (5173 or 3000) — a tab pointing elsewhere would be a third opinion about one fabricated machine.
- **All three pages render**: the storefront, the api's JSON, and the address the demo has no page for.

The non-demo path is unchanged by construction — every edit is either inside an `IS_DEMO` branch or a guard that reads identically when it is false.
