### PR TITLE
Code opens in the editor, wherever it was found

### DIFF
--- a/server/src/files.ts
+++ b/server/src/files.ts
@@ -16,7 +16,8 @@
 // it before it reaches the filesystem — a listing endpoint that accepts
 // `../../../etc` is a file server for the whole machine.
 
-import { readdirSync, readFileSync, statSync } from "node:fs";
+import { mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join, resolve, relative, sep } from "node:path";
 import { git, safeAbs } from "./git.ts";
 import { inScope } from "./config.ts";
@@ -488,6 +489,39 @@ export function fileText(rootIn: unknown, relIn: unknown, refIn?: unknown): File
   const truncated = buf.length > MAX_TEXT_BYTES;
   const text = new TextDecoder().decode(truncated ? buf.subarray(0, MAX_TEXT_BYTES) : buf);
   return { ok: true, rel: at.rel, text, bytes: st.size, ...(truncated ? { truncated: true } : {}) };
+}
+
+/**
+ * That branch's version of a file, on disk, so an editor can open it.
+ *
+ * The reason this exists rather than the viewer rendering the text it already
+ * has: only markdown is worth rendering, and everything else in a checkout is
+ * code, which belongs in the editor that knows its language. But a file found on
+ * a branch this worktree is not on has no path an editor could be pointed at —
+ * the working tree's copy is a different file wearing the right name, and that
+ * is the wrong answer that looks like it worked.
+ *
+ * So it is materialised, exactly as `prFileToTemp` does for a pull request's
+ * copy. Everything about what may be read at all — containment, ref resolution,
+ * the size ceiling, the binary refusal — is `fileText`'s, because a second
+ * reader is a second set of rules to keep in step.
+ *
+ * Written outside the checkout: a temp file inside one turns up in somebody's
+ * `git status` an hour later, wearing a name that looks like theirs.
+ */
+export function fileToTemp(rootIn: unknown, relIn: unknown, refIn: unknown): { ok: true; file: string; ref: string } | { ok: false; error: string } {
+  const ref = typeof refIn === "string" ? refIn.trim() : "";
+  if (!ref) return { ok: false, error: "no ref given" };
+  const read = fileText(rootIn, relIn, ref);
+  if (!read.ok) return { ok: false, error: read.error ?? "could not read that file" };
+  const dir = mkdtempSync(join(tmpdir(), "agentglass-ref-"));
+  // The ref in the name, because two of these open at once is the ordinary case
+  // — the same path on two branches is exactly what somebody is comparing — and
+  // an editor's tab strip showing the same basename twice says nothing.
+  const safeRef = ref.replace(/[^A-Za-z0-9._-]+/g, "-").slice(0, 40);
+  const file = join(dir, `${safeRef}-${read.rel.split("/").pop() || "file"}`);
+  writeFileSync(file, read.text);
+  return { ok: true, file, ref };
 }
 
 /**

--- a/server/src/files.ts
+++ b/server/src/files.ts
@@ -21,6 +21,7 @@ import { tmpdir } from "node:os";
 import { join, resolve, relative, sep } from "node:path";
 import { git, safeAbs } from "./git.ts";
 import { inScope } from "./config.ts";
+import { makeViewTempDir } from "./viewtemp.ts";
 
 export interface FileEntry {
   name: string;
@@ -514,7 +515,7 @@ export function fileToTemp(rootIn: unknown, relIn: unknown, refIn: unknown): { o
   if (!ref) return { ok: false, error: "no ref given" };
   const read = fileText(rootIn, relIn, ref);
   if (!read.ok) return { ok: false, error: read.error ?? "could not read that file" };
-  const dir = mkdtempSync(join(tmpdir(), "agentglass-ref-"));
+  const dir = makeViewTempDir("ref");
   // The ref in the name, because two of these open at once is the ordinary case
   // — the same path on two branches is exactly what somebody is comparing — and
   // an editor's tab strip showing the same basename twice says nothing.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -84,7 +84,7 @@ import {
   addReminder, ackReminder, cancelReminder, snoozeReminder, listReminders,
   remindersFor, firedUnacked, setReminderHook, startReminderTick, localZone,
 } from "./reminders.ts";
-import { fileText, fileTree, findFiles, grepFiles, listRefs, filesExist } from "./files.ts";
+import { fileText, fileToTemp, fileTree, findFiles, grepFiles, listRefs, filesExist } from "./files.ts";
 import {
   overview as dockerOverview, stats as dockerStats, logs as dockerLogs, inspect as dockerInspect, top as dockerTop,
   startContainer, stopContainer, restartContainer, removeContainer, dockerCapability,
@@ -2220,6 +2220,8 @@ const server = Bun.serve<WsData>({
       // `ref` is optional everywhere: absent means this working tree, which is
       // what every existing caller sends and must keep meaning.
       if (pathname === "/files/read") return json(fileText(root, url.searchParams.get("rel") || "", url.searchParams.get("ref") || undefined));
+      // A ref's copy written out so the editor can open it — see fileToTemp.
+      if (pathname === "/files/temp") return json(fileToTemp(root, url.searchParams.get("rel") || "", url.searchParams.get("ref") || ""));
       if (pathname === "/files/find") return json(findFiles(root, url.searchParams.get("q") || "", undefined, url.searchParams.get("ref") || undefined));
       if (pathname === "/files/grep") return json(grepFiles(root, url.searchParams.get("q") || "", undefined, url.searchParams.get("ref") || undefined));
       if (pathname === "/files/refs") return json(listRefs(root));

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -18,6 +18,7 @@ import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from 
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { gitAsync, safeAbs, repoRootOf } from "./git.ts";
+import { makeViewTempDir } from "./viewtemp.ts";
 import { inScope } from "./config.ts";
 import type {
   PrRepoId, PrSummary, PrBranchSummary, PrDetail, PrListResponse, PrActionResult, PrCheck, PrCheckRollup,
@@ -2484,7 +2485,7 @@ export async function prFileToTemp(rootIn: unknown, numberIn: unknown, pathIn: u
   if (r.code !== 0) return { ok: false, error: r.stderr.trim() || "GitHub would not return that file" };
   // Named for what it is, and kept out of the repository: a stray file inside a
   // checkout would show up in somebody's `git status` an hour later.
-  const dir = mkdtempSync(join(tmpdir(), "agentglass-pr-"));
+  const dir = makeViewTempDir("pr");
   const file = join(dir, `${sha.slice(0, 7)}-${path.split("/").pop() || "file"}`);
   writeFileSync(file, r.stdout);
   return { ok: true, file, sha };

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -20,6 +20,7 @@ import { readdir } from "node:fs/promises";
 import { join, basename } from "node:path";
 import { tmpdir } from "node:os";
 import type { ServerWebSocket } from "bun";
+import { isViewTemp, viewTempDirOf } from "./viewtemp.ts";
 import type { ProjectCommand, TerminalCommands, TerminalDisabledReason, TmuxWindow, PtyServerFrame, PtyClientMessage } from "../../shared/types.ts";
 import { safeAbs, repoRootOf, repoRootOfAsync } from "./git.ts";
 import { terminalActive } from "./loopwatch.ts";
@@ -461,7 +462,7 @@ export function ptyOpen(ws: PtyWs) {
    * nothing the client sent is ever interpreted as a command.
    */
   const wanted = d.view ? safeAbs(d.view) : null;
-  const tempCopy = !!wanted && wanted.startsWith(join(tmpdir(), "agentglass-pr-"));
+  const tempCopy = !!wanted && isViewTemp(wanted);
   // In scope, or a copy this server itself wrote: a pull request's file is
   // fetched to a temp path precisely because it is not in the workspace, and
   // the check has to admit that without admitting /tmp in general.
@@ -552,9 +553,7 @@ export function ptyOpen(ws: PtyWs) {
 
   // Only ours, and only the directory we made — never the file's own folder,
   // which for a working-tree peek is somebody's repository.
-  const viewDir = editor && wanted!.startsWith(join(tmpdir(), "agentglass-pr-"))
-    ? wanted!.slice(0, wanted!.lastIndexOf("/"))
-    : null;
+  const viewDir = editor ? viewTempDirOf(wanted!) : null;
   const session: Session = {
     proc, mode, grouped: HAS_SETSID, sizeDir, viewDir, closed: false, exited: false, killTimer: null,
     phoneAttach: attach

--- a/server/src/viewtemp.ts
+++ b/server/src/viewtemp.ts
@@ -1,0 +1,62 @@
+/**
+ * The copies this server writes for something to LOOK at, and the one place
+ * that knows where they live.
+ *
+ * Two things need a file on disk that the workspace does not have: a pull
+ * request's version of a file, fetched from GitHub at its head commit, and a
+ * branch's version, read out of the object store. Both are read-only snapshots,
+ * both go under the system temp directory, and both are opened in the editor by
+ * the PTY — which has to admit them without admitting `/tmp` in general.
+ *
+ * It exists because that admission was a string literal, twice, in a different
+ * file from the two that write the directories. Adding the second kind of copy
+ * therefore produced a pane with a SHELL in it: the path was not in scope and
+ * did not match the one prefix `terminal.ts` knew, so it fell back exactly as
+ * its comment promises — "silently viewing a different file is worse than
+ * viewing none". Correct behaviour, missing registration.
+ *
+ * So the only way to make one of these directories is the function whose set
+ * the check reads. A third kind cannot forget to tell the terminal about itself.
+ */
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+/** What each kind of copy is called on disk. The names are load-bearing: the
+ *  check below is a prefix test, and a rename here is a rename there. */
+const KINDS = {
+  /** A pull request's file at its head commit — see prFileToTemp. */
+  pr: "agentglass-pr-",
+  /** A branch's file, for anything the viewer does not render — see fileToTemp. */
+  ref: "agentglass-ref-",
+} as const;
+
+export type ViewTempKind = keyof typeof KINDS;
+
+/** A fresh directory for one copy. One file per directory on purpose: the PTY
+ *  opens the editor with this directory as its view root, and a shared one would
+ *  put every file anybody has ever looked at in that editor's file list. */
+export function makeViewTempDir(kind: ViewTempKind): string {
+  return mkdtempSync(join(tmpdir(), KINDS[kind]));
+}
+
+/**
+ * True for a path this server wrote as a read-only copy.
+ *
+ * Used by the PTY to decide a file outside the workspace may still be opened.
+ * A prefix test rather than a lookup of live directories, because the pane may
+ * be opened seconds or minutes after the copy was made and a registry would
+ * have to be cleaned up — and because being under a directory only this process
+ * creates is already the property that matters.
+ */
+export function isViewTemp(abs: string): boolean {
+  return Object.values(KINDS).some((p) => abs.startsWith(join(tmpdir(), p)));
+}
+
+/** The directory of such a copy, for the editor's view root — never the file's
+ *  own folder, which for a working-tree peek is somebody's repository. */
+export function viewTempDirOf(abs: string): string | null {
+  if (!isViewTemp(abs)) return null;
+  const cut = abs.lastIndexOf("/");
+  return cut > 0 ? abs.slice(0, cut) : null;
+}

--- a/server/test/files-at-ref.test.ts
+++ b/server/test/files-at-ref.test.ts
@@ -11,11 +11,11 @@
  * branch's files without touching the worktree is not a thing to mock.
  */
 import { afterEach, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, mkdirSync, rmSync, writeFileSync, existsSync } from "node:fs";
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync, existsSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-const { findFiles, grepFiles, fileText, listRefs, resolveRef } = await import("../src/files.ts");
+const { findFiles, grepFiles, fileText, fileToTemp, listRefs, resolveRef } = await import("../src/files.ts");
 
 let box = "", origin = "", clone = "";
 let hadRoot: string | undefined;
@@ -200,5 +200,79 @@ describe("which branches to offer", () => {
     const after = Bun.spawnSync(["git", "-C", clone, "rev-parse", "HEAD"]).stdout.toString();
     expect(after).toBe(before);
     expect(existsSync(join(clone, "src/billing/migrations/0097_returnlabelrequest.py"))).toBe(true);
+  });
+});
+
+/*
+ * Writing a branch's copy out so an editor can open it.
+ *
+ * Why this is not "the viewer already has the text": only markdown is worth
+ * rendering, and everything else in a checkout is code, which belongs in the
+ * editor that knows its language. The palette used to send a `.py` found on
+ * another branch to the document viewer instead, which renders MARKDOWN — so it
+ * arrived with its lines collapsed into paragraphs, its `**` bold and its
+ * backticks as chips.
+ *
+ * An editor needs a path, and this file has none here. That is the whole reason
+ * for a temp file, and the assertion below is the reason it cannot be the
+ * working tree's path.
+ */
+describe("a branch's copy, on disk for the editor", () => {
+  it("writes the branch's content, not this checkout's", () => {
+    const rel = "src/billing/migrations/0096_entry_date.py";
+    // The same path, different on each side — which is the case that makes
+    // opening the working tree's copy wrong rather than merely stale.
+    put(clone, rel, "# 0096\nDEPENDS = 'billing/0095'\nLOCAL_EDIT = True\n");
+    run(clone, "commit", "-qm", "local edit");
+
+    const r = fileToTemp(clone, rel, "origin/master");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    const wrote = readFileSync(r.file, "utf8");
+    expect(wrote).toContain("DEPENDS");
+    expect(wrote).not.toContain("LOCAL_EDIT");
+    // And the disk really does say something else, so the assertion above is
+    // about the ref rather than about a file that happened to match.
+    expect(readFileSync(join(clone, rel), "utf8")).toContain("LOCAL_EDIT");
+  });
+
+  it("writes outside the checkout", () => {
+    const r = fileToTemp(clone, "src/billing/migrations/0095_order_is_gift_wrapped.py", "origin/master");
+    expect(r.ok).toBe(true);
+    if (!r.ok) return;
+    // A temp file inside the checkout turns up in somebody's `git status` an
+    // hour later wearing a name that looks like theirs.
+    expect(r.file.startsWith(clone)).toBe(false);
+    expect(existsSync(r.file)).toBe(true);
+  });
+
+  it("names the file after the ref, so two of them are telling apart", () => {
+    const rel = "src/billing/migrations/0095_order_is_gift_wrapped.py";
+    const a = fileToTemp(clone, rel, "origin/master");
+    const b = fileToTemp(clone, rel, "master");
+    expect(a.ok && b.ok).toBe(true);
+    if (!a.ok || !b.ok) return;
+    // The same basename twice says nothing in an editor's tab strip, and the
+    // same path on two branches is exactly what somebody is comparing.
+    expect(a.file.split("/").pop()).not.toBe(b.file.split("/").pop());
+    expect(a.file.split("/").pop()).toContain("origin-master");
+  });
+
+  it("refuses a path that branch does not have, rather than writing an empty file", () => {
+    // 0097 exists HERE and not upstream. An empty temp file would open in the
+    // editor as a real, blank version of a file that does not exist.
+    const r = fileToTemp(clone, "src/billing/migrations/0097_returnlabelrequest.py", "origin/master");
+    expect(r.ok).toBe(false);
+  });
+
+  it("refuses a ref that does not exist, and one that was not given", () => {
+    expect(fileToTemp(clone, "src/billing/migrations/0095_order_is_gift_wrapped.py", "no/such/branch").ok).toBe(false);
+    expect(fileToTemp(clone, "src/billing/migrations/0095_order_is_gift_wrapped.py", "").ok).toBe(false);
+  });
+
+  it("is contained by the same rules as every other reader here", () => {
+    // `inside()` is fileText's, and this borrows it rather than growing a second
+    // set of rules to keep in step.
+    expect(fileToTemp(clone, "../../etc/passwd", "origin/master").ok).toBe(false);
   });
 });

--- a/server/test/view-temp.test.ts
+++ b/server/test/view-temp.test.ts
@@ -1,0 +1,105 @@
+/*
+ * The copies this server writes for something to look at, and the registration
+ * that has to come with them.
+ *
+ * This test exists because of a bug with no error in it. A pull request's file
+ * is fetched to a temp path so it can be opened in the editor, and `terminal.ts`
+ * admitted that path with a string literal — `agentglass-pr-` — written in a
+ * different file from the one that creates the directory. A second kind of copy
+ * was added, for a branch's version of a file, under `agentglass-ref-`. It was
+ * correct, it was tested, and opening one produced a pane with a SHELL in it:
+ * the path was not in the workspace and did not match the one prefix the
+ * terminal knew, so it fell back exactly as its comment promises — "silently
+ * viewing a different file is worse than viewing none".
+ *
+ * Nothing threw. Nothing was logged. The only symptom was a shell where an
+ * editor should have been, which reads as the editor failing to start.
+ *
+ * So the point of what follows is not that the two current prefixes match. It is
+ * that the MAKER and the CHECK cannot disagree, whatever is added later.
+ */
+import { describe, expect, it } from "bun:test";
+import { rmSync, writeFileSync, mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const { makeViewTempDir, isViewTemp, viewTempDirOf } = await import("../src/viewtemp.ts");
+
+/** Every kind the maker knows. Listed here so adding a kind without teaching
+ *  this test about it is the thing that fails, rather than the pane. */
+const KINDS = ["pr", "ref"] as const;
+
+describe("a read-only copy is openable in the editor", () => {
+  it("accepts a path from every kind of copy it can make", () => {
+    for (const kind of KINDS) {
+      const dir = makeViewTempDir(kind);
+      try {
+        const file = join(dir, "thing.py");
+        writeFileSync(file, "# hi\n");
+        // The assertion the bug needed: what the maker produced, the check
+        // admits. Not "the string starts with the right prefix" — the two sides
+        // of the same question, asked through the two functions.
+        expect(isViewTemp(file), `${kind} copies must be viewable`).toBe(true);
+        expect(viewTempDirOf(file)).toBe(dir);
+      } finally { rmSync(dir, { recursive: true, force: true }); }
+    }
+  });
+
+  it("does not admit /tmp in general", () => {
+    // The whole reason the check is a prefix and not "is it under tmp": a pane
+    // that can open anything in the system temp directory is a file viewer for
+    // whatever any other program left there.
+    const stranger = mkdtempSync(join(tmpdir(), "not-ours-"));
+    try {
+      const file = join(stranger, "thing.py");
+      writeFileSync(file, "# hi\n");
+      expect(isViewTemp(file)).toBe(false);
+      expect(viewTempDirOf(file)).toBe(null);
+    } finally { rmSync(stranger, { recursive: true, force: true }); }
+  });
+
+  it("does not admit a name that merely starts the same way outside tmp", () => {
+    // `/home/someone/agentglass-pr-notes/x.py` is not one of ours. The check is
+    // anchored at the temp directory, not at the bare prefix.
+    expect(isViewTemp("/home/someone/agentglass-pr-notes/x.py")).toBe(false);
+    expect(isViewTemp("/home/someone/agentglass-ref-notes/x.py")).toBe(false);
+  });
+
+  it("gives each copy its own directory", () => {
+    // One file per directory, because the PTY opens the editor with this
+    // directory as its view root: a shared one would put every file anybody has
+    // looked at into that editor's file list.
+    const a = makeViewTempDir("ref");
+    const b = makeViewTempDir("ref");
+    try { expect(a).not.toBe(b); }
+    finally { rmSync(a, { recursive: true, force: true }); rmSync(b, { recursive: true, force: true }); }
+  });
+});
+
+describe("nobody re-writes the prefix by hand", () => {
+  it("terminal.ts asks viewtemp instead of matching a string", async () => {
+    /*
+     * The lock for the actual bug, which the tests above cannot reach: they hold
+     * that the maker and the check agree, and the defect was that the PTY did
+     * not USE the check. It had the prefix written out, in a third file, and so
+     * knew about one kind of copy out of two.
+     *
+     * A source assertion rather than a behavioural one because the behaviour
+     * needs a pty, a websocket and an editor on PATH — and because what is being
+     * prevented is a literal being written here again, which is exactly the
+     * shape a source assertion catches.
+     */
+    const src = await Bun.file(new URL("../src/terminal.ts", import.meta.url)).text();
+    expect(src).toContain("isViewTemp");
+    // The prefixes belong to viewtemp.ts and nowhere else.
+    expect(src).not.toContain("agentglass-pr-");
+    expect(src).not.toContain("agentglass-ref-");
+  });
+
+  it("the makers do not spell their own directories either", async () => {
+    for (const f of ["../src/prs.ts", "../src/files.ts"]) {
+      const src = await Bun.file(new URL(f, import.meta.url)).text();
+      expect(src, f).not.toContain('mkdtempSync(join(tmpdir(), "agentglass');
+    }
+  });
+});

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -31,7 +31,7 @@ import ServerBanner from "./components/ServerBanner.tsx";
 import GitMissingBanner from "./components/GitMissingBanner.tsx";
 import { chordFromEvent, viewForChord, appActionForChord } from "./lib/keybindings.ts";
 import { FilePalette } from "./components/FilePalette.tsx";
-import { PeekFile, type Peek } from "./components/PeekFile.tsx";
+import { PeekFile, isRenderable, type Peek } from "./components/PeekFile.tsx";
 import { requestFilesReveal } from "./lib/filesReveal.ts";
 import { onOpenSettings, openSettings } from "./lib/openSettings.ts";
 import { onOpenPrs, onOpenPr } from "./lib/openPrs.ts";
@@ -87,6 +87,16 @@ export default function App() {
    */
   const [filesOpen, setFilesOpen] = useState(false);
   const [peek, setPeek] = useState<Peek | null>(null);
+  /* Opening a file from another branch has to fetch it first, and a click that
+     answers nothing for a beat reads as a click that missed. Named for what is
+     happening rather than a bare boolean: the note says which file. */
+  const [opening, setOpening] = useState<string | null>(null);
+  const [openErr, setOpenErr] = useState<string | null>(null);
+  useEffect(() => {
+    if (!openErr) return;
+    const t = setTimeout(() => setOpenErr(null), 4000);
+    return () => clearTimeout(t);
+  }, [openErr]);
   /** The palette's measured height, so a document it opens starts below it
    *  instead of underneath it. 0 when the palette is shut. */
   const [paletteH, setPaletteH] = useState(0);
@@ -925,10 +935,28 @@ export default function App() {
         onClose={() => setFilesOpen(false)}
         docOpen={peek !== null}
         onHeight={setPaletteH}
-        onOpenFile={(root, rel, branch, ref) =>
-          // A file found on another branch is read from that branch and is not
-          // editable — there is no file on disk to edit.
-          setPeek({ root, path: `${root}/${rel}`, label: rel, edit: !ref, branch, ref })}
+        onOpenFile={async (root, rel, branch, ref) => {
+          // On this checkout: the file itself, in the editor, writable.
+          if (!ref) { setPeek({ root, path: `${root}/${rel}`, label: rel, edit: true, branch }); return; }
+          // On another branch, and worth rendering — a document, read as one.
+          if (isRenderable(rel)) { setPeek({ root, path: `${root}/${rel}`, label: rel, edit: false, branch, ref }); return; }
+          /*
+           * On another branch, and code. It used to open in the document viewer,
+           * which renders markdown — so a .py arrived with its lines collapsed
+           * into paragraphs, its `**` bold and its backticks as chips. Code goes
+           * to the editor, which is what READABLE said all along.
+           *
+           * The editor needs a path, and this file is not on disk here: the
+           * working tree's copy is a different file wearing the right name. So
+           * the ref's copy is written out first, exactly as a pull request's is.
+           */
+          setOpening(`${rel} on ${ref}`);
+          try {
+            const r = await api.filesTemp(root, rel, ref);
+            if (!r.ok || !r.file) { setOpenErr(r.error ?? "Could not read that file on that branch"); return; }
+            setPeek({ root, path: r.file, label: `${rel} · ${ref} · read-only` });
+          } finally { setOpening(null); }
+        }}
         onRevealDir={(root, dir) => { requestFilesReveal(root, dir); goView("files"); }}
       />
       {/* The two share the screen rather than stack: the palette stays open on
@@ -937,6 +965,23 @@ export default function App() {
       {peek && (
         <PeekFile peek={peek} onClose={() => setPeek(null)}
           topPx={filesOpen && paletteH > 0 ? Math.round(paletteH) + 22 : undefined} />
+      )}
+      {/* Where the document is about to be, so the answer appears where the eye
+          already went. Both of these are one line and neither takes the focus:
+          the palette stays usable, and a failure says which file failed rather
+          than leaving a click that did nothing. */}
+      {(opening || openErr) && !peek && (
+        <div className="fixed left-1/2 -translate-x-1/2 z-[60] px-3 py-1.5 rounded-lg text-[11.5px] flex items-center gap-2"
+          style={{
+            top: filesOpen && paletteH > 0 ? Math.round(paletteH) + 34 : "12vh",
+            background: "var(--bg2)", border: "1px solid var(--border)",
+            color: openErr ? "var(--error)" : "var(--text2)",
+          }}>
+          {/* Bare: `.agx-spin` carries its own size, border and accent, and the
+              inline styles this used to have were overriding all three. */}
+          {opening && <span className="agx-spin" />}
+          <span>{openErr ?? `Opening ${opening}…`}</span>
+        </div>
       )}
       {/* Shows once when the app first runs a version it has not run before —
           the update button restarts into a new build and otherwise says nothing

--- a/web/src/components/FilePalette.tsx
+++ b/web/src/components/FilePalette.tsx
@@ -272,6 +272,31 @@ export function FilePalette({
       ?.scrollIntoView({ block: "nearest" });
   }, [cursor, rows.length]);
 
+  /**
+   * Three rows, and the rest on the scrollbar — only with a document open.
+   *
+   * Alone, this list is the thing you are looking at and it may have the screen.
+   * Over a document it is a strip you glance at while reading something else,
+   * and thirteen rows of it took most of the window to say what three rows say:
+   * the top of the answer, and that there is more.
+   *
+   * Measured off a row rather than written down as a number, because the row's
+   * height is its font's, and this app's reading size is a preference. It keeps
+   * the last measurement it managed to take: while the list is showing a note —
+   * "Searching…", "Type to search" — there is no row to measure, and falling
+   * back to zero would uncap the list for exactly as long as it takes to type.
+   */
+  const [rowH, setRowH] = useState(0);
+  useEffect(() => {
+    if (!docOpen) return;
+    const h = listRef.current?.querySelector<HTMLElement>('[data-row="0"]')?.offsetHeight;
+    if (h) setRowH(h);
+  }, [docOpen, rows, tab]);
+  /** The list's own vertical padding (py-1), so three rows are three rows and
+   *  not three rows minus the padding they sit in. */
+  const LIST_PAD = 8;
+  const listCap = docOpen && rowH && rows.length > 3 ? rowH * 3 + LIST_PAD : undefined;
+
   const openRow = useCallback((row: Row | undefined) => {
     if (!row || !root) return;
     if (row.kind === "dir") { onRevealDir(root, row.rel); onClose(); return; }
@@ -438,7 +463,10 @@ export function FilePalette({
             </div>
 
             {/* the answers */}
-            <div ref={listRef} className="flex-1 min-h-0 agx-scroll overflow-y-auto py-1">
+            <div ref={listRef} className="flex-1 min-h-0 agx-scroll overflow-y-auto py-1"
+              /* A cap, not a height: three results stay three rows tall rather
+                 than being stretched to a box sized for more. */
+              style={listCap ? { maxHeight: listCap } : undefined}>
               <Answers tab={tab} q={q} root={root} rows={rows} cursor={cursor}
                 status={status} onHover={setCursor} onPick={openRow} />
             </div>

--- a/web/src/components/FilePalette.tsx
+++ b/web/src/components/FilePalette.tsx
@@ -297,6 +297,35 @@ export function FilePalette({
   const LIST_PAD = 8;
   const listCap = docOpen && rowH && rows.length > 3 ? rowH * 3 + LIST_PAD : undefined;
 
+  /**
+   * When the list shrinks to three rows, the row you chose has to be one of them.
+   *
+   * Opening a file caps this list, and the scroll position it had in the tall
+   * box stays exactly where it was — so the row that produced the document you
+   * are now reading ends up below the window, and the three rows on screen are
+   * whichever ones happened to be at that offset. It reads as having lost your
+   * place in a list you never scrolled.
+   *
+   * Put at the TOP rather than merely brought into view, because the two rows
+   * worth seeing beside your choice are the ones after it.
+   *
+   * By hand rather than with `scrollIntoView`: that scrolls every scrollable
+   * ancestor too, and this list lives inside a fixed panel over a document.
+   * Measured from rectangles rather than `offsetTop`, which is relative to
+   * whichever ancestor happens to be positioned.
+   */
+  useEffect(() => {
+    const list = listRef.current;
+    if (!listCap || !list) return;
+    const row = list.querySelector<HTMLElement>(`[data-row="${cursor}"]`);
+    if (!row) return;
+    list.scrollTop += row.getBoundingClientRect().top - list.getBoundingClientRect().top - LIST_PAD / 2;
+    // `cursor` deliberately absent: this is for the moment the box changes size,
+    // and re-running it per keystroke would fight the `block: "nearest"` walk
+    // that lets ↓ move one row at a time instead of jumping the list.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [listCap, docOpen]);
+
   const openRow = useCallback((row: Row | undefined) => {
     if (!row || !root) return;
     if (row.kind === "dir") { onRevealDir(root, row.rel); onClose(); return; }

--- a/web/src/components/FilePalette.tsx
+++ b/web/src/components/FilePalette.tsx
@@ -90,7 +90,7 @@ export function FilePalette({
   open: boolean;
   onClose: () => void;
   /** Raise the viewer on this file. The palette stays put — see the note above. */
-  onOpenFile: (root: string, rel: string, branch: string, ref?: string) => void;
+  onOpenFile: (root: string, rel: string, branch: string, ref?: string) => void | Promise<void>;
   /** A folder is a place: go to Files and walk the tree there. */
   onRevealDir: (root: string, dir: string) => void;
   /**

--- a/web/src/components/PeekFile.tsx
+++ b/web/src/components/PeekFile.tsx
@@ -19,7 +19,7 @@ import "@xterm/xterm/css/xterm.css";
 import { FitAddon } from "@xterm/addon-fit";
 import { Portal } from "./Portal.tsx";
 import { LAYER } from "../lib/layers.ts";
-import { ptyWsUrl } from "../lib/api.ts";
+import { ptyWsUrl, IS_DEMO } from "../lib/api.ts";
 import { themeFromCss } from "./TerminalPanel.tsx";
 import { answerDecrqm } from "../lib/xtermDecrqm.ts";
 import { termOptions } from "../lib/termPrefs.ts";
@@ -127,7 +127,11 @@ export function PeekFile({ peek, onClose, topPx }: {
   /* A ref has no file on disk, so there is nothing for an editor to open. Held
      as its own name because it is the reason for several decisions below. */
   const atRef = !!peek.ref;
-  const [reading, setReading] = useState(canRender || !!peek.ref);
+  /* The demo has no PTY, so there is no editor to switch to and reading is the
+     only face there is. Without this, code opened in the demo took the editor
+     face and drew nothing — a dead panel, which is the thing the demo's terminal
+     and browser each had to be talked out of being. */
+  const [reading, setReading] = useState(canRender || !!peek.ref || IS_DEMO);
   const [text, setText] = useState<string | null>(null);
   const [textErr, setTextErr] = useState<string | null>(null);
   const [truncated, setTruncated] = useState(false);

--- a/web/src/components/PeekFile.tsx
+++ b/web/src/components/PeekFile.tsx
@@ -69,6 +69,13 @@ export type Peek = {
  *  that knows its language than in a viewer that would have to learn them all. */
 const READABLE = /\.(md|markdown|mdx)$/i;
 
+/** Exported so a caller can ask the question before deciding how to open a file
+ *  — the palette has to know, because a file on another branch has to be written
+ *  out for the editor and a document does not. One regexp, one answer: two
+ *  places disagreeing about what "renderable" means is how a `.py` ended up in
+ *  the markdown viewer. */
+export const isRenderable = (path: string) => READABLE.test(path);
+
 export function PeekFile({ peek, onClose, topPx }: {
   peek: Peek;
   onClose: () => void;
@@ -526,7 +533,17 @@ export function PeekFile({ peek, onClose, topPx }: {
               style={{ maxWidth: width ? `${width}ch` : "none", fontSize: size }}>
               {textErr && <div className="text-[12px]" style={{ color: "var(--error)" }}>{textErr}</div>}
               {text === null && !textErr && <div className="text-[12px] t-dim">Reading…</div>}
-              {text !== null && <Markdown text={text} />}
+              {/* Markdown only for markdown. A caller that lands anything else
+                  in reading mode gets it as it is: the renderer collapses
+                  newlines into paragraphs, bolds a `**`, and turns backticks
+                  into chips — which is a document's job and the exact opposite
+                  of what code needs. Callers are supposed to send code to the
+                  editor (see isRenderable), and this is the wall behind that
+                  door rather than a second opinion about where code belongs. */}
+              {text !== null && (canRender
+                ? <Markdown text={text} />
+                : <pre className="text-[12.5px] leading-relaxed whitespace-pre overflow-x-auto agx-scroll"
+                    style={{ fontFamily: "var(--mono, ui-monospace, monospace)" }}>{text}</pre>)}
               {truncated && (
                 <div className="mt-4 text-[11.5px]" style={{ color: "var(--warning)" }}>
                   This file is longer than a megabyte and is shown up to there. Open it in the editor

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -4881,11 +4881,37 @@ function buildFileTree(files: PrFile[]): TreeNode {
   return { ...root, dirs: new Map([...root.dirs].map(([k, v]) => [k, squash(v)])) };
 }
 
+/**
+ * "Open the whole file", and the second and a half it takes to say anything.
+ *
+ * This does not read the checkout: the pull request's copy is fetched from
+ * GitHub — the pull request itself to resolve its head, then the file at that
+ * commit — so two network round trips happen before a pane can appear. Without
+ * a pending state the click answered nothing for a beat, which reads as a click
+ * that missed, and the second click starts the whole thing again.
+ *
+ * Its own component because the state is per file and these are rendered from a
+ * list: one flag on the parent would put every Open button in the header into
+ * the same spinner.
+ */
+function PeekButton({ path, onPeek }: { path: string; onPeek: (p: string) => void | Promise<void> }) {
+  const [busy, setBusy] = useState(false);
+  return (
+    <button disabled={busy}
+      onClick={async () => { setBusy(true); try { await onPeek(path); } finally { setBusy(false); } }}
+      title={busy ? "Fetching this file from GitHub at the pull request's head commit…" : "Open the whole file in an editor"}
+      className="agx-btn shrink-0 flex items-center gap-1.5 text-[10px] px-1.5 py-0.5 rounded"
+      style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--text) 18%, transparent)" }}>
+      {busy ? <><span className="agx-spin" style={{ width: 9, height: 9 }} />Opening…</> : "⧉ Open"}
+    </button>
+  );
+}
+
 function FileTree({ node, sel, onPick, onPeek, seen, drafts, depth = 0 }: {
   node: TreeNode; sel: string | null; onPick: (p: string) => void;
   /** Open the whole file in an editor, over the panel. The diff shows what
    *  changed; this is for the times the answer is in the part that did not. */
-  onPeek?: (p: string) => void;
+  onPeek?: (p: string) => void | Promise<void>;
   seen: (p: string) => boolean; drafts: (p: string) => number; depth?: number;
 }) {
   return (
@@ -5152,7 +5178,7 @@ function FilesTab({ d, root, byPath, loaded, seenFiles, onSeen, sel, onSel, onSh
    *  the Review tab it is otherwise buried in. */
   onDropDraft: (d: DraftComment) => void;
   /** Open a file whole, over the panel, in an editor. */
-  onPeek?: (path: string) => void;
+  onPeek?: (path: string) => void | Promise<void>;
   onResolve: (t: PrThread) => void; onReply: (t: PrThread, body: string) => Promise<boolean>;
   onApply?: (t: PrThread, text: string) => void; busy: boolean;
 }) {
@@ -5828,13 +5854,7 @@ function FilesTab({ d, root, byPath, loaded, seenFiles, onSeen, sel, onSel, onSh
                   the top — and reaching it meant finding a terminal, getting it
                   into the right checkout, and typing the path, by which point
                   you have lost the list you were working from. */}
-              {onPeek && (
-                <button onClick={() => onPeek(f.path)} title="Open the whole file in an editor"
-                  className="agx-btn shrink-0 text-[10px] px-1.5 py-0.5 rounded"
-                  style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--text) 18%, transparent)" }}>
-                  ⧉ Open
-                </button>
-              )}
+              {onPeek && <PeekButton path={f.path} onPeek={onPeek} />}
               {/* "Viewed" is state you keep for the length of a review, not a
                   one-off tick — a switch says that and a checkbox does not. */}
               <button onClick={() => seenAndFold(f.path)} title={done ? "Mark not viewed" : "Mark viewed"}

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -783,6 +783,11 @@ const realApi = {
   filesRead: (root: string, rel: string, ref?: string) =>
     get<{ ok: boolean; rel: string; text: string; bytes: number; truncated?: boolean; error?: string }>(
       `/files/read?root=${encodeURIComponent(root)}&rel=${encodeURIComponent(rel)}${ref ? `&ref=${encodeURIComponent(ref)}` : ""}`),
+  /** That ref's copy of a file, written out so the editor can open it. For
+   *  everything the viewer does not render — which is everything but markdown. */
+  filesTemp: (root: string, rel: string, ref: string) =>
+    get<{ ok: boolean; file?: string; ref?: string; error?: string }>(
+      `/files/temp?root=${encodeURIComponent(root)}&rel=${encodeURIComponent(rel)}&ref=${encodeURIComponent(ref)}`),
   filesFind: (root: string, q: string, ref?: string) =>
     get<FindReport>(`/files/find?root=${encodeURIComponent(root)}&q=${encodeURIComponent(q)}${ref ? `&ref=${encodeURIComponent(ref)}` : ""}`),
   /** Which of these paths the working tree still has — see filesExist. */
@@ -1322,6 +1327,11 @@ const demoApi: typeof realApi = {
   machineUnlock: (_p: string) => D({ ok: false, error: "not available in the demo" }),
   filesTree: (_r: string, rel = "") => D(demo.filesTree(rel)),
   filesRead: (_r: string, rel: string, _ref?: string) => D(demo.filesRead(rel)),
+  /* No git and no disk here, so there is nothing to write a ref's copy out of.
+     Said rather than answered with a path that does not exist: the caller opens
+     an editor on whatever comes back. */
+  filesTemp: (_r: string, _rel: string, _ref: string) =>
+    D({ ok: false as const, error: "the demo has no checkout to read a branch from" }),
   filesFind: (_r: string, q: string) => D(demo.filesFind(q)),
   filesExist: (_r: string, rels: string[]) => D({ ok: true, here: rels }),
   filesRefs: (_r: string) => D({ ok: true, local: ["main", "feat/checkout-rewrite"], remote: ["origin/main", "origin/release"], head: "main" }),

--- a/web/test/peek-render-rule.test.ts
+++ b/web/test/peek-render-rule.test.ts
@@ -1,0 +1,42 @@
+/*
+ * What the file viewer renders, and what it hands to the editor.
+ *
+ * The rule was always "markdown, and nothing else" — the regexp has said so
+ * since it was written, under a comment explaining that code belongs in the
+ * editor that knows its language. What went wrong was that a SECOND place
+ * decided how to open a file and did not ask this question: the palette sent
+ * anything found on another branch to the document viewer, whatever it was, so
+ * a `.py` came out with its lines collapsed into paragraphs, its `**` bold and
+ * its backticks as chips.
+ *
+ * So the answer is exported and this holds it. One regexp, one answer.
+ */
+import { describe, expect, test } from "bun:test";
+import { isRenderable } from "../src/components/PeekFile.tsx";
+
+describe("which files are rendered rather than edited", () => {
+  test("markdown, in the spellings that mean markdown", () => {
+    for (const p of ["README.md", "docs/EXTENDING.markdown", "a/b/notes.mdx", "SHOUTING.MD"]) {
+      expect(isRenderable(p)).toBe(true);
+    }
+  });
+
+  test("code is not, whatever it is", () => {
+    // Every one of these went through the markdown renderer when opened from a
+    // branch. The .py is the one that was reported.
+    for (const p of [
+      "scripts/validate.py", "web/src/App.tsx", "server/src/index.ts", "Makefile",
+      "bun.lock", ".github/workflows/ci.yml", "src/main.rs", "index.html",
+    ]) {
+      expect(isRenderable(p)).toBe(false);
+    }
+  });
+
+  test("a name that merely mentions markdown is not markdown", () => {
+    // `.md` has to be the extension, not a substring: these are code that talks
+    // about documents, and one of them is a real file in this repository.
+    for (const p of ["web/src/lib/markdown.tsx", "server/src/mdcache.ts", "notes.md.bak", "md"]) {
+      expect(isRenderable(p)).toBe(false);
+    }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

A `.py` opened from the file palette on a branch this worktree is not on arrived in the **document** viewer: its imports collapsed into a paragraph, a `**` came out bold, its backticks came out as chips. The rule was never in doubt — `READABLE` is `/\.(md|markdown|mdx)$/i`, under a comment saying everything else in a checkout is code and belongs in the editor that knows its language. Three lines got between the rule and the file:

```
PeekFile.tsx:123   reading = canRender || !!peek.ref
PeekFile.tsx:529   in reading mode, <Markdown text={text}/>, unconditionally
App.tsx:931        the palette passes edit: !ref, and a branch search has a ref
```

The `ref` half had a good reason: a file on another branch has no path an editor could be pointed at, because the working tree's copy is a different file wearing the right name. Right about the problem, and it skipped the answer the pull-request panel had already written — materialise the blob.

**Four commits, and the second and third exist because the first two were incomplete.** All three defects are the same shape — two places deciding one thing separately — which is worth reading as one story:

1. **The palette and the viewer disagreed about what gets rendered.** Fixed at both ends on purpose: the door (the palette asks `isRenderable`, now exported so there is one regexp and one answer) and the wall (reading mode renders markdown only for markdown; anything else gets a monospaced `<pre>` with its newlines intact). `fileToTemp` writes a ref's copy out for the editor, borrowing every rule about what may be read at all from `fileText` — containment, ref resolution, the size ceiling, the binary refusal — because a second reader is a second set of rules to keep in step.

2. **`terminal.ts` and the two makers of temp copies disagreed about what is openable.** It matched the string `agentglass-pr-`, written by hand, twice, in a third file. A copy under `agentglass-ref-` was therefore neither in scope nor recognised, and the PTY did exactly what its comment promises — *"silently viewing a different file is worse than viewing none"* — and fell back to a shell. Nothing threw, nothing was logged; the only symptom was a shell where an editor should have been. `viewtemp.ts` now holds the kinds, and the only way to make one of these directories is the function whose set the check reads.

3. **The demo has no PTY, so the editor face drew nothing.** One line: reading is the only face a demo build has. That is the dead panel the demo's terminal and browser were each talked out of, reintroduced two commits later in a third place.

Also here: **the palette shows three rows over a document**, with the row you chose at the top of them — capping the list alone left the scroll where it was, so the row that produced the document you are reading ended up below the window. And **`Open` on a pull request's file says `Opening…`**: it is the slowest button in the panel because `prFileToTemp` makes two GitHub round trips, and it used to answer nothing for a second, which reads as a click that missed.

## How was it tested?

`bun run typecheck` in `web/` and `server/`, and both suites: **server 2477 ran / 1 skip / 0 fail**, **web 1904 / 0 fail**.

The parts a suite cannot reach were measured against running software, and the important one twice — with the fix and with it removed.

**The editor actually opens the ref's copy.** A real PTY over its websocket, against a two-branch repository:

```
with the shared check   /tmp/agentglass-ref-…/master-mig.py [RO]  1,1  All
                        # 0095
                        UPSTREAM = True      <- the REF's version
                        ~ ~ ~

with the literal back   serallap@…:/…/repo$
```

The working tree on the other branch says `LOCAL_EDIT`, so the first block is about the ref rather than about a file that happened to match.

**The three-row cap.** Measured against the real app — served from the server with a nine-file checkout, because the demo cannot answer this:

```
palette alone      9 rows · clientH 300 · visible 9
cursor, by ↓↓↓↓    [4]
with a doc open    clientH 98 (3×30+8) · visible 3 · firstVisible "4"
```

**The endpoint**, through the running server: `master`'s copy comes back containing `UPSTREAM` while the disk says `LOCAL_EDIT`, the temp file lands outside the checkout, and a ref that does not exist or a file that branch does not have are refused with a reason rather than written out empty.

**The demo**, before and after: the pane went from nothing at all to its own sentence, *"only markdown is readable in the demo"*.

Fifteen new tests. The one worth naming is a **source assertion** that `terminal.ts` contains no `agentglass-` prefix at all: the four tests holding that the maker and the check agree could not have caught the actual defect, which was that the PTY did not *use* the check.

Installed and exercised by hand on a real checkout before this was opened.
