### PR TITLE
Build the phone's APK when the phone changed, not on every tag

### DIFF
--- a/.github/workflows/android-apk.yml
+++ b/.github/workflows/android-apk.yml
@@ -26,7 +26,58 @@ permissions:
   contents: write
 
 jobs:
+  # Whether this run has anything to build.
+  #
+  # A tag that changes nothing the phone is made of would otherwise spend the
+  # 5m18s of Gradle described above reproducing the APK the previous tag already
+  # published — and attach it to a release as if the phone had been rebuilt and
+  # checked at that tag, which it had not. An artefact that does not exist
+  # misleads nobody; one carrying the wrong version does.
+  #
+  # `shared/` counts as the phone: it imports palettes, project, providers,
+  # session, term and types from there, so a change to the wire is a change to
+  # the app even with mobile/ untouched. So does this workflow, because a build
+  # whose recipe changed has not been proven by the last one that ran.
+  #
+  # workflow_dispatch always builds. Running it by hand is asking whether the
+  # build still works, and "nothing changed" is not an answer to that question.
+  scope:
+    runs-on: ubuntu-latest
+    outputs:
+      build: ${{ steps.q.outputs.build }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0 # the previous tag is history, not the checkout
+      - id: q
+        run: |
+          set -euo pipefail
+          if [ "${{ github.event_name }}" != "push" ]; then
+            echo "asked by hand — building"
+            echo "build=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          # The tag before this one, ignoring this one. Missing on the very first
+          # tag, and then there is no "since" to compare against.
+          prev="$(git describe --tags --abbrev=0 --match 'v*' "$GITHUB_REF_NAME^" 2>/dev/null || true)"
+          if [ -z "$prev" ]; then
+            echo "no earlier tag — building"
+            echo "build=true" >> "$GITHUB_OUTPUT"; exit 0
+          fi
+          changed="$(git diff --name-only "$prev" "$GITHUB_REF_NAME" -- mobile/ shared/ .github/workflows/android-apk.yml)"
+          if [ -n "$changed" ]; then
+            echo "changed since $prev:"; echo "$changed"
+            echo "build=true" >> "$GITHUB_OUTPUT"
+          else
+            # Said out loud rather than silently skipped: a job that vanishes
+            # from a release run reads as a job that broke.
+            echo "nothing under mobile/ or shared/ changed since $prev — the phone"
+            echo "of $prev is still the current build, and its APK is on that release."
+            echo "build=false" >> "$GITHUB_OUTPUT"
+          fi
+
   apk:
+    needs: scope
+    if: needs.scope.outputs.build == 'true'
     runs-on: ubuntu-latest
     env:
       # Whether this run can sign for real, decided once. A step's `if:` cannot


### PR DESCRIPTION
## What does this PR do?

A `v*` tag fires three workflows — `release.yml`, `desktop-binaries.yml` and this one — so a desktop-only fix spends the **5m18s of Gradle this file already documents** reproducing an APK identical to the one the previous tag published, and attaches it to the new release as if the phone had been rebuilt and checked at that tag. It had not.

A `scope` job now answers "is there anything to build" and `apk` runs only if there is:

- **`shared/` counts as the phone.** It imports `palettes`, `project`, `providers`, `session`, `term` and `types` from there, so a change to the wire is a change to the app with `mobile/` untouched — which is exactly why the phone lands last in a stack.
- **This workflow counts too.** A build whose recipe changed has not been proven by the last run of the old one.
- **`workflow_dispatch` always builds.** Running it by hand asks whether the build still works, and "nothing changed" is not an answer to that.
- **The skip says why, in the log.** A job that simply vanishes from a release run reads as a job that broke.

The consequence is deliberate and worth stating: a release for a desktop-only tag carries **no APK**. Nothing is lost — with `mobile/` untouched the previous tag's APK *is* the current phone build, and it sits on the release that actually produced it. An artefact that does not exist misleads nobody; one carrying the wrong version does.

## How was it tested?

The YAML was parsed rather than eyeballed — `jobs: ['scope', 'apk']`, `apk.needs: scope`, `apk.if: needs.scope.outputs.build == 'true'`, `scope.outputs.build` wired to the step — and the shell reasoned through its three cases: not a push (build), no earlier tag (build), and a diff against the previous tag over `mobile/ shared/ .github/workflows/android-apk.yml`.

The real proof is the next tag, and it is the one this exists for: `v0.9.1` changes `server/`, `web/` and `scripts/` only, so `scope` should report nothing changed and `apk` should be skipped with that sentence in its log. If it builds anyway, this is wrong and the release will say so by carrying an APK.

One correction to something I had assumed: this workflow does **not** run on branch pushes — only tags and manual dispatch — so gating the job cannot take a lint path away from anybody.
