### PR TITLE
One checkout picker, and none where it could not work

### DIFF
--- a/web/src/components/BrowserPanel.tsx
+++ b/web/src/components/BrowserPanel.tsx
@@ -36,7 +36,7 @@ import { browserNav, clearBrowserNav, subscribeBrowserNav } from "../lib/browser
 import { clientId, serveBrowserAsk, setBrowserAskHandler } from "../lib/browserBus.ts";
 import { api } from "../lib/api.ts";
 import { type DrivableWebview } from "../lib/browserDrive.ts";
-import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import { PagePicker } from "./browser/PagePicker.tsx";
 import { MarkupLayer } from "./browser/MarkupLayer.tsx";
 import { DemoPage } from "./browser/DemoPage.tsx";
@@ -590,7 +590,7 @@ export function BrowserView(_props: { active: boolean }) {
   return (
     <div className="flex flex-col h-full min-h-0 outline-none" tabIndex={-1} onKeyDown={onKey}>
       <div className={viewHeaderClass} style={viewHeaderStyle}>
-        <span className={viewTitleClass} style={{ color: "var(--text)" }}>Browser</span>
+        <h2 className="sr-only">Browser</h2>
         <span className="text-[10px] truncate min-w-0" style={{ color: "var(--text3)" }}>{active ? tabLabel(active) : ""}</span>
         {note && (
           <span className="ml-auto text-[10px] px-2 py-0.5 rounded shrink-0"

--- a/web/src/components/BudgetsPane.tsx
+++ b/web/src/components/BudgetsPane.tsx
@@ -2,7 +2,9 @@ import { useCallback, useEffect, useState } from "react";
 import { SettingRow } from "./SettingRow.tsx";
 import { api } from "../lib/api.ts";
 import { fmtUsd } from "../lib/format.ts";
+import type { GitRepoRef } from "../../../shared/types.ts";
 import type { Budget, BudgetPeriod, BudgetStatus } from "../../../shared/types.ts";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 
 /**
  * A number you chose, instead of one this app picked.
@@ -21,7 +23,7 @@ export function BudgetsPane({ open }: { open: boolean }) {
   const [rows, setRows] = useState<Budget[] | null>(null);
   const [status, setStatus] = useState<BudgetStatus[]>([]);
   const [models, setModels] = useState<string[]>([]);
-  const [roots, setRoots] = useState<string[]>([]);
+  const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [err, setErr] = useState<string | null>(null);
   const [busy, setBusy] = useState(false);
 
@@ -36,7 +38,7 @@ export function BudgetsPane({ open }: { open: boolean }) {
     load();
     // The projects this machine has actually worked on, so a budget is attached
     // by picking rather than by typing a path exactly right.
-    api.gitRepos().then((r) => setRoots(r.repos.map((x) => x.root))).catch(() => setRoots([]));
+    api.gitRepos().then((r) => setRepos(r.repos)).catch(() => setRepos([]));
   }, [open, load]);
 
   /** Saved as a set, because a row has no identity: two budgets can differ only
@@ -102,13 +104,11 @@ export function BudgetsPane({ open }: { open: boolean }) {
                 <option value="month">a month</option>
               </select>
               <span className="t-dim">on</span>
-              <select className="text-[11px] px-1.5 py-1 rounded-md min-w-0 max-w-[9rem]"
-                style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
-                value={b.root} onChange={(e) => patch(i, { root: e.target.value })}>
-                <option value="">everything</option>
-                {roots.map((r) => <option key={r} value={r}>{r.split("/").filter(Boolean).pop() || r}</option>)}
-                {b.root && !roots.includes(b.root) && <option value={b.root}>{b.root}</option>}
-              </select>
+              {/* "everything" is the empty root, and it has to stay reachable —
+                  a budget with no checkout is the whole machine's. */}
+              <CheckoutPicker repos={repos} value={b.root}
+                onPick={(r) => patch(i, { root: r === b.root ? "" : r })}
+                placeholder="everything" triggerMaxWidth={160} />
               <select className="text-[11px] px-1.5 py-1 rounded-md min-w-0 max-w-[11rem]"
                 style={{ color: "var(--text)", background: "color-mix(in srgb, var(--bg) 70%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 50%, transparent)" }}
                 value={b.model} onChange={(e) => patch(i, { model: e.target.value })}>

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -1,7 +1,7 @@
 import { memo, Fragment, createContext, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { diffSplit, diffWrap } from "../lib/diffPrefs.ts";
 import { subscribeWorktreeJump, worktreeJump } from "../lib/worktreeJump.ts";
-import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import { motion, AnimatePresence } from "motion/react";
 import type { FileChange, DiffHunk, WalkthroughResult, GitRepoRef } from "../../../shared/types.ts";
 import { Portal } from "./Portal.tsx";
@@ -1180,7 +1180,7 @@ export function DiffView({ active, onClose, onBack, backLabel, presetChanges, pr
                       truncates instead, which loses the tail of a preset name
                       rather than half the row. */}
                   <div className="flex items-baseline gap-2.5 min-w-0">
-                    <span className={viewTitleClass} style={{ color: "var(--text)" }}>File changes</span>
+                    <h2 className="sr-only">File changes</h2>
                     {changes && (
                       <span className="text-[10px] t-dim2 tabular-nums truncate">
                         {all.length} edits · <span style={{ color: "var(--success)" }}>+{totals.add}</span> <span style={{ color: "var(--error)" }}>−{totals.del}</span> · {presetTitle || "What the fleet changed"}

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -1270,11 +1270,16 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                   {resumeOpen && <ResumePicker onPick={resume} onClose={() => setResumeOpen(false)} />}
                 </AnimatePresence>
 
-                {/* The title belongs to the view, so it spans the view — the
-                    same bar every other section has. It used to sit inside the
+                {/* The bar belongs to the view, so it spans the view — the same
+                    one every other section has. It used to sit inside the
                     sidebar, which made Chat look like a different application:
-                    two half-width bars where the others have one. */}
-                <ViewHeader title="Chats" count={chats.length} actions={<>
+                    two half-width bars where the others have one.
+
+                    The chat count went with the word it belonged to. On its own
+                    it was a bare numeral at the far left of an otherwise empty
+                    bar, and the sidebar beside it already lists the chats it was
+                    counting. */}
+                <ViewHeader label="Chats" actions={<>
                   <button onClick={() => setResumeOpen((v) => !v)} aria-expanded={resumeOpen} aria-haspopup="listbox"
                     className="text-[11px] px-2.5 py-1 rounded-lg shrink-0" style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}
                     title="Continue a session that already exists — e.g. one you started in a terminal">↩ Resume</button>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -27,11 +27,12 @@ import { tidyPaneScreen } from "../lib/paneScreen.ts";
 import { quickSkills, pinnedSkills, togglePinnedSkill } from "../lib/quickSkills.ts";
 import { fmtTime } from "../lib/format.ts";
 import { Select } from "./Select.tsx";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 import { SCROLLBAR_CSS, CODE_FONT_STYLE } from "./ChangesModal.tsx";
 import { fmtAgo, fmtUsd, fmtTokens, modelLabelOf, modelColor } from "../lib/format.ts";
 import { sessionIsLive, resumableAgent } from "../lib/derive.ts";
 import { ctxLimitOf } from "../lib/contextWindow.ts";
-import { worktreeTag, sessionWorktree, sessionCwd } from "../lib/worktree.ts";
+import { sessionWorktree, sessionCwd } from "../lib/worktree.ts";
 import { useStuckBottom } from "../lib/useStuckBottom.ts";
 import {
   listChats, getChat, newChat, closeChat, update, send, stop, enqueue, unqueue, subscribe, chatResuming,
@@ -1251,13 +1252,6 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
   // Worktrees read as their card ("└ WEB-1042"), not as a near-duplicate of
   // the project name — with a dozen open, `orbit-WEB-1042` and
   // `orbit-WEB-1043` are one glance apart otherwise.
-  const repoOptions = useMemo(
-    () => repos.map((r) => {
-      const wt = worktreeTag(r);
-      return { value: r.root, label: wt ? `└ ${wt}` : repoName(r.root), hint: r.branch };
-    }),
-    [repos]
-  );
 
   return (
     <div className="relative flex-1 min-h-0 flex flex-col overflow-hidden">
@@ -1327,8 +1321,15 @@ export function ChatView({ active: visible, focusId, onClose = () => {} }: { act
                   <div className="flex items-center gap-2 px-4 py-2.5 border-b shrink-0" style={{ borderColor: "color-mix(in srgb, var(--border) 40%, transparent)" }}>
                     {active ? (
                       <>
-                        <Select value={active.cwd} onChange={(v) => { update(active.id, (c) => { c.cwd = v; }); setDefaultCwd(v); }}
-                          className={selCls} style={selStyle} options={repoOptions} placeholder="Pick a repo" />
+                        {/* The same control every other checkout is picked
+                            with, and a value nobody else can move: this is
+                            where THIS conversation runs, which is not the same
+                            question as what Source control is reading. */}
+                        <CheckoutPicker
+                          repos={repos} value={active.cwd}
+                          onPick={(v) => { update(active.id, (c) => { c.cwd = v; }); setDefaultCwd(v); }}
+                          placeholder="Pick a repo" triggerMaxWidth={220}
+                        />
                         {/* Only shown when there is a choice to make: on a
                             machine with one CLI installed this would be a
                             control with a single option and nothing to explain.

--- a/web/src/components/CheckoutPicker.tsx
+++ b/web/src/components/CheckoutPicker.tsx
@@ -1,0 +1,310 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import type { GitRepoRef, GitBranch } from "../../../shared/types.ts";
+import { useDismiss } from "../lib/useDismiss.ts";
+
+/**
+ * The one control for "which checkout".
+ *
+ * There were seven of these, written at seven different times, and they had
+ * drifted the way separately-maintained things do: two chevron glyphs, five
+ * widths (300, 320, 340, 460, 520), three placeholders and one — Tasks — with no
+ * filter at all, which is unusable the moment a project has a dozen worktrees.
+ * Same question, seven answers, and nothing to learn once that transferred to
+ * the next panel.
+ *
+ * Source control's was the most finished of them, so it is the one this became,
+ * comments and all. What each panel still decides for itself is WHICH list it
+ * shows and WHAT it does with the answer — this only owns how it looks, how it
+ * filters, and how it takes the keyboard.
+ *
+ * It does NOT own the value. Chat's checkout is where that conversation runs;
+ * the docked console's is where you build; Source control's is what you are
+ * reading. Those are different questions that happen to share a shape, and the
+ * one thing worse than seven pickers is one picker that silently moves four
+ * panels at once.
+ */
+
+/** The two verbs kept apart, for `branches`. Picking a repo row changes what
+ *  you are looking at; picking a branch row runs `git checkout` over the
+ *  directory you are standing in. Only Source control passes these, and only
+ *  under their own heading. */
+export interface CheckoutBranches {
+  items: GitBranch[];
+  /** Rows go flat while a write is in flight or writes are off entirely. */
+  disabled?: boolean;
+  onCheckout: (name: string) => void;
+  /** Whether a branch's upstream is gone, drawn as a chip. Passed in rather
+   *  than computed here: the rule for that lives with the panel that knows what
+   *  a track string means. */
+  gone?: (b: GitBranch) => boolean;
+}
+
+export function CheckoutPicker({
+  repos, value, onPick,
+  branches, branchLabel, placeholder = "Repo", emptyLabel = "no repos seen yet",
+  triggerMaxWidth = 240, disabled, title, onOpenChange, onDismiss,
+}: {
+  repos: GitRepoRef[];
+  /** The chosen checkout's root. Empty means nothing picked yet. */
+  value: string;
+  onPick: (root: string) => void;
+  branches?: CheckoutBranches;
+  /**
+   * What to write after the repo name on the trigger.
+   *
+   * Source control passes its working-tree poll rather than letting the button
+   * read the repo list: you switch branch from that very panel, and the list is
+   * a cached sweep, so the control at the top went on saying what it said
+   * before. `undefined` falls back to the list; `null` draws nothing.
+   */
+  branchLabel?: string | null;
+  placeholder?: string;
+  emptyLabel?: string;
+  triggerMaxWidth?: number;
+  disabled?: boolean;
+  title?: string;
+  /**
+   * The menu opened, or closed.
+   *
+   * Two callers need it. One refreshes on the way in: the lists go stale — a
+   * worktree cut since the view loaded is not in `repos`, and each row's branch
+   * is whatever the last sweep saw, which a checkout from this very panel then
+   * contradicts — and refreshing on open is what keeps that honest without a
+   * poll. The other needs to know the menu HAS the keyboard, because
+   * focus-follows-mouse must not drag the cursor back to the shell while
+   * somebody is typing into the filter.
+   */
+  onOpenChange?: (open: boolean) => void;
+  /**
+   * Called when the menu closes without a pick.
+   *
+   * The filter input takes the keyboard while it is open, so a panel that was
+   * being TYPED INTO — the terminal — has to get the cursor back or the next
+   * keystroke lands on `<body>`. Every panel that has nowhere to hand it back
+   * to simply omits this.
+   */
+  onDismiss?: () => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [query, setQuery] = useState("");
+  const [cursor, setCursor] = useState(0);
+  const box = useRef<HTMLDivElement>(null);
+  const rowsRef = useRef<HTMLDivElement>(null);
+
+  const close = (dismissed: boolean) => {
+    setOpen(false);
+    setQuery("");
+    onOpenChange?.(false);
+    if (dismissed) onDismiss?.();
+  };
+  useDismiss(open, box, () => close(true));
+
+  const here = repos.find((r) => r.root === value) ?? null;
+  /*
+   * A value the list does not offer, still shown.
+   *
+   * A checkout can move, be removed, or fall out of the open project's scope,
+   * and some of these values are STORED — a budget is attached to a root, and a
+   * chat remembers where it runs. Falling back to the placeholder would read as
+   * "everything" or "pick one" while the setting underneath still says
+   * something else entirely, so the row is kept, marked, and selectable.
+   */
+  const unlisted = value && !here ? value : "";
+  const leafOf = (p: string) => p.split("/").filter(Boolean).pop() || p;
+
+  /** Path included: a worktree is found by its card id ("20343"), which lives
+   *  in the directory name rather than in the project's. */
+  const shownRepos = useMemo(() => {
+    const q = query.trim().toLowerCase();
+    return repos.filter((r) => !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q));
+  }, [repos, query]);
+
+  const shownBranches = useMemo(() => {
+    if (!branches) return [];
+    const q = query.trim().toLowerCase();
+    const checkedOut = new Set(repos.map((r) => r.branch));
+    return branches.items
+      .filter((b) => !checkedOut.has(b.name) && (!q || b.name.toLowerCase().includes(q)))
+      .slice(0, 80);
+  }, [branches, repos, query]);
+
+  /** One list for the keyboard, because the cursor crosses the heading between
+   *  them and "third row down" has to mean the third row down. */
+  const walk = useMemo(
+    () => [
+      ...shownRepos.map((r) => ({ kind: "repo" as const, key: r.root, run: () => { onPick(r.root); close(false); } })),
+      ...shownBranches.map((b) => ({ kind: "branch" as const, key: b.name, run: () => { branches?.onCheckout(b.name); close(false); } })),
+    ],
+    [shownRepos, shownBranches], // eslint-disable-line react-hooks/exhaustive-deps
+  );
+
+  // Opening lands on what is already chosen, so ⏎ straight away is a no-op
+  // rather than a jump to whatever happens to be first.
+  useEffect(() => {
+    if (!open) return;
+    const at = shownRepos.findIndex((r) => r.root === value);
+    setCursor(at < 0 ? 0 : at);
+  }, [open]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Filtering moves the ground under the cursor — see the branch rows, which
+  // rise to meet it as repos drop out — so it is pinned back inside the list.
+  useEffect(() => { setCursor((c) => Math.min(c, Math.max(0, walk.length - 1))); }, [walk.length]);
+
+  useEffect(() => {
+    if (!open) return;
+    rowsRef.current?.querySelector<HTMLElement>("[data-cursor='1']")?.scrollIntoView({ block: "nearest" });
+  }, [cursor, open]);
+
+  const onKey = (e: React.KeyboardEvent) => {
+    if (e.key === "Escape") { e.preventDefault(); close(true); return; }
+    if (e.key === "Enter") { e.preventDefault(); walk[cursor]?.run(); return; }
+    if (e.key === "ArrowDown" || e.key === "ArrowUp") {
+      e.preventDefault();
+      if (!walk.length) return;
+      setCursor((c) => (c + (e.key === "ArrowDown" ? 1 : -1) + walk.length) % walk.length);
+    }
+  };
+
+  return (
+    <div className="relative" ref={box}>
+      {/* One line. A worktree directory carries a whole ticket name, and
+          wrapped it made the button two rows tall and shoved whatever sat
+          under the header down with it. */}
+      <button
+        onClick={() => { if (open) { close(true); return; } setOpen(true); onOpenChange?.(true); }}
+        disabled={disabled}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg shrink-0 whitespace-nowrap disabled:opacity-50"
+        style={{
+          maxWidth: triggerMaxWidth,
+          background: "color-mix(in srgb, var(--bg3) 50%, transparent)",
+          border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)",
+          color: "var(--text)",
+        }}
+        title={title ?? (here ? `${here.name}\n${here.root}` : unlisted ? `${unlisted}\nnot in the current list` : undefined)}
+      >
+        <span className="font-medium truncate min-w-0" style={unlisted ? { color: "var(--warning)" } : undefined}>
+          {here?.name ?? (unlisted ? leafOf(unlisted) : placeholder)}
+        </span>
+        {(() => {
+          const b = branchLabel === undefined ? here?.branch : branchLabel;
+          return b ? <span className="t-dim2 shrink-0 truncate" style={{ maxWidth: "9rem" }} title={`on ${b}`}>· {b}</span> : null;
+        })()}
+        <span className="t-dim2 shrink-0">▼</span>
+      </button>
+
+      {open && (
+        /* Wide enough for a whole worktree name beside its branch: those are
+           the two pieces that tell one checkout from another, and at 320 with
+           the branch clipped at 150 they were both cut off on the same row. */
+        <div
+          className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col"
+          role="listbox"
+          onKeyDown={onKey}
+          style={{
+            zIndex: 30, background: "var(--bg2)",
+            border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)",
+            minWidth: 320, maxWidth: "min(86vw, 760px)", maxHeight: 420, overflow: "hidden",
+          }}
+        >
+          <input
+            autoFocus
+            value={query}
+            onChange={(e) => setQuery(e.target.value)}
+            placeholder="Filter checkouts…"
+            aria-label="Filter checkouts"
+            className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
+            style={{
+              background: "color-mix(in srgb, var(--bg3) 50%, transparent)",
+              border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)",
+              color: "var(--text)",
+            }}
+          />
+          <div ref={rowsRef} className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
+            {unlisted && (
+              <div className="px-2.5 py-1.5 flex items-center gap-2" style={{ background: "color-mix(in srgb, var(--warning) 10%, transparent)" }}>
+                <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>SET</span>
+                <span className="min-w-0 flex-1 truncate" style={{ color: "var(--warning)" }} title={unlisted}>{unlisted}</span>
+                <span className="shrink-0 t-dim2 text-[9.5px]">not in this list</span>
+              </div>
+            )}
+            {shownRepos.map((r, i) => (
+              <button
+                key={r.root}
+                role="option"
+                aria-selected={r.root === value}
+                data-cursor={i === cursor ? "1" : undefined}
+                onMouseEnter={() => setCursor(i)}
+                onClick={() => { onPick(r.root); close(false); }}
+                className="w-full text-left px-2.5 py-1.5 flex items-center gap-2"
+                style={{
+                  background: r.root === value
+                    ? "color-mix(in srgb, var(--primary) 15%, transparent)"
+                    : i === cursor ? "color-mix(in srgb, var(--primary) 9%, transparent)" : "transparent",
+                }}
+              >
+                {/* A badge names the kind outright and reads the same wherever
+                    the row lands. It was an indent once, which says nothing as
+                    soon as the list is filtered and the parent is off screen. */}
+                <span
+                  className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                  title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
+                  style={r.worktreeOf
+                    ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
+                    : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
+                >{r.worktreeOf ? "WT" : "REPO"}</span>
+                {/* A worktree IS its branch — that's the whole point of one per
+                    ticket — so the branch gets the wide column and the folder
+                    is a terse stub of it. A project is the other way round: the
+                    folder is the identity and the branch is what happens to be
+                    checked out. The folder is shown beside it either way, since
+                    a checkout can rename the row otherwise, and a directory's
+                    identity must not move under a click. */}
+                <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.worktreeOf ? `${r.branch}\n${r.root}` : r.root}>
+                  {r.worktreeOf ? r.branch : r.name}
+                </span>
+                {!r.worktreeOf
+                  ? <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.branch}>{r.branch}</span>
+                  : r.name !== r.branch && <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.root}>{r.name}</span>}
+                {r.dirty > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.dirty} changed file${r.dirty === 1 ? "" : "s"}`}>●{r.dirty}</span>}
+                {r.behind > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.behind} behind upstream`}>↓{r.behind}</span>}
+                {r.ahead > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--success)" }} title={`${r.ahead} ahead of upstream`}>↑{r.ahead}</span>}
+              </button>
+            ))}
+
+            {shownBranches.length > 0 && (
+              <>
+                {/* Under their own heading, and last. These are the only rows in
+                    this menu that write to disk. */}
+                <div className="px-2.5 pt-2 pb-1 text-[10px] uppercase tracking-wider t-dim2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>Branches — checkout here</div>
+                {shownBranches.map((b, i) => {
+                  const at = shownRepos.length + i;
+                  return (
+                    <button
+                      key={b.name}
+                      role="option"
+                      aria-selected={false}
+                      data-cursor={at === cursor ? "1" : undefined}
+                      onMouseEnter={() => setCursor(at)}
+                      disabled={branches?.disabled}
+                      onClick={() => { branches?.onCheckout(b.name); close(false); }}
+                      className="w-full text-left px-2.5 py-1.5 flex items-center gap-2 disabled:opacity-50"
+                      style={{ background: at === cursor ? "color-mix(in srgb, var(--primary) 9%, transparent)" : "transparent" }}
+                    >
+                      <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" title="local branch — checked out in the current directory" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>BR</span>
+                      <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={b.name}>{b.name}</span>
+                      {branches?.gone?.(b) && <span className="shrink-0 text-[10px] px-1 rounded" style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 12%, transparent)" }}>gone</span>}
+                    </button>
+                  );
+                })}
+              </>
+            )}
+
+            {!repos.length && <div className="px-3 py-2 t-dim2">{emptyLabel}</div>}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -2,7 +2,7 @@
 // compose project with live CPU/mem, a streaming-ish log viewer, and start/
 // stop/restart/rm actions. Images / volumes / networks get their own tabs.
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
-import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import type { DockerOverview, DockerContainer, DockerStat, DockerCapability } from "../../../shared/types.ts";
 import { depSpec } from "../../../shared/deps.ts";
 import { api } from "../lib/api.ts";
@@ -517,7 +517,7 @@ export function DockerView({ active }: { active: boolean }) {
       className="flex-1 min-h-0 flex flex-col outline-none overflow-hidden relative">
                 <style>{SCROLLBAR_CSS}</style>
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
-                  <span className={viewTitleClass} style={{ color: "var(--text)" }}>Docker</span>
+                  <h2 className="sr-only">Docker</h2>
                   {ov?.version && <span className="text-[10px] t-dim2">Engine {ov.version}</span>}
                   {/* Scoped to the open project. The fallback case is spelled out
                       rather than shown as an empty list, so an unlabelled stack

--- a/web/src/components/FilesPanel.tsx
+++ b/web/src/components/FilesPanel.tsx
@@ -60,7 +60,7 @@ export function FilesView({ active }: { active: boolean }) {
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <ViewHeader title="Files">
+      <ViewHeader label="Files">
         <div className="relative" ref={pickerRef}>
           <button onClick={() => setRepoOpen((o) => !o)}
             className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[280px] shrink-0 whitespace-nowrap"

--- a/web/src/components/FilesPanel.tsx
+++ b/web/src/components/FilesPanel.tsx
@@ -14,10 +14,10 @@
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { api } from "../lib/api.ts";
 import type { FileEntry, GitRepoRef, GrepHit } from "../../../shared/types.ts";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 import { ViewHeader } from "./workspace/ViewHeader.tsx";
 import { PeekFile, type Peek } from "./PeekFile.tsx";
 import { subscribeFilesReveal, filesReveal } from "../lib/filesReveal.ts";
-import { useDismiss } from "../lib/useDismiss.ts";
 import { FOLDER, FOLDER_OPEN, guides, iconFor, isNoise } from "../lib/fileIcons.ts";
 
 /** How a row is drawn depends only on this, so the tree and the search results
@@ -32,10 +32,6 @@ const edge = (pct: number) => `1px solid color-mix(in srgb, var(--text) ${pct}%,
 export function FilesView({ active }: { active: boolean }) {
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState("");
-  const [repoOpen, setRepoOpen] = useState(false);
-  const [repoQuery, setRepoQuery] = useState("");
-  const pickerRef = useRef<HTMLDivElement>(null);
-  useDismiss(repoOpen, pickerRef, () => { setRepoOpen(false); setRepoQuery(""); });
 
   const repo = repos.find((r) => r.root === root) ?? null;
 
@@ -61,44 +57,8 @@ export function FilesView({ active }: { active: boolean }) {
   return (
     <div className="flex flex-col h-full min-h-0">
       <ViewHeader label="Files">
-        <div className="relative" ref={pickerRef}>
-          <button onClick={() => setRepoOpen((o) => !o)}
-            className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[280px] shrink-0 whitespace-nowrap"
-            style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: edge(20), color: "var(--text)" }}
-            title={repo ? `${repo.name}\n${repo.branch}\n${repo.root}` : "Pick a checkout"}>
-            <span className="font-medium truncate min-w-0">{repo ? (repo.worktreeOf ? repo.branch : repo.name) : "Pick a checkout"}</span>
-            {repo?.worktreeOf && <span className="shrink-0 text-[8.5px] px-1 py-[1px] rounded" style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }}>WT</span>}
-            <span className="shrink-0" style={{ color: "var(--text3)" }}>▾</span>
-          </button>
-          {repoOpen && (
-            <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col"
-              style={{ zIndex: 30, background: "var(--bg2)", border: edge(30), minWidth: 340, maxHeight: 420, overflow: "hidden" }}>
-              <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter checkouts…"
-                className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
-                style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: edge(20), color: "var(--text)" }} />
-              <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
-                {repos.filter((r) => {
-                  const q = repoQuery.trim().toLowerCase();
-                  return !q || `${r.name} ${r.branch} ${r.root}`.toLowerCase().includes(q);
-                }).map((r) => (
-                  <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); setRepoQuery(""); }}
-                    className="w-full text-left px-2.5 py-1.5 flex items-center gap-2"
-                    style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
-                      title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
-                      style={r.worktreeOf
-                        ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
-                        : { color: "var(--text3)", border: edge(25) }}>{r.worktreeOf ? "WT" : "REPO"}</span>
-                    <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.root}>
-                      {r.worktreeOf ? r.branch : r.name}
-                    </span>
-                    {!r.worktreeOf && <span className="shrink-0 truncate text-[9.5px]" style={{ maxWidth: 150, color: "var(--text3)" }} title={r.branch}>{r.branch}</span>}
-                  </button>
-                ))}
-              </div>
-            </div>
-          )}
-        </div>
+        <CheckoutPicker repos={repos} value={root} onPick={setRoot}
+          placeholder="Pick a checkout" triggerMaxWidth={280} emptyLabel="no checkouts seen yet" />
         {repo && <span className="text-[10px] truncate min-w-0" style={{ color: "var(--text3)" }} title={repo.root}>{repo.root}</span>}
       </ViewHeader>
       {root ? <FilesBody root={root} branch={repo?.branch ?? ""} active={active} />

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -11,6 +11,7 @@ import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, MergeInfo, FileChange, WalkthroughResult, WalkthroughFile, TidyReport, TidyFinding } from "../../../shared/types.ts";
 import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, forcedDeletePrompt } from "../lib/goneCleanup.ts";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 import { BasePicker } from "./BasePicker.tsx";
 import { ShellConsole } from "./ShellConsole.tsx";
 import { RescueModal } from "./RescueModal.tsx";
@@ -731,8 +732,6 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   // as somebody else's dialog next to our modals, and blocks the JS thread so
   // nothing can show progress while it is up.
   const { ask, askText, dialog } = useDialogs();
-  const [repoOpen, setRepoOpen] = useState(false);
-  const [repoQuery, setRepoQuery] = useState("");
   /**
    * One search box and one sort, shared by every list tab.
    *
@@ -1693,12 +1692,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     if (how === "checkout") setView("changes");
   };
 
-  // Source control's picker never had this; the terminal's did. Same bug, one
-  // file each, which is why it read as fixed.
-  const repoPickerRef = useRef<HTMLDivElement | null>(null);
-  useDismiss(repoOpen, repoPickerRef, () => { setRepoOpen(false); setRepoQuery(""); });
-
-  const openWorktree = (w: GitWorktree) => { setRoot(w.path); setRepoOpen(false); setSelKey(null); setView("changes"); };
+  const openWorktree = (w: GitWorktree) => { setRoot(w.path); setSelKey(null); setView("changes"); };
   // The lazygit move: a branch already checked out in a worktree can't be
   // `git checkout`ed here (git refuses a branch that is out elsewhere), so
   // switching to it OPENS that worktree; otherwise it is a plain checkout.
@@ -1957,8 +1951,8 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   // The repo picker is a switcher: repos + worktrees + local branches. It can be
   // opened from any view, so make sure the branch list is loaded when it is —
   // otherwise the branches section is empty everywhere but the Branches tab.
-  useEffect(() => {
-    if (!repoOpen || !root) return;
+  const refreshPicker = useCallback(() => {
+    if (!root) return;
     reloadBranches();
     /**
      * And the repo list itself, which is where each row's branch comes from.
@@ -1972,7 +1966,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
      */
     api.gitRepos().then(({ repos }) => setRepos(repos)).catch(() => { /* keep the stale list rather than an empty one */ });
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [repoOpen]);
+  }, [root]);
   // A different repo has different remotes: carrying the selection over asks for
   // branches from a remote this one may not even have.
   useEffect(() => { setRemoteSel(""); setRemoteRows([]); setRemoteQuery(""); }, [root]);
@@ -2141,108 +2135,14 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                     not by cutting off whatever escapes. */}
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
                   <h2 className="sr-only">Source control</h2>
-                  <div className="relative" ref={repoPickerRef}>
-                    {/* Also one line. A worktree directory carries the whole
-                        ticket name, and wrapped it made the button two rows
-                        tall and shoved the tab strip down with it. */}
-                    <button onClick={() => setRepoOpen((o) => !o)} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[240px] shrink-0 whitespace-nowrap" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
-                      title={repoRef ? `${repoRef.name}\n${repoRef.root}` : undefined}>
-                      {/* Repo AND branch. The button named only the checkout,
-                          which is the half that does not change — you switch
-                          branch from this very panel and the control at the top
-                          of it went on saying exactly what it said before. The
-                          branch comes from the working-tree poll rather than
-                          from the repo list, so it moves the instant you switch
-                          rather than at the next repo scan. */}
-                      <span className="font-medium truncate min-w-0">{repoRef?.name ?? "Repo"}</span>
-                      {currentBranchName && (
-                        <span className="t-dim2 shrink-0 truncate max-w-[9rem]" style={{ maxWidth: "9rem" }} title={`on ${currentBranchName}`}>· {currentBranchName}</span>
-                      )}
-                      <span className="t-dim2 shrink-0">▼</span>
-                    </button>
-                    {repoOpen && (
-                      <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 420, overflow: "hidden" }}>
-                        <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
-                        <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
-                          {/* Path included: a worktree is found by its card id
-                              ("20343"), which lives in the directory name. */}
-                          {repos.filter((r) => { const q = repoQuery.trim().toLowerCase(); return !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q); }).map((r) => (
-                            <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); setRepoQuery(""); setSelKey(null); }} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2" style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-                              {/* Was "└", an indent meaning "child of the line
-                                  above" — which says nothing once you filter
-                                  the list and the parent is off screen, and
-                                  left projects marked by the absence of a
-                                  character. A badge names the kind outright,
-                                  and reads the same wherever the row lands.
-                                  The terminal's picker uses the same one. */}
-                              <span
-                                className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
-                                title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
-                                style={r.worktreeOf
-                                  ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
-                                  : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
-                              >{r.worktreeOf ? "WT" : "REPO"}</span>
-                              {/* A worktree IS its branch — that's the whole point
-                                  of having one per ticket. The directory name is
-                                  a terse stub of it (`orbit-WEB-1188` for a
-                                  branch called `WEB-1188-quota-banner-copy…`),
-                                  so leading with the directory spent the wide
-                                  column on the less informative of the two and
-                                  truncated the one you were reading. Projects
-                                  keep their name, since there the folder is the
-                                  identity and the branch is just what's checked
-                                  out right now.
-
-                                  But the folder is now always shown beside it.
-                                  That rule holds only while a worktree keeps the
-                                  branch it was made for, and this app hands you a
-                                  one-click way to change it — so a checkout
-                                  RENAMED a row, and "master turned into a
-                                  worktree and the worktree into a branch" was an
-                                  accurate description of what someone saw. A
-                                  directory's identity must not move under a
-                                  click. */}
-                              <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.worktreeOf ? `${r.branch}\n${r.root}` : r.root}>
-                                {r.worktreeOf ? r.branch : r.name}
-                              </span>
-                              {!r.worktreeOf
-                                ? <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.branch}>{r.branch}</span>
-                                : r.name !== r.branch && <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.root}>{r.name}</span>}
-                              {r.dirty > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }}>●{r.dirty}</span>}
-                              {/* Same reading as the header chip. This used to be
-                                  hardcoded to zero, so the one place you pick a
-                                  repo from could never tell you one had drifted. */}
-                              {r.behind > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.behind} behind upstream`}>↓{r.behind}</span>}
-                              {r.ahead > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--success)" }} title={`${r.ahead} ahead of upstream`}>↑{r.ahead}</span>}
-                            </button>
-                          ))}
-                          {/* Local branches with no checkout of their own — the
-                              other half of a switcher. A worktree branch is
-                              already a WT row above; these switch by checking out
-                              in the current directory. */}
-                          {(() => {
-                            const q = repoQuery.trim().toLowerCase();
-                            const checkedOut = new Set(repos.map((r) => r.branch));
-                            const pickerBranches = branchData.branches.filter((b) => !checkedOut.has(b.name) && (!q || b.name.toLowerCase().includes(q)));
-                            if (!pickerBranches.length) return null;
-                            return (
-                              <>
-                                <div className="px-2.5 pt-2 pb-1 text-[10px] uppercase tracking-wider t-dim2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>Branches — checkout here</div>
-                                {pickerBranches.slice(0, 80).map((b) => (
-                                  <button key={b.name} disabled={busy || !writeEnabled} onClick={() => { checkout(b.name); setRepoOpen(false); setRepoQuery(""); }} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2 disabled:opacity-50">
-                                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" title="local branch — checked out in the current directory" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>BR</span>
-                                    <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={b.name}>{b.name}</span>
-                                    {trackChip(b.track).gone && <span className="shrink-0 text-[10px] px-1 rounded" style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 12%, transparent)" }}>gone</span>}
-                                  </button>
-                                ))}
-                              </>
-                            );
-                          })()}
-                          {!repos.length && <div className="px-3 py-2 t-dim2">no repos seen yet</div>}
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                  <CheckoutPicker
+                    repos={repos}
+                    value={root}
+                    onPick={(r) => { setRoot(r); setSelKey(null); }}
+                    branchLabel={currentBranchName || null}
+                    branches={{ items: branchData.branches, disabled: busy || !writeEnabled, onCheckout: checkout, gone: (b) => trackChip(b.track).gone }}
+                    onOpenChange={(o) => { if (o) refreshPicker(); }}
+                  />
                   {/* Scrolls rather than shoves. Eight tabs plus a long branch
                       name will not fit a narrow window, and something has to
                       give — a strip you can flick is better than controls

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -8,7 +8,7 @@ import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { ConflictMode } from "./ConflictMode.tsx";
 import { requestTermIssue } from "../lib/termIssue.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
-import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, MergeInfo, FileChange, WalkthroughResult, WalkthroughFile, TidyReport, TidyFinding } from "../../../shared/types.ts";
 import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, forcedDeletePrompt } from "../lib/goneCleanup.ts";
 import { BasePicker } from "./BasePicker.tsx";
@@ -2140,7 +2140,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                     branch chip yielding space and the tab strip scrolling —
                     not by cutting off whatever escapes. */}
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
-                  <span className={viewTitleClass} style={{ color: "var(--text)" }}>Source control</span>
+                  <h2 className="sr-only">Source control</h2>
                   <div className="relative" ref={repoPickerRef}>
                     {/* Also one line. A worktree directory carries the whole
                         ticket name, and wrapped it made the button two rows

--- a/web/src/components/MachinePanel.tsx
+++ b/web/src/components/MachinePanel.tsx
@@ -19,6 +19,7 @@ import { openExternal } from "../lib/externalUrl.ts";
 import { requestBrowserNav } from "../lib/browserNav.ts";
 import { CloseButton, CloseIcon } from "./CloseButton.tsx";
 import { ICON } from "../lib/iconSize.ts";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 
 export type MachineTab = "ports" | "resources" | "locks";
 
@@ -729,11 +730,11 @@ function Space({ repos }: { repos: GitRepoRef[] }) {
       <div className="flex items-center gap-2 px-3.5 py-2 text-[11px] flex-wrap">
         <span style={{ color: "var(--text3)" }}>⛁</span>
         <span style={{ color: "var(--text)", fontWeight: 500 }}>Disk</span>
-        <select value={root} onChange={(e) => { setRoot(e.target.value); setData(null); setOpen(false); }}
-          className="text-[10.5px] px-1.5 py-0.5 rounded outline-none min-w-0"
-          style={{ background: "var(--bg)", color: "var(--text2)", border: edge(20), maxWidth: 240 }}>
-          {repos.map((r) => <option key={r.root} value={r.root}>{r.worktreeOf ? r.branch : base(r.root)}</option>)}
-        </select>
+        {/* Which checkout to measure — a one-shot argument for the scan, not a
+            move: nothing else follows it anywhere. */}
+        <CheckoutPicker repos={repos} value={root}
+          onPick={(r) => { setRoot(r); setData(null); setOpen(false); }}
+          placeholder="Pick a checkout" triggerMaxWidth={240} />
         {data && !data.error && (
           <span className="text-[10.5px]" style={{ color: "var(--text3)" }}>
             <b style={{ color: "var(--text2)", fontWeight: 500 }}>{mb(data.bytes)}</b>

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -26,7 +26,7 @@ import { diffSplit, diffWrap } from "../lib/diffPrefs.ts";
 import { Portal } from "./Portal.tsx";
 import { subscribePrJump, prJump, clearPrJump } from "../lib/prJump.ts";
 import { shaFromHref } from "../lib/commitLink.ts";
-import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import type {
   PrSummary, PrDetail, PrRepoId, PrThread, PrComment, PrReview, PrReviewer, PrCheck, GitRepoRef, FileChange,
   PrReaction, PrAuthorAssociation, PrEvent, PrCommit, PrFile, PrCheckJob, PrLocalHead,
@@ -2537,7 +2537,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
       <style>{SCROLLBAR_CSS}{LINEBTN_CSS}{MD_CSS}{PR_ROW_CSS}{LOADING_CSS}</style>
 
       <div className={viewHeaderClass} style={viewHeaderStyle}>
-        <span className={viewTitleClass} style={{ color: "var(--text)" }}>Pull Requests</span>
+        <h2 className="sr-only">Pull Requests</h2>
         {/* No repo/worktree picker here: pull requests belong to the GitHub
             remote, and every worktree of a repo shares that one remote — so the
             picker only ever offered a dozen ways to look at the SAME list. The

--- a/web/src/components/RecipesPane.tsx
+++ b/web/src/components/RecipesPane.tsx
@@ -18,6 +18,7 @@ import type { Recipe, RecipeParam, GitRepoRef } from "../../../shared/types.ts";
 import { consoleRoot, runInConsole, consoleInTmux } from "./TerminalPanel.tsx";
 import { CloseButton } from "./CloseButton.tsx";
 import { SettingRow } from "./SettingRow.tsx";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 
 const edge = (pct: number) => `1px solid color-mix(in srgb, var(--border) ${pct}%, transparent)`;
 const PARAM_TYPES: RecipeParam["type"][] = ["text", "choice", "flag", "repo", "worktree", "branch"];
@@ -346,11 +347,9 @@ export function RunDialog({ r, repos, onClose, onNote, onRunStep, targetInTmux }
               {(p.options ?? []).map((o) => <option key={o} value={o}>{o}</option>)}
             </select>
           ) : p.type === "repo" || p.type === "worktree" ? (
-            <select value={values[p.key] ?? ""} onChange={(e) => setValues((v) => ({ ...v, [p.key]: e.target.value }))}
-              className="text-[11.5px] px-2 py-1.5 rounded-lg" style={style}>
-              <option value="">—</option>
-              {repos.map((x) => <option key={x.root} value={x.root}>{x.worktreeOf ? `${x.name} · ${x.branch}` : x.name}</option>)}
-            </select>
+            <CheckoutPicker repos={repos} value={values[p.key] ?? ""}
+              onPick={(r) => setValues((v) => ({ ...v, [p.key]: r }))}
+              placeholder="—" triggerMaxWidth={220} />
           ) : (
             <input value={values[p.key] ?? ""} onChange={(e) => setValues((v) => ({ ...v, [p.key]: e.target.value }))}
               className="text-[11.5px] px-2 py-1.5 rounded-lg" style={style} spellCheck={false} />

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -10,6 +10,7 @@
 // they control, and downloads say what you actually get.
 import { Fragment, createContext, isValidElement, useCallback, useContext, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
 import { RecipesPane } from "./RecipesPane.tsx";
+import { lastTerminalRoot } from "./TerminalPanel.tsx";
 import { Filter, Fold, SettingRow } from "./SettingRow.tsx";
 import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
@@ -2140,7 +2141,10 @@ function RequirementsPane({ open }: { open: boolean }) {
    * user already has a shell in rather than inventing one and pushing on the
    * boundary that exists to stop exactly that.
    */
-  const shellRoot = (() => { try { return localStorage.getItem("agentglass.terminalRoot") || ""; } catch { return ""; } })();
+  // Through TerminalPanel's own reader, not the raw key. A literal here is a
+  // second copy of somebody else's storage schema, and it would have gone on
+  // reading a key that had quietly stopped being written.
+  const shellRoot = lastTerminalRoot();
   const [deps, setDeps] = useState<DepReport[] | null>(null);
   const [platform, setPlatform] = useState<string>("");
   const [err, setErr] = useState<string | null>(null);

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -125,7 +125,7 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
 
   return (
     <div className="flex flex-col h-full min-h-0">
-      <ViewHeader title="Tasks">
+      <ViewHeader label="Tasks">
         <nav className="flex items-center gap-0.5" aria-label="Sources">
           {tabs.map((s) => (
             <button key={s.id} onClick={() => setSource(s.id)}

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -94,7 +94,6 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
 }) {
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState("");
-  const [repoOpen, setRepoOpen] = useState(false);
   const shown = useSyncExternalStore(subscribeTaskSources, shownTaskSources, shownTaskSources);
   const tabs = useMemo(() => sourceTabs(shown), [shown]);
   const [source, setSource] = useState<SourceId>("all");
@@ -104,9 +103,6 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
   useEffect(() => {
     if (!tabs.some((t) => t.id === source)) setSource(tabs[0]?.id ?? "all");
   }, [tabs, source]);
-  const pickerRef = useRef<HTMLDivElement>(null);
-  useDismiss(repoOpen, pickerRef, () => setRepoOpen(false));
-  const repo = repos.find((r) => r.root === root) ?? null;
 
   useEffect(() => {
     if (!active) return;
@@ -139,31 +135,15 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
             </button>
           ))}
         </nav>
-        {/* Only the GitHub half is scoped to a repository. The local list is
-            this machine's and ClickUp is a workspace's, so a repo picker over
-            either would imply a scoping that does not exist. */}
-        <div className="relative" ref={pickerRef}
-          style={{ display: source === "local" || source === "clickup" ? "none" : undefined }}>
-          <button onClick={() => setRepoOpen((o) => !o)}
-            className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg max-w-[280px] whitespace-nowrap"
-            style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: edge(20), color: "var(--text)" }}
-            title={repo?.root}>
-            <span className="font-medium truncate">{repo ? (repo.worktreeOf ? repo.branch : repo.name) : "Pick a repo"}</span>
-            <span style={{ color: "var(--text3)" }}>▾</span>
-          </button>
-          {repoOpen && (
-            <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col"
-              style={{ zIndex: 30, background: "var(--bg2)", border: edge(30), minWidth: 320, maxHeight: 420, overflow: "auto" }}>
-              {repos.map((r) => (
-                <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); }}
-                  className="w-full text-left px-2.5 py-1.5 flex items-center gap-2 hover:bg-white/5"
-                  style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-                  <span className="truncate flex-1" style={{ color: "var(--text)" }}>{r.worktreeOf ? r.branch : r.name}</span>
-                </button>
-              ))}
-            </div>
-          )}
-        </div>
+        {/*
+          * No repo picker. Switching checkout here never changed which issues
+          * you saw: they come from the GitHub remote, and every worktree of a
+          * project shares that one remote — so the control offered a dozen ways
+          * to look at the same list. All it really moved was the directory `gh`
+          * ran in and where `issueStart` would cut a worktree, and for both of
+          * those the answer that is always right is the project itself, which
+          * is what `repos[0]` already is under an open project.
+          */}
       </ViewHeader>
       {source === "local" ? <LocalBody active={active} repos={repos} here={root} onOpenChatWith={onOpenChatWith} />
       : source === "clickup" ? <ClickUpBody active={active} repos={repos} here={root} onOpenChatWith={onOpenChatWith} jump={cardJump} />

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -16,6 +16,7 @@ import { keepTermFocus } from "../lib/keepFocus.ts";
 import { focusFollowsMouse, subscribeFocusFollowsMouse, shouldFocusOnHover } from "../lib/termFocusPref.ts";
 import { cellAt, paneAt } from "../lib/tmuxHover.ts";
 import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
+import { CheckoutPicker } from "./CheckoutPicker.tsx";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -257,12 +258,24 @@ let consoleBlocked: (cmd: string) => void = () => {};
 // resort rather than routine: it only runs at the server's own ceiling, and it
 // never touches a shell that is still connected — closing a live job to make
 // room for a new tab would lose work the user can't see.
+//
+// What it spares beyond that is what is ON SCREEN. It used to spare everything
+// sharing the root of the shell being created, which worked only while the
+// terminal had a repo picker and shells came in per-repo pools: with one root
+// for the whole view, that clause spared every session there is and the ceiling
+// quietly stopped applying. Panes are the honest version of the same intent —
+// "don't close what I am looking at" — and they were what it meant all along.
 const MAX_CLIENT_SESSIONS = 60;
-function evictLru(exceptRoot: string) {
+/** Ids currently mounted in a pane, kept here because eviction is module-level
+ *  and the panes are the view's state. Written by the view on every layout
+ *  change; empty before it mounts, which is also when nothing is on screen. */
+let onScreen: readonly string[] = [];
+export function setOnScreenSessions(ids: readonly string[]): void { onScreen = ids; }
+function evictLru() {
   if (sessions.size < MAX_CLIENT_SESSIONS) return;
   let lru: Sess | null = null;
   for (const s of sessions.values()) {
-    if (s.root === exceptRoot || s.status === "live" || s.status === "connecting") continue;
+    if (onScreen.includes(s.id) || s.status === "live" || s.status === "connecting") continue;
     if (!lru || s.lastUsed < lru.lastUsed) lru = s;
   }
   if (!lru) return;
@@ -494,7 +507,7 @@ function reconnected(s: Sess) {
 
 /** A brand-new shell for `root`. Repos hold as many as you open. */
 function createSession(root: string): Sess {
-  evictLru(root);
+  evictLru();
   const tp = termOptions();
   const term = new Terminal({
     fontFamily: tp.fontFamily,
@@ -926,15 +939,16 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
    * it.
    */
   const [picked, setPicked] = useState<string>(() => { try { return localStorage.getItem(CONSOLE_ROOT_KEY) || ""; } catch { return ""; } });
+  /** The checkout menu has the keyboard, so focus-follows-mouse must leave it
+   *  alone — hovering the shell while you are typing into the filter would drag
+   *  the cursor out from under the letters. */
+  const [pickerOpen, setPickerOpen] = useState(false);
   const root = picked || fallbackRoot;
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const { ask, dialog } = useDialogs();
   /** The row for the directory we are standing in — what "here" means, by name,
    *  what it currently holds, and whether it has uncommitted work in it. */
   const here = repos.find((r) => r.root === root) ?? null;
-  const [repoOpen, setRepoOpen] = useState(false);
-  const [repoQuery, setRepoQuery] = useState("");
-  const pickerRef = useRef<HTMLDivElement>(null);
   /** Put the cursor back in the console after a menu that had to borrow the
    *  focus (the repo filter, the commands filter) closes again. Deferred a
    *  frame so it lands after the menu's own input has finished unmounting —
@@ -943,7 +957,6 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
     const s = sessions.get(sid);
     if (s) requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
   }, [sid]);
-  useDismiss(repoOpen, pickerRef, () => { setRepoOpen(false); setRepoQuery(""); focusConsole(); });
 
   // Every time the picker OPENS — not once. The `repos.length` short-circuit was
   // a fetch-once, so a worktree cut after this strip first loaded never showed:
@@ -951,15 +964,14 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
   // cheap and is the only way new worktrees (and branches) appear here the way
   // they already do in Source control.
   const [branchData, setBranchData] = useState<{ current: string; branches: GitBranch[] }>({ current: "", branches: [] });
-  useEffect(() => {
-    if (!repoOpen || IS_DEMO) return;
+  const refreshPicker = useCallback(() => {
+    if (IS_DEMO) return;
     api.gitRepos().then(({ repos: r }) => setRepos(r)).catch(() => {});
     if (root) api.gitBranches(root).then(setBranchData).catch(() => {});
-  }, [repoOpen, root]);
+  }, [root]);
   const chooseRepo = (next: string) => {
     setPicked(next);
     try { localStorage.setItem(CONSOLE_ROOT_KEY, next); } catch { /* private mode — lasts the session */ }
-    setRepoOpen(false); setRepoQuery("");
     focusConsole();
   };
   // A local branch with no worktree of its own: switch by checking it out in the
@@ -970,7 +982,6 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
     if (needsCheckoutConfirm(t) && !(await ask(checkoutConfirm(t)))) return;
     api.gitCheckout(root, name).then((r) => {
       if (!r.ok) return;
-      setRepoOpen(false); setRepoQuery("");
       api.gitRepos().then(({ repos: rr }) => setRepos(rr)).catch(() => {});
       focusConsole();
     }).catch(() => {});
@@ -1071,68 +1082,19 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
             run, and on a worktree-per-ticket repo the right directory is rarely
             the one the terminal view happens to be sitting in — so it picks its
             own, and remembers it. */}
-        <div className="relative shrink-0" ref={pickerRef} onMouseDown={(e) => e.stopPropagation()}>
+        <div className="shrink-0" onMouseDown={(e) => e.stopPropagation()}>
           {/* keepTermFocus so opening the picker does not blur the console; the
               filter input inside autofocuses on its own, and closing hands the
-              cursor back (see chooseRepo / the useDismiss above). */}
-          <button onMouseDown={keepTermFocus} onClick={() => setRepoOpen((o) => !o)} disabled={IS_DEMO}
-            className="flex items-center gap-1.5 text-[10px] px-2 py-0.5 rounded-md max-w-[200px]"
-            style={{ background: "color-mix(in srgb, var(--bg3) 60%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
-            title={root || "No repo"}>
-            <span className="truncate">{root ? repoName(root) : "No repo"}</span><span className="t-dim2">▼</span>
-          </button>
-          {repoOpen && (
-            <div className="absolute left-0 rounded-lg text-[11px] shadow-2xl flex flex-col"
-              style={{ zIndex: 40, bottom: "calc(100% + 4px)", background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 320, maxHeight: 360, overflow: "hidden" }}>
-              <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter repos…"
-                className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0"
-                style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
-              <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
-                {repos.filter((r) => { const q = repoQuery.trim().toLowerCase(); return !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q); }).map((r) => (
-                  <button key={r.root} onClick={() => chooseRepo(r.root)} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2"
-                    style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-                    {/* Same badge and same name rule as every other picker: a
-                        worktree IS its branch, a project is its folder — but the
-                        folder is now always said out loud beside it. Naming a
-                        worktree only by its branch means a checkout RENAMES the
-                        row, and that is what made "master turned into a worktree
-                        and the worktree into a branch" the honest description of
-                        what someone saw. The identity of a directory must not
-                        change under a click. */}
-                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
-                      style={r.worktreeOf
-                        ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
-                        : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>{r.worktreeOf ? "WT" : "REPO"}</span>
-                    <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={`${r.branch}\n${r.root}`}>{r.worktreeOf ? r.branch : r.name}</span>
-                    {r.worktreeOf && r.name !== r.branch && (
-                      <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.root}>{r.name}</span>
-                    )}
-                    {r.dirty > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }}>●{r.dirty}</span>}
-                  </button>
-                ))}
-                {/* Local branches with no worktree — switch by checking out in
-                    the console's current directory, same as Source control. */}
-                {(() => {
-                  const q = repoQuery.trim().toLowerCase();
-                  const checkedOut = new Set(repos.map((r) => r.branch));
-                  const branches = branchData.branches.filter((b) => !checkedOut.has(b.name) && (!q || b.name.toLowerCase().includes(q)));
-                  if (!branches.length) return null;
-                  return (
-                    <>
-                      <div className="px-2.5 pt-2 pb-1 text-[10px] uppercase tracking-wider t-dim2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>Branches — check out in {here?.name ?? "this folder"}</div>
-                      {branches.slice(0, 80).map((b) => (
-                        <button key={b.name} onClick={() => checkoutHere(b.name)} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2">
-                          <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" title="local branch — checked out in the current directory" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>BR</span>
-                          <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={b.name}>{b.name}</span>
-                        </button>
-                      ))}
-                    </>
-                  );
-                })()}
-                {!repos.length && <div className="px-3 py-2 t-dim2">Reading repos…</div>}
-              </div>
-            </div>
-          )}
+              cursor back. */}
+          <span onMouseDown={keepTermFocus}>
+            <CheckoutPicker
+              repos={repos} value={root} onPick={chooseRepo}
+              branches={{ items: branchData.branches, onCheckout: checkoutHere }}
+              onOpenChange={(o) => { setPickerOpen(o); if (o) refreshPicker(); }} onDismiss={focusConsole}
+              disabled={IS_DEMO} placeholder="No repo" triggerMaxWidth={200}
+              emptyLabel="Reading repos…"
+            />
+          </span>
         </div>
 
         {sess && <span className="text-[10px] shrink-0" style={{ color: SESS_DOT[sess.status].color }}>● {SESS_DOT[sess.status].label}</span>}
@@ -1160,7 +1122,7 @@ export function ConsoleStrip({ root: fallbackRoot, open, height, onHeight, onClo
       <div ref={slot} className="flex-1 min-h-0" style={{ background: "var(--bg)" }}
         onClick={() => sess?.term.focus()}
         onMouseEnter={(e) => {
-          if (shouldFocusOnHover({ enabled: ffm, buttons: e.buttons, typing: repoOpen, visible: open })) focusConsole();
+          if (shouldFocusOnHover({ enabled: ffm, buttons: e.buttons, typing: pickerOpen, visible: open })) focusConsole();
         }} />
     </div>
   );
@@ -1225,14 +1187,11 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
    *  anyone whose last view was the terminal. tsc cannot see it because the
    *  read is inside the `find` callback, where it looks deferred. */
   const here = repos.find((r) => r.root === root) ?? null;
-  const [repoOpen, setRepoOpen] = useState(false);
-  const [repoQuery, setRepoQuery] = useState("");
   /** Only whether the server allows commands at all — the list, its dropdown
    *  and the pins are the shared CommandBar's business now. */
   const [cmds, setCmds] = useState<TerminalCommands | null>(null);
   /** Both dropdowns live in here, so one listener can tell "clicked outside"
    *  from "clicked a row". */
-  const pickersRef = useRef<HTMLDivElement>(null);
   // The "jump to a worktree's git / changes" dropdown. Separate from the repo
   // picker above (which switches the terminal itself): this one leaves the
   // terminal where it is and takes you to Source control / File changes for the
@@ -1254,39 +1213,31 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const containerRef = useRef<HTMLDivElement>(null);
   const [, force] = useReducer((x: number) => x + 1, 0);
 
+  /*
+   * Where a new shell opens. Not a choice any more — the open project.
+   *
+   * `repos[0]` is that project: the scoped repo list leads with it and orders
+   * the worktrees after. A remembered root that is no longer in the list is
+   * DROPPED rather than kept, because a stale one from a previous scope would
+   * silently open shells, and list commands, in a repo outside the project.
+   */
   useEffect(() => {
     if (!open) return;
     api.gitRepos().then(({ repos }) => {
       setRepos(repos);
-      // When the scoped repo list doesn't contain the remembered root, DROP it
-      // rather than keep it: a stale localStorage root from a previous scope
-      // would silently open shells (and list commands) in an out-of-scope repo
-      // while the header claims "pick a repo".
       setRoot((cur) => (cur && repos.some((r) => r.root === cur) ? cur : repos[0]?.root || ""));
     }).catch(() => {});
   }, [open]);
+  /*
+   * Still written, even though nobody picks it.
+   *
+   * The docked console falls back to this key when it has no pick of its own
+   * (see `consoleRoot`). Dropping the write is what would silently break
+   * `docker exec` and recipe runs on a profile that has never opened the
+   * console's own picker — `runInConsole` just returns false, with no error and
+   * no toast.
+   */
   useEffect(() => { if (root) { try { localStorage.setItem(ROOT_KEY, root); } catch { /* ignore */ } } }, [root]);
-  // Local branches, so the picker offers them the way Source control does — the
-  // ones with a worktree are already worktree rows; these switch by checking out
-  // in the current directory. Fetched only when the picker is open.
-  const [branchData, setBranchData] = useState<{ current: string; branches: GitBranch[] }>({ current: "", branches: [] });
-  // Refresh repos AND branches whenever the picker opens — so a worktree or
-  // branch made after this view first loaded shows without a restart.
-  useEffect(() => {
-    if (!repoOpen || !root || IS_DEMO) return;
-    api.gitRepos().then(({ repos }) => setRepos(repos)).catch(() => {});
-    api.gitBranches(root).then(setBranchData).catch(() => {});
-  }, [repoOpen, root]);
-  const checkoutBranch = async (name: string) => {
-    const t = { branch: name, dir: here?.name ?? root.split("/").pop() ?? root, displacing: here?.branch ?? null, dirty: here?.dirty ?? 0 };
-    if (needsCheckoutConfirm(t) && !(await ask(checkoutConfirm(t)))) return;
-    api.gitCheckout(root, name).then((r) => {
-      if (!r.ok) return;
-      setRepoOpen(false); setRepoQuery("");
-      api.gitRepos().then(({ repos }) => setRepos(repos)).catch(() => {});
-      focusTerm();
-    }).catch(() => {});
-  };
   useEffect(() => {
     if (!open || !root) return;
     setCmds(null);
@@ -1297,6 +1248,9 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   // plain case, and a split shows several at once the way tmux does — the point
   // being to watch a build in one while working in another.
   const [paneIds, setPaneIds] = useState<string[]>([]);
+  // Eviction is module-level and the panes are here, so it is told rather than
+  // left to guess — see setOnScreenSessions.
+  useEffect(() => { setOnScreenSessions(paneIds); }, [paneIds]);
   const [focusIdx, setFocusIdx] = useState(0);
   const paneRefs = useRef<(HTMLDivElement | null)[]>([]);
 
@@ -1312,7 +1266,6 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   // The repo picker's filter takes focus off the shell while it is open, so
   // dismissing it (Escape, an outside click) has to give the shell its cursor
   // back — see focusTerm.
-  useDismiss(repoOpen, pickersRef, () => { setRepoOpen(false); focusTerm(); });
   useDismiss(wtOpen, wtRef, () => { setWtOpen(false); setWtQuery(""); setWtShowAll(false); focusTerm(); });
   // Keep the focused pane's worktree fresh.
   //
@@ -1407,14 +1360,14 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
    * app means a white window rather than a warning.
    */
   const hoverFocus = useCallback((i: number, buttons: number) => {
-    if (!shouldFocusOnHover({ enabled: ffm, buttons, typing: repoOpen || wtOpen || findOpen, visible: active && open })) return;
+    if (!shouldFocusOnHover({ enabled: ffm, buttons, typing: wtOpen || findOpen, visible: active && open })) return;
     const s = sessions.get(paneIds[i] ?? "");
     if (!s) return;
     // Only when it moves. Re-entering the pane you are already in would re-run
     // the mount effect below, which detaches and re-attaches a live terminal.
     setFocusIdx((cur) => (cur === i ? cur : i));
     requestAnimationFrame(() => { try { s.term.focus(); } catch { /* disposed mid-frame */ } });
-  }, [ffm, repoOpen, wtOpen, findOpen, active, open, paneIds]);
+  }, [ffm, wtOpen, findOpen, active, open, paneIds]);
 
   /** The tmux pane last asked for, so a pointer resting inside one does not
    *  re-send for every mousemove in the half-second before the sweep reports
@@ -1436,7 +1389,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
    * so crossing a divider is one command and sitting in a pane is none.
    */
   const hoverTmuxPane = useCallback((i: number, e: { clientX: number; clientY: number; buttons: number }) => {
-    if (!shouldFocusOnHover({ enabled: ffm, buttons: e.buttons, typing: repoOpen || wtOpen || findOpen, visible: active && open })) return;
+    if (!shouldFocusOnHover({ enabled: ffm, buttons: e.buttons, typing: wtOpen || findOpen, visible: active && open })) return;
     const s = sessions.get(paneIds[i] ?? "");
     // Fewer than two panes and there is nothing to choose between — the server
     // sends an empty list for exactly that case.
@@ -1454,7 +1407,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     if (!pane || pane.active || askedPane.current === pane.id) return;
     askedPane.current = pane.id;
     s.ws.send(ptyFrame({ t: "tmux", cmd: "selectpane", pane: pane.id }));
-  }, [ffm, repoOpen, wtOpen, findOpen, active, open, paneIds]);
+  }, [ffm, wtOpen, findOpen, active, open, paneIds]);
 
   useEffect(() => {
     if (!open) return;
@@ -1824,7 +1777,6 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
     s.term.focus();
   }, [paneIds, focusIdx]);
 
-  const repoRef = repos.find((r) => r.root === root);
   /* The demo has no server to ask, so `loadCommands` answers with a terminal
      that is switched off — and the overlay that message drives was covering the
      canned session. The demo's terminal is not disabled: it has no shell, which
@@ -1862,101 +1814,58 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
 .xterm-viewport{scrollbar-width:none!important}
 .xterm-viewport::-webkit-scrollbar{width:0!important;height:0!important}`}</style>
 
-                {/* header: repo picker + command launcher + actions */}
+                {/* header: where this pane is + command launcher + actions */}
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
                   <h2 className="sr-only">Terminal</h2>
-                  {/* keepTermFocus on the picker group so pressing the trigger
-                      or a repo row never blurs the shell; the filter input is
-                      excluded by the handler and still takes focus, and every
-                      way out of the menu below hands the cursor back. */}
-                  <div ref={pickersRef} className="flex items-center gap-3" onMouseDown={keepTermFocus}>
-                  <div className="relative">
-                    <button onClick={() => { if (repoOpen) { setRepoOpen(false); focusTerm(); } else setRepoOpen(true); }} className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}>
-                      <span className="font-medium">{repoRef ? repoName(repoRef.root) : "Pick a repo"}</span><span className="t-dim2">▼</span>
-                    </button>
-                    {repoOpen && (
-                      /* Wide enough for the whole worktree name and its branch.
-                         It used to be 320px with the branch clipped at 150, so
-                         a card-per-worktree checkout showed as "orbit-WEB-1042"
-                         beside an elided branch — the two pieces that tell them
-                         apart, both cut off. Source control shows them in full;
-                         this now matches it. */
-                      <div className="absolute left-0 mt-1 rounded-lg text-[11px] shadow-2xl flex flex-col" style={{ zIndex: 30, background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 55%, transparent)", minWidth: 460, maxWidth: "min(86vw, 760px)", maxHeight: 420, overflow: "hidden" }}>
-                        <input autoFocus value={repoQuery} onChange={(e) => setRepoQuery(e.target.value)} placeholder="Filter repos…" className="m-1.5 px-2.5 py-1.5 rounded-md text-[11px] outline-none shrink-0" style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }} />
-                        <div className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
-                          {/* The path is searchable too: with a worktree per card,
-                              "20343" is how you find one — it's in the directory
-                              name and the branch, not in the project name. */}
-                          {repos.filter((r) => { const q = repoQuery.trim().toLowerCase(); return !q || (r.name + " " + r.branch + " " + r.root).toLowerCase().includes(q); }).map((r) => {
-                            const live = sessionsFor(r.root).some((s) => s.status === "live");
-                            return (
-                              <button key={r.root} onClick={() => { setRoot(r.root); setRepoOpen(false); setRepoQuery(""); focusTerm(); }} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2" style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
-                                {/* Indented under its project — a shell in a
-                                    worktree is a shell in that branch, not in
-                                    some unrelated repo that looks similar. */}
-                                {/* A worktree gets its own mark rather than an
-                                    indent. "└" only says "child of the line
-                                    above", which stops meaning anything once
-                                    the list is filtered and the parent is off
-                                    screen — and it reads as tree drawing, not
-                                    as a kind of thing. */}
-                                <span
-                                  className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
-                                  title={r.worktreeOf ? `Worktree of ${r.worktreeOf}` : "Main checkout"}
-                                  style={r.worktreeOf
-                                    ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
-                                    : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
-                                >{r.worktreeOf ? "WT" : "REPO"}</span>
-                                {/* A worktree IS its branch — one per ticket is
-                                    the whole point — so the branch is the name
-                                    worth the wide column, and the directory is
-                                    only a terse stub of it. A project is the
-                                    other way round: the folder is the identity
-                                    and the branch is just what happens to be
-                                    checked out. Same rule Source control uses,
-                                    so the two pickers read alike.
-
-                                    `truncate` matters: without it a long
-                                    worktree name wrapped to seven lines and
-                                    collided with the branch beside it. */}
-                                <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={r.worktreeOf ? `${r.branch}\n${r.root}` : r.root}>
-                                  {r.worktreeOf ? r.branch : r.name}
-                                  {live && <span title="Live shell" style={{ color: "var(--success, #98c379)" }}> ●</span>}
-                                </span>
-                                {!r.worktreeOf && <span className="shrink-0 truncate t-dim2 text-[9.5px]" style={{ maxWidth: 150 }} title={r.branch}>{r.branch}</span>}
-                                {r.dirty > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.dirty} changed file${r.dirty === 1 ? "" : "s"}`}>●{r.dirty}</span>}
-                                {r.behind > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }} title={`${r.behind} behind upstream`}>↓{r.behind}</span>}
-                                {r.ahead > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--success)" }} title={`${r.ahead} ahead of upstream`}>↑{r.ahead}</span>}
-                              </button>
-                            );
-                          })}
-                          {/* Local branches with no checkout of their own —
-                              switch by checking out in the current directory,
-                              same as Source control's picker. */}
-                          {(() => {
-                            const q = repoQuery.trim().toLowerCase();
-                            const checkedOut = new Set(repos.map((r) => r.branch));
-                            const branches = branchData.branches.filter((b) => !checkedOut.has(b.name) && (!q || b.name.toLowerCase().includes(q)));
-                            if (!branches.length) return null;
-                            return (
-                              <>
-                                <div className="px-2.5 pt-2 pb-1 text-[10px] uppercase tracking-wider t-dim2" style={{ borderTop: "1px solid color-mix(in srgb, var(--border) 25%, transparent)" }}>Branches — check out in {here?.name ?? "this folder"}</div>
-                                {branches.slice(0, 80).map((b) => (
-                                  <button key={b.name} onClick={() => checkoutBranch(b.name)} className="w-full text-left px-2.5 py-1.5 flex items-center gap-2">
-                                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" title="local branch — checked out in the current directory" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>BR</span>
-                                    <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={b.name}>{b.name}</span>
-                                  </button>
-                                ))}
-                              </>
-                            );
-                          })()}
-                          {!repos.length && <div className="px-3 py-2 t-dim2">No repos seen yet</div>}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-
-                  </div>
+                  {/*
+                    * Where this pane is, not where to go.
+                    *
+                    * There was a repo picker here, and it could not do what it
+                    * looked like it did: the server reads a shell's directory
+                    * once, when the PTY opens (`terminal.ts`), so picking a
+                    * worktree never moved the shell in front of you — it hid
+                    * your shells and started a new one somewhere else. Moving a
+                    * live shell for real means typing `cd` into it, over
+                    * whatever you were typing, in whichever of several panes,
+                    * possibly under a running build. tmux already answers that
+                    * question, and answers it better.
+                    *
+                    * So the slot states a fact instead of offering a choice.
+                    * Which matters twice over: with no picker, nothing else on
+                    * this bar said which checkout you were in, and "I thought I
+                    * was in the worktree" is the same surprise the picker used
+                    * to cause, just mirrored.
+                    *
+                    * The answer comes from the server (see panewt.ts) rather
+                    * than from this end guessing off the pane's own directory —
+                    * that is the parent repo for every agent in a fleet, which
+                    * is what made it look unanswerable.
+                    */}
+                  {(() => {
+                    const at = detectedWt ?? here ?? null;
+                    if (!at) return null;
+                    const label = at.worktreeOf ? at.branch : at.name;
+                    return (
+                      <button
+                        onMouseDown={keepTermFocus}
+                        onClick={() => requestWorktreeJump({ view: "git", root: at.root })}
+                        title={`${at.root}\nOpen its Source control`}
+                        className="flex items-center gap-1.5 text-[11px] px-2.5 py-1 rounded-lg min-w-0 shrink"
+                        style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
+                      >
+                        <span
+                          className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                          title={at.worktreeOf ? `worktree of ${at.worktreeOf}` : "main checkout"}
+                          style={at.worktreeOf
+                            ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
+                            : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}
+                        >{at.worktreeOf ? "WT" : "REPO"}</span>
+                        <span className="font-medium truncate min-w-0">{label}</span>
+                        {at.dirty > 0 && <span className="shrink-0 text-[10px] tabular-nums" style={{ color: "var(--warning)" }} title={`${at.dirty} changed file${at.dirty === 1 ? "" : "s"}`}>●{at.dirty}</span>}
+                        <span className="t-dim2 shrink-0 text-[10px]">↗</span>
+                      </button>
+                    );
+                  })()}
 
                   {/* Commands and pins — the same control the docked console
                       mounts, so the two shells offer the same thing. Its own

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -15,7 +15,7 @@ import { checkoutConfirm, needsCheckoutConfirm } from "../lib/checkoutWarning.ts
 import { keepTermFocus } from "../lib/keepFocus.ts";
 import { focusFollowsMouse, subscribeFocusFollowsMouse, shouldFocusOnHover } from "../lib/termFocusPref.ts";
 import { cellAt, paneAt } from "../lib/tmuxHover.ts";
-import { viewHeaderClass, viewHeaderStyle, viewTitleClass } from "./workspace/ViewHeader.tsx";
+import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import { WebglAddon } from "@xterm/addon-webgl";
@@ -1864,7 +1864,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
 
                 {/* header: repo picker + command launcher + actions */}
                 <div className={viewHeaderClass} style={viewHeaderStyle}>
-                  <span className={viewTitleClass} style={{ color: "var(--text)" }}>Terminal</span>
+                  <h2 className="sr-only">Terminal</h2>
                   {/* keepTermFocus on the picker group so pressing the trigger
                       or a repo row never blurs the shell; the filter input is
                       excluded by the handler and still takes focus, and every

--- a/web/src/components/browser/MarkupLayer.tsx
+++ b/web/src/components/browser/MarkupLayer.tsx
@@ -12,6 +12,7 @@ import { requestTermIssue } from "../../lib/termIssue.ts";
 import { feedbackWindowName } from "../../lib/pageRef.ts";
 import { api } from "../../lib/api.ts";
 import type { GitRepoRef } from "../../../../shared/types.ts";
+import { CheckoutPicker } from "../CheckoutPicker.tsx";
 
 type Guest = { capturePage(): Promise<{ toDataURL(): string }> } | null;
 
@@ -241,11 +242,8 @@ export function MarkupLayer({ view, url, onNote, onDone }: {
             Draw on the page, then
           </span>
           {repos.length > 1 && (
-            <select value={repo} onChange={(e) => setRepo(e.target.value)}
-              className="text-[10px] px-1.5 py-0.5 rounded-lg outline-none"
-              style={{ background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}>
-              {repos.map((r) => <option key={r.root} value={r.root}>{r.worktreeOf ? r.branch : r.name}</option>)}
-            </select>
+            <CheckoutPicker repos={repos} value={repo} onPick={setRepo}
+              title="Which checkout the agent works in" triggerMaxWidth={180} />
           )}
           <button onClick={() => void hand()} disabled={busy || !state.shapes.length}
             className="agx-btn text-[11px] px-2.5 py-1 rounded-lg disabled:opacity-40"

--- a/web/src/components/browser/PagePicker.tsx
+++ b/web/src/components/browser/PagePicker.tsx
@@ -16,6 +16,7 @@ import { requestTermIssue } from "../../lib/termIssue.ts";
 import { seedChat } from "../../lib/chatStore.ts";
 import { api } from "../../lib/api.ts";
 import type { GitRepoRef } from "../../../../shared/types.ts";
+import { CheckoutPicker } from "../CheckoutPicker.tsx";
 
 type Guest = {
   executeJavaScript(code: string): Promise<unknown>;
@@ -209,12 +210,8 @@ export function PagePicker({ view, url, title, feedback, onNote, onDone }: {
         </div>
 
         {repos.length > 1 && (
-          <select value={repo} onChange={(e) => setRepo(e.target.value)}
-            className="text-[10.5px] px-2 py-1 rounded-lg outline-none"
-            style={{ background: "var(--bg)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text2)" }}
-            title="Which checkout the agent works in">
-            {repos.map((r) => <option key={r.root} value={r.root}>{r.worktreeOf ? r.branch : r.name}</option>)}
-          </select>
+          <CheckoutPicker repos={repos} value={repo} onPick={setRepo}
+            title="Which checkout the agent works in" triggerMaxWidth={200} />
         )}
 
         {/* Terminal first, chat as the lesser option — the same order and the

--- a/web/src/components/workspace/ViewHeader.tsx
+++ b/web/src/components/workspace/ViewHeader.tsx
@@ -17,6 +17,14 @@ import type { CSSProperties, ReactNode } from "react";
  *
  * No overflow-hidden, ever. Header controls open dropdowns positioned inside
  * this row, and clipping the row clipped the menus to a sliver.
+ *
+ * And the name of the view is NOT drawn here. "Terminal" over a terminal,
+ * "Docker" over a wall of containers: the word repeated what the panel below it
+ * already was, while the lit icon in the rail had been saying the same thing a
+ * third time. Three statements of one fact, and the widest of the three sat
+ * where the controls wanted to be — so every header started indented by a
+ * different amount depending on how long its own name happened to be. The name
+ * survives for screen readers, which cannot see the rail (see `label`).
  */
 export const VIEW_HEADER_H = 48;
 
@@ -29,20 +37,22 @@ export const viewHeaderStyle: CSSProperties = {
   borderColor: "color-mix(in srgb, var(--border) 40%, transparent)",
 };
 
-/** Same size, same weight, same nowrap, in all five. A wrapped title is what
- *  made the bars different heights in the first place. */
-export const viewTitleClass = "text-[15px] font-semibold whitespace-nowrap shrink-0";
-
 export function ViewHeader({
-  title,
-  count,
+  label,
   children,
   actions,
 }: {
-  title: string;
-  /** The one number that says how much is in here — chats, containers. Beside
-   *  the title because that is where every view already put it. */
-  count?: number;
+  /**
+   * The view's name, for assistive tech only — never painted.
+   *
+   * Sighted users have the rail: the lit icon says which view this is, and the
+   * content says it again. A screen reader has neither, so the heading stays in
+   * the document and only the pixels go. It is an `h2` rather than an
+   * `aria-label` on the row because a bare `div` with a label and no role is
+   * skipped by most readers, and a heading also puts the view back in the
+   * document outline that the rail navigates.
+   */
+  label: string;
   /** Controls that scope the view: a repo picker, an engine chip. */
   children?: ReactNode;
   /** Actions, pinned right. */
@@ -50,8 +60,7 @@ export function ViewHeader({
 }) {
   return (
     <div className={viewHeaderClass} style={viewHeaderStyle}>
-      <span className={viewTitleClass} style={{ color: "var(--text)" }}>{title}</span>
-      {count != null && <span className="text-[10px] t-dim2 tabular-nums shrink-0">{count}</span>}
+      <h2 className="sr-only">{label}</h2>
       {children}
       {actions && <div className="ml-auto flex items-center gap-2 shrink-0">{actions}</div>}
     </div>

--- a/web/test/budgets-pane.test.ts
+++ b/web/test/budgets-pane.test.ts
@@ -41,8 +41,14 @@ describe("setting one", () => {
   test("a project or model that is no longer offered is still shown", () => {
     // A repo that has moved, or a model that has not been used this month, must
     // not silently reassign somebody's budget to "everything" on next render.
-    expect(pane).toContain("!roots.includes(b.root)");
+    //
+    // The model half is still this pane's own `<select>`. The project half is
+    // the shared checkout picker now, and it owns the same guarantee — its
+    // `unlisted` branch keeps a stored root on screen, marked, when the list it
+    // is choosing from no longer offers it. Asserted there rather than here, so
+    // every panel that stores a root gets it: see checkout-picker.test.ts.
     expect(pane).toContain("!models.includes(b.model)");
+    expect(pane).toContain("<CheckoutPicker");
   });
 });
 

--- a/web/test/checkout-picker.test.ts
+++ b/web/test/checkout-picker.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from "bun:test";
+
+/*
+ * One picker, and nobody keeps a private copy.
+ *
+ * There were seven of these — Source control, Files, Tasks, Chat, the terminal
+ * view, the docked console, plus a row of bare `<select>`s in Machine, Recipes,
+ * Budgets and the browser — written at seven different times. They had drifted
+ * into two chevron glyphs, five widths, three placeholders, and one with no
+ * filter at all. Nothing learned in one of them transferred to the next.
+ *
+ * That is not a state a codebase arrives at on purpose; it is what happens when
+ * the cheapest way to add a picker is to write one. So this makes the cheap way
+ * the shared one: the local state each copy used to declare (`repoOpen`,
+ * `repoQuery`) is the shape a new copy would bring back, and it fails here.
+ *
+ * The source is read as text on purpose. What is asserted is that files do not
+ * contain a shape, and rendering ten panels — each wanting a store, a socket
+ * and a git repository — to find that out would cost far more than it says.
+ */
+const dir = new URL("../src/components/", import.meta.url);
+const read = (f: string) => Bun.file(new URL(f, dir)).text();
+
+const PICKER = "CheckoutPicker.tsx";
+
+/** Everything that draws a checkout chooser, and must do it through the one. */
+const USERS = [
+  "GitPanel.tsx", "FilesPanel.tsx", "ChatPanel.tsx", "TerminalPanel.tsx",
+  "MachinePanel.tsx", "RecipesPane.tsx", "BudgetsPane.tsx",
+  "browser/PagePicker.tsx", "browser/MarkupLayer.tsx",
+];
+
+const picker = await read(PICKER);
+const users = Object.fromEntries(await Promise.all(USERS.map(async (f) => [f, await read(f)] as const)));
+
+describe("the shared checkout picker", () => {
+  it("is the only place a checkout menu is written", () => {
+    for (const [file, src] of Object.entries(users)) {
+      expect(src.includes("CheckoutPicker"), `${file} chooses a checkout without the shared control`).toBe(true);
+      for (const shape of ["repoOpen", "repoQuery"]) {
+        expect(src.includes(shape), `${file} declares its own \`${shape}\` — that is a second picker growing`).toBe(false);
+      }
+    }
+  });
+
+  it("keeps a stored value on screen when the list no longer offers it", () => {
+    // A budget is attached to a root and a chat remembers where it runs. A
+    // checkout can move, be deleted, or fall out of the open project's scope,
+    // and falling back to the placeholder would read as "everything" or "pick
+    // one" while the setting underneath still says something else.
+    expect(picker).toContain("const unlisted = value && !here ? value : \"\";");
+    expect(picker).toContain("not in this list");
+  });
+
+  it("never decides the value for the panel", () => {
+    // Chat's checkout is where that conversation runs, the docked console's is
+    // where you build, Source control's is what you are reading. One control
+    // that quietly moved all three would be worse than the seven it replaced,
+    // so it holds no root of its own and writes to no storage key.
+    expect(/useState[^\n]*\broot\b/.test(picker), "the picker is holding a checkout of its own").toBe(false);
+    expect(picker.includes("localStorage"), "the picker is persisting somebody else's choice").toBe(false);
+  });
+
+  it("keeps looking and writing apart", () => {
+    // Repo rows change what you are looking at; branch rows run `git checkout`
+    // over the directory you are standing in. Only Source control passes the
+    // second kind, and they are the only rows in the menu that touch the disk —
+    // so they live under their own heading rather than mixed into the list.
+    expect(picker).toContain("Branches — checkout here");
+    const withBranches = Object.entries(users).filter(([, s]) => /branches=\{\{/.test(s)).map(([f]) => f);
+    expect(withBranches.sort()).toEqual(["GitPanel.tsx", "TerminalPanel.tsx"]);
+  });
+});
+
+describe("the terminal", () => {
+  const term = users["TerminalPanel.tsx"]!;
+
+  it("does not offer to move a shell it cannot move", () => {
+    // The server reads a shell's directory once, when the PTY opens, so the old
+    // picker never moved the shell in front of you — it hid your shells and
+    // started a new one elsewhere. The view header states where the pane is
+    // instead, and the one picker left is the docked console's, which is a
+    // different shell and a different question.
+    expect(term.match(/<CheckoutPicker/g)?.length ?? 0).toBe(1);
+    expect(term).toContain("requestWorktreeJump({ view: \"git\", root: at.root })");
+  });
+
+  it("still writes the key the docked console falls back to", () => {
+    // Nobody picks this root any more, but `consoleRoot()` reads it when the
+    // console has no pick of its own. Without a writer, `docker exec` and every
+    // recipe would stop working on a fresh profile — silently, because
+    // `runInConsole` only returns false.
+    expect(term).toContain("localStorage.setItem(ROOT_KEY, root)");
+  });
+});

--- a/web/test/view-header-titles.test.ts
+++ b/web/test/view-header-titles.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from "bun:test";
+
+/*
+ * No view paints its own name, and no view loses it either.
+ *
+ * The nine headers used to open with the word for the panel below them —
+ * "Terminal" over a terminal, "Docker" over a wall of containers — while the lit
+ * icon in the rail had already said the same thing. Three statements of one
+ * fact, and the widest of them sat where the controls wanted to be, so every
+ * header started indented by a different amount depending on the length of its
+ * own name.
+ *
+ * Deleting a heading is the easy half. The half that rots is the other one: the
+ * name is what a screen reader has instead of the rail, so it stays in the
+ * document as an `sr-only` heading. That is invisible by definition, which means
+ * nothing on screen would ever show it going missing — a header written next
+ * year would simply not have one, and nobody would notice for a year more. So it
+ * is asserted here rather than trusted.
+ *
+ * The source is read as text on purpose. What is being checked is that a file
+ * does not contain a shape, and rendering nine panels — each wanting a store, a
+ * socket and a git repository — to learn that would cost far more than it says.
+ */
+
+/** Every file that draws one of the workspace's top bars. */
+const VIEWS: Record<string, string> = {
+  "Terminal": "TerminalPanel.tsx",
+  "Source control": "GitPanel.tsx",
+  "Pull Requests": "PrPanel.tsx",
+  "Docker": "DockerPanel.tsx",
+  "Browser": "BrowserPanel.tsx",
+  "File changes": "ChangesModal.tsx",
+};
+
+/** The three that render the shared component instead of the raw markup; their
+ *  heading is `ViewHeader`'s, so what is checked here is the prop that feeds it. */
+const VIA_COMPONENT: Record<string, string> = {
+  "Tasks": "TasksPanel.tsx",
+  "Files": "FilesPanel.tsx",
+  "Chats": "ChatPanel.tsx",
+};
+
+const read = (f: string) => Bun.file(new URL(`../src/components/${f}`, import.meta.url)).text();
+const srcs = Object.fromEntries(await Promise.all(
+  [...Object.values(VIEWS), ...Object.values(VIA_COMPONENT), "workspace/ViewHeader.tsx"]
+    .map(async (f) => [f, await read(f)] as const),
+));
+
+describe("view headers", () => {
+  it("keeps the name in the document for screen readers", () => {
+    for (const [name, file] of Object.entries(VIEWS)) {
+      expect(
+        srcs[file]!.includes(`<h2 className="sr-only">${name}</h2>`),
+        `${file} draws a top bar with no accessible name — a screen reader has no rail to read instead`,
+      ).toBe(true);
+    }
+    for (const [name, file] of Object.entries(VIA_COMPONENT)) {
+      expect(
+        new RegExp(`<ViewHeader[^>]*\\blabel="${name}"`).test(srcs[file]!),
+        `${file} renders ViewHeader without a label, so its view has no accessible name`,
+      ).toBe(true);
+    }
+  });
+
+  it("paints no visible title", () => {
+    // The class that used to size them. Gone from the module, so any file still
+    // naming it would not compile — but it is the exact shape a copy-paste from
+    // an old header brings back, and the message here is cheaper than the type
+    // error to understand.
+    for (const [file, src] of Object.entries(srcs)) {
+      expect(src.includes("viewTitleClass"), `${file} is drawing a view title again`).toBe(false);
+    }
+  });
+
+  it("does not offer a title prop to fall back into", () => {
+    const header = srcs["workspace/ViewHeader.tsx"]!;
+    expect(/\btitle[?]?:\s*string/.test(header), "ViewHeader took its title prop back").toBe(false);
+    // `count` went with it: on its own, with no word in front, it was a bare
+    // numeral at the far left of an otherwise empty bar.
+    expect(/\bcount[?]?:\s*number/.test(header), "ViewHeader took its count prop back").toBe(false);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

**Nine panels asked the same question — "which checkout?" — and answered it seven different ways.** Source control, Files, Tasks, Chat, the terminal view, the docked console, plus bare `<select>`s in Machine, Recipes, Budgets and two in the browser. Written at different times, they had drifted into two chevron glyphs (`▾` and `▼`, split roughly half and half), five menu widths (300, 320, 340, 460, 520), three placeholders, and one — Tasks — with no filter at all, which is unusable the moment a project has a dozen worktrees. Nothing learned in one of them transferred to the next.

They are one control now: `web/src/components/CheckoutPicker.tsx`, which is Source control's, comments and all, since it was the most finished of the seven. What each panel still decides is **which list it shows and what it does with the answer**. The control owns only how it looks, how it filters and how it takes the keyboard, and it holds no root and writes to no storage key — the chat's checkout is where that conversation runs, the docked console's is where you build, Source control's is what you are reading, and one control that quietly moved all three would be worse than the seven it replaced.

**Two are deleted rather than converted, because they could not do what they looked like they did.**

*The terminal's.* The server reads a shell's directory once, when the PTY opens (`server/src/terminal.ts:444`), and sessions are keyed by socket rather than by repo — so picking a worktree never moved the shell in front of you. It filtered which pool of shells was on screen (`TerminalPanel.tsx:1372-1379`: keep the panes whose root matches, otherwise start a new one), which is a workspace switcher dressed as a branch selector. Moving a live shell for real means typing `cd` into it, over whatever you were typing, in whichever of several panes, possibly under a running build; tmux already answers that question and answers it better. The slot now states which checkout the focused pane is in — from `panewt.ts`, which the server can answer, rather than this end guessing off the pane's own directory — and opens its Source control. That also closes the mirror image of the same surprise: with no picker, nothing else on that bar said where you were.

*Tasks'.* It never changed which issues you saw. They come from the GitHub remote (`server/src/issues.ts:173`) and every worktree of a project shares that one remote, so the control offered a dozen ways to look at the same list. What it did move was the directory `gh` ran in and where `issueStart` would cut a worktree — and for both, the answer that is always right is the project itself, which is what `repos[0]` already is: `/git/repos` leads with the project and orders worktrees after it by `touchedAt` (`server/src/gitwork.ts:515-546`).

**Three things had to move with them, and each was a silent failure waiting.**

| | Why it could not be left | |
|---|---|---|
| The terminal still writes `agentglass.terminalRoot` | `consoleRoot()` falls back to that key when the docked console has no pick of its own. With no writer, `docker exec` and every recipe stop working on a fresh profile — with no error and no toast, because `runInConsole` only returns `false`, and the same `false` already means "you are in tmux". | `TerminalPanel.tsx:64` |
| Settings reads it through `lastTerminalRoot()` | It held a literal copy of another component's storage schema, and would have gone on reading a key that had quietly stopped being written. | `SettingsModal.tsx:2143` |
| Eviction spares what is **on screen**, not what shares a root | The old clause worked only while shells came in per-repo pools. With one root it spared every session there is, and the 60-shell ceiling stopped applying. Panes are what it meant all along. | `TerminalPanel.tsx:262` |

**A stored value the list no longer offers stays on screen, marked.** A budget is attached to a root and a chat remembers where it runs; a checkout can move, be deleted, or fall out of the open project's scope. Falling back to the placeholder read as "everything" while the setting underneath said something else — caught by `web/test/budgets-pane.test.ts`, which is why that guarantee now lives in the shared control instead of in one panel's `<select>`.

**And the view titles are gone.** Nine headers opened with the word for the panel below them — "Terminal" over a terminal, "Docker" over a wall of containers — while the lit icon in the rail had already said it. Three statements of one fact, and the widest of the three sat where the controls wanted to be, so every header started indented by a different amount depending on how long its own name happened to be. The name stays in the document as an `sr-only` heading, because a screen reader has no rail to read instead; it is a heading rather than an `aria-label` on the row, since a bare `div` with a label and no role is skipped by most readers. Chat's count went with the word it belonged to — on its own it was a bare numeral at the far left of an otherwise empty bar, and the sidebar beside it already lists the chats it was counting.

Two locks come with it, both parsing the source as text, because what is asserted is that files do not contain a shape — and rendering ten panels, each wanting a store, a socket and a git repository, would cost far more than it says:

- `web/test/checkout-picker.test.ts` fails if a panel declares its own `repoOpen`/`repoQuery`, if any of the nine stops going through the shared control, if the control starts holding a root or touching `localStorage`, if the `git checkout` rows are passed by anything other than Source control and the docked console, or if the terminal stops writing the key the console falls back to.
- `web/test/view-header-titles.test.ts` fails if a header paints a title again **or loses its accessible name** — the second half is the one that rots, since an `sr-only` heading is invisible by definition and nothing on screen would ever show it going missing from a header written next year.

## How was it tested?

`bunx tsc --noEmit -p web/tsconfig.json` clean, and `bun test web/test` at **1913 pass / 0 fail** across 162 files.

The two new locks were checked by breaking them, not by watching them pass: replacing one `<h2 className="sr-only">Source control</h2>` with a plain `<span>` turns `view-header-titles` red with the message it was written to give ("draws a top bar with no accessible name"), and the file was restored afterwards. A lock that has never failed is not known to be a lock.

The budgets regression was found the same way, in the opposite direction: `budgets-pane.test.ts` went red on the first full run after Budgets moved to the shared control, which is the test doing its job — a budget attached to a checkout that has since moved was reading as "everything". The fix went into `CheckoutPicker` rather than into Budgets, so every panel that stores a root gets it, and the assertion moved with it.

Then built and installed with `make desktop-install` and exercised in the running desktop app, since none of the above says how ten header bars look. The installer verifies the artefact rather than its own stdout: package stamped `6f6bce6`, `dirty: false`, and the installed renderer confirmed to be the bundle just built rather than an older one still sitting in `~/.local`.

What was exercised by hand, and why each: the terminal (no picker; the chip names the focused pane's worktree and opens its Source control; `↗ Worktree ▾` untouched), Source control and Files (same menu, and Files gains the `●dirty ↓behind ↑ahead` counters it never had), Tasks (same issues as before, one control fewer), Chat (its cwd picker now carries the badge and branch), and — the one that matters most, because its failure mode is mute — the **docked console under Docker**: pick a checkout, open a container shell, run a recipe. That is the path that breaks without the `agentglass.terminalRoot` write, and it breaks without saying anything.
