### PR TITLE
fix: the drag inside a terminal no longer dies halfway

### DIFF
--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -38,6 +38,8 @@ import { THEMES } from "../lib/themes.ts";
 import { deriveAnsi } from "../lib/termPalette.ts";
 import { termOptions, copyOnSelect, rightClickPaste } from "../lib/termPrefs.ts";
 import { useModernWidths } from "../lib/termUnicode.ts";
+import { dragHold } from "../lib/dragHold.ts";
+import { mouseModeGuard, type MouseModeGuard } from "../lib/mouseModeGuard.ts";
 import { CloseButton } from "./CloseButton.tsx";
 
 const ROOT_KEY = "agentglass.terminalRoot";
@@ -210,6 +212,68 @@ const sessionsFor = (root: string) => [...sessions.values()].filter((s) => s.roo
  *  you open the terminal. The console strip keeps using sessionsFor to find it. */
 const termSessionsFor = (root: string) => sessionsFor(root).filter((s) => s.title !== CONSOLE_TITLE);
 const notify = (s: Sess) => { s.subs.forEach((fn) => fn()); rosterChanged(); };
+
+/**
+ * Fits owed to terminals the user is currently dragging inside.
+ *
+ * Reported as two bugs and it is one: a selection dragged up a pane stops on
+ * its own halfway through the paragraph, and a tmux divider dragged sideways
+ * stops halfway and needs grabbing again. Both gestures live entirely inside
+ * tmux — with mouse mode on, xterm reports the pointer to the shell and tmux is
+ * what selects and what resizes — and both end the instant tmux's client
+ * changes size. `fitTerm` is that resize: it calls `term.resize()`, whose
+ * `onResize` sends the new grid to the server, which SIGWINCHes the shell.
+ *
+ * Measured against a real tmux over a real pty, with the drag sent as the exact
+ * SGR reports xterm produces: a 30-column divider drag moves 30 columns
+ * untouched and 13 with one resize dropped in at column 15; a 25-row selection
+ * holds all 25 rows untouched and 11 with one resize dropped in at row 12. In
+ * both the drag dies exactly where the resize landed.
+ *
+ * The refit is not wrong, only badly timed — so it waits for the button rather
+ * than being dropped. What arms this is a mousedown on a terminal's own holder,
+ * so the panel's own drags (the console strip's top edge) still refit live as
+ * they always have: those resize the slot on purpose and nothing is mid-gesture
+ * inside the shell.
+ */
+const fitHold = dragHold<Sess>((s) => fitTerm(s));
+
+/**
+ * The second way a drag dies, which is not the panel's doing but is the panel's
+ * to survive: xterm unbinds the `document` listener that reports the drag as
+ * soon as the shell turns mouse tracking off, and putting the mode back does
+ * not put the listener back. See mouseModeGuard for the measurement. One guard
+ * per session, because the byte stream it filters is per terminal.
+ */
+const modeGuards = new Map<Sess, MouseModeGuard>();
+const guardFor = (s: Sess) => {
+  let g = modeGuards.get(s);
+  if (!g) { g = mouseModeGuard(); modeGuards.set(s, g); }
+  return g;
+};
+
+/** Released on the window rather than the element: a drag ends wherever the
+ *  pointer happens to be by then, which is regularly outside the terminal it
+ *  started in. `blur` too, because a window that loses focus mid-drag (an
+ *  alt-tab, a dialog from another app) never sees the mouseup at all, and a
+ *  latch left set would hold every fit for the rest of the session. */
+function releaseTermDrag() {
+  window.removeEventListener("mouseup", releaseTermDrag);
+  window.removeEventListener("blur", releaseTermDrag);
+  fitHold.end();
+  // Hand the terminals back whatever was withheld from them, now that there is
+  // no gesture left for it to interrupt.
+  for (const [s, guard] of modeGuards) {
+    const held = guard.flush();
+    if (held.length) try { s.term.write(held); } catch { /* disposed mid-drag */ }
+  }
+}
+function armTermDrag() {
+  if (fitHold.active()) return;
+  fitHold.begin();
+  window.addEventListener("mouseup", releaseTermDrag);
+  window.addEventListener("blur", releaseTermDrag);
+}
 
 // --- roster: "is any shell alive?", for the workspace rail ---------------------
 // Per-session `subs` answer "did *this* shell change"; nothing could answer
@@ -386,7 +450,13 @@ function connect(s: Sess) {
   s.ws = ws;
   ws.onmessage = (ev) => {
     if (s.ws !== ws) return; // a stale socket (replaced by ⟲ new shell) must not touch the session
-    if (typeof ev.data !== "string") { s.term.write(new Uint8Array(ev.data as ArrayBuffer)); return; }
+    if (typeof ev.data !== "string") {
+      const bytes = new Uint8Array(ev.data as ArrayBuffer);
+      // Only while the user is dragging inside a terminal — see mouseModeGuard.
+      // Every other chunk of every other second goes through untouched.
+      s.term.write(fitHold.active() ? guardFor(s).filter(bytes) : bytes);
+      return;
+    }
     /*
      * The protocol, from the one declaration of it.
      *
@@ -609,6 +679,11 @@ function createSession(root: string): Sess {
     if (sel) navigator.clipboard?.writeText(sel).catch(() => { /* no clipboard permission */ });
   });
   const holder = document.createElement("div");
+  // Every gesture that can be interrupted by a refit starts here — see fitHold.
+  // On the holder rather than on xterm's own element because xterm calls
+  // `preventDefault` on its mousedown, and because the holder is what outlives
+  // a renderer swap.
+  holder.addEventListener("mousedown", armTermDrag);
   // Opaque themed backing, so any frame where the renderer paints nothing (a
   // WebGL context loss, a swap to the DOM renderer) shows the terminal's own
   // background colour instead of a white flash.
@@ -696,6 +771,10 @@ type TermCore = {
  * overlay (see the style block below) and takes no layout width.
  */
 function fitTerm(s: Sess) {
+  // Not while the user is dragging inside this terminal — see fitHold. The fit
+  // is owed, not cancelled: it runs on the release, when there is no gesture
+  // left for the SIGWINCH to interrupt.
+  if (fitHold.hold(s)) return;
   const el = s.term.element;
   const parent = el?.parentElement;
   const core = (s.term as unknown as TermCore)._core;
@@ -722,6 +801,7 @@ function killSession(s: Sess) {
   s.ws = null; // detach first so the close handler stays quiet
   try { ws?.close(); } catch { /* already gone */ }
   stopDemoFor(s.id);
+  modeGuards.delete(s);
   try { s.term.dispose(); } catch { /* already disposed */ }
   s.holder.remove();
   sessions.delete(s.id);

--- a/web/src/lib/dragHold.ts
+++ b/web/src/lib/dragHold.ts
@@ -1,0 +1,55 @@
+/**
+ * Work that must not land while the user is dragging.
+ *
+ * The case this exists for is refitting a terminal. A refit is `term.resize()`,
+ * which reaches the shell as a SIGWINCH, and tmux drops whatever drag it was in
+ * the middle of when its client changes size — measured against a real tmux over
+ * a real pty: a selection dragged up 25 rows keeps 11 of them if a resize lands
+ * at row 12, and a divider dragged 30 columns moves 13. Neither the button nor
+ * the pointer did anything; the gesture simply stops, and the only way on is to
+ * let go and grab again.
+ *
+ * So the work waits for the button instead of being cancelled: `hold` answers
+ * "not now" and remembers what was asked for, `end` runs it. Deliberately a Set
+ * rather than a queue — fifty fits asked for during one drag are one fit owed at
+ * the end of it, and replaying all fifty would be fifty reflows of the
+ * scrollback for a size that only ever had one answer.
+ */
+export type DragHold<T> = {
+  /** The pointer went down on something whose work should wait. */
+  begin(): void;
+  /** It came back up (or the window lost it). Runs what was held, once each. */
+  end(): void;
+  /** True when the caller should do nothing — the item is remembered for `end`. */
+  hold(item: T): boolean;
+  /** Whether a drag is in flight, for callers that only need to ask. */
+  active(): boolean;
+};
+
+export function dragHold<T>(replay: (item: T) => void): DragHold<T> {
+  let dragging = false;
+  const held = new Set<T>();
+  return {
+    begin() { dragging = true; },
+    end() {
+      // Guarded, because the release listener is armed on the window and a
+      // mouseup can arrive with no drag of ours behind it.
+      if (!dragging) return;
+      dragging = false;
+      const waiting = [...held];
+      held.clear();
+      // One item throwing must not swallow the rest: these are independent
+      // terminals, and the one that went away while the button was down is
+      // exactly the case where the others still need their fit.
+      for (const item of waiting) {
+        try { replay(item); } catch { /* whatever owned it is gone */ }
+      }
+    },
+    hold(item: T) {
+      if (!dragging) return false;
+      held.add(item);
+      return true;
+    },
+    active() { return dragging; },
+  };
+}

--- a/web/src/lib/mouseModeGuard.ts
+++ b/web/src/lib/mouseModeGuard.ts
@@ -1,0 +1,123 @@
+/**
+ * Keep the mouse mode from being switched off underneath a drag.
+ *
+ * xterm reports a drag from a `mousemove` listener it puts on `document` when
+ * the button goes down, and it takes that listener off again the moment the
+ * shell turns mouse tracking off. Turning it back on does not put the listener
+ * back — xterm only reassigns its handler, and the `addEventListener` lives in
+ * the mousedown path — so a mode that goes off and on again mid-gesture leaves
+ * a terminal that is in mouse mode, has the button held, and reports nothing
+ * until you let go and grab again.
+ *
+ * That is not a hypothesis. Measured in the running app over CDP, counting the
+ * mousemove listeners on `document` while the drag was a human's: while reports
+ * were coming out the count was 1, and from the last report to the end of the
+ * gesture it was 0 — 34 more pointer moves in one case, 32 in another, with the
+ * button never released. tmux re-synchronises its own mouse mode against the
+ * focused pane's, so an agent's TUI redrawing is enough to produce the off/on.
+ *
+ * So while a drag is in flight the tracking modes are frozen: every change to
+ * them is withheld, xterm's view of the protocol never moves, it never unbinds,
+ * and the gesture runs to the end. What was withheld is written to the terminal
+ * when the button comes up, in order, so a shell that really did change the
+ * mode gets its change a gesture later rather than never.
+ *
+ * Withholding only the resets was tried first and was not enough: the set
+ * arrives as ?1000l ?1002l ?1003l then ?1000h ?1002h ?1003h, and ?1000h alone
+ * is click-only tracking — no drag bit — so xterm unbinds on the way back up,
+ * before the ?1002h that would have restored it. Measured in the app with the
+ * partial fix installed: 42 pointer moves, 5 reports, 36 of them orphaned.
+ *
+ * Bytes rather than text on purpose. These chunks are whatever a program
+ * printed; decoding them to filter and re-encoding would corrupt a multi-byte
+ * character split across two chunks, and this runs on every chunk of a live
+ * terminal.
+ */
+
+const ESC = 0x1b, BRACKET = 0x5b, QUESTION = 0x3f, SEMI = 0x3b, LOW_L = 0x6c, LOW_H = 0x68;
+const ZERO = 0x30, NINE = 0x39;
+
+/**
+ * The modes worth withholding: the ones that carry mouse *tracking*. 1000 is
+ * click tracking, 1002 click-and-drag, 1003 any movement, 1001 the highlight
+ * variant nobody uses but which xterm still counts.
+ *
+ * Deliberately not the encodings (1006 SGR, 1005, 1015, 1016). Turning an
+ * encoding off does not unbind anything, and withholding one would leave the
+ * terminal reporting in a format the shell has stopped expecting — a worse bug
+ * than the one being fixed, and a silent one.
+ */
+const TRACKING = new Set([1000, 1001, 1002, 1003]);
+
+export type MouseModeGuard = {
+  /** Filter one chunk on its way to the terminal. Returns what to write. */
+  filter(chunk: Uint8Array): Uint8Array;
+  /** Everything withheld, to write once the drag is over. Empties itself. */
+  flush(): Uint8Array;
+};
+
+export function mouseModeGuard(): MouseModeGuard {
+  // A sequence can be split across two chunks — the shell writes bytes, not
+  // messages. What looks like the start of one is held back rather than passed
+  // through and matched too late.
+  let partial: number[] = [];
+  let withheld: number[] = [];
+
+  /** Does `bytes` starting at `i` spell a private-mode reset we should hold?
+   *  Returns the length of the sequence, 0 for "not one", -1 for "cannot tell
+   *  yet, the chunk ends inside it". */
+  const match = (bytes: number[], i: number): number => {
+    if (bytes[i] !== ESC) return 0;
+    if (i + 1 >= bytes.length) return -1;
+    if (bytes[i + 1] !== BRACKET) return 0;
+    if (i + 2 >= bytes.length) return -1;
+    if (bytes[i + 2] !== QUESTION) return 0;
+    let j = i + 3;
+    const nums: number[] = [];
+    let cur = -1;
+    for (; j < bytes.length; j++) {
+      const b = bytes[j];
+      if (b >= ZERO && b <= NINE) { cur = (cur < 0 ? 0 : cur) * 10 + (b - ZERO); continue; }
+      if (b === SEMI) { nums.push(cur); cur = -1; continue; }
+      break;
+    }
+    if (j >= bytes.length) return -1;          // the digits run off the end
+    // Both `l` and `h`. Withholding only the off was not enough, and the
+    // measurement says why: the set arrives as ?1000l ?1002l ?1003l then
+    // ?1000h ?1002h ?1003h, and the moment ?1000h lands the protocol is
+    // click-only — no drag bit — so xterm unbinds there, before the ?1002h
+    // that would have restored it. Every step of the walk has to be withheld,
+    // not just the ones that spell "off".
+    if (bytes[j] !== LOW_L && bytes[j] !== LOW_H) return 0;
+    nums.push(cur);
+    // A reset can carry several modes at once; hold it only if every one of
+    // them is a tracking mode, so `\e[?25;1002l` (cursor + mouse) still gets
+    // through rather than having its cursor half silently dropped.
+    return nums.length && nums.every((n) => TRACKING.has(n)) ? j - i + 1 : 0;
+  };
+
+  return {
+    filter(chunk: Uint8Array): Uint8Array {
+      const bytes = partial.length ? partial.concat(Array.from(chunk)) : Array.from(chunk);
+      partial = [];
+      const out: number[] = [];
+      for (let i = 0; i < bytes.length; ) {
+        const n = match(bytes, i);
+        if (n === -1) { partial = bytes.slice(i); break; }   // finish it next chunk
+        if (n > 0) { withheld.push(...bytes.slice(i, i + n)); i += n; continue; }
+        out.push(bytes[i]!);
+        i++;
+      }
+      return Uint8Array.from(out);
+    },
+    flush(): Uint8Array {
+      // The held-back resets, plus anything still half-read: the drag is over,
+      // and a partial sequence sat on any longer is a byte the shell wrote and
+      // the terminal never saw.
+      const all = withheld.concat(partial);
+      withheld = [];
+      partial = [];
+      return Uint8Array.from(all);
+    },
+  };
+}

--- a/web/test/drag-hold.test.ts
+++ b/web/test/drag-hold.test.ts
@@ -1,0 +1,103 @@
+/*
+ * The latch that stops a refit landing on top of a drag.
+ *
+ * Reported as two bugs, and measured as one: with tmux's mouse mode on, both a
+ * text selection and a divider drag live inside tmux, and both are dropped the
+ * moment tmux's client changes size. A refit is exactly that change — it calls
+ * `term.resize()`, which reaches the shell as a SIGWINCH. Measured against a
+ * real tmux over a real pty, with the gesture sent as the SGR reports xterm
+ * produces: a 30-column divider drag moves 30 columns untouched and 13 with one
+ * resize dropped in at column 15; a 25-row selection holds all 25 rows
+ * untouched and 11 with one resize dropped in at row 12.
+ *
+ * The properties below are the ones that decide whether the cure is worse than
+ * the disease: the work must not be lost (it is owed, not cancelled), it must
+ * not be replayed once per request (a drag asks for dozens of fits and there is
+ * only ever one answer), and the latch must not be able to stick — a window
+ * that loses focus mid-drag never sees the mouseup, and a latch left set would
+ * hold every fit for the rest of the session.
+ */
+import { describe, expect, it } from "bun:test";
+import { dragHold } from "../src/lib/dragHold.ts";
+
+describe("dragHold", () => {
+  it("runs work straight through when nothing is being dragged", () => {
+    const ran: string[] = [];
+    const h = dragHold<string>((x) => ran.push(x));
+    expect(h.hold("a")).toBe(false);
+    expect(h.active()).toBe(false);
+    expect(ran).toEqual([]);
+  });
+
+  it("holds work while the button is down and owes it to the release", () => {
+    const ran: string[] = [];
+    const h = dragHold<string>((x) => ran.push(x));
+    h.begin();
+    expect(h.hold("a")).toBe(true);
+    expect(ran).toEqual([]);       // nothing lands during the gesture
+    h.end();
+    expect(ran).toEqual(["a"]);    // and nothing is lost by the end of it
+  });
+
+  it("owes one replay per item however many times it was asked for", () => {
+    // The case this is really about: a ResizeObserver firing on every frame of
+    // a drag. Fifty fits asked for is one fit owed — replaying all fifty would
+    // be fifty reflows of the scrollback for a size with a single answer.
+    const ran: string[] = [];
+    const h = dragHold<string>((x) => ran.push(x));
+    h.begin();
+    for (let i = 0; i < 50; i++) h.hold("a");
+    h.hold("b");
+    h.end();
+    expect(ran.sort()).toEqual(["a", "b"]);
+  });
+
+  it("goes back to running work straight through after the release", () => {
+    const ran: string[] = [];
+    const h = dragHold<string>((x) => ran.push(x));
+    h.begin();
+    h.hold("a");
+    h.end();
+    expect(h.active()).toBe(false);
+    expect(h.hold("b")).toBe(false);
+    expect(ran).toEqual(["a"]);
+  });
+
+  it("ignores a release with no drag behind it", () => {
+    // The release is listened for on the window, so it hears mouseups that had
+    // nothing to do with a terminal.
+    const ran: string[] = [];
+    const h = dragHold<string>((x) => ran.push(x));
+    h.end();
+    h.end();
+    expect(ran).toEqual([]);
+    expect(h.active()).toBe(false);
+  });
+
+  it("keeps replaying the rest when one item throws", () => {
+    // A terminal disposed while the button was down is exactly the case where
+    // the others still need their fit.
+    const ran: string[] = [];
+    const h = dragHold<string>((x) => { if (x === "boom") throw new Error("disposed"); ran.push(x); });
+    h.begin();
+    h.hold("a"); h.hold("boom"); h.hold("b");
+    expect(() => h.end()).not.toThrow();
+    expect(ran.sort()).toEqual(["a", "b"]);
+    expect(h.active()).toBe(false);
+  });
+
+  it("does not re-hold work that arrives during the replay", () => {
+    // The replay calls the very function that asks to be held; if `end` cleared
+    // the flag after running instead of before, a fit would re-hold itself and
+    // never land.
+    const ran: string[] = [];
+    const h: ReturnType<typeof dragHold<string>> = dragHold<string>((x) => {
+      expect(h.hold(x)).toBe(false);
+      ran.push(x);
+    });
+    h.begin();
+    h.hold("a");
+    h.end();
+    expect(ran).toEqual(["a"]);
+  });
+});

--- a/web/test/mouse-mode-guard.test.ts
+++ b/web/test/mouse-mode-guard.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Withholding the mouse-mode reset that kills a drag.
+ *
+ * Measured in the running app before any of this was written: counting the
+ * mousemove listeners on `document` while the drag was a human's, the count was
+ * 1 while reports were coming out and 0 from the last report to the end of the
+ * gesture — 34 further pointer moves in one case, 32 in another, with the button
+ * never released. xterm takes that listener off when mouse tracking is turned
+ * off and does not put it back when it is turned on again.
+ *
+ * The risk in a filter that sits on a live byte stream is not that it fails to
+ * fire; it is that it eats something it should not, and does so silently. So
+ * most of what is pinned here is what must survive untouched: the encodings, a
+ * change that carries a non-mouse mode with it, and a sequence unlucky enough to
+ * be split across two chunks. What is withheld is replayed in the order the
+ * shell wrote it, so the terminal ends the gesture in the mode the shell last
+ * asked for.
+ */
+import { describe, expect, it } from "bun:test";
+import { mouseModeGuard } from "../src/lib/mouseModeGuard.ts";
+
+const enc = (s: string) => new TextEncoder().encode(s);
+const dec = (b: Uint8Array) => new TextDecoder().decode(b);
+const through = (g: ReturnType<typeof mouseModeGuard>, s: string) => dec(g.filter(enc(s)));
+
+describe("mouseModeGuard", () => {
+  it("withholds the reset that unbinds the drag, and passes the rest", () => {
+    const g = mouseModeGuard();
+    expect(through(g, "before\x1b[?1002lafter")).toBe("beforeafter");
+    expect(dec(g.flush())).toBe("\x1b[?1002l");
+  });
+
+  it("freezes the tracking modes in BOTH directions", () => {
+    // Withholding only the off was tried and measured, and it was not enough:
+    // ?1000h on its own is click-only tracking — no drag bit — so xterm unbinds
+    // on that too, before the ?1002h that would have restored it. Encodings
+    // still go straight through.
+    const g = mouseModeGuard();
+    expect(through(g, "\x1b[?1002h\x1b[?1006h")).toBe("\x1b[?1006h");
+    expect(dec(g.flush())).toBe("\x1b[?1002h");
+  });
+
+  it("leaves the encodings alone", () => {
+    // Withholding `?1006l` would leave the terminal reporting in SGR at a shell
+    // that had gone back to expecting the old encoding — a worse bug, and a
+    // silent one.
+    const g = mouseModeGuard();
+    expect(through(g, "\x1b[?1006l\x1b[?1015l\x1b[?1016l")).toBe("\x1b[?1006l\x1b[?1015l\x1b[?1016l");
+  });
+
+  it("holds the whole set an agent's TUI emits, and nothing else", () => {
+    // The exact bytes measured coming out of the app, in order.
+    const g = mouseModeGuard();
+    const blink = "\x1b[?1006l\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1006h\x1b[?1000h\x1b[?1002h\x1b[?1003h";
+    expect(through(g, blink)).toBe("\x1b[?1006l\x1b[?1006h");
+    // Replayed in the order the shell wrote them, so the mode the terminal ends
+    // up in is the one the shell last asked for.
+    expect(dec(g.flush())).toBe("\x1b[?1000l\x1b[?1002l\x1b[?1003l\x1b[?1000h\x1b[?1002h\x1b[?1003h");
+  });
+
+  it("passes a reset that carries a non-mouse mode with it", () => {
+    // `\e[?25;1002l` hides the cursor as well. Dropping half of it would be
+    // dropping something the shell asked for and nobody would connect the two.
+    const g = mouseModeGuard();
+    expect(through(g, "\x1b[?25;1002l")).toBe("\x1b[?25;1002l");
+    expect(through(g, "\x1b[?25l")).toBe("\x1b[?25l");
+  });
+
+  it("holds a multi-mode reset when every mode in it is mouse tracking", () => {
+    const g = mouseModeGuard();
+    expect(through(g, "x\x1b[?1000;1002;1003ly")).toBe("xy");
+    expect(dec(g.flush())).toBe("\x1b[?1000;1002;1003l");
+  });
+
+  it("survives a sequence split across two chunks", () => {
+    // The shell writes bytes, not messages: the split lands wherever the pty
+    // read happened to end.
+    const g = mouseModeGuard();
+    expect(through(g, "aaa\x1b[?10")).toBe("aaa");     // the tail is held back
+    expect(through(g, "02lbbb")).toBe("bbb");
+    expect(dec(g.flush())).toBe("\x1b[?1002l");
+  });
+
+  it("does not eat a split sequence that turns out to be innocent", () => {
+    const g = mouseModeGuard();
+    expect(through(g, "aaa\x1b[?2")).toBe("aaa");
+    expect(through(g, "5hbbb")).toBe("\x1b[?25hbbb");   // the cursor, not the mouse
+    expect(dec(g.flush())).toBe("");
+  });
+
+  it("gives back a half-read sequence on flush rather than swallowing it", () => {
+    // The drag is over; a partial held any longer is a byte the shell wrote and
+    // the terminal never sees.
+    const g = mouseModeGuard();
+    expect(through(g, "aaa\x1b[?10")).toBe("aaa");
+    expect(dec(g.flush())).toBe("\x1b[?10");
+  });
+
+  it("empties itself, so the next drag starts clean", () => {
+    const g = mouseModeGuard();
+    through(g, "\x1b[?1002l");
+    expect(dec(g.flush())).toBe("\x1b[?1002l");
+    expect(dec(g.flush())).toBe("");
+  });
+
+  it("leaves ordinary output completely alone", () => {
+    const g = mouseModeGuard();
+    const noisy = "\x1b[31mred\x1b[0m \x1b[2J\x1b[H \x1b[?1049h ñ→é \x1b[6n";
+    expect(through(g, noisy)).toBe(noisy);
+    expect(dec(g.flush())).toBe("");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Stops a drag inside a terminal from dying mid-gesture. Selecting text up a tmux pane stopped on its own in the middle of the paragraph, and dragging a pane divider stopped halfway and needed grabbing again — in both cases without the mouse button ever coming up. Two separate causes, each closed here.

**A refit landing mid-gesture.** With tmux's mouse mode on both gestures live inside tmux, and tmux drops the drag it is in the middle of when its client changes size — which is what `fitTerm` does, since `term.resize()` reaches the shell as a SIGWINCH. Measured over a real pty with the gesture sent as the SGR reports xterm produces: a 30-column divider drag moves 30 columns untouched and **13** with one resize dropped in at column 15; a 25-row selection holds 25 rows and **11** with one resize at row 12, tmux's own `selection_present` flipping back to 0 mid-gesture. `dragHold` now holds the refit until the button comes up and replays it once per terminal, however many times a ResizeObserver asked during the drag.

**xterm unbinding its own listener.** It reports a drag from a `mousemove` listener on `document`, added when the button goes down and removed when the mouse protocol loses its drag bit — but restoring the protocol only reassigns the handler, because the `addEventListener` lives in the mousedown path. tmux re-synchronises its mouse mode against the focused pane's, so a TUI redrawing is enough: the set arrives as `?1000l ?1002l ?1003l` then `?1000h ?1002h ?1003h`, and `?1000h` alone is click-only tracking, so xterm unbinds on the way back up — before the `?1002h` that would have restored it. Counted over CDP during a real drag: **69 pointer moves produced 26 reports and 34 orphans**, the listener count going 1 → 0 and staying there. `mouseModeGuard` freezes the four tracking modes in both directions for the length of the drag and replays them in order on release, so the terminal ends the gesture in the mode the shell last asked for. Encodings (1006 and friends) pass through untouched — withholding one would leave the terminal reporting in a format the shell had stopped expecting.

Both are armed from a mousedown on a terminal's own holder, so the console strip's top-edge drag still refits live: it resizes the slot on purpose and nothing is mid-gesture inside the shell. Released on `mouseup` and on `blur`, because a window that loses focus mid-drag never sees the mouseup.

## How was it tested?

- `make typecheck` (web + server) clean; full web suite **1931 pass / 0 fail**, including 18 new tests across `drag-hold.test.ts` and `mouse-mode-guard.test.ts`. Most of what the guard's tests pin is what must survive untouched: the encodings, a change carrying a non-mouse mode (`\e[?25;1002l`), and a sequence split across two pty chunks.
- A CDP harness against the built bundle with a real tmux behind a real pty: the divider drag goes **13/30 → 30/30** and the selection **15/25 → 25/25**, with no resize on the wire while the button is held.
- Exercised in the desktop app on the Terminal view, on two tmux panes running live agents — the case the harness could not reproduce, since it needs a TUI that makes tmux re-synchronise the mode. Confirmed there by the reporter.