### PR TITLE
chore(release): carry 0.9.2 in every manifest

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "agentglass-electron",
   "private": true,
-  "version": "0.9.0",
+  "version": "0.9.2",
   "description": "Every AI coding agent on your machine, on one screen \u2014 live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go.",
   "author": "SirAllap",
   "homepage": "https://github.com/SirAllap/agentglass",

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "agentglass",
     "slug": "agentglass-mobile",
-    "version": "0.9.0",
+    "version": "0.9.2",
     "orientation": "portrait",
     "icon": "./assets/icon.png",
     "scheme": "agentglass",

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentglass-mobile",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "private": true,
   "main": "expo-router/entry",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentglass",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "private": true,
   "description": "Every AI coding agent on your machine, on one screen — live cost, tokens and tool calls across every provider, and a hold on anything dangerous until you say go. From your desk or your phone.",
   "license": "MIT",

--- a/server/package.json
+++ b/server/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentglass-server",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "scripts": {

--- a/web/package.json
+++ b/web/package.json
@@ -1,6 +1,6 @@
 {
   "name": "agentglass-web",
-  "version": "0.9.0",
+  "version": "0.9.2",
   "private": true,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## What does this PR do?

Sets the version to `0.9.2` in the six manifests that carry one: the root, `web`, `server`, `electron` and `mobile` package.json, plus `mobile/app.json`.

v0.9.1 was tagged without touching any of them, so the installed app reported `"version": "0.9.0"` next to `"baseTag": "v0.9.1"`. This closes that drift and prepares the v0.9.2 tag for the five commits merged since v0.9.1 (#484, #485 and the view-header cleanup), all of which live under `web/`.

## How was it tested?

- `bun install --frozen-lockfile` passes and leaves `bun.lock` unmodified, which is the flag `desktop-binaries.yml` builds release installers with.
- Diff is six lines, one per manifest: the first version bump attempt was reverted because `JSON.stringify` reformatted arrays and escapes as collateral.
- The APK gate from #483 was simulated against `v0.9.1..main`: nothing under `mobile/` changed, and none of the six shared modules the phone imports changed, so `scope` resolves to `false` and no APK is rebuilt for this tag. The v0.9.0 APK stays the current phone build.