### PR TITLE
fix: the phone's width, given back without being asked twice

### DIFF
--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -457,6 +457,29 @@ export default function TerminalScreen(): React.ReactNode {
   const onState = useCallback((next: TerminalState, detail?: string): void => {
     setState(next);
     setWhy(detail ?? null);
+    /*
+     * And the switch goes off with the socket that was holding it.
+     *
+     * `fit` is not a preference, it is a claim on somebody else's window: while
+     * it is on, tmux is holding the desk's window at this phone's width. The
+     * claim lives in the socket — the server reads it off the attach and the
+     * teardown puts the window back — so a socket that is gone is a claim that
+     * is gone, and a switch still lit is describing a reflow that is no longer
+     * happening.
+     *
+     * Left on, it was worse than wrong: the next attach reads it and sends
+     * `fit=1` again, so simply leaving the app and coming back re-took the
+     * width from the desk, on nobody's instruction, right after the person at
+     * the computer had asked for it back. Reported exactly that way, and the
+     * server-side half of it is the flag cleared in `tellPhonesTheWindowMoved`.
+     *
+     * Turning it off remounts the view (`fit` is in its key), which opens a
+     * socket without the fit rather than reconnecting the old one. That costs
+     * nothing while the app is away: the new view has not laid itself out, and
+     * the socket waits for that measurement before it opens, so the reattach
+     * happens when somebody is looking rather than in a pocket.
+     */
+    if (next === "gone") setFit(false);
   }, []);
 
   /*

--- a/mobile/src/terminal/TerminalView.tsx
+++ b/mobile/src/terminal/TerminalView.tsx
@@ -17,7 +17,7 @@
  * boundary — permanently, and in a TUI that is most of the box drawing.
  */
 import { forwardRef, useCallback, useEffect, useImperativeHandle, useMemo, useRef, useState } from "react";
-import { View } from "react-native";
+import { AppState, View } from "react-native";
 import { WebView, type WebViewMessageEvent } from "react-native-webview";
 import type { PtyClientFrame, PtyServerFrame } from "../../../shared/types.ts";
 import { b64Encode } from "../lib/b64.ts";
@@ -121,6 +121,17 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
    */
   const [measured, setMeasured] = useState(false);
   const [doc] = useState(() => terminalDocument({ palette, columns }));
+  /*
+   * Bumped to open a new socket on the same pane.
+   *
+   * The effect below is keyed on what a connection IS — host, pane, root, fit —
+   * and none of those change when a socket merely dies, so nothing reopened it:
+   * the screen said "Disconnected" and stayed there. Reported from the phone as
+   * "I minimise the app, come back, and the terminal is frozen; I have to tap
+   * another tab" — and tapping another tab is exactly a remount, which is why
+   * that worked and nothing else did.
+   */
+  const [attempt, setAttempt] = useState(0);
 
   /*
    * The palette, as the page's own theme object, recomputed every render.
@@ -281,8 +292,41 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
       // `tmux ls` with sessions nobody is in.
       try { ws.close(); } catch { /* already gone */ }
     };
-    // Deliberately only what identifies the CONNECTION. See the refs above.
-  }, [host, pane, root, fit, push, measured]);
+    // Deliberately only what identifies the CONNECTION, plus `attempt`, which
+    // is the one way to ask for the same connection again. See the refs above.
+  }, [host, pane, root, fit, push, measured, attempt]);
+
+  /*
+   * Come back with the app.
+   *
+   * A phone in a pocket loses this socket: Android stops the process's timers
+   * and the network goes with the screen, so the connection is gone long before
+   * anybody looks again. Nothing here noticed, because a dead socket does not
+   * change the pane it was attached to.
+   *
+   * Only on the way IN, and only when there is nothing live. Reconnecting while
+   * the app is away would put a tmux client back on somebody's machine for a
+   * phone in a pocket — every attach is a grouped session on the desk's tmux —
+   * and reconnecting over a socket that survived would drop a session that is
+   * working to replace it with an identical one.
+   *
+   * CONNECTING counts as alive: the first foreground event often lands while
+   * the initial socket is still opening, and racing it would throw away the
+   * attach that is already on its way.
+   *
+   * The pane keeps running on the machine throughout. This reattaches a view to
+   * work that never stopped, which is the whole promise of the tmux side of the
+   * app — the frozen screen was making it look otherwise.
+   */
+  useEffect(() => {
+    const sub = AppState.addEventListener("change", (next) => {
+      if (next !== "active") return;
+      const ws = socket.current;
+      if (ws && (ws.readyState === WebSocket.CONNECTING || ws.readyState === WebSocket.OPEN)) return;
+      setAttempt((n) => n + 1);
+    });
+    return () => sub.remove();
+  }, []);
 
   const onMessage = useCallback((event: WebViewMessageEvent): void => {
     let message: { t?: string; d?: string; cols?: number; rows?: number; text?: string | null; lines?: number };

--- a/mobile/src/terminal/terminal-html.ts
+++ b/mobile/src/terminal/terminal-html.ts
@@ -189,7 +189,28 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
     unicode-range: ${NERD_ICONS_RANGE};
   }
   html, body { margin: 0; padding: 0; height: 100%; background: ${palette.bg}; overflow: hidden; }
-  #screen { position: absolute; inset: 0; }
+  /*
+   * A gutter down both sides, and the columns are counted inside it.
+   *
+   * Edge to edge is right for a desktop terminal in a window that already has
+   * a frame around it. On a phone the WebView IS the frame: the last glyph of
+   * a line ended on the bezel with nothing after it, which reads as text
+   * running underneath the edge of the screen rather than as a line that
+   * finished. Reported from the phone, and it is the one place in the app
+   * where the text had no side margin at all.
+   *
+   * inset and not padding: xterm measures the element it was opened into, so
+   * with padding it would size a grid to the full box and then draw it inside
+   * a smaller one — the last column half under the gutter, which is exactly
+   * the complaint. Insetting makes the element itself narrower, and
+   * usableWidth below reads that element rather than the window, so the CSS
+   * here stays the only place the number lives.
+   *
+   * 8px each side (SPACE.sm, what the rest of the phone app uses). It costs
+   * about 4% of the glyph at 60 columns on a 412px screen, which is under the
+   * step the font size can even move in.
+   */
+  #screen { position: absolute; inset: 0 8px; }
   /* The cursor keeps blinking behind a screen nobody is looking at otherwise,
      which on a phone is a repaint per second for no reader. */
   .xterm.agx-idle .xterm-cursor-blink { animation: none !important; }
@@ -238,6 +259,19 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
 
   var wanted = ${columns};
   /*
+   * How much width the grid actually has, which is not the window's.
+   *
+   * Read off the element the terminal is drawn into, so the gutter is declared
+   * once in the stylesheet and this follows it. The fallback is for the case
+   * that element has no layout yet: report() runs again on every resize, and
+   * the first pass is the one that would read zero.
+   */
+  var screenEl = document.getElementById('screen');
+  var usableWidth = function () {
+    var w = screenEl ? screenEl.clientWidth : 0;
+    return w > 0 ? w : Math.max(1, window.innerWidth);
+  };
+  /*
    * The finest step in the font size that can change anything.
    *
    * xterm sizes a cell by writing 32 glyphs into a span and reading its
@@ -251,7 +285,7 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
   var sizeFor = function (cols) {
     // Floor rather than round: a font half a pixel too wide loses the last
     // column, which is where a prompt's cursor lives.
-    return Math.max(4, Math.floor((window.innerWidth / cols) / ratio * STEPS) / STEPS);
+    return Math.max(4, Math.floor((usableWidth() / cols) / ratio * STEPS) / STEPS);
   };
 
   var term = new window.Terminal({
@@ -369,7 +403,7 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
       // Ties go to the later, larger size: two sizes a step apart often land on
       // the same cell, and at the same grid width the bigger glyph is the one
       // worth having.
-      if (tried.grid >= widest && tried.grid > 0 && tried.grid <= window.innerWidth) {
+      if (tried.grid >= widest && tried.grid > 0 && tried.grid <= usableWidth()) {
         widest = tried.grid;
         best = tried.size;
       }

--- a/mobile/test/terminal-takeover.test.ts
+++ b/mobile/test/terminal-takeover.test.ts
@@ -135,6 +135,39 @@ describe("the frame the desk sends when it takes its width back", () => {
     expect(screen).toContain("!following && grid.cols > columns");
   });
 
+  test("the take-over drops the attach's own claim, not just the phone's UI", () => {
+    /*
+     * The bug this pair exists to end, reported as "I take the width back on
+     * the computer and it goes narrow again on its own".
+     *
+     * `phoneAttach.fit` is what the resize handler reads to decide whether this
+     * phone's geometry moves the real window, and it was written once at attach.
+     * The take-over sent the frame and left the flag alone, so the next `resize`
+     * from that socket ran `fitWindow` and undid it — and a resize is not a
+     * gesture: a WebView re-measuring when the app comes back sends one.
+     */
+    const server = readFileSync(join(import.meta.dir, "..", "..", "server", "src", "terminal.ts"), "utf8");
+    const tell = between(server, "function tellPhonesTheWindowMoved", "\n}\n");
+    expect(tell).toContain("at.fit = false");
+    // Before the send, so a frame that throws still leaves the server true.
+    expect(tell.indexOf("at.fit = false")).toBeLessThan(tell.indexOf('ctl(ws, { t: "pane"'));
+  });
+
+  test("a phone whose socket died does not reattach still fitted", () => {
+    /*
+     * The other half, and the half that survives the app being closed: the
+     * take-over frame only reaches a phone that is there to receive it. Leaving
+     * the app with `fit` on left the switch lit over a socket that no longer
+     * existed, and the next attach read it and sent `fit=1` again — so coming
+     * back to the app took the width off the desk with nobody asking.
+     *
+     * The claim lives in the socket, so it dies with it.
+     */
+    const handler = between(screen, "const onState = useCallback", "}, []);");
+    expect(handler).toContain('next === "gone"');
+    expect(handler).toContain("setFit(false)");
+  });
+
   test("the server re-measures the window after this phone resizes it", () => {
     /*
      * The other half of the same fix, and the half without which the screen is

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -319,7 +319,7 @@ function killGroup(s: Session, sigNum: number) {
   } catch { /* already gone */ }
 }
 
-import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
+import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";
 import { prepareReviewPrompt } from "./prs.ts";
 import { claudeCode, supportsSessionName } from "./agents/claudecode.ts";
@@ -672,6 +672,37 @@ export function ptyOpen(ws: PtyWs) {
       const onPhone = phoneWindows(frame.target.socket);
       for (const w of windows) if (onPhone.has(w.id)) w.phone = true;
 
+      /*
+       * And a window still at phone width with no phone on it gets its columns
+       * back, without anybody clicking anything.
+       *
+       * The notice this used to leave on the desk said it out loud: "your phone
+       * left without putting it back", beside a button. Everything in that
+       * sentence is something the machine already knows — the window is narrow,
+       * the mark says we narrowed it, and nothing is attached to it — so making
+       * somebody read it and press a button is asking them to do a job that has
+       * no decision in it. Found on a real machine as a window pinned at 80
+       * columns inside a 285-column terminal, hours after the phone had gone.
+       *
+       * The teardown still owes the restore and still usually pays it. This is
+       * for the three ways it cannot: a socket that never closed, a restore
+       * that ran while the phone was briefly still there, and a server killed
+       * between the fit and the teardown. See `reclaimPinnedWindow`, which
+       * holds the patience and the proof; here we only answer "is this window
+       * narrower than the terminal looking at it, and is it free".
+       *
+       * Free means more than tmux's answer. A phone whose socket is up but
+       * whose tmux client has not landed yet is between two attaches, and its
+       * own teardown owes the window — reclaiming it there is the tab-switch
+       * flicker `RECLAIM_AFTER_MS` exists to avoid, arriving by another road.
+       */
+      const client = frame.client;
+      if (client) for (const w of windows) {
+        const narrow = !!w.cols && w.cols < client.cols;
+        const held = onPhone.has(w.id) || phoneAttachedTo(frame.target.socket, w.id);
+        reclaimPinnedWindow(frame.target.socket, frame.target.id, w.id, narrow && !held);
+      }
+
       // "The agent in this tab finished its turn." Group the frame's panes by
       // their window, then: the active window (the one the desk is looking at) is
       // marked seen so its dot goes out; every other window lights if any pane in
@@ -896,6 +927,28 @@ export function ptyOpen(ws: PtyWs) {
  * socket at all in its argv while the phone's attach carries `-S /tmp/...`, so
  * comparing the two spellings never matches even on the same server.
  */
+/**
+ * Whether a phone socket in THIS process is on that window, whatever tmux says.
+ *
+ * tmux answers "which windows have a phone client attached right now", and that
+ * is a narrower question than "is a phone here". A socket that is up but whose
+ * tmux client has not landed — or has just gone, with its teardown already
+ * scheduled — is a phone between two attaches, and the window it names is owed
+ * a restore by that teardown rather than by anything else.
+ *
+ * Matched by resolved socket PATH for the reason `tellPhonesTheWindowMoved`
+ * spells out: the desk's argv usually names no socket and the phone's carries
+ * the resolved one, so comparing the arrays never matches on the same server.
+ */
+function phoneAttachedTo(socket: string[], windowId: string): boolean {
+  const server = socketPath(socket);
+  for (const s of sessions.values()) {
+    const at = s.phoneAttach;
+    if (at && at.windowId === windowId && socketPath(at.socket) === server) return true;
+  }
+  return false;
+}
+
 function tellPhonesTheWindowMoved(t: TmuxTarget, windowId: string) {
   const size = windowSize(t.socket, windowId);
   if (!size) return;

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -903,6 +903,29 @@ function tellPhonesTheWindowMoved(t: TmuxTarget, windowId: string) {
   for (const [ws, s] of sessions) {
     const at = s.phoneAttach;
     if (!at || at.windowId !== windowId || socketPath(at.socket) !== server) continue;
+    /*
+     * The FLAG, and not only the frame. This is the whole of a reported bug.
+     *
+     * `at.fit` is what the resize handler reads to decide whether a phone's
+     * geometry moves the real window, and it was written once at attach and
+     * never again. So the take-over gave the desk its columns back and left
+     * the attach still claiming the window: the phone's very next `resize`
+     * frame ran `fitWindow` and squeezed it to 80 again. That frame does not
+     * need anybody to touch the phone — a WebView re-measuring after the app
+     * comes back to the foreground sends one, which is exactly the shape it
+     * was reported in ("I take the width back on the computer and it goes
+     * narrow again on its own").
+     *
+     * Clearing it does not hang up on the phone and does not end its session;
+     * it ends this phone's CLAIM on the window's size. The phone tapping fit
+     * again reattaches with `fit=1` and gets it back, which is the rule the
+     * take-over already states: it ends the reflow that is happening, it is
+     * not a lock.
+     *
+     * Before the frame rather than after, so a send that throws still leaves
+     * the server's own state true.
+     */
+    at.fit = false;
     ctl(ws, { t: "pane", cols: size.cols, rows: size.rows, fit: false, by: "desk" });
   }
 }

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2389,7 +2389,136 @@ export function attachArgvFor(
 export function fitWindow(socket: string[], sessionId: string, windowId: string, cols: number, rows: number): boolean {
   if (!SESSION_ID.test(sessionId) || !WINDOW_ID.test(windowId)) return false;
   if (!Number.isInteger(cols) || !Number.isInteger(rows) || cols < 20 || rows < 4) return false;
+  markPinned(socket, windowId);
   return tmux(socket, ["resize-window", "-t", `${sessionId}:${windowId}`, "-x", String(cols), "-y", String(rows)]) !== null;
+}
+
+/**
+ * Write the durable "this app pinned this window's size" record, if the window
+ * does not already carry one.
+ *
+ * `windowSizeOptions` writes it for every window of the group at attach, which
+ * covers the fit that runs with the attach itself. It did not cover the fits
+ * that come AFTER, and the gap is a state a machine was found in: a window at
+ * `window-size manual`, 80 columns inside a 285-column terminal, with nobody
+ * attached to it and no mark on it. The way there is the ordinary one — a
+ * phone leaves a window, the teardown restores it and clears the mark, and a
+ * resize from a socket that had not finished dying fits it again — and once
+ * the mark is gone nothing can ever prove the window is ours to put back.
+ *
+ * So the record is written wherever the pin is, not only where the pin usually
+ * starts. `resize-window` sets `window-size manual` as a side effect, so every
+ * call below IS a pin.
+ *
+ * Only when unmarked, and that is what makes it safe to call on every fit: the
+ * value being kept is what the window had before ANY of this touched it, and
+ * overwriting it with `manual` half way through a phone's visit would make the
+ * restore put back the squeeze instead of undoing it.
+ */
+function markPinned(socket: string[], windowId: string): void {
+  if (!WINDOW_ID.test(windowId)) return;
+  const marked = tmux(socket, ["show-options", "-qwv", "-t", windowId, HAD_SIZE]);
+  if (marked === null || marked.trim()) return;
+  const had = tmux(socket, ["show-options", "-qwv", "-t", windowId, "window-size"]);
+  if (had === null) return;
+  // Ledger, claim, then mark — the same order and for the same reasons as
+  // `windowSizeOptions`. See THE PIN LEDGER.
+  notePinnedSocket(socket);
+  tmux(socket, ["set-option", "-w", "-t", windowId, HAD_SIZE_BY, thisRun()]);
+  tmux(socket, ["set-option", "-w", "-t", windowId, HAD_SIZE, had.trim() || HAD_NOTHING]);
+}
+
+/**
+ * How long a window has to be phone-free before this run puts it back.
+ *
+ * Not zero, and the number is the same race the teardown's 1500ms answers from
+ * the other side: switching tabs on the phone closes one socket and opens the
+ * next, and between them there is a moment with the window pinned and no phone
+ * on it. Reclaiming inside that gap gives the desk its width back and takes it
+ * away again as the next attach lands — two reflows of a full-screen program to
+ * arrive back where it started.
+ *
+ * Two seconds is that gap with room, and it is still fast enough that a phone
+ * put down in a pocket is a window back at the desk's size before anybody has
+ * finished looking away.
+ */
+const RECLAIM_AFTER_MS = 2000;
+/**
+ * And how long before looking again at a narrow window that turned out not to
+ * be ours.
+ *
+ * The mark can only be read with a tmux call, and this runs off a poll that
+ * ticks twice a second per attached client. A window somebody narrowed
+ * themselves stays narrow for as long as they want it to, so without a backoff
+ * it would cost a spawn every couple of seconds, for ever, to be told the same
+ * thing. A minute is short enough that a window that BECOMES ours — a phone
+ * fitting it — is picked up while the phone is still on it.
+ */
+const RECHECK_MS = 60_000;
+/** Per socket and window: the next moment this window is worth looking at.
+ *  Cleared the moment a phone is back on it, so a tab switch cannot accumulate
+ *  time towards a reclaim. */
+const freeSince = new Map<string, number>();
+
+/**
+ * Put back a window this app pinned for a phone that is no longer on it.
+ *
+ * WHY THIS EXISTS. The teardown owes the restore and usually pays it: the
+ * socket closes, and 1.5 and 3 seconds later `restoreWindows` gives the desk
+ * its columns back. Three ordinary things stop that from happening, and all of
+ * them leave the same wreck — a window at phone width with nobody on it:
+ *
+ *   the socket never closes (a phone that loses its network hands the server no
+ *   FIN, so the teardown is not scheduled at all);
+ *
+ *   the restore runs while the phone is still attached to that window and
+ *   correctly skips it — both attempts are inside three seconds, and after that
+ *   nothing is watching;
+ *
+ *   this server was killed, or reinstalled, between the fit and the teardown.
+ *
+ * The boot sweep answers the third and only at a boot, and only for a mark left
+ * by a run that is dead. This answers all three while the app is running, off
+ * the poll the tab strip is already paying for.
+ *
+ * The mark is the whole of the authority. A narrow window is not evidence of
+ * anything on its own — somebody who ran `resize-window -x 80` themselves has
+ * exactly that, and undoing it would be this app editing a tmux somebody else
+ * is driving. `@agx-had-size` says the size was taken by us and what it was
+ * before, which is the same proof the boot sweep insists on.
+ */
+export function reclaimPinnedWindow(socket: string[], sessionId: string, windowId: string, free: boolean): boolean {
+  if (!SESSION_ID.test(sessionId) || !WINDOW_ID.test(windowId)) return false;
+  const key = claimKey(socket, windowId);
+  if (!free) { freeSince.delete(key); return false; }
+  const at = freeSince.get(key);
+  if (at === undefined) { freeSince.set(key, Date.now() + RECLAIM_AFTER_MS); return false; }
+  if (Date.now() < at) return false;
+  const mark = tmux(socket, ["show-options", "-qwv", "-t", windowId, HAD_SIZE])?.trim();
+  // Not ours, which is the commonest answer: somebody narrowed their own
+  // window. Asked again in a minute rather than on the next tick — see
+  // RECHECK_MS.
+  if (!mark) { freeSince.set(key, Date.now() + RECHECK_MS); return false; }
+  freeSince.delete(key);
+  // A value this code cannot act on stops being a reason to come back.
+  if (mark !== HAD_NOTHING && !WINDOW_SIZE_VALUE.test(mark)) { clearSizeMark(socket, windowId); return false; }
+  const want = mark === HAD_NOTHING ? "" : mark;
+  /*
+   * `-A` first, the option second. Measured into `restoreWindows` and repeated
+   * in the boot sweep: setting the option alone leaves the window squeezed
+   * (tmux applies `window-size` when something makes it recompute, and nothing
+   * has), and `resize-window` in either form writes `manual`, so the other
+   * order puts the squeeze back over the restore.
+   */
+  tmux(socket, ["resize-window", "-A", "-t", `${sessionId}:${windowId}`]);
+  tmux(socket, want
+    ? ["set-option", "-w", "-t", windowId, "window-size", want]
+    : ["set-option", "-uw", "-t", windowId, "window-size"]);
+  clearSizeMark(socket, windowId);
+  // A pane whose size ends where it started is not redrawn by tmux, and a
+  // program that drew itself at 80 columns stays drawn that way.
+  tmux(socket, ["refresh-client"]);
+  return true;
 }
 
 /**

--- a/server/test/tmux-reclaim.test.ts
+++ b/server/test/tmux-reclaim.test.ts
@@ -1,0 +1,178 @@
+/*
+ * A window pinned for a phone that is gone puts itself back.
+ *
+ * THE STATE THIS EXISTS TO END, found on a real machine: window `@64` at
+ * `window-size manual`, 80 columns wide, inside a 285-column terminal, with no
+ * phone attached to it and no mark on it — hours after the phone had left. The
+ * desk showed a notice explaining it and a button to fix it, which is a job
+ * with no decision in it being handed to a person.
+ *
+ * There are two halves and this file measures both against a real tmux, because
+ * neither can be reasoned about:
+ *
+ *   `fitWindow` writes the durable mark. It did not, and that is how the window
+ *   above came to be unattributable: the mark is written at ATTACH, the teardown
+ *   clears it when it restores, and a fit arriving after that restore pinned the
+ *   window again with nothing left on it to say who by.
+ *
+ *   `reclaimPinnedWindow` puts such a window back, but only after it has been
+ *   free for a moment (a phone switching tabs is briefly gone) and only when the
+ *   mark proves the size was ours to take (a window somebody narrowed themselves
+ *   is not ours to widen).
+ *
+ * Its own tmux server, its own TMUX_TMPDIR, `-f /dev/null`: this machine's
+ * config loads tmux-continuum, which restores the user's real sessions into any
+ * server that starts.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, rmSync } from "node:fs";
+import { TEST_TERM } from "./tmuxTerm.ts";
+
+/** Short, for the 108-byte unix socket path limit. The DIRECTORY carries the
+ *  pid and the socket NAME stays fixed — see tmux-attach-claim.test.ts for the
+ *  measurements behind that split. */
+const TMPDIR = `/tmp/agx-tmux-rec-${process.pid}`;
+const SOCK = "agx-rec";
+const OURS = ["-L", SOCK];
+const REAL_TMPDIR = process.env.TMUX_TMPDIR;
+const HAVE_TMUX = !!Bun.which("tmux") && !!Bun.which("python3") && process.platform === "linux";
+
+const clientEnv = (): Record<string, string> => ({ ...process.env, TERM: TEST_TERM } as Record<string, string>);
+
+const tmux = (...args: string[]): string =>
+  Bun.spawnSync(["tmux", "-f", "/dev/null", "-L", SOCK, ...args], { stdout: "pipe", stderr: "pipe", env: process.env })
+    .stdout.toString().trim();
+
+const killServer = (): void => {
+  Bun.spawnSync(["tmux", "-f", "/dev/null", "-L", SOCK, "kill-server"], { stdout: "ignore", stderr: "ignore", env: process.env });
+};
+
+/** A tmux client on a pty of an exact size, the way a terminal emulator makes
+ *  one. `resize-window -A` means "the largest client viewing this window", so
+ *  the restore has nothing to compute without a real client of a real size. */
+function deskClient(cols: number, rows: number, target: string): ReturnType<typeof Bun.spawn> {
+  return Bun.spawn(
+    ["python3", "-c",
+      "import os,pty,fcntl,struct,termios,sys,time\n" +
+      "pid,fd=pty.fork()\n" +
+      "if pid==0: os.execvp('tmux',['tmux','-f','/dev/null','-L',sys.argv[1],'attach','-t',sys.argv[2]])\n" +
+      "fcntl.ioctl(fd,termios.TIOCSWINSZ,struct.pack('HHHH',int(sys.argv[4]),int(sys.argv[3]),0,0))\n" +
+      "time.sleep(600)\n",
+      SOCK, target, String(cols), String(rows)],
+    { stdout: "ignore", stderr: "ignore", env: clientEnv() },
+  );
+}
+
+const opt = (name: string, w: string): string => tmux("show-options", "-qwv", "-t", w, name);
+const mark = (w: string): string => opt("@agx-had-size", w);
+const sizeOpt = (w: string): string => opt("window-size", w);
+const cols = (w: string): number => Number(tmux("display-message", "-p", "-t", w, "#{window_width}"));
+
+/** The wait `reclaimPinnedWindow` insists on, plus enough to be past it. Kept
+ *  as a number here rather than imported: the test is asserting that the wait
+ *  is real, and reading it from the code under test would assert nothing. */
+const PAST_THE_WAIT = 2200;
+
+let ctl: typeof import("../src/tmuxctl.ts");
+let desk: ReturnType<typeof Bun.spawn> | null = null;
+let sessionId = "", pinned = "", theirs = "";
+
+beforeAll(async () => {
+  if (!HAVE_TMUX) return;
+  mkdirSync(TMPDIR, { recursive: true });
+  process.env.TMUX_TMPDIR = TMPDIR;
+  killServer();
+
+  tmux("new-session", "-d", "-s", "desk", "-x", "200", "-y", "50", "sh", "-c", "exec sh");
+  // `-d`, so the client stays on the first window: the second one is for the
+  // window this app must NOT touch, and it must not be the one being drawn.
+  tmux("new-window", "-d", "-t", "desk", "sh", "-c", "exec sh");
+  await Bun.sleep(300);
+  desk = deskClient(200, 50, "desk");
+  await Bun.sleep(1000);
+
+  sessionId = tmux("display-message", "-p", "-t", "desk", "#{session_id}");
+  const windows = tmux("list-windows", "-t", "desk", "-F", "#{window_id}").split("\n");
+  pinned = windows[0] ?? "";
+  theirs = windows[1] ?? "";
+  ctl = await import("../src/tmuxctl.ts");
+}, 60_000);
+
+afterAll(() => {
+  try { desk?.kill(); } catch { /* already gone */ }
+  if (HAVE_TMUX) killServer();
+  try { rmSync(TMPDIR, { recursive: true, force: true }); } catch { /* nothing there */ }
+  if (REAL_TMPDIR === undefined) delete process.env.TMUX_TMPDIR;
+  else process.env.TMUX_TMPDIR = REAL_TMPDIR;
+});
+
+describe.if(HAVE_TMUX)("a window a phone left pinned", () => {
+  test("a fit records what the window had before it", () => {
+    // The state every window starts in: no size of its own, and nothing of ours
+    // on it. This is what the restore has to be able to put back.
+    expect(sizeOpt(pinned)).toBe("");
+    expect(mark(pinned)).toBe("");
+
+    expect(ctl.fitWindow(OURS, sessionId, pinned, 60, 20)).toBe(true);
+    expect(cols(pinned)).toBe(60);
+    // tmux's own word for "somebody named a size and I am holding it" —
+    // `resize-window` writes it whether or not anybody meant to.
+    expect(sizeOpt(pinned)).toBe("manual");
+    // `none` is the mark for "it carried no option of its own", which is a
+    // different instruction from any of tmux's four values: put nothing back.
+    expect(mark(pinned)).toBe("none");
+  });
+
+  test("a second fit does not overwrite what the first one saw", () => {
+    // The window is `manual` now. A mark taken again here would record THAT,
+    // and the restore would faithfully put the squeeze back.
+    expect(ctl.fitWindow(OURS, sessionId, pinned, 70, 22)).toBe(true);
+    expect(cols(pinned)).toBe(70);
+    expect(mark(pinned)).toBe("none");
+  });
+
+  test("is not reclaimed the instant it looks free", () => {
+    // A phone switching tabs closes one socket and opens the next, and between
+    // them the window is pinned with nothing on it. Acting there gives the desk
+    // its width and takes it away again — two reflows to arrive back where it
+    // started.
+    expect(ctl.reclaimPinnedWindow(OURS, sessionId, pinned, true)).toBe(false);
+    expect(cols(pinned)).toBe(70);
+  });
+
+  test("a phone coming back resets the wait rather than shortening it", async () => {
+    await Bun.sleep(PAST_THE_WAIT);
+    // `false` is "a phone is on it": the window is owed to that phone's own
+    // teardown, and the clock starts again when it goes.
+    expect(ctl.reclaimPinnedWindow(OURS, sessionId, pinned, false)).toBe(false);
+    expect(ctl.reclaimPinnedWindow(OURS, sessionId, pinned, true)).toBe(false);
+    expect(cols(pinned)).toBe(70);
+  });
+
+  test("and puts itself back once it has really been left", async () => {
+    await Bun.sleep(PAST_THE_WAIT);
+    expect(ctl.reclaimPinnedWindow(OURS, sessionId, pinned, true)).toBe(true);
+    // The desk's own client is the largest thing viewing it, which is the whole
+    // of what `-A` computes.
+    expect(cols(pinned)).toBe(200);
+    // Put back to carrying no option of its own, which is what `none` meant.
+    expect(sizeOpt(pinned)).toBe("");
+    // And the record comes off, so nothing comes back for this window again.
+    expect(mark(pinned)).toBe("");
+  });
+
+  test("a window narrowed by somebody else is left exactly as it is", async () => {
+    // No mark: this app has no evidence the size is its to give back, and a
+    // window somebody sized themselves is not a bug to be fixed. This is the
+    // same proof the boot sweep insists on, asked at a different moment.
+    tmux("resize-window", "-t", `${sessionId}:${theirs}`, "-x", "60", "-y", "20");
+    expect(cols(theirs)).toBe(60);
+    expect(mark(theirs)).toBe("");
+
+    expect(ctl.reclaimPinnedWindow(OURS, sessionId, theirs, true)).toBe(false);
+    await Bun.sleep(PAST_THE_WAIT);
+    expect(ctl.reclaimPinnedWindow(OURS, sessionId, theirs, true)).toBe(false);
+    expect(cols(theirs)).toBe(60);
+    expect(sizeOpt(theirs)).toBe("manual");
+  }, 15_000);
+});

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -2379,11 +2379,19 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       <div className="flex items-start gap-2">
                         {/* The width sentence has two states, split on `w.phone`,
                             so the present tense is only used when a phone is
-                            actually there. The second is not hypothetical: a
-                            phone that loses its network leaves exactly this —
-                            the fit is a size set on the window, so it outlives
-                            the client that asked for it, and the desk is left
-                            narrow with nothing attached to explain it.
+                            actually there.
+
+                            The second one no longer blames the phone, and that
+                            is a consequence of the server putting these back by
+                            itself: a window a phone pinned carries a mark, and
+                            a marked window with nobody on it is restored within
+                            a couple of seconds without anybody clicking. So by
+                            the time this sentence is on screen the size is one
+                            this app cannot prove it took — most often somebody's
+                            own `resize-window` — and "your phone left without
+                            putting it back" would be a guess presented as a
+                            fact. The numbers are still worth saying, and the
+                            button still works on either.
                             The zoom sentence has one state, because it is only
                             ever shown while a phone is here (see
                             `zoomedByPhone`), and it says the panes are still
@@ -2394,7 +2402,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                           {held.narrow && (held.win.phone ? (
                             <>Your phone is driving this window. It is <Cols n={held.narrow.winCols} /> columns while your terminal is <Cols n={held.narrow.deskCols} />, so tmux is drawing everything at phone width.</>
                           ) : (
-                            <>This window is still at phone size: <Cols n={held.narrow.winCols} /> columns to your terminal&apos;s <Cols n={held.narrow.deskCols} />. Your phone left without putting it back.</>
+                            <>This window is <Cols n={held.narrow.winCols} /> columns to your terminal&apos;s <Cols n={held.narrow.deskCols} />, with nothing attached to it at that size. A phone&apos;s reflow is put back on its own, so this one came from somewhere else.</>
                           ))}
                           {held.narrow && held.zoomed && " "}
                           {held.zoomed && (

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -1709,12 +1709,25 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const narrow = tmuxActive && activeWin?.cols && tmuxClient && activeWin.cols < tmuxClient.cols
     ? { winCols: activeWin.cols, deskCols: tmuxClient.cols }
     : null;
-  // One row for both reasons rather than two rows that can stack: they have the
+  // One card for both reasons rather than two that can stack: they have the
   // same cause, the same button, and the same fix — and a desk that has lost
   // both its width and its panes has one problem, not two.
   const held = activeWin && (narrow || zoomedByPhone)
     ? { win: activeWin, narrow, zoomed: zoomedByPhone }
     : null;
+  /**
+   * The state the card is describing, as one string.
+   *
+   * Only used to decide whether a dismiss still applies. Closing the card puts
+   * this key in `heldHidden`, so the card stays gone while nothing changes and
+   * comes back by itself the moment the situation is a different one: another
+   * window, another width, or a zoom on top of a width that was already wrong.
+   * That keeps the dismiss from turning into the optimistic flag the button
+   * below deliberately does not have — nothing here is remembered ACROSS a
+   * change of state, so a phone that grabs the window again is announced again.
+   */
+  const heldKey = held ? `${held.win.id}:${held.narrow?.winCols ?? 0}:${held.zoomed ? "z" : "-"}` : null;
+  const [heldHidden, setHeldHidden] = useState<string | null>(null);
   /**
    * A tmux command, minus the discriminant this helper supplies.
    *
@@ -2262,65 +2275,6 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                   </div>
                 )}
 
-                {/* Your terminal is being drawn at somebody else's width.
-
-                    A row, not an overlay: under tmux the pane is a full-screen
-                    TUI drawn edge to edge on purpose, and an overlay covers the
-                    output you are squinting at — which is the thing that sent
-                    you looking for an explanation in the first place.
-                    Deliberately OUTSIDE the `!tmuxBar` guard above: this is not
-                    the tab strip, and someone who kept tmux's own status line
-                    has exactly the same broken layout and none of the strip.
-
-                    keepTermFocus for the same reason the strip has it — the
-                    button must not take the keyboard off the pane. */}
-                {held && (
-                  <div onMouseDown={keepTermFocus} className="shrink-0 flex items-center gap-2 px-3 py-1.5 border-b text-[10.5px]"
-                    style={{ color: "var(--text2)", background: "color-mix(in srgb, var(--phone) 12%, transparent)", borderColor: "color-mix(in srgb, var(--phone) 30%, transparent)" }}>
-                    {/* The width sentence has two states, split on `w.phone`, so
-                        the present tense is only used when a phone is actually
-                        there. The second is not hypothetical: a phone that loses
-                        its network leaves exactly this — the fit is a size set on
-                        the window, so it outlives the client that asked for it,
-                        and the desk is left narrow with nothing attached to
-                        explain it.
-                        The zoom sentence has one state, because it is only ever
-                        shown while a phone is here (see `zoomedByPhone`), and it
-                        says the panes are still RUNNING: that is the actual
-                        question — a window that went from four panes to one
-                        reads like three programs died. */}
-                    <span className="min-w-0">
-                      {held.narrow && (held.win.phone ? (
-                        <>Your phone is driving this window. It is <Cols n={held.narrow.winCols} /> columns while your terminal is <Cols n={held.narrow.deskCols} />, so tmux is drawing everything at phone width.</>
-                      ) : (
-                        <>This window is still at phone size: <Cols n={held.narrow.winCols} /> columns to your terminal&apos;s <Cols n={held.narrow.deskCols} />. Your phone left without putting it back.</>
-                      ))}
-                      {held.narrow && held.zoomed && " "}
-                      {held.zoomed && (
-                        <>Your phone opened one pane here, so tmux has zoomed the window onto it — your other panes are still running, they are just not being drawn.</>
-                      )}
-                    </span>
-                    {/* Nothing is remembered from this click. The notice is a
-                        pure function of the next sweep, so if tmux did not
-                        actually move it correctly stays up — an optimistic
-                        "taken over" flag would hide a take-over that failed,
-                        and unlike the tab click above, this is not an answer
-                        the user already knows. */}
-                    {/* The label follows what is actually wrong. "Take the width
-                        back" on a window that is the right width and missing
-                        three panes would name the wrong problem, and a button
-                        that names the wrong problem is one nobody presses. */}
-                    <button onClick={() => tmuxCmd({ cmd: "takeover", window: held.win.id })}
-                      className="ml-auto shrink-0 px-2 py-0.5 rounded"
-                      style={{ color: "var(--text)", border: "1px solid color-mix(in srgb, var(--phone) 45%, transparent)" }}
-                      title={held.zoomed
-                        ? "Unzoom this window and resize it to your terminal, then leave it following your terminal — the phone stays connected and can still ask for the pane back later"
-                        : "Resize this window to your terminal and leave it following your terminal — the phone stays connected and can still ask for a reflow later"}>
-                      {held.zoomed ? "Give me my window back" : held.win.phone ? "Take the width back" : "Restore the width"}
-                    </button>
-                  </div>
-                )}
-
                 {/* the terminals — one slot per visible pane */}
                 <div className="flex-1 min-h-0 relative" style={{ background: "var(--bg)" }}>
                   {/* The gap survives — it separates two panes and is doing real
@@ -2379,6 +2333,104 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         : cmds?.reason === "config"
                         ? "Terminal disabled (terminalDisabled in config.json)"
                         : "Terminal disabled (AGENTGLASS_TERMINAL_DISABLED=1)"}
+                    </div>
+                  )}
+
+                  {/* Your terminal is being drawn at somebody else's width.
+
+                      A card that floats over the bottom right corner of the
+                      panes, NOT a row above them. As a row it took its height
+                      out of the terminal, so a phone connecting reflowed every
+                      pane on the desk and disconnecting reflowed them back:
+                      the notice about a resize was itself causing one, and a
+                      full-screen TUI redrew underneath it both times. Floating,
+                      it costs the terminal no rows at all and nothing moves.
+
+                      Anchored inside the pane box rather than to the viewport,
+                      which puts it in the screen's bottom right corner without
+                      covering the status line, and, because the whole terminal
+                      view is hidden with `visibility` when you are looking at
+                      another view, means it cannot follow you into chat or the
+                      diff the way a portal to the body would.
+
+                      Deliberately OUTSIDE the `!tmuxBar` guard above: this is
+                      not the tab strip, and someone who kept tmux's own status
+                      line has exactly the same broken layout and none of the
+                      strip.
+
+                      keepTermFocus for the same reason the strip has it — the
+                      button must not take the keyboard off the pane. Pointer
+                      events stop at the card itself, so a drag that starts
+                      anywhere else on the pane still selects text as usual. */}
+                  {held && heldKey !== heldHidden && (
+                    <div onMouseDown={keepTermFocus} role="status"
+                      className="absolute bottom-3 right-3 max-w-[21rem] flex flex-col gap-2 px-3.5 py-2.5 rounded-xl text-[10.5px] leading-relaxed"
+                      style={{
+                        zIndex: 20,
+                        color: "var(--text2)",
+                        // Opaque rather than blurred: this sits over a terminal
+                        // that repaints constantly, and a backdrop-filter here
+                        // is a per-frame cost for the whole rectangle.
+                        background: "var(--bg2)",
+                        border: "1px solid color-mix(in srgb, var(--phone) 45%, transparent)",
+                        boxShadow: "0 18px 40px -18px var(--shadow)",
+                        animation: "agx-zoom-in .12s ease-out",
+                      }}>
+                      <div className="flex items-start gap-2">
+                        {/* The width sentence has two states, split on `w.phone`,
+                            so the present tense is only used when a phone is
+                            actually there. The second is not hypothetical: a
+                            phone that loses its network leaves exactly this —
+                            the fit is a size set on the window, so it outlives
+                            the client that asked for it, and the desk is left
+                            narrow with nothing attached to explain it.
+                            The zoom sentence has one state, because it is only
+                            ever shown while a phone is here (see
+                            `zoomedByPhone`), and it says the panes are still
+                            RUNNING: that is the actual question — a window that
+                            went from four panes to one reads like three
+                            programs died. */}
+                        <span className="min-w-0">
+                          {held.narrow && (held.win.phone ? (
+                            <>Your phone is driving this window. It is <Cols n={held.narrow.winCols} /> columns while your terminal is <Cols n={held.narrow.deskCols} />, so tmux is drawing everything at phone width.</>
+                          ) : (
+                            <>This window is still at phone size: <Cols n={held.narrow.winCols} /> columns to your terminal&apos;s <Cols n={held.narrow.deskCols} />. Your phone left without putting it back.</>
+                          ))}
+                          {held.narrow && held.zoomed && " "}
+                          {held.zoomed && (
+                            <>Your phone opened one pane here, so tmux has zoomed the window onto it — your other panes are still running, they are just not being drawn.</>
+                          )}
+                        </span>
+                        {/* Closing hides the card, never the situation: the
+                            width stays wrong, and the same card comes back on
+                            its own as soon as the state is a different one (see
+                            `heldKey`). It exists because this now sits over your
+                            output instead of above it, and a card you cannot put
+                            away would be a permanent hole in the corner of a
+                            full-screen TUI. */}
+                        <CloseButton onClick={() => setHeldHidden(heldKey)}
+                          className="shrink-0 opacity-50 hover:opacity-100"
+                          title="Hide this until the window changes — the width stays as it is" />
+                      </div>
+                      {/* Nothing is remembered from this click. The notice is a
+                          pure function of the next sweep, so if tmux did not
+                          actually move it correctly stays up — an optimistic
+                          "taken over" flag would hide a take-over that failed,
+                          and unlike the tab click above, this is not an answer
+                          the user already knows. */}
+                      {/* The label follows what is actually wrong. "Take the
+                          width back" on a window that is the right width and
+                          missing three panes would name the wrong problem, and a
+                          button that names the wrong problem is one nobody
+                          presses. */}
+                      <button onClick={() => tmuxCmd({ cmd: "takeover", window: held.win.id })}
+                        className="agx-btn self-end shrink-0 px-2 py-0.5 rounded"
+                        style={{ color: "var(--text)", border: "1px solid color-mix(in srgb, var(--phone) 45%, transparent)" }}
+                        title={held.zoomed
+                          ? "Unzoom this window and resize it to your terminal, then leave it following your terminal — the phone stays connected and can still ask for the pane back later"
+                          : "Resize this window to your terminal and leave it following your terminal — the phone stays connected and can still ask for a reflow later"}>
+                        {held.zoomed ? "Give me my window back" : held.win.phone ? "Take the width back" : "Restore the width"}
+                      </button>
                     </div>
                   )}
                 </div>


### PR DESCRIPTION
## What does this PR do?

Four fixes to the same feature: a phone holding a tmux window at phone width, and the desk getting its columns back.

**The notice floats instead of stealing rows.** "Take the width back" was a row above the panes, so a phone connecting took height out of the terminal and reflowed every pane, and disconnecting reflowed them back. A notice about an unwanted resize was itself causing one, twice, under whatever full-screen TUI was drawn. It is now a card over the bottom right corner of the pane box, anchored inside it rather than portalled to the viewport so it cannot follow you into another view. Closing it hides the card, never the situation: the dismiss is keyed on window id, width and zoom, so the same card returns as soon as the state is a different one.

**The take-over really ends the phone's fit.** Reported as "I take the width back on the computer and it goes narrow again on its own", and it was two bugs pulling together. Server side, `phoneAttach.fit` was written once at attach and never cleared, and it is what the resize handler reads — so the phone's next `resize` frame ran `fitWindow` and squeezed the window again. That frame is not a gesture; a WebView re-measuring on foreground sends one. Phone side, `fit` is a claim that lives in the socket, and it survived the socket: leaving the app and coming back re-took the width with nobody asking. Both now end where the claim ends. A deliberate tap on `fit` still works: take-over is not a lock.

**A window a phone left pinned puts itself back.** Found on a machine rather than reasoned about: `window-size manual`, 80 columns inside a 285-column terminal, nobody attached, no mark, hours after the phone had gone. Two gaps. `fitWindow` wrote no durable mark, so a fit landing after a teardown's restore re-pinned the window with nothing left to prove it was ours. And nothing put a marked window back while the app was running — the teardown cannot when the socket never closes, when both its attempts land while the phone is still attached, or when the server is killed in between; the boot sweep answers only the last, only at a boot. `reclaimPinnedWindow` answers all three off the poll the tab strip already runs, after the window has been free for two seconds. The mark is the whole of the authority: a narrow window proves nothing, and undoing somebody's own `resize-window` is not this app's to do.

**Two phone-side fixes on the same screen.** The terminal grid was drawn edge to edge, so the last glyph of a line ended on the bezel and read as text running under the edge of the screen; `#screen` is now inset 8px each side and the font size is computed from that element rather than the window. And minimising the app froze the terminal until you tapped another tab, because the socket effect is keyed on what a connection is and a dead socket changes none of it; there is now a reconnect on foreground, only when nothing is CONNECTING or OPEN.

## How was it tested?

`make typecheck` (web, server) and `npm run typecheck` in `mobile/`, all clean. `bun test`: server suites for the tmux paths, `web/`, and 360 mobile tests.

New: `server/test/tmux-reclaim.test.ts`, against a real tmux on its own socket — a fit records what the window had, a second fit does not overwrite it, the reclaim waits before acting, a phone coming back resets the wait, the window is restored once it has really been left, and **a window narrowed by somebody else is left exactly as it is**. Two more cases in `mobile/test/terminal-takeover.test.ts` for the two halves of the take-over fix.

Manually, in a local desktop build of this branch: the notice appears without the terminal moving; the take-over returns the width and the phone's `fit` goes out with it; killing the phone app brings the width back on its own in 2-3 seconds; and a window narrowed by hand with `tmux resize-window -x 80` was watched for 30 seconds and never touched.

The phone half on an Android emulator running this branch's JS, against an isolated tmux session so the desk's own windows could not move: the gutter measured 21px left and 19px right where it was 0 and 0, and after killing the phone's socket while the app was backgrounded, foregrounding it reattached by itself — a new `agx-phone-*` session four seconds later, with no taps. The desk's five windows were identical before and after.
