### PR TITLE
fix: ClickUp's mark, only on machines that have ClickUp

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -120,7 +120,7 @@ import { join as joinPath, basename } from "node:path";
 import { privateHost, resolvePeer, originOf } from "./net.ts";
 import { resolveToken, tokenOk, isIntake, isAuthExempt, callerFor, allowed, scopeNeeded, type Caller, type Origin } from "./auth.ts";
 import { activeDevices, markSeen, revokeDevice, devices, publicDevice, type Scope } from "./devices.ts";
-import { credentialsPath } from "./credentials.ts";
+import { credentialsPath, hasCredential } from "./credentials.ts";
 import { startCardWatch } from "./clickupwatch.ts";
 import { mintTicket, claimTicket, pending as pendingPairings, acceptTicket, rejectTicket, collect as collectPairing, dropTicket, getTicket, MAX_ATTEMPTS } from "./pairing.ts";
 import { updateStatus, viewerStatus, startUpdate, updateLog, releaseNotes } from "./selfupdate.ts";
@@ -2084,7 +2084,11 @@ const server = Bun.serve<WsData>({
       // only a string — the pull-request masthead reading a branch name — can
       // tell a card id of ours from another tracker's before it offers to open
       // one. Empty means nothing has been read yet, which is "unknown".
-      return json({ views: savedViews(), current: currentView(), prefix: knownCardPrefix(), writeEnabled: clickupWriteEnabled(), writeForced: process.env.AGENTGLASS_CLICKUP_WRITE === "1" });
+      //
+      // `connected` is said out loud because `views` cannot say it: the
+      // built-in board is always in that list, so its length answers "yes" on a
+      // machine with no ClickUp at all. See ClickUpBoards.
+      return json({ views: savedViews(), connected: hasCredential("clickup"), current: currentView(), prefix: knownCardPrefix(), writeEnabled: clickupWriteEnabled(), writeForced: process.env.AGENTGLASS_CLICKUP_WRITE === "1" });
     }
     if (pathname === "/clickup/view") {
       // Falls back to the first board rather than to nothing, and the first

--- a/server/test/clickup-prefix.test.ts
+++ b/server/test/clickup-prefix.test.ts
@@ -98,5 +98,32 @@ describe("which board already holds a card", () => {
   });
 });
 
+/*
+ * The trap that produced ClickUp marks on repositories with no ClickUp.
+ *
+ * `savedViews()` always leads with the built-in board, which is right — nobody
+ * should have to add "assigned to me" — and it means the list is never empty.
+ * The pull-request masthead was asking `views.length > 0` as its "is ClickUp
+ * set up here" test, so it got yes on a machine that has never held a token.
+ *
+ * Pinned as a property of this module rather than as a comment somewhere else,
+ * because the next caller to reach for a count will reach for this one.
+ */
+describe("what the saved-view list can and cannot be asked", () => {
+  it("is never empty, so its length is not a test for having ClickUp", () => {
+    // No views added, no store on disk, no token anywhere.
+    expect(V.savedViews().length).toBe(1);
+    expect(V.savedViews()[0]!.id).toBe(ASSIGNED_VIEW_ID);
+    expect(V.savedViews()[0]!.builtin).toBe(true);
+  });
+
+  it("still cannot be emptied by removing everything in it", () => {
+    V.addView(view("v1"));
+    V.removeView("v1");
+    V.removeView(ASSIGNED_VIEW_ID);
+    expect(V.savedViews().map((v) => v.id)).toEqual([ASSIGNED_VIEW_ID]);
+  });
+});
+
 // The temp directory outlives the individual files each test wrote into it.
 process.on("exit", () => { try { rmSync(dir, { recursive: true, force: true }); } catch { /* going away anyway */ } });

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -364,6 +364,20 @@ export interface ListPlace {
  */
 export interface ClickUpBoards {
   views: SavedView[];
+  /**
+   * Whether there is a ClickUp token on this machine at all.
+   *
+   * Stated rather than inferred, and that is the whole reason it exists. The
+   * obvious inference — "are there any boards" — cannot answer it: `views`
+   * always carries the built-in `ASSIGNED_VIEW_ID`, which ships with the app
+   * and is not stored, so its length is never zero and a reader counting it
+   * concludes ClickUp is set up on a machine that has never seen a token. That
+   * is how a Jira shop ended up with ClickUp marks on its pull requests.
+   *
+   * Surfaces that are not the ClickUp board — the pull-request masthead, the
+   * triage chip — must gate on THIS.
+   */
+  connected: boolean;
   /** The board on screen when you last looked. */
   current?: string;
   /**

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -54,7 +54,7 @@ import { MERGE_WHY, mergeBlockedWhy, checksLine, checksStanding, standingLine, c
 import { parseQuery, applyFilters, buildFacets, activeCount, type RepoFacets } from "../lib/prFilter.ts";
 import { getHighlighter, shikiTheme, ensureLanguage } from "../lib/highlight.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
-import { cardRef, looksLikeOurs } from "../lib/cardRef.ts";
+import { cardRef, chipAction } from "../lib/cardRef.ts";
 import { requestWorktreeJump } from "../lib/worktreeJump.ts";
 import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { openCard } from "../lib/openCard.ts";
@@ -242,28 +242,28 @@ function ClickUpMark({ size = ICON.xs }: { size?: number }) {
  * is the walk everybody does by hand — read the id off the branch, switch to
  * the board, paste it in. One press instead.
  *
- * It is shown only when it would WORK, which is three different answers:
+ * It is shown only when it would WORK, which is three different answers — and
+ * which of them applies is `chipAction`'s to decide, not this component's:
  *
  *   the body has a ClickUp address   always — nothing else writes that host
  *   an id in the branch, ClickUp here   yes, if the prefix is this workspace's
  *   an id in the branch, no ClickUp     nothing, rather than a mark for a
  *                                       tracker this machine has never heard of
  *
- * With no board to land on but an address to hand, it opens ClickUp itself
+ * With no ClickUp to land in but an address to hand, it opens ClickUp itself
  * instead of a Tasks view that would only ask you to connect one.
  */
 function CardChip({ pr }: { pr: { headRefName?: string; title?: string; body?: string } }) {
   const setup = useClickupSetup();
   const ref = useMemo(() => cardRef(pr), [pr.headRefName, pr.title, pr.body]);
-  if (!ref || !setup) return null;
+  const go = chipAction(ref, setup);
+  if (!ref || !go) return null;
 
-  const inApp = setup.boards > 0 && looksLikeOurs(ref, setup.prefix);
-  if (!inApp && !ref.url) return null;
-
+  const inApp = go.in === "tasks";
   const tint = "var(--primary)";
   return (
     <button
-      onClick={() => { if (inApp) openCard(ref.query, ref.label); else openExternal(ref.url!); }}
+      onClick={() => { if (go.in === "tasks") openCard(ref.query, ref.label); else openExternal(go.url); }}
       title={inApp
         ? `Open ${ref.label} in Tasks — the ClickUp card this pull request came from`
         : `Open ${ref.label} in ClickUp`}
@@ -1940,9 +1940,14 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
    *
    * Null while the answer is in flight, which is what stops a chip flashing on
    * and off on a machine that has none.
+   *
+   * `connected` rather than a count of boards: the built-in board is in that
+   * list whether or not a token is, so counting it answered yes everywhere and
+   * taskLink.ts's rule — hide a convention-shaped id when nothing can resolve
+   * it — never once fired. See ClickUpSetup.
    */
   const taskSetup = useClickupSetup();
-  const hasTaskProvider = (taskSetup?.boards ?? 0) > 0;
+  const hasTaskProvider = taskSetup?.connected === true;
 
   const [boardMine, setBoardMine] = useState<PrSummary[]>([]);
   const [boardReview, setBoardReview] = useState<PrSummary[]>([]);

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -95,7 +95,26 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState("");
   const shown = useSyncExternalStore(subscribeTaskSources, shownTaskSources, shownTaskSources);
-  const tabs = useMemo(() => sourceTabs(shown), [shown]);
+  /*
+   * A source somebody hid, put back for as long as they are being shown a card
+   * from it.
+   *
+   * Without this the jump lands nowhere and says nothing: the effect below sets
+   * the source to "clickup", the reconcile effect above finds no such tab on
+   * the next render and steps to the first one there is, and pressing a card id
+   * on a pull request quietly opens GitHub Issues instead. Hiding a source is a
+   * preference about the TAB BAR, not a refusal to ever see a card again — and
+   * the person most likely to have hidden ClickUp is exactly the person a
+   * ClickUp address in a pull-request body can still send here.
+   *
+   * The preference itself is never rewritten. The tab is here while the errand
+   * is, and gone again the moment they pick another one.
+   */
+  const [forced, setForced] = useState<TaskSourceId | null>(null);
+  const tabs = useMemo(
+    () => sourceTabs(forced && !shown.includes(forced) ? [...shown, forced] : shown),
+    [shown, forced],
+  );
   const [source, setSource] = useState<SourceId>("all");
   /* Standing on a source that has just been hidden — or on "All" when only one
      source is left — is standing on a tab that is no longer there. Step to the
@@ -117,14 +136,20 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
      the same errand to finish. The count is watched rather than the object, so
      asking for the card you are already looking at still puts you back on this
      tab if you have since wandered to another source. */
-  useEffect(() => { if (cardJump) setSource("clickup"); }, [cardJump?.n]);
+  useEffect(() => {
+    if (!cardJump) return;
+    setForced("clickup");
+    setSource("clickup");
+  }, [cardJump?.n]);
 
   return (
     <div className="flex flex-col h-full min-h-0">
       <ViewHeader label="Tasks">
         <nav className="flex items-center gap-0.5" aria-label="Sources">
           {tabs.map((s) => (
-            <button key={s.id} onClick={() => setSource(s.id)}
+            // Picking a tab by hand ends the errand, which is what takes a
+            // borrowed tab back off the bar — see `forced`.
+            <button key={s.id} onClick={() => { setForced(null); setSource(s.id); }}
               aria-current={s.id === source ? "true" : undefined}
               className="text-[11px] px-2.5 py-1 rounded-lg whitespace-nowrap"
               style={s.id === source
@@ -2618,12 +2643,25 @@ function CardDetail({ t, today, statuses, fields, place, writable, repos, here, 
           them, so they are found the way the team already names things: the
           card id is in the branch, so GitHub's search finds them. Whatever the
           card's own field says is kept too — a link typed by hand outranks a
-          search, and a PR in another repository would never be found by one. */}
-      {!!prs.length && (
+          search, and a PR in another repository would never be found by one.
+
+          Shown when the search FAILED as well as when it found something, and
+          those are different sentences. A card with no pull requests and a card
+          whose search could not run both used to render as nothing at all —
+          `gh` missing, `gh` not logged in, a checkout that is not this card's
+          repository — so "we could not look" was displayed as "there are
+          none", which is the one thing a panel like this must not say. A card
+          that genuinely produced nothing still renders nothing: that is an
+          answer, and it is correct. */}
+      {(!!prs.length || prsErr) && (
         <div className="mb-3 pt-2.5" style={{ borderTop: edge(10) }}>
           <div className="text-[8.5px] uppercase tracking-[0.18em] mb-1.5 flex items-center gap-2" style={{ color: "var(--text4)" }}>
-            Pull requests <span>{prs.length}</span>
-            {prsErr && <span style={{ color: "var(--warning)" }}>· search failed, showing what the card states</span>}
+            Pull requests {!!prs.length && <span>{prs.length}</span>}
+            {prsErr && (
+              <span style={{ color: "var(--warning)" }}>
+                {prs.length ? "· search failed, showing what the card states" : "· could not search GitHub — this is not “none”"}
+              </span>
+            )}
           </div>
           {prs.map((p) => (
             <div key={p.number} className="flex items-center gap-2 py-1">

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1269,7 +1269,9 @@ const demoApi: typeof realApi = {
   recipeSave: (_r: Recipe) => D({ ok: false, error: "not available in the demo" }),
   recipeRemove: (_i: string) => D({ ok: true }),
   recipeRender: (_i: string, _v: Record<string, string>) => D({ ok: false, error: "not available in the demo" }),
-  clickupViews: () => D({ views: [], writeEnabled: false }),
+  // `connected: false` — the demo has no token, and every chip that gates on
+  // this stays off rather than leading somewhere that does not exist.
+  clickupViews: () => D({ views: [], connected: false, writeEnabled: false }),
   clickupSetWrites: (_o: boolean) => D({ ok: false }),
   clickupView: (_i?: string, _f?: boolean) => D({ tasks: [], statuses: [], fields: [], at: 0 }),
   clickupAddView: (_u: string) => D({ ok: false, error: "not available in the demo" }),

--- a/web/src/lib/cardMove.ts
+++ b/web/src/lib/cardMove.ts
@@ -27,11 +27,20 @@ import { cardRef, looksLikeOurs } from "./cardRef.ts";
  * we have actually read from this workspace's own cards is the other proof.
  * With neither, the honest answer is to say nothing rather than open a merge
  * form offering to move a card that does not exist.
+ *
+ * All of which is about the CARD, and there is a question before it: can this
+ * machine write to ClickUp at all. Without a token it cannot, whatever the
+ * evidence — so a pull request carrying a clickup.com address, which is proof
+ * of a card and no proof of a connection, used to open a merge form that spun
+ * on "Looking up ORBIT-1042 on ClickUp…" before admitting there was no ClickUp
+ * to look in. That is a real body: a fork of a team that uses ClickUp, or a
+ * contributor who pasted a link. Asked first, so the rest is never reached.
  */
 export function mergeCardRef(
   pr: { headRefName?: string; title?: string; body?: string },
-  setup: { boards: number; prefix?: string } | null,
+  setup: { connected: boolean; prefix?: string } | null,
 ): { label: string; query: string } | null {
+  if (!setup?.connected) return null;
   const ref = cardRef(pr);
   if (!ref) return null;
   if (ref.from === "url") return { label: ref.label, query: ref.query };

--- a/web/src/lib/cardRef.ts
+++ b/web/src/lib/cardRef.ts
@@ -140,3 +140,31 @@ export function looksLikeOurs(ref: CardRef, prefix: string | undefined): boolean
   if (!prefix) return true;
   return ref.label.toUpperCase().startsWith(prefix.toUpperCase());
 }
+
+/**
+ * What the masthead chip should DO — the three answers at the top of this file,
+ * as one decision instead of a condition spread across some JSX.
+ *
+ * It lives here, next to the evidence it weighs, because the mistake it exists
+ * to prevent is not a rendering mistake. The rule was right and the value fed
+ * to it was not: the chip asked "are there boards", the answer was always yes
+ * because the built-in board is always there, and a repository that has never
+ * heard of ClickUp got ClickUp's mark on its pull requests. A boolean called
+ * `connected` cannot be satisfied by an off-by-one, and a function returning
+ * WHERE this goes cannot be half-applied.
+ *
+ *   null            say nothing — an id from a tracker we cannot resolve
+ *   { in: "tasks" } open the card here, in the ClickUp board
+ *   { in: "clickup" } no ClickUp on this machine, but the body gave an address,
+ *                   and a URL opens without anybody's credentials
+ */
+export function chipAction(
+  ref: CardRef | null,
+  setup: { connected: boolean; prefix?: string } | null,
+): { in: "tasks" } | { in: "clickup"; url: string } | null {
+  // Null setup is "the answer has not arrived", not "no". Saying nothing until
+  // it has is what stops the chip appearing and then vanishing.
+  if (!ref || !setup) return null;
+  if (setup.connected && looksLikeOurs(ref, setup.prefix)) return { in: "tasks" };
+  return ref.url ? { in: "clickup", url: ref.url } : null;
+}

--- a/web/src/lib/clickupSetup.ts
+++ b/web/src/lib/clickupSetup.ts
@@ -15,8 +15,23 @@ import { useEffect, useState } from "react";
 import { api } from "./api.ts";
 
 export interface ClickUpSetup {
-  /** How many boards are saved. Zero means there is nothing to open a card in. */
-  boards: number;
+  /**
+   * Is there a ClickUp on this machine — a token, not a tab.
+   *
+   * This used to be `boards: number`, read off the length of the saved-view
+   * list, and it was wrong in the one direction that matters: the built-in
+   * "Assigned to me" board is always in that list, so the count was never zero
+   * and every caller asking "is ClickUp set up here" got yes. A repository
+   * whose branches are `ABC-1234-thing` — a Jira shop, a Linear shop, anybody —
+   * got a ClickUp mark on its pull requests and a chip that led to the connect
+   * screen.
+   *
+   * A count could not have been fixed by comparing it against a different
+   * number, because there is no number here that means what this means. So the
+   * server states it and this carries it, and there is nothing left to
+   * misread.
+   */
+  connected: boolean;
   /** `ORBIT-`, when a board has been read. Undefined is "unknown", never "none". */
   prefix?: string;
 }
@@ -35,11 +50,14 @@ export function clickupSetup(): Promise<ClickUpSetup> {
   // link for the next minute.
   inflight ??= api.clickupViews()
     .then((r) => {
-      const value: ClickUpSetup = { boards: r.views.length, prefix: r.prefix || undefined };
+      const value: ClickUpSetup = { connected: r.connected === true, prefix: r.prefix || undefined };
       held = { at: Date.now(), value };
       return value;
     })
-    .catch(() => ({ boards: 0 } as ClickUpSetup))
+    // A server that did not answer is not a machine with ClickUp on it. The
+    // failure is not cached (see above), so this is "not while I cannot ask"
+    // rather than "no" — and the quiet answer is the safe one either way.
+    .catch(() => ({ connected: false } as ClickUpSetup))
     .finally(() => { inflight = null; });
   return inflight;
 }

--- a/web/test/card-move.test.ts
+++ b/web/test/card-move.test.ts
@@ -16,11 +16,22 @@ import type { ListStatus } from "../../shared/providers.ts";
 describe("which card is worth offering to move", () => {
   // Stricter than the chip that merely links to the card: this one writes to
   // somebody's board.
-  const setup = (prefix?: string) => ({ boards: 1, prefix });
+  const setup = (prefix?: string) => ({ connected: true, prefix });
 
-  it("takes a ClickUp address in the body as proof", () => {
+  it("takes a ClickUp address in the body as proof, with no prefix needed", () => {
     const pr = { headRefName: "whatever", title: "x", body: "https://clickup.com/t/86abc123\n" };
-    expect(mergeCardRef(pr, { boards: 0 })?.query).toBe("86abc123");
+    expect(mergeCardRef(pr, { connected: true })?.query).toBe("86abc123");
+  });
+
+  it("offers nothing at all without a ClickUp to write to", () => {
+    // Evidence of a card is not evidence of a connection. A fork of a team that
+    // uses ClickUp carries their addresses in its bodies, and the merge form
+    // used to spin on "Looking up … on ClickUp" before admitting there was no
+    // ClickUp here. Nothing to write with, so nothing to offer.
+    const addressed = { headRefName: "whatever", title: "x", body: "https://clickup.com/t/86abc123\n" };
+    const ours = { headRefName: "ORBIT-1042-rounding", title: "x", body: "" };
+    expect(mergeCardRef(addressed, { connected: false })).toBe(null);
+    expect(mergeCardRef(ours, { connected: false, prefix: "ORBIT-" })).toBe(null);
   });
 
   it("takes a branch id when the workspace's own prefix matches it", () => {

--- a/web/test/card-ref.test.ts
+++ b/web/test/card-ref.test.ts
@@ -6,7 +6,7 @@
 // are invented; the SHAPE is what was measured, and every rule below exists
 // because of something in it.
 import { describe, expect, it } from "bun:test";
-import { cardRef, looksLikeOurs } from "../src/lib/cardRef.ts";
+import { cardRef, chipAction, looksLikeOurs } from "../src/lib/cardRef.ts";
 
 /*
  * A pull-request template, trimmed to the three parts that matter: a checklist
@@ -141,5 +141,56 @@ describe("whether an id belongs to the workspace we are connected to", () => {
     // prefix". Refusing on it would make the chip come and go with a cache.
     expect(looksLikeOurs(branchRef, undefined)).toBe(true);
     expect(looksLikeOurs(branchRef, "")).toBe(true);
+  });
+});
+
+/*
+ * What the chip does, on machines that are not the author's.
+ *
+ * Every rule below already existed and none of them fired, because the value
+ * the caller weighed them against was a count of saved boards — and the
+ * built-in "Assigned to me" board is always in that list, token or no token.
+ * So `boards > 0` was true everywhere, and a repository that has never heard
+ * of ClickUp got ClickUp's own mark on a branch called `ABC-1234-thing`.
+ *
+ * These are written against the machine, not against the id: the same pull
+ * request has to produce three different chips depending on what is connected.
+ */
+describe("what the chip should do, given what this machine has", () => {
+  const jira = cardRef({ headRefName: "ABC-1234-rounding-error" });
+  const ours = cardRef({ headRefName: "ORBIT-1042-rounding-error" });
+  const addressed = cardRef({ body: "https://clickup.com/t/8ab12cd34" });
+
+  it("says nothing at all on a machine with no ClickUp", () => {
+    // The case this whole function exists for. A Jira shop, a Linear shop,
+    // somebody with no tracker: an id in a branch name is not ours to claim.
+    expect(chipAction(jira, { connected: false })).toBe(null);
+    expect(chipAction(ours, { connected: false })).toBe(null);
+  });
+
+  it("still opens an address on a machine with no ClickUp", () => {
+    // A URL needs nobody's credentials, and the body naming one is a fact
+    // rather than a convention. Out to the browser, since there is no board
+    // here to land in.
+    expect(chipAction(addressed, { connected: false }))
+      .toEqual({ in: "clickup", url: "https://clickup.com/t/8ab12cd34" });
+  });
+
+  it("opens the card here once ClickUp is connected", () => {
+    expect(chipAction(ours, { connected: true, prefix: "ORBIT-" })).toEqual({ in: "tasks" });
+    expect(chipAction(addressed, { connected: true, prefix: "ORBIT-" })).toEqual({ in: "tasks" });
+  });
+
+  it("keeps another tracker's ids off the mark even with ClickUp connected", () => {
+    // Somebody who has ClickUp AND a repository whose branches are named for
+    // Jira. The prefix is what separates them.
+    expect(chipAction(jira, { connected: true, prefix: "ORBIT-" })).toBe(null);
+  });
+
+  it("says nothing while the answer is still in flight", () => {
+    // Null setup is "not known yet", never "no" — which is what stops the chip
+    // appearing and then vanishing a beat later.
+    expect(chipAction(ours, null)).toBe(null);
+    expect(chipAction(null, { connected: true })).toBe(null);
   });
 });


### PR DESCRIPTION
## What does this PR do?

The pull-request ↔ card cross-references were shown to everybody, because the test for "is there a ClickUp on this machine" could never come out false: `savedViews()` always leads with the built-in "Assigned to me" board, so the saved-view list is never empty, and three callers were reading its length as a connectedness signal.

On a repository that has never seen a ClickUp token, that meant:

- the masthead chip put ClickUp's own mark on a branch like `ABC-1234-thing`, with a tooltip reading "the ClickUp card this pull request came from", and landed the press on the connect screen;
- the triage chip's rule for hiding a convention-shaped id when nothing can resolve it never once fired;
- the merge dialog offered to move a card on a board this machine cannot write to.

A Jira shop, a Linear shop, and a fork of a team that uses ClickUp all hit this. So did ClickUp workspaces with custom ids switched off, where the learnt prefix is permanently empty and every `API-2024-` branch looked like a card.

The rules were already correct — `cardRef.ts` says in as many words that a Jira shop must not be shown a ClickUp mark — so nothing about them changed. What changed is the value they were weighed against. `/clickup/views` now states `connected` outright (from `hasCredential("clickup")`) and `ClickUpSetup` carries that boolean **in place of** the board count, so there is no number left for a future caller to misread. The decision behind the masthead chip moves out of JSX into `chipAction()`, next to the evidence it weighs, where it can be tested per machine rather than per id.

Three smaller things found in the same walk:

- Pressing a card id with the ClickUp source hidden set the tab and was immediately reconciled away, opening GitHub Issues without a word. The tab is now borrowed for as long as the errand lasts; the preference is never rewritten.
- A card whose PR search could not run — no `gh`, not logged in, a checkout that is not its repository — rendered identically to a card with no pull requests. "We could not look" now says so; a card that genuinely produced none still renders nothing.
- The merge dialog offered a card move without a token when the body carried a clickup.com address, spinning on "Looking up … on ClickUp" before admitting there was no ClickUp to look in. An address is proof of a card and no proof of a connection, so the connection is asked about first.

Behaviour for a connected ClickUp is unchanged, including the deliberate one where a convention-shaped id is still shown while the workspace prefix is not yet known — refusing on an unlearnt prefix would make the chip come and go with a cache.

This touches the server↔web contract: `ClickUpBoards` in `shared/providers.ts` gains `connected`, documented with why the existing `views` array cannot answer the same question.

## How was it tested?

- `bun run typecheck` clean in both `web/` and `server/`.
- All twelve ClickUp-adjacent suites pass (217 tests): `clickup`, `clickupviews`, `clickup-prefix`, `clickup-watch`, `viewcache`, `providers-fast`, `card-ref`, `card-move`, `task-link`, `task-sources`, `triage-board`, `merge-dialog`.
- New tests pin the regression rather than the fix: `chipAction` is exercised per machine in `card-ref.test.ts` (no ClickUp / connected-but-prefix-unknown / connected-with-prefix), the tokenless case is added to `card-move.test.ts`, and `clickup-prefix.test.ts` now asserts that the saved-view list cannot be emptied — so the next caller reaching for a count finds that written down.
- Verified end to end by running the real modules against a machine with no ClickUp store: before, a `ABC-1234-` branch produced a ClickUp chip; after, it produces nothing, while a clickup.com address in the body still opens outward to the browser.

The full suite has 35 failures on this branch; all 35 reproduce on an unmodified tree (confirmed via `git stash`) and are environmental — tmux, port binding, `/proc` and Tailscale, none of which this sandbox provides. None touch ClickUp.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP

---
_Generated by [Claude Code](https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP)_