### PR TITLE
feat: a + that starts an agent from the phone, and a mirror that survives a wrapped prompt

### DIFF
--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -362,6 +362,9 @@ export default function TerminalScreen(): React.ReactNode {
    * happened", and the second press opens a second agent.
    */
   const [opening, setOpening] = useState(false);
+  /** The deadline on that spinner. A ref because it is cleared from a callback
+   *  that must not re-run when it changes. */
+  const openTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
   /**
    * A pane the server has just made for us, which the strip has not caught up
    * with yet.
@@ -396,6 +399,34 @@ export default function TerminalScreen(): React.ReactNode {
     setOpening(true);
     setError(null);
     terminal.current.command({ t: "tmux", cmd: "agent", yolo: true });
+    /*
+     * And a deadline, because a spinner with no way out is worse than a
+     * refusal.
+     *
+     * Reported from QA: the control went to `…` and stayed there, for as long
+     * as anybody watched. The server had returned silently — the frame reached
+     * a guard above this command that answers nothing — and there was no second
+     * writer of `opening`, so the button was dead until the screen remounted.
+     *
+     * That server path is fixed, but it must not be the only thing standing
+     * between a user and a permanent spinner. A socket can also drop between
+     * the send and the reply, and `command()` puts nothing on the wire at all
+     * when the socket is not open, which looks identical from here. So this
+     * ends by itself and says so.
+     *
+     * Eight seconds because the work behind it is `new-window` on a local tmux
+     * — measured in tens of milliseconds — plus however long the phone's radio
+     * takes to carry two small frames. A second would race a sleeping radio; a
+     * minute is a button nobody presses twice.
+     */
+    if (openTimer.current) clearTimeout(openTimer.current);
+    openTimer.current = setTimeout(() => {
+      openTimer.current = null;
+      setOpening((waiting) => {
+        if (waiting) setError("The computer did not answer about the new tab.");
+        return false;
+      });
+    }, 8000);
   }, []);
 
 
@@ -513,6 +544,8 @@ export default function TerminalScreen(): React.ReactNode {
 
   /** What came back from that. Either a pane to go to, or a reason. */
   const onOpened = useCallback((answer: { pane: string } | { error: string }): void => {
+    // The answer landed, so the deadline above has nothing left to say.
+    if (openTimer.current) { clearTimeout(openTimer.current); openTimer.current = null; }
     setOpening(false);
     if ("error" in answer) { setError(answer.error); return; }
     // Straight there. The pane exists on the machine the moment tmux answers,

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -209,6 +209,25 @@ export default function TerminalScreen(): React.ReactNode {
    */
   const shadow = useRef<string | null>(null);
   /*
+   * The line the PANE already holds, when the field could not be made editable.
+   *
+   * The third state, and the one that was missing. `shadow` has two: a line
+   * this field can type into, or nothing at all. An agent's box that has
+   * wrapped is neither — the text is readable and its length is not (see
+   * boxedLine in terminal-html.ts), so the field can show it and cannot compute
+   * an edit against it.
+   *
+   * Treating that as `shadow = null`, which is what happened before this
+   * existed, is what makes the phone send a line the pane already has. Measured
+   * on the emulator: `esto es una linea larga escrita en el ordenador para ver
+   * si el movil la` was typed at the computer, the phone's field went empty and
+   * became a composer, and one word typed into it submitted
+   * "…si el movil la hola2" — the desk's line and the phone's word, run as one
+   * prompt. Holding what the pane has is what lets Send know there is nothing
+   * to send but a carriage return.
+   */
+  const onPane = useRef<string | null>(null);
+  /*
    * Whether somebody has started a line here, and therefore owns it.
    *
    * Not "has the keyboard". Focused and empty, the field should still follow
@@ -333,6 +352,52 @@ export default function TerminalScreen(): React.ReactNode {
   const [keyed, setKeyed] = useState("");
   const keyedSent = useRef("");
   const forgetKeys = useCallback((): void => { setKeyed(""); keyedSent.current = ""; }, []);
+  /**
+   * A `+` that is waiting on tmux, and what to say if it comes back with a
+   * reason instead of a window.
+   *
+   * A button that opens a window somewhere else on the machine has nothing on
+   * this screen to show for itself for about a second — the strip is on a
+   * two-second poll — so without this the honest reading of a press is "nothing
+   * happened", and the second press opens a second agent.
+   */
+  const [opening, setOpening] = useState(false);
+  /**
+   * A pane the server has just made for us, which the strip has not caught up
+   * with yet.
+   *
+   * Held so `load` cannot take the selection back. tmux answers with the new
+   * pane immediately; `/terminal/panes` is on a two-second poll, and the tick
+   * that lands in between carries a list this pane is not in — so the reselect
+   * inside `load` would move the user off the tab they just asked for, once,
+   * and only sometimes. A ref rather than state because it is read inside a
+   * state updater.
+   */
+  const wanted = useRef<string | null>(null);
+
+  /*
+   * Open a window in the project this pane is in, with the agent running in it.
+   *
+   * Sent as an INTENT and not a command: the frame carries `yolo` and nothing
+   * else. The directory is the server's — it reads the pane's own cwd and rolls
+   * it up to that checkout's git root — and so is the binary and the flag. A
+   * `new-window` with no directory lands in the home directory, which is the
+   * failure this button would otherwise have shipped with: an agent opened in
+   * no repository, in a tab that looks exactly like the right one.
+   *
+   * Permissions off, because that is what this button is FOR. A tab opened from
+   * a phone is a tab nobody is sitting in front of, and an agent that stops on
+   * its first tool call to ask a question there has done nothing at all. The
+   * button says so in as many words rather than hiding it in a mode.
+   */
+  const openAgent = useCallback((): void => {
+    if (!terminal.current) return;
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Medium);
+    setOpening(true);
+    setError(null);
+    terminal.current.command({ t: "tmux", cmd: "agent", yolo: true });
+  }, []);
+
 
   /**
    * Read the machine's panes, and adopt the answer only if it says something
@@ -384,6 +449,14 @@ export default function TerminalScreen(): React.ReactNode {
     const best = bestSession(all);
     setSession((current) => (current && all.some((t) => t.session === current) ? current : best));
     setActive((current) => {
+      // A pane we asked for and the strip has not listed yet — see `wanted`.
+      // Held rather than adopted, so the selection does not bounce off it.
+      const want = wanted.current;
+      if (want) {
+        if (!all.some((t) => t.paneId === want)) return current;
+        wanted.current = null;
+        return want;
+      }
       if (current && all.some((t) => t.paneId === current)) return current;
       const inSession = all.filter((t) => t.session === best);
       // The first pane with an agent under it, or the first window. Either way
@@ -438,6 +511,19 @@ export default function TerminalScreen(): React.ReactNode {
     return () => clearInterval(timer);
   }, [load]));
 
+  /** What came back from that. Either a pane to go to, or a reason. */
+  const onOpened = useCallback((answer: { pane: string } | { error: string }): void => {
+    setOpening(false);
+    if ("error" in answer) { setError(answer.error); return; }
+    // Straight there. The pane exists on the machine the moment tmux answers,
+    // so the attach does not have to wait for the strip to list it — `wanted`
+    // is what stops the next poll undoing this.
+    wanted.current = answer.pane;
+    setActive(answer.pane);
+    setWhy(null);
+    void load();
+  }, [load]);
+
   const onKey = useCallback((bytes: string): void => {
     void Haptics.selectionAsync();
     /*
@@ -451,6 +537,10 @@ export default function TerminalScreen(): React.ReactNode {
      * how a completion gets erased by the character typed after it.
      */
     claimed.current = false;
+    // And the read of it, for the same reason: a bar key changes the line under
+    // the field, so what `onPane` holds describes a screen that no longer
+    // exists. Dropped rather than refreshed — the next report seeds it again.
+    onPane.current = null;
     terminal.current?.send(bytes);
   }, []);
 
@@ -491,14 +581,26 @@ export default function TerminalScreen(): React.ReactNode {
    * middle of a line, and adopting a `null` from a pane too narrow to read
    * silently cuts the field off from the shell it is typing into.
    */
-  const onLine = useCallback((text: string | null): void => {
+  const onLine = useCallback((text: string | null, exact = true): void => {
     if (claimed.current) return;
-    shadow.current = text;
+    // Editable only when the read is exact. An inexact one still fills the
+    // field — that is the whole point, the two sides are meant to show the same
+    // thing — but it is remembered as the pane's rather than as ours, so
+    // nothing computes a difference against a length that was reconstructed.
+    shadow.current = exact ? text : null;
+    onPane.current = exact ? null : text;
     setMirror(text !== null);
     if (text !== null) setDraft(text);
   }, []);
 
-  const submit = useCallback((): void => {
+  /**
+   * Send this line, whatever route it took to be on the pane.
+   *
+   * Takes the text rather than reading `draft`, because the return key can
+   * arrive as part of a change — see `typed` — and then the text to send is the
+   * one in that event and not the one the last paint was made from.
+   */
+  const commit = useCallback((text: string): void => {
     /*
      * With the mirror on, the line is ALREADY on the pane — this key put it
      * there character by character — so sending the text again would run it
@@ -506,12 +608,13 @@ export default function TerminalScreen(): React.ReactNode {
      * this button means.
      */
     if (shadow.current !== null) {
-      if (!draft) return;
+      if (!text) return;
       void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       terminal.current?.send("\r");
       // Cleared here rather than waiting for the pane to say so: the field is
       // empty the instant Enter is pressed, everywhere else in the world.
       shadow.current = "";
+      onPane.current = null;
       // The line is gone, so nobody owns it any more and the pane may seed the
       // next one. Released here rather than on blur alone: sending is how a
       // line ends, and the keyboard usually stays up for the next one.
@@ -519,7 +622,25 @@ export default function TerminalScreen(): React.ReactNode {
       setDraft("");
       return;
     }
-    if (!draft) return;
+    /*
+     * The pane has this line and this field only READ it — so, again, Enter
+     * and nothing else.
+     *
+     * The branch below would send the text, and that is the corruption this
+     * whole `onPane` business exists to stop: measured on the emulator, a long
+     * line typed at the computer plus one word typed here ran as the two of
+     * them concatenated. `onPane` is only ever set from a line that is on the
+     * screen, so "already there" is a fact and not an assumption.
+     */
+    if (onPane.current !== null) {
+      void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+      terminal.current?.send("\r");
+      onPane.current = null;
+      claimed.current = false;
+      setDraft("");
+      return;
+    }
+    if (!text) return;
     claimed.current = false;
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
     /*
@@ -530,22 +651,66 @@ export default function TerminalScreen(): React.ReactNode {
      * replace is for pasted text, which is the only way a newline gets in
      * here; `submitBehavior` below spends the return key on sending.
      */
-    terminal.current?.send(`${draft.replace(/\n/g, "\r")}\r`);
+    terminal.current?.send(`${text.replace(/\n/g, "\r")}\r`);
     setDraft("");
-  }, [draft]);
+  }, []);
+
+  /**
+   * The bytes an edit becomes, with the one character a terminal must never be
+   * handed by accident taken out.
+   *
+   * A newline in the MIDDLE of the field can only have arrived by paste, and
+   * what it means on a pane is not what it means in a text box. Measured
+   * against a real Claude Code pane: a bare LF does not submit, it puts a
+   * SECOND ROW in the input box — and the cursor then sits on a row with no
+   * prompt marker on it, which is the exact state that turns the mirror off.
+   * So one keystroke would both fail to do what was asked and break the field
+   * that asked it. CR is what the return key is on a terminal, and it is what
+   * every other path here already sends.
+   */
+  const forPane = (keys: string): string => keys.replace(/\n/g, "\r");
 
   /*
+   * Not memoised, and that is deliberate rather than an omission: it reads
+   * `raw`, and a `typed` held across a mode switch is a field that goes on
+   * behaving like the mode it was created in. A `TextInput`'s `onChangeText` is
+   * not a memo boundary, so a new function per render costs nothing here.
+   */
+  function typed(text: string): void {
+    /*
+     * A newline at the END of the field is the return key, and it has to be
+     * caught here because it does not always arrive as one.
+     *
+     * `onSubmitEditing` is the documented route and it fires for Gboard's ✓ and
+     * for a hardware Enter — both measured on the emulator. It is not the only
+     * route: an IME that commits the return as TEXT through the input
+     * connection never raises an editor action at all, and then the newline
+     * simply lands in the field. That is the shape of "I press enter and
+     * nothing sends, and then it works the second time" — the second press
+     * comes after the composing region has been ended by the tap, and takes the
+     * other route.
+     *
+     * Both routes now end in `commit`, so whichever the keyboard chooses, the
+     * line goes. The newline itself never reaches the pane.
+     */
+    if (text.endsWith("\n")) {
+      const body = text.replace(/\n+$/, "");
+      typedBody(body);
+      commit(body);
+      return;
+    }
+    typedBody(text);
+  }
+
+  /**
    * What the field does with what was typed, which is the whole of the mode.
    *
-   * In `keys` the field is a conduit rather than a place: the character goes
-   * down the socket and the field is emptied again in the same frame, because
-   * its `value` is a constant empty string and React Native writes a
-   * controlled value back to the native input on every change event. That is
-   * also why the keyboard type changes with the mode — a predicting keyboard
-   * rewrites what it has already handed over, and here that has already been
-   * sent and cannot be taken back.
+   * In `keys` the field is a conduit rather than a place: the difference is put
+   * on the pane's stdin as it is made, and the field keeps what was typed so a
+   * backspace is an ordinary change rather than a key event Android will not
+   * deliver — see `keyed`.
    */
-  const typed = useCallback((text: string): void => {
+  function typedBody(text: string): void {
     if (raw) {
       setKeyed(text);
       // The difference, not the field. See `keyed` above for the measurement
@@ -554,7 +719,7 @@ export default function TerminalScreen(): React.ReactNode {
       // sends rather than as a retype.
       const keys = editFor(keyedSent.current, text);
       keyedSent.current = text;
-      if (keys) terminal.current?.send(keys);
+      if (keys) terminal.current?.send(forPane(keys));
       return;
     }
     setDraft(text);
@@ -562,6 +727,28 @@ export default function TerminalScreen(): React.ReactNode {
     // no longer listened to. An empty field gives it back, so clearing the
     // field and waiting is a way to pick up whatever is typed at the desk.
     claimed.current = text.length > 0;
+
+    /*
+     * A line this field only READ can still be typed onto — as long as the
+     * typing is at the END of it.
+     *
+     * That restriction is not caution, it is the whole of what is knowable.
+     * `onPane` holds a line rejoined from the rows an agent wrapped it across,
+     * so its LENGTH may be off by one per break (see boxedLine); a DEL count
+     * computed against it would delete the wrong number of characters from
+     * somebody's real prompt. An APPEND needs no length at all — what to send
+     * is the part of the field past the text that was shown, and that is exact
+     * whatever happened at the joins.
+     *
+     * Once one character has been appended, this field's own record takes over
+     * and every edit after it is ordinary: `shadow` starts from the text that
+     * was displayed, so backspacing into what was just typed is exact too, and
+     * backspacing PAST it fails the prefix test above and is left alone.
+     */
+    if (shadow.current === null && onPane.current !== null) {
+      if (!text.startsWith(onPane.current)) return;
+      shadow.current = onPane.current;
+    }
 
     const was = shadow.current;
     if (was === null) return; // a composer: nothing leaves until it is sent
@@ -572,15 +759,15 @@ export default function TerminalScreen(): React.ReactNode {
     const keys = editFor(was, text);
     if (!keys) return;
     shadow.current = text;
-    terminal.current?.send(keys);
-  }, [raw]);
+    terminal.current?.send(forPane(keys));
+  }
 
   /** What the return key does, in either mode. In `keys` nothing is being held
    *  back, so it is the key itself and goes through the bar's own route. */
   const onReturn = useCallback((): void => {
     if (raw) { onKey("\r"); return; }
-    submit();
-  }, [raw, onKey, submit]);
+    commit(draft);
+  }, [raw, onKey, commit, draft]);
 
   if (!host) return null;
 
@@ -735,6 +922,35 @@ export default function TerminalScreen(): React.ReactNode {
               );
             })}
           </ScrollView>
+          {/*
+            A new tab, with an agent already running in it.
+
+            Pinned beside the re-read rather than carried at the end of the
+            scroller, and for the reason written on that button: where a control
+            riding after the last tab SITS depends on how many tabs there are,
+            so with six windows the `+` is off the right-hand edge — and the
+            moment somebody wants a seventh is the moment there are six.
+
+            Live only while a pane is attached, because the pane is what says
+            WHERE: the server reads this pane's own directory to decide which
+            project the window opens in. Without one there is no answer that is
+            not the home directory, which is the wrong tab drawn convincingly.
+          */}
+          <Pressable
+            onPress={openAgent}
+            disabled={!open || opening}
+            accessibilityRole="button"
+            accessibilityLabel="New tab running Claude in this project, with permission prompts off"
+            style={{
+              paddingHorizontal: SPACE.md, minHeight: 44, justifyContent: "center",
+              borderLeftWidth: 1, borderLeftColor: C.border,
+            }}
+          >
+            <Text style={{
+              color: !open || opening ? C.text4 : C.primary,
+              fontSize: T.title, fontWeight: "700",
+            }}>{opening ? "…" : "+"}</Text>
+          </Pressable>
           <Pressable
             onPress={() => { void load(); }}
             accessibilityRole="button"
@@ -766,6 +982,7 @@ export default function TerminalScreen(): React.ReactNode {
             onState={onState}
             onTmux={(info) => setPrefix(prefixKey(info.prefix?.[0]))}
             onLine={onLine}
+            onOpened={onOpened}
             onGrid={(next) => setGrid(next)}
             // The desk took its width back. Two things follow, and neither is a
             // disconnect: the window's real size is now this, and this phone is

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -1147,6 +1147,33 @@ export default function TerminalScreen(): React.ReactNode {
           </Text>
         </Pressable>
       ) : null}
+      {/*
+        Something this screen was told and has nowhere else to say.
+
+        Reported from QA, and it was the message ABOUT the missing message: the
+        `+`'s deadline fired, the control came back — measured — and the
+        sentence explaining why never appeared anywhere. `error` had exactly one
+        reader, inside the "Nothing open" card, which draws only when NO pane is
+        attached. A pane is attached whenever the `+` can be pressed at all, so
+        every word written here went to a branch that could not be on screen at
+        the same time as the button that wrote it. The server's own refusal —
+        "this terminal is not attached to tmux yet" — was invisible for the same
+        reason and had never been seen either.
+
+        Tap to dismiss. It is the answer to a press, so it belongs to the person
+        who pressed and should go when they have read it, rather than sitting
+        over the pane until something else replaces it.
+      */}
+      {open && error ? (
+        <Pressable
+          onPress={() => setError(null)}
+          accessibilityRole="button"
+          accessibilityLabel={`${error}. Tap to dismiss.`}
+          style={{ paddingHorizontal: SPACE.lg, paddingVertical: SPACE.sm, backgroundColor: C.bg2 }}
+        >
+          <Text style={{ color: C.error, fontSize: T.eyebrow }}>{error}</Text>
+        </Pressable>
+      ) : null}
       {open && state !== "live" ? (
         <View style={{ paddingHorizontal: SPACE.lg, paddingVertical: SPACE.xs, backgroundColor: C.bg2 }}>
           <Text style={{ color: state === "gone" ? C.error : C.text3, fontSize: T.eyebrow }}>

--- a/mobile/src/terminal/TerminalView.tsx
+++ b/mobile/src/terminal/TerminalView.tsx
@@ -30,6 +30,15 @@ export type TerminalState = "connecting" | "live" | "gone";
 export interface TerminalHandle {
   /** Send bytes as if they had been typed. The key bar's only route in. */
   send: (bytes: string) => void;
+  /**
+   * Ask the machine's tmux for something, on the socket this pane is on.
+   *
+   * Separate from `send` because it is the opposite kind of thing: `send` puts
+   * bytes on a shell's stdin, this asks the SERVER to act — and the server is
+   * what decides what that means. The only caller today is the `+`, whose whole
+   * security argument is that the client names an intent and never a command.
+   */
+  command: (frame: PtyClientFrame) => void;
   focus: () => void;
 }
 
@@ -62,8 +71,21 @@ interface Props {
    * cursor's row, so it is refusing to guess rather than handing up a line of
    * output. A caller that seeds a field from this must treat `null` as "leave
    * it alone", never as "empty".
+   *
+   * `exact` is whether that text is something an EDIT may be computed against.
+   *
+   * True when the marker was on the cursor's own row, which is the case the
+   * mirror was built for: the field is the line and every keystroke goes on as
+   * the difference. False when the line was rejoined from the rows an agent
+   * wrapped it onto — the text is right to show and its LENGTH is not
+   * trustworthy, because a screen cannot say whether a break was a wrap, a word
+   * wrap that ate its space, or a newline. See boxedLine in terminal-html.ts.
    */
-  onLine?: (text: string | null) => void;
+  onLine?: (text: string | null, exact: boolean) => void;
+  /** A window this client asked the server to open, and the pane it landed on.
+   *  The `+` uses it to put the user inside the tab they just made rather than
+   *  leaving them to find it in a strip that repolls every two seconds. */
+  onOpened?: (opened: { pane: string; window: string; cwd: string } | { error: string }) => void;
   /** How wide and tall the tmux window really is, once the server has said.
    *  Without a fit this is the desk's size, and the difference between it and
    *  what is on screen is exactly what is missing. */
@@ -94,7 +116,7 @@ interface Props {
 const ptyFrame = (frame: PtyClientFrame): string => JSON.stringify(frame);
 
 export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalView(
-  { host, pane, root, fit, columns, palette, onState, onTmux, onLine, onGrid, onPane }, ref,
+  { host, pane, root, fit, columns, palette, onState, onTmux, onLine, onGrid, onPane, onOpened }, ref,
 ) {
   const webview = useRef<WebView>(null);
   const socket = useRef<WebSocket | null>(null);
@@ -163,8 +185,8 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
    * none of them, which is the shape this needs: the socket's lifetime belongs
    * to the pane, not to whoever happens to be listening.
    */
-  const handlers = useRef({ onState, onTmux, onLine, onGrid, onPane });
-  handlers.current = { onState, onTmux, onLine, onGrid, onPane };
+  const handlers = useRef({ onState, onTmux, onLine, onGrid, onPane, onOpened });
+  handlers.current = { onState, onTmux, onLine, onGrid, onPane, onOpened };
 
   const inject = useCallback((js: string): void => {
     webview.current?.injectJavaScript(`${js};true;`);
@@ -179,6 +201,10 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
     send: (bytes: string): void => {
       const ws = socket.current;
       if (ws && ws.readyState === 1) ws.send(ptyFrame({ t: "in", d: bytes }));
+    },
+    command: (frame: PtyClientFrame): void => {
+      const ws = socket.current;
+      if (ws && ws.readyState === 1) ws.send(ptyFrame(frame));
     },
     focus: (): void => inject("window.AGX.focus()"),
   }), [inject]);
@@ -238,6 +264,12 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
         // The only control frame worth surfacing: the server refusing, and
         // saying why. "that pane is gone" is a real answer somebody can act on.
         if (frame.t === "fatal") handlers.current.onState("gone", frame.error);
+        if (frame.t === "opened") {
+          handlers.current.onOpened?.({ pane: frame.pane, window: frame.window, cwd: frame.cwd });
+        }
+        // The refusal, and NOT through onState: see the note on `openfail`.
+        // A button that did not work must not read as a terminal that died.
+        if (frame.t === "openfail") handlers.current.onOpened?.({ error: frame.error });
         if (frame.t === "ready" && frame.pane) handlers.current.onGrid?.(frame.pane);
         // The same numbers as `ready`'s, arriving later because the window
         // moved. `ready` is sent once; this is how a size stays true after it.
@@ -329,7 +361,7 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
   }, []);
 
   const onMessage = useCallback((event: WebViewMessageEvent): void => {
-    let message: { t?: string; d?: string; cols?: number; rows?: number; text?: string | null; lines?: number };
+    let message: { t?: string; d?: string; cols?: number; rows?: number; text?: string | null; exact?: boolean; lines?: number };
     try { message = JSON.parse(event.nativeEvent.data) as typeof message; } catch { return; }
     const ws = socket.current;
 
@@ -368,7 +400,14 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
      * that treats the first as the second wipes what somebody is typing.
      */
     if (message.t === "line") {
-      handlers.current.onLine?.(typeof message.text === "string" ? message.text : null);
+      // `exact` absent is the safe reading, not the convenient one: a page from
+      // before this field existed only ever posted a single-row read, which IS
+      // exact. A default of false there would turn every mirror on an older
+      // WebView into a composer.
+      handlers.current.onLine?.(
+        typeof message.text === "string" ? message.text : null,
+        message.exact !== false,
+      );
       return;
     }
     if (message.t === "size" && message.cols && message.rows) {

--- a/mobile/src/terminal/terminal-html.ts
+++ b/mobile/src/terminal/terminal-html.ts
@@ -481,6 +481,45 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
    * border, so the row starts with the border and not with the marker.
    */
   var PROMPT = /^[\\s\\u2502\\u2503\\u250a\\u2506|]*[>$#%\\u276f\\u276d\\u203a\\u27e9\\u3009\\u25b6]\\s?/;
+  /*
+   * The horizontal rule an agent draws its input box with.
+   *
+   * Only ever used as a STOP. Walking up out of the cursor's row looking for a
+   * prompt marker has to end somewhere, and "the top of the box" is the one
+   * boundary that is drawn on the screen rather than guessed at: above it is
+   * the transcript, and a marker up there belongs to a turn that has already
+   * been sent. Eight is short enough for a narrow split and long enough that a
+   * line of dashes in somebody's output does not read as a box.
+   */
+  var RULE = /^[\\u2500\\u2501\\u2504\\u2505\\u2508\\u2509\\u254c\\u254d\\u2550-]{8,}$/;
+  /** How far up a box may reach. A prompt of twelve rows on a phone is already
+   *  more than the pane shows; past that this stops looking rather than
+   *  walking a screenful of transcript on every keystroke. */
+  var BOX_ROWS = 12;
+  /**
+   * Everything on this side of the pane divider, on one row.
+   *
+   * Lifted out of lineNow unchanged so the rows ABOVE the cursor's get the
+   * same cut: a split window shares every buffer row, so a continuation row of
+   * an agent's box reads "their output │ the rest of my line" exactly as the
+   * cursor's row does, and reading one without the cut would put the
+   * neighbour's screen into the field.
+   */
+  var afterBorder = function (text, from, to) {
+    for (var b = to - 1; b >= from; b--) {
+      var code = text.charCodeAt(b);
+      if (code === 0x2502 || code === 0x2503 || code === 0x250a || code === 0x2506 || code === 0x2551) {
+        return text.slice(b + 1, to);
+      }
+    }
+    // No divider on this row: keep everything up to the cut, INCLUDING what is
+    // before the cut's start. On the cursor's row that start is where the row
+    // begins inside a
+    // string that may also hold the rows it wrapped from, and those are part of
+    // the same line — dropping them here is how a long shell command came back
+    // as its last wrap only.
+    return text.slice(0, to);
+  };
   var lastLine;
   var lineNow = function () {
     var buffer = term.buffer.active;
@@ -553,15 +592,7 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
      * typed is full of pipes, and cutting at the last one would hand back the
      * tail of somebody's pipeline as the whole of it.
      */
-    var border = -1;
-    for (var b = at - 1; b >= rowStart; b--) {
-      var code = raw.charCodeAt(b);
-      if (code === 0x2502 || code === 0x2503 || code === 0x250a || code === 0x2506 || code === 0x2551) {
-        border = b;
-        break;
-      }
-    }
-    if (border >= 0) raw = raw.slice(border + 1);
+    raw = afterBorder(raw, rowStart, at);
     /*
      * And the prompt is at the START of what survives that cut, or there is no
      * prompt here.
@@ -598,7 +629,12 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
      * DELs into somebody's real command.
      */
     var match = PROMPT.exec(raw);
-    if (!match) return null;
+    // No marker on the cursor's row is not "no line" — an agent's box wraps a
+    // long prompt onto rows it draws itself, and the cursor spends most of a
+    // long line on one of them. See boxedLine: what comes back from there is
+    // marked inexact, because a screen cannot say whether the break between
+    // two rows was a wrap or a newline somebody typed.
+    if (!match) return boxedLine(end);
     /*
      * Trailing blanks off, and xterm's own trim is not enough.
      *
@@ -631,14 +667,88 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
     // the template literal and the file stops compiling; and spelling the
     // BROKEN form out in prose puts it in the page, where the test looking for
     // it cannot tell an explanation from a regression.
-    return raw.slice(match[0].length).replace(/\\s+$/, '');
+    return { text: raw.slice(match[0].length).replace(/\\s+$/, ''), exact: true };
   };
+  /*
+   * The same line when the agent has wrapped it onto rows of its own.
+   *
+   * ── the bug this exists to end, measured ──────────────────────────────────
+   * Claude Code draws its prompt in a box: a rule of U+2500, a row beginning
+   * "\\u276f\\u00a0", another rule. Past about the pane's width it wraps, and
+   * the second row is drawn by the program — indented under the marker, with
+   * no marker of its own and NOT flagged as wrapped in the buffer, because
+   * nothing ran off the right edge; the program moved the cursor there. So the
+   * cursor's row holds "  y mas", PROMPT finds nothing at index 0, and the
+   * read above correctly answers "I cannot tell".
+   *
+   * On a phone that reads as the feature being broken. Measured on the emulator
+   * against a real pane: a 78-character line typed at the computer put the
+   * whole of it on the pane and left the phone's field EMPTY, its placeholder
+   * flipping from "This is the pane's line" to "Write a line for this pane" —
+   * one side showing the text and the other not, which is the complaint.
+   *
+   * ── why what comes back is marked inexact ─────────────────────────────────
+   * The rows can be rejoined; they cannot be rejoined EXACTLY. A break between
+   * two rows is one of three things and the screen shows the same pixels for
+   * all of them: a hard wrap mid-word (join with nothing), a word wrap (the
+   * space at the break is not drawn, so it is lost), or a newline the person
+   * put there. Guessing wrong changes the LENGTH of what the field believes the
+   * line is, and the field's edits are counted in characters — which is exactly
+   * how DELs end up aimed at somebody's real command. So this answers with what
+   * to SHOW and says it is not something to compute an edit against; the screen
+   * treats it as a line that is already on the pane rather than as one to type
+   * into character by character.
+   */
+  var boxedLine = function (end) {
+    var buffer = term.buffer.active;
+    var top = -1, indent = 0, head = '';
+    for (var up = 1; up <= BOX_ROWS; up++) {
+      var y = end - up;
+      if (y < 0) return null;
+      var line = buffer.getLine(y);
+      if (!line) return null;
+      var text = afterBorder(line.translateToString(false), 0, term.cols).replace(/\\s+$/, '');
+      // The top of the box. A marker above it belongs to a turn that has
+      // already been sent — see the note on RULE.
+      if (RULE.test(text.trim())) return null;
+      var m = PROMPT.exec(text);
+      if (m) { top = y; indent = m[0].length; head = text.slice(m[0].length); break; }
+    }
+    if (top < 0) return null;
+    /*
+     * And every row under it has to look like a continuation of that box, or
+     * this is not one line and none of it is ours.
+     *
+     * The test is the indent: an agent aligns the wrapped rows under the text
+     * column, so the first indent-many cells of a continuation row are blank.
+     * Anything else — output that arrived under the prompt, a second pane's
+     * text past a divider we did not cut — fails here and the read goes back to
+     * answering null rather than joining two unrelated things.
+     */
+    var parts = [head];
+    for (var y2 = top + 1; y2 <= end; y2++) {
+      var row = buffer.getLine(y2);
+      if (!row) return null;
+      var full = row.translateToString(false);
+      // The cursor bounds the last row, exactly as it does in the read above:
+      // what is past it has not been typed.
+      var upto = y2 === end ? buffer.cursorX : term.cols;
+      var body = afterBorder(full, 0, upto);
+      if (body.slice(0, indent).trim() !== '') return null;
+      parts.push(body.slice(indent).replace(/\\s+$/, ''));
+    }
+    return { text: parts.join('\\n'), exact: false };
+  };
+  var lastExact = true;
   var reportLine = function () {
     try {
-      var text = lineNow();
-      if (text === lastLine) return;
+      var read = lineNow();
+      var text = read ? read.text : null;
+      var exact = read ? read.exact : true;
+      if (text === lastLine && exact === lastExact) return;
       lastLine = text;
-      post({ t: 'line', text: text });
+      lastExact = exact;
+      post({ t: 'line', text: text, exact: exact });
     } catch (e) {
       // The buffer is mid-resize. The next render says the same thing.
     }

--- a/mobile/test/mirror.test.ts
+++ b/mobile/test/mirror.test.ts
@@ -278,6 +278,37 @@ describe("a line the field could read but cannot edit", () => {
     expect(held).not.toContain("${text");
   });
 
+  test("the newline it shows is never put on the wire", () => {
+    /*
+     * Reported from QA: a 102-character line typed at the desk arrives in the
+     * field as 103 characters with a newline at the box's wrap point, because
+     * `boxedLine` joins the rows an agent drew with "\n". The text is whole —
+     * `field.replace("\n","") === original` — and one character wrong.
+     *
+     * It is wrong for DISPLAY only, and this is the assertion that says so. The
+     * field holds what the box looks like; what reaches the pane is a carriage
+     * return and nothing else, because the pane already has the line. So the
+     * newline cannot become a line break inside somebody's prompt, and cannot
+     * become a submit halfway through a shell command.
+     *
+     * Why the join is not simply fixed: the break between two rows is a hard
+     * wrap, a word wrap whose space was never drawn, or a newline somebody
+     * typed, and the screen shows the same pixels for all three. "Ends at the
+     * inner width" does not separate them — Claude word-wraps, so a wrapped row
+     * routinely ends short. That is what `exact: false` means, and this test is
+     * the guarantee that goes with it.
+     */
+    const commit = screen.slice(screen.indexOf("const commit ="), screen.indexOf("function typed("));
+    const from = commit.indexOf("if (onPane.current !== null)");
+    const held = commit.slice(from, commit.indexOf("if (!text) return;", from));
+    // The whole arm: a carriage return, and no path that puts the field's text
+    // — newline and all — on the socket.
+    expect(held).toContain('terminal.current?.send("\\r")');
+    expect(held.match(/terminal\.current\?\.send\(/g)).toHaveLength(1);
+    expect(held).not.toContain("draft");
+    expect(held).not.toContain("${text");
+  });
+
   test("typing onto it is allowed only where no length has to be believed", () => {
     /*
      * An append needs no arithmetic: what to send is the part of the field past

--- a/mobile/test/mirror.test.ts
+++ b/mobile/test/mirror.test.ts
@@ -216,10 +216,103 @@ describe("the field's claim on the line", () => {
     expect(screen).toContain("onBlur={() => { claimed.current = false; forgetKeys(); }}");
     const onKey = screen.slice(screen.indexOf("const onKey ="), screen.indexOf("const onState ="));
     expect(onKey).toContain("claimed.current = false;");
-    // Both arms of submit: the one that only sends a carriage return, and the
-    // one that sends the whole line.
-    const submit = screen.slice(screen.indexOf("const submit ="), screen.indexOf("const typed ="));
-    expect(submit.match(/claimed\.current = false;/g)).toHaveLength(2);
+    // All three arms of the send: the exact mirror, which only needs a carriage
+    // return; the line the field READ off a wrapped box, which also only needs
+    // one; and the composer, which sends the whole thing. `submit` was renamed
+    // `commit` when it stopped reading `draft` and started taking the text —
+    // see the note there on the return key arriving inside a change event.
+    const commit = screen.slice(screen.indexOf("const commit ="), screen.indexOf("function typed("));
+    expect(commit.match(/claimed\.current = false;/g)).toHaveLength(3);
+  });
+});
+
+/*
+ * The line an agent wrapped, and the two things that must not happen to it.
+ *
+ * Both were measured on the emulator against a real Claude Code pane, and they
+ * are the same bug seen from two ends. A line longer than the pane is drawn on
+ * rows the PROGRAM lays out — indented under the prompt, no marker of their
+ * own, not flagged as wrapped in the buffer — so the cursor's row has nothing
+ * for `PROMPT` to find and the read answered null:
+ *
+ *   1. the phone's field went EMPTY while the pane held the whole line, which
+ *      is "one shows the text and the other does not";
+ *   2. and the field, now a composer, sent its contents on top of what was
+ *      already there. Captured: `esto es una linea larga escrita en el
+ *      ordenador para ver si el movil la` typed at the computer plus `hola2`
+ *      typed on the phone ran as one prompt, concatenated.
+ */
+describe("a line the field could read but cannot edit", () => {
+  const screen = readFileSync(join(import.meta.dir, "..", "app", "(tabs)", "terminal.tsx"), "utf8");
+  const page = readFileSync(join(import.meta.dir, "..", "src", "terminal", "terminal-html.ts"), "utf8");
+
+  test("the page rejoins the rows rather than answering nothing", () => {
+    expect(page).toContain("var boxedLine = function (end)");
+    expect(page).toContain("if (!match) return boxedLine(end);");
+    // And says which kind of answer it is, every time, so the screen never has
+    // to infer it from the text.
+    expect(page).toContain("exact: true");
+    expect(page).toContain("exact: false");
+  });
+
+  test("it stops at the top of the box instead of walking the transcript", () => {
+    // A marker above the rule belongs to a turn that has already been sent, and
+    // joining one into the field would put an old prompt in front of the live
+    // one. The rule is drawn on the screen, so this is a boundary and not a
+    // guess.
+    expect(page).toContain("if (RULE.test(text.trim())) return null;");
+    expect(page).toContain("for (var up = 1; up <= BOX_ROWS; up++)");
+  });
+
+  test("an inexact read is held as the pane's line, never as the field's", () => {
+    expect(screen).toContain("shadow.current = exact ? text : null;");
+    expect(screen).toContain("onPane.current = exact ? null : text;");
+  });
+
+  test("and Send then sends a carriage return, not the line again", () => {
+    const commit = screen.slice(screen.indexOf("const commit ="), screen.indexOf("function typed("));
+    const from = commit.indexOf("if (onPane.current !== null)");
+    const held = commit.slice(from, commit.indexOf("if (!text) return;", from));
+    expect(held).toContain('terminal.current?.send("\\r")');
+    // The one line that would put the corruption back.
+    expect(held).not.toContain("${text");
+  });
+
+  test("typing onto it is allowed only where no length has to be believed", () => {
+    /*
+     * An append needs no arithmetic: what to send is the part of the field past
+     * the text that was shown. Everything else does — a DEL count is computed
+     * against a length, and a rejoined line's length is off by one per break
+     * that was a word wrap, because the space at the break is never drawn.
+     */
+    expect(screen).toContain("if (!text.startsWith(onPane.current)) return;");
+    expect(screen).toContain("shadow.current = onPane.current;");
+  });
+});
+
+/*
+ * The return key, and the newline that is not one.
+ *
+ * Measured against a real Claude Code pane: a bare LF does NOT submit — it puts
+ * a second row in the input box, and the cursor then sits on a row with no
+ * prompt marker, which is the state that turns the mirror off. So a keystroke
+ * that arrives as text rather than as an editor action both fails to send and
+ * breaks the field that sent it, which is exactly "I press enter, nothing
+ * happens, and it works the second time".
+ */
+describe("what the return key becomes", () => {
+  const screen = readFileSync(join(import.meta.dir, "..", "app", "(tabs)", "terminal.tsx"), "utf8");
+
+  test("a trailing newline in the field is a send, not a character", () => {
+    expect(screen).toContain('if (text.endsWith("\\n"))');
+    expect(screen).toContain('const body = text.replace(/\\n+$/, "");');
+  });
+
+  test("and no newline ever reaches the pane as one", () => {
+    expect(screen).toContain('const forPane = (keys: string): string => keys.replace(/\\n/g, "\\r");');
+    // Both writers of pane bytes from the field go through it.
+    const typed = screen.slice(screen.indexOf("function typedBody("));
+    expect(typed.match(/terminal\.current\?\.send\(forPane\(keys\)\)/g)).toHaveLength(2);
   });
 });
 

--- a/mobile/test/mirror.test.ts
+++ b/mobile/test/mirror.test.ts
@@ -331,6 +331,37 @@ describe("a line the field could read but cannot edit", () => {
  * breaks the field that sent it, which is exactly "I press enter, nothing
  * happens, and it works the second time".
  */
+/*
+ * A message with nowhere to appear is not a message.
+ *
+ * Found by QA measuring the `+`'s deadline: the guard released on time and the
+ * sentence saying why never showed up anywhere on screen. `error` had one
+ * reader, inside the "Nothing open" card, which draws only when NO pane is
+ * attached — and a pane is attached whenever the `+` can be pressed. So both
+ * the deadline's words and the server's own "not attached to tmux yet" refusal
+ * were written to a branch that cannot be on screen at the same time as the
+ * button that writes them.
+ */
+describe("where a refusal actually lands", () => {
+  const screen = readFileSync(join(import.meta.dir, "..", "app", "(tabs)", "terminal.tsx"), "utf8");
+
+  test("there is a reader for it while a pane IS open", () => {
+    expect(screen).toContain("{open && error ? (");
+  });
+
+  test("and the empty-state card is no longer the only one", () => {
+    // Two readers, not one: the card for when nothing is attached, and the row
+    // above the key bar for when something is.
+    expect(screen.match(/\{open && error \? \(|tone={error \? "bad" : "quiet"}/g)).toHaveLength(2);
+  });
+
+  test("the deadline writes a sentence, not a code", () => {
+    // Whatever it says has to be readable by somebody holding a phone — this is
+    // the one path where the app is explaining its own silence.
+    expect(screen).toContain('setError("The computer did not answer about the new tab.")');
+  });
+});
+
 describe("what the return key becomes", () => {
   const screen = readFileSync(join(import.meta.dir, "..", "app", "(tabs)", "terminal.tsx"), "utf8");
 

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -1121,6 +1121,86 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       return;
     }
 
+    /*
+     * The phone's `+`: a new window with the agent in it, in THIS project.
+     *
+     * ── where, and why the server decides it ─────────────────────────────
+     * `new-window` with no `-c` inherits the session's default directory,
+     * which on this machine is the home directory — so the button that was
+     * asked for ("open a Claude here") would have opened one in `~`, in no
+     * repository at all, and the only sign of it would be an agent that
+     * cannot find the file you then ask it about. The pane this socket is
+     * attached to is what "here" means, so its cwd is read from tmux at the
+     * moment of the press (see `paneCwd` — the sweep's copy is up to two
+     * seconds old) and rolled up to that checkout's git root.
+     *
+     * `repoRootOf` and not `projectRootOf`: a pane sitting in a linked
+     * worktree is somebody working on that branch, and folding it up to the
+     * main checkout would open the agent in the wrong tree. A directory that
+     * is not a repository at all keeps the pane's own cwd, which is still
+     * where the person is.
+     *
+     * ── and the flag ─────────────────────────────────────────────────────
+     * The client sends a boolean. Everything that reaches a command line here
+     * — the binary, the flag, the directory — is resolved on this side, which
+     * is the same division `cmd:"issue"` above already makes and the reason
+     * this socket being reachable from the UI is not a way to run things.
+     */
+    if (msg.cmd === "agent") {
+      /*
+       * Above the `!s.tmux` guard below, and that placement is a fix rather
+       * than a style choice.
+       *
+       * Everything under that guard answers a client by DOING something to
+       * tmux, so "there is no tmux" is correctly a silent no-op there. This
+       * command is the one with a caller WAITING on a reply: the phone turns
+       * its `+` into a spinner and only a frame turns it back. Reported from
+       * QA against a session whose sweep had not resolved a target — the press
+       * registered, nothing came back, and the control sat on `…` for as long
+       * as anybody watched. A button with no way out is worse than one that
+       * refuses.
+       */
+      const target = s.tmux;
+      if (!target) {
+        ctl(ws, { t: "openfail", error: "this terminal is not attached to tmux yet — try again in a moment" });
+        return;
+      }
+      const at = s.phoneAttach;
+      const where = at ? paneCwd(target.socket, at.paneId) : null;
+      // Nothing to anchor to is a reason to refuse, not to fall back on a home
+      // directory: an agent in the wrong tree is the failure this exists to
+      // prevent, and it is invisible once it has happened.
+      if (!where || !existsSync(where)) {
+        ctl(ws, { t: "openfail", error: "could not tell which project this pane is in" });
+        return;
+      }
+      const root = repoRootOf(where) ?? where;
+      if (!inScope(root)) {
+        ctl(ws, { t: "openfail", error: "that project is outside the workspace" });
+        return;
+      }
+      const bin = claudeCode.bin();
+      // The window is named after the checkout, which is what tells six of them
+      // apart in a strip — `agentglass`, `width-toast`, `phone-new-tab`.
+      const name = basename(root) || "agent";
+      const opened = bin
+        ? newWindowRunning(target, root, name, [
+            bin,
+            ...(msg.yolo === true ? ["--dangerously-skip-permissions"] : []),
+          ])
+        // No agent on this machine is not a reason to open nothing: a shell in
+        // the right project is still most of what was asked for, and the same
+        // answer `cmd:"issue"` gives.
+        : newWindowRunning(target, root, name, []);
+      if (!opened) {
+        ctl(ws, { t: "openfail", error: "tmux would not open a window" });
+        return;
+      }
+      ctl(ws, { t: "opened", pane: opened.paneId, window: opened.windowId, cwd: root });
+      s.tmuxSweep?.();
+      return;
+    }
+
     if (!s.tmux) return;
 
     /*
@@ -1236,69 +1316,6 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       } else {
         newWindowRunning(target, cwd, name, []);
       }
-      s.tmuxSweep?.();
-      return;
-    }
-
-    /*
-     * The phone's `+`: a new window with the agent in it, in THIS project.
-     *
-     * ── where, and why the server decides it ─────────────────────────────
-     * `new-window` with no `-c` inherits the session's default directory,
-     * which on this machine is the home directory — so the button that was
-     * asked for ("open a Claude here") would have opened one in `~`, in no
-     * repository at all, and the only sign of it would be an agent that
-     * cannot find the file you then ask it about. The pane this socket is
-     * attached to is what "here" means, so its cwd is read from tmux at the
-     * moment of the press (see `paneCwd` — the sweep's copy is up to two
-     * seconds old) and rolled up to that checkout's git root.
-     *
-     * `repoRootOf` and not `projectRootOf`: a pane sitting in a linked
-     * worktree is somebody working on that branch, and folding it up to the
-     * main checkout would open the agent in the wrong tree. A directory that
-     * is not a repository at all keeps the pane's own cwd, which is still
-     * where the person is.
-     *
-     * ── and the flag ─────────────────────────────────────────────────────
-     * The client sends a boolean. Everything that reaches a command line here
-     * — the binary, the flag, the directory — is resolved on this side, which
-     * is the same division `cmd:"issue"` above already makes and the reason
-     * this socket being reachable from the UI is not a way to run things.
-     */
-    if (msg.cmd === "agent") {
-      const target = s.tmux;
-      const at = s.phoneAttach;
-      const where = at ? paneCwd(target.socket, at.paneId) : null;
-      // Nothing to anchor to is a reason to refuse, not to fall back on a home
-      // directory: an agent in the wrong tree is the failure this exists to
-      // prevent, and it is invisible once it has happened.
-      if (!where || !existsSync(where)) {
-        ctl(ws, { t: "openfail", error: "could not tell which project this pane is in" });
-        return;
-      }
-      const root = repoRootOf(where) ?? where;
-      if (!inScope(root)) {
-        ctl(ws, { t: "openfail", error: "that project is outside the workspace" });
-        return;
-      }
-      const bin = claudeCode.bin();
-      // The window is named after the checkout, which is what tells six of them
-      // apart in a strip — `agentglass`, `width-toast`, `phone-new-tab`.
-      const name = basename(root) || "agent";
-      const opened = bin
-        ? newWindowRunning(target, root, name, [
-            bin,
-            ...(msg.yolo === true ? ["--dangerously-skip-permissions"] : []),
-          ])
-        // No agent on this machine is not a reason to open nothing: a shell in
-        // the right project is still most of what was asked for, and the same
-        // answer `cmd:"issue"` gives.
-        : newWindowRunning(target, root, name, []);
-      if (!opened) {
-        ctl(ws, { t: "openfail", error: "tmux would not open a window" });
-        return;
-      }
-      ctl(ws, { t: "opened", pane: opened.paneId, window: opened.windowId, cwd: root });
       s.tmuxSweep?.();
       return;
     }

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -148,6 +148,17 @@ type PhoneAttach = {
    * Using this as truth would put the same invisible lie back.
    */
   windowId: string;
+  /**
+   * The pane this socket was opened on — the id the client asked for.
+   *
+   * Routing again, and honest about the same limit as `windowId`: it is where
+   * this attach STARTED, not where the phone has since walked. That is enough
+   * for the one thing it is read for, which is "which project is this person
+   * looking at" when they ask for a new window: a phone that walked away with
+   * `^b n` is not the case the `+` button is for, and the answer would still be
+   * a directory on the same machine rather than a wrong action.
+   */
+  paneId: string;
   /** `window-size` as each window of the group had it before this phone
    *  arrived, so the way out is a restore and not a guess. */
   hadWindowSize: Record<string, string>;
@@ -319,7 +330,7 @@ function killGroup(s: Session, sigNum: number) {
   } catch { /* already gone */ }
 }
 
-import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
+import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";
 import { prepareReviewPrompt } from "./prs.ts";
 import { claudeCode, supportsSessionName } from "./agents/claudecode.ts";
@@ -557,7 +568,7 @@ export function ptyOpen(ws: PtyWs) {
   const session: Session = {
     proc, mode, grouped: HAS_SETSID, sizeDir, viewDir, closed: false, exited: false, killTimer: null,
     phoneAttach: attach
-      ? { socket: attach.socket, sessionId: attach.groupedWith, windowId: attach.windowId, hadWindowSize: attach.hadWindowSize, fit: d.fit === true, zoomed: attach.zoomed, phoneSession: attach.session, seq: ++attachSeq }
+      ? { socket: attach.socket, sessionId: attach.groupedWith, windowId: attach.windowId, paneId: String(d.pane), hadWindowSize: attach.hadWindowSize, fit: d.fit === true, zoomed: attach.zoomed, phoneSession: attach.session, seq: ++attachSeq }
       : null,
   };
   sessions.set(ws, session);
@@ -1225,6 +1236,69 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       } else {
         newWindowRunning(target, cwd, name, []);
       }
+      s.tmuxSweep?.();
+      return;
+    }
+
+    /*
+     * The phone's `+`: a new window with the agent in it, in THIS project.
+     *
+     * ── where, and why the server decides it ─────────────────────────────
+     * `new-window` with no `-c` inherits the session's default directory,
+     * which on this machine is the home directory — so the button that was
+     * asked for ("open a Claude here") would have opened one in `~`, in no
+     * repository at all, and the only sign of it would be an agent that
+     * cannot find the file you then ask it about. The pane this socket is
+     * attached to is what "here" means, so its cwd is read from tmux at the
+     * moment of the press (see `paneCwd` — the sweep's copy is up to two
+     * seconds old) and rolled up to that checkout's git root.
+     *
+     * `repoRootOf` and not `projectRootOf`: a pane sitting in a linked
+     * worktree is somebody working on that branch, and folding it up to the
+     * main checkout would open the agent in the wrong tree. A directory that
+     * is not a repository at all keeps the pane's own cwd, which is still
+     * where the person is.
+     *
+     * ── and the flag ─────────────────────────────────────────────────────
+     * The client sends a boolean. Everything that reaches a command line here
+     * — the binary, the flag, the directory — is resolved on this side, which
+     * is the same division `cmd:"issue"` above already makes and the reason
+     * this socket being reachable from the UI is not a way to run things.
+     */
+    if (msg.cmd === "agent") {
+      const target = s.tmux;
+      const at = s.phoneAttach;
+      const where = at ? paneCwd(target.socket, at.paneId) : null;
+      // Nothing to anchor to is a reason to refuse, not to fall back on a home
+      // directory: an agent in the wrong tree is the failure this exists to
+      // prevent, and it is invisible once it has happened.
+      if (!where || !existsSync(where)) {
+        ctl(ws, { t: "openfail", error: "could not tell which project this pane is in" });
+        return;
+      }
+      const root = repoRootOf(where) ?? where;
+      if (!inScope(root)) {
+        ctl(ws, { t: "openfail", error: "that project is outside the workspace" });
+        return;
+      }
+      const bin = claudeCode.bin();
+      // The window is named after the checkout, which is what tells six of them
+      // apart in a strip — `agentglass`, `width-toast`, `phone-new-tab`.
+      const name = basename(root) || "agent";
+      const opened = bin
+        ? newWindowRunning(target, root, name, [
+            bin,
+            ...(msg.yolo === true ? ["--dangerously-skip-permissions"] : []),
+          ])
+        // No agent on this machine is not a reason to open nothing: a shell in
+        // the right project is still most of what was asked for, and the same
+        // answer `cmd:"issue"` gives.
+        : newWindowRunning(target, root, name, []);
+      if (!opened) {
+        ctl(ws, { t: "openfail", error: "tmux would not open a window" });
+        return;
+      }
+      ctl(ws, { t: "opened", pane: opened.paneId, window: opened.windowId, cwd: root });
       s.tmuxSweep?.();
       return;
     }

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -776,14 +776,30 @@ function statusInConfig(t: TmuxTarget): string {
  * Passed as separate arguments rather than a shell string — tmux runs a bare
  * string through the user's login shell, and this one is fish on the machine
  * where that was last discovered the hard way.
+ *
+ * Answers WHAT IT MADE, or null. It used to answer a boolean, and the callers
+ * that ignore the value read the same either way — but a caller that has to
+ * tell somebody where the window went cannot get that from the poll:
+ * `/terminal/panes` is a list, and "the newest row" is whatever the desk
+ * created in the same second. `-P -F` is tmux's own answer to that question,
+ * asked in the command that already runs.
  */
-export function newWindowRunning(t: TmuxTarget, cwd: string, name: string, argv: string[]): boolean {
+export function newWindowRunning(
+  t: TmuxTarget, cwd: string, name: string, argv: string[],
+): { paneId: string; windowId: string } | null {
   const clean = sanitizeWindowName(name);
-  return tmux(t.socket, [
-    "new-window", "-t", t.id, "-c", cwd,
+  // Tab-separated, like every other format string here: a window name can
+  // contain spaces, and neither of these two fields can contain a tab.
+  const out = tmux(t.socket, [
+    "new-window", "-P", "-F", "#{pane_id}\t#{window_id}", "-t", t.id, "-c", cwd,
     ...(clean ? ["-n", clean] : []),
     ...argv,
-  ]) !== null;
+  ]);
+  if (out === null) return null;
+  const [paneId = "", windowId = ""] = (out.split("\n")[0] ?? "").trim().split("\t");
+  // Both, or neither. tmux printing something this does not recognise is not a
+  // reason to hand a caller a string that goes on a command line.
+  return PANE_ID.test(paneId) && WINDOW_ID.test(windowId) ? { paneId, windowId } : null;
 }
 
 /**
@@ -952,6 +968,26 @@ export function setStatusLine(t: TmuxTarget, visible: boolean): boolean {
 
 const PANE_ID = /^%\d+$/;
 const SESSION_ID = /^\$\d+$/;
+
+/**
+ * Where a pane is, as tmux answers it right now.
+ *
+ * The shell's own cwd, not the directory the window was created in — `cd` at
+ * the desk moves this, which is the point: "open a new tab here" means where
+ * the hand is, not where the window started an hour ago.
+ *
+ * Asked of tmux rather than read off the last `/terminal/panes` sweep because
+ * the two are different clocks. The sweep is up to two seconds old and is a
+ * list; this is a question about one pane, asked at the moment somebody
+ * pressed a button.
+ */
+export function paneCwd(socket: string[], paneId: string): string | null {
+  if (!PANE_ID.test(paneId)) return null;
+  const out = tmux(socket, ["display-message", "-p", "-t", paneId, "#{pane_current_path}"]);
+  const path = out?.split("\n")[0]?.trim() ?? "";
+  // Relative or empty is not a directory this may hand to `new-window -c`.
+  return path.startsWith("/") ? path : null;
+}
 
 /**
  * Which server a `-S`/`-L`/nothing spelling actually names, as a path.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -500,6 +500,31 @@ export type PtyServerFrame =
    * inactive frame is `{ active: false, windows: [], panes: [] }`.
    */
   | { t: "tmux"; active: boolean; windows: TmuxWindow[]; panes: TmuxPane[]; session?: string | null; prefix?: string[]; client?: { cols: number; rows: number } | null }
+  /**
+   * A window this socket was asked to open, and the pane it landed on.
+   *
+   * Answered rather than left to the poll, because the poll cannot tell the
+   * caller WHICH tab is theirs. `/terminal/panes` is re-read every couple of
+   * seconds and a phone that guessed "the newest one" would open whatever the
+   * desk happened to create in the same beat. The id is the only unambiguous
+   * answer, and it is what lets a `+` land the user inside the thing they just
+   * asked for instead of next to it.
+   *
+   * `cwd` is the directory the window was actually opened in — the project
+   * root, not the pane's subdirectory — so a client can say where it went
+   * without asking a second question.
+   */
+  | { t: "opened"; pane: string; window: string; cwd: string }
+  /**
+   * That window did not open, and why — which is NOT a `fatal`.
+   *
+   * `fatal` means this socket is over: the client paints "Disconnected" and the
+   * pane it was showing goes with it. A `+` that could not work out which
+   * project the pane is in has broken nothing, and answering it with the frame
+   * that tears the terminal down would turn a button that did not work into a
+   * terminal that died.
+   */
+  | { t: "openfail"; error: string }
   /** The shell ended by itself. The socket closes right behind this. */
   | { t: "exit"; code: number | null }
   /** The server is refusing, and saying why — "that pane is gone", a disabled
@@ -556,6 +581,24 @@ export type PtyClientFrame =
   /** `fit` sizes the tmux window to THIS client — see tmuxctl.ts, and the
    *  reason it exists: with a bigger client attached, `window-size largest`
    *  leaves the bottom of the pane below the panel. */
+  /**
+   * A new window running the agent, in the project the attached pane is in.
+   *
+   * The client sends no path and no command — not as a convenience, but because
+   * this is the one frame on this socket that starts a program with the
+   * permission prompts turned off, and a directory from the client would make
+   * "where" a thing the UI could choose. The server reads
+   * `#{pane_current_path}` off the pane this socket is attached to and rolls it
+   * up to that checkout's git root, which is what "the project I am working in"
+   * means on a machine whose windows live in worktrees. A `new-window` with no
+   * `-c` lands in the session's default directory — the home directory on this
+   * machine — and a phone that opens the agent in `~` has opened it in the
+   * wrong repository, silently.
+   *
+   * `yolo` buys exactly one flag, the same division `cmd:"issue"` already
+   * makes. It is a boolean rather than a string for that reason.
+   */
+  | { t: "tmux"; cmd: "agent"; yolo?: boolean }
   | { t: "tmux"; cmd: "select" | "new" | "kill" | "rename" | "move" | "takeover" | "fit"; window?: string; name?: string;
       /** `fit` only: the asking panel's own grid. Range-checked on the server —
        *  it ends up in a `resize-window`, so it is a number to validate rather


### PR DESCRIPTION
## What does this PR do?

Two things the phone could not do: start a new agent, and finish a line somebody began at the computer.

**A `+` on the tab strip** opens a new tmux window in the checkout you are looking at and starts an agent in it. The window is named after the checkout rather than after the command, so the strip still reads like the desk's. It answers in words when it cannot: a socket whose tmux target has not resolved yet gets *"this terminal is not attached to tmux yet — try again in a moment"* rather than silence, and the control gives up after eight seconds and says the computer did not answer, so a dropped socket cannot leave a spinner turning for ever.

**The mirror survives a wrapped prompt.** A long line typed at the desk used to leave the phone's field empty, because the read gave up when an agent's box wrapped it across two rows. It now recovers the whole line. The field can therefore hold a newline the pane does not have — the box's wrap point — and that newline can never travel: for a line the field merely read, sending emits a bare carriage return and never the field's text, because the pane already holds the line and sending it again is the duplication this exists to prevent. Pinned by a test, so a refactor that starts sending the field's contents fails a build instead of somebody's command.

## How was it tested?

`tsc --noEmit` clean for `server/` and `mobile/`; **398 mobile tests pass**.

Then driven on an Android emulator against a real build of this branch — desktop app installed from it, release APK built from it, verified before use by grepping the fix's strings out of the installed server binary and the APK's Hermes string table rather than trusting a build timestamp.

Measured there:

* **`+` opens a window in about two seconds**, named `agentglass` — the checkout — and it keeps that name for at least 24 seconds with tmux's `automatic-rename` on at the server level.
* **The failure path releases at eight seconds exactly.** With the phone's tmux session killed and the pane showing `[exited]`, the control was sampled once a second: nothing for seven seconds, then at t+8s *"The computer did not answer about the new tab."* appears and stays. Counted in pixels rather than read off a screenshot.
* **Enter sends on the first press.** Gboard enabled and selected, the field's action key is ✓ (`IME_ACTION_DONE`, because the field is multiline), and one tap submitted the line — with the IMEs disabled this cannot be tested at all, since `input keyevent` is not the path the bug lived on.
* **The mirror's newline stays put.** A 102-character line typed at the desk arrived in the field as 103 characters with one newline at the box's wrap point; sent, the agent received one line, described it as a single blob, and nothing was duplicated.
* **No regression in the key bar or the width controls:** `⇧Tab` moved the agent's mode, `^C` cleared the box, `↑` recalled the previous line, `80c`/`60c` changed both the label and the real tmux window from 80 to 60 columns, and `fit` set `window-size manual` with the window following the phone.

Two keys are inconclusive rather than passed: `Esc` left the agent's box unchanged and `Tab` on an empty box did nothing visible. Both match what is already known about that box — no key clears it — so neither says anything about key delivery, which the other five keys demonstrate by their effects.

Three defects were found and fixed during that run rather than after it: the `+` hung for ever on a socket with no tmux target, because its handler sat below a `return` that answers by doing nothing; the sentence explaining a failure was written to a card that only draws when no pane is attached, so it could never be on screen at the same time as the button that wrote it; and the QA notes carried absolute home paths.
