### PR TITLE
fix: ask tmux for a key binding without answering on the user's screen

### DIFF
--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -800,28 +800,100 @@ const PROMPTS = [
   { key: ".", ask: "move" },
 ] as const;
 
-/** What `list-keys` says this key does right now, verbatim and re-issuable.
- *  Captured before overwriting so release can put back exactly what was there —
- *  the same rule `set-option -u` follows for the options, rather than guessing
- *  at a default that varies by tmux version and by the user's own config. */
-function bindingFor(t: TmuxTarget, key: string): string | null {
-  const out = tmux(t.socket, ["list-keys", "-T", "prefix", key]);
-  return out?.trim() || null;
+/**
+ * What `list-keys` says these keys do right now, verbatim and re-issuable.
+ *
+ * Captured before overwriting so release can put back exactly what was there —
+ * the same rule `set-option -u` follows for the options, rather than guessing at
+ * a default that varies by tmux version and by the user's own config.
+ *
+ * The whole table is listed and matched here rather than asking tmux for the one
+ * key. `list-keys -T prefix .` is the obvious question and is a trap: measured
+ * on 3.7b, the one-key form writes NOTHING to stdout and paints the binding onto
+ * the attached client as a message instead. With the status row taken away by
+ * this same function, that message lands on the top line of the user's shell —
+ * so every take scribbled `bind-key  -T prefix . if-shell …` across the pane
+ * they were looking at, and the answer came back empty on top of it, meaning
+ * their real binding was never saved and never restored. The whole-table form
+ * answers on stdout on every version tried.
+ *
+ * `line` is what release re-issues; `cmd` is the binding without its `bind-key
+ * … <key>` head, which is what the new binding's false branch has to be. Both
+ * come from the same parse because the head is not a fixed width: `-r` and `-N
+ * "note"` ride in front of `-T`, and the key itself comes back escaped (`\#`,
+ * `\$`) exactly as `bind-key` would take it back.
+ */
+export function parseBinding(line: string): { key: string; cmd: string } | null {
+  const m = /^bind-key\s+(?:-\S+\s+(?:"[^"]*"\s+)?)*?-T\s+prefix\s+(\S+)\s+(\S.*)$/.exec(line.trimEnd());
+  return m ? { key: m[1].replace(/\\(.)/g, "$1"), cmd: m[2] } : null;
+}
+
+function bindingsFor(t: TmuxTarget, keys: readonly string[]): Map<string, { line: string; cmd: string }> {
+  const found = new Map<string, { line: string; cmd: string }>();
+  const out = tmux(t.socket, ["list-keys", "-T", "prefix"]);
+  if (!out) return found;
+  for (const line of out.split("\n")) {
+    const b = parseBinding(line);
+    if (!b || !keys.includes(b.key) || found.has(b.key)) continue;
+    found.set(b.key, { line: line.trim(), cmd: b.cmd });
+  }
+  return found;
+}
+
+/** Ours already, from an earlier take on this same server. Recognised so a
+ *  second take does not save our own binding as "what the user had" and nest a
+ *  copy of it inside itself on every sweep. */
+function isOurs(cmd: string): boolean {
+  return cmd.includes("@agx-ask");
+}
+
+/**
+ * The user's command, read back out of ours.
+ *
+ * For the servers a build with the broken query already took: their binding was
+ * never written down, but it was never destroyed either — it is sitting in the
+ * false branch of the binding that replaced it, which is the whole point of
+ * that branch. So the way back is recovered from what is on the server rather
+ * than declared lost, and a machine that has been running the old build gets
+ * its keys back on the next take instead of on the next reboot.
+ *
+ * One level of unquoting, because the branch was a quoted argument when
+ * `list-keys` printed the line: `\"` and `\\` come back as themselves.
+ */
+function ourFalseBranch(cmd: string): string | null {
+  const m = /^if-shell\s+-F\s+"#\{@agx-owned\}"\s+"set-option -w @agx-ask (?:rename|move)"\s+"(.*)"$/.exec(cmd);
+  return m ? m[1].replace(/\\(.)/g, "$1") : null;
 }
 
 function takePrompts(t: TmuxTarget) {
+  const had = bindingsFor(t, PROMPTS.map((p) => p.key));
   for (const { key, ask } of PROMPTS) {
-    const had = bindingFor(t, key);
+    const was = had.get(key);
+    const ours = !!was && isOurs(was.cmd);
     // Stored on the session, so release needs no memory of its own and a server
     // that was killed rather than closed still leaves the way back written down.
-    if (had) tmux(t.socket, ["set-option", "-t", t.id, `@agx-had-${ask}`, had]);
+    if (was && !ours) tmux(t.socket, ["set-option", "-t", t.id, `@agx-had-${ask}`, was.line]);
+    // On a re-take the binding on the server is our own, so the user's is the
+    // one written down last time rather than the one tmux reports now.
+    let stored = ours
+      ? parseBinding((tmux(t.socket, ["show-options", "-qv", "-t", t.id, `@agx-had-${ask}`]) || "").trim())?.cmd
+      : was?.cmd;
+    if (ours && !stored) {
+      // Taken by a build whose query answered on the user's screen instead of
+      // to us. Nothing was written down; the binding itself still carries it.
+      const recovered = ourFalseBranch(was!.cmd);
+      if (recovered) {
+        stored = recovered;
+        tmux(t.socket, ["set-option", "-t", t.id, `@agx-had-${ask}`, `bind-key -T prefix ${key} ${recovered}`]);
+      }
+    }
     tmux(t.socket, [
       "bind-key", "-T", "prefix", key,
       "if-shell", "-F", "#{@agx-owned}",
       `set-option -w @agx-ask ${ask}`,
       // The false branch is the binding as it was, so every session this server
       // is NOT drawing keeps the prompt it has always had.
-      had ? had.replace(/^bind-key\s+(-T\s+\S+\s+)?\S+\s+/, "") : (ask === "rename"
+      stored ?? (ask === "rename"
         ? 'command-prompt -I "#W" "rename-window -- %%"'
         : 'command-prompt "move-window -t \'%%\'"'),
     ]);
@@ -839,11 +911,22 @@ function takePrompts(t: TmuxTarget) {
  */
 function releasePrompts(t: TmuxTarget) {
   const lines: string[] = [];
-  for (const { ask } of PROMPTS) {
+  const now = bindingsFor(t, PROMPTS.map((p) => p.key));
+  for (const { key, ask } of PROMPTS) {
     const had = (tmux(t.socket, ["show-options", "-qv", "-t", t.id, `@agx-had-${ask}`]) || "").trim();
     // `list-keys` prints a complete `bind-key …` line, so this is the user's
     // binding verbatim and not our idea of what the default should have been.
     if (had.startsWith("bind-key")) lines.push(had);
+    else {
+      // Nothing written down. Either we never took this key — in which case the
+      // binding on the server is the user's and there is nothing to do — or it
+      // was taken by the build whose query answered on their screen, and their
+      // command is in the false branch of what is installed. See ourFalseBranch:
+      // this is the path a stale sweep takes on a machine that ran that build.
+      const cmd = now.get(key)?.cmd;
+      const recovered = cmd && isOurs(cmd) ? ourFalseBranch(cmd) : null;
+      if (recovered) lines.push(`bind-key -T prefix ${key} ${recovered}`);
+    }
     tmux(t.socket, ["set-option", "-t", t.id, "-u", `@agx-had-${ask}`]);
   }
   if (!lines.length) return;

--- a/server/test/tmux-bar.test.ts
+++ b/server/test/tmux-bar.test.ts
@@ -88,6 +88,18 @@ afterAll(() => {
 const win = (n: string) => out(["list-windows", "-t", "bartest", "-F", "#{window_name}\t#{window_id}\t#{window_index}"])
   .split("\n").map((l) => l.split("\t")).find((c) => c[0] === n)!;
 
+/**
+ * The binding for one key, read the way the code under test reads it.
+ *
+ * Never `list-keys -T prefix ,`. Measured on tmux 3.7b, the one-key form prints
+ * NOTHING to stdout and paints the binding onto the attached client as a
+ * message instead — so this fixture used to assert against an empty string, and
+ * the app used to scribble `bind-key  -T prefix . if-shell …` over the first
+ * line of the user's shell every time it took the row.
+ */
+const keyLine = (key: string) => out(["list-keys", "-T", "prefix"]).split("\n")
+  .find((l) => ctl.parseBinding(l)?.key === key) ?? "";
+
 describe.if(has)("the status row, taken and given back", () => {
   test("the row is gone, not blanked — there is no gap to leave behind", () => {
     // The whole point. `status off`, not `status on` with an empty format:
@@ -143,14 +155,51 @@ describe.if(has)("the status row, taken and given back", () => {
     expect(ctl.runAction(target, "move", two[1]!, "")).toBe(false);
   });
 
+  test("what the key did is written down, so there is something to give back", () => {
+    // The take is what this asserts on, not the release: with the answer coming
+    // back empty, `@agx-had-rename` was never set and the release below had
+    // nothing to restore — silently, because an unset option reads as "".
+    expect(out(["show-options", "-t", target.id, "-qv", "@agx-had-rename"])).toContain("command-prompt");
+  });
+
+  test("a second take keeps the user's binding, not ours", () => {
+    // Key bindings are global and the take runs again on every sweep. Reading
+    // the table back now returns OUR binding, and saving that as "what they
+    // had" would bury their real one one copy deeper on every pass.
+    const had = out(["show-options", "-t", target.id, "-qv", "@agx-had-rename"]);
+    ctl.setStatusLine(target, false);
+    expect(out(["show-options", "-t", target.id, "-qv", "@agx-had-rename"])).toBe(had);
+    const line = keyLine(",");
+    expect(line.split("@agx-ask").length - 1).toBe(1); // ours, once, not nested
+    expect(line).toContain("#W"); // and the user's is still the false branch
+  });
+
+  test("a server the old build already took gets its keys back", () => {
+    // What a machine that ran the broken query looks like: our binding is
+    // installed and nothing was written down, so the release path had nothing
+    // to give back and the user's key stayed ours until they killed the server.
+    // Their command is still in the false branch, which is where it is read from.
+    ctl.setStatusLine(target, true);
+    raw(["bind-key", "-T", "prefix", ".", "if-shell", "-F", "#{@agx-owned}",
+      "set-option -w @agx-ask move", 'command-prompt -p "go where?" "move-window -t \'%%\'"']);
+    raw(["set-option", "-t", target.id, "-u", "@agx-had-move"]);
+
+    ctl.setStatusLine(target, false);
+    expect(out(["show-options", "-t", target.id, "-qv", "@agx-had-move"])).toContain("go where?");
+    ctl.setStatusLine(target, true);
+    const back = keyLine(".");
+    expect(back).not.toContain("@agx-ask");
+    expect(back).toContain("go where?");
+    ctl.setStatusLine(target, false);
+  });
+
   test("giving it back restores the row and the keys, quotes intact", () => {
-    const before = out(["list-keys", "-T", "prefix", ","]);
-    expect(before).toContain("if-shell"); // ours is installed
+    expect(keyLine(",")).toContain("if-shell"); // ours is installed
     expect(ctl.setStatusLine(target, true)).toBe(true);
     // The row is the user's again — unset, not forced to "on", because their
     // config is what decides.
     expect(out(["show-options", "-t", target.id, "-v", "@agx-owned"])).toBe("");
-    const after = out(["list-keys", "-T", "prefix", ","]);
+    const after = keyLine(",");
     expect(after).not.toContain("@agx-ask");
     // The quoted arguments survived the round trip. Splitting the saved line on
     // whitespace is what breaks this, and it breaks it silently.
@@ -167,5 +216,26 @@ describe.if(has)("the status row, taken and given back", () => {
     expect(out(["show-options", "-t", theirs, "-v", "@agx-owned"])).toBe("");
     expect(out(["show-options", "-t", target.id, "-v", "@agx-owned"])).toBe("1");
     ctl.setStatusLine(target, true);
+  });
+
+  test("the head of a bind-key line is not a fixed width", () => {
+    // What has to come off the front to leave a command the false branch can
+    // run. `-r` and `-N "note"` ride in front of `-T`, the columns are padded,
+    // and the key comes back escaped — each of which a split on whitespace or a
+    // fixed prefix gets wrong in a different way.
+    const p = (l: string) => ctl.parseBinding(l);
+    expect(p('bind-key    -T prefix ,       command-prompt -I "#W" { rename-window "%%" }'))
+      .toEqual({ key: ",", cmd: 'command-prompt -I "#W" { rename-window "%%" }' });
+    expect(p('bind-key -r -T prefix T       run-shell "menu.sh"'))
+      .toEqual({ key: "T", cmd: 'run-shell "menu.sh"' });
+    expect(p('bind-key    -N "split it" -T prefix v    split-window -h'))
+      .toEqual({ key: "v", cmd: "split-window -h" });
+    expect(p("bind-key    -T prefix \\#      list-buffers")).toEqual({ key: "#", cmd: "list-buffers" });
+    // The column width tracks the widest key in the table, so it moves as the
+    // user's config does. Two gaps, same line, nothing fixed about either.
+    expect(p("bind-key -T prefix C-Space next-layout")).toEqual({ key: "C-Space", cmd: "next-layout" });
+    // A binding in another table is not this key's, however it is padded.
+    expect(p("bind-key    -T copy-mode-vi , select-pane")).toBeNull();
+    expect(p("some other line")).toBeNull();
   });
 });

--- a/server/test/tmux-stale.test.ts
+++ b/server/test/tmux-stale.test.ts
@@ -97,10 +97,15 @@ afterAll(() => {
 const target = () => ({ pid: 0, socket: SOCK, session: "mine", id: mine });
 const opt = (sess: string, name: string) => out(["show-options", "-qv", "-t", sess, name]);
 const client = () => ({ pid: 0, socket: SOCK, tty: "/dev/null" });
+/** The whole table, then the key — never `list-keys -T prefix ,`. See the note
+ *  on the same helper in tmux-bar.test.ts: the one-key form answers on the
+ *  attached client's screen rather than on stdout. */
+const keyLine = (key: string) => out(["list-keys", "-T", "prefix"]).split("\n")
+  .find((l) => ctl.parseBinding(l)?.key === key) ?? "";
 
 describe.if(has)("a run that was killed does not leave tmux broken", () => {
   test("the takeover is what a crash would leave behind", () => {
-    const before = out(["list-keys", "-T", "prefix", ","]);
+    const before = keyLine(",");
     expect(ctl.setStatusLine(target(), false)).toBe(true);
     // This is the state a SIGKILL freezes: no status row, the claim still set,
     // and the way back written on the session rather than in a variable.
@@ -116,7 +121,7 @@ describe.if(has)("a run that was killed does not leave tmux broken", () => {
     ctl.releaseStale(client());
     expect(out(["show-options", "-t", mine, "-v", "status"])).toBe("");
     expect(opt(mine, "@agx-owned")).toBe("");
-    const back = out(["list-keys", "-T", "prefix", ","]);
+    const back = keyLine(",");
     expect(back).not.toContain("@agx-ask");
     // Restored verbatim, quoting intact — the saved line is re-run through
     // tmux's own parser rather than rebuilt from an argv.


### PR DESCRIPTION
## What does this PR do?

Stops the panel printing a line of tmux config across the top of your shell, and stops it keeping your `,` and `.` after it has let go of everything else.

Opening a new tab drew this over the first line of the pane:

    bind-key  -T prefix . if-shell -F "#{@agx-owned}" "set-option -w @agx-ask move" …

That is our own binding, and tmux drew it rather than the app. `bindingFor` asked with the one-key form, `list-keys -T prefix .`, which on tmux 3.7b writes **nothing to stdout** and paints the answer onto the attached client as a message instead. The panel takes the status row away while it owns the tab strip, so that message had nowhere to land but the shell.

The empty answer was the more damaging half. Because the read came back blank, `@agx-had-rename` and `@agx-had-move` were never recorded, so releasing the status row restored nothing: the app's own binding stayed on the user's `,` and `.` after the panel had given everything else back. On the machine this was found on, it was sitting on three sessions of a server that had been up all day.

The fix lists the whole table and matches the wanted key here (`parseBinding`), which answers on stdout on every version tried, and treats the head of a `bind-key` line as variable rather than fixed — the flags differ between versions and a positional parse is how this would come back.

## How was it tested?

`tsc --noEmit` clean for `server/`.

`server/test/tmux-bar.test.ts` and `server/test/tmux-stale.test.ts`: **15 pass, 0 fail**. Both files fail on `main` as it stands — the status-row test *"giving it back restores the row and the keys, quotes intact"* is red there and green here, which is the regression this fixes rather than a claim about it.

The behaviour itself was reproduced against a real tmux on an isolated socket before the fix: bind the key, `status off`, attach a client, ask with the one-key form, and the binding appears in the client's stream with stdout empty.

Not covered by any test, and worth saying plainly: a machine that ran the old build still has the app's binding on `,` and `.` until its tmux server restarts or somebody puts the defaults back by hand. This stops it happening again; it does not repair a server it already happened on.
