### PR TITLE
fix: a teardown that only restores what it moved, and clears only what it fixed

### DIFF
--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2691,6 +2691,39 @@ export function restoreWindows(
      * Before the `-A`, so the window is recomputed once, with the layout it is
      * going to keep.
      */
+    /*
+     * What the window carries NOW, against what was recorded when this phone
+     * arrived. Three answers, and only one of them is a restore (#488).
+     *
+     * `hadWindowSize` lists every window of the group, because a phone's
+     * grouped session shares them all — but the phone only ever MOVED the one
+     * it fitted. Walking the rest was writing a snapshot over windows nothing
+     * had touched, and the snapshot ages: measured, a desk that pressed "Fit to
+     * this window" after the phone arrived had its deliberate `manual` replaced
+     * by the `largest` this record was taken with, minutes later, by a teardown
+     * for a window the phone was never on.
+     *
+     * `show-options -qwv` answers empty for a window option that is not set,
+     * rather than the inherited value — measured on 3.7b — so "" here really is
+     * "this window carries none of its own", which is what `had` spells the
+     * same way.
+     */
+    const now = (tmux(socket, ["show-options", "-qwv", "-t", id, "window-size"]) ?? "").trim();
+    // Already where it belongs. Nothing to put back, and nothing owed, so the
+    // mark comes off rather than inviting a later pass to act on it.
+    if (now === (had ?? "")) { clearSizeMark(socket, id); continue; }
+    /*
+     * Not a value this app leaves behind, so not this app's to overwrite.
+     *
+     * The only two we ever write are `manual` (a fit, via `resize-window`) and
+     * `largest` (the attach, and the desk's take-over). Anything else — a
+     * `latest`, a `smallest`, a value somebody set by hand while the phone was
+     * here — is a deliberate act by somebody who is not us, and putting an old
+     * snapshot over it is the same class of mistake as the stale restore above.
+     * The mark stays: the window is still one we touched, and a later pass can
+     * decide with fresher information than this teardown has.
+     */
+    if (now !== "manual" && now !== "largest") continue;
     if (zoomed && zoomed.windowId === id) unzoomWindow(socket, sessionId, id, zoomed.paneId);
     tmux(socket, ["resize-window", "-A", "-t", id]);
     tmux(socket, had
@@ -2703,12 +2736,25 @@ export function restoreWindows(
      * leave a window still pinned and no longer marked — the one state the
      * startup sweep can never fix, and strictly worse than the bug.
      *
-     * Only for windows this loop actually restored. The two `continue`s above
+     * Only for windows this loop actually restored. The `continue`s above
      * leave the mark deliberately: a window another phone is still on is still
      * owed the restore, and leaving the mark is what lets the next boot finish
      * the job if that phone's server is the one that gets killed.
+     *
+     * And only when the restore WORKED, which is the other half of #488. This
+     * used to clear unconditionally, so a restore that put back the wrong value
+     * — or none at all, because tmux refused the command — destroyed the only
+     * evidence that the window was ever ours. `reclaimPinnedWindow` reads that
+     * mark and nothing else; without it the safety net cannot fire on the one
+     * case that needs it, which is a teardown that has already gone wrong. The
+     * two bugs are invisible from each other's code and were found together.
+     *
+     * Verified by reading the option back rather than by trusting the write:
+     * `tmux()` returning non-null means the command was accepted, not that the
+     * value took.
      */
-    clearSizeMark(socket, id);
+    const after = (tmux(socket, ["show-options", "-qwv", "-t", id, "window-size"]) ?? "").trim();
+    if (after === (had ?? "")) clearSizeMark(socket, id);
   }
   // And make the desk repaint. A program that was resized twice has drawn
   // itself for the wrong width in between, and tmux does not redraw a pane

--- a/server/test/tmux-shutdown-restore.test.ts
+++ b/server/test/tmux-shutdown-restore.test.ts
@@ -305,18 +305,22 @@ describe.if(HAVE_TMUX)("a server going down gives the desk its window back", () 
      * in `attachArgvFor` lands on the shared window, not on our session), and
      * it is back to carrying nothing.
      *
-     * Its ROW count is the one thing that does not come back to the value it
-     * started at — 50 before, 49 after — and that is `resize-window -A` doing
-     * what it says rather than a leak. `-A` sizes a window to the largest
-     * client attached to it, and this window had never been sized against a
-     * client at all; the desk's is 50 rows with a status line, so 49 is the
-     * size it would have taken the moment anybody looked at it. The option is
-     * unset either way, which is what decides whether it goes on following
-     * clients — see the last test in this file.
+     * Its ROW count used to be the one thing that did NOT come back to where it
+     * started — 50 before, 49 after — and this file said so, calling it
+     * `resize-window -A` doing what it says rather than a leak. It was a leak,
+     * and it is the first of the three failures in #488: the teardown walked
+     * every window of the group, because a grouped session shares them all, and
+     * resized ones the phone had never been on. A window that carries the same
+     * `window-size` it carried when the phone arrived is now left alone
+     * entirely — no `-A`, no option write — so it keeps its own geometry.
+     *
+     * Asserted as `beforeOther.geom` rather than as a literal, so this reads as
+     * "unchanged" and cannot quietly encode a new side effect the way the
+     * literal did.
      */
     expect({ windowSize: sizeOpt(other), zoomed: zoom(other) })
       .toEqual({ windowSize: beforeOther.windowSize, zoomed: beforeOther.zoomed });
-    expect(geom(other)).toBe("200x49");
+    expect(geom(other)).toBe(beforeOther.geom);
     expect(Number(geom(other).split("x")[0])).toBe(Number(beforeOther.geom.split("x")[0]));
     // Our own grouped session is gone with the server — it is what the shutdown
     // kills to make the restore allowed, and leaving it would be a session in


### PR DESCRIPTION
## What does this PR do?

Fixes #488 — three linked failures in the teardown that gives a desk its window back after a phone leaves. The third is why the other two survive.

**It restored windows it had never moved.** A phone joins with a grouped session, so the record covers every window in the group, and the loop walked all of them. That wrote a snapshot taken at attach time over windows the phone was never on, and the snapshot ages: measured on a real machine, a desk that pressed "Fit to this window" after the phone arrived had its deliberate `manual` replaced, minutes later, by the `largest` the record was taken with — by a teardown for a different window. A window whose `window-size` still matches what was recorded is now left alone entirely.

**It overwrote values that were not ours.** `manual` and `largest` are the only two this app ever writes. Anything else on a window — a `latest`, a `smallest`, something set by hand while the phone was there — is somebody else's decision, and is now left alone, with the mark kept so a later pass can decide with fresher information.

**And it cleared the mark whatever happened.** `clearSizeMark` ran after every restore without looking at the result, so a restore that put back the wrong value took `@agx-had-size` with it — and that mark is the only thing `reclaimPinnedWindow` reads. The safety net added in #487 could not fire on the one case that needs it: a teardown that has already gone wrong. The mark now comes off only when the option reads back as what was recorded.

Verify-then-clear rather than never-clear, deliberately. A mark left on a window that *was* restored correctly is a window the sweep returns to for ever — that would trade a silent wrong size for a permanent background poll.

## How was it tested?

`tsc --noEmit` clean for `server/`.

The real-tmux suites, each driving its own isolated socket: `tmux-attach`, `tmux-attach-claim`, `tmux-reclaim` and `tmux-shutdown-restore` — **40 pass, 0 fail**.

One measurement this rests on, taken against tmux 3.7b rather than assumed: `show-options -qwv` answers *empty* for an option that is not set on a window, rather than the inherited value. That is what makes `""` a usable comparison for "carries none of its own", which is how the record spells the same thing.

`server/test/tmux-shutdown-restore.test.ts` changed, and it is worth reading rather than skimming. It asserted that a window nobody had touched came back at `200x49` when it started at `200x50`, and its own comment called that "`resize-window -A` doing what it says rather than a leak". It was the leak — the first of the three failures, written down as expected behaviour. It now asserts that window is unchanged, and against the value captured before the run rather than against a literal, so it cannot quietly encode a new side effect the way the literal did.

Not covered here: the full `server/` suite has 15 failures on this branch, and all 15 fail identically on `main`. Three are the `list-keys` bug that #493 fixes (`tmux-bar`, `tmux-stale` — verified failing on `origin/main` with the same three names); the other twelve are an order-dependent interaction between test files that shows up when the suite runs as one process and disappears when the files run alone. Neither set is touched by this change.
