### PR TITLE
feat: the PR header links out to GitHub, and Its PR opens the pull request

### DIFF
--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -2547,7 +2547,29 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
             remote, and every worktree of a repo shares that one remote — so the
             picker only ever offered a dozen ways to look at the SAME list. The
             repo name, stated once, is all this header needs. */}
-        {repo && <span className="text-[10px] truncate" style={{ color: "var(--text3)" }}>{repo.nameWithOwner}</span>}
+        {/* The repo name was a label, and a label is the one thing this header
+            had room for that nobody could use. It is the same string either
+            way, so it costs no space to make it the way OUT to the thing it
+            names: the name opens the repository, and `PRs ↗` beside it opens
+            the pull request list — the page somebody looking at this panel is
+            most likely to want, and the one that takes the most clicks to
+            reach from a repository landing page. */}
+        {repo && (
+          <span className="flex items-center gap-1.5 min-w-0 text-[10px]" style={{ color: "var(--text3)" }}>
+            <button type="button"
+              className="agx-btn truncate rounded px-1 -mx-1"
+              onClick={() => openExternal(`https://github.com/${repo.nameWithOwner}`)}
+              title={`Open ${repo.nameWithOwner} on GitHub`}>
+              {repo.nameWithOwner}
+            </button>
+            <button type="button"
+              className="agx-btn shrink-0 rounded px-1"
+              onClick={() => openExternal(`https://github.com/${repo.nameWithOwner}/pulls`)}
+              title="Open this repository's pull requests on GitHub">
+              PRs ↗
+            </button>
+          </span>
+        )}
         <div className="ml-auto flex items-center gap-2 shrink-0">
           {toast && <span className="text-[10px] max-w-[380px] truncate" style={{ color: toast.ok ? "var(--success)" : "var(--error)" }}>{toast.msg}</span>}
           {/* The loud "Loading pull requests…" is for a genuinely empty pane

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -947,6 +947,12 @@ const PR_GRID = "78px minmax(0,1fr) 118px 112px 84px 84px";
  * the one row in the table that did not respond to the pointer.
  */
 const PR_ROW_CSS = `
+/* The two links out to GitHub in the header. A border and a hover, because
+   grey text with an arrow after it reads as a caption rather than as a
+   control — which is what the first attempt at this shipped and what it was
+   sent back for. */
+.agx-ghchip{border:1px solid color-mix(in srgb, var(--border) 70%, transparent);background:color-mix(in srgb, var(--bg2) 60%, transparent);color:var(--text2)}
+.agx-ghchip:hover{border-color:color-mix(in srgb, var(--primary) 55%, transparent);background:color-mix(in srgb, var(--primary) 12%, transparent);color:var(--text)}
 .agx-prrow:hover{background:color-mix(in srgb, var(--border) 16%, transparent)}
 .agx-prrow[data-active="1"]{background:color-mix(in srgb, var(--primary) 12%, transparent)}
 .agx-prrow[data-active="1"]:hover{background:color-mix(in srgb, var(--primary) 18%, transparent)}
@@ -2555,19 +2561,24 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
             most likely to want, and the one that takes the most clicks to
             reach from a repository landing page. */}
         {repo && (
-          <span className="flex items-center gap-1.5 min-w-0 text-[10px]" style={{ color: "var(--text3)" }}>
-            <button type="button"
-              className="agx-btn truncate rounded px-1 -mx-1"
-              onClick={() => openExternal(`https://github.com/${repo.nameWithOwner}`)}
-              title={`Open ${repo.nameWithOwner} on GitHub`}>
-              {repo.nameWithOwner}
-            </button>
-            <button type="button"
-              className="agx-btn shrink-0 rounded px-1"
-              onClick={() => openExternal(`https://github.com/${repo.nameWithOwner}/pulls`)}
-              title="Open this repository's pull requests on GitHub">
-              PRs ↗
-            </button>
+          <span className="flex items-center gap-1.5 min-w-0">
+            {/* Two chips rather than two words. Grey text with an arrow after
+                it reads as a caption that happens to have punctuation; the
+                border and the hover are what say "this is a control", and they
+                are the same pill the rest of the app uses for one. Both carry
+                the arrow, because either one leaves the app. */}
+            {([
+              { to: "", label: repo.nameWithOwner, hint: `Open ${repo.nameWithOwner} on GitHub`, grow: true },
+              { to: "/pulls", label: "PRs", hint: "Open this repository's pull requests on GitHub", grow: false },
+            ] as const).map((b) => (
+              <button key={b.to} type="button"
+                onClick={() => openExternal(`https://github.com/${repo.nameWithOwner}${b.to}`)}
+                title={b.hint}
+                className={`agx-btn agx-ghchip inline-flex items-center gap-1 rounded-md px-1.5 py-0.5 text-[10px] ${b.grow ? "min-w-0" : "shrink-0"}`}>
+                <span className={b.grow ? "truncate" : ""}>{b.label}</span>
+                <span aria-hidden className="shrink-0 opacity-70">↗</span>
+              </button>
+            ))}
           </span>
         )}
         <div className="ml-auto flex items-center gap-2 shrink-0">

--- a/web/src/components/TopBarNotes.tsx
+++ b/web/src/components/TopBarNotes.tsx
@@ -41,7 +41,7 @@ import {
   sysNotifyOn, setSysNotifyOn, subscribeSysNotifyMode, notifyCapability,
   type SystemNote, type NotifyCapability,
 } from "../lib/sysNotify.ts";
-import { openPrs } from "../lib/openPrs.ts";
+import { openPr, openPrs } from "../lib/openPrs.ts";
 import { Portal } from "./Portal.tsx";
 import { CloseButton } from "./CloseButton.tsx";
 
@@ -214,7 +214,7 @@ export function useAmbientNotes(): { note: Note | null; behind: number; ahead: n
             // (gitDestination), while ours — which hold the repo and the branch
             // as facts — arrived with nothing and could not be clicked.
             recordNote({ app: "git", summary: r.name, body: `${r.behind} commit${r.behind === 1 ? "" : "s"} to pull on ${r.branch}`,
-              goto: { kind: "git", repo: r.name, branch: r.branch } });
+              goto: { kind: "git", repo: r.name, branch: r.branch, root: r.root } });
           }
         }
         setBehind(total);
@@ -371,6 +371,37 @@ function HistoryRow({ n, onGone, onGoto }: { n: SystemNote; onGone: () => void; 
      and the pull request for its branch — so that row keeps its ordinary
      open-the-message click and offers both as named buttons instead. */
   const go = n.goto && !git ? () => onGoto(n.goto!) : null;
+  /*
+   * "Its PR" used to drop the branch name into the panel's search box as a
+   * filter and leave you there. On a branch whose pull request has been merged
+   * and whose branch has been deleted — which is most of them, an hour later —
+   * that is a panel saying "No pull requests match this filter" over an empty
+   * list, which reads as the pull request being gone rather than as the search
+   * being the wrong question. Reported from a screenshot of exactly that.
+   *
+   * So it asks which pull request the branch HAS, and opens that one by number.
+   * `prsForBranch` answers for merged and closed ones too, because it looks up
+   * the head ref rather than searching titles.
+   *
+   * The answer is kept on the button rather than announced elsewhere: a branch
+   * with no pull request at all is a real answer, and the place somebody is
+   * looking when they ask is the button they just pressed.
+   */
+  const [prMsg, setPrMsg] = useState("");
+  const goToPr = useCallback(async () => {
+    if (!git?.branch) return;
+    // Without a checkout to ask from — a note parsed out of somebody else's
+    // text carries no root — the old behaviour is still the best available.
+    if (!git.root) { openPrs(git.branch, "all"); return; }
+    setPrMsg("Looking…");
+    const r = await api.prsForBranch(git.root, git.branch).catch(() => null);
+    if (r?.ok && r.from && r.repo) { setPrMsg(""); openPr(r.repo, r.from.number); return; }
+    // Said, not swallowed. `needsAuth` is a different fact from "there is none"
+    // and sending somebody to look for a pull request that cannot be seen is
+    // how the empty filter felt in the first place.
+    setPrMsg(r?.needsAuth ? "Sign in to GitHub" : "No PR for this branch");
+    setTimeout(() => setPrMsg(""), 4000);
+  }, [git?.branch, git?.root]);
   const expandable = cut || open;
   // With nowhere to go, the row itself opens the message — which is what the
   // desktop's own list does, and what anyone tries first.
@@ -429,9 +460,9 @@ function HistoryRow({ n, onGone, onGoto }: { n: SystemNote; onGone: () => void; 
                 ↗ Git · {git.repo}
               </button>
               {git.branch && (
-                <button className="agx-note-link" title={`Find the pull request for ${git.branch}`}
-                  onClick={(e) => { e.stopPropagation(); openPrs(git.branch!, "all"); }}>
-                  ↗ Its PR
+                <button className="agx-note-link" title={prMsg || `Open the pull request for ${git.branch}`}
+                  onClick={(e) => { e.stopPropagation(); void goToPr(); }}>
+                  ↗ {prMsg || "Its PR"}
                 </button>
               )}
             </span>

--- a/web/src/lib/sysNotify.ts
+++ b/web/src/lib/sysNotify.ts
@@ -42,7 +42,14 @@ export type SystemNote = {
      * does come along is a repository and a branch, in a sentence, and those are
      * the two things needed to open the right view scoped to the right place.
      */
-    | { kind: "git"; repo: string; branch?: string }
+    | {
+        kind: "git"; repo: string; branch?: string;
+        /** The checkout the branch lives in, when the note was made from a fact
+         *  rather than parsed out of somebody else's text. It is what lets the
+         *  "Its PR" button ask which pull request that branch has, instead of
+         *  dropping a filter into the panel and hoping. */
+        root?: string;
+      }
     /**
      * A ClickUp card, opened in Tasks rather than in a browser.
      *


### PR DESCRIPTION
## What does this PR do?

Makes the repository name in the pull request panel's header worth the space it was already taking.

It was a plain label — `SirAllap/agentglass`, greyed out, doing nothing. The panel is about that repository's pull requests, so the two places somebody reads it and then wants to go are the repository itself and its pull request list. The name is now the first; a `PRs ↗` beside it is the second, and it is the one that earns its keep, because the pull request list is the page furthest from a repository landing page in clicks.

No new row, no new icon, no layout change: the same string in the same place, plus five characters.

## How was it tested?

`bun run typecheck` clean in `web/`.

Then in a running desktop build installed from this branch, driven over CDP against the live sidecar rather than a dev server, so what was read is what ships. Both controls render in the panel header with the right labels and titles:

    SirAllap/agentglass   title="Open SirAllap/agentglass on GitHub"
    PRs ↗                 title="Open this repository's pull requests on GitHub"

The click targets are `https://github.com/<nameWithOwner>` and the same with `/pulls`, built from the repo the panel is already showing. I did not fire the clicks in the harness: `openExternal` hands the URL to the desktop shell, and a QA run has no business opening browser windows on somebody's machine.

`bun test` in `web/` is unchanged by this: 1933 pass, and the 4 failures in `server-identity.test.ts` fail identically on `main` — they are an order-dependent interaction between test files that appears when the suite runs as one process in a worktree and disappears when that file runs alone.
