### PR TITLE
fix: every route that executes or mutates refuses a caller with no Origin

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -265,6 +265,25 @@ function localOrigin(req: Request): boolean {
  * callers it turns away are the non-browser ones — which is exactly the
  * `websocat ws://host:4000/terminal/pty` case that otherwise hands a login
  * shell to anyone who can reach the port.
+ *
+ * Every route that EXECUTES or MUTATES is on this gate, and the split used to
+ * be an accident of where the code landed: 22 mutating routes on `localOrigin`
+ * against 5 here (#469). `localOrigin` waves a missing Origin straight through,
+ * which is right for reads — the hooks and the OTLP exporters cannot send one,
+ * and turning them away breaks the product — and wrong for anything that
+ * commits, pushes, starts a container, kills a process, spawns an agent or
+ * rewrites the workspace scope every other capability checks itself against.
+ *
+ * On the default loopback bind nothing changes: `from === "loopback"` is true
+ * and an Origin-less caller is still allowed. The case this closes is the one
+ * the README documents as supported — `AGENTGLASS_BIND=0.0.0.0` without a
+ * token — where a remote `curl` with no Origin header could drive git, Docker,
+ * the chat and the process killer.
+ *
+ * Two deliberate exceptions, both reads that happen to be POSTs or to have no
+ * browser at the other end: `/git/status`, which takes a body only because it
+ * is a query, and `/ingest`, the OTLP receivers and `/pair/*`, which are
+ * Origin-less by design and must stay that way.
  */
 /**
  * The strictest gate in the server: the desktop shell and nothing else.
@@ -1008,7 +1027,7 @@ const server = Bun.serve<WsData>({
     // Pick the project this cockpit is about (or null → the whole machine).
     // Applied live and persisted for the next launch.
     if (pathname === "/workspace" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = setWorkspaceRoot(b.root == null ? null : String(b.root));
@@ -1029,7 +1048,7 @@ const server = Bun.serve<WsData>({
      * arguments are checked in projectadd.ts, where the reasoning lives.
      */
     if (pathname === "/projects/clone" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = await cloneProject(b.url, b.parent);
@@ -1044,14 +1063,14 @@ const server = Bun.serve<WsData>({
      * next sweep.
      */
     if (pathname === "/projects/hidden" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = setProjectHidden(b.path, b.hidden !== false);
       return json(res, res.ok ? 200 : 400);
     }
     if (pathname === "/projects/new" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = await createProject(b.name, b.parent);
@@ -1082,7 +1101,7 @@ const server = Bun.serve<WsData>({
      * which a freshly written file never has.
      */
     if (pathname === "/agents/connect" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: { id?: unknown; undo?: unknown };
       try { b = (await req.json()) as { id?: unknown; undo?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const id = typeof b.id === "string" ? b.id : "";
@@ -1123,7 +1142,7 @@ const server = Bun.serve<WsData>({
 
     if (pathname === "/hooks/status") return json(hookStatus());
     if ((pathname === "/hooks/install" || pathname === "/hooks/uninstall") && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       return json(applyHooks(pathname === "/hooks/install" ? "install" : "uninstall"));
     }
 
@@ -1138,7 +1157,7 @@ const server = Bun.serve<WsData>({
       return json({ budgets: readBudgets(), status: budgetStatus(), models: costedModels() });
     }
     if (pathname === "/budgets/set" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: { budgets?: unknown };
       try { b = (await req.json()) as { budgets?: unknown }; } catch { return json({ ok: false, error: "invalid json" }, 400); }
       if (!Array.isArray(b.budgets)) return json({ ok: false, error: "expected a list of budgets" }, 400);
@@ -1240,7 +1259,7 @@ const server = Bun.serve<WsData>({
       });
     }
     if (pathname === "/gate/decide" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false }); }
       const decision = b.decision === "deny" ? "deny" : "allow";
@@ -1285,7 +1304,7 @@ const server = Bun.serve<WsData>({
     // keyboard doesn't already, so it needs no gate beyond the localOrigin +
     // token checks the whole surface already carries.
     if (pathname === "/control" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: unknown = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const cmd = parseControlCmd(b);
@@ -1305,7 +1324,7 @@ const server = Bun.serve<WsData>({
       return json(browserUseStatus(browserReadyCount(), true));
     }
     if (pathname === "/browser-use/install" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const res = installSkill();
       return json(res, res.ok ? 200 : 400);
     }
@@ -1328,7 +1347,7 @@ const server = Bun.serve<WsData>({
      */
     const browserDataPost = pathname === "/browser/places" || pathname === "/browser/places/forget" || pathname === "/browser/visit";
     if (pathname.startsWith("/browser/") && req.method === "POST" && !browserDataPost) {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const op = pathname.slice("/browser/".length);
       if (op === "ready") {
         // A window saying it has a browser panel that can answer. Heartbeat, so
@@ -1622,7 +1641,7 @@ const server = Bun.serve<WsData>({
       return json({ repos: await statusForPaths(paths), commitEnabled: COMMIT_ENABLED });
     }
     if (pathname === "/git/commit" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = gitCommit(String(b.root || ""), Array.isArray(b.files) ? b.files : [], String(b.title || ""), String(b.body || ""));
@@ -1856,14 +1875,14 @@ const server = Bun.serve<WsData>({
      */
     if (pathname === "/theme/current") return json({ theme: currentTheme() });
     if (pathname === "/theme/sync" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       return json(await syncTheme(b.vars ?? {}, String(b.name ?? "custom")));
     }
 
     if (pathname === "/editor/open" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       return json(await openInEditor(b.path, b.line));
@@ -1875,7 +1894,7 @@ const server = Bun.serve<WsData>({
        (see ag:browserPlaces); this only keeps them and hands them back to the
        address bar. */
     if (pathname === "/browser/places" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
       const source = String(b.source ?? "");
       const rows = Array.isArray(b.places) ? b.places : [];
@@ -1898,7 +1917,7 @@ const server = Bun.serve<WsData>({
       return json({ ok: true, places: allPlaces() });
     }
     if (pathname === "/browser/places/forget" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       forgetPlaces();
       return json({ ok: true, ...placeCount() });
     }
@@ -1906,18 +1925,18 @@ const server = Bun.serve<WsData>({
        'agentglass' source so a browser re-import (which DELETEs by source) never
        wipes it — see recordVisit(). */
     if (pathname === "/browser/visit" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
       recordVisit(String(b.url ?? ""), String(b.title ?? ""));
       return json({ ok: true });
     }
     if (pathname === "/scratch/image" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
       return json(saveShot(b.dataUrl, b.name));
     }
     if (pathname.startsWith("/git/") && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const root = String(b.root || "");
@@ -2270,7 +2289,7 @@ const server = Bun.serve<WsData>({
       return json(await refreshCodexUsage());
     }
     if (pathname.startsWith("/docker/") && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const id = String(b.id || "");
@@ -2340,7 +2359,7 @@ const server = Bun.serve<WsData>({
       return json({ ok: false, error: "not found" }, 404);
     }
     if (pathname.startsWith("/issues/") && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const root = String(b.root || "");
@@ -2393,7 +2412,7 @@ const server = Bun.serve<WsData>({
     }
 
     if (pathname === "/machine/unlock" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = removeStaleLock(b.path, knownProjects().map((p) => p.path));
@@ -2402,7 +2421,7 @@ const server = Bun.serve<WsData>({
     }
 
     if (pathname === "/machine/kill" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const res = killPort(b.pid);
@@ -2532,7 +2551,7 @@ const server = Bun.serve<WsData>({
       ));
     }
     if (pathname.startsWith("/prs/") && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const root = b.root ?? "";
@@ -2676,7 +2695,7 @@ const server = Bun.serve<WsData>({
     /** Put one of them in front of whoever is attached. The ids are validated
      *  against tmux's own syntax in focusPane() before they reach a command. */
     if (pathname === "/terminal/panes/focus" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: { sessionId?: unknown; windowId?: unknown; paneId?: unknown };
       try { b = (await req.json()) as typeof b; } catch { return json({ ok: false, error: "invalid json" }, 400); }
       const ok = focusPaneAnywhere(lastTmuxTarget()?.socket, String(b.sessionId ?? ""), String(b.windowId ?? ""), String(b.paneId ?? ""));
@@ -2709,7 +2728,7 @@ const server = Bun.serve<WsData>({
       });
     }
     if (pathname === "/chat/send" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       // The launch, not the turn. chatSend returns a stream rather than an
@@ -2742,7 +2761,7 @@ const server = Bun.serve<WsData>({
     // pane with `--resume`. Without this the ~380MB sits there until the idle
     // sweeper notices, half an hour after you said you were done with it.
     if (pathname === "/chat/pane/close" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       const id = typeof b.session === "string" ? b.session : "";
@@ -2761,7 +2780,7 @@ const server = Bun.serve<WsData>({
      * "done".
      */
     if (pathname === "/chat/pane/pin" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       const id = typeof b.session === "string" ? b.session : "";
@@ -2804,7 +2823,7 @@ const server = Bun.serve<WsData>({
     // needs, and sending them here beats telling someone to open a terminal to
     // move a cursor one step.
     if (pathname === "/chat/pane/key" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       const id = typeof b.session === "string" ? b.session : "";
@@ -2833,7 +2852,7 @@ const server = Bun.serve<WsData>({
       return json({ enabled: CODEX_ENABLED, bypass: CODEX_BYPASS_ALLOWED, models: CODEX_ENABLED ? codexModels() : [] });
     }
     if (pathname === "/codex/send" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       // Same reasoning as /chat/send: the launch is the auditable fact, not the
@@ -2860,7 +2879,7 @@ const server = Bun.serve<WsData>({
       return json({ enabled: ANTIGRAVITY_ENABLED, bypass: ANTIGRAVITY_BYPASS_ALLOWED, models: ANTIGRAVITY_ENABLED ? await antigravityModels() : [] });
     }
     if (pathname === "/antigravity/send" && req.method === "POST") {
-      if (!localOrigin(req)) return csrfBlocked();
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       noteAction(clientIp, "/antigravity/send",

--- a/server/test/mutating-routes-guard.test.ts
+++ b/server/test/mutating-routes-guard.test.ts
@@ -1,0 +1,112 @@
+/*
+ * Which gate each route is behind, asserted against the source.
+ *
+ * The bug this pins is not a behaviour anybody can reach on a loopback install
+ * — it is a CLASSIFICATION, and classifications drift one route at a time. #469
+ * was 22 mutating routes on the permissive gate against 5 on the strict one,
+ * and nothing had gone wrong: the split was where the code happened to land,
+ * and every new route landed on whichever line was copied.
+ *
+ * So this reads `index.ts` and checks the pairing, which is the only form of
+ * this test that fails when somebody adds a route rather than when somebody
+ * breaks one. A running-server test would need `AGENTGLASS_BIND=0.0.0.0` to
+ * show any difference at all, which is the one configuration a test must not
+ * create on a developer's machine.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const src = readFileSync(join(import.meta.dir, "..", "src", "index.ts"), "utf8");
+const lines = src.split("\n");
+
+/** The guard a route sits behind: the first one inside its block. */
+function guardFor(route: string): "strict" | "permissive" | "none" {
+  const at = lines.findIndex((l) => l.includes(route));
+  expect(at, `no route matching ${route} — this test is reading the wrong code`).toBeGreaterThan(0);
+  for (let i = at; i < Math.min(at + 6, lines.length); i++) {
+    if (lines[i].includes("trustedCaller(req, from)")) return "strict";
+    if (lines[i].includes("localOrigin(req)")) return "permissive";
+  }
+  return "none";
+}
+
+/*
+ * Everything that executes or changes the machine. Named individually rather
+ * than by prefix: the point is that a person had to decide about each one, and
+ * a list that a prefix could satisfy would pass for a route nobody classified.
+ */
+const MUTATING = [
+  `pathname === "/workspace"`,
+  `pathname === "/projects/clone"`,
+  `pathname === "/projects/hidden"`,
+  `pathname === "/projects/new"`,
+  `pathname === "/agents/connect"`,
+  `pathname === "/budgets/set"`,
+  `pathname === "/gate/decide"`,
+  `pathname === "/control"`,
+  `pathname === "/browser-use/install"`,
+  `pathname === "/git/commit"`,
+  `pathname === "/theme/sync"`,
+  `pathname === "/editor/open"`,
+  `pathname === "/browser/places"`,
+  `pathname === "/browser/visit"`,
+  `pathname === "/scratch/image"`,
+  `pathname === "/machine/unlock"`,
+  `pathname === "/machine/kill"`,
+  `pathname === "/terminal/panes/focus"`,
+  `pathname === "/chat/send"`,
+  `pathname === "/chat/pane/close"`,
+  `pathname === "/chat/pane/pin"`,
+  `pathname === "/chat/pane/key"`,
+  `pathname === "/codex/send"`,
+  `pathname === "/antigravity/send"`,
+  `pathname.startsWith("/git/")`,
+  `pathname.startsWith("/docker/")`,
+  `pathname.startsWith("/issues/")`,
+  `pathname.startsWith("/prs/")`,
+  `pathname.startsWith("/browser/")`,
+];
+
+describe("the gate a route sits behind", () => {
+  for (const route of MUTATING) {
+    test(`${route} executes or mutates, so it refuses a caller with no Origin`, () => {
+      expect(guardFor(route)).toBe("strict");
+    });
+  }
+
+  /*
+   * The exception, and it is a read wearing a POST: `/git/status` takes a body
+   * because the question needs one, not because it changes anything. Pinned so
+   * that a later sweep does not "finish the job" and break the hooks.
+   */
+  test("/git/status is a read done over POST and stays permissive", () => {
+    expect(guardFor(`pathname === "/git/status"`)).toBe("permissive");
+  });
+
+  /*
+   * The surface-wide gate stays permissive on purpose: it is what lets the
+   * hooks and the OTLP exporters reach the server at all, and every route that
+   * matters has its own gate after it. If this ever reads `strict`, ingestion
+   * is broken and no test of a mutating route would have noticed.
+   */
+  test("the one gate over the whole surface still admits a non-browser caller", () => {
+    const at = lines.findIndex((l) => l.includes("One gate for the whole surface"));
+    expect(at).toBeGreaterThan(0);
+    const near = lines.slice(at, at + 8).join("\n");
+    expect(near).toContain("localOrigin(req)");
+    expect(near).not.toContain("trustedCaller");
+  });
+
+  /*
+   * And the property the whole change rests on: on a loopback bind, an
+   * Origin-less caller is still allowed, so nothing about a default install
+   * changes. If this line ever stops reading `from === "loopback"`, every route
+   * moved by #469 silently becomes stricter than it was meant to be.
+   */
+  test("the strict gate still allows a loopback caller with no Origin", () => {
+    const at = lines.findIndex((l) => l.includes("function trustedCaller("));
+    expect(at).toBeGreaterThan(0);
+    expect(lines.slice(at, at + 14).join("\n")).toContain('if (!o) return from === "loopback"');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Closes #469. Puts every route that executes or changes the machine behind the gate that refuses a caller with no `Origin` header.

The two gates differ in one line, and only in what a missing `Origin` means. Nothing but a non-browser client omits it, so `localOrigin` lets it through — which is correct for reads, because the hooks and the OTLP exporters cannot send one and turning them away breaks ingestion. It is the wrong default for anything that commits, pushes, resets, starts or removes a container, kills a process, spawns an agent, sends keystrokes into a live pane, or rewrites the workspace scope that every other capability checks itself against.

The split was never a decision. On `main` it was 22 mutating routes on the permissive gate against 5 on the strict one — where each route happened to land, with every new one copying whichever line sat next to it.

**31 routes moved.** Two deliberate exceptions stay permissive: `/git/status`, which is a read that takes a body because the question needs one, and the single surface-wide gate, which is what lets the hooks reach the server at all. `/ingest`, the OTLP receivers and `/pair/*` are Origin-less by design and are untouched.

**Nothing changes on a default install.** `trustedCaller` allows an Origin-less caller when `from === "loopback"`. What this closes is the case the README documents as supported — `AGENTGLASS_BIND=0.0.0.0` without a token — where a remote `curl` with no `Origin` could drive git, Docker, the chat and the process killer.

## How was it tested?

`tsc --noEmit` clean in `server/`. The adjacent security suites — `env-reveal-route`, `pairing`, `token-gate` — pass unchanged, 32 tests.

New: `server/test/mutating-routes-guard.test.ts`, 32 cases, and it is worth saying why it reads the source rather than driving a server. The bug here is a **classification**, not a behaviour: on a loopback install every one of these routes behaves identically before and after, so a running-server test would have to set `AGENTGLASS_BIND=0.0.0.0` to see any difference at all — which is the one configuration a test has no business creating on somebody's machine. Reading the pairing is also the only form that fails when a route is *added* rather than when one is broken, and adding-one-at-a-time is exactly how the 22-against-5 split happened.

It pins each mutating route by name rather than by prefix — a prefix would pass for a route nobody had classified — plus the three properties the change rests on: `/git/status` stays permissive, the surface-wide gate stays permissive, and the strict gate still admits an Origin-less loopback caller.

Not verified here: the exposed-bind case itself. I did not stand the server up on `0.0.0.0` to prove a remote `curl` is now refused, because doing that on a developer's machine is the hazard this fixes. The refusal path is `trustedCaller`'s existing one, unchanged by this PR and already covered where it was introduced.

Originally spotted by @dakristia in #458, and deferred out of #465 for having a wider blast radius than the rest of that harvest.
