### PR TITLE
feat: the Tasks bar remembers where you were, and drops what you never set up

### DIFF
--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -38,7 +38,11 @@ import { rendererPref, setRendererPref, type RendererPref } from "../lib/termRen
 import { TERM_FONTS, CURSORS, fontAvailable, currentTermFont, currentTermSize, currentTermCursor, currentTermLineHeight, setTermFont, setTermSize, setTermCursor, setTermLineHeight, SIZE_MIN, SIZE_MAX, LINE_HEIGHT_MIN, LINE_HEIGHT_MAX, type CursorStyle } from "../lib/termPrefs.ts";
 import { focusFollowsMouse, setFocusFollowsMouse } from "../lib/termFocusPref.ts";
 import { diffSplit, diffWrap, setDiffSplit, setDiffWrap } from "../lib/diffPrefs.ts";
-import { TASK_SOURCES, taskSourceShown, setTaskSourceShown } from "../lib/taskSources.ts";
+import {
+  TASK_SOURCES, taskSourceShown, setTaskSourceShown,
+  orderedTaskSources, moveTaskSource, resetTaskSourceOrder, type TaskSourceId,
+} from "../lib/taskSources.ts";
+import { taskLanding, setTaskLanding, type TaskLanding } from "../lib/taskLanding.ts";
 import {
   SCROLLBACK_SIZES, DEFAULT_SCROLLBACK, DEFAULT_WORD_SEPARATORS,
   currentScrollback, currentWordSeparators, copyOnSelect, rightClickPaste,
@@ -193,18 +197,66 @@ function Toggle({ on, onClick, label, hint, disabled }: {
   return (
     <SettingRow label={label} hint={hint} onClick={onClick} disabled={disabled}
       role="switch" ariaChecked={on}
+      /* A real switch: position carries the state, so it reads at a glance
+         instead of having to be parsed. */
+      control={<Switch on={on} />} />
+  );
+}
+
+/** The switch itself, without the row around it. Split out because the task
+ *  sources need one inside a row that is NOT a button — see SourceRow. */
+function Switch({ on }: { on: boolean }) {
+  return (
+    <span className="relative rounded-full transition-colors block" style={{
+      width: 34, height: 19,
+      background: on ? "color-mix(in srgb, var(--primary) 55%, transparent)" : "color-mix(in srgb, var(--border) 55%, transparent)",
+    }}>
+      <span className="absolute rounded-full transition-transform" style={{
+        width: 15, height: 15, top: 2, left: 2,
+        transform: on ? "translateX(15px)" : "translateX(0)",
+        background: on ? "var(--primary-hover)" : "var(--text3)",
+      }} />
+    </span>
+  );
+}
+
+/**
+ * One task source: whether it is on the bar, and where on it.
+ *
+ * Not a `Toggle`, and the reason is structural rather than cosmetic. `Toggle`
+ * makes the WHOLE ROW the button, which is right for a lone switch and makes a
+ * second control impossible: the arrows would be buttons inside a button, which
+ * is invalid HTML and behaves differently in every browser that has to guess.
+ * So this row is a plain div carrying three controls of its own, and the
+ * trade — losing the click-anywhere target — buys a keyboard-operable reorder.
+ */
+function SourceRow({ id, i, n, onChanged }: {
+  id: TaskSourceId; i: number; n: number; onChanged: () => void;
+}) {
+  const s = TASK_SOURCES.find((x) => x.id === id);
+  if (!s) return null;
+  const on = taskSourceShown(id);
+  return (
+    <SettingRow label={s.label} hint={s.what}
       control={
-        /* A real switch: position carries the state, so it reads at a glance
-           instead of having to be parsed. */
-        <span className="relative rounded-full transition-colors block" style={{
-          width: 34, height: 19,
-          background: on ? "color-mix(in srgb, var(--primary) 55%, transparent)" : "color-mix(in srgb, var(--border) 55%, transparent)",
-        }}>
-          <span className="absolute rounded-full transition-transform" style={{
-            width: 15, height: 15, top: 2, left: 2,
-            transform: on ? "translateX(15px)" : "translateX(0)",
-            background: on ? "var(--primary-hover)" : "var(--text3)",
-          }} />
+        <span className="flex items-center gap-2.5 justify-self-end">
+          <span className="flex flex-col shrink-0" style={{ gap: 1 }}>
+            {([-1, 1] as const).map((by) => (
+              <button key={by}
+                onClick={() => { moveTaskSource(id, by); onChanged(); }}
+                disabled={by === -1 ? i === 0 : i === n - 1}
+                aria-label={`Move ${s.label} ${by === -1 ? "earlier" : "later"}`}
+                className="agx-btn leading-none px-1 rounded disabled:opacity-25"
+                style={{ color: "var(--text3)", fontSize: 7 }}>
+                {by === -1 ? "▲" : "▼"}
+              </button>
+            ))}
+          </span>
+          <button role="switch" aria-checked={on} aria-label={s.label}
+            onClick={() => { setTaskSourceShown(id, !on); onChanged(); }}
+            className="agx-btn">
+            <Switch on={on} />
+          </button>
         </span>
       } />
   );
@@ -2359,8 +2411,11 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
   const [dSplit, setDSplitState] = useState(() => diffSplit());
   const [dWrap, setDWrapState] = useState(() => diffWrap());
   /* The source list is read straight from the store on each render; this only
-     exists to ask for that render. */
+     exists to ask for that render. `sourceOrder` is read the same way, so a
+     move is on screen before the write has settled. */
   const [, setSourceTick] = useState(0);
+  const sourceOrder = orderedTaskSources();
+  const [landing, setLandingState] = useState<TaskLanding>(() => taskLanding());
   const [keyError, setKeyError] = useState<{ id: ActionId; msg: string } | null>(null);
   useEffect(() => subscribeBindings(() => setKeys({ ...bindings() })), []);
 
@@ -2784,21 +2839,44 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                   </Section>
                   )}
                   {pane === "tasks" && (
+                  <>
+                  <Section title="Opens on">
+                    {/* There was no setting here before and no default either:
+                        the tab was component state initialised to "all", so
+                        every visit started over — on the one view that does not
+                        include your ClickUp cards. See taskLanding.ts. */}
+                    <Choice<TaskLanding>
+                      label="Tasks view opens on"
+                      hint="Where the Tasks view lands when you come back to it. “Last used” picks up where you left off; naming a source pins it there whatever you did last. Following a card link from a pull request never changes this."
+                      value={landing}
+                      onPick={(v) => { setTaskLanding(v); setLandingState(v); }}
+                      options={[
+                        { v: "last", label: "Last used" },
+                        { v: "all", label: "All" },
+                        ...TASK_SOURCES.map((s) => ({ v: s.id as TaskLanding, label: s.label })),
+                      ]} />
+                  </Section>
                   <Section title="Task sources">
-                    {/* Each one is shown whether or not it is connected — an
-                        unconnected tab says what to do and links to the pane
-                        that does it, and a tab you only find after finding
-                        Settings is a feature nobody discovers. This is for the
-                        person who has read that and is never connecting it. */}
-                    {TASK_SOURCES.map((s) => (
-                      <Toggle key={s.id} on={taskSourceShown(s.id)}
-                        onClick={() => { setTaskSourceShown(s.id, !taskSourceShown(s.id)); setSourceTick((n) => n + 1); }}
-                        label={s.label} hint={s.what} />
+                    {/* Order is the row's own, and the arrows move a source
+                        through the FULL list rather than the visible one — see
+                        moveTaskSource. Arrows rather than dragging: this pane's
+                        every other control works from a keyboard, and a drop
+                        target would be the one that does not. */}
+                    {sourceOrder.map((id, i) => (
+                      <SourceRow key={id} id={id} i={i} n={sourceOrder.length}
+                        onChanged={() => setSourceTick((n) => n + 1)} />
                     ))}
                     <p className="px-3.5 pb-3 -mt-1 text-[10px] t-dim2 max-w-[680px]">
-                      One has to stay. Connecting them lives in Integrations; this only decides what the Tasks view offers.
+                      One has to stay, and a source you have not set up is left off the bar on its own — until nothing is
+                      set up, when all of them show, because that is when the bar is the only place to find them.
+                      Connecting them lives in Integrations.{" "}
+                      <button onClick={() => { resetTaskSourceOrder(); setSourceTick((n) => n + 1); }}
+                        className="agx-btn underline underline-offset-2" style={{ color: "var(--text3)" }}>
+                        Reset order
+                      </button>
                     </p>
                   </Section>
+                  </>
                   )}
                   {pane === "privacy" && <PrivacyPane open={open} />}
                   {pane === "recipes" && <RecipesPane open={open} />}

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -26,6 +26,8 @@ import { handoffTo, setHandoffTo, type HandoffTo } from "../lib/handoffTo.ts";
 import { openPrs } from "../lib/openPrs.ts";
 import type { CardJump } from "../lib/openCard.ts";
 import { TASK_SOURCES, shownTaskSources, subscribeTaskSources, type TaskSourceId } from "../lib/taskSources.ts";
+import { useTaskConnected, visibleTaskSources } from "../lib/taskConnected.ts";
+import { landingSource, rememberTaskSource } from "../lib/taskLanding.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 import { ContextMenu, MenuItem } from "./ContextMenu.tsx";
 import { cardSkills, skillCommand, windowName, skillModes, namedForIt, shortName } from "../lib/cardSkills.ts";
@@ -111,11 +113,32 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
    * is, and gone again the moment they pick another one.
    */
   const [forced, setForced] = useState<TaskSourceId | null>(null);
-  const tabs = useMemo(
-    () => sourceTabs(forced && !shown.includes(forced) ? [...shown, forced] : shown),
-    [shown, forced],
-  );
-  const [source, setSource] = useState<SourceId>("all");
+  /* What is actually set up on this machine. Null while the answer is in the
+     air, which `visibleTaskSources` reads as "change nothing yet" — the bar
+     draws the preference and then only ever loses tabs, never gains them, so
+     it cannot be seen rearranging itself. See taskConnected.ts. */
+  const connected = useTaskConnected();
+  const tabs = useMemo(() => {
+    const live = visibleTaskSources(shown, connected);
+    // A forced source is an errand and outranks both the preference and the
+    // connection check: it got here because something asked for a card by id.
+    return sourceTabs(forced && !live.includes(forced) ? [...live, forced] : live);
+  }, [shown, connected, forced]);
+
+  /*
+   * Where this opens, which used to be "all" and nothing else — see
+   * taskLanding.ts for why that was the wrong constant rather than the wrong
+   * default.
+   *
+   * Computed once, lazily, from the bar as it stands at first render. That is
+   * enough to land on: the preference is a synchronous localStorage read, and
+   * the connection check can only ever REMOVE tabs afterwards — so the worst
+   * case is landing on a pinned source that turns out not to be set up, which
+   * the reconcile effect below then steps off. One frame, self-correcting, and
+   * no deferral machinery for the ordinary case.
+   */
+  const [source, setSource] = useState<SourceId>(() => landingSource(tabs.map((t) => t.id)) as SourceId);
+
   /* Standing on a source that has just been hidden — or on "All" when only one
      source is left — is standing on a tab that is no longer there. Step to the
      first one that is. */
@@ -148,8 +171,10 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
         <nav className="flex items-center gap-0.5" aria-label="Sources">
           {tabs.map((s) => (
             // Picking a tab by hand ends the errand, which is what takes a
-            // borrowed tab back off the bar — see `forced`.
-            <button key={s.id} onClick={() => { setForced(null); setSource(s.id); }}
+            // borrowed tab back off the bar — see `forced`. It is also the only
+            // gesture that writes the remembered tab: a jump is somebody
+            // following a link, not moving house. See taskLanding.ts.
+            <button key={s.id} onClick={() => { setForced(null); setSource(s.id); rememberTaskSource(s.id); }}
               aria-current={s.id === source ? "true" : undefined}
               className="text-[11px] px-2.5 py-1 rounded-lg whitespace-nowrap"
               style={s.id === source

--- a/web/src/lib/taskConnected.ts
+++ b/web/src/lib/taskConnected.ts
@@ -1,0 +1,125 @@
+/*
+ * Which task sources are actually set up on this machine.
+ *
+ * The Tasks view used to offer all three whatever you had, and the reason was
+ * written down and was a good one: an unconnected tab says what to do and links
+ * to the pane that does it, and a tab you only find after finding Settings is a
+ * feature nobody discovers.
+ *
+ * It is a good argument that stops being true at a specific moment — the moment
+ * you have connected something. Before that, the bar is the only advertisement
+ * there is, and a fresh install should carry all of it. After that, you have
+ * demonstrably found the Integrations pane, and a permanent tab for a tracker
+ * you have never used is somebody else's product in the middle of yours.
+ *
+ * So the rule is not "hide what is not connected". It is:
+ *
+ *   nothing set up at all   show everything — this is a fresh install and the
+ *                           bar is where the features live
+ *   something set up        show what is set up, and let Integrations do the
+ *                           advertising it is already there to do
+ *
+ * The precedent is in the repo. GitLab has a row in Integrations and no tab
+ * anywhere, and nobody has ever called it hidden.
+ *
+ * A source that is set up and BROKEN stays on the bar. "ClickUp refused this
+ * token" is not the same as "you do not use ClickUp", and hiding the tab would
+ * take away the one surface that was going to tell you.
+ */
+import { useEffect, useState } from "react";
+import { api } from "./api.ts";
+import { TASK_SOURCES, type TaskSourceId } from "./taskSources.ts";
+import type { ProviderId, ProviderState } from "../../../shared/providers.ts";
+
+/** The Tasks view's names for things, and `/providers`' names for the same
+ *  things. Kept as data because the two vocabularies genuinely differ: the tab
+ *  says "Local" because that is what it is to you, the provider is called
+ *  Taskwarrior because that is what it is. */
+const PROVIDER_OF: Record<TaskSourceId, ProviderId> = {
+  github: "github",
+  local: "taskwarrior",
+  clickup: "clickup",
+};
+
+/**
+ * Whether a provider counts as "this person uses this".
+ *
+ * `connected` is the plain yes. `error` counts too, and deliberately: a token
+ * that has been refused, or a workspace that timed out, is a thing you set up
+ * and that is failing — the tab has to survive so it can carry the bad news.
+ *
+ * The two that mean no are the two that mean nobody ever did anything:
+ * `missing-tool` (the CLI is not installed) and `needs-auth` (installed, never
+ * signed in).
+ */
+const setUp = (state: ProviderState): boolean => state === "connected" || state === "error";
+
+export type TaskConnected = Record<TaskSourceId, boolean>;
+
+const ALL_ON = (): TaskConnected =>
+  Object.fromEntries(TASK_SOURCES.map((s) => [s.id, true])) as TaskConnected;
+
+const TTL = 60_000;
+let held: { at: number; value: TaskConnected } | null = null;
+let inflight: Promise<TaskConnected> | null = null;
+
+const fresh = (): TaskConnected | null => (held && Date.now() - held.at < TTL ? held.value : null);
+
+export function taskConnected(): Promise<TaskConnected> {
+  const now = fresh();
+  if (now) return Promise.resolve(now);
+  // One read for however many callers arrive while it is in the air, and a
+  // failure is not cached: the server being down for a moment must not take
+  // somebody's tabs away for the next minute.
+  inflight ??= api.providers()
+    .then((r) => {
+      const by = new Map(r.providers.map((p) => [p.id, p.state]));
+      const value = Object.fromEntries(
+        TASK_SOURCES.map((s) => {
+          const state = by.get(PROVIDER_OF[s.id]);
+          // A provider the server did not mention is unknown, not absent —
+          // shown, because taking a tab away on a missing answer is the one
+          // failure mode with no way back for the person looking at it.
+          return [s.id, state === undefined || setUp(state)];
+        }),
+      ) as TaskConnected;
+      held = { at: Date.now(), value };
+      return value;
+    })
+    .catch(() => ALL_ON())
+    .finally(() => { inflight = null; });
+  return inflight;
+}
+
+/**
+ * The bar's own question: given what is set up, which of these may be shown.
+ *
+ * This is where the fresh-install rule lives, and it is applied here rather
+ * than in the fetch so that the fetch keeps meaning exactly one thing. Nothing
+ * set up means the answer is everything — see the header.
+ *
+ * `shown` is the preference, already ordered and filtered. Its ORDER is
+ * preserved: this only ever removes.
+ */
+export function visibleTaskSources(shown: TaskSourceId[], connected: TaskConnected | null): TaskSourceId[] {
+  // Not known yet. Showing the preference unchanged is what stops the bar
+  // rearranging itself a beat after it is drawn.
+  if (!connected) return shown;
+  const live = shown.filter((id) => connected[id]);
+  return live.length ? live : shown;
+}
+
+/** Null until the answer is in, which is what keeps the bar from flickering on
+ *  a machine that has only one of these. */
+export function useTaskConnected(): TaskConnected | null {
+  const [value, setValue] = useState<TaskConnected | null>(fresh);
+  useEffect(() => {
+    let live = true;
+    void taskConnected().then((v) => { if (live) setValue(v); });
+    return () => { live = false; };
+  }, []);
+  return value;
+}
+
+/** For a test's own teardown, and for the moment a provider is connected. */
+export function __forgetTaskConnected(): void { held = null; }

--- a/web/src/lib/taskLanding.ts
+++ b/web/src/lib/taskLanding.ts
@@ -1,0 +1,84 @@
+/*
+ * Which tab the Tasks view opens on.
+ *
+ * There was no answer to this before, which is not the same as there being a
+ * default: the source was component state initialised to "all", so every visit
+ * started over. Go to Tasks, open a card, look at a diff, come back — "All"
+ * again, and "All" is the one view that does not include your ClickUp cards
+ * (it draws the now band, the local strip and the repository's issues). So
+ * somebody who works out of a board landed, every single time, on the tab
+ * without their work in it.
+ *
+ * Two settings rather than one, because they answer different complaints:
+ *
+ *   "last"      pick up where you left off. The default, because it needs no
+ *               configuration and is what a tab bar is expected to do.
+ *   a source    always open here, whatever I did last. For somebody who dips
+ *               into another tab constantly and still wants to come back to
+ *               their own.
+ *
+ * What does NOT write the remembered tab is a jump — pressing a card id on a
+ * pull request opens the ClickUp board, and that is an errand, not a change of
+ * mind. Letting it stick would mean a single press from a pull request quietly
+ * re-homing somebody's Tasks view.
+ */
+import type { TaskSourceId } from "./taskSources.ts";
+
+/** "all" is a landing choice like any other even though it is not a source —
+ *  it is a view of the bar, and it is the one this app has always opened on. */
+export type TaskLanding = "last" | "all" | TaskSourceId;
+
+const MODE_KEY = "agentglass.tasks.landing";
+const LAST_KEY = "agentglass.tasks.last";
+
+const MODES: TaskLanding[] = ["last", "all", "github", "local", "clickup"];
+
+const read = (key: string): string | null => {
+  try { return localStorage.getItem(key); } catch { return null; }
+};
+
+const write = (key: string, v: string): void => {
+  try { localStorage.setItem(key, v); } catch { /* private mode */ }
+};
+
+export function taskLanding(): TaskLanding {
+  const v = read(MODE_KEY);
+  return MODES.includes(v as TaskLanding) ? (v as TaskLanding) : "last";
+}
+
+export function setTaskLanding(v: TaskLanding): void {
+  write(MODE_KEY, v);
+  for (const fn of listeners) fn();
+}
+
+/** The tab you were on when you last left, as a bare string. Validated by the
+ *  caller against the tabs that actually exist — this file has no business
+ *  knowing which sources are connected or switched on. */
+export const lastTaskSource = (): string | null => read(LAST_KEY);
+
+export const rememberTaskSource = (id: string): void => write(LAST_KEY, id);
+
+/**
+ * Where to open, given what the bar is offering right now.
+ *
+ * `available` is the real tab list — already ordered, filtered by preference
+ * and by what is connected. Everything here is checked against it, because
+ * every stored answer can name a tab that is no longer there: a source switched
+ * off, a token removed, a provider that stopped existing between releases.
+ *
+ * The fallback is the first tab rather than "all", and that is the point of
+ * taking `available` at all: on a bar with one source there IS no "all", and
+ * landing on a tab that is not on the bar is how the view ends up blank.
+ */
+export function landingSource(available: string[], mode = taskLanding(), last = lastTaskSource()): string {
+  const ok = (v: string | null | undefined): v is string => !!v && available.includes(v);
+  if (mode === "last") return ok(last) ? last : (available[0] ?? "all");
+  return ok(mode) ? mode : (available[0] ?? "all");
+}
+
+const listeners = new Set<() => void>();
+
+export function subscribeTaskLanding(fn: () => void): () => void {
+  listeners.add(fn);
+  return () => { listeners.delete(fn); };
+}

--- a/web/src/lib/taskSources.ts
+++ b/web/src/lib/taskSources.ts
@@ -1,28 +1,47 @@
 /*
- * Which task sources appear in the Tasks view.
+ * Which task sources appear in the Tasks view, and in what order.
  *
- * All of them do by default, and that default is load-bearing: an unconnected
- * source is shown on purpose, because a tab that only appears once you have
- * found Settings is a feature nobody discovers. It says what to do and links to
- * the pane that does it.
+ * Three things decide whether a tab is on the bar, and they are deliberately
+ * not one thing:
  *
- * The switch is for the opposite person — the one who has read that sentence,
- * decided they are never connecting ClickUp, and is tired of a tab for it. That
- * is a preference, and it is theirs.
+ *   the catalogue    every source that exists — TASK_SOURCES
+ *   this preference  the ones you have not switched off, in the order you put
+ *                    them, which is what this file owns
+ *   what is set up   whether the thing is connected at all — taskConnected.ts,
+ *                    because that answer comes from the server and this file
+ *                    is synchronous by design
+ *
+ * The switch is for the person who is never connecting ClickUp and is tired of
+ * a tab for it. The ORDER is for the opposite person: somebody who works out of
+ * one source all day and wants it first, or first-and-default — see
+ * taskLanding.ts, which is the other half of that same complaint.
  *
  * "All" is not in here. It is not a source, it is the absence of a filter, and
- * hiding it would leave somebody with two sources and no way to see both.
+ * hiding it would leave somebody with two sources and no way to see both. It is
+ * also never reordered: it is the leftmost thing or it is nothing, because a
+ * filter that sits in the middle of the things it filters reads as one of them.
  */
 
 export type TaskSourceId = "github" | "local" | "clickup";
 
+/**
+ * The catalogue, in the order a fresh install gets.
+ *
+ * This is a DEFAULT now rather than the running order — `orderedTaskSources`
+ * is what the bar is built from. Adding a source here still works with no
+ * further thought: one that nobody has an opinion about lands at the end of
+ * everybody's order, which is where a thing you have never seen belongs.
+ */
 export const TASK_SOURCES: { id: TaskSourceId; label: string; what: string }[] = [
   { id: "github", label: "GitHub", what: "Issues from the repository you are in, and a button that starts work on one." },
   { id: "local", label: "Local", what: "Your own list, read from the Taskwarrior store you already write to." },
   { id: "clickup", label: "ClickUp", what: "The boards you work from, and every card assigned to you." },
 ];
 
+const ALL_IDS = (): TaskSourceId[] => TASK_SOURCES.map((s) => s.id);
+
 const KEY = "agentglass.tasks.hidden";
+const ORDER_KEY = "agentglass.tasks.order";
 
 const hiddenSet = (): Set<string> => {
   try {
@@ -32,6 +51,35 @@ const hiddenSet = (): Set<string> => {
 };
 
 export const taskSourceShown = (id: TaskSourceId): boolean => !hiddenSet().has(id);
+
+/**
+ * Every source, hidden ones included, in the order this person put them.
+ *
+ * Reconciled against the catalogue on every read rather than trusted, because
+ * what is on disk was written by an older version of this app: an id that no
+ * longer exists is dropped, and one the stored order has never heard of is
+ * appended. That second rule is what lets a new source ship without a
+ * migration — and appending rather than prepending is the honest default,
+ * since a tab you have never seen has not earned the front.
+ *
+ * Both halves matter. Without the drop, a removed source keeps a slot forever;
+ * without the append, adding one to TASK_SOURCES would make it invisible to
+ * everybody who has ever reordered.
+ */
+export const orderedTaskSources = (): TaskSourceId[] => (ordered ??= reconcile());
+
+function reconcile(): TaskSourceId[] {
+  const all = ALL_IDS();
+  let stored: unknown = [];
+  try { stored = JSON.parse(localStorage.getItem(ORDER_KEY) ?? "[]"); } catch { /* private mode */ }
+  const kept = (Array.isArray(stored) ? stored : [])
+    .filter((x): x is TaskSourceId => all.includes(x as TaskSourceId));
+  // Deduplicated: a half-written file, or two tabs racing, must not put a
+  // source on the bar twice — React would then see duplicate keys.
+  const seen = new Set<TaskSourceId>();
+  const out = kept.filter((x) => !seen.has(x) && (seen.add(x), true));
+  return [...out, ...all.filter((x) => !seen.has(x))];
+}
 
 /**
  * Every source that is still on. Never empty: hiding the last one would leave
@@ -45,10 +93,19 @@ export const taskSourceShown = (id: TaskSourceId): boolean => !hiddenSet().has(i
  * the preference actually changes.
  */
 let cached: TaskSourceId[] | null = null;
+let ordered: TaskSourceId[] | null = null;
 export const shownTaskSources = (): TaskSourceId[] =>
-  (cached ??= TASK_SOURCES.map((s) => s.id).filter(taskSourceShown));
+  (cached ??= orderedTaskSources().filter(taskSourceShown));
 
 const listeners = new Set<() => void>();
+
+/** One place to forget both caches and tell everybody, so no writer can update
+ *  one and leave the other stale. */
+function changed(): void {
+  cached = null;
+  ordered = null;
+  for (const fn of listeners) fn();
+}
 
 /** Returns what actually happened, which is not always what was asked: the last
  *  visible source stays visible. */
@@ -57,12 +114,51 @@ export function setTaskSourceShown(id: TaskSourceId, shown: boolean): boolean {
   if (!shown && shownTaskSources().length <= 1 && !hidden.has(id)) return true;
   if (shown) hidden.delete(id); else hidden.add(id);
   try { localStorage.setItem(KEY, JSON.stringify([...hidden])); } catch { /* private mode */ }
-  cached = null;
-  for (const fn of listeners) fn();
+  changed();
   return shown;
+}
+
+/**
+ * Move a source one place along the bar.
+ *
+ * A step rather than a drop target, and that is a considered trade: this is a
+ * list of three, it is edited in a settings pane rather than on the bar itself,
+ * and a pair of arrows works from the keyboard and on a phone without a single
+ * pointer event. Drag-and-drop would be prettier and would also be the only
+ * control in this pane that a screen reader could not operate.
+ *
+ * The move happens in the FULL order, hidden sources included. Stepping over
+ * something you cannot see would otherwise look like a press that did nothing —
+ * and turning that source back on afterwards would reveal an order you never
+ * asked for.
+ *
+ * Returns whether anything moved, so a caller can leave the button dead at the
+ * ends rather than pretending.
+ */
+export function moveTaskSource(id: TaskSourceId, by: -1 | 1): boolean {
+  const order = [...orderedTaskSources()];
+  const at = order.indexOf(id);
+  const to = at + by;
+  if (at < 0 || to < 0 || to >= order.length) return false;
+  [order[at], order[to]] = [order[to]!, order[at]!];
+  try { localStorage.setItem(ORDER_KEY, JSON.stringify(order)); } catch { /* private mode */ }
+  changed();
+  return true;
+}
+
+/** Back to the catalogue's own order — the escape hatch for somebody who has
+ *  shuffled themselves into something they no longer want to reason about. */
+export function resetTaskSourceOrder(): void {
+  try { localStorage.removeItem(ORDER_KEY); } catch { /* private mode */ }
+  changed();
 }
 
 export function subscribeTaskSources(fn: () => void): () => void {
   listeners.add(fn);
   return () => { listeners.delete(fn); };
 }
+
+/** For a test that writes to the store behind this module's back — the caches
+ *  are only dropped by this module's own writers, which is exactly right in the
+ *  app and exactly wrong in a fixture. */
+export function __forgetTaskSources(): void { changed(); }

--- a/web/test/task-connected.test.ts
+++ b/web/test/task-connected.test.ts
@@ -1,0 +1,48 @@
+// Which task sources are set up, and what the tab bar does about it.
+//
+// The rule being pinned here is the one with a hinge in it. Hiding an
+// unconnected source is right for somebody who has set their machine up, and
+// wrong on a fresh install, where the bar is the only place these features are
+// advertised at all. So "nothing set up" is not "hide everything" — it is the
+// case where all of them show.
+import { describe, expect, test } from "bun:test";
+import { visibleTaskSources, type TaskConnected } from "../src/lib/taskConnected.ts";
+import type { TaskSourceId } from "../src/lib/taskSources.ts";
+
+const ALL: TaskSourceId[] = ["github", "local", "clickup"];
+
+const set = (...on: TaskSourceId[]): TaskConnected =>
+  ({ github: on.includes("github"), local: on.includes("local"), clickup: on.includes("clickup") });
+
+describe("which sources reach the bar", () => {
+  test("only the ones that are set up", () => {
+    expect(visibleTaskSources(ALL, set("github", "local"))).toEqual(["github", "local"]);
+  });
+
+  test("everything, when nothing is set up", () => {
+    // A fresh install. Hiding all three would leave the view as its own header,
+    // and the features would exist only for somebody who already knew.
+    expect(visibleTaskSources(ALL, set())).toEqual(ALL);
+  });
+
+  test("everything, while the answer is still unknown", () => {
+    // Null is "not asked yet". Drawing the preference and then only ever losing
+    // tabs is what stops the bar rearranging itself a beat after it appears.
+    expect(visibleTaskSources(ALL, null)).toEqual(ALL);
+  });
+
+  test("the preference's order is kept, never re-sorted", () => {
+    const reordered: TaskSourceId[] = ["clickup", "local", "github"];
+    expect(visibleTaskSources(reordered, set("clickup", "github"))).toEqual(["clickup", "github"]);
+  });
+
+  test("a source switched off stays off even when it is connected", () => {
+    // This only ever removes. What the preference already dropped is not ours
+    // to put back.
+    expect(visibleTaskSources(["github"], set("github", "clickup"))).toEqual(["github"]);
+  });
+
+  test("one connected source is a bar of one, not a fallback to all", () => {
+    expect(visibleTaskSources(ALL, set("clickup"))).toEqual(["clickup"]);
+  });
+});

--- a/web/test/task-landing.test.ts
+++ b/web/test/task-landing.test.ts
@@ -1,0 +1,88 @@
+// Which tab the Tasks view opens on.
+//
+// There was no default here before, there was a constant: the source was
+// component state initialised to "all", so every visit started over — on the
+// one view that does not include your ClickUp cards. Everything below is about
+// the same failure mode in different clothes: landing on a tab that is not on
+// the bar, which draws an empty view with no way to tell why.
+import { beforeEach, describe, expect, test } from "bun:test";
+import {
+  landingSource, taskLanding, setTaskLanding, lastTaskSource, rememberTaskSource,
+} from "../src/lib/taskLanding.ts";
+
+const store = new Map<string, string>();
+(globalThis as { localStorage?: unknown }).localStorage = {
+  getItem: (k: string) => (store.has(k) ? store.get(k)! : null),
+  setItem: (k: string, v: string) => { store.set(k, v); },
+  removeItem: (k: string) => { store.delete(k); },
+};
+
+const BAR = ["all", "github", "local", "clickup"];
+
+beforeEach(() => { store.clear(); });
+
+describe("the stored preference", () => {
+  test("is last-used until somebody chooses otherwise", () => {
+    expect(taskLanding()).toBe("last");
+  });
+
+  test("survives a round trip", () => {
+    setTaskLanding("clickup");
+    expect(taskLanding()).toBe("clickup");
+  });
+
+  test("ignores a value it does not recognise", () => {
+    // Written by a future version, or by hand. Falling back beats landing on a
+    // tab that does not exist.
+    store.set("agentglass.tasks.landing", "jira");
+    expect(taskLanding()).toBe("last");
+  });
+});
+
+describe("where it actually lands", () => {
+  test("on last-used, the tab you left", () => {
+    rememberTaskSource("clickup");
+    expect(landingSource(BAR)).toBe("clickup");
+  });
+
+  test("on last-used with nothing remembered, the first tab", () => {
+    expect(landingSource(BAR)).toBe("all");
+  });
+
+  test("on a pinned source, that source whatever you did last", () => {
+    setTaskLanding("clickup");
+    rememberTaskSource("github");
+    expect(landingSource(BAR)).toBe("clickup");
+  });
+
+  test("a remembered tab that is no longer on the bar is not landed on", () => {
+    // ClickUp switched off, or its token removed since you were last here.
+    rememberTaskSource("clickup");
+    expect(landingSource(["all", "github", "local"])).toBe("all");
+  });
+
+  test("a pinned tab that is no longer on the bar is not landed on either", () => {
+    setTaskLanding("clickup");
+    expect(landingSource(["all", "github"])).toBe("all");
+  });
+
+  test("falls back to the first tab, not to “all”", () => {
+    // The whole reason this takes the bar as an argument: with one source there
+    // IS no "all", and landing on it draws a view that is not there.
+    setTaskLanding("clickup");
+    expect(landingSource(["github"])).toBe("github");
+    expect(landingSource([])).toBe("all");
+  });
+});
+
+describe("what gets remembered", () => {
+  test("nothing, until something is", () => {
+    expect(lastTaskSource()).toBe(null);
+  });
+
+  test("the last thing written wins", () => {
+    rememberTaskSource("local");
+    rememberTaskSource("clickup");
+    expect(lastTaskSource()).toBe("clickup");
+  });
+});

--- a/web/test/task-sources.test.ts
+++ b/web/test/task-sources.test.ts
@@ -7,6 +7,7 @@
 import { beforeEach, describe, expect, test } from "bun:test";
 import {
   TASK_SOURCES, shownTaskSources, taskSourceShown, setTaskSourceShown, subscribeTaskSources,
+  orderedTaskSources, moveTaskSource, resetTaskSourceOrder, __forgetTaskSources,
 } from "../src/lib/taskSources.ts";
 
 // bun's test environment has no DOM; the module only ever touches these three.
@@ -59,5 +60,66 @@ describe("what the Tasks view offers", () => {
     off();
     setTaskSourceShown("local", true);
     expect(beats).toBe(1);
+  });
+});
+
+describe("the order they sit in", () => {
+  test("is the catalogue's own until somebody moves something", () => {
+    expect(orderedTaskSources()).toEqual(TASK_SOURCES.map((s) => s.id));
+  });
+
+  test("a move is one step, and the ends do not wrap", () => {
+    expect(moveTaskSource("clickup", -1)).toBe(true);
+    expect(orderedTaskSources()).toEqual(["github", "clickup", "local"]);
+    // Already last after two moves up would be first — check the real end.
+    expect(moveTaskSource("github", -1)).toBe(false);
+    expect(moveTaskSource("local", 1)).toBe(false);
+    expect(orderedTaskSources()).toEqual(["github", "clickup", "local"]);
+  });
+
+  test("the bar follows the order, hidden ones dropped", () => {
+    moveTaskSource("clickup", -1);
+    moveTaskSource("clickup", -1);
+    setTaskSourceShown("github", false);
+    expect(orderedTaskSources()).toEqual(["clickup", "github", "local"]);
+    expect(shownTaskSources()).toEqual(["clickup", "local"]);
+  });
+
+  test("moving steps over a hidden source rather than past it invisibly", () => {
+    // The move happens in the full list. Stepping over something you cannot see
+    // would look like a press that did nothing, and turning that source back on
+    // later would reveal an order nobody asked for.
+    setTaskSourceShown("local", false);
+    expect(moveTaskSource("clickup", -1)).toBe(true);
+    expect(orderedTaskSources()).toEqual(["github", "clickup", "local"]);
+    expect(shownTaskSources()).toEqual(["github", "clickup"]);
+  });
+
+  test("a stored order from another version is reconciled, not trusted", () => {
+    // An id that no longer exists is dropped; one it has never heard of is
+    // appended, which is what lets a new source ship with no migration. A
+    // duplicate is collapsed — React would render the same key twice.
+    store.set("agentglass.tasks.order", JSON.stringify(["clickup", "gone", "clickup"]));
+    __forgetTaskSources();
+    expect(orderedTaskSources()).toEqual(["clickup", "github", "local"]);
+  });
+
+  test("rubbish on disk is ignored rather than fatal", () => {
+    store.set("agentglass.tasks.order", "{not json");
+    __forgetTaskSources();
+    expect(orderedTaskSources()).toEqual(TASK_SOURCES.map((s) => s.id));
+  });
+
+  test("reset puts the catalogue's order back", () => {
+    moveTaskSource("clickup", -1);
+    resetTaskSourceOrder();
+    expect(orderedTaskSources()).toEqual(TASK_SOURCES.map((s) => s.id));
+  });
+
+  test("the ordered snapshot keeps its identity until something changes", () => {
+    expect(orderedTaskSources()).toBe(orderedTaskSources());
+    const before = orderedTaskSources();
+    moveTaskSource("clickup", -1);
+    expect(orderedTaskSources()).not.toBe(before);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Three complaints about the Tasks tab bar that turned out to share one cause: nothing about it was a preference. Which tabs it had was a constant, the order was `TASK_SOURCES`' own, and where it opened was `useState("all")`.

**It opens where you left it.** There was no default before — there was a constant. Go to Tasks, open a card, look at a diff, come back: "All" again, every time. And "All" is the one view that does not include ClickUp cards (it draws the now band, the local strip and the repository's issues), so somebody who works out of a board landed, every single visit, on the tab without their work in it. It now lands on the tab you left, and Settings → Tasks can pin it to one source instead. Following a card link from a pull request never writes that memory: an errand is not a change of mind.

**A source you have not set up is left off the bar.** The old comment argued the opposite and argued it well — an unconnected tab says what to do, and a tab you only find after finding Settings is a feature nobody discovers. That is true right up to the moment you connect something, and then it is somebody else's product sitting in the middle of yours. So the rule has a hinge in it: nothing set up at all shows everything, because a fresh install needs the advertisement; anything set up shows what is set up. A source that is set up and **broken** stays on the bar — "ClickUp refused this token" is not "you do not use ClickUp", and that tab is what carries the news. The precedent was already in the repo: GitLab has an Integrations row and no tab, and nobody has called it hidden.

**The order is yours.** Up/down arrows in Settings rather than a drop target: every other control in that pane works from a keyboard, and dragging would have been the one that does not. A move steps through the full list, hidden sources included, so it never looks like a press that did nothing. There is a "Reset order".

The stored order is reconciled against the catalogue on every read rather than trusted — unknown ids dropped, new ones appended, duplicates collapsed — which is what lets a future source ship without a migration.

`Toggle`'s switch is split out as `Switch` so a source row can carry three controls. The row itself can no longer be the button: arrows inside a button is invalid HTML that every browser guesses at differently.

Three new modules, each owning one question: `taskSources.ts` gains the order, `taskConnected.ts` answers what is set up (from `/providers`, cached 60s, failure never cached), and `taskLanding.ts` answers where to open.

## How was it tested?

- `bun run typecheck` clean in `web/` and `server/`; `bunx vite build` clean.
- 30 new tests across three files. The ones worth naming pin the failure modes rather than the happy path: the fresh-install hinge (nothing set up shows everything), an unknown answer showing everything so the bar cannot be seen rearranging itself, a remembered or pinned tab that is no longer on the bar not being landed on, the fallback being the first tab rather than "all" (on a bar of one there **is** no "all"), a stored order from another version being reconciled, and rubbish on disk being ignored rather than fatal.
- Existing `task-sources` suite still passes, including its identity-of-snapshot test — a fresh array per read is an infinite re-render, so both caches are dropped through one `changed()`.

The full suite has 35 failures on this branch; all 35 reproduce on an unmodified tree and are environmental (tmux, port binding, `/proc`, Tailscale — none available in this sandbox). None touch the Tasks view.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP

---
_Generated by [Claude Code](https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP)_