### PR TITLE
feat: an issue and its pull requests, each reachable from the other

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -72,7 +72,7 @@ import { listPorts, listResources, spaceFor, killPort } from "./machine.ts";
 import { gitLocks, removeStaleLock } from "./gitlocks.ts";
 import { procDetail, revealEnv } from "./procdetail.ts";
 import {
-  listIssues, issueDetail, startIssue, finishIssue, claimIssue, commentIssue, setIssueState, currentWork,
+  listIssues, issueDetail, issuePullRequests, startIssue, finishIssue, claimIssue, commentIssue, setIssueState, currentWork,
 } from "./issues.ts";
 import { providerStatuses, connectProvider, disconnectProvider, providerWorkspaces, chooseWorkspace, addViewByUrl, replaceViewUrl, readView } from "./providers.ts";
 import { savedViews, currentView, setCurrent, removeView, knownCardPrefix, boardHolding, setWritesAllowed } from "./clickupviews.ts";
@@ -2003,6 +2003,13 @@ const server = Bun.serve<WsData>({
     }
     if (pathname === "/issues/detail") {
       return json(await issueDetail(url.searchParams.get("root") || "", url.searchParams.get("number")));
+    }
+    /* The pull requests an issue produced — the other half of the link the
+       pull-request panel already draws with `closingIssuesReferences`. Its own
+       route rather than a field on the detail: it is a second round trip to
+       GitHub, and the description should not wait on it. */
+    if (pathname === "/issues/prs") {
+      return json(await issuePullRequests(url.searchParams.get("root") || "", url.searchParams.get("number")));
     }
     if (pathname === "/issues/work") return json({ work: currentWork(url.searchParams.get("repo") || undefined) });
 

--- a/server/src/issues.ts
+++ b/server/src/issues.ts
@@ -21,7 +21,7 @@ import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, basename } from "node:path";
-import { gh } from "./prs.ts";
+import { gh, ghGraphql } from "./prs.ts";
 import { git, safeAbs } from "./git.ts";
 import { addWorktree, removeWorktree } from "./gitwork.ts";
 import { inScope } from "./config.ts";
@@ -59,6 +59,22 @@ export interface IssueWork {
 }
 
 export type StartMode = "worktree" | "shell" | "claude" | "plan" | "branch";
+
+/**
+ * A pull request that has something to do with an issue.
+ *
+ * `linked` separates the two things GitHub's timeline calls a reference: one
+ * somebody attached to the issue (and which will close it) from a `#123` that
+ * turned up in a body somewhere. See issuePullRequests.
+ */
+export interface IssuePr {
+  number: number;
+  title: string;
+  state: string;
+  url: string;
+  draft: boolean;
+  linked: boolean;
+}
 
 export interface IssuesReport { ok: boolean; issues: IssueRow[]; error?: string }
 
@@ -224,6 +240,142 @@ export async function issueDetail(rootIn: unknown, numberIn: unknown): Promise<{
   } catch (e) {
     return { ok: false, error: String(e) };
   }
+}
+
+// ---------------------------------------------------------------------------
+// the pull requests an issue produced
+// ---------------------------------------------------------------------------
+
+/*
+ * The other direction of the link the pull-request panel already draws.
+ *
+ * A pull request says which issues it closes — `closingIssuesReferences`, read
+ * in prs.ts and shown as "Merging this closes: #123". Standing on the ISSUE
+ * there was nothing, which is the half you are on when you want to know
+ * whether somebody is already doing this.
+ *
+ * Worth contrasting with the ClickUp version of the same feature, which had to
+ * GUESS: ClickUp's API exposes no link to a pull request, so cardPullRequests
+ * searches GitHub for the card id and hopes the team names its branches after
+ * it. Here the link is a real edge in GitHub's own graph, so nothing is
+ * guessed and nothing depends on a naming convention.
+ *
+ * Two kinds of edge arrive, and they are NOT the same claim:
+ *
+ *   CONNECTED_EVENT        somebody linked this pull request to this issue —
+ *                          a deliberate act, and the one that closes it
+ *   CROSS_REFERENCED_EVENT a pull request mentioned `#123` somewhere. Often
+ *                          "related to", sometimes just a changelog line.
+ *
+ * Reported apart rather than merged, for the reason `stated` exists on a
+ * ClickUp card: a mention shown as "this closes your issue" is a promise
+ * nobody made.
+ *
+ * DISCONNECTED_EVENT is asked for so that unlinking is honoured. The timeline
+ * is a log, not a state — a link that was made and then removed still has its
+ * CONNECTED_EVENT sitting in it forever, so without this an issue keeps
+ * advertising a pull request somebody deliberately detached from it.
+ */
+const ISSUE_PRS_QUERY = `query($owner:String!,$name:String!,$number:Int!){
+  repository(owner:$owner,name:$name){
+    issue(number:$number){
+      timelineItems(first:100, itemTypes:[CONNECTED_EVENT, DISCONNECTED_EVENT, CROSS_REFERENCED_EVENT]){
+        nodes{
+          __typename
+          ... on ConnectedEvent{ subject{ ... on PullRequest{ number title state url isDraft } } }
+          ... on DisconnectedEvent{ subject{ ... on PullRequest{ number } } }
+          ... on CrossReferencedEvent{ source{ ... on PullRequest{ number title state url isDraft } } }
+        }
+      }
+    }
+  }
+}`;
+
+interface RawPr { number?: number; title?: string; state?: string; url?: string; isDraft?: boolean }
+
+interface IssuePrsAnswer {
+  data?: {
+    repository?: {
+      issue?: {
+        timelineItems?: {
+          nodes?: ({ __typename?: string; subject?: RawPr; source?: RawPr } | null)[];
+        };
+      };
+    };
+  };
+}
+
+export async function issuePullRequests(
+  rootIn: unknown, numberIn: unknown,
+): Promise<{ ok: boolean; prs: IssuePr[]; error?: string }> {
+  const root = safeAbs(rootIn);
+  const number = Number(numberIn);
+  if (!root || !Number.isInteger(number) || number <= 0) return { ok: false, prs: [], error: "invalid request" };
+  if (!inScope(root)) return { ok: false, prs: [], error: "outside the open project" };
+
+  const repo = await repoOf(root);
+  const [owner, name] = (repo ?? "").split("/");
+  if (!owner || !name) return { ok: false, prs: [], error: "no GitHub repository here" };
+
+  const r = await ghGraphql<IssuePrsAnswer>(ISSUE_PRS_QUERY, { owner, name, number });
+  // Null is the transport failing, which is not an issue with no pull
+  // requests. The caller has to be able to tell those apart — see the panel,
+  // where one renders nothing and the other says so.
+  if (!r?.data?.repository?.issue) return { ok: false, prs: [], error: "could not ask GitHub" };
+  return { ok: true, prs: prsFromTimeline(r.data.repository.issue.timelineItems?.nodes ?? []) };
+}
+
+/**
+ * The timeline reduced to a list of pull requests, separated from the fetching.
+ *
+ * Split out because the reduction is the part with rules in it and the fetch is
+ * the part that needs a network: what has to be got right here is which events
+ * outrank which, and none of that has anything to do with HTTP.
+ *
+ * A timeline is a LOG. Every rule below is a consequence of that one fact —
+ * the same pull request can appear several times, in any order, saying
+ * different things each time, and only the sum of them is the truth.
+ */
+export function prsFromTimeline(
+  nodes: ({ __typename?: string; subject?: RawPr; source?: RawPr } | null | undefined)[],
+): IssuePr[] {
+  const out = new Map<number, IssuePr>();
+  const detached = new Set<number>();
+  for (const node of nodes) {
+    if (!node) continue;
+    const raw = node.subject ?? node.source;
+    const n = Number(raw?.number);
+    // A timeline node for an ISSUE rather than a pull request. Cross-references
+    // between issues are ordinary and arrive here as an inline fragment that
+    // matched nothing, so there is no number to read.
+    if (!Number.isInteger(n) || n <= 0) continue;
+    if (node.__typename === "DisconnectedEvent") { detached.add(n); continue; }
+    const linked = node.__typename === "ConnectedEvent";
+    // Re-linking after a detach is a LATER event than the detach, so the last
+    // word wins rather than the first.
+    if (linked) detached.delete(n);
+    // Nothing to show and nowhere to send a click. A disconnect above is still
+    // honoured, because it says something even when the node carries no detail.
+    if (!raw?.url) continue;
+    const had = out.get(n);
+    out.set(n, {
+      number: n,
+      title: String(raw.title ?? ""),
+      state: String(raw.state ?? "").toUpperCase(),
+      url: String(raw.url),
+      draft: raw.isDraft === true,
+      // Once linked, always linked. A pull request that closes an issue and
+      // also mentions it in a comment produces both events, and whichever
+      // happens to come last must not decide the claim.
+      linked: linked || had?.linked === true,
+    });
+  }
+
+  // Linked first, then newest — the one somebody is looking for is the one
+  // that is actually going to close this.
+  return [...out.values()]
+    .filter((p) => !detached.has(p.number))
+    .sort((a, b) => Number(b.linked) - Number(a.linked) || b.number - a.number);
 }
 
 // ------------------------------------------------------------ the writes ----

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -2214,7 +2214,7 @@ let tokenCache: { at: number; token: string } | null = null;
  * subprocess buys nothing. It stays as the fallback for the case the token
  * cannot be read (an unusual `gh` setup, a keyring that will not answer).
  */
-async function ghGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T | null> {
+export async function ghGraphql<T>(query: string, variables: Record<string, unknown>): Promise<T | null> {
   const token = await ghToken();
   if (!token) return ghJson<T>(["api", "graphql", "-f", `query=${query}`,
     ...Object.entries(variables).flatMap(([k, v]) => ["-F", `${k}=${String(v)}`])]);

--- a/server/test/issue-prs.test.ts
+++ b/server/test/issue-prs.test.ts
@@ -1,0 +1,80 @@
+/*
+ * The pull requests an issue produced, read out of GitHub's timeline.
+ *
+ * A timeline is a LOG, not a state, and every rule pinned here is a consequence
+ * of that: the same pull request appears as many times as things happened to
+ * it, in the order they happened, and only the sum is true. Reading the first
+ * event, or the last, gets a different answer from reading all of them.
+ *
+ * The other half of what this protects is the distinction between the two
+ * kinds of reference. A pull request LINKED to an issue will close it; one that
+ * merely mentions `#12` in a comment has promised nothing. Showing the second
+ * as the first is a fix somebody is told to expect and nobody is writing.
+ */
+import { describe, expect, it } from "bun:test";
+import { prsFromTimeline } from "../src/issues.ts";
+
+const pr = (number: number, over: Record<string, unknown> = {}) => ({
+  number, title: `pr ${number}`, state: "OPEN", url: `https://github.com/o/r/pull/${number}`, ...over,
+});
+
+const connected = (n: number, over = {}) => ({ __typename: "ConnectedEvent", subject: pr(n, over) });
+const mentioned = (n: number, over = {}) => ({ __typename: "CrossReferencedEvent", source: pr(n, over) });
+const disconnected = (n: number) => ({ __typename: "DisconnectedEvent", subject: { number: n } });
+
+describe("what the timeline says about an issue's pull requests", () => {
+  it("tells a link apart from a mention", () => {
+    const out = prsFromTimeline([connected(7), mentioned(9)]);
+    expect(out.find((p) => p.number === 7)!.linked).toBe(true);
+    expect(out.find((p) => p.number === 9)!.linked).toBe(false);
+  });
+
+  it("carries the state and the draft flag through", () => {
+    const [only] = prsFromTimeline([connected(7, { state: "merged", isDraft: true })]);
+    expect(only!.state).toBe("MERGED");
+    expect(only!.draft).toBe(true);
+    expect(only!.title).toBe("pr 7");
+  });
+
+  it("honours an unlink rather than advertising it forever", () => {
+    // The ConnectedEvent stays in the log after somebody detaches the pull
+    // request. Reading the log without this leaves the issue pointing at work
+    // that was deliberately taken off it.
+    expect(prsFromTimeline([connected(7), disconnected(7)])).toEqual([]);
+  });
+
+  it("takes a re-link as the later word", () => {
+    expect(prsFromTimeline([connected(7), disconnected(7), connected(7)]).map((p) => p.number)).toEqual([7]);
+  });
+
+  it("does not let a mention downgrade a link, whichever came last", () => {
+    // Closing an issue and then mentioning it in a comment is ordinary, and the
+    // events arrive in that order.
+    const [only] = prsFromTimeline([connected(7), mentioned(7)]);
+    expect(only!.linked).toBe(true);
+    expect(prsFromTimeline([mentioned(7), connected(7)])[0]!.linked).toBe(true);
+  });
+
+  it("lists each pull request once however often it appears", () => {
+    expect(prsFromTimeline([mentioned(7), mentioned(7), connected(7)]).length).toBe(1);
+  });
+
+  it("skips a node that is not a pull request", () => {
+    // An issue cross-referencing another issue matches no inline fragment, so
+    // the node arrives with nothing in it. Null nodes come from GraphQL too.
+    expect(prsFromTimeline([{ __typename: "CrossReferencedEvent" }, null, undefined, {}])).toEqual([]);
+  });
+
+  it("skips a pull request with no address, since there is nowhere to send a click", () => {
+    expect(prsFromTimeline([{ __typename: "ConnectedEvent", subject: { number: 7, title: "x" } }])).toEqual([]);
+  });
+
+  it("puts what closes the issue first, then the newest", () => {
+    const out = prsFromTimeline([mentioned(30), connected(4), mentioned(12)]);
+    expect(out.map((p) => p.number)).toEqual([4, 30, 12]);
+  });
+
+  it("says nothing about an issue nothing has touched", () => {
+    expect(prsFromTimeline([])).toEqual([]);
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2713,6 +2713,25 @@ export interface IssueDetail extends IssueRow {
   milestone: string | null;
   work: IssueWork | null;
 }
+/**
+ * A pull request that has something to do with an issue.
+ *
+ * `linked` is the difference between the two things GitHub's timeline calls a
+ * reference, and it is not cosmetic: a linked pull request is one somebody
+ * attached to the issue and is what will close it, while a mention is a `#123`
+ * that appeared in a body somewhere. Showing the second as the first promises
+ * a fix nobody committed to.
+ */
+export interface IssuePr {
+  number: number;
+  title: string;
+  /** OPEN | CLOSED | MERGED, as GitHub spells it. */
+  state: string;
+  url: string;
+  draft: boolean;
+  linked: boolean;
+}
+export interface IssuePrsReport { ok: boolean; prs: IssuePr[]; error?: string }
 export interface IssuesReport { ok: boolean; issues: IssueRow[]; error?: string }
 export interface IssueStartResult {
   ok: boolean; error?: string; work?: IssueWork; prompt?: string; cwd?: string;

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -36,6 +36,7 @@ import { requestFilesReveal } from "./lib/filesReveal.ts";
 import { onOpenSettings, openSettings } from "./lib/openSettings.ts";
 import { onOpenPrs, onOpenPr } from "./lib/openPrs.ts";
 import { onOpenCard, openCard } from "./lib/openCard.ts";
+import { onOpenIssue } from "./lib/openIssue.ts";
 import { newChat, chatResuming, applyLiveEvent } from "./lib/chatStore.ts";
 import { sessionCwd } from "./lib/worktree.ts";
 import { SearchModal } from "./components/SearchModal.tsx";
@@ -167,12 +168,16 @@ export default function App() {
   const [prJump, setPrJump] = useState<import("./lib/openPrs.ts").PrJump | null>(null);
   /** The other direction — a pull request asking for the card it came from. */
   const [cardJump, setCardJump] = useState<import("./lib/openCard.ts").CardJump | null>(null);
+  /** And a pull request asking for the GitHub issue it closes — see
+   *  lib/openIssue.ts for why that link used to leave the app. */
+  const [issueJump, setIssueJump] = useState<import("./lib/openIssue.ts").IssueJump | null>(null);
   useEffect(() => onOpenSettings((pane) => { setSettingsPane(pane ?? null); setSettingsOpen(true); }), []);
   useEffect(() => onOpenPrs((j) => { setPrJump(j); goView("pr"); }), [goView]);
   /* The other half: a sender that knows exactly which pull request it means
      gets the panel's jump, which selects and opens, instead of a search. */
   useEffect(() => onOpenPr(({ repo, number }) => { requestPrJump(repo, number); goView("pr"); }), [goView]);
   useEffect(() => onOpenCard((j) => { setCardJump(j); goView("tasks"); }), [goView]);
+  useEffect(() => onOpenIssue((j) => { setIssueJump(j); goView("tasks"); }), [goView]);
   /** Which machine tab is open, or none. One piece of state for both surfaces:
    *  the dashboard header and the workspace rail open the same panel, and a
    *  second copy would be a second poll of /proc. */
@@ -895,6 +900,7 @@ export default function App() {
       <Workspace
         prJump={prJump}
         cardJump={cardJump}
+        issueJump={issueJump}
         view={wsView} onView={setWsView}
         onSkills={() => setSkillsOpen(true)}
         onSettings={() => setSettingsOpen(true)}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -58,6 +58,7 @@ import { cardRef, chipAction } from "../lib/cardRef.ts";
 import { requestWorktreeJump } from "../lib/worktreeJump.ts";
 import { conflictBriefing, CONFLICT_ASK } from "../lib/conflictBrief.ts";
 import { openCard } from "../lib/openCard.ts";
+import { openIssue } from "../lib/openIssue.ts";
 import { useClickupSetup } from "../lib/clickupSetup.ts";
 import { CloseButton } from "./CloseButton.tsx";
 import { ICON } from "../lib/iconSize.ts";
@@ -4419,9 +4420,23 @@ function PrSidebar({ d, onEditField }: {
         <SidebarSection title="Development">
           <div className="flex flex-col gap-1">
             <span className="text-[10px]" style={{ color: "var(--text3)" }}>Merging this closes:</span>
+            {/* Into the Issues view, not out to a browser.
+                This link has been here for a while and was the only one in the
+                app that left: everything else that knows about another view
+                goes TO it — a card id opens the board, a PR number opens the
+                pull-request panel. The arrow beside it is the way out, kept
+                because an issue in another repository is a real case and the
+                Issues view reads one repository. See lib/openIssue.ts. */}
             {d.linkedIssues.map((i) => (
-              <a key={i.number} href={externalUrl(i.url)} target="_blank" rel="noreferrer noopener"
-                className="text-[11px] truncate" style={{ color: "var(--primary)" }} title={i.title}>#{i.number} {i.title}</a>
+              <span key={i.number} className="flex items-center gap-1 min-w-0">
+                <button onClick={() => openIssue(i.number)}
+                  className="agx-btn text-[11px] truncate text-left min-w-0"
+                  style={{ color: "var(--primary)" }}
+                  title={`Open #${i.number} in Tasks — ${i.title}`}>#{i.number} {i.title}</button>
+                <a href={externalUrl(i.url)} target="_blank" rel="noreferrer noopener"
+                  className="agx-btn text-[9px] shrink-0" style={{ color: "var(--text4)" }}
+                  title="Open on GitHub">↗</a>
+              </span>
             ))}
           </div>
         </SidebarSection>

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -12,7 +12,7 @@
 // with fourteen checkouts nobody can name.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { api } from "../lib/api.ts";
-import type { GitRepoRef, IssueDetail, IssueRow, IssueWork, StartMode, LocalTask, TaskCapability, TasksListResponse, SkillInfo } from "../../../shared/types.ts";
+import type { GitRepoRef, IssueDetail, IssuePr, IssueRow, IssueWork, StartMode, LocalTask, TaskCapability, TasksListResponse, SkillInfo } from "../../../shared/types.ts";
 import type { ProviderTask, ProviderTasksResponse, SavedView, ViewTasksResponse, ListStatus, ListField, ListPlace, ListMember, TaskDetail } from "../../../shared/providers.ts";
 import { ViewHeader } from "./workspace/ViewHeader.tsx";
 import { useDismiss } from "../lib/useDismiss.ts";
@@ -25,6 +25,7 @@ import { openSettings } from "../lib/openSettings.ts";
 import { handoffTo, setHandoffTo, type HandoffTo } from "../lib/handoffTo.ts";
 import { openPrs } from "../lib/openPrs.ts";
 import type { CardJump } from "../lib/openCard.ts";
+import type { IssueJump } from "../lib/openIssue.ts";
 import { TASK_SOURCES, shownTaskSources, subscribeTaskSources, type TaskSourceId } from "../lib/taskSources.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 import { ContextMenu, MenuItem } from "./ContextMenu.tsx";
@@ -83,7 +84,7 @@ const LABEL: Record<string, string> = {
 };
 
 
-export function TasksView({ active, onOpenChatWith, cardJump }: {
+export function TasksView({ active, onOpenChatWith, cardJump, issueJump }: {
   active: boolean;
   onOpenChatWith?: (cwd: string, prompt: string, title: string) => void;
   /** A pull request asking for the card it came from — see lib/openCard.ts.
@@ -91,6 +92,9 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
    *  mounted the first time somebody comes here, which may be the click that
    *  sent it: a store read at mount would be a race, a prop is not. */
   cardJump?: CardJump | null;
+  /** A pull request asking for the issue it closes. Same arrangement and same
+   *  reason as `cardJump` — see lib/openIssue.ts. */
+  issueJump?: IssueJump | null;
 }) {
   const [repos, setRepos] = useState<GitRepoRef[]>([]);
   const [root, setRoot] = useState("");
@@ -142,6 +146,16 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
     setSource("clickup");
   }, [cardJump?.n]);
 
+  /* The same errand for a GitHub issue. "All" would do — it renders the issue
+     list too — but the tab it belongs to is the honest place to land: what
+     arrives is one issue, and "All" is where you go to see everything at once.
+     Neither this nor the card jump writes the remembered tab. */
+  useEffect(() => {
+    if (!issueJump) return;
+    setForced("github");
+    setSource("github");
+  }, [issueJump?.n]);
+
   return (
     <div className="flex flex-col h-full min-h-0">
       <ViewHeader label="Tasks">
@@ -176,7 +190,7 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
         <div className="flex flex-col flex-1 min-h-0">
           {source === "all" && <NowBand onChanged={() => {}} />}
           {source === "all" && <LocalStrip active={active} onOpen={() => setSource("local")} />}
-          {root ? <IssuesBody key={root} root={root} active={active} /> : (
+          {root ? <IssuesBody key={root} root={root} active={active} jump={issueJump} /> : (
             <div className="p-5 text-[11.5px]" style={{ color: "var(--text3)" }}>No repository to read issues from.</div>
           )}
         </div>
@@ -186,7 +200,7 @@ export function TasksView({ active, onOpenChatWith, cardJump }: {
 }
 
 
-function IssuesBody({ root, active }: { root: string; active: boolean }) {
+function IssuesBody({ root, active, jump }: { root: string; active: boolean; jump?: IssueJump | null }) {
   const [state, setState] = useState<"open" | "closed" | "all">("open");
   const [mine, setMine] = useState(false);
   const [q, setQ] = useState("");
@@ -210,6 +224,27 @@ function IssuesBody({ root, active }: { root: string; active: boolean }) {
     const id = setInterval(load, 60_000);
     return () => clearInterval(id);
   }, [active, load]);
+
+  /*
+   * Serve a "show me this issue" from the pull-request panel.
+   *
+   * Waits for the list, and not out of politeness: an issue that is closed —
+   * which is most of what a merged pull request points at — has no row under
+   * the default "open" filter, so selecting it would open the detail beside a
+   * list that visibly does not contain it. Widening to "all" is the same
+   * courtesy the ClickUp board does when a jump lands on a card its filters
+   * hide.
+   *
+   * `n` is what is compared, so the same issue asked for twice is served twice;
+   * the ref starts at 0, which no request ever is.
+   */
+  const served = useRef(0);
+  useEffect(() => {
+    if (!jump || !rows || jump.n === served.current) return;
+    served.current = jump.n;
+    setSel(jump.number);
+    if (!rows.some((r) => r.number === jump.number)) setState("all");
+  }, [jump?.n, rows]);
 
   const workFor = useMemo(() => new Map(work.map((w) => [w.number, w])), [work]);
   // No timer here any more: NoteStrip owns its own life, and two timers over
@@ -363,6 +398,19 @@ function Detail({ root, number, onSay, onChanged }: {
   }, [root, number]);
   useEffect(load, [load]);
 
+  /* The pull requests for this issue, asked for separately so the description
+     is on screen without waiting on a second round trip to GitHub. */
+  const [prs, setPrs] = useState<IssuePr[]>([]);
+  const [prsErr, setPrsErr] = useState(false);
+  useEffect(() => {
+    let live = true;
+    setPrs([]); setPrsErr(false);
+    api.issuePrs(root, number)
+      .then((r) => { if (live) { setPrs(r.prs ?? []); setPrsErr(!r.ok); } })
+      .catch(() => { if (live) setPrsErr(true); });
+    return () => { live = false; };
+  }, [root, number]);
+
   const act = async (fn: () => Promise<{ ok: boolean; error?: string; detail?: string; dirty?: string[] }>) => {
     setBusy(true);
     const r = await fn();
@@ -441,6 +489,54 @@ function Detail({ root, number, onSay, onChanged }: {
         </Field>
         <Field k="Milestone">{d.milestone ?? "None"}</Field>
       </div>
+
+      {/* The pull requests this issue produced.
+          The mirror of the pull-request sidebar's "Merging this closes", and
+          the reason the pair is worth having: standing on an issue, the
+          question is almost always "is somebody already on this", and the
+          answer was a trip to a browser.
+
+          Better founded than the ClickUp version of the same row. That one
+          searches GitHub for a card id and depends on the team naming its
+          branches after it; this is a real edge in GitHub's own graph. Which
+          is why the two claims are kept apart — a pull request LINKED to this
+          issue will close it, one that merely mentions it has promised
+          nothing. */}
+      {(!!prs.length || prsErr) && (
+        <div className="mb-4 pt-3" style={{ borderTop: edge(10) }}>
+          <div className="text-[8.5px] uppercase tracking-[0.18em] mb-1.5 flex items-center gap-2" style={{ color: "var(--text4)" }}>
+            Pull requests {!!prs.length && <span>{prs.length}</span>}
+            {prsErr && <span style={{ color: "var(--warning)" }}>· could not ask GitHub — this is not “none”</span>}
+          </div>
+          {prs.map((p) => (
+            <div key={p.number} className="flex items-center gap-2 py-1">
+              <button onClick={() => openPrs(String(p.number), p.state === "OPEN" ? "open" : "all")}
+                className="text-left flex-1 min-w-0 rounded px-1 -mx-1 hover:bg-white/5"
+                title="Open this in Pull Requests">
+                <span className="tabular-nums" style={{ color: "var(--primary)" }}>#{p.number}</span>
+                <span className="ml-1.5 text-[10px] tracking-[0.06em] px-1.5 rounded"
+                  style={p.state === "MERGED"
+                    ? { color: "#a371f7", background: "#a371f721" }
+                    : p.state === "CLOSED"
+                    ? { color: "var(--error)", background: "color-mix(in srgb, var(--error) 13%, transparent)" }
+                    : { color: "var(--success)", background: "color-mix(in srgb, var(--success) 13%, transparent)" }}>
+                  {p.draft ? "DRAFT" : p.state}
+                </span>
+                {/* Said only of the ones it is true of. A row with nothing here
+                    mentioned the issue and made no promise about it. */}
+                {p.linked && (
+                  <span className="ml-1.5 text-[10px]" style={{ color: "var(--text4)" }}
+                    title="linked to this issue on GitHub — merging it closes this">closes this</span>
+                )}
+                <div className="truncate text-[10.5px]" style={{ color: "var(--text3)" }}>{p.title || p.url}</div>
+              </button>
+              <a href={externalUrl(p.url)} target="_blank" rel="noreferrer noopener"
+                className="agx-btn text-[10px] px-1.5 py-0.5 rounded shrink-0"
+                style={{ color: "var(--text3)", border: edge(20) }} title="Open on GitHub">↗</a>
+            </div>
+          ))}
+        </div>
+      )}
 
       <div className="text-[11.5px]" style={{ color: "var(--text2)" }}>
         {d.body.trim() ? <Markdown text={d.body} /> : <span style={{ color: "var(--text3)" }}>No description.</span>}

--- a/web/src/components/workspace/Workspace.tsx
+++ b/web/src/components/workspace/Workspace.tsx
@@ -58,7 +58,7 @@ const KEEP_RUNNING = new Set<ViewId>(["term", "chat"]);
  */
 
 export function Workspace({
-  view, onView, onSkills, onSettings, onMachine, chatFocusId, dashboard, prJump, cardJump,
+  view, onView, onSkills, onSettings, onMachine, chatFocusId, dashboard, prJump, cardJump, issueJump,
 }: {
   view: ViewId;
   onView: (v: ViewId) => void;
@@ -74,6 +74,7 @@ export function Workspace({
   prJump?: import("../../lib/openPrs.ts").PrJump | null;
   /** The same errand the other way round — see lib/openCard.ts. */
   cardJump?: import("../../lib/openCard.ts").CardJump | null;
+  issueJump?: import("../../lib/openIssue.ts").IssueJump | null;
 }) {
   const openChat = useCallback(() => onView("chat"), [onView]);
 
@@ -165,7 +166,7 @@ export function Workspace({
               {v.id === "dash"
                 ? dashboard(active)
                 : <Body id={v.id} active={active} openChat={openChat} openChatWith={openChatWith} prJump={prJump}
-                    cardJump={cardJump} reviewInTerminal={reviewInTerminal} chatFocusId={chatFocusId} />}
+                    cardJump={cardJump} issueJump={issueJump} reviewInTerminal={reviewInTerminal} chatFocusId={chatFocusId} />}
             </div>
           );
         })}
@@ -176,7 +177,7 @@ export function Workspace({
 
 /** The non-dashboard views, and the props each one wants. Split out so the map
  *  above stays about mounting rather than about plumbing. */
-function Body({ id, active, openChat, openChatWith, reviewInTerminal, chatFocusId, prJump, cardJump }: {
+function Body({ id, active, openChat, openChatWith, reviewInTerminal, chatFocusId, prJump, cardJump, issueJump }: {
   id: ViewId; active: boolean;
   openChat: () => void;
   openChatWith: (cwd: string, prompt: string, title: string) => void;
@@ -184,10 +185,11 @@ function Body({ id, active, openChat, openChatWith, reviewInTerminal, chatFocusI
   chatFocusId?: string | null;
   prJump?: import("../../lib/openPrs.ts").PrJump | null;
   cardJump?: import("../../lib/openCard.ts").CardJump | null;
+  issueJump?: import("../../lib/openIssue.ts").IssueJump | null;
 }) {
   switch (id) {
     case "files": return <FilesView active={active} />;
-    case "tasks": return <TasksView active={active} onOpenChatWith={openChatWith} cardJump={cardJump} />;
+    case "tasks": return <TasksView active={active} onOpenChatWith={openChatWith} cardJump={cardJump} issueJump={issueJump} />;
     case "git": return <GitView active={active} onOpenChat={openChat} />;
     case "diff": return <DiffView active={active} />;
     case "pr": return <PrView active={active} onOpenChatWith={openChatWith} onReviewInTerminal={reviewInTerminal} jumpTo={prJump} />;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { ImportedPlace } from "./desktop.ts";
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, AgentModel, ChatImage, ConflictBlock, ConflictFile, MergeSessionView, BlockChoice, MergeInfo, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrSummary, PrActionResult, PrLocalHead, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord, IssuesReport, IssueDetail, IssueWork, IssueStartResult, IssueActionResult, StartMode, PortsReport, ResourceReport, SpaceReport, TreeReport, FindReport, GrepReport, AgentPane, PanesResponse, TasksListResponse, RemindersResponse, Reminder, TaskWriteResponse, TidyReport, Recipe, RecipesResponse, BrowserUseStatus, ProviderUsage, GitLocksReport, ProcDetail, PrBranchSummary } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, AgentModel, ChatImage, ConflictBlock, ConflictFile, MergeSessionView, BlockChoice, MergeInfo, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrSummary, PrActionResult, PrLocalHead, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord, IssuesReport, IssuePrsReport, IssueDetail, IssueWork, IssueStartResult, IssueActionResult, StartMode, PortsReport, ResourceReport, SpaceReport, TreeReport, FindReport, GrepReport, AgentPane, PanesResponse, TasksListResponse, RemindersResponse, Reminder, TaskWriteResponse, TidyReport, Recipe, RecipesResponse, BrowserUseStatus, ProviderUsage, GitLocksReport, ProcDetail, PrBranchSummary } from "../../../shared/types.ts";
 import type { ProvidersResponse, ProviderStatus, ProviderTasksResponse, SavedView, ClickUpBoards, ViewTasksResponse, TaskDetail, ProviderTask, ListStatus, ListField, ListPlace, ListMember } from "../../../shared/providers.ts";
 
 /** What every ClickUp write answers with: the card as it now stands, or why not. */
@@ -744,6 +744,11 @@ const realApi = {
       + `&q=${encodeURIComponent(q)}&assignee=${encodeURIComponent(assignee)}`),
   issueDetail: (root: string, number: number) =>
     get<{ ok: boolean; issue?: IssueDetail; error?: string }>(`/issues/detail?root=${encodeURIComponent(root)}&number=${number}`),
+  /** The pull requests that close or mention an issue. Its own call rather than
+   *  part of the detail: it is a second round trip, and the description should
+   *  be on screen before it finishes. */
+  issuePrs: (root: string, number: number) =>
+    get<IssuePrsReport>(`/issues/prs?root=${encodeURIComponent(root)}&number=${number}`),
   /** Everything with a worktree still on disk, so the list can say what is in
    *  progress without asking per row. */
   issuesWork: (repo = "") => get<{ work: IssueWork[] }>(`/issues/work?repo=${encodeURIComponent(repo)}`),
@@ -1310,6 +1315,9 @@ const demoApi: typeof realApi = {
   reminderSnooze: (_i: string, _m: number) => D({ ok: false }),
   issuesList: (_r: string, s = "open", q = "", a = "") => D(demo.issues(s, q, a)),
   issueDetail: (_r: string, n: number) => D(demo.issueDetail(n)),
+  // No linked pull requests in the demo: the fixtures have no GitHub graph
+  // behind them, and an invented link is a link somebody would click.
+  issuePrs: (_r: string, _n: number) => D({ ok: true, prs: [] }),
   issuesWork: (_repo?: string) => D(demo.issuesWork()),
   issueStart: (_r: string, _n: number, _m: StartMode) => D({ ok: false, error: "not available in the demo" }),
   issueFinish: (_r: string, _n: number, _f?: boolean) => D({ ok: false, error: "not available in the demo" }),

--- a/web/src/lib/openIssue.ts
+++ b/web/src/lib/openIssue.ts
@@ -1,0 +1,51 @@
+/*
+ * "Show me that issue."
+ *
+ * The third of these, and the shape is settled by now: openPrs.ts takes you
+ * from a card to a pull request, openCard.ts from a pull request back to its
+ * ClickUp card, and this one from a pull request to the GitHub issue it closes.
+ *
+ * It exists because that last link was already on screen and went the wrong
+ * way. The pull-request sidebar has said "Merging this closes: #123" for a
+ * while — the server reads `closingIssuesReferences` and has always had it —
+ * but the number was an `<a target="_blank">`, so the one cross-reference
+ * GitHub hands us for free was the one that put you in a browser. Everything
+ * else in this app that knows about another view goes TO it.
+ *
+ * A number and a repository travel, not an issue. The Tasks view already knows
+ * how to read one and is the thing that owns the reading; handing it a row
+ * would mean the pull-request panel holding an opinion about what an issue
+ * looks like, and inventing one for an issue that has since been deleted or
+ * transferred.
+ */
+
+export interface IssueJump {
+  /** The issue number, which is what the Issues view selects by. */
+  number: number;
+  /**
+   * The checkout to read it from, when the sender knows one.
+   *
+   * Usually empty, and that is correct rather than lazy: the Issues view has no
+   * repository picker, deliberately — issues come from the remote, and every
+   * worktree of a project shares it. So the receiver's own root is right nearly
+   * always, and this is here for the case it is not.
+   */
+  root?: string;
+  /** Rises per request, so asking for the same issue twice is two arrivals
+   *  rather than one that looks already served. */
+  n: number;
+}
+
+let listener: ((j: IssueJump) => void) | null = null;
+let seq = 0;
+
+export function onOpenIssue(fn: ((j: IssueJump) => void) | null): () => void {
+  listener = fn;
+  return () => { if (listener === fn) listener = null; };
+}
+
+/** Open the Tasks view on this GitHub issue. */
+export function openIssue(number: number, root?: string): void {
+  if (!Number.isInteger(number) || number <= 0) return;
+  listener?.({ number, root, n: ++seq });
+}


### PR DESCRIPTION
## What does this PR do?

Both halves of the GitHub issue ↔ pull request link, which turned out to be one half missing and one half pointing outwards.

**The pull request already knew, and sent you away.** The server has read `closingIssuesReferences` for a while and the sidebar has said "Merging this closes: #123" — but the number was an `<a target="_blank">`, so the one cross-reference GitHub hands us for free was the only link in the app that left it. Everything else that knows about another view goes **to** it: a card id opens the board, a PR number opens the pull-request panel. It now opens the Issues view, through the same one-slot bus `openCard` and `openPrs` already use. The arrow out stays beside it, because an issue in another repository is a real case and the Issues view reads one repository.

**The issue knew nothing.** Standing on an issue the question is almost always "is somebody already on this", and there was no answer short of a browser. There is now a Pull requests section in the issue detail, and it is better founded than the ClickUp row it mirrors: that one searches GitHub for a card id and depends on the team naming branches after it, because ClickUp's API exposes no link at all. This is a real edge in GitHub's own graph — nothing guessed, no naming convention relied on.

Which is why the two claims stay apart. A pull request **linked** to an issue will close it and is labelled "closes this"; one that merely mentions `#12` in a comment has promised nothing and is listed plainly. Merging the two would be a fix somebody is told to expect and nobody is writing — the same reason a ClickUp card distinguishes `stated`.

A GitHub timeline is a log rather than a state, and that is where the rules are, so the reduction is a pure function with its own tests:

- an unlink is honoured — a `ConnectedEvent` sits in the log forever after somebody detaches the pull request, so without this an issue keeps advertising work deliberately taken off it;
- a re-link outranks the unlink before it, because it is the later event;
- a mention never downgrades a link, whichever arrived last;
- a pull request appears once however many times it is touched.

A jump waits for the list before selecting: a closed issue — which is most of what a merged pull request points at — has no row under the default "open" filter, so the detail would open beside a list visibly not containing it. The filter widens instead, the same courtesy the ClickUp board already does for a card its filters hide.

This touches the server↔web contract: `IssuePr` and `IssuePrsReport` are added to `server/src/issues.ts` (the authority) and mirrored in `shared/types.ts`, and `/issues/prs` is a new route. `ghGraphql` is exported from `prs.ts` so `issues.ts` can reach GitHub's graph without a second `gh` spawn — the helper already prefers `fetch` over the CLI for the measured reason recorded there.

## How was it tested?

- `bun run typecheck` clean in `web/` and `server/`; `bunx vite build` clean.
- 10 new tests in `server/test/issue-prs.test.ts`, written against the log-not-state property: link vs mention, unlink honoured, re-link winning, a mention not downgrading a link in either arrival order, one row per pull request however often it appears, non-pull-request timeline nodes skipped (an issue cross-referencing an issue matches no inline fragment and arrives empty), a pull request with no address skipped since there is nowhere to send a click, and the ordering — what closes the issue first, then newest.
- The branch was rebuilt from `main` rather than left stacked on #497, so the two can merge in either order; typecheck, tests and build were re-run after that rebuild.

The full suite has 35 failures on this branch; all 35 reproduce on an unmodified tree and are environmental (tmux, port binding, `/proc`, Tailscale). None touch issues or pull requests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP

---
_Generated by [Claude Code](https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP)_