### PR TITLE
fix: the branch's pull requests were read once and never again

### DIFF
--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1380,8 +1380,46 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
      request". Silence used to cover both, and the two want different actions
      from you — one is nothing to do, the other is `gh auth login`. */
   const [prAskFailed, setPrAskFailed] = useState<string | null>(null);
+  /* Two reasons to ask GitHub again — see the effect below. `gitTick` moves on
+     any repository mutation this app can see; `refocus` on coming back to the
+     window, which is the only way a merge done in a browser reaches us. */
+  const [gitTick, setGitTick] = useState(0);
+  const [refocus, setRefocus] = useState(0);
+  useEffect(() => subscribeGitChanged(() => setGitTick((n) => n + 1)), []);
+  useEffect(() => {
+    const back = () => { if (document.visibilityState === "visible") setRefocus((n) => n + 1); };
+    window.addEventListener("focus", back);
+    document.addEventListener("visibilitychange", back);
+    return () => { window.removeEventListener("focus", back); document.removeEventListener("visibilitychange", back); };
+  }, []);
   // Whoever opened it. A branch you are standing in is yours to care about
   // however it got its pull request.
+  /*
+   * Asked again, rather than once and for ever.
+   *
+   * The dependencies used to be the root and the branch alone, which means
+   * this asked when you ARRIVED on a branch and never again. A pull request
+   * merged from anywhere else — the browser, another session, an auto-merge —
+   * left the chip saying "2 PRs land here" for as long as the panel stayed on
+   * that branch. Reported from a screenshot of exactly that, two minutes after
+   * both of them had merged.
+   *
+   * Two triggers, and neither is a poll:
+   *
+   *   `gitTick` is the same counter the rest of this panel already re-reads on
+   *   — any repository mutation from this app, another window, or a `git` typed
+   *   into the terminal — so a merge that lands through the app is reflected
+   *   with everything else.
+   *
+   *   `refocus` covers the case the bus cannot see: the merge happened on
+   *   github.com, in a browser, and nothing on this machine moved. Coming back
+   *   to the window is the moment a stale answer is about to be read, and it is
+   *   also the only moment worth spending a GitHub call on.
+   *
+   * Deliberately NOT a timer. `prsForBranch` shells out to `gh`, and the rate
+   * limit is shared with the PR panel; a chip nobody is looking at should cost
+   * nothing.
+   */
   useEffect(() => {
     if (!root || !currentBranchName) { setBranchPr(null); setPrsOntoBranch([]); setPrRepo(null); setPrAskFailed(null); return; }
     let live = true;
@@ -1407,7 +1445,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
          "could not ask". */
       .catch(() => { if (live) { setBranchPr(null); setPrsOntoBranch([]); setPrRepo(null); setPrAskFailed("GitHub did not answer"); } });
     return () => { live = false; };
-  }, [root, currentBranchName]);
+  }, [root, currentBranchName, gitTick, refocus]);
   /* The chip's whole decision, in one value: whether there is anything to draw
      and, if there is, exactly which pull request pressing it opens. Held here
      rather than spelled into the `onClick` because that is where it was when it


### PR DESCRIPTION
## What does this PR do?

Stops the branch header's pull request chip from believing something that stopped being true.

Its effect depended on `[root, currentBranchName]`, which means it asked GitHub once — when you arrived on the branch — and then never asked again. Anything that changed on the GitHub side afterwards was invisible: a pull request merged from a browser, from another session, or by auto-merge left the chip reading `2 PRs land here`, and the tooltip listing them by number, for as long as the panel stayed on that branch.

Reported from a screenshot showing exactly that: two pull requests listed as open, both merged two minutes earlier.

Two triggers now, and neither one is a poll:

- **`gitTick`** — the same git bus the rest of this panel already re-reads on, so a merge that lands through the app is reflected along with everything else it refreshes.
- **`refocus`** — window focus and `visibilitychange`, which is the only way a merge done on github.com reaches a machine where nothing moved. It is also the moment a stale answer is about to be read, which makes it the one worth spending a call on.

Deliberately no timer: `prsForBranch` shells out to `gh`, on a rate limit shared with the whole PR panel, and a chip nobody is looking at should cost nothing.

## How was it tested?

`bun run typecheck` clean in `web/`, both configs.

`bun test` in `web/`: 1958 pass. The 4 failures in `server-identity.test.ts` fail identically on `main` — an order-dependent interaction between test files that appears when the suite runs as one process in a worktree and disappears when that file runs alone.

The behaviour itself was confirmed the way it was found, before the change: `#497` and `#498` were merged at 14:49 and the chip still listed them as open at 14:51, with `gh pr view` reporting `MERGED` for both at the same moment. The fix is a re-ask on two events rather than a new mechanism, so what changes is when the existing call happens, not what it returns.
