### PR TITLE
fix: the phone's tmux bar stays hidden, and a wandered client gets a fresh mirror

### DIFF
--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -96,6 +96,21 @@ const BRIDGE = materializeBridge(bridgeFile);
 // processes without bound. Each idle shell costs a pty and a sleeping process.
 const MAX_SESSIONS = Math.max(4, Number(process.env.AGENTGLASS_MAX_TERMINALS || 200));
 
+/**
+ * How many times the sweep will re-hide the bar on the same session after it
+ * was turned back on, before the flip stands. Re-asserting FOREVER would make
+ * `prefix : set status on` a fight the user cannot win, and nobody owns a
+ * setting that reverts on its own — so each session gets this many heals per
+ * explicit hide, then the user's choice on it wins. A plugin or reload that
+ * flips the bar once is healed without ceremony; a person who flips it back
+ * three times is deciding. See the sweep in ptyOpen.
+ */
+const TMUX_BAR_HEAL_BUDGET = 3;
+
+/** How many failed remounts in a row buy a minute off — a switch that keeps
+ *  failing must not loop creating and killing a mirror every tick. */
+const REMOUNT_FAILS_BEFORE_QUIET = 3;
+const REMOUNT_QUIET_MS = 60_000;
 export type PtyWsData = { kind: "pty"; root: string; cols: number; rows: number;
   /** A file to open in an editor instead of dropping to a shell. A PATH, never
    *  a command: this socket is reachable from the UI, and "run this string"
@@ -246,6 +261,16 @@ type Session = {
    *  no reason to connect it to us. It is the session and not a boolean because
    *  the one we borrowed from is not always the one we end up on. */
   tmuxStatusHiddenOn?: TmuxTarget | null;
+  /** The re-hides still owed to the session whose bar came back on. Each heal
+   *  spends one; when it reaches zero the flip stands, because re-asserting
+   *  forever is a fight the user cannot win. Reset to a fresh budget whenever
+   *  the panel explicitly asks to hide again — that is a new consent. See
+   *  `TMUX_BAR_HEAL_BUDGET` and the sweep in ptyOpen. */
+  tmuxBarHealBudget?: { sessionId: string; left: number } | null;
+  /** Consecutive failed remounts (each would otherwise have created and killed
+   *  a mirror) and the timestamp until which the sweep stops trying. */
+  remountFails?: number;
+  remountQuietUntil?: number;
   /**
    * The group this session joined, when it is a phone looking at a pane.
    *
@@ -330,7 +355,7 @@ function killGroup(s: Session, sigNum: number) {
   } catch { /* already gone */ }
 }
 
-import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
+import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, remountPhoneClient, isPhoneSession, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";
 import { prepareReviewPrompt } from "./prs.ts";
 import { claudeCode, supportsSessionName } from "./agents/claudecode.ts";
@@ -603,12 +628,6 @@ export function ptyOpen(ws: PtyWs) {
     // middle of a themed panel. Best-effort, and silent when there is no theme
     // file yet: this is a repaint, not a precondition.
     applyThemeTo(t.socket);
-    // Re-apply the panel's answer to the new session. Without this a restored
-    // session comes up with tmux's own status line on top of our tabs, and
-    // nothing in the panel changed to make the browser re-ask for it.
-    if (session.tmuxStatusVisible === false && !session.tmuxStatusHiddenOn) {
-      if (setStatusLine(t, false)) session.tmuxStatusHiddenOn = t;
-    }
   };
 
   /*
@@ -664,6 +683,85 @@ export function ptyOpen(ws: PtyWs) {
       lastTarget = frame.target;
       if (frame.target.id !== session.tmux?.id) followSession(frame.target);
       else session.tmux = frame.target; // a rename keeps the id and changes the name
+      /*
+       * The strip's half of the bargain: while the panel draws its own window
+       * list, tmux's own bar must not be on screen — and the ways it can get
+       * there are keybindings, not bugs: `prefix :` and a bare `set status on`,
+       * a plugin's or config's `set status …` without `-g`, a reload that
+       * re-sources one, a client moved onto a session that never had `status
+       * off`. None of them change the session we are tracking, so `followSession`
+       * never sees them — which is exactly how the bar used to come back and
+       * STAY. So the choice is re-asserted every tick, off the two fields the
+       * frame already reads, and a flip heals within half a second instead of
+       * sticking until the session changes or the panel is reopened.
+       *
+       * The block stands back only when the panel has explicitly asked for
+       * tmux's own bar (`visible: true` — the web panel's toggle). Until the
+       * panel says, the strip is the app's and the bar is asserted: the phone
+       * never sends the toggle, and its strip is always the app's.
+       *
+       * Who gets re-asserted depends on whose session the client is on:
+       *
+       *  - OUR mirror (`agx-phone-…`): the bar belongs to the app here, so
+       *    anything that turns it on or drops the claim is undone, with no
+       *    budget. Hiding on the mirror costs nobody else anything, and the
+       *    claim plus the prompt keys are what the phone's own prompts run
+       *    on — which is also why a config that never had a bar still gets
+       *    them on the mirror.
+       *  - A user's own session, on an ATTACH that had a mirror: the client
+       *    wandered (`^b s`, an `attach-session` typed in, a continuum
+       *    restore), and re-hiding there would take the DESK's bar away —
+       *    `status` is a session option and the desk is on that session too.
+       *    A fresh mirror of it is made and the client switched back, which
+       *    is how the panel keeps its strip without touching the user's.
+       *    A switch that keeps failing is braked: three misses in a row buy
+       *    a minute off, because looping a create-and-kill every tick would
+       *    be its own bug.
+       *  - A user's own session with no mirror behind it (a plain shell that
+       *    ran `tmux`): the panel's answer hides it, as it always has, and
+       *    this is also what heals a flip on it — up to a budget. See
+       *    `TMUX_BAR_HEAL_BUDGET`: forever would take the user's own
+       *    override away.
+       */
+      if (session.tmuxStatusVisible !== true) {
+        const t = frame.target;
+        if (isPhoneSession(t.session)) {
+          if (frame.status !== "off" || !frame.owned) {
+            if (setStatusLine(t, false)) session.tmuxStatusHiddenOn = t;
+          }
+        } else if (session.phoneAttach) {
+          if (session.tmuxClient && (session.remountQuietUntil ?? 0) <= Date.now()) {
+            if (remountPhoneClient(session.tmuxClient, t)) {
+              session.remountFails = 0;
+            } else {
+              session.remountFails = (session.remountFails ?? 0) + 1;
+              if (session.remountFails >= REMOUNT_FAILS_BEFORE_QUIET) {
+                session.remountQuietUntil = Date.now() + REMOUNT_QUIET_MS;
+                // The reason, said once at the moment of giving up rather than
+                // every tick: run the failing switch once more and keep what
+                // tmux answers. `remountPhoneClient` swallows stderr, which is
+                // exactly what a loop must not do with it.
+                const r = Bun.spawnSync(
+                  ["tmux", ...session.tmuxClient.socket, "switch-client", "-c", session.tmuxClient.tty, "-t", t.id],
+                  { stdout: "pipe", stderr: "pipe", timeout: 4000, env: process.env },
+                );
+                const why = r.stderr.toString().trim() || r.stdout.toString().trim() || "switch-client failed";
+                console.warn(`[terminal] could not put the phone back on a mirror (${why}); not trying again for a minute`);
+              }
+            }
+          }
+        } else if (frame.status === "on") {
+          const budget = session.tmuxBarHealBudget;
+          if (budget?.sessionId === t.id && budget.left <= 0) {
+            // Argued out: the flip on this session stands — the user won.
+          } else if (setStatusLine(t, false)) {
+            session.tmuxStatusHiddenOn = t;
+            session.tmuxBarHealBudget = budget?.sessionId === t.id
+              ? { sessionId: t.id, left: budget.left - 1 }
+              : { sessionId: t.id, left: TMUX_BAR_HEAL_BUDGET - 1 };
+          }
+        }
+      }
     } else {
       // Unreachable: the server went away, or the client is mid-attach. Drop it
       // and resolve again next tick rather than answer from something stale.
@@ -1084,6 +1182,10 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       // resolved yet: this is a preference about tmux's chrome, not about one
       // session, and it has to survive the client being switched to another.
       s.tmuxStatusVisible = visible;
+      // A fresh explicit hide is a fresh consent: the next session whose bar
+      // comes back on gets a full heal budget again, whatever a previous one
+      // spent arguing.
+      s.tmuxBarHealBudget = null;
       if (!s.tmux) return;
       if (setStatusLine(s.tmux, visible)) s.tmuxStatusHiddenOn = visible ? null : s.tmux;
       return;

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -278,6 +278,24 @@ export interface TmuxFrame {
    * Null when tmux answered without one, never a guess.
    */
   client: { cols: number; rows: number } | null;
+  /**
+   * Whether the session this client is on is drawing its status line right
+   * now — tmux's own effective answer, and the only thing that decides if
+   * the original bar is on screen.
+   *
+   * Everything that can put the bar back when the panel chose its own strip
+   * lands here: a `set status on` typed through the command prompt, a
+   * plugin's bare `set status …`, a config line without `-g`, a client moved
+   * onto a session that never had `status off`. The sweep reads these two
+   * fields in the call it already makes for the windows, and re-asserts from
+   * them, so a flip heals within a tick instead of sticking until the
+   * session changes.
+   */
+  status: string;
+  /** `@agx-owned` on that session: this app took its bar (and its prompt
+   *  keys) over, and still holds the claim. `releaseStale` sweeps the
+   *  sessions where the claim survived the process that made it. */
+  owned: boolean;
   /** pane id -> window id for every pane of this session. Server-internal, off
    *  the wire: it exists so the sweep can tell which window a finished agent's
    *  pane belongs to. */
@@ -314,7 +332,14 @@ export function readFrame(c: TmuxClient): TmuxFrame | null {
     // against the size of the terminal showing it is a comparison the desk
     // needs twice a second, and it costs nothing here and a subprocess a tick
     // anywhere else.
-    "list-clients", "-F", "c\t#{client_tty}\t#{session_name}\t#{session_id}\t#{client_width}\t#{client_height}",
+    //
+    // `#{status}` and `#{@agx-owned}` ride along for the same reason: the
+    // panel's answer to "whose bar is this" can be flipped by a keybinding,
+    // and the sweep that already reads the windows is where the re-assertion
+    // has to live. Both evaluate against the client's own session — measured,
+    // `list-clients` answers a session-local `status off` and `@agx-owned 1`
+    // for the client attached to that session and nobody else's.
+    "list-clients", "-F", "c\t#{client_tty}\t#{session_name}\t#{session_id}\t#{client_width}\t#{client_height}\t#{status}\t#{@agx-owned}",
     ";",
     "list-windows", "-a",
     // `@agx-ask` rides along in the format string rather than in a second
@@ -336,7 +361,7 @@ export function readFrame(c: TmuxClient): TmuxFrame | null {
   ]);
   if (!out) return null;
   const f = parseFrame(out, c.tty);
-  return f ? { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows, panes: f.panes, client: f.client, windowOfPane: f.windowOfPane } : null;
+  return f ? { target: { pid: c.pid, socket: c.socket, session: f.session, id: f.id }, windows: f.windows, panes: f.panes, client: f.client, status: f.status, owned: f.owned, windowOfPane: f.windowOfPane } : null;
 }
 
 /**
@@ -347,15 +372,17 @@ export function readFrame(c: TmuxClient): TmuxFrame | null {
  * *names* are not unique enough to bet a `kill-window` on — resurrect happily
  * restores a second session called `main` — and the id is what tmux itself uses.
  */
-export function parseFrame(out: string, tty: string): { session: string; id: string; client: { cols: number; rows: number } | null; windows: TmuxWindow[]; panes: TmuxPane[]; windowOfPane: Map<string, string> } | null {
+export function parseFrame(out: string, tty: string): { session: string; id: string; client: { cols: number; rows: number } | null; status: string; owned: boolean; windows: TmuxWindow[]; panes: TmuxPane[]; windowOfPane: Map<string, string> } | null {
   let session: string | null = null;
   let id: string | null = null;
   let client: { cols: number; rows: number } | null = null;
+  let status = "";
+  let owned = false;
   const windowRows: string[] = [];
   const paneRows: string[] = [];
   for (const line of out.split("\n")) {
     if (line.startsWith("c\t")) {
-      const [, clientTty, name, sid, width, height] = line.split("\t");
+      const [, clientTty, name, sid, width, height, st, own] = line.split("\t");
       if (clientTty === tty && name && sid) {
         session = name; id = sid;
         // Only ours. Every other client on this server is on the same list and
@@ -363,6 +390,8 @@ export function parseFrame(out: string, tty: string): { session: string; id: str
         // window against the size of whoever is squeezing it.
         const cols = Number(width), rows = Number(height);
         client = Number.isInteger(cols) && Number.isInteger(rows) && cols > 0 && rows > 0 ? { cols, rows } : null;
+        status = (st ?? "").trim();
+        owned = (own ?? "").trim() === "1";
       }
     } else if (line.startsWith("w\t")) {
       windowRows.push(line);
@@ -385,7 +414,7 @@ export function parseFrame(out: string, tty: string): { session: string; id: str
     if (tag !== "p" || sid !== id || !winId || !paneId || !PANE_ID.test(paneId)) continue;
     windowOfPane.set(paneId, winId);
   }
-  return { session, id, client, windows: parseWindows(mine.join("\n")), panes: parsePaneGeometry(paneRows, id), windowOfPane };
+  return { session, id, client, status, owned, windows: parseWindows(mine.join("\n")), panes: parsePaneGeometry(paneRows, id), windowOfPane };
 }
 
 /**
@@ -1026,13 +1055,16 @@ export function setStatusLine(t: TmuxTarget, visible: boolean): boolean {
     // session with an invisible status line and no way to know why.
     return BORROWED.map((opt) => tmux(t.socket, ["set-option", "-t", t.id, "-u", opt]) !== null).every(Boolean);
   }
-  // Nothing to take from someone whose config runs without one — there is no
-  // row to reclaim, and the panel's strip is already the only window list.
-  if (statusInConfig(t) === "off") return false;
   // Set before the rebind, so a keypress landing between the two finds the flag
   // already true rather than falling through to a prompt with nowhere to draw.
   tmux(t.socket, ["set-option", "-t", t.id, "@agx-owned", "1"]);
   takePrompts(t);
+  // Nothing to take from someone whose config runs without a bar — the row
+  // does not exist, so "hidden" is already true. The claim and the prompt
+  // keys still go on: `prefix ,` and `prefix .` draw over the top line with
+  // or without a bar, and the re-assertion the panel runs off this flag
+  // depends on the claim being there to find.
+  if (statusInConfig(t) === "off") return true;
   // The row itself. `status off` rather than a blanked `status-format[0]`: a row
   // held open for prompts that no longer arrive there is just a gap.
   const off = tmux(t.socket, ["set-option", "-t", t.id, "status", "off"]) !== null;
@@ -2181,6 +2213,73 @@ function claimAlive(claim: string): boolean {
  *  built in `attachArgvFor` below. One regex so the two cannot drift, and
  *  declared above both readers rather than between them. */
 const PHONE_SESSION = /^agx-phone-(\d+)-[a-z0-9]+$/;
+
+/** Is this session name one of the mirrors this app makes? The mirror is the
+ *  only session whose bar the panel may re-assert: it is ours, and hiding it
+ *  costs nobody else anything. The session the mirror shares its windows with
+ *  is the user's, and re-asserting there would take the desk's bar away. */
+export function isPhoneSession(session: string | null | undefined): boolean {
+  return typeof session === "string" && PHONE_SESSION.test(session);
+}
+
+/**
+ * Put the phone's view back on one of OUR mirrors when its client has
+ * wandered onto a session that is not ours.
+ *
+ * `prefix s`, an `attach-session` typed into the pane, a continuum restore —
+ * all of them move the tmux client off the grouped mirror this app made, and
+ * the mirror dies with the client (`destroy-unattached`). The session the
+ * client lands on has no `status off` of its own, so tmux's own bar comes
+ * back — and hiding it THERE would take the desk's bar away too, because
+ * `status` is a session option and the desk is attached to that same session.
+ *
+ * So instead of hiding on the moved-to session, a fresh mirror of it is made —
+ * the same shape `attachArgvFor` builds: grouped (`new-session -t`), sharing
+ * the windows, sized `largest` so the desk is not squeezed, `status off` — and
+ * OUR client is switched back onto it by tty. The old mirror is already gone;
+ * the new one dies the same way when the client leaves.
+ *
+ * No fit and no zoom here: both were owed by the window the phone originally
+ * opened, and this move has nothing to do with it. The new mirror renders the
+ * moved-to window at the desk's size, exactly as a fresh attach would.
+ *
+ * `destroy-unattached` is set LAST on purpose: measured, tmux kills a session
+ * carrying it the moment it has no attached client — so a detached mirror
+ * created with it already set would be gone before `switch-client` reached it.
+ *
+ * The name is a contract, not a label: `PHONE_SESSION` (and so `phoneWindows`,
+ * the strip's phone mark, the #487 width notice, and `reclaimPinnedWindow`)
+ * treats any `agx-phone-…` session as "a phone is on this window". That is
+ * correct here — the caller only remounts an attach that HAD a mirror
+ * (`session.phoneAttach`), so the new session is a phone by definition — but
+ * it is load-bearing: a mirror ever remounted for a desk client would need its
+ * own prefix, not a silent fifth reader of this one.
+ */
+export function remountPhoneClient(c: TmuxClient, target: TmuxTarget): boolean {
+  if (!SESSION_ID.test(target.id)) return false;
+  if (isPhoneSession(target.session)) return false;
+  // The digits the regex needs are the client's own pid; the suffix is random
+  // so two remounts on the same client cannot collide.
+  const name = `agx-phone-${c.pid}-${Math.random().toString(36).slice(2, 8)}`;
+  const created = tmux(c.socket, [
+    "new-session", "-d", "-t", target.id, "-s", name,
+    ";", "set-option", "-t", name, "window-size", "largest",
+    ";", "set-option", "-t", name, "status", "off",
+  ]);
+  if (created === null) return false;
+  // Address our own client by its tty: `switch-client` run from the server has
+  // no client context of its own, and the tty is how tmux names the client
+  // back — the same field `readFrame` matches on. The flags are the 3.7 order:
+  // `-c` is the target client, `-t` the target session (`focusPane` uses only
+  // `-t`, so it never met the swap).
+  if (tmux(c.socket, ["switch-client", "-c", c.tty, "-t", name]) === null) {
+    tmux(c.socket, ["kill-session", "-t", name]);
+    return false;
+  }
+  // The client is on it now, so the mirror dies when the phone leaves.
+  tmux(c.socket, ["set-option", "-t", name, "destroy-unattached", "on"]);
+  return true;
+}
 
 /**
  * What a window's zoom is, and whether zooming it would mean anything.

--- a/server/test/tmux-watchdog.test.ts
+++ b/server/test/tmux-watchdog.test.ts
@@ -1,0 +1,260 @@
+/*
+ * The bar the panel repaints, kept off — against a real tmux server with a
+ * real attached client.
+ *
+ * The panel draws its own window list and hides tmux's own status line on the
+ * grouped mirror it attaches through (`agx-phone-…`). The hiding is a session
+ * option, and session options can be flipped back by the user's own keyboard:
+ * `prefix :` and a bare `set status on`, a plugin's `set status …` without
+ * `-g`, a config line without `-g` re-sourced by `prefix r` or tpm's `I`/`U`.
+ * The sweep re-asserts the choice once per tick, off the two fields the frame
+ * already reads (`#{status}` and `#{@agx-owned}`), and a client moved onto a
+ * session that never had `status off` is answered by remounting a fresh mirror
+ * rather than hiding the user's own session — hiding THERE would take the
+ * desk's bar away, because `status` is a session option and the desk is on
+ * that same session.
+ *
+ * What is under test is the three pieces the sweep is built from: the frame
+ * reporting the flip, `setStatusLine` healing it, and `remountPhoneClient`
+ * putting the client back on a mirror that costs nobody else anything.
+ *
+ * The tests are stateful and ordered on purpose: the flip, the heal, the
+ * reload, and the session-switch are one story about the same mirror.
+ *
+ * Runs against its own tmux server on a private socket, with `-f /dev/null`
+ * so no `~/.tmux.conf` and no restore plugin can reach in.
+ */
+import { afterAll, beforeAll, describe, expect, test } from "bun:test";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { readFrame, setStatusLine, remountPhoneClient, isPhoneSession } from "../src/tmuxctl.ts";
+import type { TmuxClient, TmuxTarget } from "../src/tmuxctl.ts";
+import { TEST_TERM } from "./tmuxTerm.ts";
+
+// Own socket AND an empty config — see tmux-attach.test.ts for what each half
+// is for. Unique per run, or a leftover server from a previous one is what
+// this talks to.
+const SOCK = ["-L", `agx-watchdog-${process.pid}`];
+const TMPDIR = `/tmp/agx-tmux-watchdog-${process.pid}`;
+const REAL_TMPDIR = process.env.TMUX_TMPDIR;
+const has = !!Bun.which("tmux") && !!Bun.which("python3") && process.platform === "linux";
+
+/** `env: process.env` is load-bearing — measured on Bun 1.3.9, a
+ *  `Bun.spawnSync` with no `env` gets the environment as it was when the
+ *  PROCESS started, not `process.env` as it is now. See tmux-bar.test.ts. */
+const raw = (args: string[]) =>
+  Bun.spawnSync(["tmux", "-f", "/dev/null", ...SOCK, ...args], { stdout: "pipe", stderr: "pipe", timeout: 4000, env: process.env });
+const out = (args: string[]) => raw(args).stdout.toString().trim();
+
+/** A real attached client on a pty, the way a terminal emulator makes one.
+ *  Held open by a sleep; killed in afterAll. */
+function clientOn(target: string): ReturnType<typeof Bun.spawn> {
+  return Bun.spawn(
+    ["python3", "-c",
+      "import os,pty,sys,time\n" +
+      "pid,fd=pty.fork()\n" +
+      "if pid==0: os.execvp('tmux',['tmux','-f','/dev/null','-L',sys.argv[1],'attach','-t',sys.argv[2]])\n" +
+      "time.sleep(600)\n",
+      SOCK[1]!, target],
+    // `TERM` is declared, not inherited: tmux refuses `TERM=dumb`, which is
+    // what a CI job step has, so this attach would do nothing there — the same
+    // rule every other pty-building test in this directory follows (see
+    // tmuxTerm.ts, and the lint that keeps us honest).
+    { stdout: "ignore", stderr: "ignore", env: { ...process.env, TERM: TEST_TERM } },
+  );
+}
+
+let pty: ReturnType<typeof Bun.spawn> | null = null;
+let realId = "";
+let currentMirror = "";
+let currentMirrorId = "";
+let tty = "";
+
+beforeAll(async () => {
+  if (!has) return;
+  // Set here and put back in afterAll rather than at module load: `bun test`
+  // runs a suite's files in one process, and the other tmux files are entitled
+  // to the environment they were written against.
+  mkdirSync(TMPDIR, { recursive: true });
+  process.env.TMUX_TMPDIR = TMPDIR;
+  raw(["kill-server"]);
+  raw(["new-session", "-d", "-s", "real", "-n", "one"]);
+  raw(["new-window", "-d", "-t", "real", "-n", "two"]);
+  realId = out(["display-message", "-p", "-t", "real", "#{session_id}"]);
+  // The mirror a phone attach would leave, in the state the attach leaves it:
+  // grouped on `real`, its own `status off`, and — once the client is on it —
+  // `destroy-unattached` so it dies with the client. `destroy-unattached`
+  // comes LAST on purpose: measured, tmux kills a detached session carrying it
+  // the moment it has no client.
+  raw(["new-session", "-d", "-t", "real", "-s", "agx-phone-1-abc"]);
+  raw(["set-option", "-t", "agx-phone-1-abc", "window-size", "largest"]);
+  raw(["set-option", "-t", "agx-phone-1-abc", "status", "off"]);
+  currentMirror = "agx-phone-1-abc";
+  currentMirrorId = out(["display-message", "-p", "-t", currentMirror, "#{session_id}"]);
+  pty = clientOn(currentMirror);
+  await Bun.sleep(1200);
+  tty = out(["list-clients", "-F", "#{client_tty}"]).split("\n")[0] ?? "";
+  raw(["set-option", "-t", currentMirror, "destroy-unattached", "on"]);
+});
+
+afterAll(() => {
+  pty?.kill();
+  raw(["kill-server"]);
+  if (REAL_TMPDIR === undefined) delete process.env.TMUX_TMPDIR;
+  else process.env.TMUX_TMPDIR = REAL_TMPDIR;
+  try { rmSync(TMPDIR, { recursive: true, force: true }); } catch { /* already gone */ }
+});
+
+const client = (): TmuxClient => ({ pid: 0, socket: SOCK, tty });
+const real = (): TmuxTarget => ({ pid: 0, socket: SOCK, session: "real", id: realId });
+const mirror = (): TmuxTarget => ({ pid: 0, socket: SOCK, session: currentMirror, id: currentMirrorId });
+
+describe("the bar the panel repaints, kept off", () => {
+  // The repo's tmux-test guard, per-file: `describe.if`/`test.if` print bogus
+  // results on a machine with no tmux (see tmux-bar.test.ts), so the body
+  // itself is what closes. `beforeAll` closes the same way.
+  if (!has) return;
+
+  test("the frame reports the client's own session's status and claim", () => {
+    // The two fields the sweep re-asserts from, answered per client: the
+    // mirror's own `status off` comes back as such, and the claim is absent —
+    // the attach leaves `status off`, not the claim; the sweep's first
+    // re-assert is what sets it.
+    const f = readFrame(client())!;
+    expect(f.target.session).toBe(currentMirror);
+    expect(f.status).toBe("off");
+    expect(f.owned).toBe(false);
+  });
+
+  test("`prefix :` flipping the option is visible to the same frame", () => {
+    // The mechanism the user's keybinding uses: a bare `set status on` on the
+    // session the client is on. The mirror is ours, so nothing else is on it
+    // with us — the bar that comes back is tmux's own. The flip knows nothing
+    // about the claim, and there is none yet, so both halves of the state the
+    // sweep reads are in front of it.
+    raw(["set-option", "-t", currentMirror, "status", "on"]);
+    const f = readFrame(client())!;
+    expect(f.status).toBe("on");
+    expect(f.owned).toBe(false);
+  });
+
+  test("and re-asserting heals it within the sweep's own call", () => {
+    // Exactly what the sweep does when it finds a mirror with `status` on:
+    // setStatusLine takes it again, and the next frame reads off.
+    expect(setStatusLine(mirror(), false)).toBe(true);
+    const f = readFrame(client())!;
+    expect(f.status).toBe("off");
+    expect(f.owned).toBe(true);
+  });
+
+  test("a config reload with `set -g status on` does not bring the bar back", () => {
+    // `prefix r` / tpm's `I` and `U` re-source the config, which re-applies
+    // `set -g status on`. The mirror's session-local `off` shadows the global
+    // — measured against a real client — so the frame keeps reporting off and
+    // the sweep has nothing to do.
+    const dir = mkdtempSync(join(tmpdir(), "agx-watchdog-reload-"));
+    const file = join(dir, "reload.conf");
+    writeFileSync(file, "set -g status on\n");
+    raw(["source-file", file]);
+    expect(readFrame(client())!.status).toBe("off");
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  test("a client moved to the user's own session reports ITS bar, not ours", () => {
+    // `prefix s`, an `attach-session` typed into the pane, a continuum
+    // restore — all of them switch the client onto a session that never had
+    // `status off`. The mirror dies with the client (`destroy-unattached`),
+    // which is why nothing here restores it. What is left is a frame that
+    // says the bar is on and unclaimed — the remount below is the answer.
+    raw(["switch-client", "-c", tty, "-t", "real"]);
+    awaitTty();
+    const f = readFrame(client())!;
+    expect(f.target.session).toBe("real");
+    expect(f.status).toBe("on");
+    expect(f.owned).toBe(false);
+    expect(out(["list-sessions", "-F", "#{session_name}"]).split("\n")).not.toContain("agx-phone-1-abc");
+  });
+
+  test("remounting puts the client back on a mirror, and never touches the desk's bar", () => {
+    // The moved-to session is the user's: hiding its bar would hide the
+    // desk's too. The remount makes a fresh mirror of it and switches our
+    // client back — the user session's options are read, not written.
+    expect(remountPhoneClient(client(), real())).toBe(true);
+    const f = readFrame(client())!;
+    expect(isPhoneSession(f.target.session)).toBe(true);
+    expect(f.target.session).not.toBe("agx-phone-1-abc");
+    expect(f.status).toBe("off");
+    currentMirror = f.target.session;
+    currentMirrorId = out(["display-message", "-p", "-t", currentMirror, "#{session_id}"]);
+    // The desk's session was not touched: it carries no `status` of its own,
+    // which is the same "no local option" it had before the phone arrived.
+    expect(out(["show-options", "-t", "real", "-v", "status"])).toBe("");
+    // And the new mirror dies with the client when it leaves, like the old
+    // one did — `destroy-unattached` is set the same way.
+    expect(out(["show-options", "-t", currentMirror, "-v", "destroy-unattached"])).toBe("on");
+  });
+
+  test("remounting refuses a session that is already a mirror", () => {
+    const before = out(["list-sessions", "-F", "#{session_name}"]);
+    expect(remountPhoneClient(client(), mirror())).toBe(false);
+    expect(out(["list-sessions", "-F", "#{session_name}"])).toBe(before);
+  });
+
+  test("taking the bar twice does not overwrite the way back", () => {
+    // The sweep re-asserts, and re-asserting must not clobber the recorded
+    // original binding: release puts back what the user had, not our own
+    // `if-shell` line. A second take on the same target is a no-op for the
+    // key, so `@agx-had-rename` still holds the original.
+    raw(["bind-key", "-T", "prefix", ",", 'command-prompt -p "(rename-window)" "rename-window -- %%"']);
+    raw(["new-session", "-d", "-s", "twice"]);
+    const id = out(["display-message", "-p", "-t", "twice", "#{session_id}"]);
+    const t: TmuxTarget = { pid: 0, socket: SOCK, session: "twice", id };
+    expect(setStatusLine(t, false)).toBe(true);
+    const first = out(["show-options", "-qv", "-t", "twice", "@agx-had-rename"]);
+    expect(first).toContain("command-prompt");
+    expect(first).not.toContain("@agx-ask");
+    expect(setStatusLine(t, false)).toBe(true);
+    expect(out(["show-options", "-qv", "-t", "twice", "@agx-had-rename"])).toBe(first);
+    expect(setStatusLine(t, true)).toBe(true);
+    // The whole prefix table, because `list-keys -T prefix <key>` answers on
+    // the client's screen instead of stdout on tmux ≥ 3.7 (see
+    // tmux-list-keys-one-key-form in project memory).
+    const back = out(["list-keys", "-T", "prefix"]);
+    // tmux re-lists the key canonically, without the quotes around the
+    // prompt text, so the assertion matches the unquoted form. The check is
+    // scoped to the `,` row: `.` is ours from the first take and stays ours
+    // by design (release restores only what it recorded), so the whole table
+    // still shows `@agx-ask` on it.
+    const comma = back.split("\n").find((l) => l.includes("prefix ,"));
+    expect(comma).toContain('command-prompt -p (rename-window)');
+    expect(comma).not.toContain("@agx-ask");
+  });
+
+  test("a config that runs without a bar still gets the claim and the prompt keys", () => {
+    // `status off` in the user's global config: there is no row to reclaim,
+    // but the claim and the prompt takeover still go on — `prefix ,` and
+    // `prefix .` draw over the top line with or without a bar, and the
+    // re-assertion the sweep runs off `@agx-owned` depends on it being there.
+    raw(["set-option", "-g", "status", "off"]);
+    raw(["new-session", "-d", "-s", "barless"]);
+    const id = out(["display-message", "-p", "-t", "barless", "#{session_id}"]);
+    const t: TmuxTarget = { pid: 0, socket: SOCK, session: "barless", id };
+    expect(setStatusLine(t, false)).toBe(true);
+    expect(out(["show-options", "-t", "barless", "-v", "@agx-owned"])).toBe("1");
+    expect(out(["list-keys", "-T", "prefix"])).toContain("@agx-ask");
+    expect(setStatusLine(t, true)).toBe(true);
+    raw(["set-option", "-g", "status", "on"]);
+  });
+});
+
+/** Wait until the client has settled on the named session — the frame read
+ *  races the client landing, and a stale answer would blame the wrong one. */
+function awaitTty(): void {
+  for (let i = 0; i < 20; i++) {
+    const sess = out(["list-clients", "-F", "#{session_name}"]).split("\n")[0] ?? "";
+    if (sess === "real") return;
+    Bun.sleepSync(50);
+  }
+}


### PR DESCRIPTION
## What does this PR do?

The tmux status bar the panel hides on the phone's mirror used to come back and **stay** — every way it returns is a keybinding, not a bug (`prefix : set status on`, a plugin or config line without `-g`, a reload, a continuum restore, a client moved onto another session). None change the session being tracked, so the old one-shot hide never saw them. The sweep now re-asserts `status off` + the `@agx-owned` claim every tick, off two fields the frame already reads — and when the client has wandered onto the **user's own** session, a fresh mirror is remounted rather than hiding there (hiding would take the desk's bar away too, because `status` is a session option).

Review follow-ups from the first pass, both in:
- **Bounded re-assert on the user's own session** (`TMUX_BAR_HEAL_BUDGET` = 3 per explicit hide): after three heals on the same session the flip stands — a forever-arguing sweep is a setting nobody can own. The mirror branch stays unconditional; the web panel's explicit `visible: true` stands the whole block down.
- **A brake on the remount**: three consecutive failed switches buy a minute off, reason logged once at the moment of giving up, instead of creating and killing a mirror every tick.
- The sweep gate is `!== true`, not `=== false`: the phone never sends the `status` toggle, so the old gate was dead code on mobile.

Two things measured on tmux 3.7b:
- `switch-client`'s `-c`/`-t` **swapped** meaning in 3.7 (`-c` is now the target client) — the old form failed with "can't find client", so the remount silently never moved anybody.
- The `agx-phone-…` prefix is load-bearing beyond this function (phoneWindows, the strip's phone mark, #487's width notice, reclaimPinnedWindow) — the remount stays inside the contract by construction; noted beside the function.

## How was it tested?

- `server/test/tmux-watchdog.test.ts` (new): 9 ordered tests against a real tmux on a private socket — frame reports the flip, heal, reload, moved client, remount (and its refusal of a mirror target), double-take preserves the way back, bar-less config still claimed. 9/9.
- `bun run typecheck` clean; full server suite 2528 pass — the 12 failures are identical on main (tasks-write ×10, agent-routes, pane-routes).
- The sweep wiring itself (heal budget, remount brake, gate) is terminal.ts-internal and not unit-tested — a real-build pass with a real tmux is the verification it's waiting for.