### PR TITLE
fix: the four integration defects, and the two fields nobody read

### DIFF
--- a/server/src/clickup.ts
+++ b/server/src/clickup.ts
@@ -1238,6 +1238,23 @@ export interface WriteOutcome {
   task?: ProviderTask;
   /** Somebody else changed it between the read and the write. */
   conflict?: boolean;
+  /**
+   * The token was refused — reconnect, rather than try again.
+   *
+   * `conflict` has always been a field rather than a sentence, and this is the
+   * other failure with a different remedy, so it gets the same treatment. The
+   * read path (`CallResult`) has carried it all along and the writes computed
+   * it and threw it away: `put` classifies 401/403 and then every caller
+   * flattened the result to `{ ok: false, error }`.
+   *
+   * NOT a general error taxonomy, and deliberately not: this provider answers
+   * 401 for a card that does not exist (see findTask), so a code claiming to
+   * name the cause would be wrong on exactly the case people hit most. Two
+   * flags for the two remedies the app can actually offer — reload, reconnect
+   * — and prose for the human, which is the only thing that can be honest
+   * about the rest.
+   */
+  unauthorised?: boolean;
 }
 
 /**
@@ -1298,7 +1315,7 @@ export async function assignSelf(taskId: string, on: boolean, expectUpdated?: nu
     assignees: on ? { add: [n] } : { rem: [n] },
   });
   __reset();
-  return r.ok ? { ok: true, task: toTask(r.data!, me) } : { ok: false, error: r.error };
+  return r.ok ? { ok: true, task: toTask(r.data!, me) } : { ok: false, error: r.error, unauthorised: r.unauthorised };
 }
 
 /** Move a card to another status. The value must be one the LIST accepts —
@@ -1369,7 +1386,7 @@ export async function setAssignee(taskId: string, userId: number, on: boolean, e
   });
   __reset();
   const me = redacted("clickup")?.accountId;
-  return r.ok ? { ok: true, task: toTask(r.data!, me) } : { ok: false, error: r.error };
+  return r.ok ? { ok: true, task: toTask(r.data!, me) } : { ok: false, error: r.error, unauthorised: r.unauthorised };
 }
 
 export async function setStatus(taskId: string, status: string, expectUpdated?: number): Promise<WriteOutcome> {
@@ -1382,7 +1399,7 @@ export async function setStatus(taskId: string, status: string, expectUpdated?: 
   const r = await put(`/task/${encodeURIComponent(taskId)}`, token, { status });
   __reset();
   const me = redacted("clickup")?.accountId;
-  return r.ok ? { ok: true, task: toTask(r.data!, me) } : { ok: false, error: r.error };
+  return r.ok ? { ok: true, task: toTask(r.data!, me) } : { ok: false, error: r.error, unauthorised: r.unauthorised };
 }
 
 /** A drop-down custom field, by id, to one of its own options. */
@@ -1400,7 +1417,10 @@ export async function setField(taskId: string, fieldId: string, optionId: string
       signal: ctl.signal,
     });
     __reset();
-    if (r.status === 401 || r.status === 403) return { ok: false, error: "ClickUp refused this token" };
+    // This one talks to ClickUp directly rather than through `put`, so it
+    // classifies for itself — and has to say the same thing, or a refused token
+    // would be a reconnect prompt on three routes and prose on the fourth.
+    if (r.status === 401 || r.status === 403) return { ok: false, unauthorised: true, error: "ClickUp refused this token" };
     if (!r.ok) return { ok: false, error: `ClickUp answered ${r.status}` };
     return { ok: true };
   } catch {

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2062,6 +2062,10 @@ const server = Bun.serve<WsData>({
       return json(await providerWorkspaces((url.searchParams.get("id") ?? "") as ProviderId));
     }
     if (pathname.startsWith("/providers/") && req.method === "POST") {
+      // Connect, disconnect, choose a workspace: this route stores and deletes
+      // the credentials every other integration reads. #469 swept the routes
+      // that run code and missed the one that holds the keys to them.
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
       const id = String(b.id ?? "") as ProviderId;
       const r = pathname === "/providers/connect"
@@ -2097,6 +2101,10 @@ const server = Bun.serve<WsData>({
       return json({ ok: true, ...renderSteps(r, values) });
     }
     if (pathname.startsWith("/recipes/") && req.method === "POST") {
+      // A recipe is a saved command line the app will later run. Saving one is
+      // therefore a write to the set of things this machine can be asked to
+      // execute, which is the definition the sweep is sorting on.
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const { saveRecipe, removeRecipe } = await import("./recipes.ts");
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
       const r = pathname === "/recipes/save" ? saveRecipe(b as never)
@@ -2177,6 +2185,11 @@ const server = Bun.serve<WsData>({
       return json(r.ok ? { ok: true, ...r.data } : { ok: false, error: r.error });
     }
     if (pathname.startsWith("/clickup/") && req.method === "POST") {
+      // Assign somebody, move a card, set a field, add or drop a board, and
+      // switch writing on. The change does not land on this machine, which is
+      // exactly why it was easy to miss: it lands in a shared workspace where
+      // colleagues can see it and where nothing here can take it back.
+      if (!trustedCaller(req, from)) return csrfBlocked();
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
       const id = String(b.id ?? "");
       const seen = typeof b.updated === "number" ? b.updated : undefined;
@@ -2323,6 +2336,9 @@ const server = Bun.serve<WsData>({
      * follows.
      */
     if (pathname.startsWith("/tasks/write/") && req.method === "POST") {
+      // `/tasks/write/` — the path says it. Taskwarrior is the user's own
+      // store and these verbs add, complete and delete rows in it.
+      if (!trustedCaller(req, from)) return csrfBlocked();
       // Every verb carries the fingerprint the client was looking at. A write
       // whose precondition has moved answers 409 with the fresh list — it is
       // never retried here, because retrying against a store that moved is
@@ -2346,6 +2362,10 @@ const server = Bun.serve<WsData>({
       return json(r, r.conflict ? 409 : r.ok ? 200 : 400);
     }
     if (pathname.startsWith("/tasks/remind") && req.method === "POST") {
+      // Touching no Taskwarrior lock is not the same as changing nothing: a
+      // reminder is stored here and later fires a desktop notification, so
+      // this route writes state AND schedules something that interrupts.
+      if (!trustedCaller(req, from)) return csrfBlocked();
       // None of these touch Taskwarrior or its lock. That is what keeps the
       // engine working when the task list cannot be read at all.
       const b = await req.json().catch(() => ({})) as Record<string, unknown>;
@@ -2900,6 +2920,9 @@ const server = Bun.serve<WsData>({
 
     // --- LLM walkthrough: AI-authored review itinerary for the changes ---
     if (pathname === "/walkthrough" && req.method === "POST") {
+      // Spawns the `claude` CLI, or spends an API key. It executes and it
+      // costs money — the two properties the strict gate exists for.
+      if (!trustedCaller(req, from)) return csrfBlocked();
       let b: any = {};
       try { b = await req.json(); } catch { return json({ error: "invalid json" }, 400); }
       if (!WALKTHROUGH_ENABLED) {

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -867,7 +867,7 @@ const SEARCH_CHECKS = `query($q:String!,$first:Int!,$after:String){
         ... on User{login}
         ... on Team{name}
       }}}
-      commits(last:1){nodes{commit{statusCheckRollup{
+      commits(last:1){nodes{commit{oid statusCheckRollup{
         state
         contexts(first:0){checkRunCountsByState{state count} statusContextCountsByState{state count}}
       }}}}
@@ -1000,11 +1000,12 @@ async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after
   // row is complete the moment this lands. A PR missing from the answer keeps
   // the first-pass row: `checksLoaded` stays false, the review chip stays off,
   // and the stats stay at zero — all of which read as "not yet", which is true.
-  type SecondPass = { rollup: PrCheckRollup; stats: Pick<PrSummary, "additions" | "deletions" | "changedFiles" | "reviewDecision" | "reviewers"> };
+  type SecondPass = { rollup: PrCheckRollup; stats: Pick<PrSummary, "additions" | "deletions" | "changedFiles" | "reviewDecision" | "reviewers" | "headSha"> };
   const second = new Map<number, SecondPass>();
   for (const n of checksRes?.data?.search?.nodes ?? []) {
     if (!n?.number) continue;
-    const roll = n.commits?.nodes?.[0]?.commit?.statusCheckRollup;
+    const head = n.commits?.nodes?.[0]?.commit;
+    const roll = head?.statusCheckRollup;
     const ctx = roll?.contexts;
     second.set(n.number, {
       rollup: rollupFromCounts(ctx?.checkRunCountsByState, ctx?.statusContextCountsByState, roll?.state),
@@ -1014,6 +1015,12 @@ async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after
         changedFiles: n.changedFiles ?? 0,
         reviewDecision: n.reviewDecision ?? null,
         reviewers: mapReviewers(n.reviewRequests?.nodes),
+        /* The commit the rollup above belongs to, read off the same node rather
+           than asked for separately — which is the whole reason it can be
+           trusted as a merge precondition. A row says "green"; that word is
+           about THIS commit, and a merge sent without it lands on whatever the
+           tip is by then. See mergePr's --match-head-commit. */
+        headSha: typeof head?.oid === "string" ? head.oid : undefined,
       },
     });
   }

--- a/server/test/mutating-routes-guard.test.ts
+++ b/server/test/mutating-routes-guard.test.ts
@@ -61,11 +61,25 @@ const MUTATING = [
   `pathname === "/chat/pane/key"`,
   `pathname === "/codex/send"`,
   `pathname === "/antigravity/send"`,
+  `pathname === "/walkthrough"`,
   `pathname.startsWith("/git/")`,
   `pathname.startsWith("/docker/")`,
   `pathname.startsWith("/issues/")`,
   `pathname.startsWith("/prs/")`,
   `pathname.startsWith("/browser/")`,
+  /*
+   * The five families the first sweep walked past, and they are worth naming
+   * as a group because they share the reason they were missed: none of them
+   * runs a subprocess, so none of them looked like "executes". They change
+   * durable state anyway — a stored credential, a saved command line, a
+   * colleague's card in a shared workspace, the user's own task store, a
+   * scheduled interruption — and "mutates" was always half the rule.
+   */
+  `pathname.startsWith("/providers/")`,
+  `pathname.startsWith("/recipes/")`,
+  `pathname.startsWith("/clickup/")`,
+  `pathname.startsWith("/tasks/write/")`,
+  `pathname.startsWith("/tasks/remind")`,
 ];
 
 describe("the gate a route sits behind", () => {

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1848,6 +1848,16 @@ export interface PrSummary {
    *  "not yet" rather than "nobody was asked". */
   reviewers?: PrReviewer[];
   checks: PrCheckRollup;
+  /**
+   * The commit `checks` describes — and therefore the only commit a merge
+   * started from this row is allowed to land.
+   *
+   * Arrives with the second pass, off the same GraphQL node as the rollup, so
+   * the two can never disagree. Undefined until then, which is honest: before
+   * the checks are in, this row has no opinion about a commit and nothing
+   * should merge from it.
+   */
+  headSha?: string;
   /** This checkout is on the PR's head branch — "you are here". */
   isCurrentBranch?: boolean;
   /** Whether `checks` has actually been fetched. The list arrives in two

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -66,6 +66,17 @@ import { pins, isPinned, togglePin, subscribePins } from "../lib/prPins.ts";
 import { TriageBoard } from "./TriageBoard.tsx";
 import { FileRail } from "./FileRail.tsx";
 
+/**
+ * The second half of a merge, named once.
+ *
+ * A merge from the detail view is two writes to two systems: GitHub, then the
+ * card's status in ClickUp. The button says which one it is on, and the string
+ * is a constant because the tooltip has to recognise it — comparing against a
+ * literal typed twice is how the reassuring sentence ("the merge still stands")
+ * silently stops appearing after a copy edit.
+ */
+const MOVING_CARD = "Moving the card…";
+
 type Filter = "mine" | "review" | "all";
 type Tab = "overview" | "conversation" | "commits" | "files" | "checks" | "review";
 // The open/closed axis, orthogonal to the scope views. "closed" holds merged +
@@ -890,17 +901,12 @@ function DiffPane({ file, split, wrap, onPick, sel, expand, rowAfter, permalink 
  * A spinner in the middle of the space it is going to fill says where the
  * content will be and that something is still happening.
  *
- * Reduced motion gets a pulse rather than nothing: a ring that has stopped
- * turning reads as a spinner that has hung, which is the opposite of the
- * message.
+ * The ring itself is `.agx-spin` from index.css and nothing here. This file
+ * used to inject a second rule under that same name, and a `<style>` in the
+ * body beats a stylesheet in the head — so mounting this panel restyled every
+ * spinner in the app and unmounting it put them back. The reduced-motion pulse
+ * that rule argued for was the better answer and moved to index.css with it.
  */
-const LOADING_CSS = `
-@keyframes agxspin{to{transform:rotate(360deg)}}
-@keyframes agxbreathe{0%,100%{opacity:.3}50%{opacity:.85}}
-.agx-spin{border-radius:50%;border:2px solid color-mix(in srgb,var(--text) 24%,transparent);border-top-color:var(--primary);animation:agxspin .7s linear infinite}
-@media (prefers-reduced-motion:reduce){.agx-spin{animation:agxbreathe 1.6s ease-in-out infinite}}
-`;
-
 function Loading({ label, fill, size = 22 }: { label: string; fill?: boolean; size?: number }) {
   return (
     <div role="status" aria-live="polite"
@@ -1425,6 +1431,10 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [jump, repo, openPr]);
   const [busy, setBusy] = useState(false);
+  /** What the merge control is doing right now, "" when it is doing nothing.
+   *  A sentence rather than a boolean because the merge is two writes and they
+   *  fail differently — see doMerge. */
+  const [mergeWork, setMergeWork] = useState("");
   const [toast, setToast] = useState<{ ok: boolean; msg: string } | null>(null);
   // Automation comments render in full by default now that they render as
   // markdown rather than as their own source: the fold stays folded, so a 40 KB
@@ -2292,21 +2302,46 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
       card: mergeCardRef(detail, clickup),
     });
     if (!choice) return;
-    const merged = await act("Merge", () => api.prMerge(root, detail.number, method, {
-      deleteBranch: choice.deleteBranch, headSha: head,
-      subject: choice.subject, body: choice.body,
-    }));
-    const move = choice.card;
-    if (!merged || !move) return;
-    // `updated` is the precondition, not decoration: somebody else moving the
-    // card while the merge form was open should come back as a conflict rather
-    // than quietly winning.
-    const r = await api.clickupStatus(move.id, move.to, move.updated)
-      .catch((e) => ({ ok: false, error: String(e) }));
-    flash(r.ok, mergeNote(true, {
-      asked: true, ok: r.ok, to: move.to,
-      error: r.ok ? undefined : ("conflict" in r && r.conflict ? "somebody moved it while this was open" : r.error),
-    }));
+    /*
+     * What the merge control says while this runs.
+     *
+     * `busy` alone could not say it. It is one flag for every action on the
+     * panel, so a button reading it can only know that SOMETHING is happening —
+     * and the merge button, dimmed and still reading "Squash and merge" through
+     * a `gh` subprocess and then a write to ClickUp, read as a button that had
+     * not registered the press. That is the state people press twice.
+     *
+     * Two names rather than one, because these are two writes to two systems
+     * and the second is the one that can take a while on somebody else's
+     * network. Which half it is on is worth saying: once it reads MOVING_CARD
+     * the irreversible part is already done, and the button's tooltip says so
+     * — that is the difference between waiting and wondering whether to try
+     * the merge again.
+     */
+    try {
+      setMergeWork("Merging…");
+      const merged = await act("Merge", () => api.prMerge(root, detail.number, method, {
+        deleteBranch: choice.deleteBranch, headSha: head,
+        subject: choice.subject, body: choice.body,
+      }));
+      const move = choice.card;
+      if (!merged || !move) return;
+      setMergeWork(MOVING_CARD);
+      // `updated` is the precondition, not decoration: somebody else moving the
+      // card while the merge form was open should come back as a conflict rather
+      // than quietly winning.
+      const r = await api.clickupStatus(move.id, move.to, move.updated)
+        .catch((e) => ({ ok: false, error: String(e) }));
+      flash(r.ok, mergeNote(true, {
+        asked: true, ok: r.ok, to: move.to,
+        unauthorised: "unauthorised" in r ? r.unauthorised : undefined,
+        error: r.ok ? undefined : ("conflict" in r && r.conflict ? "somebody moved it while this was open" : r.error),
+      }));
+    } finally {
+      // `finally`, so a throw anywhere above cannot leave the button spinning
+      // for ever — a spinner that never stops is a worse lie than no spinner.
+      setMergeWork("");
+    }
   };
 
   /**
@@ -2546,7 +2581,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
     <RepoCtx.Provider value={repo?.nameWithOwner}>
     <MentionCtx.Provider value={mentions}>
     <div className="flex flex-col h-full min-h-0">
-      <style>{SCROLLBAR_CSS}{LINEBTN_CSS}{MD_CSS}{PR_ROW_CSS}{LOADING_CSS}</style>
+      <style>{SCROLLBAR_CSS}{LINEBTN_CSS}{MD_CSS}{PR_ROW_CSS}</style>
 
       <div className={viewHeaderClass} style={viewHeaderStyle}>
         <h2 className="sr-only">Pull Requests</h2>
@@ -2721,7 +2756,25 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
                   // Only what this app can really do. `merge` uses the method
                   // the panel already remembers, so the board never quietly
                   // picks a different one from the detail.
-                  if (what === "merge") void act("Merge", () => api.prMerge(root, p.number, mergeMethod, {}));
+                  //
+                  // `headSha` is not optional here either, and it used to be
+                  // missing. A card lands in "Green, ready to land" because of
+                  // its check rollup, and that rollup is about ONE commit; a
+                  // merge sent with no head to match against lands on whatever
+                  // the tip is when it arrives — the author's push from thirty
+                  // seconds ago, untested in this combination and never seen by
+                  // the person who pressed the button. The detail view has
+                  // always passed it (see doMerge); this was the one merge in
+                  // the app that could land a commit nobody had looked at.
+                  //
+                  // No head means the second pass has not landed, so the row
+                  // has no checks either and no lane that offers Merge. Refused
+                  // rather than sent unguarded, because "the guard was not
+                  // available" is not a reason to skip the guard.
+                  if (what === "merge") {
+                    if (!p.headSha) { flash(false, "Merge — still reading this one's checks"); return; }
+                    void act("Merge", () => api.prMerge(root, p.number, mergeMethod, { headSha: p.headSha }));
+                  }
                   else if (what === "rerun") void act("Re-run checks", () => api.prRerun(root, p.number));
                   else openPr(p.number);
                 }} />
@@ -3014,7 +3067,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
                     <div className="min-w-0 flex-1">
                       {tab === "overview" ? (
                         <Overview
-                          d={d} root={root} busy={busy} openThreads={openThreads.length}
+                          d={d} root={root} busy={busy} mergeWork={mergeWork} openThreads={openThreads.length}
                           conversationCount={d.comments.length + d.reviews.length + d.threads.length}
                           behind={behind} localHead={localHead}
                           conflictFiles={conflictFiles}
@@ -3363,12 +3416,17 @@ function ConflictActions({ root, number, branch, base, disabled }: {
   );
 }
 
-function Overview({ d, root, busy, openThreads, conversationCount, behind, localHead, conflictFiles, method, onMethod, onLocalReview, onReviewInTerminal, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onCancelAutoMerge, onDraft, onGoThreads, onEditRequest, awaitingChecks }: {
+function Overview({ d, root, busy, mergeWork, openThreads, conversationCount, behind, localHead, conflictFiles, method, onMethod, onLocalReview, onReviewInTerminal, onMerge, onClose, onUpdateBranch, onRerun, onAutoMerge, onCancelAutoMerge, onDraft, onGoThreads, onEditRequest, awaitingChecks }: {
   d: PrDetail;
   /** The checkout this pull request is being read from — where a conflict would
    *  be prepared. */
   root: string;
-  busy: boolean; openThreads: number; conversationCount: number;
+  busy: boolean;
+  /** What the merge is doing, "" when it is not running. `busy` cannot answer
+   *  this: it is true for every action on the panel, so a merge button reading
+   *  it would say "Merging…" while a comment was being posted. */
+  mergeWork: string;
+  openThreads: number; conversationCount: number;
   /** How many commits the branch is behind its base, once asked. Null while the
    *  question is still out, which is why the button appears a beat late rather
    *  than the whole page arriving late. */
@@ -3661,8 +3719,16 @@ function Overview({ d, root, busy, openThreads, conversationCount, behind, local
           {!conflicted && (
           <span className="flex items-center rounded overflow-hidden shrink-0" style={{ border: "1px solid var(--primary)" }}>
             <button onClick={() => { if (isBehind && !confirmBehind) { setConfirmBehind(true); return; } onMerge(method); }}
-              disabled={busy || (!canMerge && !isBehind)}
-              title={canMerge
+              /* `mergeWork` as well as `busy`, and it is not redundant: the card
+                 move runs AFTER the merge action has settled, so for those
+                 seconds `busy` is false again and the button was live while the
+                 second half of its own operation was still in flight. */
+              disabled={busy || !!mergeWork || (!canMerge && !isBehind)}
+              title={mergeWork
+                ? (mergeWork === MOVING_CARD
+                  ? "The pull request is merged. Moving its ClickUp card to the merged status — if this part fails, the merge still stands."
+                  : "Merging…")
+                : canMerge
                 ? `${MERGE_LABEL[method]}${d.mergePolicy?.deletesBranch ? " — GitHub deletes the branch" : " and delete the branch"}`
                 : isBehind
                   ? `${d.baseRefName} has moved on${behind ? ` by ${behind} commit${behind === 1 ? "" : "s"}` : ""}. The checks that passed ran against the old base — merging now is untested in this combination.`
@@ -3688,7 +3754,22 @@ function Overview({ d, root, busy, openThreads, conversationCount, behind, local
                     color: "var(--bg)", fontWeight: 600,
                   }
                 : { background: "var(--primary)", color: "var(--bg)", fontWeight: 500 }}>
-              {isBehind ? (confirmBehind ? "Merge anyway?" : `${MERGE_LABEL[method]} · behind`) : MERGE_LABEL[method]}
+              {mergeWork
+                ? (
+                  /* The ring the rest of the app spins, sized to a 10.5px
+                     button and tinted to the button's own foreground —
+                     `.agx-spin` is drawn in `--primary`, which is this
+                     button's BACKGROUND and would have been an invisible
+                     spinner on the one control that most needs one. */
+                  <span className="inline-flex items-center gap-1.5">
+                    <span aria-hidden className="agx-spin shrink-0"
+                      style={{ width: 9, height: 9,
+                        borderColor: "color-mix(in srgb, currentColor 30%, transparent)",
+                        borderTopColor: "currentColor" }} />
+                    {mergeWork}
+                  </span>
+                )
+                : isBehind ? (confirmBehind ? "Merge anyway?" : `${MERGE_LABEL[method]} · behind`) : MERGE_LABEL[method]}
             </button>
             {methods.length > 1 && (
               <Select

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -20,6 +20,7 @@ import { browserPlaces, CAN_IMPORT_COOKIES, cookieSources, importCookies, forget
 import { loadProfiles } from "../lib/browserProfiles.ts";
 import { addVisible, allSites, bestSource, dropVisible, lockedWhy, reachable, siteView } from "../lib/cookiePick.ts";
 import { PROVIDERS, type ProviderSpec, type ProviderStatus, type ProviderState } from "../../../shared/providers.ts";
+import { checkedLine } from "../lib/providerFreshness.ts";
 import { fmtAgo } from "../lib/format.ts";
 import type { ActionRecord, GateRecord } from "../../../shared/types.ts";
 import { mergeActivity, gateLine, actorLabel, type ActivityRow } from "../lib/activity.ts";
@@ -2040,6 +2041,10 @@ function ProviderCard({ spec, status, checking, onChanged }: {
   const connected = status?.state === "connected";
   const wantsToken = spec.auth === "token";
   const line = "1px solid color-mix(in srgb, var(--border) 40%, transparent)";
+  /* Empty while the check is still out: a row that has not answered yet has
+     nothing to be stale about, and "Checked at 14:32" beside "Checking…" is a
+     contradiction on one line. */
+  const checked = waiting ? "" : checkedLine(status?.at);
 
   const connect = async () => {
     if (!token.trim()) return;
@@ -2078,6 +2083,15 @@ function ProviderCard({ spec, status, checking, onChanged }: {
         hint={<>
           <span className="block">{spec.what}</span>
           {status?.detail && <span className="block mt-0.5" style={{ color: "var(--text2)" }}>{status.detail}</span>}
+          {/* When that verdict was actually taken. The row above is read from a
+              cache — deliberately, because asking ClickUp live costs ten
+              seconds of its latency for a question the token answers — and a
+              cached verdict drawn with no date claims to be a live one. Said
+              only once the answer is old enough for the difference to matter;
+              see checkedLine. */}
+          {checked && (
+            <span className="block mt-0.5 text-[11px]" style={{ color: "var(--text3)" }}>{checked}</span>
+          )}
           {/* Half of a provider can be down while the other half looks fine —
               the ClickUp card bell fails on its own three-minute timer and
               used to do it in total silence (T27). Warning-coloured rather

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -673,7 +673,18 @@ textarea.bg-transparent:focus-visible { outline: none !important; }
 .agx-veil { animation: agx-veil-in 140ms ease 220ms both; }
 
 /* A pending request, drawn rather than spelled. Border-only so it costs one
-   element, and paused with every other ambient loop when the page is idle. */
+   element, and paused with every other ambient loop when the page is idle.
+
+   THE definition, and the word matters: this rule used to have a twin. PrPanel
+   carried its own `.agx-spin` in a `<style>` tag it rendered, with a different
+   border and a different reduced-motion answer — and because a style element in
+   the body comes after the stylesheet in the head, the twin won. So every
+   spinner in the app (the workspace's, Docker's, the rescue modal's) quietly
+   changed shape when the pull-request panel was mounted and changed back when
+   it was not. One name, one rule, wherever it is spun.
+
+   Sized by the caller where it is not 11px: `style={{ width, height }}` on the
+   element, which is how the fill-the-pane loader gets its 22. */
 @keyframes agx-spin { to { transform: rotate(360deg); } }
 .agx-spin {
   display: inline-block;
@@ -684,8 +695,13 @@ textarea.bg-transparent:focus-visible { outline: none !important; }
   border-top-color: var(--primary);
   animation: agx-spin 0.7s linear infinite;
 }
+/* A pulse, not a slower rotation. This was the twin's answer and it is the
+   better one: a ring still turning, only lazily, reads as a spinner that has
+   hung — which is the opposite of what a spinner is for. Reduced motion asks
+   for less movement, so the movement goes and the "still working" stays. */
+@keyframes agx-breathe { 0%, 100% { opacity: 0.3; } 50% { opacity: 0.85; } }
 @media (prefers-reduced-motion: reduce) {
-  .agx-spin { animation-duration: 2s; }
+  .agx-spin { animation: agx-breathe 1.6s ease-in-out infinite; }
 }
 
 /* The notification list behind the top bar's bell.

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -3,7 +3,11 @@ import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, Di
 import type { ProvidersResponse, ProviderStatus, ProviderTasksResponse, SavedView, ClickUpBoards, ViewTasksResponse, TaskDetail, ProviderTask, ListStatus, ListField, ListPlace, ListMember } from "../../../shared/providers.ts";
 
 /** What every ClickUp write answers with: the card as it now stands, or why not. */
-type ClickUpWrite = { ok: boolean; error?: string; conflict?: boolean; task?: ProviderTask };
+/* `conflict` and `unauthorised` are the two failures with a remedy the app can
+   name — reload, reconnect — so both are fields. Everything else is prose,
+   because this provider answers 401 for a card that does not exist and a code
+   pretending to know which it was would be wrong on the common case. */
+type ClickUpWrite = { ok: boolean; error?: string; conflict?: boolean; unauthorised?: boolean; task?: ProviderTask };
 import { DEPS, type DepsResponse } from "../../../shared/deps.ts";
 import * as demo from "./demo.ts";
 

--- a/web/src/lib/cardMove.ts
+++ b/web/src/lib/cardMove.ts
@@ -117,9 +117,19 @@ export function statusColor(statuses: ListStatus[], status: string): string | un
  * request IS merged, and telling somebody otherwise sends them to un-merge
  * something. So the wording always leads with the merge.
  */
-export function mergeNote(merged: boolean, move: { asked: boolean; ok?: boolean; to?: string; error?: string }): string {
+export function mergeNote(
+  merged: boolean,
+  move: { asked: boolean; ok?: boolean; to?: string; error?: string; unauthorised?: boolean },
+): string {
   if (!merged) return "Merge failed";
   if (!move.asked) return "Merged";
   if (move.ok) return `Merged · card moved to ${move.to}`;
+  /*
+   * A refused token is the one failure here that pressing the button again
+   * cannot fix, and the sentence has to say so — otherwise "ClickUp refused
+   * this token" reads as a hiccup and the next move is a retry that will be
+   * refused in exactly the same way. Where to go instead is the actual news.
+   */
+  if (move.unauthorised) return "Merged — the card did not move: ClickUp refused this token. Reconnect it in Settings.";
   return `Merged — but the card did not move: ${move.error || "ClickUp refused"}`;
 }

--- a/web/src/lib/providerFreshness.ts
+++ b/web/src/lib/providerFreshness.ts
@@ -1,0 +1,63 @@
+/*
+ * How old a provider's answer is, said only when the age changes what it means.
+ *
+ * `ProviderStatus.at` has been set since the field was written — the ClickUp
+ * snapshot's timestamp, or the card watcher's last run — and its own doc
+ * comment says it exists "so the page can say 'as of' instead of implying it
+ * just asked". No page said it. The field was written in three places and read
+ * in none, which is the failure mode a status field is most prone to: the
+ * server does the honest work and the screen quietly presents a cached verdict
+ * as a live one.
+ *
+ * Two decisions live here rather than in the JSX, because both are judgements
+ * and neither is obvious from a render:
+ *
+ * 1. WHEN it is worth saying. A row that was checked four seconds ago is not
+ *    telling you anything by admitting it, and "checked just now" on four rows
+ *    is four lines of noise on the one screen people open when something is
+ *    already wrong. Under the window, this says nothing at all.
+ *
+ * 2. THAT IT IS A CLOCK TIME, not "3m ago". Settings stops re-polling the
+ *    moment nothing is `pending`, so a relative age computed at render is
+ *    frozen at render — a pane left open for half an hour would still read
+ *    "3m ago", which is a staleness indicator that has itself gone stale. A
+ *    clock time is true whenever it is read.
+ */
+
+/**
+ * How fresh an answer has to be before its age is not worth mentioning.
+ *
+ * Two minutes, from the two things `at` can be: the ClickUp task snapshot,
+ * whose cache TTL is 60s, and the card watcher, which runs on a three-minute
+ * timer. One minute would put a healthy watcher permanently in the "worth
+ * mentioning" bucket for no reason; two clears the snapshot's TTL and still
+ * catches an answer that has genuinely stopped being refreshed.
+ */
+export const FRESH_MS = 120_000;
+
+/** `14:32`, in the reader's own clock. */
+function clock(at: number): string {
+  const d = new Date(at);
+  const p = (x: number) => String(x).padStart(2, "0");
+  return `${p(d.getHours())}:${p(d.getMinutes())}`;
+}
+
+/**
+ * The line to put under a provider's detail, or "" for no line.
+ *
+ * "" rather than null so the caller can render it without a conditional that
+ * would have to decide the same thing a second time.
+ */
+export function checkedLine(at: number | undefined, now = Date.now()): string {
+  if (!at || at > now) return "";
+  if (now - at < FRESH_MS) return "";
+  const age = now - at;
+  const day = 86_400_000;
+  // Past a day the clock time alone is ambiguous and reads as today's, which
+  // is the one way this line could actively mislead.
+  if (age >= day) {
+    const days = Math.floor(age / day);
+    return `Checked ${days} day${days === 1 ? "" : "s"} ago`;
+  }
+  return `Checked at ${clock(at)}`;
+}

--- a/web/test/card-move.test.ts
+++ b/web/test/card-move.test.ts
@@ -131,6 +131,21 @@ describe("what it says afterwards", () => {
   it("still names the merge first when ClickUp gave no reason at all", () => {
     expect(mergeNote(true, { asked: true, ok: false })).toBe("Merged — but the card did not move: ClickUp refused");
   });
+
+  it("sends a refused token to Settings instead of inviting a retry", () => {
+    // The one failure here that pressing the button again cannot fix. Without
+    // this, "ClickUp refused this token" reads as a hiccup.
+    const said = mergeNote(true, { asked: true, ok: false, unauthorised: true, error: "ClickUp refused this token" });
+    expect(said).toContain("Merged");
+    expect(said).toContain("Reconnect it in Settings");
+  });
+
+  it("still leads with the merge when the token was refused", () => {
+    expect(mergeNote(true, { asked: true, ok: false, unauthorised: true })).toStartWith("Merged");
+    // And a merge that did NOT land is still reported as a failed merge,
+    // whatever ClickUp thought of the token.
+    expect(mergeNote(false, { asked: true, unauthorised: true })).toBe("Merge failed");
+  });
 });
 
 describe("the panel", () => {

--- a/web/test/provider-freshness.test.ts
+++ b/web/test/provider-freshness.test.ts
@@ -1,0 +1,47 @@
+/*
+ * The rule is "say it only when it changes what the row means", so the tests
+ * are mostly about SILENCE — the cases where this must render nothing. A
+ * staleness line that appears on a healthy row is not a smaller bug than one
+ * that never appears; it is four lines of noise on the screen people open when
+ * something is already wrong.
+ */
+import { describe, expect, test } from "bun:test";
+import { checkedLine, FRESH_MS } from "../src/lib/providerFreshness.ts";
+
+// Fixed, because a clock time is asserted below and a test that reads the real
+// clock passes at 14:32 and fails at midnight.
+const NOW = new Date(2026, 7, 9, 14, 32, 0).getTime();
+
+describe("checkedLine", () => {
+  test("says nothing when the provider never reported a time", () => {
+    expect(checkedLine(undefined, NOW)).toBe("");
+    expect(checkedLine(0, NOW)).toBe("");
+  });
+
+  test("says nothing about an answer that is still fresh", () => {
+    expect(checkedLine(NOW, NOW)).toBe("");
+    expect(checkedLine(NOW - 1_000, NOW)).toBe("");
+    expect(checkedLine(NOW - (FRESH_MS - 1), NOW)).toBe("");
+  });
+
+  test("speaks the moment the answer is past the window", () => {
+    // Exactly at the boundary, so the time named is the window ago — 14:30,
+    // not the 14:32 it is now. Which is the whole point of the line.
+    expect(checkedLine(NOW - FRESH_MS, NOW)).toBe("Checked at 14:30");
+  });
+
+  test("gives the clock time the answer was taken, not the time now", () => {
+    // Twenty minutes old: 14:12, not 14:32.
+    expect(checkedLine(NOW - 20 * 60_000, NOW)).toBe("Checked at 14:12");
+  });
+
+  test("past a day it counts days, because a bare clock time reads as today's", () => {
+    expect(checkedLine(NOW - 26 * 3_600_000, NOW)).toBe("Checked 1 day ago");
+    expect(checkedLine(NOW - 3 * 86_400_000, NOW)).toBe("Checked 3 days ago");
+  });
+
+  test("a timestamp from the future is a clock disagreement, not news", () => {
+    // Answering "checked in 5 minutes" would be worse than answering nothing.
+    expect(checkedLine(NOW + 5 * 60_000, NOW)).toBe("");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Six items from an integration-reliability pass: one real bug, two UI defects, three pieces of consistency.

**The board's quick-merge merged without `--match-head-commit`.** `prs.ts` says that flag is not optional, and there were four `prMerge` call sites: the detail dialog passed `headSha`, auto-merge correctly does not (it fires on a future commit), and the triage board passed `{}`. So a card that reached "Green, ready to land" against one commit's checks could land whatever the tip happened to be by the time you pressed. The head SHA now rides on the same GraphQL node as the rollup the row vouches for, so the commit a card promises and the commit it merges are the same one by construction, at no extra query. A row with no head has not had its second pass yet, which means no checks and no Merge lane, so the press is refused rather than sent unguarded.

**The merge button had no pending state.** It rendered its label, disabled at 40% opacity, unchanged through a `gh` subprocess and then a ClickUp write. It now has its own `mergeWork` state — not the panel-wide `busy` flag, which would have said "Merging…" while a comment posted, and which was false again while the card move was still in flight.

**`.agx-spin` was defined twice.** `index.css` had it, and `PrPanel.tsx` injected a `<style>` with the same class, a different border and a different reduced-motion answer. A style element in the body beats a stylesheet in the head, so every spinner in the app changed shape when the PR panel was mounted and changed back when it was not. One rule now, in `index.css`, keeping the twin's reduced-motion *pulse* — a ring still turning reads as one that has hung.

**Five more mutating route families moved to `trustedCaller`** — `/walkthrough`, `/providers/`, `/recipes/`, `/clickup/`, `/tasks/write/`, `/tasks/remind` — finishing #496. They were missed there because none runs a subprocess, so none read as *executes*; but *mutates* was always half the rule, and `/providers/` stores and deletes the credentials every other integration reads. **No reachable exploit**: the only thing the stricter gate adds is refusing an Origin-less *remote* caller, which the token gate already refuses. This is hygiene, not a hole.

**Two fields nobody read**: `WriteOutcome.unauthorised` and `ProviderStatus.at`, written in three places and read in none.

## How was it tested?

`tsc --noEmit` clean for `server/` and `web/`. Web suite 1966 pass; the touched server suites green, including the route-guard test from #496, which gained six entries and lost no assertion — the six routes were moved in `index.ts` first and named in the test afterwards, so they are new assertions that hold rather than relaxed ones.

Then measured against a real desktop build installed from this branch and driven over CDP, because every UI claim in it was reasoned rather than seen:

- **One `.agx-spin` rule, and it stays one.** Every stylesheet enumerated before and after mounting the PR panel: a single rule, from the stylesheet, never a `<style>` tag. The duplicate is confirmed gone rather than assumed gone.
- **The merge button's spinner is visible on both backgrounds.** Resolved colours with contrast computed: **7.49:1** against the blue button (ring drawn in `--bg` over `--primary`) and **14.64:1** against the hazard background. The `currentColor` reasoning holds.
- **Reduced motion breathes rather than rotates.** With `prefers-reduced-motion: reduce` the animation resolves to `agx-breathe` at 1.6s, and to `agx-spin` at 0.7s without it.
- **The phone is unaffected by the route moves.** `trusted()` is `isPrivate(h) || trustedName(h)`, and `trustedName` accepts tailnet names, so a phone's Origin passes the stricter gate exactly as it passed the looser one.

Not verified end to end: a real board merge through the new `headSha` path. No pull request was open to land from the board while this was tested, and the refusal it guards is a sub-second window on a fast list. What changed is which value is passed, and all four call sites were read.

The four failures in `web/test/server-identity.test.ts` fail identically on `main` — an order-dependent interaction between test files that appears when the suite runs as one process in a worktree and disappears when that file runs alone.
