### PR TITLE
fix: tmux had nowhere to draw a message, so it drew on the pane

### DIFF
--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -1065,11 +1065,41 @@ export function setStatusLine(t: TmuxTarget, visible: boolean): boolean {
   // or without a bar, and the re-assertion the panel runs off this flag
   // depends on the claim being there to find.
   if (statusInConfig(t) === "off") return true;
-  // The row itself. `status off` rather than a blanked `status-format[0]`: a row
-  // held open for prompts that no longer arrive there is just a gap.
-  const off = tmux(t.socket, ["set-option", "-t", t.id, "status", "off"]) !== null;
-  if (!off) { releasePrompts(t); tmux(t.socket, ["set-option", "-t", t.id, "-u", "@agx-owned"]); }
-  return off;
+  /*
+   * The row itself — kept, and blanked, rather than switched off.
+   *
+   * `status off` was the obvious answer and it was wrong, for the reason this
+   * file has now met twice: tmux still has messages to draw, and with no status
+   * row it draws them ON THE PANE. Measured against a real attached client on a
+   * private server: with `status off`, `display-message "Saving… AI00"` arrives
+   * as a bare paint at the cursor — no cursor-home before it, no repaint after —
+   * so it lands in the middle of whatever the pane was showing and stays there
+   * until something else redraws that line. Reported from a desk running
+   * tmux-continuum: every autosave stamped a line across an agent's box and ate
+   * the line under it, and the pane appeared to flicker as the agent redrew.
+   *
+   * Same measurement with the row kept and `status-format[0]` blank: the
+   * message is written after a `\r\n` into the reserved row, the pane is
+   * untouched, and the cursor comes back to the pane's own last line. Nothing
+   * on screen moves.
+   *
+   * It costs one row, which is exactly what the old comment here refused to
+   * spend — "a row held open for prompts that no longer arrive there is just a
+   * gap". The premise was wrong. They do arrive: `prefix ,`, `prefix .`, every
+   * `display-message` any plugin makes, and continuum's autosave. A gap that
+   * catches them is cheaper than a pane they land in.
+   *
+   * `status-style` goes with it so the reserved row takes the terminal's own
+   * background instead of tmux's default green, and all three options are in
+   * BORROWED, so the restore gives back exactly what was taken.
+   */
+  const kept = [
+    ["status", "on"],
+    ["status-format[0]", ""],
+    ["status-style", "bg=default,fg=default"],
+  ].map(([opt, val]) => tmux(t.socket, ["set-option", "-t", t.id, opt!, val!]) !== null).every(Boolean);
+  if (!kept) { releasePrompts(t); tmux(t.socket, ["set-option", "-t", t.id, "-u", "@agx-owned"]); }
+  return kept;
 }
 
 // ---------------------------------------------------------------------------

--- a/server/test/tmux-bar.test.ts
+++ b/server/test/tmux-bar.test.ts
@@ -101,11 +101,27 @@ const keyLine = (key: string) => out(["list-keys", "-T", "prefix"]).split("\n")
   .find((l) => ctl.parseBinding(l)?.key === key) ?? "";
 
 describe.if(has)("the status row, taken and given back", () => {
-  test("the row is gone, not blanked — there is no gap to leave behind", () => {
-    // The whole point. `status off`, not `status on` with an empty format:
-    // a row held open for prompts that no longer arrive there is just a gap.
+  test("the row is kept and blanked, because tmux still has messages to draw", () => {
+    /*
+     * This test used to assert the opposite — `status off`, "a row held open
+     * for prompts that no longer arrive there is just a gap" — and the premise
+     * was wrong. They do arrive.
+     *
+     * Measured against a real attached client on a private server: with
+     * `status off`, `display-message "Saving… AI00"` reaches the client as a
+     * bare paint at the cursor, with no cursor-home before it and no repaint
+     * after, so it lands in the middle of the pane and stays until something
+     * redraws that line. Reported from a desk running tmux-continuum, where
+     * every autosave stamped a line across an agent's box and ate the line
+     * under it. With the row kept and the format blank, the same message is
+     * written after a `\r\n` into the reserved row and the pane is untouched.
+     *
+     * The cost is one row, paid once, against a pane that is corrupted every
+     * time any plugin says anything.
+     */
     expect(ctl.setStatusLine(target, false)).toBe(true);
-    expect(out(["show-options", "-t", target.id, "-v", "status"])).toBe("off");
+    expect(out(["show-options", "-t", target.id, "-v", "status"])).toBe("on");
+    expect(out(["show-options", "-t", target.id, "-v", "status-format[0]"])).toBe("");
     expect(out(["show-options", "-t", target.id, "-v", "@agx-owned"])).toBe("1");
   });
 

--- a/server/test/tmux-stale.test.ts
+++ b/server/test/tmux-stale.test.ts
@@ -107,9 +107,11 @@ describe.if(has)("a run that was killed does not leave tmux broken", () => {
   test("the takeover is what a crash would leave behind", () => {
     const before = keyLine(",");
     expect(ctl.setStatusLine(target(), false)).toBe(true);
-    // This is the state a SIGKILL freezes: no status row, the claim still set,
+    // This is the state a SIGKILL freezes: the row kept and blanked (tmux needs
+    // somewhere to draw a message that is not the pane), the claim still set,
     // and the way back written on the session rather than in a variable.
-    expect(out(["show-options", "-t", mine, "-v", "status"])).toBe("off");
+    expect(out(["show-options", "-t", mine, "-v", "status"])).toBe("on");
+    expect(out(["show-options", "-t", mine, "-v", "status-format[0]"])).toBe("");
     expect(opt(mine, "@agx-owned")).toBe("1");
     expect(opt(mine, "@agx-had-rename")).toContain("bind-key");
     expect(before).toContain("command-prompt");

--- a/server/test/tmux-watchdog.test.ts
+++ b/server/test/tmux-watchdog.test.ts
@@ -141,24 +141,42 @@ describe("the bar the panel repaints, kept off", () => {
   });
 
   test("and re-asserting heals it within the sweep's own call", () => {
-    // Exactly what the sweep does when it finds a mirror with `status` on:
-    // setStatusLine takes it again, and the next frame reads off.
+    /*
+     * Exactly what the sweep does when it finds a mirror it does not own:
+     * `setStatusLine` takes it again.
+     *
+     * What "taken" LOOKS like changed, and the change is the point. The row is
+     * now kept and blanked rather than switched off, because with no row at all
+     * tmux draws its messages on the pane — measured, a `display-message`
+     * lands as a bare paint at the cursor with no repaint after it, which is
+     * how continuum's autosave stamped a line across an agent's box. So the
+     * assertion is: the row exists (`status on`), it carries our claim, and it
+     * is blank — not that it is gone.
+     */
     expect(setStatusLine(mirror(), false)).toBe(true);
     const f = readFrame(client())!;
-    expect(f.status).toBe("off");
+    expect(f.status).toBe("on");
     expect(f.owned).toBe(true);
+    expect(out(["show-options", "-qv", "-t", currentMirror, "status-format[0]"])).toBe("");
   });
 
   test("a config reload with `set -g status on` does not bring the bar back", () => {
     // `prefix r` / tpm's `I` and `U` re-source the config, which re-applies
-    // `set -g status on`. The mirror's session-local `off` shadows the global
-    // — measured against a real client — so the frame keeps reporting off and
-    // the sweep has nothing to do.
+    // `set -g status on`. The mirror carries the panel's own session-local
+    // options, which shadow the global — measured against a real client — so a
+    // reload changes nothing the sweep has to answer.
+    //
+    // The row is `on` here because the previous test took it: kept and blanked
+    // rather than switched off, so tmux has somewhere to draw a message that is
+    // not the pane. What the reload must not do is put the user's FORMAT back,
+    // and that is what the second assertion pins.
     const dir = mkdtempSync(join(tmpdir(), "agx-watchdog-reload-"));
     const file = join(dir, "reload.conf");
     writeFileSync(file, "set -g status on\n");
     raw(["source-file", file]);
-    expect(readFrame(client())!.status).toBe("off");
+    expect(readFrame(client())!.status).toBe("on");
+    expect(out(["show-options", "-qv", "-t", currentMirror, "status-format[0]"])).toBe("");
+    expect(readFrame(client())!.owned).toBe(true);
     rmSync(dir, { recursive: true, force: true });
   });
 
@@ -185,6 +203,9 @@ describe("the bar the panel repaints, kept off", () => {
     const f = readFrame(client())!;
     expect(isPhoneSession(f.target.session)).toBe(true);
     expect(f.target.session).not.toBe("agx-phone-1-abc");
+    // A fresh mirror is created with the row already off — it has nothing to
+    // catch yet and nobody attached. The sweep's first re-assert is what turns
+    // it into the kept-and-blank row the test above pins.
     expect(f.status).toBe("off");
     currentMirror = f.target.session;
     currentMirrorId = out(["display-message", "-p", "-t", currentMirror, "#{session_id}"]);


### PR DESCRIPTION
## What does this PR do?

Stops tmux drawing its own chrome across the pane.

Reported as: a line of tmux status appearing over an agent's box, eating the line under it, and the terminal flickering while the agent redrew. The trigger turned out to be a keystroke — `prefix + s`, a tmux-resurrect save — and it happens several times an hour on a desk running continuum.

The panel hid the status row with `status off`. tmux still has messages to say: a resurrect save, any plugin's `display-message`, the prompts the panel rebinds. With no row to put them in, it writes them onto the client's screen.

Measured against a real attached client on a private server, `status off`:

    \x1b[?25l\x1b[30m\x1b[43mSaving... AI00 …\x1b[m\x0f\x1b[20;1H

A bare paint at the cursor. No cursor-home before it, no repaint after — so it lands wherever the pane happened to be drawing and stays until something else redraws that line.

The same message with the row kept and `status-format[0]` blank:

    \x1b[?25l\x1b[30m\x1b[43m\r\nSaving... AI00 …\x1b[m\x0f\x1b[19;1H

Written after a carriage return, into the reserved row. The pane is untouched and the cursor returns to the pane's own last line.

So the row is now kept and blanked — `status on`, empty `status-format[0]`, and a style that takes the terminal's own background — instead of switched off. It costs one row, which is exactly what the comment there refused to spend: *"a row held open for prompts that no longer arrive there is just a gap"*. The premise was wrong; they do arrive.

The watchdog added in #500 decided the bar was back by reading `status !== "off"`, which is now true for ever. It keys on the claim (`@agx-owned`) instead, so it re-asserts when somebody takes the row rather than on every tick.

## How was it tested?

`tsc --noEmit` clean for `server/`.

The four real-tmux suites, each on its own private socket: `tmux-watchdog`, `tmux-bar`, `tmux-stale`, `tmux-attach` — **48 pass, 0 fail**.

The before/after escape sequences above are the measurement the change rests on, taken from a client attached over a pty at a known size, not from reading tmux's source.

Three assertions changed rather than were deleted, and all three encoded the old decision explicitly:

- `tmux-bar`: *"the row is gone, not blanked — there is no gap to leave behind"* now asserts the row exists, is ours, and is blank, with the measurement in the comment. It is renamed, because the name was the claim.
- `tmux-stale`: the state a SIGKILL freezes is now a kept blank row rather than no row.
- `tmux-watchdog`: the heal assertion, and the config-reload one, follow the same contract.

Not covered by a test: the visual symptom itself. What a client receives is asserted; what a person sees on screen when continuum saves is not, and there is no honest way to assert that from a test.
