### PR TITLE
fix: the buttons that send work to an agent, on machines without tmux

### DIFF
--- a/server/src/agentticket.ts
+++ b/server/src/agentticket.ts
@@ -1,0 +1,134 @@
+/*
+ * Starting an agent in a terminal that has no tmux.
+ *
+ * The buttons that send a pull request, an issue or a card to an agent all went
+ * one way: `cmd:"issue"` over the terminal socket, which opens a tmux window
+ * running the agent. Without a tmux client under the shell the request was
+ * dropped by the client before it was sent and again by the server if it
+ * arrived — twice silent, and on macOS unconditionally, since the detection
+ * only ever read /proc. The detection is portable now (procchildren.ts); this
+ * is the other half, for a machine with no tmux at all.
+ *
+ * A pane is what a tmux-less terminal has instead of a window, and the panel
+ * already knows how to open one. What it could not do is open one RUNNING
+ * something: a PTY session is opened by a websocket, and the three things it
+ * could already be — a shell, a file in an editor, an existing tmux pane — are
+ * all named by short query parameters.
+ *
+ * A prompt is not short. It is a card's description or a review brief, which is
+ * kilobytes, and a URL is the wrong place for it — the limit is unspecified, it
+ * lands in logs, and it is the query string of a GET.
+ *
+ * So the prompt is handed over first, on an authenticated POST, and the socket
+ * carries a ticket. That keeps the rule this endpoint has always followed and
+ * which the file-viewer states plainly: the client says WHAT, the server
+ * decides HOW. The client never names a binary or a flag — it passes text and a
+ * boolean, exactly as it already does over the tmux socket.
+ */
+import { randomBytes } from "node:crypto";
+
+export interface AgentRequest {
+  /** The worktree to start in. Validated by the caller against the open
+   *  project before it is ever stored — a ticket is not a way around scope. */
+  cwd: string;
+  /** What the agent is started with. Empty means a plain shell, which is what
+   *  the tmux path does too. */
+  prompt: string;
+  /** Permission prompts off. A BOOLEAN, and the flag it buys is written here:
+   *  a socket reachable from the UI must not be able to name an argument. */
+  yolo: boolean;
+  /** The session name, already through `sessionTitle`. */
+  title: string;
+}
+
+/**
+ * Short, because a ticket is not a secret worth keeping — it is a nonce that
+ * lives for seconds behind an endpoint that already required a token to mint.
+ * Long enough that guessing one inside its lifetime is not a thing to think
+ * about.
+ */
+const ID_BYTES = 18;
+
+/**
+ * How long a ticket is good for.
+ *
+ * The gap it has to cover is one websocket opening, which is milliseconds on
+ * the same machine. A minute is generous for a browser that was mid-repaint,
+ * and short enough that an abandoned request is not sitting in memory when
+ * somebody comes back an hour later.
+ */
+const TTL_MS = 60_000;
+
+/** A ceiling, so a bug upstream cannot turn this into an unbounded store. Far
+ *  above what a person produces: these are minted one press at a time. */
+const MAX = 64;
+
+const pending = new Map<string, { at: number; req: AgentRequest }>();
+
+const sweep = (now: number): void => {
+  for (const [id, v] of pending) if (now - v.at > TTL_MS) pending.delete(id);
+};
+
+export function mintAgentTicket(req: AgentRequest, now = Date.now()): string {
+  sweep(now);
+  // Oldest first, and only when full. A press that evicts somebody else's
+  // pending press is worse than a refusal, but at 64 outstanding tickets the
+  // thing that has gone wrong is not somebody pressing buttons.
+  if (pending.size >= MAX) {
+    const oldest = [...pending.entries()].sort((a, b) => a[1].at - b[1].at)[0];
+    if (oldest) pending.delete(oldest[0]);
+  }
+  const id = randomBytes(ID_BYTES).toString("base64url");
+  pending.set(id, { at: now, req });
+  return id;
+}
+
+/**
+ * Take a ticket, once.
+ *
+ * Single use rather than merely expiring: the socket that claims it is the one
+ * that opens the pane, and a ticket that could be claimed twice is a way to
+ * start the same agent twice from one press — which, in a worktree, is two
+ * agents editing the same files.
+ */
+export function claimAgentTicket(id: string, now = Date.now()): AgentRequest | null {
+  sweep(now);
+  const held = pending.get(String(id || ""));
+  if (!held) return null;
+  pending.delete(id);
+  return now - held.at > TTL_MS ? null : held.req;
+}
+
+/** For a test's own teardown, and so one suite cannot leave a ticket for the
+ *  next. */
+export function __clearAgentTickets(): void { pending.clear(); }
+
+/**
+ * The command line an agent request becomes.
+ *
+ * Here rather than at either call site because there are now two — a tmux
+ * window and a plain pane — and they must not drift. The whole point of this
+ * change is that the two paths do the same thing; building the argv twice is
+ * how they would stop.
+ *
+ * Empty when there is no agent binary, and the callers read that as "open a
+ * plain shell in the worktree": no agent available is not a reason to open
+ * nothing, since a shell in the right tree is still most of what was asked for.
+ */
+export function agentArgv(
+  bin: string | null | undefined,
+  req: { prompt: string; yolo: boolean; title: string },
+  canName: boolean,
+): string[] {
+  if (!bin) return [];
+  // `--name` is what `/rename` writes, set before the first turn rather than
+  // typed into a program that may not have finished starting. The value is data
+  // from the client and the flag is ours — the same division as the permission
+  // flag below.
+  const named = req.title && canName ? ["--name", req.title] : [];
+  const skip = req.yolo ? ["--dangerously-skip-permissions"] : [];
+  // The prompt is LAST and is one element. Never split, never through a shell:
+  // a review brief contains quotes, newlines and backticks, and every one of
+  // them is text.
+  return [bin, ...named, ...skip, req.prompt];
+}

--- a/server/src/antigravity.ts
+++ b/server/src/antigravity.ts
@@ -32,7 +32,16 @@ import { startKeepalive, drainStderr, MODEL_RE, SESSION_RE } from "./chat.ts";
 import type { AgentModel, IngestBody } from "../../shared/types.ts";
 
 const agyBin = () => Bun.which("agy");
-export const ANTIGRAVITY_ENABLED = !!agyBin() && process.env.AGENTGLASS_ANTIGRAVITY_DISABLED !== "1";
+/*
+ * Resolved per call, not once at import.
+ *
+ * It used to be a constant computed when this module first loaded, so a
+ * `agy` installed while the server was running stayed invisible until a
+ * restart — with nothing on screen to suggest why. remote.ts documents the
+ * same trap with a measurement against a stub that was silently bypassed;
+ * the lesson was learnt there and not here.
+ */
+export const ANTIGRAVITY_ENABLED = (): boolean => !!agyBin() && process.env.AGENTGLASS_ANTIGRAVITY_DISABLED !== "1";
 
 /** What `source_app` every synthesized event carries.
  *

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -25,7 +25,16 @@ import { startKeepalive, drainStderr, MODEL_RE, SESSION_RE } from "./chat.ts";
 import type { CodexModel, TimelineEntry } from "../../shared/types.ts";
 
 const codexBin = () => Bun.which("codex");
-export const CODEX_ENABLED = !!codexBin() && process.env.AGENTGLASS_CODEX_DISABLED !== "1";
+/*
+ * Resolved per call, not once at import.
+ *
+ * It used to be a constant computed when this module first loaded, so a
+ * `codex` installed while the server was running stayed invisible until a
+ * restart — with nothing on screen to suggest why. remote.ts documents the
+ * same trap with a measurement against a stub that was silently bypassed;
+ * the lesson was learnt there and not here.
+ */
+export const CODEX_ENABLED = (): boolean => !!codexBin() && process.env.AGENTGLASS_CODEX_DISABLED !== "1";
 
 const CORS = {
   "Access-Control-Allow-Origin": "*",

--- a/server/src/codexusage.ts
+++ b/server/src/codexusage.ts
@@ -175,7 +175,7 @@ const REFRESH_TIMEOUT_MS = 60_000;
  * by the number of windows somebody happens to have open.
  */
 export async function refreshCodexUsage(): Promise<{ ok: boolean; error?: string }> {
-  if (!CODEX_ENABLED) return { ok: false, error: "Codex is not available on this machine" };
+  if (!CODEX_ENABLED()) return { ok: false, error: "Codex is not available on this machine" };
   return singleFlight("codex-usage-refresh", async () => {
     // codexModels() is synchronous and already exported (server/src/codex.ts:127).
     const model = usageRefreshModel(codexModels());

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -44,7 +44,7 @@ import { askBrowser, browserReadyCount, noteBrowserReady, parseAsk, setBrowserSi
 import { browserUseStatus, installSkill } from "./browseruse.ts";
 import { otlpTracesToEvents, otlpLogsToEvents } from "./otlp.ts";
 import { decodeOtlpTraces, decodeOtlpLogs } from "./otlp_pb.ts";
-import { statusForPaths, commit as gitCommit, COMMIT_ENABLED, gitAsync, gitCapability } from "./git.ts";
+import { statusForPaths, commit as gitCommit, COMMIT_ENABLED, gitAsync, gitCapability, safeAbs as gitSafeAbs } from "./git.ts";
 import { dependencyReport } from "./deps.ts";
 import {
   workingTree, lastCommitChanges, discoverRepos, stage, unstage, stageAll, unstageAll, discard,
@@ -99,7 +99,8 @@ import {
   branchBehind,
   prBranches, prsForBranch } from "./prs.ts";
 import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
-import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, lastTmuxTarget, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
+import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, lastTmuxTarget, sessionTitle, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
+import { mintAgentTicket } from "./agentticket.ts";
 import { listPanes, focusPaneAnywhere, activePane, sweepPinnedWindows, pinnedSockets } from "./tmuxctl.ts";
 import { withAgentSessions } from "./paneloc.ts";
 import { notePaneFromHook, paneDirs, paneAgentNote } from "./panewt.ts";
@@ -110,7 +111,7 @@ import { codexStream, codexModels, codexTranscript, codexCwd, CODEX_ENABLED, COD
 import { antigravityStream, antigravityModels, ANTIGRAVITY_ENABLED, ANTIGRAVITY_BYPASS_ALLOWED } from "./antigravity.ts";
 import { paneAlive, killPane, forgetPane, startPaneSweeper, sendKey, sendableKey, capture as capturePane, pinPane, panes, classifyPanes, idleEvictMs } from "./tmuxpane.ts";
 import { startScanner, ownsSession, knownProjects, resyncScope, scanningEnabled } from "./transcripts.ts";
-import { workspaceRoot, setWorkspaceRoot, inScope, sessionInScope, readBudgets, writeBudgets, hiddenProjects, setProjectHidden, configPath } from "./config.ts";
+import { workspaceRoot, setWorkspaceRoot, inScope, sessionInScope, chatBypassAllowed, readBudgets, writeBudgets, hiddenProjects, setProjectHidden, configPath } from "./config.ts";
 import { cloneProject, createProject } from "./projectadd.ts";
 import { budgetStatus } from "./budget.ts";
 import type { Budget } from "../../shared/types.ts";
@@ -857,6 +858,10 @@ const server = Bun.serve<WsData>({
         // nothing else — the server looks it up and builds the command, so a
         // socket path can never arrive from a client. See PtyWsData.pane.
         pane: url.searchParams.get("pane") || undefined,
+        // A single-use ticket for an agent to start in this pane, minted at
+        // POST /terminal/agent. An opaque id, never a prompt and never a
+        // command — see PtyWsData.agent.
+        agent: url.searchParams.get("agent") || undefined,
         // Reflow the tmux window to this client instead of keeping the desk's
         // size. A choice the phone makes per connection — see attachArgvFor.
         fit: url.searchParams.get("fit") === "1",
@@ -2729,6 +2734,35 @@ const server = Bun.serve<WsData>({
       return json(ok ? { ok } : { ok, error: "tmux would not go there — the pane may be gone" }, ok ? 200 : 409);
     }
 
+    /*
+     * A ticket for starting an agent in a pane, for a terminal with no tmux.
+     *
+     * POST rather than a query parameter on the socket because what it carries
+     * is a prompt — a card's description, a review brief — which is kilobytes
+     * and does not belong in a URL. The reply is an opaque id the client hands
+     * back when it opens the pane, good once and for a minute.
+     *
+     * The directory is vetted HERE as well as at claim time. A ticket that
+     * cannot be used is better refused at the press, where there is something
+     * on screen to say so, than at the socket, where there is a blank pane.
+     */
+    if (pathname === "/terminal/agent" && req.method === "POST") {
+      if (!trustedCaller(req, from)) return csrfBlocked();
+      if (!TERMINAL_ENABLED) return json({ ok: false, error: "the terminal is disabled here" }, 403);
+      let b: { cwd?: unknown; prompt?: unknown; yolo?: unknown; title?: unknown };
+      try { b = (await req.json()) as typeof b; } catch { return json({ ok: false, error: "invalid json" }, 400); }
+      const cwd = gitSafeAbs(b.cwd);
+      if (!cwd || !inScope(cwd) || !fsExists(cwd)) {
+        return json({ ok: false, error: "that directory is not in the open project" }, 400);
+      }
+      const prompt = typeof b.prompt === "string" ? b.prompt : "";
+      // Bypass is a permission, not a parameter: the same gate the chat engines
+      // go through, so a socket cannot buy the flag the config refuses.
+      const yolo = b.yolo === true && chatBypassAllowed();
+      const id = mintAgentTicket({ cwd, prompt, yolo, title: sessionTitle(b.title) });
+      return json({ ok: true, ticket: id });
+    }
+
     if (pathname === "/terminal/commands") {
       const root = url.searchParams.get("root") || "";
       return body(await singleFlight(`cmds:${root}`, async () => JSON.stringify(await projectCommands(root))));
@@ -2876,7 +2910,7 @@ const server = Bun.serve<WsData>({
     // the panel needs both to draw a single dropdown, and asking twice would
     // let it render a model picker for a CLI that turns out not to be there.
     if (pathname === "/codex/enabled") {
-      return json({ enabled: CODEX_ENABLED, bypass: CODEX_BYPASS_ALLOWED, models: CODEX_ENABLED ? codexModels() : [] });
+      return json({ enabled: CODEX_ENABLED(), bypass: CODEX_BYPASS_ALLOWED, models: CODEX_ENABLED() ? codexModels() : [] });
     }
     if (pathname === "/codex/send" && req.method === "POST") {
       if (!trustedCaller(req, from)) return csrfBlocked();
@@ -2903,7 +2937,7 @@ const server = Bun.serve<WsData>({
     // internal schema, so there is nothing here that could be read without
     // guessing at it — see server/src/antigravity.ts.
     if (pathname === "/antigravity/enabled") {
-      return json({ enabled: ANTIGRAVITY_ENABLED, bypass: ANTIGRAVITY_BYPASS_ALLOWED, models: ANTIGRAVITY_ENABLED ? await antigravityModels() : [] });
+      return json({ enabled: ANTIGRAVITY_ENABLED(), bypass: ANTIGRAVITY_BYPASS_ALLOWED, models: ANTIGRAVITY_ENABLED() ? await antigravityModels() : [] });
     }
     if (pathname === "/antigravity/send" && req.method === "POST") {
       if (!trustedCaller(req, from)) return csrfBlocked();

--- a/server/src/procchildren.ts
+++ b/server/src/procchildren.ts
@@ -1,0 +1,158 @@
+/*
+ * Whose children are these — on Linux, and on a Mac.
+ *
+ * Two callers walk a process tree looking for tmux: `tmuxClientPid`, which
+ * finds the client so its panes can be driven, and `tmuxRunning`, which asks
+ * only whether one is there. Both read `/proc/<pid>/task/<pid>/children`, and
+ * both opened with the same line:
+ *
+ *     if (process.platform !== "linux") return null;
+ *
+ * That was written for a question where "no" is a fine answer everywhere else.
+ * Its caller was deciding whether the panel should hide its own tab strip
+ * because tmux brings one, and a Mac keeping agentglass's own chrome is exactly
+ * right — the comment says so, and it is correct.
+ *
+ * The line was then load-bearing for a second question with a different shape:
+ * "may I dispatch this request", asked by the buttons that send a pull request
+ * or a card to an agent. There, "no" is not a fallback — it is a press that
+ * does nothing, on every Mac, for ever, with no message. Same value, two
+ * questions, and it only answers one of them. (The panel-chrome caller keeps
+ * its behaviour: it is asking about a tmux the user is looking at, and this
+ * module answers that identically.)
+ *
+ * So the walk becomes portable and the platform check goes away. /proc where
+ * there is one, `ps` where there is not.
+ */
+import { readFileSync } from "node:fs";
+
+/**
+ * Direct children of a pid.
+ *
+ * Empty for a pid with none, and empty for a pid we cannot ask about — the two
+ * are not distinguished on purpose. Every caller is hunting for something in
+ * the tree, so "not found" and "could not look" lead to the same place, and a
+ * thrown error in a poll loop would not.
+ */
+export function childrenOf(pid: number): number[] {
+  if (!Number.isInteger(pid) || pid <= 0) return [];
+  return process.platform === "linux" ? fromProc(pid) : fromPs(pid);
+}
+
+/** The name a pid is running under, or "". */
+export function commOf(pid: number): string {
+  if (!Number.isInteger(pid) || pid <= 0) return "";
+  if (process.platform === "linux") {
+    try { return readFileSync(`/proc/${pid}/comm`, "utf8").trim(); } catch { return ""; }
+  }
+  return snapshot().comm.get(pid) ?? "";
+}
+
+/**
+ * `children` needs CONFIG_PROC_CHILDREN. Where the kernel was built without it
+ * the file is simply absent, which reads here as "no children" — the same
+ * answer this module gives for anything it cannot see.
+ */
+function fromProc(pid: number): number[] {
+  try {
+    return readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8")
+      .trim().split(/\s+/).filter(Boolean).map(Number).filter((n) => Number.isInteger(n) && n > 0);
+  } catch { return []; }
+}
+
+/*
+ * The `ps` snapshot, and why it is cached.
+ *
+ * There is no per-process file to read on a Mac, so the whole table is read at
+ * once and indexed. That is one spawn instead of one per node, which matters:
+ * these walks recurse, and they run inside the terminal's poll — a spawn per
+ * node per tick would put a process table's worth of forks on the same thread
+ * that serves the PTY.
+ *
+ * Held for a second. Long enough that one walk is one spawn however deep it
+ * goes, short enough that a tmux started while you watch shows up in the next
+ * tick rather than the next minute.
+ */
+const TTL_MS = 1000;
+let held: { at: number; kids: Map<number, number[]>; comm: Map<number, string> } | null = null;
+
+/** Test seam: the snapshot is a fact about the machine, and a suite must be
+ *  able to state one instead of having the developer's own. */
+let stub: string | null = null;
+export function __setPsSnapshot(text: string | null): void { stub = text; held = null; }
+
+function snapshot(): { kids: Map<number, number[]>; comm: Map<number, string> } {
+  if (held && Date.now() - held.at < TTL_MS) return held;
+  const text = stub ?? runPs();
+  const parsed = parsePs(text);
+  held = { at: Date.now(), ...parsed };
+  return held;
+}
+
+function runPs(): string {
+  try {
+    // `-o` with trailing `=` suppresses the header, so there is no first line to
+    // skip and no locale-dependent column name to match.
+    const p = Bun.spawnSync(["ps", "-axo", "pid=,ppid=,comm="], { stdout: "pipe", stderr: "ignore" });
+    return p.success ? new TextDecoder().decode(p.stdout) : "";
+  } catch { return ""; }
+}
+
+/**
+ * `ps` output into a child index.
+ *
+ * `comm` on macOS is the executable PATH, not a bare name — `/usr/local/bin/tmux`
+ * rather than `tmux` — and it can contain spaces. So the line is split on the
+ * first two runs of whitespace only, and everything after them is the command,
+ * kept whole.
+ */
+export function parsePs(text: string): { kids: Map<number, number[]>; comm: Map<number, string> } {
+  const kids = new Map<number, number[]>();
+  const comm = new Map<number, string>();
+  for (const line of (text || "").split("\n")) {
+    const m = /^\s*(\d+)\s+(\d+)\s+(.*)$/.exec(line);
+    if (!m) continue;
+    const pid = Number(m[1]);
+    const ppid = Number(m[2]);
+    const name = m[3]!.trim();
+    if (!Number.isInteger(pid) || pid <= 0) continue;
+    comm.set(pid, name);
+    // A process whose parent is itself would loop the walk. Real on nothing,
+    // but this is parsing a table we do not own.
+    if (ppid !== pid) (kids.get(ppid) ?? kids.set(ppid, []).get(ppid)!).push(pid);
+  }
+  return { kids, comm };
+}
+
+function fromPs(pid: number): number[] {
+  return snapshot().kids.get(pid) ?? [];
+}
+
+/**
+ * Is this name tmux — given a bare comm on Linux and a full path on macOS.
+ *
+ * "tmux: client" and "tmux: server" both report as `tmux` in Linux's comm, and
+ * the prefix test that has always been here keeps them. The basename is taken
+ * first so `/opt/homebrew/bin/tmux` matches without `/usr/bin/tmuxinator`
+ * matching by accident on the directory.
+ */
+export const isTmuxComm = (comm: string): boolean => {
+  const base = (comm || "").split("/").pop() ?? "";
+  return base === "tmux" || base.startsWith("tmux:") || base.startsWith("tmux ");
+};
+
+/**
+ * Walk down from a pid looking for tmux, and answer with the pid running it.
+ *
+ * Depth-limited for the same reason it always was: this reads a table that can
+ * contain a cycle, and a poll loop is the worst place to discover one.
+ */
+export function findTmuxBelow(pid: number, depth = 0): number | null {
+  if (depth > 4) return null;
+  for (const c of childrenOf(pid)) {
+    if (isTmuxComm(commOf(c))) return c;
+    const deeper = findTmuxBelow(c, depth + 1);
+    if (deeper) return deeper;
+  }
+  return null;
+}

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -118,6 +118,17 @@ export type PtyWsData = { kind: "pty"; root: string; cols: number; rows: number;
    *  runs; see editorFor. */
   view?: string;
   /**
+   * A ticket for an agent to start in this pane, minted by POST /terminal/agent.
+   *
+   * A ticket rather than the prompt itself, and that is not indirection for its
+   * own sake: the prompt is a card's description or a review brief, which is
+   * kilobytes and has no business in a query string. What the client holds is
+   * an opaque single-use id for text it supplied a moment earlier; the binary
+   * and every flag are chosen by the server, exactly as for `view`. See
+   * agentticket.ts.
+   */
+  agent?: string;
+  /**
    * Open that file for EDITING rather than for reading.
    *
    * Two different intents, and they must not be one flag with a default. Read
@@ -355,10 +366,23 @@ function killGroup(s: Session, sigNum: number) {
   } catch { /* already gone */ }
 }
 
+import { findTmuxBelow } from "./procchildren.ts";
 import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, remountPhoneClient, isPhoneSession, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";
 import { prepareReviewPrompt } from "./prs.ts";
 import { claudeCode, supportsSessionName } from "./agents/claudecode.ts";
+import { agentArgv, claimAgentTicket } from "./agentticket.ts";
+
+/*
+ * What a client is told when it sends a tmux-shaped request to a terminal with
+ * no tmux in it.
+ *
+ * Said rather than implied: the panel's own answer is to open the agent in a
+ * pane instead (see the `agent` ticket below), so a client reaching this line
+ * is one that could not — an older build, or the phone, which has no pane to
+ * open. Both deserve the reason.
+ */
+const NO_TMUX = "this terminal has no tmux — open the agent in a pane instead, or start tmux here";
 import { applyThemeTo } from "./themesync.ts";
 
 const enc = new TextEncoder();
@@ -399,27 +423,20 @@ const ctl = (ws: PtyWs, frame: PtyServerFrame) => { try { ws.send(JSON.stringify
  * way instead of forcing everyone into tmux, which would be a poor trade for
  * anyone who doesn't use it.
  *
- * Reads /proc rather than asking the shell: the shell is busy being a terminal
- * and injecting a command to interrogate it would echo into whatever the user
- * is typing. Linux-only by design — on anything else the answer is "no" and
- * the panel keeps its own chrome, which is the correct fallback.
+ * Reads the process tree rather than asking the shell: the shell is busy being
+ * a terminal and injecting a command to interrogate it would echo into whatever
+ * the user is typing.
+ *
+ * It used to say "Linux-only by design — on anything else the answer is 'no'
+ * and the panel keeps its own chrome, which is the correct fallback". That was
+ * true of THIS caller and false of the flag's other reader: `tmuxActive` also
+ * gated the dispatch of a pull request or a card to an agent, where "no" was
+ * not a fallback but a button that did nothing, on every Mac. The walk is
+ * portable now (procchildren.ts); this caller's behaviour is unchanged, since
+ * a machine with no tmux still answers no and still keeps its own chrome.
  */
 function tmuxRunning(pid: number, depth = 0): boolean {
-  if (process.platform !== "linux" || depth > 4) return false;
-  let children: string[];
-  try {
-    // `children` needs CONFIG_PROC_CHILDREN; when absent this simply reads
-    // empty and we report no tmux, rather than throwing.
-    children = readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim().split(/\s+/).filter(Boolean);
-  } catch { return false; }
-  for (const c of children) {
-    let comm: string;
-    try { comm = readFileSync(`/proc/${c}/comm`, "utf8").trim(); } catch { continue; }
-    // "tmux: client" / "tmux: server" both report as `tmux` in comm.
-    if (comm === "tmux" || comm.startsWith("tmux")) return true;
-    if (tmuxRunning(Number(c), depth + 1)) return true;
-  }
-  return false;
+  return findTmuxBelow(pid, depth) !== null;
 }
 
 /**
@@ -556,8 +573,39 @@ export function ptyOpen(ws: PtyWs) {
     return;
   }
 
+  /*
+   * An agent, in a pane, for a terminal with no tmux.
+   *
+   * The fourth thing a session can be, alongside a shell, a file in an editor
+   * and an existing tmux pane — and it follows the same rule as the other
+   * three: the client names WHAT (a ticket it was given for text it supplied),
+   * and the server decides HOW. The binary and every flag are chosen here.
+   *
+   * The ticket is claimed once, and a claim that fails is not an error: it is a
+   * reload of a page whose ticket has already been spent, or one that sat past
+   * its minute. Falling back to a plain shell in the requested directory is the
+   * same answer the tmux path gives when there is no agent binary — a shell in
+   * the right tree is still most of what was asked for.
+   */
+  const ticket = typeof d.agent === "string" && d.agent ? claimAgentTicket(d.agent) : null;
+  const agentBin = ticket ? claudeCode.bin() : null;
+  const agentRun = ticket ? agentArgv(agentBin, ticket, supportsSessionName(agentBin)) : [];
+
+  /*
+   * Where the pane opens.
+   *
+   * The ticket's directory wins when it still validates, rather than the `root`
+   * the socket happened to carry: a worktree cut for an issue is the whole
+   * point of the request, and an agent started in the wrong tree is the failure
+   * that is invisible once it has happened. Re-checked here rather than trusted
+   * from the mint — the ticket has been out of our hands, and scope can change
+   * while it is.
+   */
+  const startIn = ticket && inScope(ticket.cwd) && existsSync(ticket.cwd) ? ticket.cwd : cwd;
+
   const run = attach
     ? attach.argv
+    : agentRun.length ? agentRun
     : editor ? [...editor.split(/\s+/), ...readonlyFlags, wanted!] : [shell, ...args];
 
   let argv: string[];
@@ -579,7 +627,7 @@ export function ptyOpen(ws: PtyWs) {
 
   let proc: ReturnType<typeof Bun.spawn>;
   try {
-    proc = Bun.spawn(argv, { cwd, env, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
+    proc = Bun.spawn(argv, { cwd: startIn, env, stdin: "pipe", stdout: "pipe", stderr: "pipe" });
   } catch (e) {
     ctl(ws, { t: "fatal", error: `could not start shell: ${String(e)}` });
     ws.close(1011, "spawn failed");
@@ -601,7 +649,7 @@ export function ptyOpen(ws: PtyWs) {
   // needs it to know it is looking at a slice: without a fit, tmux renders at
   // the desk's width and the columns past the phone's own never arrive.
   ctl(ws, {
-    t: "ready", mode, shell: basename(shell), cwd, resize: !!sizeDir,
+    t: "ready", mode, shell: basename(shell), cwd: startIn, resize: !!sizeDir,
     ...(attach?.grid ? { pane: attach.grid } : {}),
   });
 
@@ -1303,8 +1351,6 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       return;
     }
 
-    if (!s.tmux) return;
-
     /*
      * "The pointer is over that pane" — focus follows mouse, inside tmux.
      *
@@ -1315,7 +1361,7 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
      * unable to do anything a hover should not.
      */
     if (msg.cmd === "selectpane") {
-      if (typeof msg.pane === "string") selectPane(s.tmux, msg.pane);
+      if (s.tmux && typeof msg.pane === "string") selectPane(s.tmux, msg.pane);
       return;
     }
 
@@ -1330,7 +1376,21 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
      * button actions into arbitrary execution in the user's shell.
      */
     if (msg.cmd === "review") {
-      const target = s.tmux;
+      let target = s.tmux;
+      if (!target) {
+        /*
+         * Resolve NOW rather than wait for the next poll.
+         *
+         * The sweep runs every 500ms and the first one is 500ms after the
+         * socket opens, so a button pressed the instant this terminal appears
+         * asks a question nobody has looked up yet. Answering "no tmux" then
+         * would send a tmux user's card to a pane — right answer, wrong
+         * machine. The sweep is synchronous and cheap, so it is simply run.
+         */
+        s.tmuxSweep?.();
+        target = s.tmux;
+      }
+      if (!target) { ctl(ws, { t: "openfail", error: NO_TMUX }); return; }
       const number = msg.number;
       // A review of nothing, in nowhere, is not a request this can serve.
       if (typeof number !== "number" || !msg.root) return;
@@ -1367,7 +1427,21 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
      * this handler can verify.
      */
     if (msg.cmd === "issue") {
-      const target = s.tmux;
+      let target = s.tmux;
+      if (!target) {
+        /*
+         * Resolve NOW rather than wait for the next poll.
+         *
+         * The sweep runs every 500ms and the first one is 500ms after the
+         * socket opens, so a button pressed the instant this terminal appears
+         * asks a question nobody has looked up yet. Answering "no tmux" then
+         * would send a tmux user's card to a pane — right answer, wrong
+         * machine. The sweep is synchronous and cheap, so it is simply run.
+         */
+        s.tmuxSweep?.();
+        target = s.tmux;
+      }
+      if (!target) { ctl(ws, { t: "openfail", error: NO_TMUX }); return; }
       const cwd = safeAbs(msg.cwd);
       if (!cwd || !inScope(cwd) || !existsSync(cwd)) return;
       const name = typeof msg.name === "string" ? msg.name : "issue";
@@ -1376,51 +1450,42 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       if (msg.agent === true && prompt) {
         const bin = claudeCode.bin();
         /*
-         * The permission prompts, off when asked for — and only ever as this
-         * one fixed argument.
+         * What runs is decided HERE, not by the client.
          *
-         * The client sends a boolean and the server owns the string. That is
-         * the same rule this handler already follows for the command itself:
-         * what runs is decided here, so a socket reachable from the UI cannot
-         * become a way to pass arbitrary arguments to a binary. `yolo === true`
-         * buys exactly one flag and nothing else.
-         *
-         * It is worth offering because the failure it prevents is silent: an
-         * agent handed a card, left in another tmux window, stopping on its
-         * first tool call and waiting for an answer nobody is there to give.
-         * And it is worth being a CHOICE for the mirror-image reason.
+         * The client sends text and two booleans; the binary, `--name` and
+         * `--dangerously-skip-permissions` are the server's, so a socket
+         * reachable from the UI cannot become a way to pass arbitrary
+         * arguments. `sessionTitle` is what makes sure a card title cannot be
+         * anything but a title. The reasoning for each flag, and the argv
+         * itself, live in agentticket.ts — shared with the pane path.
          */
-        /*
-         * The session, named after the card.
-         *
-         * Six windows into an afternoon, `claude` in a worktree called
-         * `app-ORBIT-1042` tells you nothing about which of five cards is in
-         * front of you, and the CLI's session picker lists them all as the same
-         * word. `--name` is what `/rename` writes, set before the first turn
-         * instead of after it — so there is no moment where the session exists
-         * unnamed and nothing has to be typed into a program that may not have
-         * finished starting.
-         *
-         * The value is DATA from the client and the flag is ours, which is the
-         * same division this handler already makes for `--dangerously-skip-
-         * permissions`. It reaches tmux as one element of an argv array, never
-         * through a shell, and `sessionTitle` is what makes sure a card title
-         * cannot be anything but a title.
-         */
-        const named = title && supportsSessionName(bin) ? ["--name", title] : [];
-        const args = msg.yolo === true
-          ? [...named, "--dangerously-skip-permissions", prompt]
-          : [...named, prompt];
+        // Built by agentticket.ts, which the tmux-less pane path also uses.
+        // Two call sites building the same command line is how the two paths
+        // would quietly stop doing the same thing.
+        const argv = agentArgv(bin, { prompt, yolo: msg.yolo === true, title }, supportsSessionName(bin));
         // No agent available is not a reason to open nothing: a shell in the
         // right worktree is still most of what was asked for.
-        if (bin) newWindowRunning(target, cwd, name, [bin, ...args]);
-        else newWindowRunning(target, cwd, name, []);
+        newWindowRunning(target, cwd, name, argv);
       } else {
         newWindowRunning(target, cwd, name, []);
       }
       s.tmuxSweep?.();
       return;
     }
+
+    /*
+     * Everything below acts ON tmux, so with none there is nothing to do and
+     * silence is right.
+     *
+     * It used to sit ABOVE `review` and `issue`, and that is what the dispatch
+     * audit found: those two are not commands about tmux, they are a pull
+     * request or a card being sent to an agent, and they were swallowed here on
+     * every machine with no tmux client — which, until procchildren.ts, meant
+     * every Mac, with no message. They answer for themselves now, above.
+     * `cmd:"agent"` was moved out earlier for the same reason: a button with no
+     * way out is worse than one that refuses.
+     */
+    if (!s.tmux) return;
 
     const action = msg.cmd as TmuxAction;
     if (!["select", "new", "kill", "rename", "move", "takeover", "fit"].includes(action)) return;

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -23,6 +23,7 @@ import { homedir, tmpdir } from "node:os";
 import { dirname, join, normalize } from "node:path";
 import type { TmuxWindow, TmuxPane, AgentPane } from "../../shared/types.ts";
 import { parsePanes, PANE_FORMAT } from "./paneloc.ts";
+import { findTmuxBelow } from "./procchildren.ts";
 
 /** How long a tmux call may take before we give up on it. Generous for a local
  *  socket, and short enough that a wedged tmux server cannot stall the poll. */
@@ -72,23 +73,15 @@ export interface TmuxTarget {
  * the user is halfway through typing. `tmux: client` and `tmux: server` both
  * report as `tmux` in comm, but the server is a daemon and never a child of our
  * shell, so anything found here is a client.
+ *
+ * Portable since the dispatch audit. It used to open with
+ * `process.platform !== "linux"`, which made this null on every Mac — right for
+ * the caller that asks "should the panel hide its own tab strip", and wrong for
+ * the one that asks "may I send this pull request to an agent", which silently
+ * dropped the request instead. See procchildren.ts.
  */
 export function tmuxClientPid(pid: number, depth = 0): number | null {
-  if (process.platform !== "linux" || depth > 4) return null;
-  let children: string[];
-  try {
-    // `children` needs CONFIG_PROC_CHILDREN; when absent this reads empty and
-    // we report no tmux, rather than throwing.
-    children = readFileSync(`/proc/${pid}/task/${pid}/children`, "utf8").trim().split(/\s+/).filter(Boolean);
-  } catch { return null; }
-  for (const c of children) {
-    let comm: string;
-    try { comm = readFileSync(`/proc/${c}/comm`, "utf8").trim(); } catch { continue; }
-    if (comm === "tmux" || comm.startsWith("tmux")) return Number(c);
-    const deeper = tmuxClientPid(Number(c), depth + 1);
-    if (deeper) return deeper;
-  }
-  return null;
+  return findTmuxBelow(pid, depth);
 }
 
 /** The terminal a process is attached to, as tmux reports it in `client_tty`. */

--- a/server/test/agent-ticket.test.ts
+++ b/server/test/agent-ticket.test.ts
@@ -1,0 +1,109 @@
+/*
+ * Starting an agent in a pane, for a terminal with no tmux.
+ *
+ * Two things are pinned here and they fail in opposite directions.
+ *
+ * The TICKET is about not doing something twice: it stands in for a prompt too
+ * big to put in a URL, and a ticket that could be claimed twice would start two
+ * agents in one worktree from one press — two processes editing the same files,
+ * which is the kind of thing you notice an hour later.
+ *
+ * The ARGV is about the two paths staying one path. A tmux window and a plain
+ * pane now run the same agent, and they run it by calling this. If they ever
+ * build their own, the flags drift and the difference shows up as "it behaves
+ * differently on my machine".
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { mintAgentTicket, claimAgentTicket, agentArgv, __clearAgentTickets } from "../src/agentticket.ts";
+
+afterEach(() => { __clearAgentTickets(); });
+
+const req = (over = {}) => ({ cwd: "/w/tree", prompt: "fix the spinner", yolo: false, title: "", ...over });
+
+describe("the ticket", () => {
+  it("comes back with what was put in", () => {
+    const id = mintAgentTicket(req());
+    expect(claimAgentTicket(id)).toEqual(req());
+  });
+
+  it("can only be claimed once", () => {
+    // One press must not become two agents in the same worktree.
+    const id = mintAgentTicket(req());
+    expect(claimAgentTicket(id)).not.toBeNull();
+    expect(claimAgentTicket(id)).toBeNull();
+  });
+
+  it("expires", () => {
+    const id = mintAgentTicket(req(), 0);
+    expect(claimAgentTicket(id, 61_000)).toBeNull();
+  });
+
+  it("is still good just inside its minute", () => {
+    const id = mintAgentTicket(req(), 0);
+    expect(claimAgentTicket(id, 59_000)).not.toBeNull();
+  });
+
+  it("says nothing about an id it never issued", () => {
+    expect(claimAgentTicket("nope")).toBeNull();
+    expect(claimAgentTicket("")).toBeNull();
+  });
+
+  it("gives out ids that are not each other", () => {
+    const ids = new Set(Array.from({ length: 50 }, () => mintAgentTicket(req())));
+    expect(ids.size).toBe(50);
+  });
+
+  it("does not grow without bound", () => {
+    // A bug upstream must not turn this into a store. The oldest goes; the
+    // newest — the press somebody is waiting on — stays.
+    for (let i = 0; i < 100; i++) mintAgentTicket(req({ prompt: `p${i}` }));
+    const last = mintAgentTicket(req({ prompt: "the one just pressed" }));
+    expect(claimAgentTicket(last)?.prompt).toBe("the one just pressed");
+  });
+});
+
+describe("the command line an agent request becomes", () => {
+  it("puts the prompt last, as one argument", () => {
+    // A review brief has quotes, newlines and backticks in it. Every one of
+    // them is text, never a shell's business.
+    const p = "a `weird` prompt\nwith 'quotes' and \"more\"";
+    expect(agentArgv("/bin/claude", { prompt: p, yolo: false, title: "" }, false))
+      .toEqual(["/bin/claude", p]);
+  });
+
+  it("buys exactly one flag with yolo, and only when asked", () => {
+    expect(agentArgv("/bin/claude", { prompt: "go", yolo: true, title: "" }, false))
+      .toEqual(["/bin/claude", "--dangerously-skip-permissions", "go"]);
+    expect(agentArgv("/bin/claude", { prompt: "go", yolo: false, title: "" }, false))
+      .toEqual(["/bin/claude", "go"]);
+  });
+
+  it("names the session when the binary understands it", () => {
+    expect(agentArgv("/bin/claude", { prompt: "go", yolo: false, title: "ORBIT-1042" }, true))
+      .toEqual(["/bin/claude", "--name", "ORBIT-1042", "go"]);
+  });
+
+  it("leaves the name off a binary that does not take one", () => {
+    // An older CLI would refuse to start at all rather than ignore it.
+    expect(agentArgv("/bin/claude", { prompt: "go", yolo: false, title: "ORBIT-1042" }, false))
+      .toEqual(["/bin/claude", "go"]);
+  });
+
+  it("leaves the name off when there is no title", () => {
+    expect(agentArgv("/bin/claude", { prompt: "go", yolo: false, title: "" }, true))
+      .toEqual(["/bin/claude", "go"]);
+  });
+
+  it("orders the flags the way the tmux path always has", () => {
+    // Both callers share this now; the order is the one that already shipped.
+    expect(agentArgv("/bin/claude", { prompt: "go", yolo: true, title: "T" }, true))
+      .toEqual(["/bin/claude", "--name", "T", "--dangerously-skip-permissions", "go"]);
+  });
+
+  it("is empty with no agent binary, which callers read as “open a shell”", () => {
+    // No agent available is not a reason to open nothing: a shell in the right
+    // worktree is still most of what was asked for.
+    expect(agentArgv(null, { prompt: "go", yolo: false, title: "" }, true)).toEqual([]);
+    expect(agentArgv("", { prompt: "go", yolo: false, title: "" }, true)).toEqual([]);
+  });
+});

--- a/server/test/deps-catalog.test.ts
+++ b/server/test/deps-catalog.test.ts
@@ -67,13 +67,69 @@ describe("the requirements catalogue matches what the app actually runs", () => 
     }
   });
 
-  test("the tools with a working fallback are deliberately absent", () => {
-    // rg and fd make search faster; without them it falls back to `git grep`
-    // and a walk, so nothing stands down and neither earns a row. Written down
-    // because the next person to read the spawn list will wonder why.
-    expect(ALL).toContain('Bun.which("rg")');
-    expect(ALL).toContain('Bun.which("fd")');
-    expect(DEPS.some((d) => d.bin === "rg" || d.bin === "fd")).toBe(false);
+  /**
+   * Every binary the app runs is either catalogued or exempt ON PURPOSE.
+   *
+   * The check above this one runs catalogue → source, and that direction alone
+   * is what let three tools go missing: `tailscale`, `codex` and `agy` were all
+   * being spawned, all gating a whole feature, and none of them listed. Nothing
+   * failed, because nothing was asking this question.
+   *
+   * The exemptions are the point. A tool leaves this list by having a reason
+   * written next to it, so "it is not in the catalogue" stops being something
+   * that happens by omission and becomes something somebody decided.
+   */
+  const EXEMPT: Record<string, string> = {
+    // Faster search and file-finding. Without them it falls back to `git grep`
+    // and `git ls-tree`, so nothing stands down — the feature is there either
+    // way, and the panel reports which one answered. This was the catalogue's
+    // own call before this test existed and it still holds.
+    rg: "search falls back to `git grep`; nothing stands down",
+    fd: "file-finding falls back to `git ls-tree`; nothing stands down",
+    fdfind: "the Debian name for fd, looked for beside it",
+    // POSIX furniture. A machine without these is not a machine this app can be
+    // told to run on, and a row for `cp` would be noise on a page whose value
+    // is that everything on it is worth reading.
+    sh: "POSIX; present anywhere this runs",
+    cp: "POSIX; present anywhere this runs",
+    du: "POSIX; present anywhere this runs",
+    ps: "POSIX; present anywhere this runs, and the fallback when /proc is absent",
+    // Probed as the older alias beside `python3`, which IS catalogued.
+    python: "tried alongside python3, which has the row",
+  };
+
+  test("every binary the app runs is catalogued, or exempt with a reason", () => {
+    const catalogued = new Set(DEPS.map((d) => d.bin));
+    const unexplained = [...spawned()]
+      .filter((bin) => !catalogued.has(bin) && !(bin in EXEMPT))
+      .sort();
+    // The message names them, because "expected [] to equal [x]" on a list of
+    // binaries is a puzzle and this is meant to be read by whoever added one.
+    expect(unexplained.join(", ") || null).toBeNull();
+  });
+
+  test("no exemption outlives the code that earned it", () => {
+    // An exemption for something the app no longer runs is a note about a
+    // decision nobody can check any more.
+    const run = spawned();
+    const stale = Object.keys(EXEMPT).filter((bin) => !run.has(bin)).sort();
+    expect(stale.join(", ") || null).toBeNull();
+  });
+
+  test("the agent CLIs are listed, because each is a whole engine", () => {
+    // The gap this test was written for. `codex` and `agy` are chat engines
+    // beside Claude Code: absent, the engine is simply not offered, which is
+    // exactly the shape `task` has and the reason `task` earned its row.
+    for (const id of ["codex", "agy"]) {
+      const d = DEPS.find((x) => x.id === id);
+      expect(d?.required).toBe(false);
+      expect(ALL).toContain(`Bun.which("${d?.bin}")`);
+    }
+  });
+
+  test("Tailscale is listed, because remote access has no other route", () => {
+    expect(ALL).toContain('Bun.which("tailscale"');
+    expect(DEPS.some((d) => d.bin === "tailscale")).toBe(true);
   });
 
   test("every required tool can be offered, not just linked", () => {

--- a/server/test/procchildren.test.ts
+++ b/server/test/procchildren.test.ts
@@ -1,0 +1,119 @@
+/*
+ * Walking a process tree, on a machine that has /proc and on one that does not.
+ *
+ * This module exists because the walk it replaces opened with
+ * `process.platform !== "linux"`, and that line was doing two jobs. For "should
+ * the panel hide its own tab strip", answering no on a Mac is right. For "may I
+ * send this pull request to an agent" — the same flag, read by a different
+ * caller — it was a button that did nothing, on every Mac, with no message.
+ *
+ * The `ps` half is what could not be tested before and is most of what is here:
+ * a Mac's `comm` is a full path with spaces in it, not a bare name, so the
+ * parsing is where this would go wrong quietly.
+ */
+import { afterEach, describe, expect, it } from "bun:test";
+import { parsePs, isTmuxComm, childrenOf, __setPsSnapshot } from "../src/procchildren.ts";
+
+afterEach(() => { __setPsSnapshot(null); });
+
+describe("reading a ps table", () => {
+  it("indexes children by parent", () => {
+    const { kids } = parsePs("  1     0 /sbin/launchd\n 42     1 /bin/zsh\n 77    42 /opt/homebrew/bin/tmux\n");
+    expect(kids.get(1)).toEqual([42]);
+    expect(kids.get(42)).toEqual([77]);
+  });
+
+  it("keeps a command with spaces in it whole", () => {
+    // Splitting on whitespace would leave "/Applications/My" as the name.
+    const { comm } = parsePs("100 1 /Applications/My App.app/Contents/MacOS/My App\n");
+    expect(comm.get(100)).toBe("/Applications/My App.app/Contents/MacOS/My App");
+  });
+
+  it("ignores anything that is not a row", () => {
+    // A header if one slips through, a blank line, a truncated line.
+    const { kids, comm } = parsePs("  PID  PPID COMM\n\n   x   y   z\n 9 1 /bin/sh\n");
+    expect(comm.get(9)).toBe("/bin/sh");
+    expect(kids.get(1)).toEqual([9]);
+    expect(comm.size).toBe(1);
+  });
+
+  it("does not let a process parent itself", () => {
+    // Not a thing that happens, but this parses a table we do not own, and a
+    // self-parent is an infinite walk.
+    const { kids } = parsePs("5 5 /bin/sh\n");
+    expect(kids.get(5)).toBeUndefined();
+  });
+
+  it("survives empty and rubbish input", () => {
+    expect(parsePs("").kids.size).toBe(0);
+    expect(parsePs("\n\n\n").comm.size).toBe(0);
+  });
+});
+
+describe("what counts as tmux", () => {
+  it("takes a bare name and a full path", () => {
+    // Linux comm is bare; macOS ps gives the path it was executed from.
+    expect(isTmuxComm("tmux")).toBe(true);
+    expect(isTmuxComm("/opt/homebrew/bin/tmux")).toBe(true);
+    expect(isTmuxComm("/usr/bin/tmux")).toBe(true);
+  });
+
+  it("takes tmux's own client and server names", () => {
+    expect(isTmuxComm("tmux: client")).toBe(true);
+    expect(isTmuxComm("tmux: server")).toBe(true);
+  });
+
+  it("is not fooled by something that merely starts with the word", () => {
+    // The old test was `comm.startsWith("tmux")`, which these would pass.
+    expect(isTmuxComm("tmuxinator")).toBe(false);
+    expect(isTmuxComm("/usr/bin/tmuxp")).toBe(false);
+    expect(isTmuxComm("")).toBe(false);
+  });
+});
+
+describe("children of a pid", () => {
+  it("reads this machine's own tree", () => {
+    // Whatever the platform, the walk has to answer for a real pid without
+    // throwing — that is the property the poll loop depends on.
+    expect(Array.isArray(childrenOf(process.pid))).toBe(true);
+  });
+
+  it("answers empty for a pid that cannot be asked about", () => {
+    // "Not found" and "could not look" lead to the same place on purpose: every
+    // caller is hunting for something, and a throw in a poll would not.
+    expect(childrenOf(0)).toEqual([]);
+    expect(childrenOf(-1)).toEqual([]);
+    expect(childrenOf(2 ** 31)).toEqual([]);
+  });
+
+  it("agrees with `ps` about a real process tree", async () => {
+    /*
+     * The cross-check this module is worth having.
+     *
+     * `parsePs` is the macOS path and cannot be exercised through `childrenOf`
+     * on a Linux runner, so it would otherwise be tested only against strings
+     * written by the same person who wrote the parser. Here it parses the
+     * output of a real `ps` and has to reach the same answer /proc does, about
+     * a tree made on purpose a moment earlier.
+     *
+     * `; true` matters: dash exec's a lone command, so `sh -c 'sleep 4'` leaves
+     * no child at all and the test would pass by finding nothing twice.
+     */
+    const proc = Bun.spawn(["sh", "-c", "sleep 4; true"], { stdout: "ignore", stderr: "ignore" });
+    try {
+      await Bun.sleep(400);
+      const viaProc = [...childrenOf(proc.pid)].sort();
+      const out = Bun.spawnSync(["ps", "-axo", "pid=,ppid=,comm="], { stdout: "pipe" });
+      const { kids, comm } = parsePs(new TextDecoder().decode(out.stdout));
+      const viaPs = [...(kids.get(proc.pid) ?? [])].sort();
+
+      expect(viaPs.length).toBe(1);
+      expect(comm.get(viaPs[0]!) ?? "").toContain("sleep");
+      // On Linux both are real answers and must match. Anywhere else
+      // `childrenOf` IS the ps path, so this is the same list twice.
+      expect(viaProc).toEqual(viaPs);
+    } finally {
+      proc.kill();
+    }
+  });
+});

--- a/shared/deps.ts
+++ b/shared/deps.ts
@@ -33,7 +33,8 @@
 export type DepPlatform = "linux" | "darwin" | "win32";
 
 export type DepId =
-  | "git" | "claude" | "python" | "tmux" | "gh" | "glab" | "docker" | "nvim" | "task"
+  | "git" | "claude" | "codex" | "agy" | "python" | "tmux" | "gh" | "glab" | "docker" | "nvim" | "task"
+  | "tailscale"
   | "setsid" | "script" | "ss" | "dbus-monitor" | "notify-send" | "opener" | "pkexec" | "bash";
 
 export interface DepSpec {
@@ -179,6 +180,24 @@ export const DEPS: DepSpec[] = [
     url: "https://neovim.io",
     note: "With any other $EDITOR the app hands you the command to paste instead.",
     pkg: { apt: "neovim", dnf: "neovim", pacman: "neovim", zypper: "neovim", apk: "neovim", brew: "neovim" },
+  },
+  {
+    id: "codex", bin: "codex", title: "Codex CLI", required: false,
+    what: "Runs chats on OpenAI's Codex instead of Claude, as a second engine in the same panel.",
+    url: "https://developers.openai.com/codex/cli",
+    note: "One of three agent CLIs this app can drive. Missing simply means the engine is not offered.",
+  },
+  {
+    id: "agy", bin: "agy", title: "Antigravity CLI", required: false,
+    what: "Runs chats on Antigravity, as a third engine alongside Claude Code and Codex.",
+    url: "https://antigravity.google",
+    note: "Like Codex, its absence removes an option and nothing else.",
+  },
+  {
+    id: "tailscale", bin: "tailscale", title: "Tailscale", required: false,
+    what: "Reaching this dashboard from your phone over your own tailnet, without opening a port.",
+    url: "https://tailscale.com/download",
+    note: "Only needed for remote access. The remote pane reports its absence rather than failing — everything local works without it.",
   },
   {
     id: "setsid", bin: "setsid", title: "setsid (util-linux)", required: false,

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -6,7 +6,7 @@
 // running job — reopening reattaches to the live session, scrollback intact.
 import { Fragment, useCallback, useEffect, useReducer, useRef, useState, useSyncExternalStore } from "react";
 import { subscribeTermReview, termReview, clearTermReview } from "../lib/termReview.ts";
-import { subscribeTermIssue, termIssue, clearTermIssue } from "../lib/termIssue.ts";
+import { subscribeTermIssue, termIssue, clearTermIssue, type TermIssue } from "../lib/termIssue.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { dirName } from "../lib/worktree.ts";
 import { requestWorktreeJump } from "../lib/worktreeJump.ts";
@@ -144,6 +144,14 @@ type Sess = {
   /** A tmux client is running in this shell — the panel hides its own tabs and
    *  split while that's true, since tmux owns those. */
   tmux: boolean;
+  /** The server refused an open and said why. Read once by whoever asked and
+   *  then cleared: it is an answer to a request, not a state of the shell. */
+  openFail?: string | null;
+  /** A one-use agent ticket this pane was created with, spent on first connect.
+   *  Held rather than passed so a reconnect cannot try to spend it twice — the
+   *  server would refuse the second, but a shell that silently became an agent
+   *  on reconnect is worse than either. */
+  agentTicket?: string | null;
   /** tmux's own windows, as tmux reports them. The panel draws these as tabs so
    *  the strip belongs to the app rather than to whatever .tmux.conf this
    *  machine carries; tmux still decides what is in it and which is active. */
@@ -447,7 +455,11 @@ function connect(s: Sess) {
   if (s.ws || IS_DEMO) return;
   s.status = "connecting";
   notify(s);
-  const ws = new WebSocket(ptyWsUrl(s.root, s.term.cols, s.term.rows));
+  const ticket = s.agentTicket ?? undefined;
+  // Spent here, not on arrival: a reconnect after a drop must open a shell,
+  // not start the agent a second time in the same worktree.
+  s.agentTicket = null;
+  const ws = new WebSocket(ptyWsUrl(s.root, s.term.cols, s.term.rows, undefined, false, ticket));
   ws.binaryType = "arraybuffer";
   s.ws = ws;
   ws.onmessage = (ev) => {
@@ -495,6 +507,12 @@ function connect(s: Sess) {
       s.tmuxSession = typeof f.session === "string" ? f.session : null;
       s.tmuxClient = f.client ?? null;
       s.tmuxPrefix = Array.isArray(f.prefix) ? f.prefix : [];
+      notify(s);
+    } else if (f.t === "openfail") {
+      // Not fatal to the shell — the socket is fine and this pane keeps
+      // working. It is an answer to something that was asked, so it is recorded
+      // for the asker and also written where the person is looking.
+      s.openFail = f.error || "could not open that";
       notify(s);
     } else if (f.t === "exit" || f.t === "fatal") {
       s.status = f.t === "exit" ? "exited" : "error";
@@ -578,7 +596,7 @@ function reconnected(s: Sess) {
 }
 
 /** A brand-new shell for `root`. Repos hold as many as you open. */
-function createSession(root: string): Sess {
+function createSession(root: string, agentTicket?: string): Sess {
   evictLru();
   const tp = termOptions();
   const term = new Terminal({
@@ -710,7 +728,7 @@ function createSession(root: string): Sess {
       .catch(() => { /* no clipboard permission — the menu stayed shut, nothing pasted */ });
   });
   const id = `t${++seq}-${Date.now().toString(36)}`;
-  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, search, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, tmuxWindows: [], tmuxPanes: [], tmuxSession: null, tmuxClient: null, tmuxPrefix: [], tmuxPrefixAt: 0, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
+  const sess: Sess = { id, root, title: `shell ${sessionsFor(root).length + 1}`, term, fit, search, holder, ws: null, status: "idle", mode: null, shell: "shell", canResize: true, opened: false, tmux: false, openFail: null, agentTicket: agentTicket ?? null, tmuxWindows: [], tmuxPanes: [], tmuxSession: null, tmuxClient: null, tmuxPrefix: [], tmuxPrefixAt: 0, pending: [], createdAt: Date.now(), lastUsed: Date.now(), retries: 0, retryTimer: null, subs: new Set() };
   term.onData((d) => {
     sess.lastUsed = Date.now();
     /*
@@ -1317,7 +1335,10 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   const wtSeen = useRef(new Map<string, string>());
   const wtRef = useRef<HTMLDivElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
-  const [, force] = useReducer((x: number) => x + 1, 0);
+  // The value is used, not just the dispatch: a session is MUTATED in place
+  // and notified through `subs`, so an effect watching `sess.openFail` has no
+  // identity change to fire on. This tick is that change.
+  const [sessTick, force] = useReducer((x: number) => x + 1, 0);
 
   /*
    * Where a new shell opens. Not a choice any more — the open project.
@@ -1676,6 +1697,14 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
   // a split you didn't ask for.
   const tmuxActive = !!sess?.tmux;
   const status: SessStatus = sess?.status ?? "idle";
+  /* Whether a request can be SENT at all — a question about the transport.
+     What used to gate these was `tmuxActive`, which is a question about the
+     machine, and answering it in the client is what made six buttons do
+     nothing on every Mac. The server answers the tmux question now. */
+  const socketLive = status === "live";
+  /** The dispatch we are waiting on an answer for, so a refusal can be served
+   *  by the pane path rather than only reported. */
+  const lastIssue = useRef<TermIssue | null>(null);
 
   /*
    * tmux's windows, drawn by us.
@@ -1916,19 +1945,63 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
    */
   const review = useSyncExternalStore(subscribeTermReview, termReview, termReview);
   useEffect(() => {
-    if (!review || !tmuxActive) return;
+    if (!review || !socketLive) return;
     tmuxCmd({ cmd: "review", root: review.root, number: review.number });
     clearTermReview();
-  }, [review, tmuxActive, tmuxCmd]);
+  }, [review, socketLive, tmuxCmd]);
 
   /** The same door for starting work on an issue: a worktree the server has
    *  already cut, and a prompt it wrote. Never a command — see termIssue.ts. */
   const issue = useSyncExternalStore(subscribeTermIssue, termIssue, termIssue);
   useEffect(() => {
-    if (!issue || !tmuxActive) return;
+    if (!issue || !socketLive) return;
+    // Remembered before it is sent, because the fallback below needs it and the
+    // slot is cleared here: a second press must not be blocked waiting on the
+    // first one's answer.
+    lastIssue.current = issue;
     tmuxCmd({ cmd: "issue", cwd: issue.cwd, name: issue.name, prompt: issue.prompt, agent: issue.agent, yolo: issue.yolo, title: issue.title });
     clearTermIssue();
-  }, [issue, tmuxActive, tmuxCmd]);
+  }, [issue, socketLive, tmuxCmd]);
+
+  /*
+   * The server refused, so open the agent in a pane instead.
+   *
+   * This is the half of the dispatch that did not exist. Both effects above
+   * used to require `tmuxActive`, so on a machine with no tmux client the
+   * request was dropped before it was sent — and `tmuxActive` came from a
+   * detection that read /proc and returned false on every Mac, whatever was
+   * installed. Six buttons, no message, nothing in a log.
+   *
+   * The gate is the SOCKET now, not tmux: whether this can be sent at all is a
+   * question about the transport, and whether tmux can serve it is the server's
+   * to answer — it resolves its own sweep before refusing, so "not looked up
+   * yet" is never mistaken for "no tmux here".
+   *
+   * A refusal is not an error to show and move on from. It is the request
+   * arriving at the other path: a pane, opened in the same worktree, running
+   * the same agent with the same argv.
+   */
+  useEffect(() => {
+    const why = sess?.openFail;
+    if (!why || !sess) return;
+    sess.openFail = null;
+    const want = lastIssue.current;
+    lastIssue.current = null;
+    if (!want) { sess.term.writeln(`\r\n\x1b[33m${why}\x1b[0m`); return; }
+    void (async () => {
+      const r = await api.termAgentTicket(want.cwd, want.agent ? want.prompt : "", !!want.yolo, want.title ?? "")
+        .catch(() => ({ ok: false, error: "could not reach the server" } as { ok: boolean; ticket?: string; error?: string }));
+      if (!r.ok || !r.ticket) {
+        // Said in the terminal the person is looking at, rather than swallowed.
+        // This is the case the audit was about, so it does not get to be quiet.
+        sess.term.writeln(`\r\n\x1b[33mcould not start the agent here: ${r.error ?? "no ticket"}\x1b[0m`);
+        return;
+      }
+      const pane = createSession(want.cwd, r.ticket);
+      setPaneIds((ids) => (ids.length >= 4 ? [...ids.slice(1), pane.id] : [...ids, pane.id]));
+      setFocusIdx((i) => Math.min(i + 1, 3));
+    })();
+  }, [sess, sessTick]);
 
   const addShell = useCallback(() => {
     if (!root || IS_DEMO) return;

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -342,8 +342,12 @@ export function adoptServer(next: { origin?: string | null; token?: string | nul
 }
 
 /** WebSocket URL for a real PTY shell in `root` (the in-browser terminal). */
-export const ptyWsUrl = (root: string, cols: number, rows: number, view?: string, edit = false) =>
+export const ptyWsUrl = (root: string, cols: number, rows: number, view?: string, edit = false, agent?: string) =>
   withToken(`${SERVER.replace(/^http/, "ws")}/terminal/pty?root=${encodeURIComponent(root)}&cols=${cols}&rows=${rows}`
+    // A single-use ticket for an agent to start in this pane — never the prompt
+    // itself, which is kilobytes and has no business in a URL. See
+    // api.termAgentTicket and the server's agentticket.ts.
+    + (agent ? `&agent=${encodeURIComponent(agent)}` : "")
     // A file to open instead of a shell. A path — the server decides what runs
     // with it, and refuses one outside the open project.
     + (view ? `&view=${encodeURIComponent(view)}` : "")
@@ -753,6 +757,10 @@ const realApi = {
    *  be on screen before it finishes. */
   issuePrs: (root: string, number: number) =>
     get<IssuePrsReport>(`/issues/prs?root=${encodeURIComponent(root)}&number=${number}`),
+  /** Hand the server a prompt and get a ticket to open a pane with. The way a
+   *  terminal with no tmux starts an agent — see server/src/agentticket.ts. */
+  termAgentTicket: (cwd: string, prompt: string, yolo: boolean, title: string) =>
+    post<{ ok: boolean; ticket?: string; error?: string }>("/terminal/agent", { cwd, prompt, yolo, title }),
   /** Everything with a worktree still on disk, so the list can say what is in
    *  progress without asking per row. */
   issuesWork: (repo = "") => get<{ work: IssueWork[] }>(`/issues/work?repo=${encodeURIComponent(repo)}`),
@@ -1322,6 +1330,8 @@ const demoApi: typeof realApi = {
   // No linked pull requests in the demo: the fixtures have no GitHub graph
   // behind them, and an invented link is a link somebody would click.
   issuePrs: (_r: string, _n: number) => D({ ok: true, prs: [] }),
+  termAgentTicket: (_c: string, _p: string, _y: boolean, _t: string) =>
+    D({ ok: false, error: "not available in the demo" }),
   issuesWork: (_repo?: string) => D(demo.issuesWork()),
   issueStart: (_r: string, _n: number, _m: StartMode) => D({ ok: false, error: "not available in the demo" }),
   issueFinish: (_r: string, _n: number, _f?: boolean) => D({ ok: false, error: "not available in the demo" }),


### PR DESCRIPTION
## What does this PR do?

An audit of what agentglass shells out to — what happens when the user does not have it, and whether we say so — found one real break, and it was platform-wide rather than exotic.

Six buttons dispatch through `cmd:"issue"` / `cmd:"review"` on the terminal socket: review this pull request, run its checks, resolve conflicts, start an issue, hand over a card, run a card's skill. Both commands were gated on `tmuxActive` in the client, and both sat under `if (!s.tmux) return;` on the server — two layers of silence over one condition.

The condition was worse than "no tmux installed". `tmuxActive` came from `tmuxClientPid`, which opened with `process.platform !== "linux"` and read `/proc`. **On macOS it was false unconditionally** — tmux installed, running and attached did not matter. Press the button, the view switches to the terminal, nothing happens, nothing is logged, and the request sits in its one-slot bus for ever, because the early return also skipped the clear.

That line was not wrong where it was written. Its original caller asks "should the panel hide its own tab strip, because tmux brings one", and a Mac keeping agentglass's own chrome is exactly right — the comment says so. It then became load-bearing for a second question with a different shape, and answered only one of them. Same failure as the ClickUp chip in #489: a value that means one thing, read as if it meant another.

Three changes, meant to be read together:

- **The walk is portable** (`procchildren.ts`): `/proc` where there is one, a cached `ps` table where there is not. The chrome caller is unaffected — a machine with no tmux still answers no, and still keeps its own tabs.
- **The dispatch has a second path.** With no tmux the agent opens in a plain pane instead, in the same worktree, running the same argv — now built in one place (`agentticket.ts`) so the tmux window and the pane cannot drift. The prompt travels as a single-use ticket rather than a query parameter, because a review brief is kilobytes and has no business in a URL. The ticket keeps the rule this endpoint already follows and states plainly for `view`: the client says WHAT, the server decides HOW — the binary and every flag are chosen server-side, as before.
- **What cannot be served is said.** `review` and `issue` moved above the tmux guard and answer for themselves, following the precedent `cmd:"agent"` already set here ("a button with no way out is worse than one that refuses"). The client's gate is now the socket rather than the machine: whether this can be *sent* is a question about the transport, and whether tmux can *serve* it is the server's — which resolves its own sweep before refusing, so "not looked up yet" is never mistaken for "no tmux here". No timers, no grace windows.

Also from the audit:

- `CODEX_ENABLED` and `ANTIGRAVITY_ENABLED` were constants computed at import, so a CLI installed while the server was running stayed invisible until a restart, with nothing on screen to suggest why. `remote.ts` documents that exact trap with a measurement against a stub that was silently bypassed; the lesson had not reached these two.
- `tailscale`, `codex` and `agy` were being spawned, each gating a whole feature, and none was in the requirements catalogue. The existing consistency test only ever ran catalogue → source, so nothing was asking the other question. It runs **both ways** now, with exemptions that each carry a written reason.

One thing this PR deliberately does **not** change: `rg` and `fd` stay out of the catalogue. That was a deliberate call with a test asserting it — they have working fallbacks (`git grep`, `git ls-tree`) and nothing stands down without them. It is now an explicit exemption with its reason attached rather than an absence, so the next person has to mean it.

## How was it tested?

- `bun run typecheck` clean in `web/` and `server/`; `bunx vite build` clean.
- 24 new tests across two files. `agent-ticket` pins the two things that fail in opposite directions: a ticket claimed twice would start two agents in one worktree from one press, and an argv built at two call sites would drift — so the flag order, the prompt being last and one argument, `--name` only where the binary takes it, and empty-means-open-a-shell are all fixed.
- `procchildren` tests the `ps` parser, which is the macOS path and the part most likely to go wrong quietly: a Mac's `comm` is a full path that can contain spaces. It also **cross-checks against reality** — it spawns a real process tree, parses real `ps` output, and requires the same answer `/proc` gives. That catches a parser that merely agrees with its author. `isTmuxComm` now rejects `tmuxinator`, which the old `startsWith("tmux")` accepted.
- The catalogue suite grew from 8 to 13 tests and covers the direction that was missing.
- The three tmux suites were run **with and without this branch's changes** and are byte-identical at 32 pass / 11 fail — those 11 are the sandbox's pre-existing failures (no ports, no `/proc` peers, no Tailscale), not regressions. The full suite's 35 failures reproduce unmodified on `main` for the same reasons.

What could not be tested locally: the macOS path end to end, since this runner is Linux. The parser is verified against real `ps` output and the platform branch is a one-line switch, but the honest statement is that a Mac has not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP

---
_Generated by [Claude Code](https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP)_