### PR TITLE
fix: a conflict is not a green pull request, and the board could not see one

### DIFF
--- a/mobile/test/now-queue.test.ts
+++ b/mobile/test/now-queue.test.ts
@@ -26,7 +26,9 @@ const rollup = (over: Partial<PrSummary["checks"]> = {}) => ({
 });
 
 const pr = (over: Partial<PrSummary> = {}): PrSummary => ({
-  number: 482, title: "Round prices at the cart boundary", author: "someone",
+  number: 482,
+  // Defaulted before the spread, so a case can still say CONFLICTING.
+  mergeable: "MERGEABLE", title: "Round prices at the cart boundary", author: "someone",
   state: "OPEN", isDraft: false, headRefName: "fix/x", baseRefName: "main",
   url: "https://github.com/a/b/pull/482", updatedAt: new Date(NOW - 60_000).toISOString(),
   reviewDecision: null, additions: 84, deletions: 31, changedFiles: 6,

--- a/mobile/test/queue-truth.test.ts
+++ b/mobile/test/queue-truth.test.ts
@@ -29,7 +29,9 @@ const rollup = (over: Partial<PrSummary["checks"]> = {}) => ({
 });
 
 const pr = (over: Partial<PrSummary> = {}): PrSummary => ({
-  number: 482, title: "Round prices at the cart boundary", author: "me",
+  number: 482,
+  // Defaulted before the spread, so a case can still say CONFLICTING.
+  mergeable: "MERGEABLE", title: "Round prices at the cart boundary", author: "me",
   state: "OPEN", isDraft: false, headRefName: "fix/x", baseRefName: "main",
   url: "https://github.com/a/b/pull/482", updatedAt: new Date(NOW - 60_000).toISOString(),
   reviewDecision: null, additions: 84, deletions: 31, changedFiles: 6,

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -770,6 +770,9 @@ export function mapSummary(p: any, withChecks: boolean): PrSummary {
   return {
     number: p.number,
     title: p.title || "",
+    // `gh pr list` gives this straight; anything it does not recognise is
+    // UNKNOWN rather than assumed mergeable — see the field's own comment.
+    mergeable: p.mergeable === "CONFLICTING" || p.mergeable === "MERGEABLE" ? p.mergeable : "UNKNOWN",
     author: p.author?.login || "",
     state: (p.state || "OPEN") as PrSummary["state"],
     isDraft: !!p.isDraft,
@@ -862,7 +865,7 @@ const SEARCH_ROWS = `query($q:String!,$first:Int!,$after:String){
 const SEARCH_CHECKS = `query($q:String!,$first:Int!,$after:String){
   search(query:$q, type:ISSUE, first:$first, after:$after){
     nodes{ ... on PullRequest {
-      number additions deletions changedFiles reviewDecision
+      number additions deletions changedFiles reviewDecision mergeable
       reviewRequests(first:5){nodes{requestedReviewer{
         ... on User{login}
         ... on Team{name}
@@ -1000,7 +1003,7 @@ async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after
   // row is complete the moment this lands. A PR missing from the answer keeps
   // the first-pass row: `checksLoaded` stays false, the review chip stays off,
   // and the stats stay at zero — all of which read as "not yet", which is true.
-  type SecondPass = { rollup: PrCheckRollup; stats: Pick<PrSummary, "additions" | "deletions" | "changedFiles" | "reviewDecision" | "reviewers" | "headSha"> };
+  type SecondPass = { rollup: PrCheckRollup; stats: Pick<PrSummary, "additions" | "deletions" | "changedFiles" | "reviewDecision" | "reviewers" | "headSha" | "mergeable"> };
   const second = new Map<number, SecondPass>();
   for (const n of checksRes?.data?.search?.nodes ?? []) {
     if (!n?.number) continue;
@@ -1021,6 +1024,19 @@ async function fetchList(repo: PrRepoId, filter: PrFilter, state: PrState, after
            about THIS commit, and a merge sent without it lands on whatever the
            tip is by then. See mergePr's --match-head-commit. */
         headSha: typeof head?.oid === "string" ? head.oid : undefined,
+        /*
+         * Mergeability rides with the checks, in the same node, for the same
+         * reason the head SHA does: the board files a row by what it needs, and
+         * "it conflicts" is a different fact from "a check is red". It used to
+         * live only on `PrDetail`, so the board could not see it and filed a
+         * conflicting pull request as green — which is what it looked like.
+         *
+         * `UNKNOWN` is passed through rather than smoothed to MERGEABLE: GitHub
+         * answers it while it is still working the merge out, and a caller that
+         * cannot tell "no conflict" from "not computed yet" would show a
+         * conflict flashing on and off.
+         */
+        mergeable: n.mergeable === "CONFLICTING" || n.mergeable === "MERGEABLE" ? n.mergeable : "UNKNOWN",
       },
     });
   }

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -1849,6 +1849,19 @@ export interface PrSummary {
   reviewers?: PrReviewer[];
   checks: PrCheckRollup;
   /**
+   * Whether GitHub can merge this without a human resolving something.
+   *
+   * On the SUMMARY as well as the detail, because the triage board files a row
+   * by what it needs and a conflict is a different need from a red check. It
+   * was detail-only, so the board read the checks alone and filed a conflicting
+   * pull request as "open, green, nobody has been asked to look yet".
+   *
+   * `UNKNOWN` is a real answer and not a missing one: GitHub computes this
+   * lazily and says UNKNOWN while it is still working, so a caller must not
+   * treat it as "no conflict".
+   */
+  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
+  /**
    * The commit `checks` describes — and therefore the only commit a merge
    * started from this row is allowed to land.
    *
@@ -2094,7 +2107,6 @@ export interface PrMergePolicy {
 
 export interface PrDetail extends PrSummary {
   body: string;
-  mergeable: "MERGEABLE" | "CONFLICTING" | "UNKNOWN";
   mergeState: PrMergeState;
   /** Parsed out of the body — unchecked boxes are a merge signal on repos
    *  whose template carries a real checklist. */

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -802,7 +802,23 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
    *  One repo's refs serve every base picker on screen — the header's and one
    *  per worktree row — because a worktree family shares its refs. */
   const [baseRefs, setBaseRefs] = useState<{ name: string; remote: boolean }[]>([]);
-  const mergeState = tree?.branch.state ?? "clean";
+  /*
+   * The tree that is on screen belongs to a root, and until this read said so
+   * it was trusted for whichever root you had just switched to.
+   *
+   * `loadTree` is async and records the root it answered for in `treeFor`. The
+   * conflict screen keys off this value, so between switching worktree and the
+   * new tree arriving, a conflict belonging to the checkout you LEFT was drawn
+   * over the one you opened — reported as the resolver appearing "para todos
+   * los wt/branches", with the file list beside it reading "nothing to commit,
+   * working tree clean" because that half had already caught up.
+   *
+   * A tree from somewhere else is not evidence about here, so it reads clean
+   * until the right one lands. Clean is the safe default: the worst it does is
+   * show the ordinary strip for one refresh, where the alternative locks the
+   * panel into a conflict screen for a repository that has none.
+   */
+  const mergeState = treeFor === root ? (tree?.branch.state ?? "clean") : "clean";
   /**
    * Which two sides git has stopped between, as git has them — not as the
    * checkout's base branch suggests.
@@ -822,10 +838,12 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
    */
   const inConflict = mergeState !== "clean" && mergeState !== "bisecting";
   useEffect(() => {
-    if (!open || !root || mergeState === "clean") { setConflicts([]); setMerge(null); return; }
+    // `treeFor` for the same reason as `mergeState` above: asking the server
+    // about a root whose tree has not arrived yet answers about the wrong one.
+    if (!open || !root || treeFor !== root || mergeState === "clean") { setConflicts([]); setMerge(null); return; }
     api.gitConflicts(root).then((r) => setConflicts(r.files ?? [])).catch(() => {});
     api.gitMergeInfo(root).then((r) => setMerge(r.ok ? r : null)).catch(() => {});
-  }, [open, root, mergeState, tree]);
+  }, [open, root, treeFor, mergeState, tree]);
 
   /**
    * Hand the conflict to Claude, in the repo it happened in.

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -1779,6 +1779,30 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
       .then((r) => { if (req === detailReq.current) setConflictFiles(r.ok ? { files: r.conflicts, stale: !!r.stale, resolvedLocally: r.resolvedLocally } : null); })
       .catch(() => { if (req === detailReq.current) setConflictFiles(null); });
   }, [root]);
+
+  /*
+   * Ask GitHub a second time when it says it does not know yet.
+   *
+   * `mergeable` is computed lazily: the first request starts the work and
+   * answers UNKNOWN, and a request a moment later gets the result. Nothing here
+   * asked again, so the panel sat on "GitHub has not finished working it out"
+   * — with no Resolve conflicts button and no conflict in the lane — until the
+   * next poll came round. Reported as the button taking an age to appear on a
+   * pull request that was already conflicting.
+   *
+   * Once, not a loop, and only from UNKNOWN. If the second answer is still
+   * UNKNOWN then GitHub is genuinely busy and the poll is the right pace;
+   * retrying harder would be one request per render on the one field that
+   * costs GitHub work to compute.
+   */
+  const askedAgain = useRef<number | null>(null);
+  useEffect(() => {
+    const n = detail?.number;
+    if (!root || !n || detail?.mergeable !== "UNKNOWN" || askedAgain.current === n) return;
+    askedAgain.current = n;
+    const t = setTimeout(() => { void loadDetailRef.current?.(n); }, 1500);
+    return () => clearTimeout(t);
+  }, [root, detail?.number, detail?.mergeable]);
   loadDetailRef.current = loadDetail;
 
   useEffect(() => {

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -751,6 +751,7 @@ const chk = (name: string, state: PrCheckState, workflow = "CI"): PrCheck =>
 
 const PR_SUMMARIES: PrSummary[] = [
   {
+    mergeable: "MERGEABLE" as const,
     number: 482, title: "Round prices at the cart boundary, not per line",
     author: "rmoreno", state: "OPEN", isDraft: false,
     headRefName: "fix/rounding-boundary", baseRefName: "main",
@@ -761,6 +762,7 @@ const PR_SUMMARIES: PrSummary[] = [
     checks: rollup({ ok: 3, bad: ["e2e (checkout)"], skipped: 1 }), checksLoaded: true,
   },
   {
+    mergeable: "MERGEABLE" as const,
     number: 479, title: "Cache the price table per request",
     author: "jkwan", state: "OPEN", isDraft: false,
     headRefName: "perf/price-cache", baseRefName: "main",
@@ -771,6 +773,7 @@ const PR_SUMMARIES: PrSummary[] = [
     checks: rollup({ ok: 5 }), checksLoaded: true,
   },
   {
+    mergeable: "MERGEABLE" as const,
     number: 476, title: "Bump bun to 1.1.38",
     author: "acme-bot", state: "OPEN", isDraft: false,
     headRefName: "deps/bun-1.1.38", baseRefName: "main",
@@ -781,6 +784,7 @@ const PR_SUMMARIES: PrSummary[] = [
     checks: rollup({ ok: 5 }), checksLoaded: true,
   },
   {
+    mergeable: "MERGEABLE" as const,
     number: 471, title: "Otel spans around the approval gate",
     author: "you", state: "OPEN", isDraft: true,
     headRefName: "feat/gate-spans", baseRefName: "main",
@@ -791,6 +795,7 @@ const PR_SUMMARIES: PrSummary[] = [
     checks: rollup({ ok: 2, pending: 3 }), checksLoaded: true,
   },
   {
+    mergeable: "MERGEABLE" as const,
     number: 468, title: "Stabilise the checkout test under load",
     author: "jkwan", state: "OPEN", isDraft: false,
     headRefName: "test/checkout-flake", baseRefName: "main",
@@ -801,6 +806,7 @@ const PR_SUMMARIES: PrSummary[] = [
     checks: rollup({ ok: 2, bad: ["integration (postgres)"], skipped: 1 }), checksLoaded: true,
   },
   {
+    mergeable: "MERGEABLE" as const,
     number: 465, title: "Retry the charge before failing the order",
     author: "you", state: "OPEN", isDraft: false,
     headRefName: "fix/charge-retry", baseRefName: "main",
@@ -812,6 +818,7 @@ const PR_SUMMARIES: PrSummary[] = [
     isCurrentBranch: true,
   },
   {
+    mergeable: "MERGEABLE" as const,
     number: 461, title: "Drop the legacy coupon table",
     author: "t-okafor", state: "OPEN", isDraft: false,
     headRefName: "chore/drop-coupons-v1", baseRefName: "main",

--- a/web/src/lib/prLanes.ts
+++ b/web/src/lib/prLanes.ts
@@ -125,10 +125,41 @@ export function fileInLane(p: PrSummary, stake: Stake): Filed {
       return { lane: "review",
         reason: `Asked of you — and ${plural(c.failure, "check")} ${c.failure === 1 ? "is" : "are"} red, so read it knowing the author still has work.` };
     }
+    if (p.mergeable === "CONFLICTING") {
+      // Still yours to read — a review that was asked for is the one thing
+      // nobody else can do — but said, because a reviewer who does not know it
+      // conflicts will approve something that cannot land.
+      return { lane: "review",
+        reason: "Asked of you — and it conflicts with the base branch, so it cannot land as it stands." };
+    }
     return { lane: "review",
       reason: changesAsked
         ? "You asked for changes and were re-requested — this is the fix, not the first look."
         : "Asked of you. Nobody else can unblock it." };
+  }
+
+  /*
+   * A conflict, before anything green is said about it.
+   *
+   * The lane below has always CALLED itself "red checks or conflicts" and never
+   * tested the second half: `fileInLane` read the checks and the review and
+   * nothing else. So a pull request with every check green and a file
+   * conflicting with main was filed as "Open, green, and nobody has been asked
+   * to look yet" — reported from a board showing exactly that beside GitHub's
+   * own "Merging is blocked". Worse, it could reach "Green, ready to land",
+   * whose whole promise is that the only thing missing is a press; pressing it
+   * fails.
+   *
+   * Checks and mergeability are two different facts and the board was reading
+   * one of them. `UNKNOWN` is deliberately not treated as a conflict: GitHub
+   * answers it while it is still working the merge out, and calling that
+   * blocked would flash every fresh pull request through the red lane.
+   */
+  if (p.mergeable === "CONFLICTING") {
+    return { lane: stake.mine ? "blocked" : "others",
+      reason: stake.mine
+        ? "Conflicts with the base branch — nothing else can move until they are resolved."
+        : "Conflicts with the base branch. Reviewing it is wasted work until the author rebases." };
   }
 
   /*

--- a/web/test/pr-lanes.test.ts
+++ b/web/test/pr-lanes.test.ts
@@ -145,6 +145,45 @@ describe("the board", () => {
     expect(b.get("land")![0]!.filed.reason).toContain("merge");
   });
 
+describe("a conflict is not a green pull request", () => {
+  /*
+   * The lane called itself "red checks or conflicts" from the day it was
+   * written and only ever tested the checks. Reported from a board showing
+   * "Open, green, and nobody has been asked to look yet" beside GitHub's own
+   * "Merging is blocked — 1 file conflict with main".
+   */
+  it("files a conflicting pull request of yours under blocked, however green", () => {
+    const { lane, reason } = fileInLane(pr({ mergeable: "CONFLICTING" }), MINE);
+    expect(lane).toBe("blocked");
+    expect(reason).toContain("Conflicts");
+  });
+
+  it("never calls a conflicting one ready to land, even approved and green", () => {
+    // The worst case, because that lane's promise is that a press is all that
+    // is missing — and the press fails.
+    const { lane } = fileInLane(pr({ reviewDecision: "APPROVED", mergeable: "CONFLICTING" }), MINE);
+    expect(lane).not.toBe("land");
+  });
+
+  it("keeps a review that was asked of you, and says it conflicts", () => {
+    // Still yours to read; a reviewer who does not know would approve
+    // something that cannot land.
+    const { lane, reason } = fileInLane(pr({ mergeable: "CONFLICTING" }), ASKED);
+    expect(lane).toBe("review");
+    expect(reason).toContain("conflicts");
+  });
+
+  it("files somebody else's conflicting one where it is not your problem", () => {
+    expect(fileInLane(pr({ mergeable: "CONFLICTING" }), NEITHER).lane).toBe("others");
+  });
+
+  it("does NOT treat UNKNOWN as a conflict", () => {
+    // GitHub answers UNKNOWN while it is still working the merge out. Calling
+    // that blocked would flash every fresh pull request through the red lane.
+    expect(fileInLane(pr({ mergeable: "UNKNOWN" }), MINE).lane).toBe("flight");
+  });
+});
+
   it("caps a lane at something that fits on a screen", () => {
     // Forty cards in a column is a scroll inside a scroll — worse than the flat
     // list the board replaced.

--- a/web/test/prFilter.test.ts
+++ b/web/test/prFilter.test.ts
@@ -14,6 +14,8 @@ function pr(over: Partial<PrSummary> = {}): PrSummary {
   seq += 1;
   return {
     number: over.number ?? seq,
+    // Defaulted before the spread, so a case can still say CONFLICTING.
+    mergeable: "MERGEABLE",
     title: "a pull request",
     author: "octocat",
     state: "OPEN",


### PR DESCRIPTION
## What does this PR do?

Three faults reported from one screenshot each, with one root between them: **mergeability and checks are different facts, and only one of them reached the places that decide.**

**The board filed a conflicting pull request as green.** `fileInLane` read the check rollup and the review and nothing else, so a pull request with every check passing and a file conflicting with main was filed *"Open, green, and nobody has been asked to look yet"* — beside GitHub's own *"Merging is blocked — 1 file conflict with main"*. Worse, it could reach **Green, ready to land**, a lane whose entire promise is that a human press is all that is missing. The lane called itself "red checks or conflicts" from the day it was written and never tested the second half.

**It could not have done better: the data was not there.** `mergeable` lived on `PrDetail` only, so the list the board is built from never carried it. It now rides on `PrSummary`, read in the same GraphQL node as the head SHA and the rollup, at no extra query. `UNKNOWN` is passed through rather than smoothed to `MERGEABLE` — GitHub computes this lazily and says UNKNOWN while it is still working, and a caller that cannot tell "no conflict" from "not computed yet" would flash a conflict on and off on every fresh pull request.

**The panel waited for GitHub to make its mind up.** The first request starts the computation and answers UNKNOWN; a request a moment later gets the result. Nothing asked again, so the detail sat on *"GitHub has not finished working it out"* — no **Resolve conflicts** button, no conflict in the lane — until the next poll came round. It now asks once more after 1.5s, only from UNKNOWN, once per pull request. If the second answer is still UNKNOWN, GitHub is genuinely busy and the poll is the right pace.

**And the conflict screen belonged to whichever root answered last.** `loadTree` records which root its answer is for, and `mergeState` did not check it. Switching worktree drew the conflict of the checkout you left over the one you opened — the resolver appearing for every worktree and branch, with the file list beside it reading *"nothing to commit, working tree clean"*, because that half had already caught up. A tree from somewhere else is not evidence about here, so it reads clean until the right one lands.

## How was it tested?

`tsc --noEmit` clean for `web/` (both configs) and `server/`.

`web/test/pr-lanes.test.ts` gains five cases, and they are the shape of the bug rather than the shape of the code: a conflicting pull request of yours is **blocked** however green, it is **never** filed ready-to-land even approved and green, one asked of you stays in review **and says it conflicts** (a reviewer who does not know will approve something that cannot land), somebody else's is not your problem, and **UNKNOWN is not treated as a conflict**. 21 pass.

Server PR suites: 106 pass across 8 files, including the one that pins the `gh` JSON field extraction that `mapSummary` now also reads `mergeable` from.

`bun test` in `web/`: 1971 pass. The 4 failures in `server-identity.test.ts` fail identically on `main` — an order-dependent interaction between test files that appears when the suite runs as one process in a worktree and disappears when that file runs alone.

Verified against the live server rather than assumed: `/git/status` and `/git/conflicts` for the checkout in the screenshot answered `state: "clean"` with zero conflicting files while the app was drawing the resolver, which is what placed the fault in the client's stale tree rather than in the backend.

Not covered by a test: the 1.5s re-ask. It needs GitHub to answer UNKNOWN on demand, which is a race against their computation and not something to pin in CI.
