### PR TITLE
fix: the spacing scale this app already had, written down and held to

### DIFF
--- a/web/src/components/BasePicker.tsx
+++ b/web/src/components/BasePicker.tsx
@@ -151,7 +151,7 @@ export function BasePicker({
                     className="w-full text-left px-2.5 py-1.5 flex items-center gap-2"
                     style={{ color: "var(--text3)" }}
                     title="Forget the override and go back to the base this app works out on its own">
-                    <span className="shrink-0 text-[8.5px] px-1 py-[1px] rounded" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>AUTO</span>
+                    <span className="shrink-0 text-[8.5px] px-1 py-px rounded" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>AUTO</span>
                     <span className="min-w-0 flex-1 truncate">work it out for me</span>
                   </button>
                   {shown.slice(0, 200).map((b) => (
@@ -162,7 +162,7 @@ export function BasePicker({
                       {/* Which kind of ref this is, because it changes what you
                           get: `master` is your copy, which may be weeks behind
                           the `origin/master` next to it. */}
-                      <span className="shrink-0 text-[8.5px] px-1 py-[1px] rounded"
+                      <span className="shrink-0 text-[8.5px] px-1 py-px rounded"
                         style={b.remote
                           ? { color: "var(--info)", border: "1px solid color-mix(in srgb, var(--info) 35%, transparent)" }
                           : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>

--- a/web/src/components/ChangesModal.tsx
+++ b/web/src/components/ChangesModal.tsx
@@ -697,7 +697,7 @@ function GroupBlock({ g, collapsed, selId, reviewed, fold, onToggleCollapse, onS
           numeric drops underneath, where it still reads fine. */}
       <div className="flex items-start gap-1.5 px-1.5 py-1 rounded-md" style={{ background: "color-mix(in srgb, var(--bg3) 30%, transparent)" }}>
         <button onClick={onToggleCollapse} className="flex items-start gap-1.5 min-w-0 flex-1 text-left">
-          <span className="text-[10px] t-dim2 transition-transform shrink-0 mt-[3px]" style={{ transform: collapsed ? "rotate(-90deg)" : "none" }}>▾</span>
+          <span className="text-[10px] t-dim2 transition-transform shrink-0 mt-1" style={{ transform: collapsed ? "rotate(-90deg)" : "none" }}>▾</span>
           <span className="min-w-0 flex-1">
             <span className="block text-[11px] font-semibold leading-snug" title={g.label}
               style={{ color: "var(--text2, var(--text))", display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden", overflowWrap: "anywhere" }}>

--- a/web/src/components/ChatPanel.tsx
+++ b/web/src/components/ChatPanel.tsx
@@ -423,7 +423,7 @@ function EffortDial({ chat }: { chat: Chat }) {
         title={"How hard the model thinks, sent as --effort.\n\nDefault leaves the CLI's own setting alone.\nChanging this restarts the chat's session, keeping the conversation."}
         className="flex items-center gap-1.5 text-[10px] px-2 py-1 rounded-md"
         style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}>
-        <span className="flex items-end gap-[2px]" aria-hidden>
+        <span className="flex items-end gap-0.5" aria-hidden>
           {CHAT_EFFORTS.map((_, i) => (
             <span key={i} style={{
               width: 3, height: 4 + i * 2, borderRadius: 1,

--- a/web/src/components/CheckoutPicker.tsx
+++ b/web/src/components/CheckoutPicker.tsx
@@ -224,7 +224,7 @@ export function CheckoutPicker({
           <div ref={rowsRef} className="agx-scroll overflow-y-auto pb-1" style={{ minHeight: 0 }}>
             {unlisted && (
               <div className="px-2.5 py-1.5 flex items-center gap-2" style={{ background: "color-mix(in srgb, var(--warning) 10%, transparent)" }}>
-                <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>SET</span>
+                <span className="shrink-0 text-[8.5px] leading-none px-1 py-0.5 rounded" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 40%, transparent)" }}>SET</span>
                 <span className="min-w-0 flex-1 truncate" style={{ color: "var(--warning)" }} title={unlisted}>{unlisted}</span>
                 <span className="shrink-0 t-dim2 text-[9.5px]">not in this list</span>
               </div>
@@ -248,7 +248,7 @@ export function CheckoutPicker({
                     the row lands. It was an indent once, which says nothing as
                     soon as the list is filtered and the parent is off screen. */}
                 <span
-                  className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                  className="shrink-0 text-[8.5px] leading-none px-1 py-0.5 rounded"
                   title={r.worktreeOf ? `worktree of ${r.worktreeOf}` : "main checkout"}
                   style={r.worktreeOf
                     ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
@@ -292,7 +292,7 @@ export function CheckoutPicker({
                       className="w-full text-left px-2.5 py-1.5 flex items-center gap-2 disabled:opacity-50"
                       style={{ background: at === cursor ? "color-mix(in srgb, var(--primary) 9%, transparent)" : "transparent" }}
                     >
-                      <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" title="local branch — checked out in the current directory" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>BR</span>
+                      <span className="shrink-0 text-[8.5px] leading-none px-1 py-0.5 rounded" title="local branch — checked out in the current directory" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>BR</span>
                       <span className="min-w-0 flex-1 truncate font-medium" style={{ color: "var(--text)" }} title={b.name}>{b.name}</span>
                       {branches?.gone?.(b) && <span className="shrink-0 text-[10px] px-1 rounded" style={{ color: "var(--error)", background: "color-mix(in srgb, var(--error) 12%, transparent)" }}>gone</span>}
                     </button>

--- a/web/src/components/CommandBar.tsx
+++ b/web/src/components/CommandBar.tsx
@@ -487,7 +487,7 @@ export function CommandBar({ root, disabled, font, onRun, runTargetInTmux, onClo
                 hidden rather than absent, so revealing it cannot re-flow the
                 row and nothing can clip it. Going back to the dropdown to find
                 the row you pinned is the long way round. */}
-            <CloseButton onMouseDown={keepTermFocus} onClick={() => togglePin(root, cmd)} style={{ color: "var(--text3)" }} title={`Unpin ${cmd}`} className="shrink-0 w-[15px] pr-[4px] opacity-0 transition-opacity motion-reduce:transition-none group-hover:opacity-100 group-focus-within:opacity-100" />
+            <CloseButton onMouseDown={keepTermFocus} onClick={() => togglePin(root, cmd)} style={{ color: "var(--text3)" }} title={`Unpin ${cmd}`} className="shrink-0 w-[15px] pr-1 opacity-0 transition-opacity motion-reduce:transition-none group-hover:opacity-100 group-focus-within:opacity-100" />
           </span>
         ))}
         {!pins.length && !!root && (

--- a/web/src/components/ConflictMode.tsx
+++ b/web/src/components/ConflictMode.tsx
@@ -645,7 +645,7 @@ function Review({ root, staged, files, busy, writeEnabled, act, ask, merge, step
 
       <div className="flex-1 min-h-0 overflow-auto agx-scroll py-1">
         {rows.map((r) => (
-          <div key={r.path} className="flex items-center gap-2 px-4 py-[3px] text-[11px] font-mono">
+          <div key={r.path} className="flex items-center gap-2 px-4 py-1 text-[11px] font-mono">
             <span className="shrink-0 w-[1ch]" style={{ color: r.decided ? "var(--warning)" : "var(--text3)" }}>{r.decided ? "◆" : "·"}</span>
             <span className="min-w-0 truncate" style={{ color: r.decided ? "var(--text)" : "var(--text2)" }}>{r.path}</span>
             {r.decided && <span className="shrink-0 text-[10px] px-1 rounded" style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 35%, transparent)" }}>you decided this</span>}

--- a/web/src/components/DashboardView.tsx
+++ b/web/src/components/DashboardView.tsx
@@ -112,7 +112,7 @@ export function DashboardView({
                 style={windowMs === w.ms
                   ? { background: "color-mix(in srgb, var(--primary) 22%, transparent)", color: "var(--primary-hover)" }
                   : { color: "var(--text4)" }}>
-                {w.label}{beyond && <sup className="ml-[1px] text-[7px] opacity-70" aria-hidden>*</sup>}
+                {w.label}{beyond && <sup className="ml-px text-[7px] opacity-70" aria-hidden>*</sup>}
               </button>
             );
           })}

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -118,7 +118,7 @@ function Stack({ id, label, n, open, active, onToggle, onActivate, children }: {
 function StackRow({ label, meta, dim, onClick }: { label: string; meta?: string; dim?: boolean; onClick: () => void }) {
   return (
     <div onClick={onClick} title={label}
-      className="flex items-center gap-2 pl-6 pr-2 py-[3px] cursor-pointer rounded-md"
+      className="flex items-center gap-2 pl-6 pr-2 py-1 cursor-pointer rounded-md"
       style={{ opacity: dim ? 0.5 : 1 }}>
       <span className="min-w-0 flex-1 truncate text-[10.5px]" style={{ color: "var(--text2)" }}>{label}</span>
       {meta && <span className="text-[10px] t-dim2 shrink-0 tabular-nums">{meta}</span>}
@@ -137,7 +137,7 @@ function ContainerRow({ c, stat, active, writeEnabled, busy, dense, onSelect, on
   const port = /(\d+)->/.exec(c.ports || "")?.[1];
   return (
     <div onClick={onSelect} data-cid={active ? "active" : undefined}
-      className={`group grid items-center gap-x-2 pl-2 pr-1.5 rounded-md cursor-pointer ${dense ? "py-[2px]" : "py-1"}`}
+      className={`group grid items-center gap-x-2 pl-2 pr-1.5 rounded-md cursor-pointer ${dense ? "py-0.5" : "py-1"}`}
       // A grid, not a flex row: every container's numbers line up in the same
       // columns, which is what makes a list of twelve scannable instead of
       // twelve individually-arranged lines. lazydocker does the same.
@@ -775,7 +775,7 @@ export function DockerView({ active }: { active: boolean }) {
                     >
                       <span style={{ fontSize: 11 }}>{consoleOpen ? "▾" : "▸"}</span>
                       <span>Console</span>
-                      <kbd className="text-[8.5px] px-1 py-[1px] rounded" style={{ border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: 0.85 }}>shell</kbd>
+                      <kbd className="text-[8.5px] px-1 py-px rounded" style={{ border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)", opacity: 0.85 }}>shell</kbd>
                     </button>
                     <span className="ml-auto">Logs auto-refresh · stats every 5s</span>
                   </div>

--- a/web/src/components/FilePalette.tsx
+++ b/web/src/components/FilePalette.tsx
@@ -588,7 +588,7 @@ function RowView({ row, i, on, onHover, onPick }: {
         )}
       </div>
       {row.kind === "file" && row.hits && (
-        <div className="mt-1 flex flex-col gap-[1px]">
+        <div className="mt-1 flex flex-col gap-px">
           {row.hits.slice(0, 4).map((h, n) => (
             <div key={n} className="flex items-baseline gap-2 text-[11px]">
               <span className="shrink-0 tabular-nums w-[42px] text-right" style={{ color: "var(--info)", opacity: 0.75 }}>{h.line}</span>
@@ -702,7 +702,7 @@ function RepoChip({ repo, repos, openState, onPick }: {
               )}
               {shown.map((r) => (
                 <button key={r.root} onClick={() => onPick(r.root)}
-                  className="w-full text-left px-3 py-1.5 flex flex-col gap-[2px]"
+                  className="w-full text-left px-3 py-1.5 flex flex-col gap-0.5"
                   style={{ background: r.root === repo?.root ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
                   {/*
                     * The FOLDER leads, not the branch.
@@ -832,7 +832,7 @@ function ScopeChip({ repo, repos, ref_, refs, openState, onPickRoot, onPickRef }
               {copies.length > 0 && <Group first hint="what is on disk now, your uncommitted work included">Working copies</Group>}
               {copies.map((r) => (
                 <button key={r.root} onClick={() => onPickRoot(r.root)}
-                  className="w-full text-left px-3 py-1.5 flex flex-col gap-[2px]"
+                  className="w-full text-left px-3 py-1.5 flex flex-col gap-0.5"
                   style={{ background: r.root === repo?.root && !ref_ ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
                   <span className="flex items-center gap-2 min-w-0">
                     <span className="truncate" style={{ color: "var(--text)" }}>{shortPath(r.root)}</span>
@@ -954,7 +954,7 @@ function RefChip({ value, refs, openState, onPick }: {
                   a branch, so filtering it out with the branch names would take
                   away the way back. */}
               <button onClick={() => onPick("")}
-                className="w-full text-left px-3 py-1.5 flex flex-col gap-[2px]"
+                className="w-full text-left px-3 py-1.5 flex flex-col gap-0.5"
                 style={{ background: !on ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent" }}>
                 <span style={{ color: "var(--text)" }}>working tree</span>
                 <span className="text-[9.5px]" style={{ color: "var(--text4)" }}>what is on disk now, uncommitted changes included</span>

--- a/web/src/components/FilesPanel.tsx
+++ b/web/src/components/FilesPanel.tsx
@@ -323,7 +323,7 @@ function Tree({ root, active, onOpen, reveal }: {
         return (
           <button key={e.rel} data-row={e.rel}
             onClick={() => { setCursor(e.rel); if (e.dir) toggle(e.rel); else onOpen(e.rel); }}
-            className="w-full text-left flex items-center py-[2px] text-[12px] leading-[1.5] hover:bg-white/5"
+            className="w-full text-left flex items-center py-0.5 text-[12px] leading-[1.5] hover:bg-white/5"
             style={{
               paddingLeft: 14, paddingRight: 16,
               background: on ? "color-mix(in srgb, var(--primary) 15%, transparent)" : undefined,
@@ -441,7 +441,7 @@ function ContentHits({ root, q, onOpen }: { root: string; q: string; onOpen: (re
       </Count>
       {groups.map((g) => (
         <PathRow key={g.rel} rel={g.rel} onOpen={onOpen}>
-          <div className="mt-1 flex flex-col gap-[1px]">
+          <div className="mt-1 flex flex-col gap-px">
             {g.hits.map((h, i) => (
               <div key={i} className="flex items-baseline gap-2 text-[11px]">
                 {/* The line number is a coordinate, not prose — its own tint,

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -2100,7 +2100,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
     return (
       <button onClick={() => setView(id)} title={`${VIEW_LABEL[id]}${n ? ` (${n})` : ""} — press ${num}`}
         aria-keyshortcuts={String(num)}
-        className="text-[10.5px] leading-none rounded-[5px] transition-colors flex items-baseline gap-[5px] whitespace-nowrap shrink-0"
+        className="text-[10.5px] leading-none rounded-[5px] transition-colors flex items-baseline gap-1.5 whitespace-nowrap shrink-0"
         style={{
           padding: "7px 7px 4px",
           background: on ? "color-mix(in srgb, var(--primary) 15%, transparent)" : "transparent",
@@ -2203,7 +2203,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                       name will not fit a narrow window, and something has to
                       give — a strip you can flick is better than controls
                       pushed off the right edge. */}
-                  <div className="flex items-center gap-[9px] ml-1 min-w-0 overflow-x-auto agw-noscrollbar">
+                  <div className="flex items-center gap-2.5 ml-1 min-w-0 overflow-x-auto agw-noscrollbar">
                     {VIEW_GROUPS.map((g) => <ViewGroup key={g.label} views={g.views} />)}
                   </div>
                   <div className="ml-auto flex items-center gap-1.5 min-w-0" style={{ opacity: treeStale ? 0.5 : 1, transition: "opacity .18s ease" }}>

--- a/web/src/components/Header.tsx
+++ b/web/src/components/Header.tsx
@@ -264,7 +264,7 @@ export function Header({
               title={beyond ? `Events are kept for ${retentionDays} days, so this window is answered from the last ${retentionDays}d. Statistics (s) → “spend per day” goes further back.` : undefined}
               style={windowMs === w.ms ? { background: "color-mix(in srgb, var(--primary) 22%, transparent)", color: "var(--primary-hover)" } : { color: "var(--text4)" }}>
               {w.label}
-              {beyond && <sup className="ml-[1px] text-[8px] opacity-70" aria-hidden>*</sup>}
+              {beyond && <sup className="ml-px text-[8px] opacity-70" aria-hidden>*</sup>}
             </button>
           );
         })}

--- a/web/src/components/MachinePanel.tsx
+++ b/web/src/components/MachinePanel.tsx
@@ -646,7 +646,7 @@ function Line({ label, cpu, rss, depth, title, aside, kind, caret, onClick, spar
   return (
     <Row
       {...(onClick ? { onClick, type: "button" as const } : {})}
-      className={`grid items-center w-full text-left px-3.5 py-[3px] text-[11.5px] ${onClick ? "hover:bg-white/5" : ""}`}
+      className={`grid items-center w-full text-left px-3.5 py-1 text-[11.5px] ${onClick ? "hover:bg-white/5" : ""}`}
       style={{
         gridTemplateColumns: COLS, borderBottom: edge(6),
         background: selected ? "color-mix(in srgb, var(--primary) 14%, transparent)" : undefined,
@@ -770,7 +770,7 @@ function Space({ repos }: { repos: GitRepoRef[] }) {
             <Card k="Rebuildable" v={mb(data.freeable)} tint="var(--success)" />
             <Card k="Biggest" v={data.dirs[0] ? `${data.dirs[0].name}` : "—"} small />
           </div>
-          <div className="flex flex-col gap-[3px]">
+          <div className="flex flex-col gap-1">
             {data.dirs.slice(0, 8).map((d) => (
               <div key={d.path} className="flex items-center gap-2 text-[10.5px]">
                 {/* A bar, because "676 MB" and "3 MB" in a column of numbers is

--- a/web/src/components/MergeDialog.tsx
+++ b/web/src/components/MergeDialog.tsx
@@ -441,7 +441,7 @@ export function MergeDialog({ pending }: { pending: Pending | null }) {
  *  the same treatment the panel gives refs everywhere else. */
 function Ref({ children }: { children: React.ReactNode }) {
   return (
-    <code className="px-1 py-[1px] rounded text-[10.5px]"
+    <code className="px-1 py-px rounded text-[10.5px]"
       style={{ background: "color-mix(in srgb, var(--text) 8%, transparent)", color: "var(--text2)" }}>{children}</code>
   );
 }

--- a/web/src/components/NeedsPopover.tsx
+++ b/web/src/components/NeedsPopover.tsx
@@ -58,7 +58,7 @@ function Action({ children, onClick, primary }: { children: React.ReactNode; onC
   return (
     <button
       onClick={onClick}
-      className="text-[10px] px-2 py-[3px] rounded"
+      className="text-[10px] px-2 py-1 rounded"
       style={{
         color: primary ? "var(--bg)" : "var(--text2)",
         background: primary ? "var(--primary)" : "transparent",
@@ -93,7 +93,7 @@ function Row({ it, exact, hits, onChat, onApprove, onProject, onPane }: {
             another one is legitimate — but reading it as though it came from the
             project in front of you is how you go looking in the wrong tree. */}
         {it.otherProject && (
-          <span className="text-[10px] uppercase tracking-wider px-1.5 py-[1px] rounded shrink-0"
+          <span className="text-[10px] uppercase tracking-wider px-1.5 py-px rounded shrink-0"
             style={{ color: "var(--text3)", border: "1px solid var(--border)" }}
             title={`This is not the project you have open — it lives in ${it.project}`}>
             {it.otherProject}
@@ -104,7 +104,7 @@ function Row({ it, exact, hits, onChat, onApprove, onProject, onPane }: {
           strip; this is the place it gets to be read. */}
       <div className="text-[11px]" style={{ color: "var(--text2)", overflowWrap: "anywhere" }}>{it.because}</div>
       {it.cwd && (
-        <div className="text-[10px] mt-[3px] font-mono truncate" style={{ color: "var(--text4)" }} title={it.cwd}>{short(it.cwd)}</div>
+        <div className="text-[10px] mt-1 font-mono truncate" style={{ color: "var(--text4)" }} title={it.cwd}>{short(it.cwd)}</div>
       )}
       <div className="flex items-center gap-1.5 mt-2 flex-wrap">
         {it.chatId && <Action primary onClick={() => onChat(it.chatId!)}>Open its chat</Action>}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -2962,7 +2962,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
                   return <Dot tint={stateTint(sum)} title={`#${p.number} — ${what}`} />;
                 })()}
                 <button onClick={() => openPr(p.number)} title={p.title}
-                  className="text-[10px] pr-1 py-[1px] tabular-nums"
+                  className="text-[10px] pr-1 py-px tabular-nums"
                   style={{ color: p.number === selected ? "var(--text)" : "var(--text2)" }}>
                   #{p.number}
                 </button>
@@ -2986,7 +2986,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
                 title={isPinned(repo.nameWithOwner, d.number)
                   ? `#${d.number} is on the bar — click to take it off`
                   : `Keep #${d.number} on this bar, one click away from anywhere in this panel`}
-                className="text-[10px] px-1.5 py-[1px] rounded shrink-0 ml-auto"
+                className="text-[10px] px-1.5 py-px rounded shrink-0 ml-auto"
                 style={isPinned(repo.nameWithOwner, d.number)
                   ? { color: "var(--primary-hover)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }
                   : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--text) 16%, transparent)" }}>
@@ -4360,7 +4360,11 @@ function FieldPicker({ anchor, title, hint, multi, loading, options, selected, o
     <Portal>
       <div ref={box} className="fixed rounded-lg overflow-hidden flex flex-col"
         style={{ left, top, width: W, maxHeight: maxH, border: "1px solid color-mix(in srgb, var(--text) 24%, transparent)", background: "color-mix(in srgb, var(--bg2) 98%, black)", boxShadow: "0 18px 44px -18px rgba(0,0,0,.8)" }}>
-        <div className="px-3 pt-2 pb-1.5 shrink-0" style={{ borderBottom: "1px solid color-mix(in srgb, var(--text) 11%, transparent)" }}>
+        {/* px-5 to match viewHeaderClass, which is the row directly above this
+            one. At px-3 the filter chips started 8px to the left of the repo
+            chips they sit under — two left edges in one header, which is the
+            kind of thing you notice without being able to name. */}
+        <div className="px-5 pt-2 pb-1.5 shrink-0" style={{ borderBottom: "1px solid color-mix(in srgb, var(--text) 11%, transparent)" }}>
           <div className="text-[11px] font-semibold" style={{ color: "var(--text)" }}>{title}</div>
           <div className="text-[10px]" style={{ color: "var(--text3)" }}>{hint}</div>
         </div>
@@ -5265,7 +5269,7 @@ function FindBar({ value, onChange, inputRef, listRef, hits, groups, at, onGo, o
                     const e = excerpt(m);
                     return (
                       <button key={idx} data-hit={on ? "on" : undefined} onClick={() => onGo(idx)}
-                        className="w-full text-left flex items-baseline gap-2 px-2.5 py-[3px] hover:bg-white/5"
+                        className="w-full text-left flex items-baseline gap-2 px-2.5 py-1 hover:bg-white/5"
                         style={{
                           background: on ? "color-mix(in srgb, var(--primary) 18%, transparent)" : undefined,
                           // A rail, not a border: the row keeps its height and
@@ -5895,7 +5899,7 @@ function FilesTab({ d, root, byPath, loaded, seenFiles, onSeen, sel, onSel, onSh
             are choosing how much is in front of you. */}
         <span className="inline-flex rounded overflow-hidden shrink-0" style={{ border: "1px solid color-mix(in srgb, var(--text) 18%, transparent)" }}>
           {([[true, "One file"], [false, "All files"]] as const).map(([v, label]) => (
-            <button key={label} onClick={() => setOne(v)} className="px-2 py-[1px]"
+            <button key={label} onClick={() => setOne(v)} className="px-2 py-px"
               style={oneFile === v
                 ? { background: "color-mix(in srgb, var(--primary) 20%, transparent)", color: "var(--text)" }
                 : { color: "var(--text3)" }}>{label}</button>

--- a/web/src/components/SettingsModal.tsx
+++ b/web/src/components/SettingsModal.tsx
@@ -154,7 +154,7 @@ function SetupCard({ title, steps, note, error }: {
         {steps.map((st, i) => (
           <li key={st.title} className="grid items-start gap-x-3 px-4 py-3"
             style={{ gridTemplateColumns: "20px minmax(0,1fr) auto", borderTop: i === 0 ? undefined : "1px solid color-mix(in srgb, var(--border) 22%, transparent)" }}>
-            <span className="mt-[1px] w-5 h-5 rounded-full grid place-items-center text-[10.5px] tabular-nums shrink-0"
+            <span className="mt-px w-5 h-5 rounded-full grid place-items-center text-[10.5px] tabular-nums shrink-0"
               style={st.done === true
                 ? { color: "var(--success)", background: "color-mix(in srgb, var(--success) 16%, transparent)" }
                 : st.done === false
@@ -241,7 +241,7 @@ function SourceRow({ id, i, n, onChanged }: {
     <SettingRow label={s.label} hint={s.what}
       control={
         <span className="flex items-center gap-2.5 justify-self-end">
-          <span className="flex flex-col shrink-0" style={{ gap: 1 }}>
+          <span className="flex flex-col shrink-0 gap-px">
             {([-1, 1] as const).map((by) => (
               <button key={by}
                 onClick={() => { moveTaskSource(id, by); onChanged(); }}
@@ -2602,7 +2602,13 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                   {/* One page per concern instead of one long scroll: four
                       sections stacked vertically meant the shortcuts, the part
                       you come here to change, were always below the fold. */}
-                  <div className="shrink-0 w-[186px] py-2 px-2 flex flex-col gap-0.5 border-r agx-scroll overflow-y-auto" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
+                  {/* px-2.5, not px-2, and the 2px is the point: every nav item is a
+                      button with its own px-2.5, so the container's padding plus
+                      the button's decides where the TEXT lands. At px-2 it landed
+                      at 18px while "Settings" in the header above starts at 20px
+                      — two left edges in one dialog, close enough to look like a
+                      mistake rather than a choice. */}
+                  <div className="shrink-0 w-[186px] py-2 px-2.5 flex flex-col gap-0.5 border-r agx-scroll overflow-y-auto" style={{ borderColor: "color-mix(in srgb, var(--border) 25%, transparent)" }}>
                     <input value={q} onChange={(e) => setQ(e.target.value)} placeholder="Search settings"
                       className="mb-1 px-2.5 py-1.5 rounded-lg text-[12.5px] outline-none shrink-0"
                       style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)", color: "var(--text)" }} />
@@ -2614,7 +2620,14 @@ export function SettingsModal({ open, onClose, sound, onSound, scale, onZoom, on
                       if (!groups.length) return <div className="px-2.5 py-3 text-[12.5px]" style={{ color: "var(--text4)" }}>No settings match “{q.trim()}”.</div>;
                       return groups.map(({ g, tabs }) => (
                         <div key={g} className={`flex flex-col gap-0.5${g === "" ? " mt-auto pt-2" : ""}`}>
-                          {g !== "" && <div className="px-2.5 pt-2 pb-0.5 text-[11px] uppercase tracking-[0.14em]" style={{ color: "var(--text4)" }}>{g}</div>}
+                          {/* A group heading gets more room ABOVE it than its
+                              items get between them — measured at 42px either
+                              side before this, which is why "Agents & work"
+                              read as belonging to the row above rather than to
+                              the rows below. The rule is in tailwind.config.js
+                              beside the scale, because it is about meaning
+                              rather than size: a heading hugs what it names. */}
+                          {g !== "" && <div className="px-2.5 pt-4 pb-1 text-[11px] uppercase tracking-[0.14em]" style={{ color: "var(--text4)" }}>{g}</div>}
                           {tabs.map((t) => (
                             <button key={t.id} onClick={() => setPane(t.id)}
                               className="w-full text-left px-2.5 py-1.5 rounded-lg text-[13px] flex items-center gap-2"

--- a/web/src/components/StatsModal.tsx
+++ b/web/src/components/StatsModal.tsx
@@ -27,7 +27,7 @@ function Heatmap({ data }: { data: number[] }) {
   const max = Math.max(1, ...data);
   return (
     <div className="w-full">
-      <div className="grid gap-[4px] w-full" style={{ gridTemplateColumns: "30px repeat(24, minmax(0,1fr))" }}>
+      <div className="grid gap-1 w-full" style={{ gridTemplateColumns: "30px repeat(24, minmax(0,1fr))" }}>
         <span />
         {Array.from({ length: 24 }, (_, h) => (
           <span key={h} className="text-[8px] t-dim2 text-center tabular-nums">{h % 3 === 0 ? h : ""}</span>
@@ -82,7 +82,7 @@ function SpendHistory({ history }: { history: UsageHistory | null }) {
 
   return (
     <div className="flex flex-col gap-2">
-      <div className="flex items-end gap-[2px] h-28">
+      <div className="flex items-end gap-0.5 h-28">
         {days.map((d) => {
           const summarised = !!seam && d.day < seam;
           // A day with spend never renders as nothing: a 1px floor keeps a
@@ -348,7 +348,7 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                             return (
                               <div key={s.skill} className="grid grid-cols-[minmax(0,160px)_1fr_auto] gap-x-3 items-center">
                                 <span className="truncate text-[11px]" style={{ color: "var(--text2)" }} title={s.skill}>{s.skill}</span>
-                                <div className="flex gap-[3px]">
+                                <div className="flex gap-1">
                                   {s.buckets.map((n, i) => (
                                     <div
                                       key={i}

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -2161,7 +2161,7 @@ function ClickUpRow({ t, today, on, onPick, grid, showWho, showSprint, showEst, 
         </div>
       </div>
       {showWho && (
-        <span className="flex items-center" style={{ paddingLeft: 3 }}>
+        <span className="flex items-center pl-1">
           {(t.people ?? []).slice(0, 3).map((p, n) => <Face key={n} p={p} n={n} />)}
           {(t.people?.length ?? 0) > 3 && (
             <span className="text-[8.5px] ml-1" style={{ color: "var(--text4)" }}>+{(t.people!.length) - 3}</span>
@@ -2640,7 +2640,7 @@ function CardDetail({ t, today, statuses, fields, place, writable, repos, here, 
               className="w-full text-left rounded px-1 -mx-1 py-0.5 hover:bg-white/5 text-[11.5px] leading-tight flex items-center gap-1.5"
               style={{ color: t.mine ? "var(--success)" : "var(--text2)" }}>
               {!!t.people?.length && (
-                <span className="inline-flex items-center shrink-0" style={{ paddingLeft: 3 }}>
+                <span className="inline-flex items-center shrink-0 pl-1">
                   {t.people.slice(0, 4).map((p, n) => <Face key={n} p={p} n={n} />)}
                 </span>
               )}

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -2145,7 +2145,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                           title="Reading which worktree this pane is working in"
                           style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text3)" }}
                         >
-                          <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>WT</span>
+                          <span className="shrink-0 text-[8.5px] leading-none px-1 py-0.5 rounded" style={{ color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>WT</span>
                           <span className="animate-pulse">Reading this pane…</span>
                         </span>
                       ) : null;
@@ -2158,7 +2158,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         style={{ background: "color-mix(in srgb, var(--bg3) 50%, transparent)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)", color: "var(--text)" }}
                       >
                         <span
-                          className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded"
+                          className="shrink-0 text-[8.5px] leading-none px-1 py-0.5 rounded"
                           title={at.worktreeOf ? `worktree of ${at.worktreeOf}` : "main checkout"}
                           style={at.worktreeOf
                             ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" }
@@ -2182,7 +2182,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                           onMouseDown={keepTermFocus}
                           onClick={() => requestWorktreeJump({ view: "diff", filter: dirName(at.root) })}
                           title={`Open ${dirName(at.root)}'s changes in File changes`}
-                          className="agx-btn shrink-0 flex items-center gap-1 px-2 py-[1px] rounded leading-none"
+                          className="agx-btn shrink-0 flex items-center gap-1 px-2 py-px rounded leading-none"
                           style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--border) 45%, transparent)" }}
                         >Diff <span className="t-dim2 text-[10px]">↗</span></button>
                         {/* Only when the branch HAS one. A dashed "no pull
@@ -2194,7 +2194,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                             onMouseDown={keepTermFocus}
                             onClick={() => openPr(chipPr.repo, chipPr.pr.number)}
                             title={`#${chipPr.pr.number} ${chipPr.pr.title}\n${chipPr.pr.state === "OPEN" && chipPr.pr.isDraft ? "Draft" : chipPr.pr.state.toLowerCase()} · open it in Pull requests`}
-                            className="agx-btn shrink-0 flex items-center gap-1 px-2 py-[1px] rounded leading-none tabular-nums"
+                            className="agx-btn shrink-0 flex items-center gap-1 px-2 py-px rounded leading-none tabular-nums"
                             style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}
                           >PR #{chipPr.pr.number} <span className="t-dim2 text-[10px]">↗</span></button>
                         )}
@@ -2267,7 +2267,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                               /* Auto-detected from what the focused pane's agent is doing — the one you
                                  almost certainly want, pinned above the list and out of the filter. */
                               <div className="w-full px-2.5 py-1.5 flex items-center gap-2 shrink-0" style={{ background: "color-mix(in srgb, var(--primary) 12%, transparent)", borderBottom: "1px solid color-mix(in srgb, var(--border) 30%, transparent)" }}>
-                                <span className="shrink-0 text-[10px] uppercase tracking-wider px-1 py-[2px] rounded self-start mt-0.5" title="Where this pane's agent is working — from its directory and its transcript" style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>This pane</span>
+                                <span className="shrink-0 text-[10px] uppercase tracking-wider px-1 py-0.5 rounded self-start mt-0.5" title="Where this pane's agent is working — from its directory and its transcript" style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 45%, transparent)" }}>This pane</span>
                                 <span className="min-w-0 flex-1 flex flex-col leading-tight" title={`${detected.branch}\n${detected.root}`}>
                                   <span className="truncate font-medium" style={{ color: "var(--text)" }}>{detected.branch}</span>
                                   <span className="truncate text-[10px]" style={{ color: "var(--text3)" }}>{dirName(detected.root)}</span>
@@ -2282,7 +2282,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                                 const wt = !!r.worktreeOf;
                                 return (
                                   <div key={r.root} className="w-full px-2.5 py-1.5 flex items-center gap-2" style={{ background: r.root === root ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent" }}>
-                                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-[2px] rounded self-start mt-0.5" title={wt ? `Worktree of ${r.worktreeOf}` : "Main checkout"} style={wt ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" } : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>{wt ? "WT" : "REPO"}</span>
+                                    <span className="shrink-0 text-[8.5px] leading-none px-1 py-0.5 rounded self-start mt-0.5" title={wt ? `Worktree of ${r.worktreeOf}` : "Main checkout"} style={wt ? { color: "var(--primary)", background: "color-mix(in srgb, var(--primary) 16%, transparent)", border: "1px solid color-mix(in srgb, var(--primary) 32%, transparent)" } : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 40%, transparent)" }}>{wt ? "WT" : "REPO"}</span>
                                     {/* The branch is the descriptive name (`WEB-1042-fix-the-cart`); the
                                         folder (`orbit-WEB-1042`) is the terse stub below it. A ticket number
                                         alone is not something anyone recognises without having memorised it. */}
@@ -2406,7 +2406,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                           onClick={() => { if (w.id !== activeWindow) { setPendingWindow(w.id); tmuxCmd({ cmd: "select", window: w.id }); } }}
                           onDoubleClick={() => setRenaming(w.id)}
                           title={`Window ${w.index}${w.flags ? ` (${w.flags})` : ""} — double-click to rename`}
-                          className={`group flex items-center gap-1.5 px-1 py-[1px] text-[10.5px] cursor-pointer shrink-0 transition-colors${w.id === activeWindow ? " font-semibold" : ""}`}
+                          className={`group flex items-center gap-1.5 px-1 py-px text-[10.5px] cursor-pointer shrink-0 transition-colors${w.id === activeWindow ? " font-semibold" : ""}`}
                           style={w.id === activeWindow
                             ? { color: "var(--primary-hover)" }
                             : { color: "var(--text2)" }}>

--- a/web/src/components/ToolMix.tsx
+++ b/web/src/components/ToolMix.tsx
@@ -44,7 +44,7 @@ export function ToolMix({ events }: { events: WatchEvent[] }) {
   return (
     <Panel eyebrow="Tool mix" title="What the fleet is doing" right={<span className="text-[10px] t-dim2">{total} runs</span>}>
       <div className="flex flex-col justify-center h-full gap-3">
-        <div className="flex h-4 rounded-full overflow-hidden gap-[2px]" style={{ background: "color-mix(in srgb, var(--border) 22%, transparent)" }}>
+        <div className="flex h-4 rounded-full overflow-hidden gap-0.5" style={{ background: "color-mix(in srgb, var(--border) 22%, transparent)" }}>
           {seg.map((m) => (
             <motion.div
               key={m.name}

--- a/web/src/components/TopBar.tsx
+++ b/web/src/components/TopBar.tsx
@@ -342,7 +342,7 @@ export function TopBar({
           edge, a hover state and a pressable surface — and the open project
           carries the weight, since "which project am I in" is the one thing
           this corner exists to answer. */}
-      <button onClick={onOpenProject} className="agx-btn flex items-center gap-1.5 shrink-0 min-w-0 rounded-md pl-1.5 pr-1 py-[3px]"
+      <button onClick={onOpenProject} className="agx-btn flex items-center gap-1.5 shrink-0 min-w-0 rounded-md pl-1.5 pr-1 py-1"
         title={workspace ? `${workspace}\nClick to switch project` : workspace === null ? "Every repo on this machine — click to open a single project" : "Reading the open project…"}
         style={{
           ...NO_DRAG,
@@ -407,7 +407,7 @@ export function TopBar({
         {alarm ? (
           <button ref={chip} onClick={() => setNeedsOpen((v) => !v)}
             aria-label="What needs you" aria-expanded={needsOpen}
-            className="flex items-center gap-2 px-2.5 py-[1px] rounded-full min-w-0"
+            className="flex items-center gap-2 px-2.5 py-px rounded-full min-w-0"
             style={{
               color: "var(--warning)",
               border: "1px solid color-mix(in srgb, var(--warning) 50%, transparent)",
@@ -481,7 +481,7 @@ export function TopBar({
         )}
         <span className="shrink-0" style={{ width: 1, height: 12, background: "color-mix(in srgb, var(--text) 14%, transparent)" }} />
         <button onClick={onOpenPalette} title="Search anything (⌘K)"
-          className="hidden sm:block text-[9.5px] px-1.5 py-[1px] rounded shrink-0"
+          className="hidden sm:block text-[9.5px] px-1.5 py-px rounded shrink-0"
           style={{ color: "var(--text3)", border: edge(16), ...NO_DRAG }}>⌘K</button>
         {/*
           * Find a file — shaped like the thing it opens, not like a chip.
@@ -498,7 +498,7 @@ export function TopBar({
           * the clock have the better claim on the space.
           */}
         <button onClick={onOpenFiles} title={`Find a file (${chordLabel(appChordFor("files.palette"))})`}
-          className="agx-topbar-find group flex items-center gap-2 shrink-0 rounded-md px-2 py-[3px]"
+          className="agx-topbar-find group flex items-center gap-2 shrink-0 rounded-md px-2 py-1"
           style={NO_DRAG}>
           {/* 14, not 11. A glyph standing in for a whole control is the one
               thing on a bar that cannot be read at the size of a label. */}
@@ -506,7 +506,7 @@ export function TopBar({
           <span className="hidden md:block text-[10.5px] whitespace-nowrap" style={{ color: "var(--text3)" }}>
             Find a file…
           </span>
-          <span className="hidden md:block text-[9px] px-1 py-[1px] rounded shrink-0 tabular-nums"
+          <span className="hidden md:block text-[9px] px-1 py-px rounded shrink-0 tabular-nums"
             style={{ color: "var(--text4)", border: edge(16) }}>
             {chordLabel(appChordFor("files.palette"))}
           </span>

--- a/web/src/components/TopBarNotes.tsx
+++ b/web/src/components/TopBarNotes.tsx
@@ -414,7 +414,7 @@ function HistoryRow({ n, onGone, onGoto }: { n: SystemNote; onGone: () => void; 
         : go && n.goto?.kind === "card" ? `Open ${n.goto.label} in Tasks`
         : expandable ? (open ? "Show less" : "Show the whole message") : undefined}>
       <div className="flex items-start gap-2">
-        <span className="flex flex-col min-w-0 flex-1 gap-[3px]">
+        <span className="flex flex-col min-w-0 flex-1 gap-1">
           <span className="flex items-center gap-2">
             <Cap>{n.app}</Cap>
             <Cap dim>{ago(n.at)}</Cap>

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -236,7 +236,7 @@ export function ViewRail({
             style={{ background: "var(--primary)" }} />
         )}
         {pip?.count ? (
-          <span className="absolute top-[5px] right-[6px] min-w-[14px] h-[14px] px-[3px] grid place-items-center rounded-full text-[10px] font-bold tabular-nums"
+          <span className="absolute top-[5px] right-[6px] min-w-[14px] h-[14px] px-1 grid place-items-center rounded-full text-[10px] font-bold tabular-nums"
             style={{ background: "var(--success)", color: "#06281c" }}>{pip.count}</span>
         ) : pip?.dot ? (
           <span className="absolute top-[7px] right-[9px] w-[6px] h-[6px] rounded-full"
@@ -297,7 +297,7 @@ export function ViewRail({
         if (dragId && !e.currentTarget.contains(e.relatedTarget as Node | null)) setSlot(null);
       }}
       onDrop={commit}
-      className="w-[52px] shrink-0 flex flex-col gap-[3px] p-2 overflow-visible"
+      className="w-[52px] shrink-0 flex flex-col gap-1 p-2 overflow-visible"
       style={{
         borderRight: "1px solid color-mix(in srgb, var(--primary) 14%, transparent)",
         background: "color-mix(in srgb, var(--bg) 55%, transparent)",
@@ -308,7 +308,7 @@ export function ViewRail({
           "put it at the bottom of the top group", and a container sized to its
           contents would have quietly refused. */}
       <div
-        className="flex-1 flex flex-col gap-[3px]"
+        className="flex-1 flex flex-col gap-1"
         onDragOver={(e) => overDrawer(e, "work")}
         onDrop={commit}
       >
@@ -316,7 +316,7 @@ export function ViewRail({
       </div>
 
       <div
-        className="pt-2 flex flex-col gap-[3px]"
+        className="pt-2 flex flex-col gap-1"
         style={{ borderTop: "1px solid color-mix(in srgb, var(--primary) 10%, transparent)" }}
         onDragOver={(e) => overDrawer(e, "utility")}
         onDrop={commit}
@@ -353,7 +353,7 @@ export function ViewRail({
         </div>
       )}
 
-      <div className="flex flex-col gap-[3px]">
+      <div className="flex flex-col gap-1">
         {/* A second hairline, because everything below is not a view at all:
             these open OVER whatever you are in and hand it straight back. A
             divider is the cheapest way to say "these do not change where you
@@ -382,7 +382,7 @@ export function ViewRail({
             style={{ color: restoreAt ? "var(--primary-hover)" : "var(--text4)" }}
           >
             <PlusIcon size={ICON.rail} />
-            <span className="absolute top-[5px] right-[6px] min-w-[14px] h-[14px] px-[3px] grid place-items-center rounded-full text-[10px] font-bold tabular-nums"
+            <span className="absolute top-[5px] right-[6px] min-w-[14px] h-[14px] px-1 grid place-items-center rounded-full text-[10px] font-bold tabular-nums"
               style={{ background: "color-mix(in srgb, var(--primary) 70%, transparent)", color: "var(--bg)" }}>{hiddenViews.length}</span>
           </button>
         )}

--- a/web/tailwind.config.js
+++ b/web/tailwind.config.js
@@ -10,6 +10,46 @@ export default {
       screens: {
         tall: { raw: "(min-width: 1280px) and (min-height: 860px)" },
       },
+      /*
+       * The spacing scale, written down.
+       *
+       * This app already had a rhythm and no record of it. Measured across
+       * web/src: 3,714 spacing utilities, of which 97.8% already land on a 2px
+       * grid — `0.5` `1` `1.5` `2` `2.5` `3` `3.5` `4` `5` `6` and a handful of
+       * layout-sized steps above. What was missing was not the rhythm. It was
+       * anything that SAID so, and anything that stopped the exceptions: fifty
+       * arbitrary values on odd pixels (`py-[3px]`, `gap-[9px]`) and eleven
+       * inline `padding: 17`s that no scale ever produced.
+       *
+       * So this is not a new scale imposed on the app. It is the app's own
+       * scale, declared — which is what lets spacing-scale.test.ts refuse the
+       * next `gap-[7px]` without anybody having to notice it in review.
+       *
+       * Tailwind's own `spacing` is deliberately NOT overridden. It feeds
+       * `w-`, `h-`, `top-`, `translate-` and more, so narrowing it here would
+       * break sizing that has nothing to do with this. The scale is enforced by
+       * the test, which reads intent; the config states it.
+       *
+       * The steps, and what each is for:
+       *
+       *   px   1px   hairline — inside a pill, where 2px is already too much
+       *   0.5  2px   inside a chip or a dense control
+       *   1    4px   between things that belong together
+       *   1.5  6px   the default gap in a row of controls
+       *   2    8px   between elements in a group
+       *   2.5  10px  a row that carries a control rather than only text
+       *   3    12px  between groups
+       *   3.5  14px  a group that needs to clear a neighbour
+       *   4    16px  panel padding, narrow
+       *   5    20px  panel padding
+       *   6    24px  between sections
+       *   8+   32px+ page-level layout only
+       *
+       * A step above a GROUP HEADING is never the same as a step between two of
+       * its items — that was the Settings nav's bug and it is the one rule here
+       * that is about meaning rather than size.
+       */
+      spacing: {},
       fontFamily: {
         // The whole app is set in this, so it is the one that decides how
         // agentglass reads. The order is the platform's own monospace first —

--- a/web/test/spacing-scale.test.ts
+++ b/web/test/spacing-scale.test.ts
@@ -1,0 +1,111 @@
+/*
+ * The spacing scale, enforced.
+ *
+ * The app already had a rhythm and no record of it. Measured across web/src
+ * when this was written: 3,714 spacing utilities, of which 97.8% already land
+ * on a 2px grid. The disorder was never the common case — it was that nothing
+ * declared the grid and nothing stopped the exceptions poking through it:
+ * arbitrary values on odd pixels (`py-[3px]`, `gap-[9px]`) and inline
+ * `paddingLeft: 3`, neither of which any scale produces.
+ *
+ * So this does not invent a scale. It holds the app to its own, the same way
+ * deps-catalog.test.ts holds the requirements page to what the code actually
+ * runs — and for the same reason: a convention nothing checks is a convention
+ * that has already drifted, quietly, in the direction of whoever was last in a
+ * hurry.
+ *
+ * Two rules, and the second is the one that matters:
+ *
+ *   1. Spacing goes through Tailwind's scale, which is a 2px grid.
+ *   2. An arbitrary value (`gap-[9px]`) or an inline `padding:` has to be
+ *      exempt BY NAME, with a reason. That is what turns "off the scale" from
+ *      something that happens into something somebody decided.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "..", "src");
+
+function sources(dir: string, out: string[] = []): string[] {
+  for (const e of readdirSync(dir)) {
+    const p = join(dir, e);
+    if (statSync(p).isDirectory()) sources(p, out);
+    else if (p.endsWith(".tsx") || p.endsWith(".ts")) out.push(p);
+  }
+  return out;
+}
+const FILES = sources(SRC).map((f) => ({ f, s: readFileSync(f, "utf8") }));
+
+/** The axes a spacing step can be applied to. `space-` and `gap-` included:
+ *  they are the same decision as padding, made between children instead. */
+const AXIS = String.raw`(?:p|px|py|pt|pb|pl|pr|m|mx|my|mt|mb|ml|mr|gap|gap-x|gap-y|space-x|space-y)`;
+
+/**
+ * Arbitrary pixel values that are allowed to stay, each because a step cannot
+ * express it.
+ *
+ * All five are horizontal indents that align text under something specific — a
+ * glyph, a checkbox, an avatar — so the number is a measurement of that thing
+ * and not a rhythm. Rounding them to the scale would misalign the very column
+ * they exist to line up with.
+ */
+const ALLOWED_ARBITRARY = new Set(["pl-[18px]", "pl-[22px]", "pl-[30px]", "pl-[50px]", "ml-[60px]"]);
+
+describe("spacing goes through the scale", () => {
+  test("no arbitrary pixel spacing except the indents that align to a glyph", () => {
+    const strays: string[] = [];
+    for (const { f, s } of FILES) {
+      for (const m of s.matchAll(new RegExp(String.raw`\b${AXIS}-\[[0-9]+px\]`, "g"))) {
+        if (!ALLOWED_ARBITRARY.has(m[0])) strays.push(`${f.replace(SRC, "web/src")}: ${m[0]}`);
+      }
+    }
+    // Named rather than counted: the failure has to tell whoever added one
+    // where it is, or the next person just adds it to a number.
+    expect(strays.join("\n") || null).toBeNull();
+  });
+
+  test("every allowed indent is still used", () => {
+    // An exemption for something nobody writes any more is a note about a
+    // decision that can no longer be checked.
+    const all = FILES.map((x) => x.s).join("\n");
+    const stale = [...ALLOWED_ARBITRARY].filter((v) => !all.includes(v)).sort();
+    expect(stale.join(", ") || null).toBeNull();
+  });
+
+  test("inline spacing still lands on the grid", () => {
+    /*
+     * `style={{ paddingLeft: 3 }}` is what gets past every other check here: it
+     * is not a class, so no scale applies, and 3 is not a number any grid
+     * produces. Three of those existed when this was written.
+     *
+     * The rule is the GRID, not the class. Twenty-six inline values survive
+     * this deliberately — `paddingLeft: 8`, `gap: 10` — and they are all even
+     * and all fine: several are computed from a tree depth or a measured
+     * column, which a static class cannot express. Demanding a class there
+     * would push people back to arbitrary values, which is the thing this file
+     * exists to stop.
+     *
+     * `0` is a reset rather than a measurement and is left alone.
+     */
+    const strays: string[] = [];
+    for (const { f, s } of FILES) {
+      for (const m of s.matchAll(/(padding|margin|gap)(?:Top|Bottom|Left|Right)?:\s*([0-9]+)(?![.0-9a-z%])/g)) {
+        const v = Number(m[2]);
+        if (v === 0 || v % 2 === 0) continue;
+        strays.push(`${f.replace(SRC, "web/src")}: ${m[0]} — odd pixels are off the 2px grid`);
+      }
+    }
+    expect(strays.join("\n") || null).toBeNull();
+  });
+
+  test("the scale is written down where the other design decisions are", () => {
+    // Colours, type and shadows are all declared in the Tailwind config with a
+    // reason. Spacing was the one that was not, which is how it drifted.
+    const cfg = readFileSync(join(import.meta.dir, "..", "tailwind.config.js"), "utf8");
+    expect(cfg).toContain("The spacing scale, written down");
+    // The rule that is about meaning rather than size, and the one that was
+    // actually broken in the Settings nav.
+    expect(cfg).toContain("GROUP HEADING");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Reported as "the spacing between elements follows no rule, things are stuck together and it looks ugly". I measured it rather than argued about it, and the measurement corrected the complaint in a useful direction — so the fix is different from, and smaller than, the one I first proposed.

**The rhythm was never the problem.** Across `web/src`: 3,714 spacing utilities, of which **97.8% already land on a 2px grid** — `0.5` `1` `1.5` `2` `2.5` `3` `3.5` `4` `5` `6` plus a few layout steps above. My earlier count of "159 distinct utilities" counted *names* (`px-2`, `py-2` and `mt-2` are three names and one step), which made the app look far more disordered than it is. Counting by step tells the true story.

Two things actually were wrong:

**Nothing declared it.** `tailwind.config.js` states the colour palette, the font stack and its fallback order, the shadows and the animations, each with a reason. Spacing was the one design decision never written down — which is exactly how a convention drifts without anybody noticing a step.

**Nothing stopped the exceptions.** Fifty arbitrary values sat off the grid on odd pixels (`py-[3px]`, `gap-[9px]`, `gap-[5px]`, `mt-[1px]`), plus three inline `paddingLeft: 3`s that no scale produces.

So: the scale is now declared beside the other design decisions with what each step is for, the off-grid values are mapped onto it, and `spacing-scale.test.ts` holds the app to it. An arbitrary value has to be exempt **by name, with a reason** — the same shape `deps-catalog.test.ts` uses. Five exemptions survive, all horizontal indents that align text under a specific glyph: the number there is a measurement of that thing, and rounding it would misalign the very column it exists to line up with.

Tailwind's own `spacing` is deliberately **not** narrowed. It feeds `w-`, `h-`, `top-` and `translate-`, so restricting it would break sizing that has nothing to do with this. The config states the scale; the test enforces it.

### The visible defects

Found by running the app and measuring the DOM, not by reading CSS:

- **The Settings nav gave a group heading exactly as much room above it as two ordinary items got between them** — 42px either side — so "Agents & work" read as belonging to the row above rather than to the rows below. That rule now sits in the config next to the scale, because it is about meaning rather than size: a heading hugs what it names.
- **That dialog's two halves had different left padding**, so the nav's text started at 18px under a title starting at 20px.
- **The pull-request panel's filter row used `px-3` under a header using the shared `px-5`**, putting two left edges 8px apart in one header.

## How was it tested?

- `bun run typecheck` clean in `web/`; `bunx vite build` clean.
- Web suite: 1,975 pass. The 4 failures are the sandbox's pre-existing `server-identity` port-binding tests, unrelated and identical on `main`.
- 4 new tests in `web/test/spacing-scale.test.ts`: no off-grid arbitrary values, no stale exemption, inline spacing still on the grid, and the scale is actually written down where the other design decisions live.
- **Verified visually against the running app.** I started the server on :4000 and drove headless Chromium over CDP — the same recipe `scripts/smoke.ts` and CI already use — screenshotting seven panels before and after. The group headings now separate; nothing else moved.

Two honest limits: the **Docker and Pull requests panels rendered empty** in this sandbox (no `gh`, no Docker daemon), so I could only judge their headers; and the inline-spacing rule enforces the *grid*, not "must be a class" — 26 even inline values survive on purpose, several computed from a tree depth or a measured column, which a static class cannot express. Demanding a class there would push people back to arbitrary values, which is the thing this file exists to stop.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP

---
_Generated by [Claude Code](https://claude.ai/code/session_013YzvQVCNKnCA9JeMnRorfP)_