### PR TITLE
fix(browser): the title bar was costing the page 48px to say nothing

### DIFF
--- a/web/src/components/BrowserPanel.tsx
+++ b/web/src/components/BrowserPanel.tsx
@@ -36,7 +36,6 @@ import { browserNav, clearBrowserNav, subscribeBrowserNav } from "../lib/browser
 import { clientId, serveBrowserAsk, setBrowserAskHandler } from "../lib/browserBus.ts";
 import { api } from "../lib/api.ts";
 import { type DrivableWebview } from "../lib/browserDrive.ts";
-import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import { PagePicker } from "./browser/PagePicker.tsx";
 import { MarkupLayer } from "./browser/MarkupLayer.tsx";
 import { DemoPage } from "./browser/DemoPage.tsx";
@@ -589,14 +588,21 @@ export function BrowserView(_props: { active: boolean }) {
 
   return (
     <div className="flex flex-col h-full min-h-0 outline-none" tabIndex={-1} onKeyDown={onKey}>
-      <div className={viewHeaderClass} style={viewHeaderStyle}>
-        <h2 className="sr-only">Browser</h2>
-        <span className="text-[10px] truncate min-w-0" style={{ color: "var(--text3)" }}>{active ? tabLabel(active) : ""}</span>
-        {note && (
-          <span className="ml-auto text-[10px] px-2 py-0.5 rounded shrink-0"
-            style={{ color: "var(--warning)", border: "1px solid color-mix(in srgb, var(--warning) 35%, transparent)" }}>{note}</span>
-        )}
-      </div>
+      {/*
+       * No view header here, and this is the only view without one.
+       *
+       * Every other panel spends those 48px on controls. This one had nothing
+       * to put in them: the page's own title, which the tab strip two rows
+       * below was already showing, and a message that appears for three
+       * seconds a few times a day. A browser is the one view whose content is
+       * a whole other application's chrome — an address bar, a tab strip and
+       * a title above them is a third bar of ours before the page gets a
+       * pixel, and the page is what you came for.
+       *
+       * The heading stays for screen readers, which have no rail to read the
+       * view's name from (see ViewHeader).
+       */}
+      <h2 className="sr-only">Browser</h2>
 
       {/* The strip is always there, even with one page: a tab bar that appears
           on the second tab shoves everything below it down, and the `+` is how
@@ -964,6 +970,20 @@ export function BrowserView(_props: { active: boolean }) {
       )}
 
       <div className="flex-1 min-h-0 relative" style={{ background: "var(--bg2)" }}>
+        {/*
+         * What just happened, over the page rather than above it.
+         *
+         * This lived in the header, which is why the header lived: three
+         * seconds of "told the agent about it" was holding a permanent row
+         * open. Floating it costs the page nothing when there is nothing to
+         * say, and a guest page cannot be drawn over by a sibling, so it sits
+         * on the container rather than inside the tab that owns the webview.
+         */}
+        {note && (
+          <div className="agx-zoom-in absolute bottom-3 right-3 text-[10px] px-2.5 py-1.5 rounded-md shadow-lg pointer-events-none"
+            style={{ zIndex: 20, color: "var(--warning)", background: "var(--bg2)",
+              border: "1px solid color-mix(in srgb, var(--warning) 35%, transparent)" }}>{note}</div>
+        )}
         {tabs.map((t) => (
           /*
            * The inactive tabs are hidden; the active one says NOTHING.


### PR DESCRIPTION
## What does this PR do?

Removes the browser view's header row, and gives the 48px to the page.

The row held two things. The first was the page's title, which the tab strip two rows below it was already showing, in a strip that is always there even with one tab. The second was `note` — a message that appears for about three seconds when you point at an element, tell an agent about it, or draw on the page. So a permanent row was being held open by a duplicate and by something that is not on screen almost all of the time.

A browser is the one view whose content is another application's chrome. The user's window already carries the app's title bar, our rail, a tab strip and an address bar before this view draws anything of the site; a fifth bar above them, to caption a page that captions itself, is the one that should go. Every other view spends its header on controls that scope it (a repo picker, an engine chip); this one had none to put there, and the header comment in `ViewHeader.tsx` already argues the same point about the view's name — three statements of one fact, and the widest of them sitting where controls want to be.

The heading itself stays, `sr-only`. A screen reader has no rail to read the view's name from, and it keeps the view in the document outline the rail navigates.

The message moves onto the page instead: a floating card, bottom right, over the guest rather than above it. It costs nothing when there is nothing to say. It sits on the container that holds the webviews rather than inside the active tab's wrapper, because a sibling of a guest page cannot be drawn over one — the same reason the empty-state card lives there.

## How was it tested?

`tsc --noEmit` clean for both of `web/`'s configs, including after dropping the now-unused `ViewHeader` import.

`bun test` in `web/`: 1975 pass. The 4 failures in `server-identity.test.ts` fail identically on `main` — an order-dependent interaction between test files that shows up when the suite runs as one process and disappears when that file runs alone.

Installed as a desktop build from this branch and opened on a real page: the header is gone, the address bar is now the top of the view, and the page starts directly under the toolbar. Nothing else in the view moved — the tab strip, the profile control and the viewport picker are where they were.

Not exercised by a test: the floating message. It is three seconds of state driven by `setTimeout` in a view built around Electron `<webview>` elements, which the suite has no way to mount.
