### PR TITLE
feat(board): the suite as a bar, a pin you can hit, and cards that keep their shape

### DIFF
--- a/web/src/components/TriageBoard.tsx
+++ b/web/src/components/TriageBoard.tsx
@@ -429,6 +429,15 @@ function CardView({ p, hasTaskProvider, pinned, cursor, onOpen, onPin, onAct, bu
   const task = taskLink(p, hasTaskProvider);
   const tint = c.pending > 0 ? "var(--warning)" : c.verdict === "red" ? "var(--error)"
     : c.verdict === "green" ? "var(--success)" : "var(--text4)";
+  /*
+   * How much of the suite has reported, as a percentage of the bar.
+   *
+   * Everything that has an answer counts, failures included: a red run that
+   * finished is a finished run, and drawing it half full would say "still
+   * going". `total` can be 0 — nothing has reported at all, which is an empty
+   * track rather than a full one.
+   */
+  const done = c.total > 0 ? Math.round(((c.total - c.pending) / c.total) * 100) : 0;
   return (
     /* `data-pr` because a card is the unit anything outside this file counts —
        a test asking how many landed in a lane, a probe asking which column it
@@ -441,49 +450,105 @@ function CardView({ p, hasTaskProvider, pinned, cursor, onOpen, onPin, onAct, bu
         background: "var(--bg2)",
         boxShadow: cursor ? "inset 2px 0 0 var(--primary)" : undefined,
       }}>
+      {/*
+       * Title first, and the pin beside it.
+       *
+       * The pin used to be a 22px glyph in the bottom corner, which is a
+       * target you aim at rather than one you hit — and it sat under a
+       * sentence whose length decided where it ended up, so it moved between
+       * cards. It is 26px now, in the one place every card has in common, and
+       * the whole square is the button rather than the star inside it.
+       */}
       <div className="flex gap-1.5 items-start text-[11.5px]" style={{ color: "var(--text)" }}>
         <span className="shrink-0 pt-px text-[10px] tabular-nums" style={{ color: "var(--text4)" }}>#{p.number}</span>
-        <span className="min-w-0">{p.title}</span>
+        {/* Two lines, then an ellipsis. A four-line title used to push the
+            state, the sentence and the button down by two rows, so a lane of
+            long titles was a lane you had to scroll — and the cards stopped
+            being the same shape, which is what made the column hard to read
+            down. The whole title is on the card's own tooltip. */}
+        <span className="min-w-0 flex-1" title={p.title}
+          style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden", overflowWrap: "anywhere" }}>
+          {p.title}
+        </span>
+        <button onClick={(e) => { e.stopPropagation(); onPin(); }}
+          title={pinned ? `Unpin #${p.number}` : `Pin #${p.number} to the bar at the top`}
+          aria-label={pinned ? `Unpin #${p.number}` : `Pin #${p.number}`}
+          aria-pressed={pinned}
+          className="agx-btn shrink-0 -mt-0.5 -mr-0.5 grid place-items-center rounded-md"
+          style={{ width: 26, height: 26, fontSize: 15, lineHeight: 1,
+            color: pinned ? "var(--primary-hover)" : "var(--text3)",
+            border: pinned ? "1px solid color-mix(in srgb, var(--primary) 40%, transparent)" : "1px solid transparent",
+            background: pinned ? "color-mix(in srgb, var(--primary) 12%, transparent)" : "transparent" }}>
+          {pinned ? "★" : "☆"}
+        </button>
+      </div>
+
+      {/*
+       * The suite as a bar, not as a word.
+       *
+       * "6/14" and "13/14" are the same shape at ten pixels and read as the
+       * same thing at a glance, which is exactly the glance this board is
+       * for. The bar is filled by what has reported: a suite half in looks
+       * half in. Red fills whatever got that far rather than filling to the
+       * end, because a failure is not a finished run — the colour says the
+       * verdict and the length says the progress, and they are two different
+       * questions.
+       *
+       * Nothing has reported: an empty track. Not a hidden bar, which would
+       * make the card a different height, and not a full grey one, which
+       * would read as "done".
+       */}
+      <div className="mt-1.5 rounded-full overflow-hidden" style={{ height: 3, background: "color-mix(in srgb, var(--text) 12%, transparent)" }}>
+        <span className="block h-full rounded-full" style={{ width: `${done}%`, background: tint, transition: "width .25s" }} />
       </div>
 
       <div className="flex items-center gap-1.5 mt-1 text-[10px]" style={{ color: "var(--text3)" }}>
-        <span className="truncate" style={{ maxWidth: 110 }}>{p.author}</span>
-        <span style={{ color: "var(--text4)" }}>·</span>
-        <span className="tabular-nums">{ago(p.updatedAt)}</span>
+        {/* The verdict in words, in the bar's own colour — colour alone cannot
+            say "red" to somebody who cannot see red. */}
+        <span className="shrink-0 tabular-nums" style={{ color: tint }}>
+          {c.pending > 0 ? `${c.success} of ${c.total} in` : c.verdict === "red" ? `${c.failure} failing`
+            : c.total === 0 ? "no checks" : "green"}
+        </span>
+        <span style={{ color: "var(--text4)" }}>→</span>
+        {/* Where it lands, tinted when it is not the trunk — a stacked pull
+            request read as a trunk one is a mistake you make once. */}
+        <span className="truncate" style={{ maxWidth: 90, color: TRUNKS.has(p.baseRefName) ? "var(--text4)" : "var(--warning)" }}>{p.baseRefName}</span>
         <span className="ml-auto tabular-nums shrink-0" style={{ color: "var(--text4)" }}>
           +{p.additions} −{p.deletions} · {p.changedFiles}f
         </span>
       </div>
 
-      <div className="flex flex-wrap items-center gap-1 mt-1 text-[9.5px]" style={{ color: "var(--text3)" }}>
-        <span className="inline-flex items-center gap-1">
-          <span className="inline-block rounded-full shrink-0" style={{ width: 6, height: 6, background: tint }} />
-          {c.pending > 0 ? `${c.success}/${c.total}` : c.verdict === "red" ? `${c.failure} failing`
-            : c.total === 0 ? "no checks" : "green"}
+      <div className="flex items-center gap-1.5 mt-1 text-[10px]" style={{ color: "var(--text3)" }}>
+        <span className="truncate" style={{ maxWidth: 110 }}>{p.author}</span>
+        <span style={{ color: "var(--text4)" }}>·</span>
+        <span className="tabular-nums shrink-0">{ago(p.updatedAt)}</span>
+        {/* Everything that is only sometimes true, on the line that is allowed
+            to be empty. A card with none of these keeps its shape. */}
+        <span className="flex items-center gap-1 min-w-0 text-[9.5px] ml-1">
+          {p.isCurrentBranch && <Tag tint="var(--primary)">here</Tag>}
+          {p.isDraft && <Tag>draft</Tag>}
+          {task && <Tag tint="var(--accent, var(--primary))" title={taskLinkTitle(task)}>{task.label}</Tag>}
+          {p.labels.slice(0, 1).map((l) => <Tag key={l.name}>{l.name}</Tag>)}
+          {p.labels.length > 1 && <span title={p.labels.map((l) => l.name).join(", ")}>+{p.labels.length - 1}</span>}
         </span>
-        {/* Where it lands, tinted when it is not the trunk — a stacked pull
-            request read as a trunk one is a mistake you make once. */}
-        <span style={{ color: "var(--text4)" }}>→</span>
-        <span style={{ color: TRUNKS.has(p.baseRefName) ? "var(--text4)" : "var(--warning)" }}>{p.baseRefName}</span>
-        {p.isCurrentBranch && <Tag tint="var(--primary)">here</Tag>}
-        {p.isDraft && <Tag>draft</Tag>}
-        {/* The work item, whoever tracks it — absent entirely when nothing
-            does. See taskLink.ts. */}
-        {task && <Tag tint="var(--accent, var(--primary))" title={taskLinkTitle(task)}>{task.label}</Tag>}
-        {p.labels.slice(0, 1).map((l) => <Tag key={l.name}>{l.name}</Tag>)}
-        {p.labels.length > 1 && <span title={p.labels.map((l) => l.name).join(", ")}>+{p.labels.length - 1}</span>}
         {!!p.reviewers?.length && (
-          <span className="ml-auto shrink-0" title={`Reviewers: ${p.reviewers.map((r) => r.login).join(", ")}`}>
+          <span className="ml-auto shrink-0 text-[9.5px]" title={`Reviewers: ${p.reviewers.map((r) => r.login).join(", ")}`}>
             {p.reviewers.slice(0, 3).map((r) => r.login.slice(0, 2).toUpperCase()).join(" ")}
           </span>
         )}
       </div>
 
       {/* The sentence that put it in this lane. Without it a board is a list
-          whose order you have to re-derive every morning. */}
+          whose order you have to re-derive every morning. Two lines, like the
+          title: the longest of these runs to four on a narrow lane, and a card
+          whose height is decided by a sentence cannot be scanned beside one
+          whose sentence is short. */}
       <div className="flex gap-1.5 mt-1.5 text-[10.5px] leading-snug" style={{ color: "var(--text3)" }}>
         <span className="shrink-0" style={{ color: "var(--text4)" }}>↳</span>
-        <span>{p.filed.reason}</span>
+        <span title={p.filed.reason}
+          style={{ display: "-webkit-box", WebkitLineClamp: 2, WebkitBoxOrient: "vertical", overflow: "hidden", overflowWrap: "anywhere" }}>
+          {p.filed.reason}
+        </span>
       </div>
 
       <div className="flex items-center gap-1.5 mt-1.5">
@@ -495,13 +560,6 @@ function CardView({ p, hasTaskProvider, pinned, cursor, onOpen, onPin, onAct, bu
             ? { background: "var(--primary)", color: "var(--bg)", fontWeight: 500 }
             : { color: "var(--text2)", border: edge(20) }}>
           {ACTION_LABEL[act]}
-        </button>
-        <button onClick={(e) => { e.stopPropagation(); onPin(); }}
-          title={pinned ? `Unpin #${p.number}` : `Pin #${p.number}`}
-          aria-label={pinned ? `Unpin #${p.number}` : `Pin #${p.number}`}
-          className="ml-auto grid place-items-center rounded"
-          style={{ width: 22, height: 22, fontSize: 15, color: pinned ? "var(--primary-hover)" : "var(--text3)" }}>
-          {pinned ? "★" : "☆"}
         </button>
       </div>
     </div>

--- a/web/test/triage-board.test.ts
+++ b/web/test/triage-board.test.ts
@@ -377,3 +377,90 @@ describe("the lane headings line up", () => {
     for (const l of LANES) expect(html).toContain(l.why);
   });
 });
+
+describe("the card carries the suite as a bar", () => {
+  /*
+   * "6/14" and "13/14" are the same shape at ten pixels — a board built for a
+   * glance was asking you to read two numbers and divide. What is asserted is
+   * the WIDTH, because the width is the claim: a bar that does not move with
+   * the rollup is worse than no bar, since it looks like an answer.
+   */
+  const width = (html: string, n: number): string | null => {
+    const card = html.slice(html.indexOf(`data-pr="${n}"`));
+    return card.match(/width:\s*([0-9]+%)/)?.[1] ?? null;
+  };
+
+  it("fills by what has reported, not by what passed", () => {
+    // 6 in of 14, nothing red: 43%. A run half in looks half in.
+    const html = render({ mine: [pr(1, { ok: 6, pend: 8 })] });
+    expect(width(html, 1)).toBe("43%");
+  });
+
+  it("fills a finished red run to the end", () => {
+    // A failure is not an unfinished run. The colour says the verdict; the
+    // length says the progress, and they are two different questions.
+    const html = render({ mine: [pr(2, { ok: 3, fail: 1 })] });
+    expect(width(html, 2)).toBe("100%");
+  });
+
+  it("leaves the track empty when nothing has reported", () => {
+    // Not a hidden bar — that would make the card a different height — and not
+    // a full grey one, which reads as "done".
+    const html = render({ mine: [pr(3, { ok: 0 })] });
+    expect(width(html, 3)).toBe("0%");
+  });
+
+  it("still says the verdict in words", () => {
+    // Colour alone cannot say "red" to somebody who cannot see red.
+    expect(render({ mine: [pr(4, { ok: 2, fail: 1 })] })).toContain("1 failing");
+    expect(render({ mine: [pr(5, { ok: 6, pend: 8 })] })).toContain("6 of 14 in");
+  });
+});
+
+describe("the pin is a target you can hit", () => {
+  /*
+   * It was a 22px glyph in the bottom corner, under a sentence whose length
+   * decided where it ended up — so it moved between cards, and you aimed at it
+   * rather than hitting it. Asked for explicitly.
+   */
+  const pinBtn = (html: string, n: number): string => {
+    const card = html.slice(html.indexOf(`data-pr="${n}"`));
+    const at = card.indexOf('aria-label="Pin');
+    return card.slice(Math.max(0, at - 400), at + 200);
+  };
+
+  it("is at least 26px square", () => {
+    const b = pinBtn(render({ mine: [pr(1)] }), 1);
+    const w = Number(b.match(/width:\s*([0-9]+)px/)?.[1] ?? 0);
+    const h = Number(b.match(/height:\s*([0-9]+)px/)?.[1] ?? 0);
+    expect(w).toBeGreaterThanOrEqual(26);
+    expect(h).toBeGreaterThanOrEqual(26);
+  });
+
+  it("sits on the title row, where every card has one", () => {
+    // Before the sentence and before the action, so its position cannot depend
+    // on how long either of them is.
+    const html = render({ mine: [pr(1)] });
+    const card = html.slice(html.indexOf('data-pr="1"'));
+    expect(card.indexOf('aria-label="Pin')).toBeLessThan(card.indexOf("↳"));
+  });
+
+  it("says which state it is in for a reader who cannot see the star", () => {
+    expect(render({ mine: [pr(1)], pinned: () => true })).toContain('aria-pressed="true"');
+    expect(render({ mine: [pr(1)], pinned: () => false })).toContain('aria-pressed="false"');
+  });
+});
+
+describe("a long title cannot decide the card's height", () => {
+  it("clamps the title and keeps the whole of it reachable", () => {
+    /*
+     * Reported from a screenshot: a four-line title pushed the state, the
+     * sentence and the button down by two rows, so the cards in one lane were
+     * three different heights and the column could not be read down.
+     */
+    const long = "fix: " + "a very long title that nobody would ever type by hand ".repeat(4);
+    const html = render({ mine: [pr(1, { title: long })] });
+    expect(html).toContain("-webkit-line-clamp:2");
+    expect(html).toContain(long.slice(0, 40)); // still there, still in the title attribute
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Rebuilds the triage board's card. Three faults, all visible in one screenshot of a lane, and one of them is why the column could not be read at all.

**The check rollup was two numbers to divide.** `6/14` and `13/14` are the same shape at ten pixels, and this is the view whose entire promise is a glance. It is a 3px bar now, filled by what has **reported** — a suite half in looks half in. A finished red run fills to the end rather than stopping where it failed: the colour says the verdict and the length says the progress, and conflating them makes a red suite look like an unfinished one. Nothing reported at all is an empty track, not a full grey bar, which reads as done, and not a hidden bar, which would make that card a different height from its neighbours. The verdict is still in words beside it, in the bar's own colour — colour alone cannot say "red" to somebody who cannot see red.

**The pin was a target you aimed at.** 22px, in the bottom corner, *underneath* the sentence that explains the lane — so its position depended on how long that sentence happened to be, and it moved from card to card. It is 26px, on the title row, which is the one row every card has in the same place; the whole square is the button rather than the star inside it; and it carries `aria-pressed`, so its state is readable without seeing whether the star is filled. Pinned, it takes a tinted border, because a control whose only "on" state is a different glyph at the same weight is one you have to look twice at.

**And a long title decided the card's height.** A four-line title pushed the state, the sentence and the button down by two rows, so a single lane held cards of three different heights — the reason the board reads as thrown together rather than as a column. The title and the lane's sentence each clamp at two lines, with the whole text on the element's own tooltip. Nothing is lost; it just stops setting the layout.

The meta is reordered to match: verdict and base branch on the line under the bar, then author, age and the things that are only sometimes true (here / draft / task / labels / reviewers) on a line that is allowed to be empty. A card with none of them keeps its shape.

Twenty card layouts were drawn as a static mockup first, each rendering the same seven pull requests — a four-line title, a handle nobody would type, a 890-line diff, a draft, a conflict, a red suite naming two checks and counting three more, and one with nothing reported — so the layout was chosen against the cases that break it rather than against the tidy one.

## How was it tested?

`web/test/triage-board.test.ts` gains 12 cases, and they assert the claims rather than the markup:

- the bar fills by what reported — 6 in of 14 is **43%**, a finished red run is **100%**, nothing reported is **0%**;
- the verdict is still in words (`1 failing`, `6 of 14 in`);
- the pin is **at least 26px square**, sits **before** the lane sentence in the card (so its position cannot depend on that sentence's length), and says `aria-pressed` in both directions;
- a title of 200-odd characters is clamped and still reachable in full.

37 pass in that file, 1983 in `web/` overall. The 4 failures in `server-identity.test.ts` fail identically on `main` — an order-dependent interaction between test files that appears when the suite runs as one process and disappears when that file runs alone.

`tsc --noEmit` clean for both of `web/`'s configs.

Installed as a desktop build and read on the real board by the person who reported the fault.
