### PR TITLE
feat(tmux): reopen the session you left, instead of asking you to attach it

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -102,6 +102,7 @@ import { generateWalkthrough, WALKTHROUGH_ENABLED } from "./walkthrough.ts";
 import { ptyOpen, ptyMessage, ptyClose, projectCommands, shutdownTerminals, lastTmuxTarget, sessionTitle, TERMINAL_ENABLED, PTY_BACKEND, type PtyWsData } from "./terminal.ts";
 import { mintAgentTicket } from "./agentticket.ts";
 import { listPanes, focusPaneAnywhere, activePane, sweepPinnedWindows, pinnedSockets } from "./tmuxctl.ts";
+import { repairLast, snapshot } from "./tmuxsnapshot.ts";
 import { withAgentSessions } from "./paneloc.ts";
 import { notePaneFromHook, paneDirs, paneAgentNote } from "./panewt.ts";
 import { chatSend, activeTurns, CHAT_ENABLED, CHAT_BYPASS_ALLOWED, CHAT_ENGINE_DEFAULT } from "./chat.ts";
@@ -3433,6 +3434,33 @@ for (const sig of ["SIGINT", "SIGTERM"] as const) {
  */
 const unpinned = sweepPinnedWindows(pinnedSockets());
 if (unpinned) console.log(`🪟 tmux: ${unpinned} window(s) released — a previous run was killed before it could put window-size back`);
+
+/*
+ * Keep a copy of the user's last good resurrect save, and put `last` back if a
+ * dying server's save has landed on top of it.
+ *
+ * Measured on a real machine, and it cost a working session: a save fired while
+ * tmux was being killed, wrote a file with one pane in it, and `last` moved to
+ * that — leaving a nine-pane save from ten minutes earlier on disk and
+ * unreachable by anything that restores. resurrect has no notion of "poorer",
+ * and racing continuum's timer would be two savers on one server, which is its
+ * own way to lose sessions. So: copy, and repair the pointer THEIR restore
+ * reads. See tmuxsnapshot.ts for what it will and will not touch.
+ *
+ * At boot and then every few minutes. A tick that finds the same save does
+ * nothing at all, which is nearly every tick.
+ */
+const SNAPSHOT_TICK_MS = 4 * 60 * 1000;
+function guardResurrect(): void {
+  const put = repairLast();
+  if (put) {
+    console.log(`💾 tmux: restored resurrect's "last" to ${put.restored} — a save from a dying server had replaced it (the poor one is kept as last.clobbered)`);
+  }
+  const took = snapshot();
+  if (took) console.log(`💾 tmux: kept a copy of ${took.split("/").pop()}`);
+}
+guardResurrect();
+setInterval(guardResurrect, SNAPSHOT_TICK_MS).unref?.();
 
 // Parent-death watchdog: a server must never outlive whoever launched it.
 //

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -405,6 +405,7 @@ function killGroup(s: Session, sigNum: number) {
 
 import { findTmuxBelow } from "./procchildren.ts";
 import { recall, remember } from "./tmuxmemory.ts";
+import { deskAttachArgv } from "./tmuxctl.ts";
 import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, remountPhoneClient, isPhoneSession, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";
 import { prepareReviewPrompt } from "./prs.ts";
@@ -641,10 +642,33 @@ export function ptyOpen(ws: PtyWs) {
    */
   const startIn = ticket && inScope(ticket.cwd) && existsSync(ticket.cwd) ? ticket.cwd : cwd;
 
+  /*
+   * A plain terminal, opened where you left it.
+   *
+   * The panel's client is normally the only client on its tmux server, so
+   * closing agentglass detaches the session — and opening it again started a
+   * BARE SHELL, so the work was still running and simply not on screen. The
+   * way back was `tmux attach -t <name>` typed into that new shell, every
+   * time, which is the complaint this answers.
+   *
+   * Last on purpose, so it can only ever replace the bare shell: a tap on a
+   * specific pane, an agent ticket and the file viewer all still win, because
+   * each of those is somebody asking for a particular thing. This is the case
+   * where nobody asked for anything, and "the session you were in" is a better
+   * answer to that than "a fresh prompt".
+   *
+   * `deskAttachArgv` returns null unless that session is still live on that
+   * socket, so a machine rebooted since — or a session killed — falls through
+   * to the shell exactly as before. See tmuxmemory.ts.
+   */
+  const resume = (!attach && !agentRun.length && !editor && !d.pane)
+    ? (() => { const seen = recall(); return seen ? deskAttachArgv(seen.socket, seen.session) : null; })()
+    : null;
+
   const run = attach
     ? attach.argv
     : agentRun.length ? agentRun
-    : editor ? [...editor.split(/\s+/), ...readonlyFlags, wanted!] : [shell, ...args];
+    : editor ? [...editor.split(/\s+/), ...readonlyFlags, wanted!] : resume ?? [shell, ...args];
 
   let argv: string[];
   let mode: Session["mode"] = "pty";

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -339,7 +339,44 @@ const owed = new Set<PhoneAttach>();
  * not know which of the machine's tmux servers is the user's.
  */
 let lastTarget: TmuxTarget | null = null;
-export const lastTmuxTarget = (): TmuxTarget | null => lastTarget;
+
+/**
+ * Seeded from disk, so the answer survives a restart.
+ *
+ * "Null until a terminal has been opened once this run" was honest and it was
+ * also the whole of the complaint: close the app, reopen it, and the session
+ * you were in is not on offer — the panel's client was the only one on that
+ * server, so closing detached it, and a detached server is one `listPanes`
+ * skips. You had to attach from a terminal outside the app to be shown your
+ * own session back.
+ *
+ * A remembered socket is not a live client and is not pretended to be one: the
+ * pid is 0, the id is empty, and nothing that needs a client will accept it.
+ * What it does carry is the socket, which is the durable half and the only part
+ * anybody asks a stale target for.
+ */
+export const lastTmuxTarget = (): TmuxTarget | null => {
+  if (lastTarget) return lastTarget;
+  const seen = recall();
+  return seen ? { pid: 0, socket: ["-S", seen.socket], session: seen.session, id: "" } : null;
+};
+
+/**
+ * Write it down, when it has changed.
+ *
+ * `readFrame` runs on a poll, so this is reached constantly; the guard is what
+ * keeps that from being a write per tick. `socketPath` resolves `-L work` and
+ * the path it means to one spelling — the stored value has to be comparable
+ * with what discovery finds, and only the path is.
+ */
+let remembered = "";
+function rememberTarget(t: TmuxTarget): void {
+  const path = socketPath(t.socket);
+  const key = `${path}\u0000${t.session}`;
+  if (!path || key === remembered) return;
+  remembered = key;
+  remember(path, t.session);
+}
 
 const clampCols = (v: unknown) => Math.min(500, Math.max(20, Math.floor(Number(v)) || 0));
 const clampRows = (v: unknown) => Math.min(300, Math.max(5, Math.floor(Number(v)) || 0));
@@ -367,6 +404,7 @@ function killGroup(s: Session, sigNum: number) {
 }
 
 import { findTmuxBelow } from "./procchildren.ts";
+import { recall, remember } from "./tmuxmemory.ts";
 import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, remountPhoneClient, isPhoneSession, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";
 import { prepareReviewPrompt } from "./prs.ts";
@@ -729,6 +767,9 @@ export function ptyOpen(ws: PtyWs) {
     const frame = session.tmuxClient ? readFrame(session.tmuxClient) : null;
     if (frame) {
       lastTarget = frame.target;
+      // And on disk, so the next run knows where you were. Cheap enough to do
+      // on every frame: it is one small write and only when the target changed.
+      rememberTarget(frame.target);
       if (frame.target.id !== session.tmux?.id) followSession(frame.target);
       else session.tmux = frame.target; // a rename keeps the id and changes the name
       /*

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -370,10 +370,28 @@ export const lastTmuxTarget = (): TmuxTarget | null => {
  * with what discovery finds, and only the path is.
  */
 let remembered = "";
-function rememberTarget(t: TmuxTarget): void {
+let settling = "";
+let settlingSince = 0;
+function rememberTarget(t: TmuxTarget, now = Date.now()): void {
   const path = socketPath(t.socket);
+  if (!path) return;
+  /*
+   * A phone's mirror is a session this app made, not a place the user works.
+   * Remembering one would bring back an empty grouped session on the next cold
+   * start, named after a device that is not here.
+   */
+  if (isPhoneSession(t.session)) return;
+
   const key = `${path}\u0000${t.session}`;
-  if (!path || key === remembered) return;
+  /*
+   * Only once the panel has SETTLED here. tmux moves a client through sessions
+   * on its way past — after a restore it put this one on `docker` for a moment
+   * — and the last one touched is not the one the day was spent in. See
+   * SETTLE_MS.
+   */
+  if (key !== settling) { settling = key; settlingSince = now; return; }
+  if (now - settlingSince < SETTLE_MS) return;
+  if (key === remembered) return;
   remembered = key;
   remember(path, t.session);
 }
@@ -404,7 +422,7 @@ function killGroup(s: Session, sigNum: number) {
 }
 
 import { findTmuxBelow } from "./procchildren.ts";
-import { recall, remember } from "./tmuxmemory.ts";
+import { recall, remember, SETTLE_MS } from "./tmuxmemory.ts";
 import { deskAttachArgv } from "./tmuxctl.ts";
 import { resolveClient, readFrame, runAction, setStatusLine, releaseStale, clearAsk, prefixKeys, newWindowRunning, paneCwd, selectPane, attachArgvFor, restoreWindows, endPhoneSession, phoneWindows, fitWindow, reclaimPinnedWindow, windowSize, socketPath, scrollPhonePane, leaveCopyMode, remountPhoneClient, isPhoneSession, type TmuxClient, type TmuxTarget, type TmuxAction } from "./tmuxctl.ts";
 import { paneFinished, markSeen } from "./agentdone.ts";

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2407,12 +2407,13 @@ export function deskAttachArgv(socketPath: string, session: string): string[] | 
    *   - `tmux` with no arguments starts the server and attaches you to the
    *     session IT just made. A resurrect/continuum setup then restores your
    *     real sessions behind you, and you are sitting in `0` watching none of
-   *     them. Reported exactly that way: "las tabs no son ni las de alavera".
+   *     them. Reported exactly that way: the tabs on screen were not the
+   *     ones that session had.
    *   - `start-server` is not a way to wait for the restore either: a server
    *     with no sessions exits immediately, so it leaves nothing behind at all.
    *   - `-A` means attach-or-create, so the same command covers a live server
-   *     that already has it. The name is exact — `-s alav` makes a session
-   *     called `alav` beside `alavera` rather than matching it.
+   *     that already has it. The name is exact — `-s work` makes a session
+   *     called `work` beside `workbench` rather than matching it.
    *
    * What makes it land where it should is that creating the session STARTS the
    * server, which sources their configuration, which is what fires continuum's

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -24,6 +24,7 @@ import { dirname, join, normalize } from "node:path";
 import type { TmuxWindow, TmuxPane, AgentPane } from "../../shared/types.ts";
 import { parsePanes, PANE_FORMAT } from "./paneloc.ts";
 import { findTmuxBelow } from "./procchildren.ts";
+import { recall } from "./tmuxmemory.ts";
 
 /** How long a tmux call may take before we give up on it. Generous for a local
  *  socket, and short enough that a wedged tmux server cannot stall the poll. */
@@ -1573,15 +1574,32 @@ export type PaneWireRow = Omit<AgentPane, "agentSession"> & { socket: string[] }
 
 export function listPanes(known?: string[]): PaneWireRow[] {
   const rows: PaneWireRow[] = [];
+  /* The server we were last on, read once rather than per socket. Null when
+     nothing is remembered, which is exactly how this behaved before. */
+  const ours = recall()?.socket ?? null;
   for (const socket of tmuxSockets(known)) {
-    // Only servers somebody is attached to. "Take me there" means nothing on a
-    // server nobody is looking at, and skipping them is not a nicety: this
-    // project's own test suite leaves a tmux server behind on a stray socket,
-    // and a resurrect/continuum config then restores the user's real sessions
-    // into it — so an unattached server can be a convincing duplicate of the
-    // one you actually work in, with different pane ids. Offering those was
-    // offering to move a window nobody would see move.
-    if (!tmux(socket, ["list-clients", "-F", "#{client_tty}"])?.trim()) continue;
+    /*
+     * Servers somebody is attached to — or the one we ourselves were last on.
+     *
+     * The filter is doing a real job and keeps it: this project's own test
+     * suite leaves a tmux server behind on a stray socket, and a
+     * resurrect/continuum config then restores the user's real sessions into
+     * it, so an unattached server CAN be a convincing duplicate of the one you
+     * work in, with different pane ids. Offering those was offering to move a
+     * window nobody would see move.
+     *
+     * But agentglass's own panel is usually the only client on the server it
+     * shows, so closing the app detaches that session — and this line then hid
+     * the session the app had just put down. Reported as having to run
+     * `tmux attach -t <name>` in a terminal outside the app after every
+     * restart, to be shown your own work again.
+     *
+     * A socket this app was demonstrably attached to is not a stray, whatever
+     * the client count says now, and it is the ONE detached server that gets
+     * through. Everything else is unchanged. See tmuxmemory.ts.
+     */
+    const mine = ours !== null && socketPath(socket) === ours;
+    if (!mine && !tmux(socket, ["list-clients", "-F", "#{client_tty}"])?.trim()) continue;
     const out = tmux(socket, ["list-panes", "-a", "-F", PANE_FORMAT]);
     if (!out) continue;
     const nested = nestedSessions(socket);

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2394,6 +2394,25 @@ function unzoomWindow(socket: string[], sessionId: string, windowId: string, onl
  */
 export function deskAttachArgv(socketPath: string, session: string): string[] | null {
   if (!socketPath) return null;
+  /*
+   * No tmux on this machine, so there is no command to build.
+   *
+   * Everything below reads "no server answered" as "the machine has just been
+   * turned on" and offers to start one — and a missing BINARY answers exactly
+   * the same way, because both make `tmux()` return null. Without this the
+   * panel would open on `tmux: command not found` instead of on a shell.
+   *
+   * Only reachable for somebody who had tmux when the memory was written and
+   * does not now, which is narrow and is still a broken terminal. Same check
+   * `tmuxpane.ts` already makes before it offers a pane.
+   *
+   * The PATH is passed explicitly because `Bun.which()` SNAPSHOTS it —
+   * measured on 1.3.9, changing `process.env.PATH` afterwards does not change
+   * its answer, while the `{ PATH }` option does. So the bare call answers
+   * about the environment this process started in rather than the one it is
+   * in, and cannot be asked about a machine without tmux at all.
+   */
+  if (!Bun.which("tmux", { PATH: process.env.PATH ?? "" })) return null;
   const socket = ["-S", socketPath];
   const out = tmux(socket, ["list-sessions", "-F", "#{session_id}\t#{session_name}"]);
 

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2375,6 +2375,38 @@ function unzoomWindow(socket: string[], sessionId: string, windowId: string, onl
   return tmux(socket, ["resize-pane", "-Z", "-t", target]) !== null;
 }
 
+/**
+ * The command that puts the desk back where it was: a plain `tmux attach`.
+ *
+ * Deliberately NOT `attachArgvFor`. That one is the phone's: it makes a grouped
+ * session of its own so two screens can look at one window at different sizes,
+ * and it marks `window-size` so the desk's width can be handed back. The desk
+ * is the session — it wants the real one, at its own size, with no group and
+ * nothing owed on the way out. What the user was typing by hand is exactly
+ * this, and this is what they should stop having to type.
+ *
+ * Resolved to a session ID before it is run. A name is matched by PREFIX
+ * unless you fight the syntax, so attaching to a remembered `work` could land
+ * you in `workbench` — silently, and in somebody else's windows. `$3` is
+ * unambiguous. Null when the session is not there any more, which is the whole
+ * check: a socket path is reused across boots, so "remembered" is a lead and
+ * the live list is the answer.
+ */
+export function deskAttachArgv(socketPath: string, session: string): string[] | null {
+  if (!socketPath || !session) return null;
+  const socket = ["-S", socketPath];
+  const out = tmux(socket, ["list-sessions", "-F", "#{session_id}\t#{session_name}"]);
+  if (!out) return null;
+  for (const line of out.split("\n")) {
+    const [id, name] = line.split("\t");
+    // Exact, not a prefix, and the id has to be one before it is passed on.
+    if (name === session && id && SESSION_ID.test(id)) {
+      return ["tmux", ...socket, "attach-session", "-t", id];
+    }
+  }
+  return null;
+}
+
 export function attachArgvFor(
   known: string[] | undefined,
   paneId: string,

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2401,18 +2401,33 @@ export function deskAttachArgv(socketPath: string, session: string): string[] | 
    * Nothing answered: there is no server on that socket at all, which is what
    * a machine looks like after it has been turned on.
    *
-   * The answer is `tmux` with no arguments, and that is not a shortcut — it is
-   * precisely what the user does by hand, and the ONLY thing that works then:
-   * there is no session to attach to yet. Starting the server is what fires
-   * whatever their configuration does on start, so a resurrect/continuum setup
-   * restores their last session by itself. We restore nothing and install
-   * nothing; we start the server the same way they would and get out of the
-   * way.
+   * `new-session -A -s <name>`, and every word of it was measured on tmux 3.7
+   * because the obvious spellings are wrong:
    *
-   * A socket has to have been remembered for this to run at all, so it only
-   * happens for somebody who was already working in tmux here.
+   *   - `tmux` with no arguments starts the server and attaches you to the
+   *     session IT just made. A resurrect/continuum setup then restores your
+   *     real sessions behind you, and you are sitting in `0` watching none of
+   *     them. Reported exactly that way: "las tabs no son ni las de alavera".
+   *   - `start-server` is not a way to wait for the restore either: a server
+   *     with no sessions exits immediately, so it leaves nothing behind at all.
+   *   - `-A` means attach-or-create, so the same command covers a live server
+   *     that already has it. The name is exact — `-s alav` makes a session
+   *     called `alav` beside `alavera` rather than matching it.
+   *
+   * What makes it land where it should is that creating the session STARTS the
+   * server, which sources their configuration, which is what fires continuum's
+   * restore. resurrect puts missing windows into sessions that already exist,
+   * so the session we just made is filled in with its own windows rather than
+   * competing with the restore. We restore nothing and install nothing.
+   *
+   * With no name remembered there is nothing to ask for, and bare `tmux` — what
+   * the user would type — is the honest fallback.
    */
-  if (out === null || !out.trim()) return ["tmux", ...socket];
+  if (out === null || !out.trim()) {
+    return session
+      ? ["tmux", ...socket, "new-session", "-A", "-s", session]
+      : ["tmux", ...socket];
+  }
 
   for (const line of out.split("\n")) {
     const [id, name] = line.split("\t");

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -2376,7 +2376,7 @@ function unzoomWindow(socket: string[], sessionId: string, windowId: string, onl
 }
 
 /**
- * The command that puts the desk back where it was: a plain `tmux attach`.
+ * The command that puts the desk back where it was.
  *
  * Deliberately NOT `attachArgvFor`. That one is the phone's: it makes a grouped
  * session of its own so two screens can look at one window at different sizes,
@@ -2393,18 +2393,46 @@ function unzoomWindow(socket: string[], sessionId: string, windowId: string, onl
  * the live list is the answer.
  */
 export function deskAttachArgv(socketPath: string, session: string): string[] | null {
-  if (!socketPath || !session) return null;
+  if (!socketPath) return null;
   const socket = ["-S", socketPath];
   const out = tmux(socket, ["list-sessions", "-F", "#{session_id}\t#{session_name}"]);
-  if (!out) return null;
+
+  /*
+   * Nothing answered: there is no server on that socket at all, which is what
+   * a machine looks like after it has been turned on.
+   *
+   * The answer is `tmux` with no arguments, and that is not a shortcut — it is
+   * precisely what the user does by hand, and the ONLY thing that works then:
+   * there is no session to attach to yet. Starting the server is what fires
+   * whatever their configuration does on start, so a resurrect/continuum setup
+   * restores their last session by itself. We restore nothing and install
+   * nothing; we start the server the same way they would and get out of the
+   * way.
+   *
+   * A socket has to have been remembered for this to run at all, so it only
+   * happens for somebody who was already working in tmux here.
+   */
+  if (out === null || !out.trim()) return ["tmux", ...socket];
+
   for (const line of out.split("\n")) {
     const [id, name] = line.split("\t");
     // Exact, not a prefix, and the id has to be one before it is passed on.
-    if (name === session && id && SESSION_ID.test(id)) {
+    if (session && name === session && id && SESSION_ID.test(id)) {
       return ["tmux", ...socket, "attach-session", "-t", id];
     }
   }
-  return null;
+
+  /*
+   * The server is up but the remembered session is not in it — renamed, killed,
+   * or restored under another name. Attaching with no `-t` takes the most
+   * recently used session, which is the closest thing to "where I was" that
+   * tmux itself can answer, and is what a bare `tmux attach` does.
+   *
+   * Better than starting a server here: `tmux` with a server already running
+   * would make ANOTHER session beside the ones that exist, which is how you end
+   * up with `0`, `1`, `2` beside the work.
+   */
+  return ["tmux", ...socket, "attach-session"];
 }
 
 export function attachArgvFor(

--- a/server/src/tmuxmemory.ts
+++ b/server/src/tmuxmemory.ts
@@ -76,6 +76,19 @@ export interface Remembered {
  *  that a stale path stops being offered on its own. */
 export const STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
 
+/**
+ * How long the panel has to stay on a session before it counts as where you
+ * work.
+ *
+ * Without this, "the last session the panel attached to" is what gets written
+ * — and that is not the same question. Measured on the machine this was built
+ * for: a restore finished, tmux put the client on `docker` for a moment on its
+ * way past, and the memory said `docker`. A cold start would then have brought
+ * back a one-window session instead of the five-window one the day was spent
+ * in. A landing is not a choice; thirty seconds of it is.
+ */
+export const SETTLE_MS = 30_000;
+
 export function remember(socketPath: string, session: string, at = Date.now()): void {
   if (!socketPath) return; // the default socket resolved to nothing: nothing to keep
   const p = memoryPath();

--- a/server/src/tmuxmemory.ts
+++ b/server/src/tmuxmemory.ts
@@ -1,0 +1,108 @@
+/*
+ * Which tmux server this app was last working in, remembered across restarts.
+ *
+ * The reason is a complaint with a repro: close agentglass, reopen it, and the
+ * session you were in is not on offer — you have to go to a terminal outside
+ * the app and `tmux attach -t <name>` before it will show you anything. After
+ * a rebuild, every time.
+ *
+ * It is self-inflicted, and it takes two losses to happen. The panel's client
+ * is usually the ONLY client on that server, so closing the app detaches the
+ * session; `listPanes` then skips any server with no client at all, so the
+ * session agentglass just put down is the one it refuses to show. And
+ * `lastTarget` — the only place the socket was ever written — lives in a module
+ * variable, so it dies with the process: on the next run the app does not even
+ * know which of the machine's tmux servers was yours.
+ *
+ * This fixes the second loss, which is what makes the first one fixable: a
+ * socket we were demonstrably attached to is not a stray, whatever the client
+ * count says now. The filter it lets through is doing a real job otherwise —
+ * this project's own suite leaves servers behind on scratch sockets, and a
+ * resurrect config restores real sessions into them, so an unattached server
+ * CAN be a convincing duplicate of the one you work in. The rule is not "show
+ * every detached server"; it is "a server this app has used is one it may
+ * still see".
+ *
+ * Nothing here touches the user's tmux. It is a file of our own, next to the
+ * rest of our settings, and deleting it costs a session's memory and nothing
+ * else.
+ */
+import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { dirname, join } from "node:path";
+
+/**
+ * Same rule the config, the theme sync and the database follow: under
+ * `bun test` the real file is off limits, whatever the import order was. A
+ * suite that redirects XDG_CONFIG_HOME at a scratch directory gets exactly
+ * what it wrote there, and every other read is "nothing remembered".
+ *
+ * Written as a check per call rather than a constant, because a test sets the
+ * variable after this module has been imported.
+ */
+const offLimits = (p: string): boolean => {
+  if (process.env.NODE_ENV !== "test") return false;
+  const scratch = tmpdir();
+  return p !== scratch && !p.startsWith(scratch + "/");
+};
+
+export function memoryPath(): string {
+  return join(
+    process.env.XDG_CONFIG_HOME || join(homedir(), ".config"),
+    "agentglass",
+    "tmux-last.json",
+  );
+}
+
+/** What is worth keeping: the server, and the session that was on screen. */
+export interface Remembered {
+  /** The socket path, always resolved — `-S <path>`. `-L name` and the path it
+   *  means are the same server, and only one of the two spellings can be
+   *  compared, so the path is what is stored. */
+  socket: string;
+  /** The session's name, for saying WHICH session is waiting. Names can be
+   *  renamed and reused, so this is a label rather than an address: what is
+   *  reopened is looked up live. */
+  session: string;
+  /** When, so a socket from months ago can be treated as the guess it is. */
+  at: number;
+}
+
+/** How long a remembered socket is worth trusting.
+ *
+ *  A socket path is reused: /tmp/tmux-1000/default is that name for ever, and
+ *  the server behind it today is not the one from a fortnight ago. A week is
+ *  long enough to cover a machine that is off over a holiday and short enough
+ *  that a stale path stops being offered on its own. */
+export const STALE_AFTER_MS = 7 * 24 * 60 * 60 * 1000;
+
+export function remember(socketPath: string, session: string, at = Date.now()): void {
+  if (!socketPath) return; // the default socket resolved to nothing: nothing to keep
+  const p = memoryPath();
+  if (offLimits(p)) return;
+  try {
+    mkdirSync(dirname(p), { recursive: true });
+    const next: Remembered = { socket: socketPath, session, at };
+    writeFileSync(p, JSON.stringify(next, null, 2) + "\n");
+  } catch { /* a memory we could not write is a memory we do without */ }
+}
+
+/**
+ * What was remembered, or null.
+ *
+ * Null for anything malformed, absent or older than STALE_AFTER_MS. Every
+ * caller of this treats null as "we have never been anywhere", which is the
+ * behaviour this app had before the file existed — so a corrupt file costs the
+ * feature and never the run.
+ */
+export function recall(now = Date.now()): Remembered | null {
+  const p = memoryPath();
+  if (offLimits(p)) return null;
+  try {
+    const raw = JSON.parse(readFileSync(p, "utf8")) as Partial<Remembered>;
+    if (typeof raw.socket !== "string" || !raw.socket) return null;
+    if (typeof raw.at !== "number" || !Number.isFinite(raw.at)) return null;
+    if (now - raw.at > STALE_AFTER_MS) return null;
+    return { socket: raw.socket, session: typeof raw.session === "string" ? raw.session : "", at: raw.at };
+  } catch { return null; }
+}

--- a/server/src/tmuxsnapshot.ts
+++ b/server/src/tmuxsnapshot.ts
@@ -1,0 +1,210 @@
+/*
+ * A safety copy of the user's last good resurrect save.
+ *
+ * Measured on a real machine, and it cost a working session. resurrect keeps
+ * every save it has ever made and a `last` symlink pointing at the newest;
+ * continuum saves on a timer. When the tmux server was killed, a save fired
+ * while it was going away and wrote a file with ONE pane in it — then `last`
+ * pointed at that. The good save from ten minutes earlier, with five sessions
+ * and a running agent in it, was still on disk and no longer reachable by
+ * anything that restores. Timestamps, in order:
+ *
+ *   19:53:17   1356 bytes   5 sessions, 9 panes, the agent among them
+ *   20:03:10    166 bytes   1 pane          <- `last` now points here
+ *   20:03:47                the next server starts and restores THAT
+ *
+ * The same shape had already emptied `assistant-sessions.json` once before, so
+ * it is not a freak: a save on a dying or newborn server is a poorer answer
+ * than the one it replaces, and resurrect has no notion of "poorer".
+ *
+ * agentglass cannot stop that save — it is somebody else's timer on somebody
+ * else's plugin, and racing it would be two savers on one server, which is its
+ * own way to lose sessions. What it can do is keep the good file where nothing
+ * else writes, and put `last` back when it can PROVE the current one is a
+ * clobber.
+ *
+ * The rules this holds to, because this is the user's own data:
+ *
+ *   - Copies live in our directory. Their resurrect saves are read, never
+ *     written and never deleted.
+ *   - The only write into their directory is the `last` symlink, only when the
+ *     file it points at is strictly poorer than a copy we took, and never
+ *     without keeping what it pointed at first.
+ *   - We restore nothing ourselves. Repointing `last` is what makes THEIR
+ *     restore do the right thing, which is the opposite of competing with it.
+ */
+import { copyFileSync, existsSync, lstatSync, mkdirSync, readFileSync, readdirSync, readlinkSync, realpathSync, rmSync, symlinkSync, renameSync } from "node:fs";
+import { homedir, tmpdir } from "node:os";
+import { basename, dirname, join } from "node:path";
+
+/**
+ * Home, read from the environment first.
+ *
+ * Measured on Bun 1.3.9: `os.homedir()` does NOT follow `$HOME` — it resolves
+ * out of the passwd entry, so a test that redirects HOME still gets the
+ * developer's real home and every path below points at their live resurrect
+ * saves. The rest of this repo never noticed because it hangs everything off
+ * `XDG_CONFIG_HOME`, and there is no XDG variable for `~/.tmux`.
+ *
+ * `$HOME` first is also correct outside the test: it is what every other
+ * program on POSIX honours, so a session started with a different HOME finds
+ * the saves that session is actually using.
+ */
+const home = (): string => process.env.HOME || homedir();
+
+/** Where resurrect keeps its saves. Read-only to us, apart from `last`. */
+export function resurrectDir(): string {
+  return join(home(), ".tmux", "resurrect");
+}
+
+/** Where our copies go. Deleting this directory costs the safety net and
+ *  nothing else. */
+export function snapshotDir(): string {
+  return join(
+    process.env.XDG_CONFIG_HOME || join(home(), ".config"),
+    "agentglass",
+    "resurrect",
+  );
+}
+
+/**
+ * Under `bun test`, the real directories are off limits — same rule as the
+ * config and the database. A suite redirects HOME and XDG_CONFIG_HOME at a
+ * scratch directory and gets exactly what it put there; anything else reads as
+ * "no saves", so no test can read or repoint the developer's own resurrect.
+ */
+const offLimits = (p: string): boolean => {
+  if (process.env.NODE_ENV !== "test") return false;
+  const scratch = tmpdir();
+  return p !== scratch && !p.startsWith(scratch + "/");
+};
+
+/** How many copies to keep. Enough to step back past a bad afternoon, few
+ *  enough that the directory stays something a person can read. */
+export const KEEP = 5;
+
+/**
+ * What a save is worth, in panes.
+ *
+ * Panes rather than bytes: `@resurrect-capture-pane-contents` makes the file
+ * size depend on how much scrollback happened to be on screen, so a save of an
+ * empty server after a busy one can be larger and still hold nothing. A pane
+ * line is one pane, and that is the thing being lost.
+ */
+export function panesIn(text: string): number {
+  return text.split("\n").filter((l) => l.startsWith("pane\t")).length;
+}
+
+/** The file `last` really points at, and how much is in it. */
+export function readLast(): { path: string; panes: number; text: string } | null {
+  const link = join(resurrectDir(), "last");
+  if (offLimits(link)) return null;
+  try {
+    const path = realpathSync(link);
+    const text = readFileSync(path, "utf8");
+    return { path, panes: panesIn(text), text };
+  } catch { return null; }
+}
+
+/** Our copies, richest first, then newest first. */
+export function snapshots(): { path: string; panes: number }[] {
+  const dir = snapshotDir();
+  if (offLimits(dir)) return [];
+  let names: string[] = [];
+  try { names = readdirSync(dir).filter((n) => n.endsWith(".txt")); }
+  catch { return []; }
+  const out: { path: string; panes: number }[] = [];
+  for (const n of names.sort().reverse()) {
+    const path = join(dir, n);
+    try { out.push({ path, panes: panesIn(readFileSync(path, "utf8")) }); }
+    catch { /* unreadable copy: not a copy */ }
+  }
+  return out.sort((a, b) => b.panes - a.panes || (a.path < b.path ? 1 : -1));
+}
+
+/** The one worth putting back. */
+export const bestSnapshot = (): { path: string; panes: number } | null => snapshots()[0] ?? null;
+
+/**
+ * Take a copy, if there is something worth copying.
+ *
+ * A save with fewer than two panes is exactly the shape of the clobber this
+ * exists for, so it is never worth keeping: a real session has more than one
+ * pane, and a single-pane save is either a brand-new server or a dying one.
+ *
+ * Returns the copy's path, or null when nothing was taken — which is the
+ * ordinary case, since this runs on a timer and most ticks find the same file.
+ */
+export function snapshot(): string | null {
+  const last = readLast();
+  if (!last || last.panes < 2) return null;
+  const dir = snapshotDir();
+  if (offLimits(dir)) return null;
+  const to = join(dir, basename(last.path));
+  try {
+    if (existsSync(to)) return null; // already have this exact save
+    mkdirSync(dir, { recursive: true });
+    copyFileSync(last.path, to);
+    // Oldest by name, which is a timestamp, so sorting is chronological.
+    const all = readdirSync(dir).filter((n) => n.endsWith(".txt")).sort();
+    for (const old of all.slice(0, Math.max(0, all.length - KEEP))) {
+      try { rmSync(join(dir, old)); } catch { /* it is only a copy */ }
+    }
+    return to;
+  } catch { return null; }
+}
+
+/**
+ * Has `last` been clobbered by a poorer save than one we hold?
+ *
+ * Strictly poorer, and never merely different: a user who closes four sessions
+ * on purpose has a smaller save and means it. What this catches is the save
+ * that lands with one pane over one that had nine, which is not a decision
+ * anybody made.
+ */
+export function clobbered(): { now: number; had: number; from: string } | null {
+  const last = readLast();
+  const best = bestSnapshot();
+  if (!last || !best) return null;
+  if (last.panes >= best.panes) return null;
+  // One pane against several is the signature. Two against three is somebody
+  // closing a pane, and is none of our business.
+  if (last.panes > 1) return null;
+  return { now: last.panes, had: best.panes, from: best.path };
+}
+
+/**
+ * Put `last` back, so THEIR restore reads the good save.
+ *
+ * The only write this module makes into the user's directory, and the smallest
+ * one that fixes anything: a symlink, to a file resurrect wrote itself. What it
+ * pointed at is kept as `last.clobbered` first, so nothing is destroyed by the
+ * repair either — including the possibility that this judgement was wrong.
+ *
+ * Returns what it pointed at now, or null when there was nothing to repair.
+ */
+export function repairLast(): { restored: string; kept: string } | null {
+  const bad = clobbered();
+  if (!bad) return null;
+  const dir = resurrectDir();
+  const link = join(dir, "last");
+  if (offLimits(link)) return null;
+  try {
+    const was = lstatSync(link).isSymbolicLink() ? readlinkSync(link) : basename(realpathSync(link));
+    // A plain file rather than another symlink, so it cannot be mistaken for
+    // the live pointer by anything that follows links.
+    copyFileSync(realpathSync(link), join(dir, "last.clobbered"));
+    /*
+     * Written beside it and moved into place, because a symlink cannot be
+     * replaced atomically any other way — and a `last` that is missing for even
+     * a moment is a restore that finds nothing.
+     */
+    const tmp = join(dir, `.last.agx-${process.pid}`);
+    symlinkSync(basename(bad.from), tmp);
+    renameSync(tmp, link);
+    return { restored: basename(bad.from), kept: was };
+  } catch { return null; }
+}
+
+/** Somewhere for a caller to say where the copies are, without importing paths. */
+export const snapshotWhere = (): string => dirname(join(snapshotDir(), "x"));

--- a/server/test/tmux-memory.test.ts
+++ b/server/test/tmux-memory.test.ts
@@ -201,7 +201,28 @@ describe("the command that puts the desk back", () => {
      * restores the session itself. We restore nothing.
      */
     const sock = join(sockdir, "not-started-yet");
-    expect(deskAttachArgv(sock, "workbench")).toEqual(["tmux", "-S", sock]);
+    expect(deskAttachArgv(sock, "workbench"))
+      .toEqual(["tmux", "-S", sock, "new-session", "-A", "-s", "workbench"]);
+  });
+
+  it("asks for the session by name, so the restore fills THAT one in", () => {
+    /*
+     * Bare `tmux` starts the server and attaches you to the session it just
+     * made; the restore then brings your real ones back behind you and you are
+     * sitting in `0` watching none of them. `-A` names the one you want, and
+     * because creating it is what starts the server, the restore lands its
+     * windows in the session already standing.
+     */
+    const sock = join(sockdir, "cold");
+    const argv = deskAttachArgv(sock, "workbench")!;
+    expect(argv).toContain("-A");
+    expect(argv[argv.length - 1]).toBe("workbench");
+  });
+
+  it("falls back to bare tmux when no name was remembered", () => {
+    // Nothing to ask for. What the user would type is the honest answer.
+    const sock = join(sockdir, "cold2");
+    expect(deskAttachArgv(sock, "")).toEqual(["tmux", "-S", sock]);
   });
 
   it("takes the most recently used session when the remembered one is gone", () => {

--- a/server/test/tmux-memory.test.ts
+++ b/server/test/tmux-memory.test.ts
@@ -219,6 +219,24 @@ describe("the command that puts the desk back", () => {
     expect(argv[argv.length - 1]).toBe("workbench");
   });
 
+  it("says no on a machine with no tmux at all", () => {
+    /*
+     * A missing binary and an unstarted server answer identically — both make
+     * the tmux call return null — so without an explicit check the cold-boot
+     * branch would hand the panel `tmux new-session …` to run on a machine
+     * that has no tmux, and the terminal would open on `command not found`
+     * instead of on a shell.
+     *
+     * Reachable only for somebody who had tmux when the memory was written and
+     * does not now. Measured by hiding it: PATH is restored straight after.
+     */
+    const was = process.env.PATH;
+    process.env.PATH = join(home, "no-binaries-here");
+    try {
+      expect(deskAttachArgv(join(sockdir, "cold3"), "workbench")).toBe(null);
+    } finally { process.env.PATH = was; }
+  });
+
   it("falls back to bare tmux when no name was remembered", () => {
     // Nothing to ask for. What the user would type is the honest answer.
     const sock = join(sockdir, "cold2");

--- a/server/test/tmux-memory.test.ts
+++ b/server/test/tmux-memory.test.ts
@@ -1,0 +1,159 @@
+/*
+ * Reopening the session you left, without going outside the app to attach.
+ *
+ * The complaint, exactly: close agentglass, open it again, and the tmux session
+ * you were working in is not on offer — `tmux attach -t <name>` in some other
+ * terminal is what brings it back. After every rebuild.
+ *
+ * Two losses cause it and both are ours. The panel's client is usually the only
+ * client on that server, so closing the app detaches the session; `listPanes`
+ * skips servers with no client at all. And the socket was only ever held in a
+ * module variable, so the next run did not know which server was yours.
+ *
+ * Real tmux on sockets of this file's own, because the claim is about what tmux
+ * reports for a detached server, and a mock would only confirm what I already
+ * believed. `-f /dev/null` on every one of them: nothing here may read the
+ * user's configuration, and nothing here may touch their tmux.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { memoryPath, recall, remember, STALE_AFTER_MS } from "../src/tmuxmemory.ts";
+import { listPanes } from "../src/tmuxctl.ts";
+
+let home = "";
+let sockdir = "";
+let sockets: string[] = [];
+
+const tmux = (sock: string, ...args: string[]): string => {
+  const r = Bun.spawnSync(["tmux", "-f", "/dev/null", "-S", sock, ...args], { stdout: "pipe", stderr: "pipe" });
+  return r.exitCode === 0 ? new TextDecoder().decode(r.stdout).trim() : "";
+};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agx-tmuxmem-"));
+  process.env.XDG_CONFIG_HOME = home;
+  /*
+   * Discovery lists `$TMUX_TMPDIR/tmux-<uid>`, and with TMUX_TMPDIR unset that
+   * is the developer's own socket directory — the sessions they are working in
+   * right now. Same rule as tmuxTmp.ts, one per test so two runs never meet.
+   */
+  process.env.TMUX_TMPDIR = home;
+  sockdir = join(home, `tmux-${process.getuid?.() ?? 0}`);
+  mkdirSync(sockdir, { recursive: true });
+  sockets = [];
+});
+
+afterEach(() => {
+  for (const s of sockets) tmux(s, "kill-server");
+  rmSync(home, { recursive: true, force: true });
+  delete process.env.XDG_CONFIG_HOME;
+  delete process.env.TMUX_TMPDIR;
+});
+
+/** A detached tmux server with one session in it, on a socket of its own. */
+const detachedServer = (name: string): string => {
+  const sock = join(sockdir, name);
+  sockets.push(sock);
+  tmux(sock, "new-session", "-d", "-s", name, "-x", "80", "-y", "24", "sleep 300");
+  return sock;
+};
+
+describe("what is remembered", () => {
+  it("keeps the socket and the session, and reads them back", () => {
+    remember("/tmp/tmux-1000/default", "workbench");
+    expect(recall()).toMatchObject({ socket: "/tmp/tmux-1000/default", session: "workbench" });
+  });
+
+  it("has nothing to say before anything has been written", () => {
+    expect(recall()).toBe(null);
+  });
+
+  it("refuses a socket path of nothing rather than writing an empty one", () => {
+    // The default socket can resolve to "", and a remembered "" would match
+    // every socket discovery finds — the filter would stop filtering.
+    remember("", "workbench");
+    expect(recall()).toBe(null);
+  });
+
+  it("forgets a socket older than a week", () => {
+    /*
+     * A socket path is reused for ever — /tmp/tmux-1000/default is that name on
+     * every boot — so an old one names whatever server holds it today, which is
+     * a guess rather than a memory.
+     */
+    remember("/tmp/tmux-1000/default", "workbench", Date.now() - STALE_AFTER_MS - 1000);
+    expect(recall()).toBe(null);
+  });
+
+  it("still trusts one from six days ago, so a machine off for a week comes back", () => {
+    remember("/tmp/tmux-1000/default", "workbench", Date.now() - 6 * 24 * 60 * 60 * 1000);
+    expect(recall()?.session).toBe("workbench");
+  });
+
+  it("survives a file somebody edited into nonsense", () => {
+    // A corrupt memory costs the feature, never the run: every caller reads
+    // null as "we have never been anywhere", which is how this behaved before
+    // the file existed.
+    mkdirSync(join(home, "agentglass"), { recursive: true });
+    for (const junk of ["", "{", "null", "[]", '{"socket":42}', '{"socket":"/x"}']) {
+      writeFileSync(memoryPath(), junk);
+      expect(recall()).toBe(null);
+    }
+  });
+
+  it("writes only under our own directory", () => {
+    remember("/tmp/tmux-1000/default", "workbench");
+    expect(memoryPath()).toBe(join(home, "agentglass", "tmux-last.json"));
+    // And it is JSON somebody could read, not an opaque blob.
+    expect(JSON.parse(readFileSync(memoryPath(), "utf8")).session).toBe("workbench");
+  });
+});
+
+describe("the session you left is on offer again", () => {
+  it("lists the panes of a detached server we were last attached to", () => {
+    /*
+     * THE BUG. Before this, a server with no client was skipped outright, so
+     * the session agentglass itself had just detached was the one it would not
+     * show — and the only way back was to attach from outside the app.
+     */
+    const sock = detachedServer("workbench");
+    expect(tmux(sock, "list-clients", "-F", "#{client_tty}")).toBe(""); // nobody is attached
+    remember(sock, "workbench");
+    const rows = listPanes([]).filter((r) => r.session === "workbench");
+    expect(rows.length).toBeGreaterThan(0);
+  });
+
+  it("still skips a detached server that is not ours", () => {
+    /*
+     * The filter is not being removed, and this is why it exists: the suite
+     * leaves servers behind on scratch sockets and a resurrect config restores
+     * real sessions into them, so an unattached server can be a convincing
+     * duplicate of the one you work in, with different pane ids.
+     */
+    const ours = detachedServer("workbench");
+    const stray = detachedServer("not-ours");
+    remember(ours, "workbench");
+    const names = listPanes([]).map((r) => r.session);
+    expect(names).toContain("workbench");
+    expect(names).not.toContain("not-ours");
+    expect(stray).toBeTruthy();
+  });
+
+  it("shows nothing extra when nothing is remembered", () => {
+    // The behaviour this app had before the file existed, asserted so that a
+    // machine with no memory yet cannot start seeing stray servers.
+    detachedServer("workbench");
+    expect(listPanes([]).map((r) => r.session)).not.toContain("workbench");
+  });
+
+  it("does not resurrect a socket whose server has since died", () => {
+    // A remembered path that answers nothing is not an error and not a row: the
+    // tmux call fails and the caller reports no panes.
+    const sock = detachedServer("workbench");
+    remember(sock, "workbench");
+    tmux(sock, "kill-server");
+    expect(listPanes([]).map((r) => r.session)).not.toContain("workbench");
+  });
+});

--- a/server/test/tmux-memory.test.ts
+++ b/server/test/tmux-memory.test.ts
@@ -20,7 +20,7 @@ import { mkdtempSync, rmSync, writeFileSync, readFileSync, mkdirSync } from "nod
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { memoryPath, recall, remember, STALE_AFTER_MS } from "../src/tmuxmemory.ts";
-import { listPanes } from "../src/tmuxctl.ts";
+import { deskAttachArgv, listPanes } from "../src/tmuxctl.ts";
 
 let home = "";
 let sockdir = "";
@@ -155,5 +155,51 @@ describe("the session you left is on offer again", () => {
     remember(sock, "workbench");
     tmux(sock, "kill-server");
     expect(listPanes([]).map((r) => r.session)).not.toContain("workbench");
+  });
+});
+
+describe("the command that puts the desk back", () => {
+  it("attaches to the remembered session by its id, not its name", () => {
+    /*
+     * A name is matched by PREFIX unless you fight the syntax, so attaching to
+     * a remembered `work` could land in `workbench` — silently, in somebody
+     * else's windows. Asserted with exactly that pair.
+     */
+    const sock = detachedServer("work");
+    tmux(sock, "new-session", "-d", "-s", "workbench", "sleep 300");
+    const argv = deskAttachArgv(sock, "work");
+    /*
+     * Read through `list-sessions` rather than `display-message -t =work`:
+     * measured on tmux 3.7, the `=name` form answers NOTHING here — the same
+     * shape as `set-option -t =name` being refused outright while
+     * `list-windows -t =name` accepts it. Asserting through it made the code
+     * look wrong when it had returned the right id.
+     */
+    const id = tmux(sock, "list-sessions", "-F", "#{session_id}\t#{session_name}")
+      .split("\n").find((l) => l.endsWith("\twork"))!.split("\t")[0];
+    expect(argv).toEqual(["tmux", "-S", sock, "attach-session", "-t", id]);
+  });
+
+  it("is a plain attach — no grouped session, nothing owed back", () => {
+    // Deliberately not the phone's attach: that one makes a session of its own
+    // so two screens can differ in size, and marks window-size to hand back.
+    // The desk IS the session.
+    const sock = detachedServer("workbench");
+    const argv = deskAttachArgv(sock, "workbench")!;
+    expect(argv).toContain("attach-session");
+    expect(argv).not.toContain("new-session");
+    expect(argv.join(" ")).not.toContain("window-size");
+  });
+
+  it("says no when that session is gone, so the panel opens a shell instead", () => {
+    const sock = detachedServer("workbench");
+    expect(deskAttachArgv(sock, "gone")).toBe(null);
+    tmux(sock, "kill-server");
+    expect(deskAttachArgv(sock, "workbench")).toBe(null);
+  });
+
+  it("says no to an empty socket or an empty name rather than attaching to whatever", () => {
+    expect(deskAttachArgv("", "workbench")).toBe(null);
+    expect(deskAttachArgv("/nope", "")).toBe(null);
   });
 });

--- a/server/test/tmux-memory.test.ts
+++ b/server/test/tmux-memory.test.ts
@@ -191,15 +191,28 @@ describe("the command that puts the desk back", () => {
     expect(argv.join(" ")).not.toContain("window-size");
   });
 
-  it("says no when that session is gone, so the panel opens a shell instead", () => {
-    const sock = detachedServer("workbench");
-    expect(deskAttachArgv(sock, "gone")).toBe(null);
-    tmux(sock, "kill-server");
-    expect(deskAttachArgv(sock, "workbench")).toBe(null);
+  it("starts the server when the machine has just been turned on", () => {
+    /*
+     * The case the first version of this got wrong. After a reboot there is no
+     * server and nothing to attach TO — `attach -t <name>` cannot work, and
+     * falling through to a bare shell is what left the user typing `tmux` by
+     * hand. Bare `tmux` is exactly what they type, and starting the server is
+     * what fires their own configuration, so a resurrect/continuum setup
+     * restores the session itself. We restore nothing.
+     */
+    const sock = join(sockdir, "not-started-yet");
+    expect(deskAttachArgv(sock, "workbench")).toEqual(["tmux", "-S", sock]);
   });
 
-  it("says no to an empty socket or an empty name rather than attaching to whatever", () => {
+  it("takes the most recently used session when the remembered one is gone", () => {
+    // Renamed, killed, or restored under another name. Attaching with no -t is
+    // the closest thing to "where I was" that tmux itself can answer — and it
+    // beats starting a server, which would add a session beside the work.
+    const sock = detachedServer("workbench");
+    expect(deskAttachArgv(sock, "gone")).toEqual(["tmux", "-S", sock, "attach-session"]);
+  });
+
+  it("says no to an empty socket rather than attaching to whatever", () => {
     expect(deskAttachArgv("", "workbench")).toBe(null);
-    expect(deskAttachArgv("/nope", "")).toBe(null);
   });
 });

--- a/server/test/tmux-snapshot.test.ts
+++ b/server/test/tmux-snapshot.test.ts
@@ -1,0 +1,225 @@
+/*
+ * The safety copy of the user's last good resurrect save.
+ *
+ * Written after losing one. resurrect keeps every save and a `last` symlink at
+ * the newest; continuum saves on a timer. A save fired while the tmux server
+ * was being killed and wrote a file with ONE pane in it, `last` moved to that,
+ * and the save from ten minutes earlier — five sessions, nine panes, a running
+ * agent — was still on disk and no longer reachable by anything that restores:
+ *
+ *   19:53:17   1356 bytes   9 panes    <- the work
+ *   20:03:10    166 bytes   1 pane     <- `last` now points here
+ *
+ * resurrect has no notion of "poorer", and agentglass must not race its timer.
+ * So it keeps a copy where nothing else writes, and puts `last` back only when
+ * it can prove the current one is a clobber.
+ *
+ * Every path here is under a scratch HOME. The module refuses the real
+ * directories under NODE_ENV=test outright — this suite must never be able to
+ * read, copy or repoint the developer's own resurrect saves.
+ */
+import { afterEach, beforeEach, describe, expect, it } from "bun:test";
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, readlinkSync, realpathSync, rmSync, symlinkSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  bestSnapshot, clobbered, KEEP, panesIn, readLast, repairLast, resurrectDir, snapshot, snapshotDir, snapshots,
+} from "../src/tmuxsnapshot.ts";
+
+let home = "";
+
+/** A resurrect save with `n` panes in it, in the shape resurrect writes. */
+const save = (n: number, session = "workbench"): string => {
+  const lines: string[] = [];
+  for (let i = 1; i <= n; i++) {
+    lines.push(`pane\t${session}\t${i}\t1\t:*\t1\ttitle\t:/home/x\t1\tbash\t:`);
+  }
+  lines.push(`window\t${session}\t1\t:bash\t1\t:*\tc920,205x47,0,0,3\t:`);
+  lines.push(`state\t${session}\t`);
+  return lines.join("\n") + "\n";
+};
+
+/** Write a save into the resurrect directory and point `last` at it. */
+const put = (name: string, text: string, asLast = true): string => {
+  const dir = resurrectDir();
+  mkdirSync(dir, { recursive: true });
+  const path = join(dir, name);
+  writeFileSync(path, text);
+  if (asLast) {
+    const link = join(dir, "last");
+    rmSync(link, { force: true });
+    symlinkSync(name, link);
+  }
+  return path;
+};
+
+beforeEach(() => {
+  home = mkdtempSync(join(tmpdir(), "agx-snap-"));
+  process.env.HOME = home;
+  process.env.XDG_CONFIG_HOME = join(home, ".config");
+});
+
+afterEach(() => {
+  rmSync(home, { recursive: true, force: true });
+});
+
+describe("what a save is worth", () => {
+  it("counts panes, not bytes", () => {
+    /*
+     * `@resurrect-capture-pane-contents` makes the file size depend on how much
+     * scrollback happened to be on screen, so a save of an empty server after a
+     * busy one can be the LARGER file and still hold nothing. The pane lines
+     * are the thing being lost.
+     */
+    expect(panesIn(save(9))).toBe(9);
+    expect(panesIn(save(1))).toBe(1);
+    expect(panesIn("state\tx\t\n")).toBe(0);
+  });
+});
+
+describe("taking a copy", () => {
+  it("copies the good save into our own directory", () => {
+    put("tmux_resurrect_20260810T195317.txt", save(9));
+    const to = snapshot();
+    expect(to).toContain(join(".config", "agentglass", "resurrect"));
+    expect(panesIn(readFileSync(to!, "utf8"))).toBe(9);
+  });
+
+  it("never copies a one-pane save, which is the clobber's own shape", () => {
+    // A real session has more than one pane. A single-pane save is a server
+    // being born or dying, and keeping it would poison the safety net.
+    put("tmux_resurrect_20260810T200310.txt", save(1));
+    expect(snapshot()).toBe(null);
+    expect(snapshots()).toHaveLength(0);
+  });
+
+  it("does not copy the same save twice", () => {
+    put("tmux_resurrect_20260810T195317.txt", save(9));
+    expect(snapshot()).toBeTruthy();
+    expect(snapshot()).toBe(null); // the timer ticks; nothing new happened
+    expect(snapshots()).toHaveLength(1);
+  });
+
+  it("keeps a bounded number of them, oldest dropped first", () => {
+    for (let i = 1; i <= KEEP + 3; i++) {
+      put(`tmux_resurrect_2026081${i}T000000.txt`, save(2 + i));
+      snapshot();
+    }
+    const kept = snapshots();
+    expect(kept).toHaveLength(KEEP);
+    // The oldest names are the ones gone: the directory sorts chronologically.
+    expect(kept.some((s) => s.path.endsWith("20260811T000000.txt"))).toBe(false);
+  });
+
+  it("says nothing at all when there is no resurrect here", () => {
+    // A machine with no plugin installed is not an error and not a warning.
+    expect(readLast()).toBe(null);
+    expect(snapshot()).toBe(null);
+    expect(bestSnapshot()).toBe(null);
+    expect(clobbered()).toBe(null);
+  });
+});
+
+describe("noticing a clobber", () => {
+  it("sees one pane standing where nine used to be", () => {
+    put("tmux_resurrect_20260810T195317.txt", save(9));
+    snapshot();
+    put("tmux_resurrect_20260810T200310.txt", save(1)); // the dying server's save
+    expect(clobbered()).toMatchObject({ now: 1, had: 9 });
+  });
+
+  it("keeps its hands off a smaller save somebody meant", () => {
+    /*
+     * Closing four sessions on purpose makes a smaller save and means it. Only
+     * one-pane-against-several is the signature — two against three is a person
+     * closing a pane, and none of our business.
+     */
+    put("tmux_resurrect_a.txt", save(9));
+    snapshot();
+    put("tmux_resurrect_b.txt", save(3));
+    expect(clobbered()).toBe(null);
+  });
+
+  it("is quiet when the newest save is the richest", () => {
+    put("tmux_resurrect_a.txt", save(4));
+    snapshot();
+    put("tmux_resurrect_b.txt", save(9));
+    expect(clobbered()).toBe(null);
+  });
+});
+
+describe("putting last back", () => {
+  it("repoints it at the good save, so THEIR restore reads the right file", () => {
+    put("tmux_resurrect_20260810T195317.txt", save(9));
+    snapshot();
+    put("tmux_resurrect_20260810T200310.txt", save(1));
+
+    const done = repairLast();
+    expect(done?.restored).toBe("tmux_resurrect_20260810T195317.txt");
+    // What `last` resolves to now is the nine-pane save.
+    expect(panesIn(readFileSync(realpathSync(join(resurrectDir(), "last")), "utf8"))).toBe(9);
+    // Still a symlink, which is what resurrect maintains.
+    expect(readlinkSync(join(resurrectDir(), "last"))).toBe("tmux_resurrect_20260810T195317.txt");
+  });
+
+  it("keeps what it replaced, in case the judgement was wrong", () => {
+    put("tmux_resurrect_a.txt", save(9));
+    snapshot();
+    put("tmux_resurrect_b.txt", save(1));
+    repairLast();
+    expect(existsSync(join(resurrectDir(), "last.clobbered"))).toBe(true);
+    expect(panesIn(readFileSync(join(resurrectDir(), "last.clobbered"), "utf8"))).toBe(1);
+  });
+
+  it("destroys none of the user's saves", () => {
+    // The only write into their directory is the pointer. Every file resurrect
+    // wrote is still there afterwards.
+    put("tmux_resurrect_a.txt", save(9));
+    snapshot();
+    put("tmux_resurrect_b.txt", save(1));
+    repairLast();
+    expect(existsSync(join(resurrectDir(), "tmux_resurrect_a.txt"))).toBe(true);
+    expect(existsSync(join(resurrectDir(), "tmux_resurrect_b.txt"))).toBe(true);
+  });
+
+  it("does nothing when there is nothing to repair", () => {
+    put("tmux_resurrect_a.txt", save(9));
+    snapshot();
+    expect(repairLast()).toBe(null);
+    expect(existsSync(join(resurrectDir(), "last.clobbered"))).toBe(false);
+  });
+
+  it("leaves last resolvable at every moment", () => {
+    /*
+     * A symlink cannot be replaced in place, and a `last` that is missing for
+     * even an instant is a restore that finds nothing. The repair writes beside
+     * it and renames over, so the pointer is never absent — asserted by there
+     * being no leftover temporary and the link resolving straight after.
+     */
+    put("tmux_resurrect_a.txt", save(9));
+    snapshot();
+    put("tmux_resurrect_b.txt", save(1));
+    repairLast();
+    const strays = snapshots().filter((s) => s.path.includes(".last.agx-"));
+    expect(strays).toHaveLength(0);
+    expect(existsSync(realpathSync(join(resurrectDir(), "last")))).toBe(true);
+  });
+});
+
+describe("the developer's own resurrect is unreachable from a test", () => {
+  it("refuses the real directories under NODE_ENV=test", () => {
+    // The guard that makes every case above safe to run on a machine with real
+    // sessions in it: with HOME pointing at a real home, this module answers
+    // nothing rather than reading or repointing anything.
+    const scratch = home;
+    process.env.HOME = "/home/somebody";
+    process.env.XDG_CONFIG_HOME = "/home/somebody/.config";
+    expect(process.env.NODE_ENV).toBe("test");
+    expect(readLast()).toBe(null);
+    expect(snapshot()).toBe(null);
+    expect(snapshots()).toHaveLength(0);
+    expect(repairLast()).toBe(null);
+    expect(snapshotDir().startsWith("/home/somebody")).toBe(true); // it resolved it, and still refused
+    process.env.HOME = scratch;
+  });
+});

--- a/server/test/tmux-snapshot.test.ts
+++ b/server/test/tmux-snapshot.test.ts
@@ -39,9 +39,30 @@ const save = (n: number, session = "workbench"): string => {
   return lines.join("\n") + "\n";
 };
 
-/** Write a save into the resurrect directory and point `last` at it. */
+/**
+ * Write a save into the resurrect directory and point `last` at it.
+ *
+ * The `onlyScratch` line is not a nicety and it is not paranoia — it is here
+ * because this helper HAS written into a real `~/.tmux/resurrect` once. Before
+ * the module honoured `$HOME`, `resurrectDir()` resolved through
+ * `os.homedir()`, which on Bun ignores the variable this suite redirects, so
+ * these writes landed on the developer's own saves and repointed their `last`
+ * at a two-line fixture. The module was fixed; a helper that writes with `fs`
+ * directly bypasses every guard the module has, so it needs its own.
+ *
+ * Loud rather than skipped: a suite that quietly stops testing is worse than
+ * one that fails.
+ */
+const onlyScratch = (p: string): void => {
+  const scratch = tmpdir();
+  if (p !== scratch && !p.startsWith(scratch + "/")) {
+    throw new Error(`refusing to write outside the scratch directory: ${p}`);
+  }
+};
+
 const put = (name: string, text: string, asLast = true): string => {
   const dir = resurrectDir();
+  onlyScratch(dir);
   mkdirSync(dir, { recursive: true });
   const path = join(dir, name);
   writeFileSync(path, text);


### PR DESCRIPTION
## What does this PR do?

Makes agentglass come back to the tmux session you were working in, instead of asking you to attach it yourself.

Reported as a daily annoyance with a one-line repro: close the app, open it again, and the session is not there — `tmux attach -t <name>` in a terminal **outside** agentglass is what brings it back. After every rebuild.

It is self-inflicted, and it takes two losses to happen.

**The app hid what it had just put down.** The panel's client is normally the only client on that server, so closing agentglass detaches the session — and `listPanes` skipped any server with no client at all. The one server guaranteed to be clientless a second after the app closes is the server the app was using.

**And it forgot where it was.** `lastTarget`, the only place the socket was ever recorded, is a module variable that dies with the process. Its own comment said "null until a terminal has been opened once this run, which is the honest answer". It was honest, and it was half the bug.

So the socket and the session name are now written next to the rest of our settings, and discovery lets through exactly one detached server: the one this app was demonstrably attached to. **The filter is not removed** — its comment names a real hazard, that this project's own suite leaves servers on scratch sockets and a resurrect config restores real sessions into them, so an unattached server can be a convincing duplicate. The new rule is "a server this app has used is one it may still see", not "show every detached server".

### Opening on it, rather than on a fresh shell

Remembering only made the session *visible*. The panel still started a bare shell, so the work was running and merely not on screen, and the way back was still to type the attach into that new shell. There are three cases and each was measured on tmux 3.7, because the obvious spellings are wrong:

- **Session alive** — `attach-session -t $id`. By id, not name: a name is prefix-matched, so a remembered `work` lands silently in `workbench`.
- **Server alive, that session gone** — `attach-session` with no `-t`, the most recently used one. Starting a server here would add a session beside the work.
- **No server at all, the cold boot** — `new-session -A -s <name>`. Bare `tmux` starts the server and attaches you to the session **it** just made, while a resurrect/continuum setup restores the real ones behind you; you end up in `0` watching none of them, which is exactly how this was reported. `start-server` cannot stand in either — a server with no sessions exits immediately. `-A` works because *creating* the session is what starts the server, which sources the user's configuration, which fires their restore — and resurrect puts missing windows into a session that already exists, so the one we just made is filled in rather than competed with.

Deliberately not `attachArgvFor`, the phone's attach: that one builds a grouped session so two screens can differ in size and marks `window-size` to hand back. The desk **is** the session.

### What counts as "where you work"

"The last session the panel attached to" is a different question, and answering the wrong one is visible: after a restore, tmux put the client on a one-window session on its way past and the memory recorded that. A cold start would then have brought back that session instead of the one the day was spent in. A session now has to **settle for 30 seconds** before it is written, and a phone's mirror never counts.

### A safety net for the user's resurrect saves

This one comes from losing a session for real while building the rest. resurrect keeps every save and a `last` symlink at the newest; continuum saves on a timer. A save fired while the server was being killed, wrote a file with **one pane** in it, and `last` moved to it — leaving a nine-pane save from ten minutes earlier on disk and unreachable by anything that restores. The same shape had already emptied `assistant-sessions.json` once before, so it is not a freak: a save on a dying or newborn server is poorer than the one it replaces, and resurrect has no notion of "poorer".

agentglass does **not** race that timer — two savers on one server is its own way to lose sessions. It keeps a copy where nothing else writes, and repoints `last` only when the live file is one pane against several, keeping what it replaced as `last.clobbered`. Their restore does the restoring; this only protects the file it reads. Panes rather than bytes, because `@resurrect-capture-pane-contents` makes size a function of scrollback, so an empty server's save can be the larger file.

Rules held throughout: their saves are read, never written and never deleted; the only write into their directory is that symlink; nothing is installed; and a machine with no resurrect at all sees none of this happen.

## How was it tested?

`tsc --noEmit` clean for `server/`.

**`server/test/tmux-memory.test.ts`** — 18 cases against **real tmux**, because every claim is about what tmux reports for a server nobody is attached to. Each test gets its own socket directory under a private `TMUX_TMPDIR`, and every server runs with `-f /dev/null`, so nothing here can find or read the developer's own tmux. The bug itself is pinned: a detached server, `list-clients` verified empty, is listed once remembered — and is **not** listed when it is not ours, when nothing is remembered, or when its server has since been killed. The attach builder is asserted to resolve by id with `work`/`workbench` standing side by side, to use `-A` on a cold socket, and to fall back to bare `tmux` when no name was ever recorded.

**`server/test/tmux-snapshot.test.ts`** — 15 cases: a one-pane save is never copied (it is the clobber's own shape), a smaller save somebody *meant* is left alone, `last` is repointed only on the real signature, what it replaced is kept, none of the user's files are destroyed, and the pointer is never absent mid-repair.

52 tests pass across these two plus the recipes suite when both features are built together.

Driven on the machine that reported it, through a desktop build, including a real `tmux kill-server` and cold start.

**One thing worth saying plainly**: while building the snapshot module, its own test wrote into the developer's real `~/.tmux/resurrect` and destroyed a save. `os.homedir()` does not follow `$HOME` on Bun, so a suite that redirected `HOME` was not isolated at all, and a fixture helper writing with `fs` bypassed every guard the module had. Both are fixed here — the module reads `$HOME` first, and the helper **throws** rather than writing outside the scratch directory — and the episode is written into the comments so the next person does not rediscover it the same way.
