### PR TITLE
feat(recipes): a saved command can run when the app starts

### DIFF
--- a/server/src/recipes.ts
+++ b/server/src/recipes.ts
@@ -48,6 +48,18 @@ function load(): Store {
     cache = { recipes: [] };
   }
   cache!.recipes = Array.isArray(cache!.recipes) ? cache!.recipes : [];
+  /*
+   * A file that did not go through saveRecipe has not met its guards.
+   *
+   * A boot recipe is command execution at start — the one thing the save path
+   * polices hardest, and the one thing a hand-written file can carry without
+   * ever being asked. So the read path runs the same check and forgets the
+   * boot flag on anything that would have been refused, rather than fire it
+   * on faith. The recipe still shows in the list, only a hand-edited
+   * `rm -rf` with `"boot": true` no longer runs.
+   */
+  cache!.recipes = cache!.recipes.map((r) =>
+    r && r.boot && invalid(r) ? { ...r, boot: false } : r);
   return cache!;
 }
 
@@ -156,6 +168,20 @@ export function invalid(r: Partial<Recipe>): string | null {
   if (r.scope === "repo" && !r.repo) return "A recipe scoped to a repository needs one";
   for (const p of r.params ?? []) {
     if (!/^[A-Za-z0-9_-]+$/.test(p.key || "")) return `"${p.key}" is not a usable parameter name`;
+  }
+  /*
+   * A command that runs at start runs with nobody watching it start. That is
+   * fine for a `docker compose up -d`, and it is not fine for anything the
+   * file would otherwise make somebody confirm first: there is no Run dialog
+   * at boot to hold a value, to say "always ask first", or to stand between a
+   * line and `rm -rf`. Each of these is refused here, once, so a boot recipe
+   * that got in can actually run — and the app never meets one it has to
+   * silently skip.
+   */
+  if (r.boot) {
+    if ((r.params ?? []).length) return "A command that runs at start cannot have parameters — nothing is there to fill them in";
+    if (r.confirm) return "A command that runs at start cannot ask first — it fires with nobody to ask";
+    if (looksDestructive(r.steps)) return "A command that runs at start cannot read as destructive — it fires with nobody to confirm it";
   }
   return null;
 }

--- a/server/test/recipes.test.ts
+++ b/server/test/recipes.test.ts
@@ -1,5 +1,5 @@
 import { afterAll, beforeEach, describe, expect, it } from "bun:test";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
@@ -50,6 +50,38 @@ describe("keeping a recipe", () => {
     expect(R.saveRecipe({ ...base, scope: "repo" }).error).toContain("repository");
     expect(R.saveRecipe({ ...base, params: [{ key: "a b", label: "x", type: "text" }] }).error).toContain("parameter");
     expect(R.recipes()).toHaveLength(0);
+  });
+
+  it("refuses one that runs at start but could not be asked about", () => {
+    // A boot recipe fires with nobody to fill a box, to click "ask first", or
+    // to read a destructive line. Each refusal is what lets the rest get in:
+    // the saved set never contains one the app would have to skip.
+    const plain = { ...base, params: [] as never[] };
+    expect(R.saveRecipe({ ...plain, boot: true, params: base.params }).error).toContain("parameters");
+    expect(R.saveRecipe({ ...plain, boot: true, confirm: true }).error).toContain("ask first");
+    expect(R.saveRecipe({ ...plain, boot: true, steps: ["git reset --hard"] }).error).toContain("destructive");
+    expect(R.recipes()).toHaveLength(0);
+  });
+
+  it("keeps a clean one that runs at start", () => {
+    const r = R.saveRecipe({ ...base, params: [], boot: true, steps: ["docker compose up -d"] });
+    expect(r.ok).toBe(true);
+    expect(R.recipes()[0]!.boot).toBe(true);
+  });
+
+  it("forgets boot on a hand-written recipe the save path would have refused", () => {
+    // The read path is command execution: a file written by hand — or copied
+    // from another machine — never met the boot rules, and must not fire an
+    // unconfirmed destructive line on every app start. It stays in the list;
+    // it just does not run at boot.
+    writeFileSync(join(dir, "commands.json"), JSON.stringify({ recipes: [
+      { id: "bad", name: "bad", desc: "", steps: ["rm -rf ~/code"], scope: "global", boot: true, addedAt: 0 },
+      { id: "good", name: "good", desc: "", steps: ["docker compose up -d"], scope: "global", boot: true, addedAt: 0 },
+    ] }));
+    R.__setRecipesPath(join(dir, "commands.json")); // drop the cache so the file is actually read
+    const loaded = R.recipes();
+    expect(loaded.find((r) => r.id === "bad")!.boot).toBe(false);
+    expect(loaded.find((r) => r.id === "good")!.boot).toBe(true);
   });
 });
 

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2988,6 +2988,10 @@ export interface Recipe {
   /** Ask before running, every time. Set by the author, and forced on by the
    *  server for anything that reads as destructive. */
   confirm?: boolean;
+  /** Run in the docked console each time the app starts, without being asked.
+   *  Mutually exclusive with parameters, a confirm, and anything destructive —
+   *  there is nobody at boot to ask. */
+  boot?: boolean;
   addedAt: number;
 }
 

--- a/web/src/App.tsx
+++ b/web/src/App.tsx
@@ -34,6 +34,7 @@ import { FilePalette } from "./components/FilePalette.tsx";
 import { PeekFile, isRenderable, type Peek } from "./components/PeekFile.tsx";
 import { requestFilesReveal } from "./lib/filesReveal.ts";
 import { onOpenSettings, openSettings } from "./lib/openSettings.ts";
+import { runBootRecipes } from "./components/RecipesPane.tsx";
 import { onOpenPrs, onOpenPr } from "./lib/openPrs.ts";
 import { onOpenCard, openCard } from "./lib/openCard.ts";
 import { onOpenIssue } from "./lib/openIssue.ts";
@@ -255,6 +256,18 @@ export default function App() {
   // fleet spine reads them in every view, and holding them would freeze a
   // streaming answer mid-word.
   const { events, conn, lastEvent, openTools } = useLive(anyPanelOpen);
+  /*
+   * The saved commands marked "run when the app starts" fire exactly once per
+   * app load, when the live socket first opens — the moment the server is
+   * certainly there. A reconnect later is a server problem, not an app start,
+   * and must not re-fire them.
+   */
+  const bootFired = useRef(false);
+  useEffect(() => {
+    if (conn !== "open" || bootFired.current) return;
+    bootFired.current = true;
+    runBootRecipes();
+  }, [conn]);
   // The live socket is the app's only real-time source, and until now the chat
   // panel was the one view that never saw it — a resumed session sat frozen on
   // whatever had been true when you opened it while the agent kept working.

--- a/web/src/components/RecipesPane.tsx
+++ b/web/src/components/RecipesPane.tsx
@@ -14,6 +14,7 @@
  */
 import { useCallback, useEffect, useState } from "react";
 import { api } from "../lib/api.ts";
+import { retryLoad } from "../lib/retryLoad.ts";
 import type { Recipe, RecipeParam, GitRepoRef } from "../../../shared/types.ts";
 import { consoleRoot, runInConsole, consoleInTmux } from "./TerminalPanel.tsx";
 import { CloseButton } from "./CloseButton.tsx";
@@ -80,6 +81,7 @@ export function RecipesPane({ open }: { open: boolean }) {
             {r.scope === "global" ? "global" : (r.repo?.split("/").pop() ?? "repo")} · {r.steps.length} step{r.steps.length === 1 ? "" : "s"}
             {r.params?.length ? ` · ${r.params.length} param${r.params.length === 1 ? "" : "s"}` : ""}
             {r.tmux ? " · tmux" : ""}
+            {r.boot ? " · at start" : ""}
           </>}
           control={<span className="flex items-center gap-2">
             <button onClick={() => setRunning(r)} className="text-[12px] px-2.5 py-1 rounded-lg whitespace-nowrap"
@@ -122,6 +124,10 @@ function Editor({ r, repos, onChange, onSave, onDrop, onCancel }: {
   onChange: (r: Recipe) => void; onSave: (r: Recipe) => void; onDrop: (r: Recipe) => void; onCancel: () => void;
 }) {
   const set = (patch: Partial<Recipe>) => onChange({ ...r, ...patch });
+  /** Boot and the two things that would need asking are mutually exclusive —
+   *  the server refuses saving the combination, so the editor says so up
+   *  front rather than letting the save be the first to find out. */
+  const cannotBoot = !!(r.params?.length) || !!r.confirm;
   const inp = "w-full text-[11.5px] px-2 py-1.5 rounded-lg outline-none";
   const style = { background: "var(--bg2)", border: edge(22), color: "var(--text)" };
   return (
@@ -165,8 +171,20 @@ function Editor({ r, repos, onChange, onSave, onDrop, onCancel }: {
           Run inside tmux <span style={{ color: "var(--text4)" }}>— survives closing the app</span>
         </label>
         <label className="flex items-center gap-1.5 text-[11px] pb-1.5" style={{ color: "var(--text2)" }}>
-          <input type="checkbox" checked={!!r.confirm} onChange={(e) => set({ confirm: e.target.checked })} />
+          <input type="checkbox" checked={!!r.confirm} onChange={(e) => set({ confirm: e.target.checked })}
+            disabled={!!r.boot} title={r.boot ? "A command that runs at start fires with nobody to ask" : undefined} />
           Always ask first
+        </label>
+        {/* A boot recipe runs the moment the app opens, with nobody to fill a
+            box or click anything. The server refuses saving one that has
+            parameters, asks first, or reads as destructive — these two
+            checkboxes just keep the editor from leading somewhere the save
+            would refuse. */}
+        <label className="flex items-center gap-1.5 text-[11px] pb-1.5" style={{ color: cannotBoot ? "var(--text4)" : "var(--text2)" }}>
+          <input type="checkbox" checked={!!r.boot} disabled={cannotBoot}
+            title={cannotBoot ? "Remove the parameters or the ask-first to run it at start" : undefined}
+            onChange={(e) => set(e.target.checked ? { boot: true, confirm: false } : { boot: false })} />
+          Run when the app starts <span style={{ color: "var(--text4)" }}>— in the docked console, on every open</span>
         </label>
       </div>
 
@@ -193,7 +211,7 @@ function Editor({ r, repos, onChange, onSave, onDrop, onCancel }: {
             <CloseButton onClick={() => set({ params: (r.params ?? []).filter((_, j) => j !== i) })} style={{ color: "var(--text4)" }} className="rounded" />
           </div>
         ))}
-        <button onClick={() => set({ params: [...(r.params ?? []), { key: "", label: "", type: "text" }] })}
+        <button onClick={() => set({ boot: false, params: [...(r.params ?? []), { key: "", label: "", type: "text" }] })}
           className="self-start text-[10.5px] px-2 py-0.5 rounded" style={{ border: edge(20), color: "var(--text3)" }}>＋ parameter</button>
       </div>
 
@@ -248,6 +266,38 @@ export function runRecipeSteps(root: string, steps: string[], wrapInTmux: boolea
     }, 150);
   } else send();
   return { ran: true };
+}
+
+/**
+ * Fire the commands marked "run when the app starts".
+ *
+ * Called once per app load, once the live socket is up. The steps go to the
+ * docked console — the same surface every recipe runs in — so the console's
+ * shell starts tmux, attaches to the last session, whatever the saved lines
+ * say, whether or not the console is on screen. The saved set cannot contain
+ * a boot recipe with parameters, an ask-first, or a destructive line: the
+ * server refuses those at save time AND strips `boot` from a hand-written
+ * file that carries them anyway, so nothing this side ever meets one that
+ * would need asking or skipping.
+ *
+ * A module flag rather than a caller's ref: the caller (App) re-renders for
+ * many reasons, but "this app load" is exactly the lifetime of this module.
+ */
+let bootFired = false;
+export function runBootRecipes(): void {
+  if (bootFired) return;
+  bootFired = true;
+  const root = consoleRoot();
+  if (!root) return;
+  // Retried like the command bar's own first read: the window is up before
+  // the sidecar is listening, and a fetch that loses that race must not lose
+  // the whole automation. Four goes over ~8s, then it stops.
+  retryLoad(() => api.recipes(root)
+    .then(({ recipes }) => {
+      for (const r of recipes) if (r.boot) runRecipeSteps(root, r.steps, !!r.tmux);
+      return true;
+    })
+    .catch(() => false));
 }
 
 /**


### PR DESCRIPTION
## What does this PR do?

Gives a saved command a "run when the app starts" flag, so a dev server, a docker stack, or anything else that should be up before the first keystroke is up without being asked for.

They fire **once per app load**, when the live socket first opens — the moment the server is certainly there. A reconnect later is a server problem and not an app start, so it must not re-fire them, and the flag that guarantees that lives in the module rather than in a component ref: "this app load" is exactly the lifetime of the module, while the component re-renders for many reasons. The steps go to the docked console, the same surface every recipe already runs in, whether or not the console is on screen.

The interesting half is what a boot recipe is **not** allowed to be. A command that runs at start runs with nobody watching it start: there is no Run dialog at boot to hold a value, to honour "always ask first", or to stand between a line and `rm -rf`. So three things are refused outright — parameters, an ask-first, and anything that reads as destructive — and refusing them at save time is what lets the rest run unattended. The app never meets a boot recipe it would have to silently skip.

**And the read path runs the same check.** Refusing on write polices the app's own UI and nothing else; `commands.json` is a file on disk that anything can write, and a hand-edited `{ "steps": ["rm -rf …"], "boot": true }` would otherwise be unconfirmed command execution on every app start. `load()` now drops the `boot` flag from anything `invalid()` would have refused — a copy, not a mutation, so reading the file cannot rewrite it. The recipe still appears in the list and can still be run by hand; it just does not fire on its own.

Explicitly **not** for tmux. Attaching a session at boot from the docked console would be a second client on the session the terminal panel is already resuming, which is the window-size fight, and a second opinion about which session is yours. That job belongs to #514.

## How was it tested?

`tsc --noEmit` clean for `server/` and for both of `web/`'s configs.

`server/test/recipes.test.ts` gains cases for each refusal — parameters, ask-first, destructive — and for a clean boot recipe surviving, plus the one that matters most: **a file edited by hand to carry `boot: true` on a destructive line comes back with the flag gone.** That is the assertion standing between this feature and unattended `rm -rf`. 19 pass in that file.

Rebased on `main` after #514 landed and re-checked there, so what this branch adds is the five files above and nothing else.

Built as a desktop app from this branch and driven: the flag appears on the recipe editor, is disabled with a reason for a recipe that has parameters, and a clean boot recipe runs in the docked console on the next app start. The machine's own `commands.json` was left with no boot recipe, deliberately — the tmux one that prompted this is now redundant.
