### PR TITLE
feat(term): resume any session in this project, from the bar

### DIFF
--- a/server/src/agentsessions.ts
+++ b/server/src/agentsessions.ts
@@ -96,6 +96,30 @@ function readable(t: string): boolean {
   return !!t && !t.startsWith("<") && !t.startsWith("/") && !t.startsWith("Caveat:");
 }
 
+/**
+ * The name somebody gave this session, if they gave it one.
+ *
+ * `/rename` appends `{"type":"custom-title","customTitle":…}` to the transcript
+ * — it does not rewrite the head — so this is read from the TAIL, and the last
+ * one wins. Measured on a real 5.8MB transcript: the first title line sits at
+ * 18% of the file and the last one at the very end, which is why the head read
+ * that finds a summary never found a name, and a card showed the first user
+ * message under a session the CLI lists as "handover-notes".
+ */
+function nameFrom(tail: string): string {
+  let name = "";
+  for (const line of tail.split("\n")) {
+    if (!line.includes('"custom-title"')) continue;
+    try {
+      const o = JSON.parse(line) as Record<string, unknown>;
+      if (o.type === "custom-title" && typeof o.customTitle === "string" && o.customTitle.trim()) {
+        name = o.customTitle.trim().slice(0, 200);
+      }
+    } catch { /* half a line at the start of a tail read */ }
+  }
+  return name;
+}
+
 /** The last thing said, from the tail of a transcript. */
 function lastFrom(tail: string): string {
   const lines = tail.split("\n");
@@ -181,15 +205,17 @@ export async function sessionsForProject(root: string, limit = LIMIT): Promise<A
     try {
       const f = Bun.file(join(projects, projectSlug(s.cwd), `${s.id}.jsonl`));
       const head = await f.slice(0, Math.min(HEAD_BYTES, s.size)).text();
-      s.title = titleFrom(head);
+      const tail = s.size > TAIL_BYTES ? await f.slice(Math.max(0, s.size - TAIL_BYTES), s.size).text() : head;
+      // A name somebody typed beats a summary the CLI guessed, which beats the
+      // first thing they said. That is also the order `/resume` shows them in,
+      // and the picker agreeing with the CLI is the point.
+      s.title = nameFrom(tail) || titleFrom(head);
       const opening = openingFrom(head);
       // Only when it says something the title does not. A card that repeats its
       // own heading in smaller type is two lines of nothing.
       s.opening = opening && opening !== s.title ? opening : "";
-      // The tail, for "where did this get to". Skipped on a small file, where
-      // the head already covers the whole conversation.
-      if (s.size > TAIL_BYTES) s.last = lastFrom(await f.slice(Math.max(0, s.size - TAIL_BYTES), s.size).text());
-      else s.last = lastFrom(head);
+      // Where it got to, out of the same tail.
+      s.last = lastFrom(tail);
       if (s.last === s.title || s.last === s.opening) s.last = "";
     } catch { /* unreadable: the row still resumes, it just arrives unnamed */ }
   }));

--- a/server/src/agentsessions.ts
+++ b/server/src/agentsessions.ts
@@ -1,0 +1,197 @@
+/**
+ * Every Claude Code session belonging to a project, whichever checkout it ran in.
+ *
+ * What this exists for: resuming one is three steps by hand — open a tab, start
+ * the agent, type `/resume`, find the session in a list — and the list `/resume`
+ * shows is scoped to the directory the agent happens to be running in. A card
+ * worked on in a worktree is invisible from the main checkout, so the sessions
+ * you most want back are the ones the built-in list cannot offer.
+ *
+ * Read from disk rather than from this app's database, and that is deliberate:
+ * `/resume` reads `~/.claude/projects/<slug>/<id>.jsonl`, so reading the same
+ * files is the only way to be sure the two lists agree. A session the scanner
+ * never ingested — a machine where agentglass was installed last week, a
+ * transcript older than the retention window — is still there on disk and is
+ * still resumable, and a picker that quietly omitted it would be worse than no
+ * picker at all.
+ *
+ * The cost is bounded on purpose: the slug is a pure function of the path, so a
+ * project's transcripts are found by NAMING the directories rather than by
+ * walking every project on the machine, and only the head of each transcript is
+ * read (the title is in the first user message, and the files run to hundreds of
+ * megabytes).
+ */
+import { readdirSync, statSync, existsSync } from "node:fs";
+import { join } from "node:path";
+import { claudeHome, projectSlug } from "./agents/claudecode.ts";
+import { worktrees } from "./gitwork.ts";
+import { inScope } from "./config.ts";
+
+export interface AgentSession {
+  /** The id `--resume` takes: the transcript's file name. */
+  id: string;
+  /** What the session is called: the CLI's own summary when it wrote one, and
+   *  the first user message otherwise — the same text `/resume` shows. */
+  title: string;
+  /** How it started, when that is not already the title. A summary is four
+   *  words and a title is not always enough to tell two mornings apart. */
+  opening: string;
+  /** Where it got to: the last thing said in the transcript. Read from the tail
+   *  because "which one was I on" is answered by the end, not the beginning. */
+  last: string;
+  /** The checkout it ran in — where the resumed session has to start. */
+  cwd: string;
+  /** Last write to the transcript, ms since epoch. What "3 minutes ago" is. */
+  at: number;
+  /** Bytes on disk. The CLI's own list shows it, and it is the one honest hint
+   *  of how long a conversation is before you open it. */
+  size: number;
+}
+
+/** How much of a transcript is read to find its first user message. The head
+ *  carries a `summary` line, a `user` line and little else; 64 KB is generous
+ *  and still a single read. */
+const HEAD_BYTES = 64 * 1024;
+
+/** How much of the END is read, for "where it got to". Smaller than the head:
+ *  one exchange is all a card shows, and these files are on the hot path of a
+ *  menu somebody is waiting on. */
+const TAIL_BYTES = 32 * 1024;
+
+/** Newest first, and capped: this is a menu, not an archive. */
+const LIMIT = 120;
+
+/**
+ * The paths a project's sessions can have run in.
+ *
+ * Every linked worktree, plus the main checkout. `git worktree list` is the
+ * authority — guessing from the directory name (`repo`, `repo-CARD-1`) finds the
+ * common case and misses a worktree somebody put elsewhere, which is exactly the
+ * one they will be looking for.
+ */
+async function checkoutsOf(root: string): Promise<string[]> {
+  const out = new Set<string>([root]);
+  try {
+    for (const w of await worktrees(root)) if (w.path) out.add(w.path);
+  } catch { /* not a git repo, or git is unavailable: the root alone is honest */ }
+  return [...out];
+}
+
+/** Text out of one transcript line, whatever shape its content is in. */
+function textOf(o: Record<string, unknown>): string {
+  const msg = o.message as { content?: unknown } | undefined;
+  const c = msg?.content;
+  const text = typeof c === "string"
+    ? c
+    : Array.isArray(c)
+      ? c.map((p) => (p && typeof p === "object" && typeof (p as { text?: unknown }).text === "string"
+        ? (p as { text: string }).text : "")).join(" ")
+      : "";
+  return text.replace(/\s+/g, " ").trim();
+}
+
+/** Is this line worth showing a person? Tool results, hook preambles and slash
+ *  commands are the transcript's plumbing, not its conversation. */
+function readable(t: string): boolean {
+  return !!t && !t.startsWith("<") && !t.startsWith("/") && !t.startsWith("Caveat:");
+}
+
+/** The last thing said, from the tail of a transcript. */
+function lastFrom(tail: string): string {
+  const lines = tail.split("\n");
+  // The first line of a tail read is usually half a line; it parses or it does
+  // not, and either way the loop below is walking backwards past it.
+  for (let i = lines.length - 1; i >= 1; i--) {
+    const line = lines[i];
+    if (!line.startsWith("{")) continue;
+    let o: Record<string, unknown>;
+    try { o = JSON.parse(line) as Record<string, unknown>; } catch { continue; }
+    if (o.type !== "assistant" && o.type !== "user") continue;
+    const t = textOf(o);
+    if (readable(t)) return t.slice(0, 240);
+  }
+  return "";
+}
+
+/** The first user message, ignoring any summary line. This is what the card
+ *  shows under a four-word title. */
+function openingFrom(head: string): string {
+  for (const line of head.split("\n")) {
+    if (!line.startsWith("{")) continue;
+    let o: Record<string, unknown>;
+    try { o = JSON.parse(line) as Record<string, unknown>; } catch { continue; }
+    if (o.type !== "user") continue;
+    const t = textOf(o);
+    if (readable(t)) return t.slice(0, 240);
+  }
+  return "";
+}
+
+/** The first user message in a transcript's head, as one line. */
+function titleFrom(head: string): string {
+  for (const line of head.split("\n")) {
+    if (!line.startsWith("{")) continue;
+    let o: Record<string, unknown>;
+    try { o = JSON.parse(line) as Record<string, unknown>; } catch { continue; }
+    // The CLI's own summary line, when it has written one — that is the text
+    // `/resume` shows, so preferring it keeps the two lists reading alike.
+    if (o.type === "summary" && typeof o.summary === "string" && o.summary.trim()) {
+      return o.summary.trim().slice(0, 200);
+    }
+    if (o.type !== "user") continue;
+    // A slash command or a hook's injected preamble is not what the session was
+    // about; keep looking rather than titling forty sessions "/clear".
+    const clean = textOf(o);
+    if (readable(clean)) return clean.slice(0, 200);
+  }
+  return "";
+}
+
+/**
+ * Sessions for this project, newest first.
+ *
+ * `root` is a repository root; every checkout of it is searched. Paths outside
+ * the workspace are refused rather than listed — the same rule the terminal's
+ * own frames pass through, because what comes back here becomes a `-c` and a
+ * command line.
+ */
+export async function sessionsForProject(root: string, limit = LIMIT): Promise<AgentSession[]> {
+  if (!root || !inScope(root)) return [];
+  const projects = join(claudeHome(), "projects");
+  if (!existsSync(projects)) return [];
+  const rows: AgentSession[] = [];
+  for (const cwd of await checkoutsOf(root)) {
+    const dir = join(projects, projectSlug(cwd));
+    let names: string[];
+    try { names = readdirSync(dir); } catch { continue; }
+    for (const n of names) {
+      if (!n.endsWith(".jsonl")) continue;
+      const file = join(dir, n);
+      let st;
+      try { st = statSync(file); } catch { continue; }
+      if (!st.isFile() || st.size === 0) continue;
+      rows.push({ id: n.slice(0, -".jsonl".length), title: "", opening: "", last: "", cwd, at: st.mtimeMs, size: st.size });
+    }
+  }
+  rows.sort((a, b) => b.at - a.at);
+  const shown = rows.slice(0, limit);
+  // Titles only for what is actually shown. A machine with a thousand
+  // transcripts would otherwise pay a read per session to fill a menu of forty.
+  await Promise.all(shown.map(async (s) => {
+    try {
+      const f = Bun.file(join(projects, projectSlug(s.cwd), `${s.id}.jsonl`));
+      const head = await f.slice(0, Math.min(HEAD_BYTES, s.size)).text();
+      s.title = titleFrom(head);
+      const opening = openingFrom(head);
+      // Only when it says something the title does not. A card that repeats its
+      // own heading in smaller type is two lines of nothing.
+      s.opening = opening && opening !== s.title ? opening : "";
+      // The tail, for "where did this get to". Skipped on a small file, where
+      // the head already covers the whole conversation.
+      if (s.size > TAIL_BYTES) s.last = lastFrom(await f.slice(Math.max(0, s.size - TAIL_BYTES), s.size).text());
+      else s.last = lastFrom(head);
+      if (s.last === s.title || s.last === s.opening) s.last = "";
+    } catch { /* unreadable: the row still resumes, it just arrives unnamed */ }
+  }));
+  return shown;
+}

--- a/server/src/clickupwatch.ts
+++ b/server/src/clickupwatch.ts
@@ -379,7 +379,7 @@ export function stopCardWatch(): void {
  * destination that leaves this app.
  *
  * The title, though, is enough: the watcher already keeps every card of yours
- * it has seen, with its id and its `PROJ-…` label, in the file it uses to tell
+ * it has seen, with its id and its `ORBIT-…` label, in the file it uses to tell
  * a status change from a new assignment. Looking a title up in that costs
  * nothing and is not a guess.
  *

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -1965,7 +1965,8 @@ export function setPrBaseHook(fn: PrBaseLookup | null): void { prBaseFor = fn; }
 /**
  * What this branch is measured against, in order of how much the answer is
  * actually *known*: an override somebody wrote down, then the base its pull
- * request declares, then the shape of history, then the trunk.
+ * request declares, then what the branch tracks, then the shape of history,
+ * then the trunk.
  *
  * Whatever wins, what comes back is the freshest copy of that branch (see
  * `freshest`). That is not a detail — it is the difference between a number and
@@ -1995,13 +1996,39 @@ export async function baseOf(root: string, branch: string): Promise<string | nul
       // very problem this is measuring.
       base = `origin/${declared}`;
     } else {
-      const trunk = await defaultBranch(root);
-      // No base recorded anywhere: infer the branch this one was stacked on (its
-      // base is THAT, not the trunk). Falls back to the trunk when there is
-      // nothing between HEAD and it. A branch is not its own base; the trunk
-      // checkout simply has none.
-      const inferred = await inferBase(root, branch, trunk);
-      base = inferred ?? (!trunk || trunk === branch || trunk.replace(/^origin\//, "") === branch ? null : trunk);
+      /*
+       * What the branch says it tracks, before anything is inferred from the
+       * shape of history.
+       *
+       * `git worktree add -b card --track origin/other` and `git checkout -b
+       * card origin/other` both write `branch.card.merge`, so this is not a
+       * guess: somebody said what this was cut from and git wrote it down. The
+       * inference below cannot see it — `--merged <branch>` only matches a base
+       * this branch still contains, and the moment the base picks up a commit
+       * of its own it stops being an ancestor and drops out of the candidates,
+       * leaving the trunk. Which is the report: a branch stacked on another
+       * feature branch showed "origin/master" as its base while the header
+       * beside it correctly read "tracking origin/<that branch>".
+       *
+       * Skipped when the upstream is this branch's own remote copy, which is
+       * what tracking means for every branch that has simply been pushed —
+       * `sameBranch` because `origin/card` and `card` are one branch under two
+       * names.
+       */
+      const up = (await gitAsync(root, ["rev-parse", "--symbolic-full-name", `${branch}@{upstream}`])).stdout
+        .trim().replace(/^refs\/remotes\//, "").replace(/^refs\/heads\//, "");
+      const tracked = up && validRef(up) && !(await sameBranch(root, up, branch)) ? up : "";
+      if (tracked) {
+        base = tracked;
+      } else {
+        const trunk = await defaultBranch(root);
+        // No base recorded anywhere: infer the branch this one was stacked on (its
+        // base is THAT, not the trunk). Falls back to the trunk when there is
+        // nothing between HEAD and it. A branch is not its own base; the trunk
+        // checkout simply has none.
+        const inferred = await inferBase(root, branch, trunk);
+        base = inferred ?? (!trunk || trunk === branch || trunk.replace(/^origin\//, "") === branch ? null : trunk);
+      }
     }
   }
   if (base) base = await freshest(root, base);

--- a/server/src/gitwork.ts
+++ b/server/src/gitwork.ts
@@ -2494,7 +2494,7 @@ export function addWorktree(rootIn: string, pathIn: unknown, branch: string, new
   const r = run(root, newBranch ? ["worktree", "add", "-b", branch, abs, ...from] : ["worktree", "add", abs, branch]);
   // Record what the new branch was cut from, so a later "sync" merges from its
   // REAL base instead of falling back to the trunk. Without this a card stacked
-  // on another feature branch (base = PROJ-…, not master) synced against master
+  // on another feature branch (base = ORBIT-…, not master) synced against master
   // and pulled in changes that never belonged on it — the exact failure this
   // config exists to prevent. Only for a genuinely new branch off a start point;
   // `git worktree add <path> <existing-branch>` adopts a branch whose base, if

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1820,15 +1820,33 @@ const server = Bun.serve<WsData>({
        * out with the list rather than becoming a button that goes nowhere.
        */
       const live = listPanes(lastTmuxTarget()?.socket).map(({ socket: _s, ...p }) => p);
+      /*
+       * A note is only believed while the agent it was written for is STILL the
+       * one in that pane — `paneDirs` has applied this rule for a while and this
+       * route skipped it, at a cost: tmux reuses pane ids, so a note from a
+       * session that ended yesterday named a pane holding somebody's shell
+       * today. Pressed, it took the desk to a `fish` prompt in another session
+       * and the tab strip came back showing that session's windows, which reads
+       * exactly like the two tabs you had open having vanished.
+       *
+       * The test is the directory: the pane has to have an agent running in the
+       * one the note recorded.
+       */
+      const agentsAt = new Map(live.map((p) => [p.paneId, p.agentCwds ?? []]));
       const where = new Map<string, (typeof live)[number] & { agentSession: string | null }>();
       for (const p of withAgentSessions(live, (id) => {
         const n = paneAgentNote(id);
-        return n ? { sessionId: n.session_id, at: n.at } : null;
+        if (!n || !(agentsAt.get(id) ?? []).includes(n.cwd)) return null;
+        return { sessionId: n.session_id, at: n.at };
       })) if (p.agentSession) where.set(p.agentSession, p);
       const sessions: AgentSessionRow[] = rows.map((r) => {
         const p = where.get(r.id);
-        return p
-          ? { ...r, openIn: { session: p.session, windowId: p.windowId, windowIndex: p.windowIndex, windowName: p.windowName, paneId: p.paneId } }
+        // And the pane and the session have to agree about where they are. Two
+        // cheap facts pointing the same way is what makes this a place to send
+        // somebody rather than a guess.
+        const sure = p && (agentsAt.get(p.paneId) ?? []).includes(r.cwd);
+        return sure && p
+          ? { ...r, openIn: { session: p.session, sessionId: p.sessionId, windowId: p.windowId, windowIndex: p.windowIndex, windowName: p.windowName, paneId: p.paneId } }
           : r;
       });
       return json({ ok: true, sessions });

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,7 +2,7 @@
 // here, before the imports below open the database and start their timers.
 import "./cookieentry.ts";
 import type { ServerWebSocket } from "bun";
-import type { IngestBody, WsFrame, WorkingTree, PanesResponse } from "../../shared/types.ts";
+import type { IngestBody, WsFrame, WorkingTree, PanesResponse, AgentSessionRow } from "../../shared/types.ts";
 import { slackReachable } from "./slackreach.ts";
 import { normalize, detectError, clampIngestTimestamp, externalIngestError } from "./ingest.ts";
 import { db } from "./db.ts";
@@ -45,7 +45,7 @@ import { askBrowser, browserReadyCount, noteBrowserReady, parseAsk, setBrowserSi
 import { browserUseStatus, installSkill } from "./browseruse.ts";
 import { otlpTracesToEvents, otlpLogsToEvents } from "./otlp.ts";
 import { decodeOtlpTraces, decodeOtlpLogs } from "./otlp_pb.ts";
-import { statusForPaths, commit as gitCommit, amend as gitAmend, COMMIT_ENABLED, gitAsync, gitCapability, safeAbs as gitSafeAbs } from "./git.ts";
+import { statusForPaths, commit as gitCommit, amend as gitAmend, COMMIT_ENABLED, gitAsync, gitCapability, repoRootOf, safeAbs as gitSafeAbs } from "./git.ts";
 import { dependencyReport } from "./deps.ts";
 import {
   workingTree, lastCommitChanges, discoverRepos, stage, unstage, stageAll, unstageAll, discard,
@@ -68,6 +68,7 @@ import {
   createTag, deleteTag, pushTag, deleteRemoteTag,
   prepareConflictMerge,
 } from "./gitwork.ts";
+import { sessionsForProject } from "./agentsessions.ts";
 import { changeRows, fileDiff } from "./changerows.ts";
 import { repoStats, generateChangelog } from "./gitinsights.ts";
 import { saveShot } from "./shots.ts";
@@ -1793,6 +1794,44 @@ const server = Bun.serve<WsData>({
       const scope = url.searchParams.get("scope") === "all" ? "all" : "head";
       const key = `graph:${root}:${limit}:${scope}`;
       return body(await singleFlight(key, () => whileRefsHoldAsync(key, root, () => logGraph(root, limit, scope))));
+    }
+    /*
+     * The agent sessions this project has, whichever checkout they ran in.
+     *
+     * What the terminal's resume picker draws. Read from disk — the same files
+     * `/resume` reads — so the two lists cannot disagree; see agentsessions.ts
+     * for why that matters more than reading this app's own database.
+     */
+    if (pathname === "/agent/sessions") {
+      // Folded to the repository the path belongs to, so asking from a worktree
+      // returns the whole family rather than that one checkout — which is the
+      // point of the picker.
+      const asked = url.searchParams.get("root") || "";
+      const root = repoRootOf(asked) ?? asked;
+      const rows = await sessionsForProject(root);
+      /*
+       * And which of them are already running, and where.
+       *
+       * A session open in a pane is not one to resume — resuming it twice is
+       * two agents appending to one transcript. The picker needs to say so and
+       * offer the trip instead, so the same join the phone's pane list uses is
+       * applied here: the live pane list, plus the note a hook wrote when the
+       * agent last ran. A note pointing at a pane that has since closed drops
+       * out with the list rather than becoming a button that goes nowhere.
+       */
+      const live = listPanes(lastTmuxTarget()?.socket).map(({ socket: _s, ...p }) => p);
+      const where = new Map<string, (typeof live)[number] & { agentSession: string | null }>();
+      for (const p of withAgentSessions(live, (id) => {
+        const n = paneAgentNote(id);
+        return n ? { sessionId: n.session_id, at: n.at } : null;
+      })) if (p.agentSession) where.set(p.agentSession, p);
+      const sessions: AgentSessionRow[] = rows.map((r) => {
+        const p = where.get(r.id);
+        return p
+          ? { ...r, openIn: { session: p.session, windowId: p.windowId, windowIndex: p.windowIndex, windowName: p.windowName, paneId: p.paneId } }
+          : r;
+      });
+      return json({ ok: true, sessions });
     }
     if (pathname === "/git/worktrees") {
       const root = url.searchParams.get("root") || "";

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -3657,6 +3657,15 @@ export interface PendingLineComment {
   line: number | null;
   startLine: number | null;
   body: string;
+  /**
+   * The comment's own page on GitHub.
+   *
+   * A pending comment cannot be edited from here — it belongs to a review
+   * GitHub is holding, and there is no endpoint that changes one without
+   * submitting. So the honest affordance is to hand the reader the place where
+   * it CAN be edited, which is one click and no round trip.
+   */
+  url: string;
 }
 
 /**
@@ -3686,7 +3695,7 @@ export async function pendingReview(nameWithOwner: string, n: number): Promise<{
    * Measured on a real pull request: node id `PRR_kwDOAjkAGs8…`, databaseId
    * 4925096670, same review.
    */
-  const q = `query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviews(states:[PENDING],first:1){nodes{id databaseId comments(first:100){nodes{path line originalLine startLine body}}}}}}}`;
+  const q = `query($o:String!,$r:String!,$n:Int!){repository(owner:$o,name:$r){pullRequest(number:$n){reviews(states:[PENDING],first:1){nodes{id databaseId comments(first:100){nodes{url path line originalLine startLine body}}}}}}}`;
   const r = await gh(["api", "graphql", "-f", `query=${q}`, "-F", `o=${owner}`, "-F", `r=${name}`, "-F", `n=${n}`]);
   if (r.code !== 0) return null;
   try {
@@ -3697,7 +3706,11 @@ export async function pendingReview(nameWithOwner: string, n: number): Promise<{
       /* `line` is null on a comment whose line no longer exists in the current
          diff — an outdated one. `originalLine` is where it was written, which
          is the only honest thing to show for it. */
-      .map((c: any) => ({ path: String(c.path), line: c.line ?? c.originalLine ?? null, startLine: c.startLine ?? null, body: String(c.body ?? "") }));
+      .map((c: any) => ({
+        path: String(c.path), line: c.line ?? c.originalLine ?? null,
+        startLine: c.startLine ?? null, body: String(c.body ?? ""),
+        url: typeof c.url === "string" ? c.url : "",
+      }));
     return { id: String(node.id), restId: Number.isSafeInteger(node.databaseId) ? Number(node.databaseId) : null, comments };
   } catch { return null; }
 }

--- a/server/src/recipes.ts
+++ b/server/src/recipes.ts
@@ -85,7 +85,7 @@ export function recipesFor(root: string): Recipe[] {
   return recipes().filter((r) => r.scope === "global" || (!!r.repo && (root === r.repo || root.startsWith(r.repo + "/") || sameFamily(root, r.repo))));
 }
 
-/** `~/code/app` and `~/code/app-PROJ-1` are the same project to a person, and
+/** `~/code/app` and `~/code/app-ORBIT-1` are the same project to a person, and
  *  git worktrees are conventionally cut as siblings named after the parent. */
 function sameFamily(root: string, repo: string): boolean {
   const base = repo.split("/").pop() ?? "";

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -25,7 +25,7 @@ import type { ProjectCommand, TerminalCommands, TerminalDisabledReason, TmuxWind
 import { safeAbs, repoRootOf, repoRootOfAsync } from "./git.ts";
 import { terminalActive } from "./loopwatch.ts";
 import { inScope, workspaceRoot, terminalDisabledSource, tmuxTerminal } from "./config.ts";
-import { engineAttachArgv, engineConsoleArgv, engineWindowRunning } from "./tmuxpane.ts";
+import { engineAttachArgv, engineConsoleArgv, engineWindowRunning, engineSplitRunning } from "./tmuxpane.ts";
 import { SKIP_DIRS } from "./gitwork.ts";
 
 // The PTY backend is POSIX-only: every strategy below needs a real
@@ -1732,6 +1732,49 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
       } else {
         void engineWindowRunning(cwd, name, []).then(() => s.tmuxSweep?.());
       }
+      return;
+    }
+
+    /*
+     * Resume a session the picker found.
+     *
+     * The three steps this replaces are: open a tab, start the agent, type
+     * `/resume` and hunt through a list scoped to whatever directory that tab
+     * happened to be in. The last part is the one that cannot be fixed by
+     * typing faster — a session from a worktree is not in the list you get from
+     * the main checkout, which is exactly the one you are usually after.
+     *
+     * The id is a file name and the cwd a directory, both from this server's
+     * own `/agent/sessions`; they are checked again here anyway. A session id
+     * shaped like anything else does not reach `--resume`.
+     */
+    /** What Claude Code names a transcript: a uuid, and nothing else reaches
+     *  `--resume`. */
+    const SESSION_ID = /^[0-9a-fA-F-]{8,64}$/;
+    if (msg.cmd === "resume") {
+      const cwd = safeAbs(msg.cwd);
+      if (!cwd || !inScope(cwd) || !existsSync(cwd)) return;
+      const id = typeof msg.id === "string" && SESSION_ID.test(msg.id) ? msg.id : "";
+      if (!id) return;
+      const bin = claudeCode.bin();
+      if (!bin) {
+        ctl(ws, { t: "openfail", error: claudeCode.missingReason() });
+        return;
+      }
+      // The server's argv, not the client's: the binary, `--resume` and the one
+      // flag the picker is allowed to ask for.
+      const argv = [bin, "--resume", id, ...(msg.yolo === true ? ["--dangerously-skip-permissions"] : [])];
+      const name = basename(cwd) || "resume";
+      void (async () => {
+        // Beside what is on screen, when asked — and a window when there is
+        // nothing to split, which is the honest fallback rather than a refusal
+        // for a press that has an obvious answer.
+        const opened = msg.split === true
+          ? (await engineSplitRunning(cwd, cwd, argv)) ?? (await engineWindowRunning(cwd, name, argv))
+          : await engineWindowRunning(cwd, name, argv);
+        if (!opened) { ctl(ws, { t: "openfail", error: "the engine would not open a window" }); return; }
+        s.tmuxSweep?.();
+      })();
       return;
     }
 

--- a/server/src/terminal.ts
+++ b/server/src/terminal.ts
@@ -1771,7 +1771,23 @@ export function ptyMessage(ws: PtyWs, raw: string | Buffer) {
     // The panel's own grid goes with it, for `fit`: only the client knows how
     // big the thing you are looking at is. Range-checked in runAction, because
     // it ends up as an argument to `resize-window`.
-    if (!runAction(s.tmux, action, msg.window, msg.name, msg.cols, msg.rows, msg.after === true)) return;
+    /*
+     * Where a new tab starts.
+     *
+     * The panel sends the project it is showing; this checks it rather than
+     * trusting it, because it ends up as `-c` on a command line. Three
+     * questions, in order: is it a string, does it exist, and is it inside the
+     * workspace — the same envelope `cmd:"issue"` and `cmd:"agent"` pass
+     * through, and for the same reason.
+     *
+     * Nothing usable means no `-c` at all, which is tmux's own behaviour and
+     * not a guessed home directory. See the `new` case in tmuxctl.ts.
+     */
+    const wanted = typeof msg.root === "string" ? msg.root : "";
+    const startIn = wanted && existsSync(wanted) && inScope(repoRootOf(wanted) ?? wanted)
+      ? (repoRootOf(wanted) ?? wanted)
+      : undefined;
+    if (!runAction(s.tmux, action, msg.window, msg.name, msg.cols, msg.rows, msg.after === true, startIn)) return;
     if (action === "takeover") tellPhonesTheWindowMoved(s.tmux, msg.window!);
     // Answer now rather than at the next tick. The command has already been
     // applied by the time it returns, so the strip can be correct within a

--- a/server/src/tmuxctl.ts
+++ b/server/src/tmuxctl.ts
@@ -570,6 +570,9 @@ export function runAction(
   /** `move` only: land AFTER the named window rather than before it. The one
    *  way to make a window the last in its strip — see that case. */
   after?: boolean,
+  /** `new` only: where the window starts. Already validated by the caller —
+   *  see the `new` case for why the absence of one is not a fallback. */
+  cwd?: string,
 ): boolean {
   // Windows are addressed by tmux's id, never by the index the tab is showing.
   // The strip is up to a poll out of date, and an index is not a name: kill
@@ -600,7 +603,17 @@ export function runAction(
       // tmux's default is the first free index, which is the end unless killing
       // a middle window left a gap. That is the same rule the unbound `c` uses,
       // so a strip that fills a gap is at least a rule the user already has.
-      return tmux(t.socket, ["new-window", "-t", t.id]) !== null;
+      //
+      // And `-c`, which is the whole of the second report: without it tmux
+      // starts the window in the SESSION's directory — where the server was
+      // launched from, which on a desktop build is agentglass's own install
+      // checkout. Every new tab opened there while the panel said `orbit`.
+      // "SIEMPRE SIEMPRE SIEMPRE debe abrirse desde la raíz del proyecto
+      // seleccionado", and the panel is the only thing that knows which that
+      // is. No path means tmux's old behaviour rather than a guess: a shell in
+      // the wrong tree is the failure this is fixing, and a home directory
+      // would be a different one.
+      return tmux(t.socket, ["new-window", "-t", t.id, ...(cwd ? ["-c", cwd] : [])]) !== null;
     case "kill":
       return id === null ? false : tmux(t.socket, ["kill-window", "-t", id]) !== null;
     case "rename": {

--- a/server/src/tmuxpane.ts
+++ b/server/src/tmuxpane.ts
@@ -331,6 +331,38 @@ export async function engineWindowRunning(
   return paneId.startsWith("%") && windowId.startsWith("@") ? { paneId, windowId } : null;
 }
 
+/**
+ * Split the window the panel is looking at, and run something in the new pane.
+ *
+ * The other half of "open this session": a tab is a fresh window, a split is
+ * beside what you are already reading, and which of the two you want depends on
+ * whether the session you are resuming is the thing you are doing or a thing you
+ * are consulting.
+ *
+ * The target is the engine session rather than a pane id, deliberately: tmux
+ * splits the ACTIVE pane of the current window, which is the pane the panel is
+ * showing. A pane id from the client would be a second source of truth about
+ * that, out of date by however long the frame took to arrive.
+ *
+ * `-h` — beside, not below. A terminal is wider than it is tall on every screen
+ * this runs on, and half the height of a pane is not enough transcript to read.
+ */
+export async function engineSplitRunning(
+  root: string, cwd: string, argv: string[],
+): Promise<{ paneId: string } | null> {
+  const session = engineSessionName(root);
+  if (!validSessionName(session)) return null;
+  ensureConf();
+  const there = await tmux(["has-session", "-t", `=${session}`]);
+  // Nothing to split. The caller opens a window instead — a refusal here is not
+  // a reason to leave a press with no answer.
+  if (!there.ok) return null;
+  const out = await tmux(["split-window", "-h", "-P", "-F", "#{pane_id}", "-t", session, "-c", cwd, ...argv]);
+  if (!out.ok) return null;
+  const paneId = (out.stdout.split("\n")[0] ?? "").trim();
+  return paneId.startsWith("%") ? { paneId } : null;
+}
+
 /** Window names reach a status line and a shell prompt, so they are held to
  *  printable, single-line and short — the same rule tmuxctl applies, and a dot
  *  removed on top: tmux reads one as a pane separator in a target, so a window

--- a/server/test/agent-sessions.test.ts
+++ b/server/test/agent-sessions.test.ts
@@ -1,0 +1,111 @@
+/*
+ * The sessions a project has, wherever they ran.
+ *
+ * Asked for like this: "que este desplegable me abra directamente la tab o el
+ * pane… muéstrame todas las sesiones que haya en todas las rutas del proyecto,
+ * ya que puede que hayan sesiones en worktrees que no se muestren".
+ *
+ * That last clause is the whole feature. `/resume` lists the transcripts of the
+ * directory the agent is running in, so a session from a worktree is invisible
+ * from the main checkout — and those are the ones being looked for, because a
+ * worktree is where the work was. This walks every checkout `git worktree list`
+ * reports and reads the same files the CLI reads.
+ *
+ * Against real files in a real repository: the whole thing is a directory name
+ * derived from a path, a `readdir`, and two reads of a JSONL. Mocking any of
+ * those would be mocking the feature.
+ */
+import { afterAll, beforeAll, describe, expect, it } from "bun:test";
+import { spawnSync } from "node:child_process";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+let repo: string, wt: string, home: string;
+let mod: typeof import("../src/agentsessions.ts");
+let slug: (cwd: string) => string;
+
+const run = (dir: string, ...args: string[]) => spawnSync("git", ["-C", dir, ...args], { encoding: "utf8" });
+
+/** A transcript, in the shape the CLI writes: a summary line, then the turns. */
+function transcript(dir: string, id: string, lines: unknown[]): void {
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, `${id}.jsonl`), lines.map((l) => JSON.stringify(l)).join("\n") + "\n");
+}
+
+const user = (text: string) => ({ type: "user", message: { role: "user", content: text } });
+const assistant = (text: string) => ({ type: "assistant", message: { role: "assistant", content: [{ type: "text", text }] } });
+
+beforeAll(async () => {
+  repo = mkdtempSync(join(tmpdir(), "agx-sess-"));
+  home = mkdtempSync(join(tmpdir(), "agx-claude-"));
+  process.env.AGENTGLASS_ROOT = repo;
+  process.env.AGENTGLASS_CLAUDE_HOME = home;
+  run(repo, "init", "-q", "-b", "main");
+  run(repo, "config", "user.email", "t@example.com");
+  run(repo, "config", "user.name", "t");
+  writeFileSync(join(repo, "a.txt"), "one\n");
+  run(repo, "add", "-A");
+  run(repo, "commit", "-qm", "first");
+  wt = `${repo}-CARD-1`;
+  run(repo, "worktree", "add", "-q", "-b", "CARD-1", wt);
+
+  ({ projectSlug: slug } = await import("../src/agents/claudecode.ts"));
+  const projects = join(home, "projects");
+  // One in the main checkout, one in the worktree — the case the CLI's own list
+  // cannot show you from here.
+  transcript(join(projects, slug(repo)), "11111111-1111-1111-1111-111111111111", [
+    { type: "summary", summary: "Rounding at the cart boundary" },
+    user("why is the total a cent low"),
+    assistant("because the discount rounds twice"),
+  ]);
+  transcript(join(projects, slug(wt)), "22222222-2222-2222-2222-222222222222", [
+    user("/clear"),
+    user("port the runbook to the wiki"),
+    assistant("moved the last three sections"),
+  ]);
+  mod = await import("../src/agentsessions.ts");
+});
+
+afterAll(() => {
+  for (const d of [wt, repo, home]) { try { rmSync(d, { recursive: true, force: true }); } catch { /* fine */ } }
+});
+
+describe("sessions for a project", () => {
+  it("finds the ones that ran in a worktree, not only the main checkout", async () => {
+    const rows = await mod.sessionsForProject(repo);
+    expect(rows.map((r) => r.cwd).sort()).toEqual([repo, wt].sort());
+  });
+
+  it("names each one the way /resume does — the CLI's summary when there is one", async () => {
+    const rows = await mod.sessionsForProject(repo);
+    const main = rows.find((r) => r.cwd === repo)!;
+    expect(main.title).toBe("Rounding at the cart boundary");
+    // And the opening still shows, because a four-word summary is not enough to
+    // tell two mornings apart — which is why the cards carry both.
+    expect(main.opening).toBe("why is the total a cent low");
+  });
+
+  it("falls back to the first real user message, skipping the plumbing", async () => {
+    /* A slash command is not what the session was about. Titling forty sessions
+       "/clear" is the failure this avoids. */
+    const rows = await mod.sessionsForProject(repo);
+    const card = rows.find((r) => r.cwd === wt)!;
+    expect(card.title).toBe("port the runbook to the wiki");
+  });
+
+  it("says where each one got to, which is what 'which one was I on' asks", async () => {
+    const rows = await mod.sessionsForProject(repo);
+    expect(rows.find((r) => r.cwd === wt)!.last).toBe("moved the last three sections");
+  });
+
+  it("hands back an id `--resume` can take", async () => {
+    const rows = await mod.sessionsForProject(repo);
+    expect(rows.every((r) => /^[0-9a-f-]{36}$/.test(r.id))).toBe(true);
+  });
+
+  it("refuses a path outside the workspace rather than listing it", async () => {
+    // What comes back becomes a `-c` and a command line.
+    expect(await mod.sessionsForProject("/etc")).toEqual([]);
+  });
+});

--- a/server/test/agent-sessions.test.ts
+++ b/server/test/agent-sessions.test.ts
@@ -99,6 +99,26 @@ describe("sessions for a project", () => {
     expect(rows.find((r) => r.cwd === wt)!.last).toBe("moved the last three sections");
   });
 
+  it("uses the name somebody gave it, over any guess", async () => {
+    /*
+     * `/rename` APPENDS `{"type":"custom-title",…}` — it does not rewrite the
+     * head — so a name has to be read from the tail, and the last one wins.
+     * Measured on a real 5.8MB transcript: the first title line sat at 18% of
+     * the file and the last at the very end, which is why a head-only read
+     * showed the first user message under a session the CLI lists by name.
+     */
+    const projects = join(home, "projects");
+    transcript(join(projects, slug(repo)), "33333333-3333-3333-3333-333333333333", [
+      { type: "summary", summary: "a guess nobody chose" },
+      user("start on the exit survey"),
+      assistant("done"),
+      { type: "custom-title", customTitle: "first name", sessionId: "33333333" },
+      { type: "custom-title", customTitle: "handover", sessionId: "33333333" },
+    ]);
+    const rows = await mod.sessionsForProject(repo);
+    expect(rows.find((r) => r.id.startsWith("33333333"))!.title).toBe("handover");
+  });
+
   it("hands back an id `--resume` can take", async () => {
     const rows = await mod.sessionsForProject(repo);
     expect(rows.every((r) => /^[0-9a-f-]{36}$/.test(r.id))).toBe(true);

--- a/server/test/app-spawns-on-engine.test.ts
+++ b/server/test/app-spawns-on-engine.test.ts
@@ -33,8 +33,11 @@ describe("where the app opens its windows", () => {
   });
 
   it("opens them on the engine instead, all three of them", () => {
-    // Review, issue, and the phone's plus.
-    expect(terminal.match(/engineWindowRunning\(/g)?.length).toBe(4);
+    /* Review, issue, the phone's plus — and the resume picker, twice: once for
+       "in a tab", once as the fallback when there is no window to split. */
+    expect(terminal.match(/engineWindowRunning\(/g)?.length).toBe(6);
+    // Beside what is on screen, when the picker asks for that.
+    expect(terminal).toContain("engineSplitRunning(cwd, cwd, argv)");
     expect(terminal).toContain("`pr-${number}`");
   });
 

--- a/server/test/new-tab-starts-in-the-project.test.ts
+++ b/server/test/new-tab-starts-in-the-project.test.ts
@@ -1,0 +1,55 @@
+/*
+ * A new tab opens in the project on screen.
+ *
+ * Reported with two screenshots: the panel's chip said the repository was
+ * `~/code/orbit`, the prompt in the tab that had just been opened said
+ * `~/code/agentglass-work`, and the ask was not subtle — "SIEMPRE SIEMPRE
+ * SIEMPRE debe abrirse desde la raíz del proyecto seleccionado".
+ *
+ * `new-window` with no `-c` starts in the SESSION's directory, and the session
+ * was created by the server, so its directory is wherever the server was
+ * launched from. On a desktop build that is agentglass's own install checkout —
+ * which is why the wrong path was always the same wrong path, and why it looked
+ * like the app was ignoring the repository rather than answering a different
+ * question.
+ *
+ * Held on the command rather than on a running tmux: what broke is one missing
+ * argument, and a server here would prove tmux honours `-c`, which is not in
+ * doubt.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
+
+describe("the + on the tab strip", () => {
+  it("starts the window somewhere, when it was told where", () => {
+    const ctl = read("server/src/tmuxctl.ts");
+    expect(ctl).toContain('return tmux(t.socket, ["new-window", "-t", t.id, ...(cwd ? ["-c", cwd] : [])]) !== null;');
+  });
+
+  it("checks the path before it becomes an argument", () => {
+    /* It arrives from a browser, so: a string, an existing directory, and
+       inside the workspace — the same envelope the agent and issue frames pass
+       through. Anything else means no `-c`, which is tmux's own behaviour and
+       not a guessed home directory. */
+    const term = read("server/src/terminal.ts");
+    expect(term).toContain('const wanted = typeof msg.root === "string" ? msg.root : "";');
+    expect(term).toContain("existsSync(wanted) && inScope(repoRootOf(wanted) ?? wanted)");
+    expect(term).toContain("msg.after === true, startIn)");
+  });
+
+  it("is sent the project the panel is showing", () => {
+    // The panel is the only thing that knows which repository is selected; the
+    // server can only see where a pane happens to be.
+    const panel = read("web/src/components/TerminalPanel.tsx");
+    expect(panel).toContain('tmuxCmd({ cmd: "new", root })');
+  });
+
+  it("carries the path on the frame both ends read", () => {
+    const types = read("shared/types.ts");
+    expect(types).toContain("root?: string };");
+  });
+});

--- a/server/test/sync-base.test.ts
+++ b/server/test/sync-base.test.ts
@@ -66,6 +66,44 @@ describe("base branch", () => {
     expect((await gw.baseOf(repo, "CARD-1"))).toBe("main");
   });
 
+  /*
+   * A branch stacked on another feature branch, which is most of them here.
+   *
+   * Reported with three screenshots: the base picker offered "origin/master —
+   * current base" on a worktree cut from another card's branch, while the
+   * header two centimetres away read "tracking origin/<that branch>". Both were
+   * reading the same repository; only one of them was asking git what the
+   * branch says about itself.
+   *
+   * Inference cannot answer this. `for-each-ref --merged <branch>` only matches
+   * a base the branch still contains, so the moment the base picks up a commit
+   * of its own it stops being an ancestor, drops out of the candidates, and the
+   * ladder falls through to the trunk. Tracking is written down at checkout
+   * time and stays true.
+   */
+  it("takes what the branch tracks over a guess at the shape of history", async () => {
+    run(repo, "branch", "feature-lane");
+    run(repo, "worktree", "add", "-q", "-b", "CARD-2", `${repo}-CARD-2`, "feature-lane");
+    run(`${repo}-CARD-2`, "branch", "--set-upstream-to=feature-lane", "CARD-2");
+    // The base moves on, which is what puts it out of reach of inference.
+    run(repo, "checkout", "-q", "feature-lane");
+    writeFileSync(join(repo, "lane.txt"), "lane\n");
+    run(repo, "add", "-A"); run(repo, "commit", "-qm", "on the lane");
+    run(repo, "checkout", "-q", "main");
+    expect(await gw.baseOf(repo, "CARD-2")).toBe("feature-lane");
+    rmSync(`${repo}-CARD-2`, { recursive: true, force: true });
+    run(repo, "worktree", "prune");
+  });
+
+  it("does not call a branch its own base when tracking is just where it pushes", async () => {
+    /* Every pushed branch tracks a copy of ITSELF. Read as a base that would
+       measure a branch against itself and report zero for ever — and zero is
+       exactly what a wrong base usually reports. */
+    run(repo, "branch", "CARD-3", "main");
+    run(repo, "branch", "--set-upstream-to=CARD-3", "CARD-3");
+    expect(await gw.baseOf(repo, "CARD-3")).not.toBe("CARD-3");
+  });
+
   it("treats clearing an override that was never set as done, not as an error", async () => {
     // `git config --unset` exits 5 on a missing key. Taken literally, the
     // picker's "work it out for me" would fail on every branch that never had

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -611,6 +611,17 @@ export type PtyClientFrame =
    * makes. It is a boolean rather than a string for that reason.
    */
   | { t: "tmux"; cmd: "agent"; yolo?: boolean }
+  /**
+   * Bring a past session back — the picker's "open this one".
+   *
+   * `id` is a transcript's name and `cwd` the checkout it ran in; both come
+   * from `/agent/sessions`, and both are checked again on arrival because this
+   * socket is reachable from a browser and they end up on a command line.
+   * `split` puts it beside what is on screen instead of in a window of its own,
+   * and `yolo` is the only flag the client may ask for — the binary and every
+   * other argument are the server's.
+   */
+  | { t: "tmux"; cmd: "resume"; id: string; cwd: string; split?: boolean; yolo?: boolean }
   | { t: "tmux"; cmd: "select" | "new" | "kill" | "rename" | "move" | "takeover" | "fit"; window?: string; name?: string;
       /** `fit` only: the asking panel's own grid. Range-checked on the server —
        *  it ends up in a `resize-window`, so it is a number to validate rather
@@ -2000,6 +2011,38 @@ export interface PrLabel { name: string; color?: string }
 
 /** Somebody asked for a review. A team has no avatar and no login, so it is
  *  named rather than pictured — the row must not draw a broken image for it. */
+/**
+ * One resumable agent session, as the terminal's picker draws it.
+ *
+ * Read from `~/.claude/projects` — the same transcripts `/resume` lists — so
+ * the picker and the CLI cannot disagree about what exists. See
+ * server/src/agentsessions.ts.
+ */
+export interface AgentSessionRow {
+  /** What `--resume` takes. */
+  id: string;
+  title: string;
+  /** The first user message, when the title came from somewhere else. */
+  opening: string;
+  /** The last thing said in it. "Which one was I on" is a question about the
+   *  end of a conversation, not its beginning. */
+  last: string;
+  /** The checkout it ran in, and where resuming it has to start. */
+  cwd: string;
+  /** Last write to the transcript, ms since epoch. */
+  at: number;
+  size: number;
+  /** Where it is running right now, when it is. A session already open is not
+   *  one to resume — it is one to go to. */
+  openIn?: {
+    session: string;
+    windowId: string;
+    windowIndex: string;
+    windowName: string;
+    paneId: string;
+  };
+}
+
 export interface PrReviewer {
   /** A user's login, or a team's name when `isTeam`. */
   login: string;

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -619,7 +619,14 @@ export type PtyClientFrame =
       /** `move` only: land AFTER the named window instead of before it. What
        *  the trailing drop zone at the end of the tab strip sends — it is the
        *  only way to make a window the last one. */
-      after?: boolean };
+      after?: boolean;
+      /** `new` only: the project the panel is showing, so the tab opens in it.
+       *  Without it tmux starts the window in the SESSION's directory, which is
+       *  wherever the server happened to be launched from — for a desktop build
+       *  that is the install checkout, so every new tab landed in agentglass's
+       *  own tree instead of the repository on screen. Checked on the server
+       *  against the workspace before it reaches a command line. */
+      root?: string };
 
 /**
  * Every key any member of a union carries, and what that key can hold.

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -2035,7 +2035,11 @@ export interface AgentSessionRow {
   /** Where it is running right now, when it is. A session already open is not
    *  one to resume — it is one to go to. */
   openIn?: {
+    /** The tmux session's NAME, for saying where; and its id, for going there.
+     *  Both, because a name is what a person reads and an id is what addresses
+     *  the same session on a server where names repeat. */
     session: string;
+    sessionId: string;
     windowId: string;
     windowIndex: string;
     windowName: string;

--- a/web/src/components/CheckoutPicker.tsx
+++ b/web/src/components/CheckoutPicker.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useMemo, useRef, useState } from "react";
 import { CHIP, CHIP_SURFACE, CHIP_SURFACE_CLS } from "./workspace/Chrome.tsx";
+import { ICON } from "../lib/iconSize.ts";
 import type { GitRepoRef, GitBranch } from "../../../shared/types.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 
@@ -193,7 +194,12 @@ export function CheckoutPicker({
           const b = branchLabel === undefined ? here?.branch : branchLabel;
           return b ? <span className="t-dim2 shrink-0 truncate" style={{ maxWidth: "9rem" }} title={`on ${b}`}>· {b}</span> : null;
         })()}
-        <span className="t-dim2 shrink-0">▼</span>
+        {/* The same caret `ScopeChip` draws, so the picker in this header and the
+            one in every other header are the same object down to the arrow. */}
+        <svg width={ICON.xs} height={ICON.xs} viewBox="0 0 12 12" fill="none" aria-hidden
+          className="shrink-0" style={{ opacity: 0.7 }}>
+          <path d="M3 5l3 3 3-3" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
       </button>
 
       {open && (

--- a/web/src/components/ConflictMode.tsx
+++ b/web/src/components/ConflictMode.tsx
@@ -505,7 +505,17 @@ function Body({ file, picks, labels, cursor, opened, editing, onCursor, onPick, 
   const order = file.blocks.map((b) => b.index);
 
   return (
-    <div className="py-2">
+    /*
+     * One width for the whole file, and it is the longest line in it.
+     *
+     * The lines are `white-space: pre`, so a long one scrolls this pane
+     * sideways — and everything painted here (an ours/theirs tint, the taken
+     * side's green bar, the cursor rail) is a plain block, which is as wide as
+     * the pane and not as wide as what the pane can scroll to. Scroll right and
+     * the tint ends mid-air over code that is still conflicted. Same shape of
+     * bug as the diff panes; same fix.
+     */
+    <div className="py-2" style={{ width: "max-content", minWidth: "100%" }}>
       {file.segments.map((seg, i) => {
         if (seg.kind === "text") {
           const prevIsConflict = i > 0;

--- a/web/src/components/ConflictMode.tsx
+++ b/web/src/components/ConflictMode.tsx
@@ -82,10 +82,22 @@ const Cap = ({ k }: { k: string }) => (
 );
 
 function Line({ n, text, tone }: { n: number; text: string; tone?: "ours" | "theirs" }) {
+  /* Pinned to the left edge and opaque, like the diff panes: the lines are
+     `white-space: pre`, so a long one scrolls this pane sideways, and a number
+     that scrolls away with the code stops answering the only question it is
+     there for. Opaque because the code passes BEHIND it — the tint is mixed
+     into `--bg` rather than laid over it, which is the same trick `numBg` does
+     next door. */
+  const stampBg = tone === "ours" ? "color-mix(in srgb, var(--primary) 8%, var(--bg))"
+    : tone === "theirs" ? "color-mix(in srgb, var(--warning) 8%, var(--bg))"
+      : "var(--bg)";
   return (
     <div className="flex" style={{ whiteSpace: "pre" }}>
-      <span className="shrink-0 text-right tabular-nums select-none pr-2"
-        style={{ width: "5ch", color: "var(--text3)", opacity: 0.6 }}>{n}</span>
+      {/* The fade is on the DIGITS, not on the box. `opacity` on the element
+          takes its background down with it, and a 60% gutter is a gutter you
+          can read the code through. */}
+      <span className="shrink-0 text-right tabular-nums select-none pr-2 sticky left-0 z-[1]"
+        style={{ width: "5ch", color: "var(--text3)", background: stampBg }}><span style={{ opacity: 0.6 }}>{n}</span></span>
       <span className="pl-2" style={{ color: tone ? "var(--text)" : "var(--text2)" }}>{text || " "}</span>
     </div>
   );

--- a/web/src/components/DockerPanel.tsx
+++ b/web/src/components/DockerPanel.tsx
@@ -2,6 +2,7 @@
 // compose project with live CPU/mem, a streaming-ish log viewer, and start/
 // stop/restart/rm actions. Images / volumes / networks get their own tabs.
 import { useCallback, useEffect, useMemo, useRef, useState, useSyncExternalStore } from "react";
+import { PlayIcon, RefreshIcon } from "../lib/glyphIcons.tsx";
 import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import type { DockerOverview, DockerContainer, DockerStat, DockerCapability } from "../../../shared/types.ts";
 import { depSpec } from "../../../shared/deps.ts";
@@ -181,7 +182,7 @@ function ContainerRow({ c, stat, active, writeEnabled, busy, dense, onSelect, on
       <div className="flex items-center gap-1" onClick={(e) => e.stopPropagation()}>
         {writeEnabled && (running
           ? <>
-              <DockerAction onClick={() => onAction("restart")} disabled={busy} tint="var(--warning)" title="Restart">⟳</DockerAction>
+              <DockerAction onClick={() => onAction("restart")} disabled={busy} tint="var(--warning)" title="Restart"><RefreshIcon /></DockerAction>
               <DockerAction onClick={() => onAction("stop")} disabled={busy} tint="var(--error)" title="Stop">■</DockerAction>
             </>
           : <>
@@ -540,7 +541,7 @@ export function DockerView({ active }: { active: boolean }) {
                         : { color: "var(--text3)", border: "1px solid color-mix(in srgb, var(--border) 35%, transparent)" }}>
                       Dense
                     </button>
-                    <button onClick={() => { loadOverview(); loadStats(); }} title="Refresh" className="text-[13px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}>⟳</button>
+                    <button onClick={() => { loadOverview(); loadStats(); }} title="Refresh" className="text-[13px] px-2 py-1 rounded-lg" style={{ color: "var(--text2)" }}><RefreshIcon /></button>
                   </div>
                 </div>
 
@@ -577,7 +578,7 @@ export function DockerView({ active }: { active: boolean }) {
                             {writeEnabled && (
                               <span className="flex items-center gap-1 ml-2">
                                 {cs.some((c) => c.state !== "running") && (
-                                  <DockerAction onClick={() => doGroupAction(cs, "start")} disabled={busy} tint="var(--success)" title={`Start every stopped container in ${proj}`}>▶</DockerAction>
+                                  <DockerAction onClick={() => doGroupAction(cs, "start")} disabled={busy} tint="var(--success)" title={`Start every stopped container in ${proj}`}><PlayIcon /></DockerAction>
                                 )}
                                 {cs.some((c) => c.state === "running") && (
                                   <>

--- a/web/src/components/FileRail.tsx
+++ b/web/src/components/FileRail.tsx
@@ -17,7 +17,8 @@ import { useMemo } from "react";
 // they came from, rather than squeeze all three into something none of them can
 // be read in.
 import type { PrDetail } from "../../../shared/types.ts";
-import { railScan, checksAbout, threadsAbout, queuedOn, railAge,  railPreview, type RailDraft, type RailMention } from "../lib/fileRail.ts";
+import { railScan, checksAbout, threadsAbout, queuedOn, heldOn, railAge,  railPreview, type RailDraft, type RailHeld, type RailMention } from "../lib/fileRail.ts";
+import { openExternal } from "../lib/externalUrl.ts";
 import { mergeBlockedWhy, checksLine, checksStanding, standingLine, mergeVerdict } from "../lib/mergeReason.ts";
 import { ICON } from "../lib/iconSize.ts";
 
@@ -78,7 +79,7 @@ const lines = (line: number, startLine?: number | null) =>
 export type RailVerdict = "approve" | "request_changes" | "comment";
 
 export function FileRail({
-  d, path, drafts, loading, queuedCount, verdict,
+  d, path, drafts, held, loading, queuedCount, verdict,
   onGoConversation, onGoChecks, onGoReview, onGoToMention, onMerge, canMerge, awaitingChecks,
   onApprove, onRequestChanges, onComment, onSubmit, body, onBody, busyWhat,
 }: {
@@ -92,6 +93,10 @@ export function FileRail({
    *  no section, which is the difference between "nothing queued" and "this
    *  panel cannot know". */
   drafts?: RailDraft[];
+  /** Every comment GitHub is holding in your unsubmitted review, all files. The
+   *  rail keeps this file's. Optional for the same reason `drafts` is: no prop
+   *  is "this caller cannot know", not "there are none". */
+  held?: RailHeld[];
   /** The detail on screen is being refreshed. Everything below is filtered from
    *  it, so while this is true an empty answer is a wait and not a fact — see
    *  the empty states. */
@@ -195,6 +200,7 @@ export function FileRail({
   const failing = useMemo(() => checksAbout(d.checks.failing ?? [], path), [d.checks.failing, path]);
   const threads = useMemo(() => threadsAbout(d, path), [d, path]);
   const queued = useMemo(() => queuedOn(drafts, path), [drafts, path]);
+  const heldHere = useMemo(() => heldOn(held, path), [held, path]);
   const standing = checksStanding(d.checks, awaitingChecks);
   const allClear = d.mergeState === "CLEAN" && standing === "green";
   /*
@@ -246,7 +252,14 @@ export function FileRail({
   /* The whole review's queued lines, not this file's — what one submit is about
      to send. `drafts` is every file's, so its length is the same number rather
      than an estimate of it, and either prop alone is enough to say this. */
-  const willSend = queuedCount ?? drafts?.length;
+  const willSend = (queuedCount ?? drafts?.length) === undefined
+    ? undefined
+    : (queuedCount ?? drafts?.length ?? 0) + (held?.length ?? 0);
+  /* `held` counts here because submitting from this app finishes the review
+     GitHub is holding rather than opening a second one — so those comments go
+     out with this verdict. The box used to read "No line comments queued" over
+     three comments drafted on the website, which is the one sentence that made
+     somebody submit thinking they were sending nothing. */
   const goesWith = willSend
     ? `${willSend} line comment${willSend === 1 ? " goes" : "s go"} with it — one notification, not ${willSend + 1}.`
     : willSend === 0
@@ -465,6 +478,34 @@ export function FileRail({
                   ))}
                 </>
               )}
+            </Sec>
+          )}
+
+          {/* Started on the website and left there. Shown short on purpose: the
+              Review tab prints these whole, and what this column is for is
+              noticing one exists on the file you are reading — with the way to
+              the only place it can be edited, which is GitHub. */}
+          {heldHere.length > 0 && (
+            <Sec title="Drafted on GitHub"
+              action={{ label: "Review", on: onGoReview }}>
+              <p className="m-0 mb-1.5 text-[10px]" style={{ color: "var(--text4)" }}>
+                {heldHere.length} comment{heldHere.length === 1 ? "" : "s"} in your unsubmitted review — they go out when you submit.
+              </p>
+              {heldHere.map((h, i) => (
+                <div key={i} className="mb-2 last:mb-0 text-[11px] flex items-start gap-1.5">
+                  <span className="min-w-0">
+                    <span style={{ color: "var(--primary)" }}>
+                      {h.line == null ? "Outdated" : lines(h.line)}
+                    </span>
+                    <Quote body={h.body} max={90} />
+                  </span>
+                  {h.url && (
+                    <button onClick={() => openExternal(h.url!)} title="Edit this comment on GitHub"
+                      className="agx-btn shrink-0 ml-auto text-[9.5px] px-1 rounded"
+                      style={{ color: "var(--primary)" }}>Edit ↗</button>
+                  )}
+                </div>
+              ))}
             </Sec>
           )}
         </>

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -16,6 +16,7 @@ import { requestTermIssue } from "../lib/termIssue.ts";
 import { useDismiss } from "../lib/useDismiss.ts";
 import { viewHeaderClass, viewHeaderStyle } from "./workspace/ViewHeader.tsx";
 import { CHIP } from "./workspace/Chrome.tsx";
+import { ICON } from "../lib/iconSize.ts";
 import type { GitRepoRef, WorkingTree, GitFileChange, GitBranch, GitBranchInfo, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, ConflictBlock, BlockChoice, MergeInfo, FileChange, WalkthroughResult, WalkthroughFile, TidyReport, TidyFinding, GitSubmodule } from "../../../shared/types.ts";
 import { partitionByWorktree, splitReadable, goneConfirmTitle, goneConfirmBody, forcedDeletePrompt } from "../lib/goneCleanup.ts";
 import { CheckoutPicker } from "./CheckoutPicker.tsx";
@@ -618,7 +619,13 @@ function DirRow({ name, depth, count, collapsed, onToggle }: {
   return (
     <div onClick={onToggle} className="flex items-center gap-1.5 py-0.5 rounded-md cursor-pointer select-none hover:opacity-80"
       style={{ paddingLeft: 8 + depth * 12 }}>
-      <span className="w-2.5 text-[10px] shrink-0 t-dim2">{collapsed ? "▶" : "▼"}</span>
+      {/* Drawn and rotated rather than two typed characters. A 10px ▶ is a
+          speck: the same finding that took the ▾ out of the notification rows
+          and out of the git group headings. */}
+      <svg width={ICON.xs} height={ICON.xs} viewBox="0 0 12 12" fill="none" aria-hidden
+        className="shrink-0" style={{ color: "var(--text4)", transform: collapsed ? "rotate(-90deg)" : "none", transition: "transform .12s" }}>
+        <path d="M2.5 4.5L6 8l3.5-3.5" stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round" />
+      </svg>
       <span className="text-[11px] truncate" style={{ color: "var(--text2)" }}>{name}</span>
       {/* Only meaningful while folded — otherwise you can just count the rows. */}
       {collapsed && <span className="text-[10px] tabular-nums t-dim2">{count}</span>}
@@ -2928,7 +2935,17 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
                     */}
                     <button onClick={refreshAll} disabled={refreshing} title="Refresh this view and the working tree"
                       className="text-[11px] px-2 py-1 rounded-lg disabled:opacity-60" style={{ color: refreshed ? "var(--success)" : "var(--text2)" }}>
-                      <span className={refreshing ? "inline-block animate-spin" : "inline-block"}>{refreshed && !refreshing ? "✓" : "⟳"}</span>
+                      <span className={refreshing ? "inline-flex animate-spin" : "inline-flex"} aria-hidden>
+                        {refreshed && !refreshing ? (
+                          <svg width={ICON.sm} height={ICON.sm} viewBox="0 0 14 14" fill="none">
+                            <path d="M3 7.4l2.6 2.6L11 4.6" stroke="currentColor" strokeWidth="1.8" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        ) : (
+                          <svg width={ICON.sm} height={ICON.sm} viewBox="0 0 14 14" fill="none">
+                            <path d="M12 7a5 5 0 1 1-1.6-3.7M12 2.2V4.8H9.4" stroke="currentColor" strokeWidth="1.6" strokeLinecap="round" strokeLinejoin="round" />
+                          </svg>
+                        )}
+                      </span>
                     </button>
                   </div>
                 </div>

--- a/web/src/components/GitPanel.tsx
+++ b/web/src/components/GitPanel.tsx
@@ -1102,6 +1102,16 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
 
   const all = useMemo(() => [...(tree?.staged ?? []), ...(tree?.unstaged ?? [])], [tree]);
   const selected = useMemo(() => all.find((c) => keyOf(c) === selKey) ?? all[0] ?? null, [all, selKey]);
+  /*
+   * What the LIST marks, which is not the same as what was clicked.
+   *
+   * With nothing clicked yet the pane already shows the first file — that is
+   * the `?? all[0]` above — but the rows compared against `selKey`, which is
+   * still null, so a diff was on screen while every row beside it looked
+   * equally unselected. Reported for this list and for the pull-request one,
+   * which had the same split between "what is displayed" and "what is marked".
+   */
+  const activeKey = selected ? keyOf(selected) : null;
 
   /**
    * Mid-merge, open the conflict — in the resolver, not in the file list.
@@ -2457,7 +2467,7 @@ export function GitView({ active, onOpenChat }: { active: boolean; onOpenChat?: 
   const renderFiles = (changes: GitFileChange[], action: "stage" | "unstage", onAction: (c: GitFileChange) => void, prefix: string) => {
     const row = (c: GitFileChange, depth?: number) => (
       <FileRow key={prefix + c.file_path} c={c} root={root} writeEnabled={writeEnabled} depth={depth}
-        desc={descMap.get(c.file_path)?.description} active={selKey === keyOf(c)}
+        desc={descMap.get(c.file_path)?.description} active={activeKey === keyOf(c)}
         onSelect={() => setSelKey(keyOf(c))} action={action} onAction={() => onAction(c)}
         onBlame={writeEnabled ? () => setBlamePath({ path: c.file_path }) : undefined}
         onMenu={(x, y) => setRowMenu({

--- a/web/src/components/MachinePanel.tsx
+++ b/web/src/components/MachinePanel.tsx
@@ -11,6 +11,7 @@
 // One surface, reachable from the dashboard and from inside the workspace,
 // because "is 5173 still up?" is a question you have while looking at anything.
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { RefreshIcon } from "../lib/glyphIcons.tsx";
 import { Portal } from "./Portal.tsx";
 import { api } from "../lib/api.ts";
 import type { GitLock, GitLocksReport, GitRepoRef, ProcDetail, MachineTotals, PortEntry, PortsReport, ProcEntry, ResourceReport, SpaceReport } from "../../../shared/types.ts";
@@ -557,7 +558,7 @@ function Resources() {
           </span>
           <button onClick={load} title="Sample again now"
             className="agx-btn ml-auto shrink-0 px-1.5 py-0.5 rounded text-[11px]"
-            style={{ color: "var(--text2)", border: edge(18) }}>⟳</button>
+            style={{ color: "var(--text2)", border: edge(18) }}><RefreshIcon /></button>
         </div>
 
         {/* The whole machine, above our share of it.

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -65,7 +65,7 @@ import { Avatar } from "./Avatar.tsx";
 import { StatusPill } from "./StatusPill.tsx";
 import { PeekFile, type Peek } from "./PeekFile.tsx";
 import { MERGE_WHY, mergeBlockedWhy, checksLine, checksStanding, standingLine, checksShort, mergeVerdict } from "../lib/mergeReason.ts";
-import { parseQuery, applyFilters, buildFacets, activeCount, type RepoFacets } from "../lib/prFilter.ts";
+import { parseQuery, applyFilters, peopleMatched, buildFacets, activeCount, type RepoFacets } from "../lib/prFilter.ts";
 import { getHighlighter, shikiTheme, ensureLanguage } from "../lib/highlight.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 import { cardRef, chipAction } from "../lib/cardRef.ts";
@@ -1254,8 +1254,12 @@ function PinnedCapsule({ pinned, pinState, selected, current, onOpen }: {
   );
 }
 
-function PrRow({ p, active, onSelect, onReview, pinned, onTogglePin }: {
+function PrRow({ p, active, onSelect, onReview, pinned, onTogglePin, q }: {
   p: PrSummary; active: boolean; onSelect: () => void; onReview: () => void;
+  /** What is in the filter box, so a row that is here because of a PERSON can
+   *  say which one. Without it a search for "javi" returns rows whose author
+   *  column says somebody else, and the list looks like it ignored you. */
+  q?: string;
   /** On the bar at the top. Undefined where there is no repository to pin it
    *  against, and the control then does not appear at all. */
   pinned?: boolean; onTogglePin?: () => void;
@@ -1310,6 +1314,18 @@ function PrRow({ p, active, onSelect, onReview, pinned, onTogglePin }: {
         </div>
         <div className="flex items-center gap-1.5 mt-0.5 min-w-0 text-[10px]" style={{ color: "var(--text3)" }}>
           <span className="truncate shrink-0" style={{ maxWidth: 140 }}>{p.author}</span>
+          {/* Why this row is in the answer. Assignees and requested reviewers
+              both — on a board they are one question, "where is this person",
+              and which hat they wear on a given pull request is not what was
+              being asked. */}
+          {peopleMatched(p, q ?? "").slice(0, 3).map((login) => (
+            <span key={login} className="shrink-0 flex items-center gap-1 rounded px-1"
+              title={`${login} is on this pull request`}
+              style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 16%, transparent)" }}>
+              <Avatar login={login} size={ICON.xs} />
+              <span className="truncate" style={{ maxWidth: 110 }}>{login}</span>
+            </span>
+          ))}
           {/*
             * Where it lands.
             *
@@ -3554,7 +3570,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
               <div style={{ opacity: listState.loading ? 0.45 : 1, transition: "opacity .15s" }}>
                 <PrTableHead />
                 {visiblePrs.map((p) => (
-                  <PrRow key={p.number} p={p} active={p.number === rowCursor}
+                  <PrRow key={p.number} p={p} active={p.number === rowCursor} q={filters.text}
                     onSelect={() => openPr(p.number)} onReview={() => doLocalReview(p.number)}
                     pinned={!!repo && isPinned(repo.nameWithOwner, p.number)}
                     onTogglePin={repo ? () => togglePin(repo.nameWithOwner, p.number, p.title) : undefined} />

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -141,7 +141,7 @@ const DETAIL_CACHE_MAX = 40;
 /** A line comment sitting in YOUR unsubmitted review on GitHub. Not a thread —
  *  it has no id to reply to and no state to resolve — and not one of our own
  *  drafts either, which live only in this browser until they are sent. */
-type PendingLine = { path: string; line: number | null; startLine?: number | null; body: string };
+type PendingLine = { path: string; line: number | null; startLine?: number | null; body: string; url?: string };
 
 const detailKey = (root: string, n: number) => `${root}#${n}`;
 const heldDetail = (root: string, n: number): PrDetail | null => DETAIL_CACHE.get(detailKey(root, n)) ?? null;
@@ -3928,7 +3928,7 @@ export function PrView({ active, onOpenChatWith, onReviewInTerminal, jumpTo }: {
                   />
                   </div>
                   <FileRail d={d} path={showingFile ?? selFile}
-                    drafts={myDrafts}
+                    drafts={myDrafts} held={held}
                     /* The window where the held copy is on screen and the
                        refresh has not landed — exactly when an empty answer is
                        a wait rather than a fact. */
@@ -6572,12 +6572,17 @@ function PeekButton({ path, onPeek }: { path: string; onPeek: (p: string) => voi
   );
 }
 
-function FileTree({ node, sel, onPick, onPeek, seen, drafts, depth = 0 }: {
+function FileTree({ node, sel, onPick, onPeek, seen, drafts, pending, depth = 0 }: {
   node: TreeNode<PrFile>; sel: string | null; onPick: (p: string) => void;
   /** Open the whole file in an editor, over the panel. The diff shows what
    *  changed; this is for the times the answer is in the part that did not. */
   onPeek?: (p: string) => void | Promise<void>;
-  seen: (p: string) => boolean; drafts: (p: string) => number; depth?: number;
+  seen: (p: string) => boolean; drafts: (p: string) => number;
+  /** How many comments GitHub is holding in an unsubmitted review on this file.
+   *  A different thing from `drafts`, which never left this browser, and the
+   *  reason the tree needs its own mark: a review you started on the website is
+   *  invisible here otherwise, and you find out you had one by submitting. */
+  pending: (p: string) => number; depth?: number;
 }) {
   return (
     <>
@@ -6586,13 +6591,14 @@ function FileTree({ node, sel, onPick, onPeek, seen, drafts, depth = 0 }: {
           <div className="truncate text-[10px] px-1 py-0.5" style={{ paddingLeft: 6 + depth * 10, color: "var(--text3)" }} title={dir.path}>
             {dir.name}
           </div>
-          <FileTree node={dir} sel={sel} onPick={onPick} onPeek={onPeek} seen={seen} drafts={drafts} depth={depth + 1} />
+          <FileTree node={dir} sel={sel} onPick={onPick} onPeek={onPeek} seen={seen} drafts={drafts} pending={pending} depth={depth + 1} />
         </div>
       ))}
       {node.files.map((f) => {
         const base = f.path.split("/").pop() ?? f.path;
         const on = sel === f.path;
         const n = drafts(f.path);
+        const pend = pending(f.path);
         return (
           <button key={f.path} onClick={() => onPick(f.path)}
             // Alt-click opens it whole, which is the gesture that costs nothing
@@ -6611,6 +6617,18 @@ function FileTree({ node, sel, onPick, onPeek, seen, drafts, depth = 0 }: {
                 opening it. */}
             {(() => { const g = statusGlyph(f.status); return <span className="shrink-0 text-center leading-none" style={{ width: 12, fontSize: 10, color: g.tint }} title={g.title}>{g.ch}</span>; })()}
             <span className="truncate text-[10.5px]">{base}</span>
+            {/* Something is drafted here, on GitHub. A count would read as the
+                thread count two marks along; a speech bubble with a pen says
+                what it is, and the title says the rest. */}
+            {pend > 0 && (
+              <span className="shrink-0 ml-1" title={`${pend} comment${pend === 1 ? "" : "s"} drafted on GitHub in your unsubmitted review`}>
+                <svg width={ICON.xs} height={ICON.xs} viewBox="0 0 16 16" fill="none" aria-hidden="true"
+                  stroke="var(--primary)" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+                  <path d="M2.5 4.2a1.7 1.7 0 0 1 1.7-1.7h7.6a1.7 1.7 0 0 1 1.7 1.7v4.6a1.7 1.7 0 0 1-1.7 1.7H6.4L3.2 13v-2.5h-.7z" />
+                  <path d="M6 6.6h4" />
+                </svg>
+              </span>
+            )}
             {n > 0 && <span className="ml-auto text-[10px] shrink-0" style={{ color: "var(--warning)" }}>{n}</span>}
             {f.comments > 0 && <span className="ml-auto text-[10px] shrink-0" style={{ color: "var(--primary)" }}>{f.comments}</span>}
             {seen(f.path) && <span className="ml-auto text-[10px] shrink-0" style={{ color: "var(--success)" }}>✓</span>}
@@ -6916,6 +6934,7 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
   };
 
   const draftsFor = (p: string) => drafts.filter((x) => x.path === p).length;
+  const heldFor = (p: string) => held.filter((x) => x.path === p).length;
   /** This file's pending comments, keyed the way a diff row asks for them:
    *  the side letter and the line, so a row can find its own without scanning
    *  the whole list on every render. */
@@ -7588,7 +7607,7 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
               node={buildFileTree(shownFiles)} sel={showing}
               onPick={(path) => { onSel(path); setFolded((cur) => { const n = new Set(cur); n.delete(path); return n; }); scrollToFileStable(() => frameRef.current?.querySelector(`[data-path="${CSS.escape(path)}"]`)); }}
               seen={(path) => seenFiles.includes(path)}
-              drafts={draftsFor} onPeek={onPeek}
+              drafts={draftsFor} pending={heldFor} onPeek={onPeek}
             />
           </aside>
         )}
@@ -7818,6 +7837,18 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
                                     style={{ background: "color-mix(in srgb, var(--primary) 12%, transparent)", color: "var(--text2)" }}>
                                     <span>drafted on GitHub</span>
                                     <span className="ml-auto" style={{ color: "var(--text3)" }}>sent when you submit</span>
+                                    {/* The way OUT to the only place it can be
+                                        edited. No API changes a comment inside
+                                        a pending review without submitting the
+                                        review, so the honest affordance is the
+                                        page where it can be changed rather than
+                                        a button here that would have to lie. */}
+                                    {h.url && (
+                                      <button onClick={() => openExternal(h.url!)}
+                                        title="Edit this pending comment on GitHub"
+                                        className="agx-btn shrink-0 text-[10px] px-1.5 py-0.5 rounded"
+                                        style={{ color: "var(--primary)" }}>Edit ↗</button>
+                                    )}
                                   </div>
                                   <div className="px-2.5 py-2"><Md body={h.body} /></div>
                                 </div>
@@ -7930,6 +7961,15 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
                       style={{ background: "color-mix(in srgb, var(--primary) 12%, transparent)", color: "var(--text2)" }}>
                       <span>drafted on GitHub{h.line == null ? " · outdated" : `:${h.line}`}</span>
                       <span className="ml-auto" style={{ color: "var(--text3)" }}>the diff does not reach its line</span>
+                      {/* And here more than anywhere: this one has no row to sit
+                          under, so the page where it lives is the only place it
+                          can be seen in context. */}
+                      {h.url && (
+                        <button onClick={() => openExternal(h.url!)}
+                          title="Edit this pending comment on GitHub"
+                          className="agx-btn shrink-0 text-[10px] px-1.5 py-0.5 rounded"
+                          style={{ color: "var(--primary)" }}>Edit ↗</button>
+                      )}
                     </div>
                     <div className="px-2.5 py-2"><Md body={h.body} /></div>
                   </div>
@@ -9708,8 +9748,14 @@ function ReviewTab({ d, root, held, drafts, seen, busy, busyWhat, draft, onDraft
             </div>
           ) : (
             <div className="text-[10.5px]" style={{ color: "var(--text3)" }}>
-              No line comments queued here. Open <button onClick={onGoFiles} style={{ color: "var(--primary)" }}>files</button> and
-              use the “+” on a line to attach one.
+              {/* "Nothing queued" was a lie whenever GitHub was holding a review
+                  started on the website: nothing is queued HERE, and something
+                  is going out. The box below says how many; this line stops
+                  contradicting it. */}
+              {held.length > 0
+                ? <>Nothing queued from here — {held.length} comment{held.length === 1 ? " is" : "s are"} already drafted on GitHub, below.</>
+                : <>No line comments queued here. Open <button onClick={onGoFiles} style={{ color: "var(--primary)" }}>files</button> and
+                  use the “+” on a line to attach one.</>}
             </div>
           )}
 
@@ -9729,8 +9775,18 @@ function ReviewTab({ d, root, held, drafts, seen, busy, busyWhat, draft, onDraft
               {held.map((c, i) => (
                 <div key={`${c.path}:${c.line}:${i}`} className="px-2.5 py-2"
                   style={{ borderTop: i ? "1px solid color-mix(in srgb, var(--text) 10%, transparent)" : undefined }}>
-                  <div className="text-[10px] tabular-nums truncate" style={{ color: "var(--text3)" }}
-                    title={c.path}>{c.path}{c.line === null ? " · outdated" : `:${c.line}`}</div>
+                  <div className="text-[10px] tabular-nums flex items-center gap-2">
+                    <span className="truncate" title={c.path}>{c.path}{c.line === null ? " · outdated" : `:${c.line}`}</span>
+                    {/* The way to change it. Nothing in this app can: the API
+                        has no endpoint for a comment inside a pending review,
+                        so the button that would edit it here would have to
+                        submit the review to do it. */}
+                    {c.url && (
+                      <button onClick={() => openExternal(c.url!)} title="Edit this comment on GitHub"
+                        className="agx-btn shrink-0 ml-auto px-1.5 py-0.5 rounded"
+                        style={{ color: "var(--primary)" }}>Edit ↗</button>
+                    )}
+                  </div>
                   <div className="mt-1"><Md body={c.body} /></div>
                 </div>
               ))}

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -5316,7 +5316,34 @@ function FieldPicker({ anchor, title, hint, multi, loading, options, selected, o
                  than two buttons pressed hopefully. */
               <div className="px-1 text-[10.5px]" style={{ color: "var(--text2)" }}>
                 <div className="mb-1" style={{ color: "var(--text4)" }}>This will:</div>
-                {ghChanged > 0 && <div>· {title} on GitHub</div>}
+                {/* WHO, not just "something will change here".
+                    It said "Request reviewers on GitHub" for a step that was
+                    taking a reviewer OFF — the same sentence for both
+                    directions, while the ClickUp lines under it named the
+                    person either way. Reported as: it should say remove that
+                    user, with their avatar like adding one has. */}
+                {ghChanged > 0 && (() => {
+                  const add = sel.filter((x) => !selected.includes(x));
+                  const gone = selected.filter((x) => !sel.includes(x));
+                  const line = (v: string, on: boolean) => {
+                    const o = options.find((x) => x.value === v);
+                    return (
+                      <div key={`${on ? "+" : "-"}${v}`} className="flex items-center gap-1.5 pl-3">
+                        <span className="shrink-0" style={{ color: on ? "var(--success)" : "var(--error)" }}>{on ? "+" : "−"}</span>
+                        {o?.avatar != null && <Avatar login={o.avatar} size={14} />}
+                        {o?.color != null && <span className="w-2 h-2 rounded-full shrink-0" style={{ background: `#${o.color}` }} />}
+                        <span className="truncate">{o?.label ?? v}</span>
+                      </div>
+                    );
+                  };
+                  return (
+                    <>
+                      <div>· {title} on GitHub</div>
+                      {add.map((v) => line(v, true))}
+                      {gone.map((v) => line(v, false))}
+                    </>
+                  );
+                })()}
                 {/* Nothing that is not a change: with an empty plan there is
                     nothing to confirm and this step does not happen at all. */}
                 {plan.lines.map((l) => <div key={l}>· {l}</div>)}
@@ -5430,7 +5457,6 @@ function ClickUpSide({ d, folded, onFold, onPlan, note }: {
   const [was, setWas] = useState<Set<number>>(new Set());
   const [pick, setPick] = useState<string>("");
   const [q, setQ] = useState("");
-  const [stOpen, setStOpen] = useState(false);
   /* Folded away, and it comes back.
      This is the optional half of the errand and most presses of this menu are
      only about the reviewer — so it can be put away to a strip, which leaves
@@ -5586,28 +5612,38 @@ function ClickUpSide({ d, folded, onFold, onPlan, note }: {
                 colour its board gave it, and a row of bordered words throws
                 that away — which is the one thing that makes this list
                 readable at a glance. */}
-            <button onClick={() => setStOpen((o) => !o)}
-              className="agx-btn w-full text-left rounded px-1 py-1 hover:bg-white/5 flex items-center gap-2">
-              <span className="min-w-0 truncate">
-                <StatusPill status={pick || card.status} color={statusColor(statuses, pick || card.status)} />
-              </span>
-              {!pick && <span className="text-[9.5px]" style={{ color: "var(--text4)" }}>unchanged</span>}
-              <span className="ml-auto shrink-0" style={{ color: "var(--text4)" }}>▾</span>
-            </button>
-            {stOpen && (
-              <div className="agx-scroll mt-1 rounded-lg flex flex-col overflow-y-auto"
-                style={{ background: "var(--bg2)", border: "1px solid color-mix(in srgb, var(--text) 24%, transparent)", maxHeight: 220 }}>
-                <button className="text-left px-2 py-1.5 hover:bg-white/5 text-[10.5px]"
-                  style={{ color: "var(--text3)" }}
-                  onClick={() => { setPick(""); setStOpen(false); }}>
-                  leave it where it is
-                </button>
-                {statuses.filter((x) => x.status !== card.status).map((x) => (
-                  <button key={x.status} className="text-left px-2 py-1.5 hover:bg-white/5"
-                    onClick={() => { setPick(x.status); setStOpen(false); }}>
-                    <StatusPill status={x.status} color={x.color} dim={x.type === "done" || x.type === "closed"} />
-                  </button>
-                ))}
+            {/*
+              * The app's own Select, not a list drawn in the flow.
+              *
+              * This was an absolutely-placed panel under the button, inside a
+              * column that clips and scrolls and has a "Done" button under it:
+              * the list opened INSIDE the container, most of the statuses were
+              * unreachable, and near the bottom of the screen there was nowhere
+              * for it to go. Reported exactly that way. `Select` portals out of
+              * the clipping and flips above the trigger when down does not fit,
+              * which is what every other menu in this app does.
+              *
+              * "leave it where it is" is an option rather than a button above
+              * the list, because it is one of the choices — and being the empty
+              * value it is also what the control already holds.
+              */}
+            <Select
+              value={pick}
+              onChange={setPick}
+              title="Status"
+              options={[
+                { value: "", label: "leave it where it is" },
+                ...statuses.filter((x) => x.status !== card.status).map((x) => ({
+                  value: x.status, label: x.status, tint: x.color, pill: true,
+                  dim: x.type === "done" || x.type === "closed",
+                })),
+              ]}
+            />
+            {!pick && (
+              <div className="mt-1 text-[9.5px] flex items-center gap-2" style={{ color: "var(--text4)" }}>
+                <span>now</span>
+                <StatusPill status={card.status} color={statusColor(statuses, card.status)} />
+                <span>· unchanged</span>
               </div>
             )}
           </div>
@@ -7750,7 +7786,16 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
                     how a click in the tree lands on a file you then cannot
                     scroll, and it is not what GitHub does. Long files are
                     folded by default instead, which is the honest cap. */}
-                <div className="flex" style={{ overflowX: "auto" }}>
+                {/* No overflow here, deliberately. `overflow-x: auto` alone is
+                    not one axis: the other computes to `auto` too, so this was
+                    a second scroll container wrapped around the diff's own —
+                    two vertical scrollbars side by side at the edge of the
+                    column, one of them themed and one of them not, and the
+                    inner one behaving like it was dead because the outer had
+                    the wheel. Measured in Chrome: `overflow-x:auto` reports
+                    `overflowY: auto`. The diff pane inside scrolls itself, and
+                    the files column is the one that scrolls vertically. */}
+                <div className="flex min-w-0">
                   {/* An image first, and a file with no hunks second.
                       `gh pr diff` still emits a header for a binary file — just
                       "Binary files … differ" and nothing else — so the parser

--- a/web/src/components/PrPanel.tsx
+++ b/web/src/components/PrPanel.tsx
@@ -7576,8 +7576,16 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
         {(oneFile || shownFiles.length > 4) && (
           <aside className="shrink-0 agx-tree3 sticky top-[68px] z-10 agx-scroll hidden md:block pr-1"
             style={{ borderRight: "1px solid color-mix(in srgb, var(--text) 11%, transparent)" }}>
+            {/* `showing`, not `sel`.
+                
+                In one-file mode the first file is on screen before anybody has
+                clicked anything, and `sel` is still null — so the pane showed a
+                diff while the tree beside it marked nothing, and the row you
+                were reading looked no different from the eleven you were not.
+                `showing` is the same expression the diff itself renders from,
+                which is what makes them agree. */}
             <FileTree
-              node={buildFileTree(shownFiles)} sel={sel}
+              node={buildFileTree(shownFiles)} sel={showing}
               onPick={(path) => { onSel(path); setFolded((cur) => { const n = new Set(cur); n.delete(path); return n; }); scrollToFileStable(() => frameRef.current?.querySelector(`[data-path="${CSS.escape(path)}"]`)); }}
               seen={(path) => seenFiles.includes(path)}
               drafts={draftsFor} onPeek={onPeek}
@@ -7610,7 +7618,8 @@ function FilesTab({ d, root, byPath, loaded, diffErr, seenFiles, onSeen, sel, on
       {(oneFile ? shownFiles.filter((f) => f.path === showing) : shownFiles).map((f) => {
         const done = seenFiles.includes(f.path);
         const open = !folded.has(f.path);
-        const focused = sel === f.path;
+        // Same reason as the tree above: what is on screen is what is marked.
+        const focused = showing === f.path;
         const nd = draftsFor(f.path);
         const pendingHere = pendingBy(f.path);
         const heldHere = heldBy(f.path);

--- a/web/src/components/RebaseModal.tsx
+++ b/web/src/components/RebaseModal.tsx
@@ -11,6 +11,7 @@
  * modal closes on start; the conflict screen owns the rest.
  */
 import { useEffect, useState } from "react";
+import { CaretIcon } from "../lib/glyphIcons.tsx";
 import { motion, AnimatePresence } from "motion/react";
 import { Portal } from "./Portal.tsx";
 import { CloseButton } from "./CloseButton.tsx";
@@ -114,8 +115,8 @@ export function RebaseModal({ root, base, branch, onClose, onDone }: {
                           has no drag util, and for a list that is at most a few
                           dozen rows, two 14px buttons are faster and forgiving. */}
                       <span className="shrink-0 flex flex-col">
-                        <button disabled={i === 0} onClick={() => move(i, -1)} className="text-[8px] leading-none px-0.5 t-dim2 disabled:opacity-25" title="Move up">▲</button>
-                        <button disabled={i === steps.length - 1} onClick={() => move(i, 1)} className="text-[8px] leading-none px-0.5 t-dim2 disabled:opacity-25" title="Move down">▼</button>
+                        <button disabled={i === 0} onClick={() => move(i, -1)} className="inline-flex items-center justify-center rounded t-dim2 disabled:opacity-25" title="Move up"><CaretIcon className="rotate-180" /></button>
+                        <button disabled={i === steps.length - 1} onClick={() => move(i, 1)} className="inline-flex items-center justify-center rounded t-dim2 disabled:opacity-25" title="Move down"><CaretIcon /></button>
                       </span>
                       <select value={s.action} onChange={(e) => setAction(i, e.target.value as RebaseStep["action"])} title={ACTION_HINT[s.action]}
                         className="shrink-0 text-[10px] px-1.5 py-0.5 rounded outline-none"

--- a/web/src/components/ResumeSessions.tsx
+++ b/web/src/components/ResumeSessions.tsx
@@ -1,0 +1,251 @@
+/**
+ * Every past agent session in this project, one press away.
+ *
+ * By hand it is four steps: open a tab, start the agent, type `/resume`, and
+ * find the session in a list. The fourth is the one that cannot be fixed by
+ * typing faster — the CLI's list is scoped to the directory the agent happens
+ * to be running in, so a session from a worktree is simply not in the list you
+ * get from the main checkout, and those are usually the ones being looked for.
+ *
+ * So this asks the server for the whole project's transcripts (every checkout,
+ * see agentsessions.ts) and opens the chosen one where you say: a tab of its
+ * own, or a split beside what you are already reading.
+ *
+ * Cards rather than lines, asked for in those words: a title is four words the
+ * CLI guessed, and four words is not enough to tell two mornings apart. Each
+ * card carries how the session started and where it got to, which between them
+ * are what "was it this one" is actually answered by.
+ *
+ * A session that is ALREADY running is not one to resume — resuming it twice is
+ * two agents appending to one transcript. Those cards are dimmed, say which
+ * window they are in, and offer the trip instead of the launch.
+ */
+import { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from "react";
+import { motion, AnimatePresence } from "motion/react";
+import type { AgentSessionRow } from "../../../shared/types.ts";
+import { api } from "../lib/api.ts";
+import { ago } from "../lib/fileRecents.ts";
+import { Portal } from "./Portal.tsx";
+import { LAYER } from "../lib/layers.ts";
+import { CHIP, CHIP_SURFACE, CHIP_SURFACE_CLS } from "./workspace/Chrome.tsx";
+import { ICON } from "../lib/iconSize.ts";
+
+const YOLO_KEY = "agentglass.resume.yolo";
+
+/** Bytes as the CLI shows them — the one honest hint of how long a conversation
+ *  is before opening it. */
+function weight(size: number): string {
+  if (size >= 1024 * 1024) return `${(size / (1024 * 1024)).toFixed(1)}MB`;
+  if (size >= 1024) return `${Math.round(size / 1024)}KB`;
+  return `${size}B`;
+}
+
+/** The checkout's own name, which is what tells `orbit` from `orbit-CARD-1`. */
+const where = (cwd: string) => cwd.split("/").filter(Boolean).pop() ?? cwd;
+
+export function ResumeSessions({ root, disabled, onOpen, onGo }: {
+  /** The project on screen. Its whole family of checkouts is searched. */
+  root: string;
+  disabled?: boolean;
+  /** Start it: a window of its own, or a split beside what is on screen. */
+  onOpen: (s: AgentSessionRow, how: { split: boolean; yolo: boolean }) => void;
+  /** Take me to the pane it is already running in. */
+  onGo: (at: NonNullable<AgentSessionRow["openIn"]>) => void;
+}) {
+  const [open, setOpen] = useState(false);
+  const [rows, setRows] = useState<AgentSessionRow[] | null>(null);
+  const [err, setErr] = useState("");
+  const [q, setQ] = useState("");
+  const [yolo, setYolo] = useState(() => {
+    try { return localStorage.getItem(YOLO_KEY) === "1"; } catch { return false; }
+  });
+  const btnRef = useRef<HTMLButtonElement>(null);
+  const [pos, setPos] = useState<{ top?: number; bottom?: number; left: number; maxHeight: number }>(
+    { top: 0, left: 0, maxHeight: 460 });
+
+  const close = useCallback(() => { setOpen(false); setQ(""); }, []);
+
+  /* Asked for when the menu opens, not on a timer: a transcript list is a
+     directory read per checkout and this is a menu, not a live view. */
+  useEffect(() => {
+    if (!open || !root) return;
+    let alive = true;
+    setErr("");
+    api.agentSessions(root)
+      .then((r) => { if (alive) { setRows(r.sessions ?? []); if (!r.ok) setErr("could not read the sessions"); } })
+      .catch(() => { if (alive) setErr("could not read the sessions"); });
+    return () => { alive = false; };
+  }, [open, root]);
+
+  useLayoutEffect(() => {
+    if (!open || !btnRef.current) return;
+    const r = btnRef.current.getBoundingClientRect();
+    const below = window.innerHeight - r.bottom - 12;
+    const above = r.top - 12;
+    // The same rule every other menu in this app uses: up only when down does
+    // not fit and up is roomier.
+    const up = below < 240 && above > below;
+    setPos({
+      top: up ? undefined : r.bottom + 6,
+      bottom: up ? window.innerHeight - r.top + 6 : undefined,
+      left: Math.max(8, Math.min(r.left, window.innerWidth - 560)),
+      maxHeight: Math.max(220, Math.min(560, up ? above : below)),
+    });
+  }, [open]);
+
+  useEffect(() => {
+    if (!open) return;
+    const onKey = (e: KeyboardEvent) => { if (e.key === "Escape") { e.stopPropagation(); close(); } };
+    window.addEventListener("keydown", onKey, true);
+    return () => window.removeEventListener("keydown", onKey, true);
+  }, [open, close]);
+
+  const shown = useMemo(() => {
+    const needle = q.trim().toLowerCase();
+    const all = rows ?? [];
+    if (!needle) return all;
+    return all.filter((s) => `${s.title} ${s.opening} ${s.last} ${where(s.cwd)}`.toLowerCase().includes(needle));
+  }, [rows, q]);
+
+  const setYoloKept = (v: boolean) => {
+    setYolo(v);
+    try { localStorage.setItem(YOLO_KEY, v ? "1" : "0"); } catch { /* private mode */ }
+  };
+
+  return (
+    <>
+      <button ref={btnRef} disabled={disabled || !root}
+        onClick={() => (open ? close() : setOpen(true))}
+        title="Resume a past agent session from this project — any of its checkouts"
+        className={`${CHIP} ${CHIP_SURFACE_CLS} flex items-center gap-1.5 shrink-0 disabled:opacity-40`}
+        style={CHIP_SURFACE}>
+        <svg width={ICON.xs} height={ICON.xs} viewBox="0 0 16 16" fill="none" aria-hidden="true"
+          stroke="currentColor" strokeWidth="1.4" strokeLinecap="round" strokeLinejoin="round">
+          <path d="M2.6 8a5.4 5.4 0 1 0 1.6-3.8" />
+          <path d="M2.4 2.6v3h3" />
+          <path d="M8 5.2V8l2 1.4" />
+        </svg>
+        <span>Sessions</span>
+        <span style={{ color: "var(--text4)" }}>▾</span>
+      </button>
+
+      <Portal z={LAYER.menu}>
+        <AnimatePresence>
+          {open && (
+            <>
+              <div className="fixed inset-0" style={{ zIndex: 9998 }} onClick={close} />
+              <motion.div
+                initial={{ opacity: 0, y: -8, scale: 0.98 }} animate={{ opacity: 1, y: 0, scale: 1 }}
+                exit={{ opacity: 0, y: -8, scale: 0.98 }}
+                transition={{ type: "spring", stiffness: 420, damping: 32 }}
+                className="fixed rounded-xl overflow-hidden flex flex-col"
+                style={{
+                  ...(pos.bottom == null ? { top: pos.top } : { bottom: pos.bottom }),
+                  left: pos.left, width: 540, maxHeight: pos.maxHeight, zIndex: 9999,
+                  background: "color-mix(in srgb, var(--bg2) 97%, black)",
+                  border: "1px solid color-mix(in srgb, var(--border) 70%, transparent)",
+                  boxShadow: "0 24px 60px -18px rgba(0,0,0,0.7)",
+                }}>
+                <div className="p-2 flex items-center gap-2 shrink-0"
+                  style={{ borderBottom: "1px solid color-mix(in srgb, var(--text) 10%, transparent)" }}>
+                  <input autoFocus value={q} onChange={(e) => setQ(e.target.value)}
+                    placeholder="Filter these sessions…"
+                    className="flex-1 min-w-0 rounded-md px-2 py-1 text-[11px] outline-none"
+                    style={{ background: "color-mix(in srgb, var(--text) 6%, transparent)", color: "var(--text)" }} />
+                  {/* Remembered, and stated where the press happens: what a
+                      resumed agent may do without asking is not something to
+                      find out afterwards. */}
+                  <label className="flex items-center gap-1.5 text-[10px] shrink-0 cursor-pointer"
+                    title="Start it with --dangerously-skip-permissions"
+                    style={{ color: yolo ? "var(--warning)" : "var(--text3)" }}>
+                    <input type="checkbox" checked={yolo} onChange={(e) => setYoloKept(e.target.checked)} />
+                    yolo
+                  </label>
+                </div>
+
+                <div className="agx-scroll flex-1 min-h-0 overflow-y-auto p-2 flex flex-col gap-1.5">
+                  {rows === null && !err && (
+                    <p className="m-0 px-1 py-2 text-[10.5px]" style={{ color: "var(--text4)" }}>Reading the transcripts…</p>
+                  )}
+                  {err && <p className="m-0 px-1 py-2 text-[10.5px]" style={{ color: "var(--warning)" }}>{err}</p>}
+                  {rows !== null && !err && shown.length === 0 && (
+                    <p className="m-0 px-1 py-2 text-[10.5px]" style={{ color: "var(--text4)" }}>
+                      {rows.length ? "Nothing matches that." : "No agent sessions in this project yet."}
+                    </p>
+                  )}
+                  {shown.map((s) => {
+                    const at = s.openIn;
+                    return (
+                      <div key={s.id} className="rounded-lg px-2.5 py-2 group/rs"
+                        style={{
+                          border: "1px solid color-mix(in srgb, var(--text) 10%, transparent)",
+                          background: "color-mix(in srgb, var(--text) 3%, transparent)",
+                          // Running already: still legible, plainly not on offer.
+                          opacity: at ? 0.62 : 1,
+                        }}>
+                        <div className="flex items-start gap-2">
+                          <div className="min-w-0 flex-1">
+                            <div className="text-[11.5px] truncate" style={{ color: "var(--text)" }}
+                              title={s.title || s.id}>{s.title || "(untitled session)"}</div>
+                            {!!s.opening && (
+                              <div className="text-[10px] mt-0.5 leading-snug" style={{
+                                color: "var(--text3)", display: "-webkit-box", WebkitLineClamp: 2,
+                                WebkitBoxOrient: "vertical", overflow: "hidden",
+                              }}>{s.opening}</div>
+                            )}
+                            {!!s.last && (
+                              <div className="text-[10px] mt-0.5 truncate" style={{ color: "var(--text4)" }}
+                                title={s.last}>↳ {s.last}</div>
+                            )}
+                          </div>
+                          <div className="shrink-0 flex items-center gap-1">
+                            {at ? (
+                              <button onClick={() => { onGo(at); close(); }}
+                                title={`Running in ${at.session}:${at.windowIndex} ${at.windowName}`}
+                                className="agx-btn text-[10px] px-1.5 py-0.5 rounded"
+                                style={{ color: "var(--primary)", border: "1px solid color-mix(in srgb, var(--primary) 35%, transparent)" }}>
+                                Go →
+                              </button>
+                            ) : (
+                              <>
+                                <button onClick={() => { onOpen(s, { split: false, yolo }); close(); }}
+                                  title="Resume it in a tab of its own"
+                                  className="agx-btn text-[10px] px-1.5 py-0.5 rounded"
+                                  style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--text) 18%, transparent)" }}>
+                                  Tab
+                                </button>
+                                <button onClick={() => { onOpen(s, { split: true, yolo }); close(); }}
+                                  title="Resume it beside this pane"
+                                  className="agx-btn text-[10px] px-1.5 py-0.5 rounded"
+                                  style={{ color: "var(--text2)", border: "1px solid color-mix(in srgb, var(--text) 18%, transparent)" }}>
+                                  Split
+                                </button>
+                              </>
+                            )}
+                          </div>
+                        </div>
+                        <div className="flex items-center gap-2 mt-1 text-[9.5px]" style={{ color: "var(--text4)" }}>
+                          <span className="truncate" title={s.cwd}>{where(s.cwd)}</span>
+                          <span>·</span>
+                          <span>{ago(s.at)}</span>
+                          <span>·</span>
+                          <span>{weight(s.size)}</span>
+                          {at && (
+                            <span className="ml-auto truncate" style={{ color: "var(--primary)" }}
+                              title={`${at.session}:${at.windowIndex} ${at.windowName} · ${at.paneId}`}>
+                              open in {at.windowIndex} {at.windowName}
+                            </span>
+                          )}
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </motion.div>
+            </>
+          )}
+        </AnimatePresence>
+      </Portal>
+    </>
+  );
+}

--- a/web/src/components/Select.tsx
+++ b/web/src/components/Select.tsx
@@ -50,7 +50,8 @@ export function Select({
   const [open, setOpen] = useState(false);
   const btnRef = useRef<HTMLButtonElement>(null);
   const listRef = useRef<HTMLDivElement>(null);
-  const [pos, setPos] = useState({ top: 0, left: 0, right: 0, minWidth: 0 });
+  const [pos, setPos] = useState<{ top?: number; bottom?: number; left: number; right: number; minWidth: number; maxHeight: number }>(
+    { top: 0, left: 0, right: 0, minWidth: 0, maxHeight: 420 });
   // Replacing a native <select> means re-implementing everything it gave for
   // free. `cursor` is the roving highlight; `typed` backs type-ahead, which is
   // how anyone picks from a long list without reaching for the mouse.
@@ -58,10 +59,22 @@ export function Select({
   const typed = useRef({ buf: "", at: 0 });
 
   useLayoutEffect(() => {
-    if (open && btnRef.current) {
-      const r = btnRef.current.getBoundingClientRect();
-      setPos({ top: r.bottom + 6, left: r.left, right: window.innerWidth - r.right, minWidth: r.width });
-    }
+    if (!open || !btnRef.current) return;
+    const r = btnRef.current.getBoundingClientRect();
+    const below = window.innerHeight - r.bottom - 12;
+    const above = r.top - 12;
+    /* Up when down does not fit and up is roomier — the same rule `BasePicker`
+       uses, and for the same reason: a control near the bottom of the window
+       opened a list that ran off the screen, so the options nobody could reach
+       were the ones at the end. Not flipped for a few pixels' gain, which only
+       moves the list somewhere the eye is not. */
+    const up = below < 220 && above > below;
+    setPos({
+      top: up ? undefined : r.bottom + 6,
+      bottom: up ? window.innerHeight - r.top + 6 : undefined,
+      left: r.left, right: window.innerWidth - r.right, minWidth: r.width,
+      maxHeight: Math.max(180, Math.min(420, up ? above : below)),
+    });
   }, [open]);
 
   // Open on the current value, so ↑/↓ start from where the user already is.
@@ -154,10 +167,10 @@ export function Select({
                 aria-label={title ?? "Options"}
                 className="fixed p-1.5 rounded-xl flex flex-col gap-0.5 overflow-y-auto agw-noscrollbar"
                 style={{
-                  top: pos.top,
+                  ...(pos.bottom == null ? { top: pos.top } : { bottom: pos.bottom }),
                   ...(align === "right" ? { right: pos.right } : { left: pos.left }),
                   minWidth: Math.max(pos.minWidth, 140),
-                  maxHeight: "min(60vh, 420px)",
+                  maxHeight: pos.maxHeight,
                   zIndex: 9999,
                   background: "color-mix(in srgb, var(--bg2) 97%, black)",
                   border: "1px solid color-mix(in srgb, var(--border) 70%, transparent)",

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -11,6 +11,7 @@
 // second half is the half nobody builds, and it is the reason a machine ends up
 // with fourteen checkouts nobody can name.
 import { Fragment, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { RefreshIcon } from "../lib/glyphIcons.tsx";
 import { api } from "../lib/api.ts";
 import type { GitRepoRef, IssueDetail, IssuePr, IssueRow, IssueWork, StartMode, LocalTask, TaskCapability, TasksListResponse, SkillInfo } from "../../../shared/types.ts";
 import type { ProviderTask, ProviderTasksResponse, SavedView, SavedFolder, ViewTasksResponse, ListStatus, ListField, ListPlace, ListMember, TaskDetail } from "../../../shared/providers.ts";
@@ -303,7 +304,7 @@ function IssuesBody({ root, active, jump }: { root: string; active: boolean; jum
             className="flex-1 min-w-0 bg-transparent outline-none text-[11px]" style={{ color: "var(--text)" }} />
         </span>
         <button onClick={load} title="Refresh" className="agx-btn text-[11px] px-2 py-1 rounded"
-          style={{ color: "var(--text2)", border: edge(20) }}>⟳</button>
+          style={{ color: "var(--text2)", border: edge(20) }}><RefreshIcon /></button>
       </div>
 
       {note && <NoteStrip note={note} onClose={() => setNote(null)} />}

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -36,6 +36,7 @@ import { useClickupSetup } from "../lib/clickupSetup.ts";
 import { api, IS_DEMO, ptyWsUrl, hasToken, probeAuth, reauthPrompt } from "../lib/api.ts";
 import { playDemoSession } from "../lib/demoTerm.ts";
 import { CommandBar, loadCommands } from "./CommandBar.tsx";
+import { ResumeSessions } from "./ResumeSessions.tsx";
 import { SCROLLBAR_CSS } from "./diff/DiffLines.tsx";
 import { wantsWebgl, wantsCanvas, fallBackToCanvas } from "../lib/termRenderer.ts";
 import { isFindChord, isAppChord } from "../lib/termKeys.ts";
@@ -2287,6 +2288,17 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                       dropdown state lives inside it, which is why it sits
                       outside the pickers group above. */}
                   <CommandBar root={root} disabled={disabled} font={TERM_FONT} onRun={run} runTargetInTmux={!!sess?.tmux} onClose={focusTerm} />
+
+                  {/* Past sessions, in the middle of the bar where it can be
+                      seen. The one control here that is about work you have
+                      already done rather than the shell in front of you — see
+                      ResumeSessions for why it lists every checkout. */}
+                  <ResumeSessions
+                    root={root}
+                    disabled={disabled || !sess?.tmux}
+                    onOpen={(sn, how) => { tmuxCmd({ cmd: "resume", id: sn.id, cwd: sn.cwd, split: how.split, yolo: how.yolo }); focusTerm(); }}
+                    onGo={(at) => { void api.focusPane({ sessionId: at.session, windowId: at.windowId, paneId: at.paneId }); }}
+                  />
 
                   {/* keepTermFocus so none of these buttons — split, restart,
                       clear, the status pill — steals the shell's cursor on

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -2297,7 +2297,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                     root={root}
                     disabled={disabled || !sess?.tmux}
                     onOpen={(sn, how) => { tmuxCmd({ cmd: "resume", id: sn.id, cwd: sn.cwd, split: how.split, yolo: how.yolo }); focusTerm(); }}
-                    onGo={(at) => { void api.focusPane({ sessionId: at.session, windowId: at.windowId, paneId: at.paneId }); }}
+                    onGo={(at) => { void api.focusPane({ sessionId: at.sessionId, windowId: at.windowId, paneId: at.paneId }); }}
                   />
 
                   {/* keepTermFocus so none of these buttons — split, restart,

--- a/web/src/components/TerminalPanel.tsx
+++ b/web/src/components/TerminalPanel.tsx
@@ -2684,7 +2684,7 @@ export function TermView({ active, onClose = () => {} }: { active: boolean; onCl
                         boxShadow: dropOn === "__end__" ? "inset -2px 0 0 0 var(--primary)" : undefined,
                       }}
                       aria-hidden />
-                    <button onClick={() => tmuxCmd({ cmd: "new" })} className="shrink-0 px-1.5 py-0.5 rounded-md text-[11px]" style={{ color: "var(--text3)" }} title={`New tmux window (${px} c puts it next to this one)`}>+</button>
+                    <button onClick={() => tmuxCmd({ cmd: "new", root })} className="shrink-0 px-1.5 py-0.5 rounded-md text-[11px]" style={{ color: "var(--text3)" }} title={`New tmux window (${px} c puts it next to this one)`}>+</button>
                     {/* Not on the engine. That server keeps its status line off
                         by design — the config gate refuses any config that turns
                         it on — so the button would be offering a bar that cannot

--- a/web/src/components/TriageBoard.tsx
+++ b/web/src/components/TriageBoard.tsx
@@ -211,13 +211,38 @@ export function TriageBoard({
     const hay = [
       `#${p.number}`, String(p.number), p.title, p.author, p.headRefName, p.baseRefName,
       ...(p.labels ?? []).map((l) => l.name),
+      /* The PEOPLE, which is the question this box is actually asked: "where is
+         Javi on this board". It matched the author and stopped, so typing a
+         name dimmed every card — including the one saying "Waiting on
+         javidoe" in as many words. Assignees and requested reviewers both:
+         who owns it and who is being waited on are one question to somebody
+         looking for their own name. */
+      ...(p.assignees ?? []),
+      ...(p.reviewers ?? []).map((r) => r.login),
     ].join(" ").toLowerCase();
     return hay.includes(needle);
   }, [needle]);
   const hits = useMemo(() => (needle ? cards.filter(matches).length : 0), [needle, cards, matches]);
+  /**
+   * Lanes opened past their cap, by lane id.
+   *
+   * The cap keeps the board a glance, and the four it left over used to be a
+   * button that sent you to the TABLE — a different surface, sorted
+   * differently, with the lane you were reading nowhere in it. "¿Qué sentido
+   * tiene tener las cards entonces?" is the right question: the rest of a lane
+   * belongs in the lane. The board already holds those rows; only the slice was
+   * hiding them.
+   */
+  const [openLanes, setOpenLanes] = useState<Record<string, boolean>>({});
   const [cur, setCur] = useState<{ lane: number; row: number }>({ lane: 0, row: 0 });
   const frame = useRef<HTMLDivElement>(null);
-  const shown = useCallback((i: number) => (lanes.get(cols[i]?.id ?? "review") ?? []).slice(0, LANE_CAP), [lanes, cols]);
+  // Keyboard navigation walks exactly what is drawn — an opened lane included,
+  // or j past the cap would step onto a card nobody can see.
+  const shown = useCallback((i: number) => {
+    const id = cols[i]?.id ?? "review";
+    const all = lanes.get(id) ?? [];
+    return openLanes[id] ? all : all.slice(0, LANE_CAP);
+  }, [lanes, cols, openLanes]);
   const at = shown(cur.lane)[cur.row];
 
   // Keep the cursor on something. Lanes empty and fill as checks land, and a
@@ -427,7 +452,8 @@ export function TriageBoard({
           <div className="grid gap-2.5 h-full" style={{ gridTemplateColumns: `repeat(${cols.length}, minmax(268px, 1fr))` }}>
             {cols.map((l, i) => {
               const all = lanes.get(l.id) ?? [];
-              const rows = all.slice(0, LANE_CAP);
+              const opened = !!openLanes[l.id];
+              const rows = opened ? all : all.slice(0, LANE_CAP);
               const more = all.length - rows.length;
               return (
                 /* A column is a box of its own height: heading fixed, cards
@@ -482,13 +508,25 @@ export function TriageBoard({
                             pinned={pinned(p.number)} onOpen={() => onOpen(p.number)} onPin={() => onTogglePin(p)}
                             onAct={onAct} busy={busy} acting={acting} dim={!matches(p)} root={root} />
                         ))}
-                        {/* Counted, not hidden. A lane may be forty on a bad
-                            week, and the column scrolls but the cap is what
-                            keeps the board a glance rather than a list. */}
+                        {/* Counted, and openable HERE. The cap is what keeps
+                            the board a glance on a bad week; the rest of the
+                            lane is one press away and lands in the lane it
+                            belongs to, not in a table on the other side of the
+                            panel. The column already scrolls. */}
                         {more > 0 && (
-                          <button onClick={onShowTable} className="w-full rounded-md py-1 text-[10px]"
+                          <button onClick={() => setOpenLanes((o) => ({ ...o, [l.id]: true }))}
+                            title={`Show the other ${more} in this lane`}
+                            className="w-full rounded-md py-1 text-[10px]"
                             style={{ color: "var(--text3)", border: edge(16) }}>
                             +{more} more in this lane
+                          </button>
+                        )}
+                        {opened && all.length > LANE_CAP && (
+                          <button onClick={() => setOpenLanes((o) => ({ ...o, [l.id]: false }))}
+                            title={`Back to the first ${LANE_CAP}`}
+                            className="w-full rounded-md py-1 text-[10px]"
+                            style={{ color: "var(--text4)", border: edge(12) }}>
+                            Show fewer
                           </button>
                         )}
                         {all.length === 0 && (

--- a/web/src/components/TriageBoard.tsx
+++ b/web/src/components/TriageBoard.tsx
@@ -490,7 +490,12 @@ export function TriageBoard({
                     </h3>
                   </div>
 
-                  <div className="flex-1 min-h-0 overflow-y-auto agx-scroll">
+                  {/* `pb-2`: the last thing in a lane sat flush against the
+                      bottom edge of the column, and a bordered button there
+                      reads as clipped — "el botón Show fewer está como
+                      comido". Cards had `mb-2` between them and nothing after
+                      the final one. */}
+                  <div className="flex-1 min-h-0 overflow-y-auto agx-scroll pb-2">
                     {waiting ? (
                       /* The shape of the thing being waited for, and no text:
                          a lane cannot honestly say how many it will hold. */
@@ -516,7 +521,7 @@ export function TriageBoard({
                         {more > 0 && (
                           <button onClick={() => setOpenLanes((o) => ({ ...o, [l.id]: true }))}
                             title={`Show the other ${more} in this lane`}
-                            className="w-full rounded-md py-1 text-[10px]"
+                            className="w-full rounded-md py-1 mb-2 text-[10px]"
                             style={{ color: "var(--text3)", border: edge(16) }}>
                             +{more} more in this lane
                           </button>
@@ -524,7 +529,7 @@ export function TriageBoard({
                         {opened && all.length > LANE_CAP && (
                           <button onClick={() => setOpenLanes((o) => ({ ...o, [l.id]: false }))}
                             title={`Back to the first ${LANE_CAP}`}
-                            className="w-full rounded-md py-1 text-[10px]"
+                            className="w-full rounded-md py-1 mb-2 text-[10px]"
                             style={{ color: "var(--text4)", border: edge(12) }}>
                             Show fewer
                           </button>

--- a/web/src/components/diff/DiffLines.tsx
+++ b/web/src/components/diff/DiffLines.tsx
@@ -335,6 +335,21 @@ export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel 
   const built = useMemo(() => source.map((h) => ({ h, rows: unifiedRows(h) })), [source]);
   return (
     <div className="agx-scroll flex-1 min-w-0 overflow-auto text-[12px] leading-[1.6]" data-vscroll style={CODE_FONT_STYLE}>
+      {/*
+       * One width for the whole file, and it is the widest line in it.
+       *
+       * Every hunk used to size itself, so scrolling right ran off the end of
+       * the short ones: their rows stopped where their own longest line did and
+       * the tint, the hunk bar and the row you were reading all gave way to bare
+       * background, while a hunk further down still had text out there. Nothing
+       * was missing — the paint simply ended at a different x per hunk.
+       *
+       * `max-content` here is the widest line in the FILE (the widest child),
+       * and `min-width:100%` keeps a short file filling the pane. The children
+       * are plain blocks, so they take this width rather than each measuring
+       * their own.
+       */}
+      <div style={{ width: "max-content", minWidth: "100%" }}>
       {built.map(({ h, rows }, hi) => (
         <div key={hi}>
           <div data-hunk className="z-10 py-0.5 t-dim2" style={{ position: "var(--agx-hunk-pos, sticky)" as CSSProperties["position"], top: "var(--agx-hunk-top, 0px)", background: "color-mix(in srgb, var(--info) 12%, var(--bg))" }}>
@@ -343,7 +358,11 @@ export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel 
               {hunkAction && hunkAction(hi)}
             </span>
           </div>
-          <div className="grid" style={{ gridTemplateColumns: wrap ? "4ch 4ch minmax(0,1fr)" : "4ch 4ch max-content" }}>
+          {/* `minmax(max-content,1fr)`, not `max-content`: the column has to be
+              at least as wide as the longest line in this hunk AND absorb
+              whatever the file's width leaves over, or the row's background
+              stops at the end of its own text. */}
+          <div className="grid" style={{ gridTemplateColumns: wrap ? "4ch 4ch minmax(0,1fr)" : "4ch 4ch minmax(max-content,1fr)" }}>
             {rows.map((r, ri) => {
               // A review comment thread anchored to this line, rendered right
               // under it as a row spanning every column — GitHub's placement, so
@@ -373,6 +392,7 @@ export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel 
           </div>
         </div>
       ))}
+      </div>
     </div>
   );
 }
@@ -409,9 +429,13 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
     // left has no vertical scrollbar — forward vertical wheel to the right side
     if (rightRef.current && e.deltaY) { rightRef.current.scrollTop += e.deltaY; e.preventDefault(); }
   };
-  const side = (which: "l" | "r") =>
-    built.map(({ h, rows }, hi) => (
-      <div key={hi} style={{ minWidth: "max-content" }}>
+  const side = (which: "l" | "r") => (
+    /* Same rule as the unified pane: one width for the column, taken from the
+       widest line in it, so a short hunk does not stop painting halfway across
+       a scroll the file's longest line paid for. */
+    <div style={{ width: "max-content", minWidth: "100%" }}>
+    {built.map(({ h, rows }, hi) => (
+      <div key={hi}>
         <div data-hunk className="z-10 py-0.5 t-dim2 whitespace-pre" style={{ position: "var(--agx-hunk-pos, sticky)" as CSSProperties["position"], top: "var(--agx-hunk-top, 0px)", background: "color-mix(in srgb, var(--info) 12%, var(--bg))" }}>
           <span className="sticky left-0 inline-block px-3">@@ -{h.oldStart},{h.oldLines} +{h.newStart},{h.newLines} @@</span>
         </div>
@@ -426,7 +450,7 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
           return (
             <Fragment key={ri}>
               <div data-ln={cell ? `${which === "l" ? "L" : "R"}${cell.num}` : undefined}
-                className="flex" style={{ minWidth: "100%", background: cell ? cellBg(cell.kind) : HATCH }}>
+                className="flex" style={{ width: "max-content", minWidth: "100%", background: cell ? cellBg(cell.kind) : HATCH }}>
                 <div data-side={which} className="text-right pr-1.5 tabular-nums select-none shrink-0 sticky left-0 z-[1] agx-gutter" style={{ width: "3.6ch", background: numBg(cell?.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
                   <LineBtn n={cell?.num} side={which === "l" ? "LEFT" : "RIGHT"} onPick={onPick} />
                   <span className="opacity-40">{cell?.num ?? ""}</span>
@@ -438,7 +462,9 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
           );
         })}
       </div>
-    ));
+    ))}
+    </div>
+  );
 
   // WRAP: one aligned grid, no horizontal scroll — lines wrap in place and both
   // sides keep matching row heights (grid rows take the taller of the two).

--- a/web/src/components/diff/DiffLines.tsx
+++ b/web/src/components/diff/DiffLines.tsx
@@ -351,13 +351,29 @@ type DiffProps = {
 
 // --- unified diff, with old|new gutters, uncapped -----------------------------
 
+/*
+ * Horizontal only, and this is the whole of the reason.
+ *
+ * A box that scrolls sideways is a scroll container on BOTH axes — there is no
+ * such thing as one-axis overflow in CSS: `overflow-x: auto` computes
+ * `overflow-y: auto` unless the other axis is set. So every diff pane was also
+ * a vertical scroller sitting inside a column that is already one, which is the
+ * "doble scroll" report: two vertical bars at the edge of the same column, and
+ * the inner one never moving because the diff is never given a height of its
+ * own to overflow.
+ *
+ * `hidden` clips nothing here: the pane's height IS its content's, in every
+ * caller — the pull request's file column, the Diff view and the preset viewer
+ * all scroll vertically themselves, and this pane grows inside them.
+ */
 export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel }: DiffProps & { hunkAction?: (hunkIndex: number) => ReactNode }) {
   const wrapCls = wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre";
   const source = hunks ?? c?.hunks ?? NO_HUNKS;
   const built = useMemo(() => source.map((h) => ({ h, rows: unifiedRows(h) })), [source]);
   const gw = useMemo(() => gutterWidth(source.reduce((n, h) => Math.max(n, h.oldStart + h.oldLines, h.newStart + h.newLines), 0)), [source]);
   return (
-    <div className="agx-scroll flex-1 min-w-0 overflow-auto text-[12px] leading-[1.6]" data-vscroll style={CODE_FONT_STYLE}>
+    <div className="agx-scroll flex-1 min-w-0 text-[12px] leading-[1.6]" data-vscroll
+      style={{ ...CODE_FONT_STYLE, overflowX: "auto", overflowY: "hidden" }}>
       {/*
        * One width for the whole file, and it is the widest line in it.
        *
@@ -511,7 +527,8 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
   // sides keep matching row heights (grid rows take the taller of the two).
   if (wrap) {
     return (
-      <div className="agx-split agx-scroll flex-1 min-w-0 overflow-auto text-[12px] leading-[1.6]" data-vscroll style={CODE_FONT_STYLE} onMouseDown={onDown}>
+      <div className="agx-split agx-scroll flex-1 min-w-0 text-[12px] leading-[1.6]" data-vscroll
+        style={{ ...CODE_FONT_STYLE, overflowX: "auto", overflowY: "hidden" }} onMouseDown={onDown}>
         <style>{SPLIT_SEL_CSS}</style>
         {built.map(({ h, rows }, hi) => (
           <div key={hi}>
@@ -544,7 +561,10 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
       <div ref={leftRef} data-side="l" className="agx-scroll flex-1 min-w-0" style={{ overflowX: "auto", overflowY: "hidden" }} onWheel={onLeftWheel}>
         {side("l")}
       </div>
-      <div ref={rightRef} data-side="r" data-vscroll className="agx-scroll flex-1 min-w-0 border-l" style={{ overflow: "auto", borderColor: "color-mix(in srgb, var(--text) 16%, transparent)" }} onScroll={syncTop}>
+      {/* Both sides horizontal-only now, so neither is a vertical scroller and
+          the sync below has nothing left to fight over: they grow to the same
+          height inside whatever scrolls the page. */}
+      <div ref={rightRef} data-side="r" data-vscroll className="agx-scroll flex-1 min-w-0 border-l" style={{ overflowX: "auto", overflowY: "hidden", borderColor: "color-mix(in srgb, var(--text) 16%, transparent)" }} onScroll={syncTop}>
         {side("r")}
       </div>
     </div>

--- a/web/src/components/diff/DiffLines.tsx
+++ b/web/src/components/diff/DiffLines.tsx
@@ -48,7 +48,13 @@ export const SPLIT_SEL_CSS = '.agx-split[data-sel="l"] [data-side="r"]{user-sele
  *  20x20 rather than the 19 it used to be: it is an icon-only control, and the
  *  house floor for a hit area is 20x20 — an odd box also cannot sit on the 2px
  *  grid, which is how it ended up nudged by a stray -13px. */
-export const LINEBTN_CSS = '.agx-gutter{position:relative}.agx-linebtn{position:absolute;right:-14px;top:50%;transform:translateY(-50%);width:20px;height:20px;display:flex;align-items:center;justify-content:center;border-radius:6px;background:var(--primary);color:#fff;font-size:16px;font-weight:600;line-height:1;opacity:0;transition:opacity .12s,transform .12s;cursor:pointer;z-index:3;box-shadow:0 1px 3px rgba(0,0,0,.35)}.agx-gutter:hover .agx-linebtn,.agx-linebtn:focus-visible,.agx-linebtn[data-open="1"]{opacity:1}.agx-linebtn:hover{transform:translateY(-50%) scale(1.08)}';
+/* `sticky`, not `relative`, and it took a probe to find out why it mattered:
+   this rule is on the same element as the `sticky left-4ch` utility, wins the
+   cascade, and quietly pinned the line numbers to the code instead of to the
+   pane. They scrolled off the left with everything else and a diff scrolled
+   sideways had nothing left saying which line you were on. Sticky establishes a
+   containing block just as well, so the absolutely placed "+" is unaffected. */
+export const LINEBTN_CSS = '.agx-gutter{position:sticky}.agx-linebtn{position:absolute;right:-14px;top:50%;transform:translateY(-50%);width:20px;height:20px;display:flex;align-items:center;justify-content:center;border-radius:6px;background:var(--primary);color:#fff;font-size:16px;font-weight:600;line-height:1;opacity:0;transition:opacity .12s,transform .12s;cursor:pointer;z-index:3;box-shadow:0 1px 3px rgba(0,0,0,.35)}.agx-gutter:hover .agx-linebtn,.agx-linebtn:focus-visible,.agx-linebtn[data-open="1"]{opacity:1}.agx-linebtn:hover{transform:translateY(-50%) scale(1.08)}';
 
 /** Themed, slim scrollbars for the diff's scrollers (primary-tinted thumb). */
 export const SCROLLBAR_CSS = '.agx-scroll{scrollbar-width:thin;scrollbar-color:color-mix(in srgb,var(--primary) 45%,transparent) transparent}.agx-scroll::-webkit-scrollbar{width:11px;height:11px}.agx-scroll::-webkit-scrollbar-track{background:transparent}.agx-scroll::-webkit-scrollbar-thumb{background:color-mix(in srgb,var(--primary) 38%,transparent);border-radius:999px;border:3px solid transparent;background-clip:padding-box}.agx-scroll::-webkit-scrollbar-thumb:hover{background:color-mix(in srgb,var(--primary) 62%,transparent);background-clip:padding-box}.agx-scroll::-webkit-scrollbar-corner{background:transparent}';
@@ -226,6 +232,22 @@ const cellFg = (k?: DiffKind) => (k === "del" ? "var(--error)" : k === "add" ? "
 const numBg = (k?: DiffKind) => (k === "del" ? "color-mix(in srgb, var(--error) 13%, var(--bg))" : k === "add" ? "color-mix(in srgb, var(--success) 13%, var(--bg))" : "var(--bg)");
 const SEL_BG = "color-mix(in srgb, var(--primary) 20%, transparent)";
 
+/**
+ * How wide a line-number gutter has to be for THIS file.
+ *
+ * It was a flat 4ch, which is three digits and a breath. A file whose hunks are
+ * down at line 1851 needs four, and the numbers simply ran out of their box —
+ * harmless while the box was transparent and the neighbour was empty, and very
+ * much not once the gutters became opaque and pinned: the old number ran under
+ * the new one and read as "18511851".
+ *
+ * `+1` is the gap to the code, `Math.max` keeps a short file looking like every
+ * other short file rather than shrinking to two characters.
+ */
+function gutterWidth(maxLine: number): string {
+  return `${Math.max(4, String(Math.max(1, maxLine)).length + 1)}ch`;
+}
+
 function Marked({ segs, kind }: { segs: Seg[]; kind: "del" | "add" }) {
   const bg = kind === "del" ? "color-mix(in srgb, var(--error) 22%, transparent)" : "color-mix(in srgb, var(--success) 22%, transparent)";
   return <>{segs.map((s, i) => (s.hi ? <span key={i} style={{ background: bg, borderRadius: "2px" }}>{s.text}</span> : <span key={i}>{s.text}</span>))}</>;
@@ -333,6 +355,7 @@ export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel 
   const wrapCls = wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre";
   const source = hunks ?? c?.hunks ?? NO_HUNKS;
   const built = useMemo(() => source.map((h) => ({ h, rows: unifiedRows(h) })), [source]);
+  const gw = useMemo(() => gutterWidth(source.reduce((n, h) => Math.max(n, h.oldStart + h.oldLines, h.newStart + h.newLines), 0)), [source]);
   return (
     <div className="agx-scroll flex-1 min-w-0 overflow-auto text-[12px] leading-[1.6]" data-vscroll style={CODE_FONT_STYLE}>
       {/*
@@ -358,35 +381,52 @@ export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel 
               {hunkAction && hunkAction(hi)}
             </span>
           </div>
-          {/* `minmax(max-content,1fr)`, not `max-content`: the column has to be
-              at least as wide as the longest line in this hunk AND absorb
-              whatever the file's width leaves over, or the row's background
-              stops at the end of its own text. */}
-          <div className="grid" style={{ gridTemplateColumns: wrap ? "4ch 4ch minmax(0,1fr)" : "4ch 4ch minmax(max-content,1fr)" }}>
+          {/*
+            * Rows, not a grid, and this is the reason: `position: sticky` on a
+            * grid ITEM is measured against its grid area, so a sticky line
+            * number can only stick inside its own 4ch column — which is to say
+            * it cannot move at all. The numbers scrolled away with the code and
+            * a diff scrolled sideways had nothing left to say which line you
+            * were on. In a flex row the gutter's containing block is the row,
+            * which is as wide as the file, so it pins to the left edge.
+            *
+            * The columns still line up: both gutters are a fixed 4ch, exactly
+            * as the grid tracks were.
+            */}
+          <div>
             {rows.map((r, ri) => {
               // A review comment thread anchored to this line, rendered right
-              // under it as a row spanning every column — GitHub's placement, so
-              // the note sits with the code it is about instead of at the far
-              // bottom of the file.
+              // under it, full width — GitHub's placement, so the note sits with
+              // the code it is about instead of at the far bottom of the file.
               const after = rowAfter?.(r.newN, r.oldN);
+              const tint = inSel(sel ?? null, r.newN, "RIGHT") || inSel(sel ?? null, r.oldN, "LEFT") ? SEL_BG : cellBg(r.kind);
               return (
-                <div key={ri} className="contents">
-                  <div className="text-right pr-1.5 tabular-nums select-none sticky z-[1]" style={{ left: 0, background: numBg(r.kind) }}><span className="opacity-40">{r.oldN ?? ""}</span></div>
-                  <div className="text-right pr-1.5 tabular-nums select-none sticky z-[1] agx-gutter" style={{ left: "4ch", background: numBg(r.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
-                    <LineBtn n={r.newN ?? r.oldN} side={r.newN != null ? "RIGHT" : "LEFT"} onPick={onPick} />
-                    <span className="opacity-40">{r.newN ?? ""}</span>
+                <Fragment key={ri}>
+                  <div className="flex" style={{ width: "max-content", minWidth: "100%" }}>
+                    {/* Opaque, not tinted-transparent: the code passes BEHIND
+                        these two and a translucent gutter shows the line you
+                        are trying to read through the number telling you which
+                        one it is. `numBg` mixes the row's tint into `--bg`. */}
+                    <div className="shrink-0 text-right pr-1.5 tabular-nums select-none sticky left-0 z-[2]"
+                      style={{ width: gw, background: numBg(r.kind) }}><span className="opacity-40">{r.oldN ?? ""}</span></div>
+                    <div className="shrink-0 text-right pr-1.5 tabular-nums select-none sticky z-[2] agx-gutter"
+                      style={{ width: gw, left: gw, background: numBg(r.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
+                      <LineBtn n={r.newN ?? r.oldN} side={r.newN != null ? "RIGHT" : "LEFT"} onPick={onPick} />
+                      <span className="opacity-40">{r.newN ?? ""}</span>
+                    </div>
+                    {/* `data-ln` names the row the way a search result does —
+                        "R412", "L88" — so a hit found across every file has
+                        somewhere to scroll to. Side follows the same rule the
+                        matcher uses: a removal exists on the left, everything
+                        else is reported where the reader will look for it. */}
+                    <div data-ln={r.newN != null ? `R${r.newN}` : r.oldN != null ? `L${r.oldN}` : undefined}
+                      className={`${wrapCls} px-1.5 flex-1 ${wrap ? "min-w-0" : ""}`}
+                      style={{ background: tint, color: cellFg(r.kind) }}>
+                      <span className="select-none opacity-60">{r.kind === "add" ? "+" : r.kind === "del" ? "−" : " "} </span><Code text={r.text} segs={r.segs} kind={r.kind} />
+                    </div>
                   </div>
-                  {/* `data-ln` names the row the way a search result does —
-                      "R412", "L88" — so a hit found across every file has
-                      somewhere to scroll to. Side follows the same rule the
-                      matcher uses: a removal exists on the left, everything
-                      else is reported where the reader will look for it. */}
-                  <div data-ln={r.newN != null ? `R${r.newN}` : r.oldN != null ? `L${r.oldN}` : undefined}
-                    className={`${wrapCls} px-1.5`} style={{ background: inSel(sel ?? null, r.newN, "RIGHT") || inSel(sel ?? null, r.oldN, "LEFT") ? SEL_BG : cellBg(r.kind), color: cellFg(r.kind) }}>
-                    <span className="select-none opacity-60">{r.kind === "add" ? "+" : r.kind === "del" ? "−" : " "} </span><Code text={r.text} segs={r.segs} kind={r.kind} />
-                  </div>
-                  {after && <div style={{ gridColumn: "1 / -1" }}>{after}</div>}
-                </div>
+                  {after}
+                </Fragment>
               );
             })}
           </div>
@@ -408,6 +448,7 @@ export function UnifiedDiff({ c, hunks, wrap, hunkAction, rowAfter, onPick, sel 
 export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) {
   const source = hunks ?? c?.hunks ?? NO_HUNKS;
   const built = useMemo(() => source.map((h) => ({ h, rows: splitRows(h) })), [source]);
+  const gw = useMemo(() => gutterWidth(source.reduce((n, h) => Math.max(n, h.oldStart + h.oldLines, h.newStart + h.newLines), 0)), [source]);
   const wrapCls = wrap ? "whitespace-pre-wrap break-all" : "whitespace-pre";
   const leftRef = useRef<HTMLDivElement>(null);
   const rightRef = useRef<HTMLDivElement>(null);
@@ -451,7 +492,7 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
             <Fragment key={ri}>
               <div data-ln={cell ? `${which === "l" ? "L" : "R"}${cell.num}` : undefined}
                 className="flex" style={{ width: "max-content", minWidth: "100%", background: cell ? cellBg(cell.kind) : HATCH }}>
-                <div data-side={which} className="text-right pr-1.5 tabular-nums select-none shrink-0 sticky left-0 z-[1] agx-gutter" style={{ width: "3.6ch", background: numBg(cell?.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
+                <div data-side={which} className="text-right pr-1.5 tabular-nums select-none shrink-0 sticky left-0 z-[1] agx-gutter" style={{ width: gw, background: numBg(cell?.kind), boxShadow: "1px 0 0 0 color-mix(in srgb, var(--border) 22%, transparent)" }}>
                   <LineBtn n={cell?.num} side={which === "l" ? "LEFT" : "RIGHT"} onPick={onPick} />
                   <span className="opacity-40">{cell?.num ?? ""}</span>
                 </div>
@@ -477,7 +518,7 @@ export function SplitDiff({ c, hunks, wrap, rowAfter, onPick, sel }: DiffProps) 
             <div data-hunk className="z-10 px-3 py-0.5 t-dim2 whitespace-pre" style={{ position: "var(--agx-hunk-pos, sticky)" as CSSProperties["position"], top: "var(--agx-hunk-top, 0px)", background: "color-mix(in srgb, var(--info) 12%, var(--bg))" }}>
               @@ -{h.oldStart},{h.oldLines} +{h.newStart},{h.newLines} @@
             </div>
-            <div className="grid" style={{ gridTemplateColumns: "3.6ch minmax(0,1fr) 3.6ch minmax(0,1fr)" }}>
+            <div className="grid" style={{ gridTemplateColumns: `${gw} minmax(0,1fr) ${gw} minmax(0,1fr)` }}>
               {rows.map((row, ri) => {
                 const after = rowAfter?.(row.r?.num, row.l?.num);
                 return (

--- a/web/src/components/git/Lists.tsx
+++ b/web/src/components/git/Lists.tsx
@@ -21,7 +21,7 @@ import type {
   GitBranch, GitTag, GitStash, GitWorktree, GitRemote, GitRemoteBranch,
   GitSubmodule, GitReflogEntry,
 } from "../../../../shared/types.ts";
-import { Row, Chip, RowAction, GroupHead, Empty, wash, type Tone } from "./ui.tsx";
+import { Row, Chip, RowAction, GroupHead, Empty, TickBox, wash, type Tone } from "./ui.tsx";
 import { primaryAction, actionsFor, grouped, groupByPrefix, type GitKind, type GitRowState } from "../../lib/gitActions.ts";
 
 export interface ListRow {
@@ -212,11 +212,9 @@ export function branchRows(
       run: (id) => ctx.run(id, b),
       title: (
         <span className="flex items-center gap-2 min-w-0">
-          <span onClick={(e) => { e.stopPropagation(); ctx.onPick(b.name); }}
-            className={`shrink-0 cursor-pointer text-[11px] ${ctx.picked.size ? "" : "opacity-0 group-hover:opacity-100"} transition-opacity`}
-            style={{ color: ctx.picked.has(b.name) ? "var(--primary)" : "var(--text3)" }}
-            title={ctx.picked.has(b.name) ? "Untick" : "Tick for a bulk action"}>
-            {ctx.picked.has(b.name) ? "☑" : "☐"}
+          <span className={`shrink-0 ${ctx.picked.size ? "" : "opacity-0 group-hover:opacity-100 focus-within:opacity-100"} transition-opacity`}>
+            <TickBox on={ctx.picked.has(b.name)} onClick={() => ctx.onPick(b.name)}
+              title={ctx.picked.has(b.name) ? "Untick" : "Tick for a bulk action"} />
           </span>
           <span className="truncate">{b.name}</span>
         </span>

--- a/web/src/components/git/Lists.tsx
+++ b/web/src/components/git/Lists.tsx
@@ -147,7 +147,10 @@ function Detail({ row, disabled }: { row: ListRow; disabled?: boolean }) {
           style={{ color: "var(--text)", fontFamily: "var(--font-mono, ui-monospace, monospace)", letterSpacing: "-0.01em" }}>
           {row.name}
         </div>
-        {!!row.chips && <div className="flex flex-wrap items-center gap-1.5 mt-2">{row.chips}</div>}
+        {/* `chips-stack`: down here there is room for the whole thing, so the
+            chip wraps rather than running off the column — the row's ellipsis
+            is a row's compromise and this is not a row. */}
+        {!!row.chips && <div className="chips-stack flex flex-wrap items-start gap-1.5 mt-2 min-w-0">{row.chips}</div>}
       </div>
 
       {!!row.facts?.length && (
@@ -346,7 +349,13 @@ export function commitRows(
     gutter: <GraphCell row={graph[i]} width={width} selected={ctx.picked.has(l.hash!)} />,
     run: (id) => ctx.run(id, l.hash!, l.subject ?? ""),
     title: <span className="truncate" style={{ fontFamily: "var(--font-sans)" }}>{l.subject}</span>,
-    chips: l.refs ? <Chip tone="good">{l.refs}</Chip> : undefined,
+    /* `clip`, and capped: this is the one chip in the app whose text is not a
+       word but a list of branch names, and on a busy commit it is longer than
+       the subject it sits beside. Uncapped it ate the row and drew itself over
+       the date and author — reported as "se ve por encima del texto". */
+    chips: l.refs
+      ? <span className="chip-ref"><Chip tone="good" clip title={l.refs}>{l.refs}</Chip></span>
+      : undefined,
     facts: [l.date, l.hash, l.author],
   }));
 }

--- a/web/src/components/git/ui.tsx
+++ b/web/src/components/git/ui.tsx
@@ -237,7 +237,15 @@ export function Row({ rail, title, chips, facts, action, selected, current, onCl
 
 /** A chip. Small, round, and the only place a status word is allowed to be
  *  coloured — everything else on the card is text or grey. */
-export function Chip({ tone = "neutral", children, title }: { tone?: Tone; children: ReactNode; title?: string }) {
+export function Chip({ tone = "neutral", children, title, clip }: {
+  tone?: Tone; children: ReactNode; title?: string;
+  /** This chip carries arbitrary text — a commit's refs, not a status word.
+   *  It gives up its `shrink-0` and ellipsizes instead, because a chip that
+   *  refuses to shrink in a flex row does not get clipped by the row: it
+   *  OVERFLOWS it and paints over whatever is beside it. Which is what a
+   *  branch name of sixty characters did to the date and author next to it. */
+  clip?: boolean;
+}) {
   return (
     /*
      * `.chip`'s own geometry: 6px radius, 1px/6px padding, no bold.
@@ -247,7 +255,7 @@ export function Chip({ tone = "neutral", children, title }: { tone?: Tone; child
      * as loud as the branch name they were describing, and put a third radius
      * on a screen that already had two.
      */
-    <span className="shrink-0 text-[9.5px] px-1.5 py-px rounded-md whitespace-nowrap"
+    <span className={`text-[9.5px] px-1.5 py-px rounded-md whitespace-nowrap ${clip ? "min-w-0 truncate" : "shrink-0"}`}
       style={{ color: TONE[tone], background: wash(tone === "neutral" ? "--text" : `--${tone === "good" ? "success" : tone === "warn" ? "warning" : tone === "bad" ? "error" : "primary"}`, tone === "neutral" ? 10 : 14) }}
       title={title}>
       {children}

--- a/web/src/components/git/ui.tsx
+++ b/web/src/components/git/ui.tsx
@@ -34,7 +34,7 @@
  * defines. What changed is how much of each one there is.
  */
 import type { CSSProperties, ReactNode } from "react";
-import { ICON } from "../../lib/iconSize.ts";
+import { HIT, ICON } from "../../lib/iconSize.ts";
 import { CHIP } from "../workspace/Chrome.tsx";
 
 export const edge = (pct: number): string => `1px solid color-mix(in srgb, var(--text) ${pct}%, transparent)`;
@@ -269,6 +269,38 @@ export function RowAction({ label, danger, disabled, onClick, title }: {
         {label}
       </button>
     </span>
+  );
+}
+
+/**
+ * The tick that puts a row into a bulk action.
+ *
+ * It was the character `☐` at 11px — which renders as a seven-pixel outline
+ * with no tick you can see when it is ON, in a list where the whole point is
+ * knowing which rows you have selected. Reported as "el checkbox es ENANO, ni
+ * se ve", and it was not a control at all: a `<span>` with an onClick, no role,
+ * no keyboard, no target.
+ *
+ * Drawn now, at `ICON.sm` inside the app's own `HIT` square — the same
+ * geometry every other icon-only control in this app has — with a real tick and
+ * a filled box when it is on, because "is this one selected" has to be
+ * answerable from across the room and not by squinting at a glyph.
+ */
+export function TickBox({ on, onClick, title }: { on: boolean; onClick: (e: React.MouseEvent) => void; title?: string }) {
+  const colour = on ? "var(--primary)" : "var(--text4)";
+  return (
+    <button
+      type="button" role="checkbox" aria-checked={on} title={title}
+      onClick={(e) => { e.stopPropagation(); onClick(e); }}
+      className="inline-flex items-center justify-center rounded shrink-0 transition-colors"
+      style={{ width: HIT - 6, height: HIT - 6, color: colour }}
+    >
+      <svg width={ICON.sm} height={ICON.sm} viewBox="0 0 14 14" fill="none" aria-hidden>
+        <rect x="1.75" y="1.75" width="10.5" height="10.5" rx="3"
+          fill={on ? "var(--primary)" : "transparent"} stroke="currentColor" strokeWidth="1.5" />
+        {on && <path d="M4.2 7.1l2 2 3.6-4" stroke="var(--bg)" strokeWidth="1.9" strokeLinecap="round" strokeLinejoin="round" />}
+      </svg>
+    </button>
   );
 }
 

--- a/web/src/index.css
+++ b/web/src/index.css
@@ -192,6 +192,27 @@
     border-radius: 6px;
     border: 1px solid color-mix(in srgb, var(--border) 60%, transparent);
   }
+  /* The one chip whose text is not a word: a commit's refs, which on a busy
+     commit is three branch names and longer than the subject beside it.
+     Capped in a row, because the row also holds the subject, the date and the
+     author, and an uncapped chip does not get clipped by the row — it overflows
+     and paints over them. */
+  .chip-ref {
+    display: flex;
+    min-width: 0;
+    max-width: 45%;
+  }
+  /* And uncapped in the detail column, where there is room for the whole thing
+     and a name cut at the edge of a 28rem aside is text nobody can read. The
+     chip's own `truncate` is undone here for the same reason. */
+  .chips-stack .chip-ref {
+    max-width: 100%;
+  }
+  .chips-stack .chip-ref > * {
+    white-space: normal;
+    overflow-wrap: anywhere;
+    text-overflow: clip;
+  }
   .t-dim {
     color: var(--text3);
   }

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1151,7 +1151,7 @@ const realApi = {
   /** Whether the agent on this machine can post to Slack — see slackreach.ts. */
   notifyReach: () => get<{ ok: boolean; slack: boolean }>("/notify/reach"),
   prPendingReview: (root: string, number: number) =>
-    post<{ ok: boolean; id: string | null; comments: { path: string; line: number | null; startLine: number | null; body: string }[] }>("/prs/pending-review", { root, number }),
+    post<{ ok: boolean; id: string | null; comments: { path: string; line: number | null; startLine: number | null; body: string; url: string }[] }>("/prs/pending-review", { root, number }),
   /** `recipe` is which entry of the Review menu; empty means "the one this pull
    *  request calls for". `card` is the tracker id the panel already worked out
    *  from the branch — the server has no ClickUp reader, and the prompt that

--- a/web/src/lib/api.ts
+++ b/web/src/lib/api.ts
@@ -1,5 +1,5 @@
 import type { ImportedPlace } from "./desktop.ts";
-import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, AgentModel, ChatImage, ConflictBlock, ConflictFile, MergeSessionView, BlockChoice, MergeInfo, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrSummary, PrActionResult, PrLocalHead, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, PrCheckRollup, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord, IssuesReport, IssuePrsReport, IssueDetail, IssueWork, IssueStartResult, IssueActionResult, StartMode, PortsReport, ResourceReport, SpaceReport, TreeReport, FindReport, GrepReport, AgentPane, PanesResponse, TasksListResponse, RemindersResponse, Reminder, TaskWriteResponse, TidyReport, Recipe, RecipesResponse, ReviewRecipe, ReviewRecipesResponse, BrowserUseStatus, ProviderUsage, GitLocksReport, ProcDetail, PrBranchSummary, ChangeRow, ChangeRowsResult, FileDiff, GitFileChange, RepoStats, Changelog, GitSubmodule, BlameLine, FileHistoryEntry, GitBisectStatus, GitGrepHit } from "../../../shared/types.ts";
+import type { WatchEvent, SessionRollup, StatsSummary, SkillInfo, FileChange, DiffHunk, Insight, SearchHit, PendingGate, GateRecord, SessionDetail, GitStatusResponse, CommitResult, WalkthroughResult, WalkthroughInputFile, GitRepoRef, FsCompletion, WorkingTree, GitActionResult, GitBranch, GitCommit, GitStash, GitGraphLine, GitWorktree, WorktreeLeftovers, GitRemote, GitRemoteBranch, GitTag, GitReflogEntry, GitLogEntry, DockerOverview, DockerStat, DockerActionResult, DockerCapability, TerminalCommands, CodexStatus, AgentCliStatus, AgentModel, ChatImage, ConflictBlock, ConflictFile, MergeSessionView, BlockChoice, MergeInfo, UpdateStatus, ReleaseNotes, PrListResponse, PrDetail, PrSummary, PrActionResult, PrLocalHead, GitCapability, HookSetupStatus, HookSetupResult, PrCheckJob, PrCheckRollup, ChatEngine, TmuxEngineInfo, ChatEffort, RemoteStatus, PairState, PairedDevice, DeviceScope, ChatPaneList, Budget, BudgetStatus, AgentProbe, UsageHistory, ActionRecord, IssuesReport, IssuePrsReport, IssueDetail, IssueWork, IssueStartResult, IssueActionResult, StartMode, PortsReport, ResourceReport, SpaceReport, TreeReport, FindReport, GrepReport, AgentPane, PanesResponse, TasksListResponse, RemindersResponse, Reminder, TaskWriteResponse, TidyReport, Recipe, RecipesResponse, ReviewRecipe, ReviewRecipesResponse, BrowserUseStatus, ProviderUsage, GitLocksReport, ProcDetail, PrBranchSummary, ChangeRow, ChangeRowsResult, FileDiff, GitFileChange, RepoStats, Changelog, GitSubmodule, BlameLine, FileHistoryEntry, GitBisectStatus, GitGrepHit, AgentSessionRow } from "../../../shared/types.ts";
 import type { ProvidersResponse, ProviderStatus, ProviderTasksResponse, SavedView, SavedFolder, ClickUpBoards, ViewTasksResponse, TaskDetail, ProviderTask, ListStatus, ListField, ListPlace, ListMember } from "../../../shared/providers.ts";
 
 /** What every ClickUp write answers with: the card as it now stands, or why not. */
@@ -416,6 +416,10 @@ const realApi = {
   paneDirs: (windowId: string) =>
     get<{ ok: boolean; pane: string | null; dirs: string[] }>(`/terminal/pane-dirs?window=${encodeURIComponent(windowId)}`),
   /** Put one in front of whoever is attached to tmux. */
+  /** Every resumable agent session for this project, across all its checkouts,
+   *  with where each one is running when it is. See agentsessions.ts. */
+  agentSessions: (root: string) =>
+    get<{ ok: boolean; sessions: AgentSessionRow[] }>(`/agent/sessions?root=${encodeURIComponent(root)}`),
   focusPane: (p: { sessionId: string; windowId: string; paneId: string }) =>
     post<{ ok: boolean; error?: string }>("/terminal/panes/focus", p),
   // --- the pane engine's tmux, driven entirely from the UI ---
@@ -1240,6 +1244,7 @@ const demoApi: typeof realApi = {
   // lands the panel on the sentence it already has for that case.
   agentPanes: () => D({ ok: false, reason: "not in the demo", panes: [] as AgentPane[] }),
   paneDirs: () => D({ ok: true, pane: null, dirs: [] as string[] }),
+  agentSessions: (_root: string) => D({ ok: true, sessions: [] as AgentSessionRow[] }),
   focusPane: (_p: { sessionId: string; windowId: string; paneId: string }) => D({ ok: false, error: "not in the demo" }),
   stats: (windowMs: number, provider?: string) => D(demo.stats(windowMs, provider)),
   usageDaily: (days = 90) => D(demo.usageDaily(days)),

--- a/web/src/lib/demo.ts
+++ b/web/src/lib/demo.ts
@@ -453,7 +453,7 @@ export function gitGraph(): { lines: GitGraphLine[] } {
 export function gitWorktrees(): { worktrees: GitWorktree[] } {
   return { worktrees: [
     { path: "/home/you/code/shop-api", branch: "main", head: "9f2c1a7", current: true, bare: false, locked: false },
-    { path: "/home/you/code/shop-api-PROJ-42", branch: "feat/PROJ-42-callbacks", head: "3b7d0e2", current: false, bare: false, locked: false },
+    { path: "/home/you/code/shop-api-ORBIT-42", branch: "feat/ORBIT-42-callbacks", head: "3b7d0e2", current: false, bare: false, locked: false },
     { path: "/home/you/code/shop-api-hotfix", branch: "hotfix/cache-ttl", head: "a1c9f34", current: false, bare: false, locked: true },
   ] };
 }

--- a/web/src/lib/fileRail.ts
+++ b/web/src/lib/fileRail.ts
@@ -517,6 +517,39 @@ export interface RailDraft {
 }
 
 /**
+ * A line comment GitHub is holding in a review you started on the website and
+ * never submitted.
+ *
+ * Same shape as a draft plus the one thing that makes it different: it lives on
+ * a server, so it has an address. No API edits a comment inside a pending
+ * review without submitting the whole review, so everything this app can offer
+ * about one is a way to READ it and a way to get to where it can be changed —
+ * which is exactly `url`.
+ */
+export interface RailHeld {
+  path: string;
+  /** Null when the diff moved under it — GitHub calls that outdated. */
+  line: number | null;
+  body: string;
+  /** The comment's own page. Empty when the server could not resolve one. */
+  url?: string;
+}
+
+/**
+ * The ones on this file, top of the file first.
+ *
+ * Outdated comments (`line === null`) sort last: they are attached to a version
+ * of the file that is no longer on screen, so there is no row to put them
+ * beside and no order to put them in.
+ */
+export function heldOn(held: RailHeld[] | undefined, path: string | null): RailHeld[] {
+  if (!path || !held) return [];
+  return held
+    .filter((c) => c.path === path)
+    .sort((a, b) => (a.line ?? Number.MAX_SAFE_INTEGER) - (b.line ?? Number.MAX_SAFE_INTEGER));
+}
+
+/**
  * What YOU have queued on this file.
  *
  * The other sections here answer "what did somebody else say"; this one answers

--- a/web/src/lib/glyphIcons.tsx
+++ b/web/src/lib/glyphIcons.tsx
@@ -1,0 +1,63 @@
+/*
+ * The three shapes that kept being typed instead of drawn.
+ *
+ * A refresh, a play and a caret appear in six places across this app and every
+ * one of them was a CHARACTER — `⟳`, `▶`, `▼` — inside a clickable element.
+ * That walks past the icon ladder entirely, because the ladder is about
+ * `<svg width={ICON.x}>`: a glyph has no size of its own beyond its font, draws
+ * about 60% of the ink its font-size implies, and gives its control no height.
+ * The branch list's tick box was the report that found it ("es ENANO, ni se
+ * ve") and these are the rest of the family.
+ *
+ * Deliberately here rather than in `workspace/icons.tsx`: that file is the
+ * rail's iconography, which is a set with a common weight and a common
+ * silhouette. These are utilities.
+ */
+import { ICON } from "./iconSize.ts";
+
+type P = { size?: number; className?: string };
+const svg = (size: number, className?: string) => ({
+  width: size, height: size, viewBox: "0 0 14 14", fill: "none",
+  stroke: "currentColor", strokeWidth: 1.6,
+  strokeLinecap: "round" as const, strokeLinejoin: "round" as const,
+  "aria-hidden": true, className,
+});
+
+/** Circular arrow. The one that spins while something is in flight. */
+export function RefreshIcon({ size = ICON.sm, className }: P) {
+  return (
+    <svg {...svg(size, className)}>
+      <path d="M12 7a5 5 0 1 1-1.6-3.7M12 2.2V4.8H9.4" />
+    </svg>
+  );
+}
+
+/** A filled triangle: start, run, play. Filled because an outline at 14px
+ *  reads as a caret rather than as a button that starts something. */
+export function PlayIcon({ size = ICON.sm, className }: P) {
+  return (
+    <svg {...svg(size, className)} fill="currentColor" stroke="none">
+      <path d="M4.5 2.8l6.5 4.2-6.5 4.2z" />
+    </svg>
+  );
+}
+
+/** A tick, for "this finished and it went well". */
+export function DoneIcon({ size = ICON.sm, className }: P) {
+  return (
+    <svg {...svg(size, className)} strokeWidth={1.8}>
+      <path d="M3 7.4l2.6 2.6L11 4.6" />
+    </svg>
+  );
+}
+
+/** The caret every menu, picker and disclosure in this app points down with.
+ *  Rotate it with a transform rather than swapping it for `▲`: one control that
+ *  MOVES reads as the same thing in two states. */
+export function CaretIcon({ size = ICON.xs, className }: P) {
+  return (
+    <svg {...svg(size, className)} strokeWidth={1.4}>
+      <path d="M3.5 5.5L7 9l3.5-3.5" />
+    </svg>
+  );
+}

--- a/web/src/lib/prFilter.ts
+++ b/web/src/lib/prFilter.ts
@@ -200,10 +200,50 @@ export function activeCount(s: FilterState): number {
   return n;
 }
 
+/**
+ * What the box matches: the number, the title, and the PEOPLE.
+ *
+ * It was number, title and author, which answers "whose pull request is this"
+ * and not the question actually asked of a board — "where is Javi on this".
+ * Typing a reviewer's name found nothing, while the card under the cursor said
+ * "Waiting on javidoe" in as many words.
+ *
+ * Assignees and requested reviewers both, because on this board they are the
+ * same question wearing two hats: the one is who owns it, the other is who is
+ * being waited on, and a person looking for their own name does not care which
+ * column it landed in. The facets stay the exact filters they were — this is
+ * the free-text box, where a partial name is the whole point.
+ *
+ * Logins, because that is what a row carries. A display name is not on the
+ * summary at all, so matching it would need a fetch per row.
+ */
+/**
+ * Who on this row the query names, when that is why it is here.
+ *
+ * A row that matched on its title explains itself; one that matched because a
+ * person's login contains "javi" does not, and a list that answers a name with
+ * rows carrying somebody else's name in the author column reads as broken. The
+ * caller draws this beside the row — see PrRow.
+ *
+ * Empty when the text matches the title or the author, because then the row is
+ * already legible, and empty when there is no text at all.
+ */
+export function peopleMatched(p: PrSummary, text: string): string[] {
+  const q = text.trim().toLowerCase();
+  if (!q) return [];
+  if (p.title.toLowerCase().includes(q) || p.author.toLowerCase().includes(q)) return [];
+  const who = [...(p.assignees ?? []), ...(p.reviewers ?? []).map((r) => r.login)];
+  return who.filter((l, i) => l.toLowerCase().includes(q) && who.indexOf(l) === i);
+}
+
 function textMatch(p: PrSummary, text: string): boolean {
   const q = text.trim().toLowerCase();
   if (!q) return true;
-  return String(p.number).includes(q) || p.title.toLowerCase().includes(q) || p.author.toLowerCase().includes(q);
+  if (String(p.number).includes(q) || p.title.toLowerCase().includes(q) || p.author.toLowerCase().includes(q)) return true;
+  // `?? []` on both: a row from a fixture, an older cache or a by-branch lookup
+  // may carry neither field, and a filter is not the place to find that out.
+  if ((p.assignees ?? []).some((a) => a.toLowerCase().includes(q))) return true;
+  return (p.reviewers ?? []).some((r) => r.login.toLowerCase().includes(q));
 }
 
 // AND across facets, OR within a facet. A facet with nothing selected is a

--- a/web/test/diff-scroll-paint.test.ts
+++ b/web/test/diff-scroll-paint.test.ts
@@ -129,3 +129,36 @@ describe("the same rule where lines are painted next to code", () => {
     expect(s).toContain('<div className="py-2" style={{ width: "max-content", minWidth: "100%" }}>');
   });
 });
+
+/*
+ * And exactly one thing scrolls vertically in a column.
+ *
+ * Reported twice — "no entiendo este doble scroll", then "sigue estando… es
+ * como que el scroll de dentro no funciona, es inútil". Measured in the real
+ * app this time (headless Chrome over the demo build, Files tab, window shrunk
+ * until things overflow): before, the split panes reported `overflowY: auto`
+ * and were scroll containers nobody had asked for; after, `overflowY: hidden`
+ * and the only vertical scroller left in that column is the column itself.
+ *
+ * The rule underneath: CSS has no one-axis overflow. `overflow-x: auto` alone
+ * computes `overflow-y: auto` too, so anything that scrolls sideways is also a
+ * vertical scroll container unless the other axis is spelled out. Every diff
+ * pane scrolls sideways.
+ */
+describe("the diff pane scrolls sideways and nothing else", () => {
+  test("both axes are spelled out, because setting one sets the other", () => {
+    const src = readFileSync(join(import.meta.dir, "..", "src", "components", "diff", "DiffLines.tsx"), "utf8");
+    /* Four panes: unified, split-wrapped, and the split pair. The split's LEFT
+       column was written this way from the start — its vertical scroll was
+       always the right column's job — which is the shape the other three have
+       now adopted. */
+    expect((src.match(/overflowX: "auto", overflowY: "hidden"/g) ?? []).length).toBe(4);
+    // `overflow-auto` on a pane is the shape this replaced: it is both axes.
+    expect(src).not.toContain("min-w-0 overflow-auto text-[12px]");
+  });
+
+  test("the pull request's file card wraps it in no scroller of its own", () => {
+    const pr = readFileSync(join(import.meta.dir, "..", "src", "components", "PrPanel.tsx"), "utf8");
+    expect(pr).not.toContain('<div className="flex" style={{ overflowX: "auto" }}>');
+  });
+});

--- a/web/test/diff-scroll-paint.test.ts
+++ b/web/test/diff-scroll-paint.test.ts
@@ -51,22 +51,72 @@ describe("one width for the whole file", () => {
     expect((split(false).match(/width:max-content;min-width:100%/g) ?? []).length).toBeGreaterThanOrEqual(2);
   });
 
-  test("the text column absorbs the slack rather than stopping at its own text", () => {
-    /* `max-content` alone was the bug in the unified pane: the column is as wide
-       as the longest line in THAT hunk, and the row's background ends there. */
+  test("every unified row carries the file's width", () => {
+    /* The grid this replaced sized one column per HUNK, so a short hunk stopped
+       painting where its own longest line ended. Now the row is the box: as wide
+       as its content, never narrower than the pane. */
     const html = uni(false);
-    expect(html).toContain("minmax(max-content,1fr)");
-    expect(html).not.toMatch(/grid-template-columns:4ch 4ch max-content/);
+    expect(html).not.toContain("grid-template-columns");
+    expect((html.match(/class="flex" style="width:max-content;min-width:100%"/g) ?? []).length).toBe(6);
   });
 
   test("a split row is at least as wide as the column it sits in", () => {
     expect(split(false)).toContain("width:max-content;min-width:100%");
   });
 
-  test("wrapped mode does not scroll sideways, so it keeps its fr columns", () => {
-    // Nothing to fix here, and pinned so the fix above does not spread into it:
-    // wrapping means there is no overflow to paint into.
-    expect(uni(true)).toContain("4ch 4ch minmax(0,1fr)");
+  test("the text cell grows into the slack rather than stopping at its text", () => {
+    /* `max-content` on a grid column was the first shape of this bug; the rows
+       are flex now, so the equivalent is the text cell being the one that
+       flexes. Without it a short line's tint ends where the line does. */
+    const html = uni(false);
+    expect(html).toMatch(/class="[^"]*flex-1[^"]*"[^>]*style="[^"]*background:/);
+  });
+});
+
+/*
+ * And the numbers stay while it scrolls.
+ *
+ * Reported straight after the paint fix: "los números de las líneas se deben
+ * quedar, ¿no?". They were already written as sticky and had never once stuck,
+ * because `.agx-gutter{position:relative}` — the rule that places the hover "+"
+ * — sits on the same element and wins the cascade. Measured, not read: a probe
+ * in headless Chrome reported `position: relative` and the gutter at x=-170
+ * after scrolling right; now it reports `sticky` and x=0.
+ *
+ * The second half is that sticky only works at all if the row is the element
+ * that is as wide as the file — a sticky GRID ITEM is stuck to its own grid
+ * area, which is 4ch wide and goes nowhere. That is why the unified pane draws
+ * flex rows instead of a grid.
+ */
+describe("the line numbers stay put", () => {
+  test("the gutter rule does not fight the sticky it sits on", () => {
+    const css = readFileSync(join(import.meta.dir, "..", "src", "components", "diff", "DiffLines.tsx"), "utf8");
+    expect(css).toContain(".agx-gutter{position:sticky}");
+    expect(css).not.toContain(".agx-gutter{position:relative}");
+  });
+
+  test("both unified gutters are sticky and opaque", () => {
+    const html = uni(false);
+    // Two per row: the old-side number pinned at 0 and the new-side one pinned
+    // a gutter's width along, each with a background mixed into --bg so the
+    // code passes behind them instead of through them.
+    expect(html).toMatch(/class="[^"]*sticky left-0[^"]*"[^>]*style="[^"]*background:color-mix\(in srgb, var\(--\w+\) 13%, var\(--bg\)\)|background:var\(--bg\)/);
+    expect((html.match(/sticky/g) ?? []).length).toBeGreaterThanOrEqual(6);
+  });
+
+  test("the rows are flex, because a sticky grid item sticks to nothing", () => {
+    expect(uni(false)).not.toContain('class="contents"');
+  });
+
+  test("the gutter is as wide as the biggest line number in the file", () => {
+    /* A flat 4ch fits three digits. Once the gutters went opaque, a four-digit
+       file drew "18511851" — the old number ran under the new one. */
+    const deep = renderToStaticMarkup(React.createElement(UnifiedDiff, {
+      hunks: [{ oldStart: 1851, oldLines: 1, newStart: 1851, newLines: 1, lines: [" a()"] }], wrap: false,
+    } as never));
+    expect(deep).toContain("width:5ch");
+    // And a short file still looks like every other short file.
+    expect(uni(false)).toContain("width:4ch");
   });
 });
 

--- a/web/test/diff-scroll-paint.test.ts
+++ b/web/test/diff-scroll-paint.test.ts
@@ -1,0 +1,81 @@
+/*
+ * Scroll a diff sideways and it keeps being a diff.
+ *
+ * Reported with two screenshots: scrolled right, the tint on the rows, the blue
+ * hunk bar and everything else painted simply stopped, and past that edge there
+ * was bare background with code still in it.
+ *
+ * Nothing was missing. Every hunk sized itself — a `max-content` grid column
+ * per hunk in the unified pane, `min-width: max-content` per hunk in the split
+ * one — so a file whose widest line is in hunk 1 scrolls to hunk 1's width
+ * while hunk 4 stops painting at its own, several hundred pixels earlier. The
+ * hunk header had it worse: a plain block is as wide as the pane, never as wide
+ * as the pane's scrollWidth.
+ *
+ * Measured in Chrome before and after, on a pane 418px wide holding a 574px
+ * file: the second hunk's rows were 70px wide and sat at x = -28 (entirely off
+ * to the left) once scrolled right; afterwards every row is 516px and reaches
+ * the right edge.
+ *
+ * The rule, and what this file holds: inside a horizontal scroller, one element
+ * owns the width — `width: max-content; min-width: 100%` — and everything
+ * painted inside it is a block that inherits that width. A column that has to
+ * absorb the slack uses `minmax(max-content, 1fr)`, never bare `max-content`.
+ */
+import { describe, expect, test } from "bun:test";
+import React from "react";
+import { renderToStaticMarkup } from "react-dom/server";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { UnifiedDiff, SplitDiff } from "../src/components/diff/DiffLines.tsx";
+
+/** Two hunks of very different widths — the shape that showed the bug. */
+const HUNKS = [
+  {
+    oldStart: 1, oldLines: 3, newStart: 1, newLines: 3,
+    lines: [" const short = 1", `-const removed = "${"x".repeat(120)}"`, `+const added = "${"x".repeat(120)}"`],
+  },
+  { oldStart: 40, oldLines: 3, newStart: 40, newLines: 3, lines: [" tiny()", "-old()", "+new()"] },
+] as never;
+
+const uni = (wrap: boolean) => renderToStaticMarkup(React.createElement(UnifiedDiff, { hunks: HUNKS, wrap } as never));
+const split = (wrap: boolean) => renderToStaticMarkup(React.createElement(SplitDiff, { hunks: HUNKS, wrap } as never));
+
+describe("one width for the whole file", () => {
+  test("the unified pane hangs its hunks off a single max-content box", () => {
+    expect(uni(false)).toContain("width:max-content;min-width:100%");
+  });
+
+  test("each split column does the same", () => {
+    // One per side: the two columns scroll independently, so each owns a width.
+    expect((split(false).match(/width:max-content;min-width:100%/g) ?? []).length).toBeGreaterThanOrEqual(2);
+  });
+
+  test("the text column absorbs the slack rather than stopping at its own text", () => {
+    /* `max-content` alone was the bug in the unified pane: the column is as wide
+       as the longest line in THAT hunk, and the row's background ends there. */
+    const html = uni(false);
+    expect(html).toContain("minmax(max-content,1fr)");
+    expect(html).not.toMatch(/grid-template-columns:4ch 4ch max-content/);
+  });
+
+  test("a split row is at least as wide as the column it sits in", () => {
+    expect(split(false)).toContain("width:max-content;min-width:100%");
+  });
+
+  test("wrapped mode does not scroll sideways, so it keeps its fr columns", () => {
+    // Nothing to fix here, and pinned so the fix above does not spread into it:
+    // wrapping means there is no overflow to paint into.
+    expect(uni(true)).toContain("4ch 4ch minmax(0,1fr)");
+  });
+});
+
+describe("the same rule where lines are painted next to code", () => {
+  test("the conflict view owns its width too", () => {
+    /* Same `white-space: pre` body, same tinted blocks over it — held as source
+       because rendering it needs a conflicted file, and what broke is one style
+       on one element. */
+    const s = readFileSync(join(import.meta.dir, "..", "src", "components", "ConflictMode.tsx"), "utf8");
+    expect(s).toContain('<div className="py-2" style={{ width: "max-content", minWidth: "100%" }}>');
+  });
+});

--- a/web/test/first-row-marked.test.ts
+++ b/web/test/first-row-marked.test.ts
@@ -1,0 +1,50 @@
+/*
+ * What is on screen is what is marked.
+ *
+ * Three file lists in this app show a file before anybody has clicked one — the
+ * Git panel's Changes, the pull-request Files tab, and the Diff view — because
+ * a pane that opens empty is a pane that makes you click to find out it works.
+ * All three did it the same way, with a `?? first` fallback where the diff is
+ * rendered, and two of them compared the ROWS against the click state instead.
+ *
+ * So a diff sat on the right while every row on the left looked equally
+ * unselected, and the file you were reading was indistinguishable from the
+ * eleven you were not. Reported for both of them in one message.
+ *
+ * Held on the source: rendering these three lists needs a repository, a pull
+ * request and a diff between them, and what actually broke is one expression in
+ * each — the one that decides what the row compares itself to.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const SRC = join(import.meta.dir, "..", "src", "components");
+const read = (f: string) => readFileSync(join(SRC, f), "utf8");
+
+describe("the row that is being displayed", () => {
+  it("is the one the Changes list marks", () => {
+    const s = read("GitPanel.tsx");
+    // `selected` carries the `?? all[0]` fallback; `selKey` is only what was
+    // clicked, and starts null.
+    expect(s).toContain("const activeKey = selected ? keyOf(selected) : null;");
+    expect(s).toContain("active={activeKey === keyOf(c)}");
+    expect(s).not.toContain("active={selKey === keyOf(c)}");
+  });
+
+  it("is the one the pull request's tree and file card mark", () => {
+    const s = read("PrPanel.tsx");
+    /* `showing` is the same expression the diff itself renders from — in
+       one-file mode `sel ?? shownFiles[0]`. Marking against `sel` is what left
+       the tree blank over a file that was on screen. */
+    expect(s).toContain("node={buildFileTree(shownFiles)} sel={showing}");
+    expect(s).toContain("const focused = showing === f.path;");
+  });
+
+  it("is the one the Diff view marks", () => {
+    // This one was right from the start and is pinned so it stays that way:
+    // the list is handed the healed selection, not the raw state.
+    const s = read("diff/DiffPage.tsx");
+    expect(s).toContain("selKey={selected?.key ?? null}");
+  });
+});

--- a/web/test/gone-cleanup.test.ts
+++ b/web/test/gone-cleanup.test.ts
@@ -24,29 +24,29 @@ const entry = (path: string, bytes: number, vsMain: "absent" | "differs" = "abse
 
 describe("partitionByWorktree", () => {
   it("puts a branch with a worktree on the held side", () => {
-    const a = branch("PROJ-1"), b = branch("PROJ-2");
-    const { free, held } = partitionByWorktree([a, b], new Map([["PROJ-2", "/code/repo-PROJ-2"]]));
-    expect(free.map((x) => x.name)).toEqual(["PROJ-1"]);
-    expect(held.map((x) => x.name)).toEqual(["PROJ-2"]);
+    const a = branch("ORBIT-1"), b = branch("ORBIT-2");
+    const { free, held } = partitionByWorktree([a, b], new Map([["ORBIT-2", "/code/repo-ORBIT-2"]]));
+    expect(free.map((x) => x.name)).toEqual(["ORBIT-1"]);
+    expect(held.map((x) => x.name)).toEqual(["ORBIT-2"]);
   });
 
   it("an empty map means nothing is held", () => {
     // The state this map is built from is only populated by the Worktrees tab,
     // so an empty one used to be the normal case from the Branches tab — and it
     // silently sent every branch down the delete-directly path that fails.
-    const { free, held } = partitionByWorktree([branch("PROJ-1")], new Map());
+    const { free, held } = partitionByWorktree([branch("ORBIT-1")], new Map());
     expect(free).toHaveLength(1);
     expect(held).toHaveLength(0);
   });
 });
 
 describe("splitReadable", () => {
-  const b = branch("PROJ-1");
-  const map = new Map([["PROJ-1", "/code/repo-PROJ-1"]]);
+  const b = branch("ORBIT-1");
+  const map = new Map([["ORBIT-1", "/code/repo-ORBIT-1"]]);
 
   it("treats a successful report as removable", () => {
     // THE regression. A good report has no `error` field at all.
-    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1", { entries: [entry("a.env", 40)], skipped: 12 })]);
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-ORBIT-1", { entries: [entry("a.env", 40)], skipped: 12 })]);
     expect(refused).toEqual([]);
     expect(removable).toHaveLength(1);
     expect(removable[0]!.report.entries.map((e) => e.path)).toEqual(["a.env"]);
@@ -55,13 +55,13 @@ describe("splitReadable", () => {
   it("an empty checkout is still removable", () => {
     // No files and no error: nothing to lose, and it must not read as a failure
     // just because the list is empty.
-    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1")]);
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-ORBIT-1")]);
     expect(refused).toEqual([]);
     expect(removable).toHaveLength(1);
   });
 
   it("refuses a checkout that reported an error", () => {
-    const { removable, refused } = splitReadable([b], map, [report("/code/repo-PROJ-1", { error: "could not read that checkout" })]);
+    const { removable, refused } = splitReadable([b], map, [report("/code/repo-ORBIT-1", { error: "could not read that checkout" })]);
     expect(removable).toEqual([]);
     expect(refused[0]!.why).toBe("could not read that checkout");
   });
@@ -74,7 +74,7 @@ describe("splitReadable", () => {
   });
 
   it("refuses a branch whose worktree path is unknown", () => {
-    const { removable, refused } = splitReadable([b], new Map(), [report("/code/repo-PROJ-1")]);
+    const { removable, refused } = splitReadable([b], new Map(), [report("/code/repo-ORBIT-1")]);
     expect(removable).toEqual([]);
     expect(refused).toHaveLength(1);
   });

--- a/web/test/icon-scale.test.ts
+++ b/web/test/icon-scale.test.ts
@@ -119,3 +119,47 @@ describe("close controls", () => {
     expect(bad, "use <CloseButton/> from components/CloseButton.tsx").toEqual([]);
   });
 });
+
+describe("a glyph is not a control", () => {
+  /**
+   * The gap this closes, found the hard way.
+   *
+   * Every rule above is about `<svg width={ICON.x}>`, so a control drawn with a
+   * CHARACTER walked straight past all of them. The branch list's tick box was
+   * `☐` at 11px inside a `<span onClick>`: seven pixels of outline, no tick you
+   * could see when it was on, no role, no keyboard, and a target the size of
+   * the glyph. Reported as "el checkbox es ENANO, ni se ve", on the one list
+   * where knowing what you have selected is the entire feature.
+   *
+   * So: a box, a tick, a caret or a spinner that IS the control gets drawn.
+   * A glyph sitting next to a word ("⌫ 3 gone", "▣ stash some files…") is
+   * decoration on a labelled button and stays — the label is the control.
+   */
+  const GLYPHS = "☐☑☒▶▼▸▾▴◀⟳↻⌕";
+
+  test("no clickable element is a bare glyph", () => {
+    const bad: string[] = [];
+    for (const { rel, text } of FILES) {
+      for (let i = 0; i < text.length; i++) {
+        if (!GLYPHS.includes(text[i]!)) continue;
+        /* Walk BACK to the element this glyph sits in rather than matching the
+           tag with a regex: an attribute holding an arrow function contains a
+           `>`, so `<span([^>]*)>` stops at `=>` and every handler in the app
+           slips through. That is exactly how the first version of this guard
+           passed over the very control it was written for. */
+        const before = text.slice(Math.max(0, i - 400), i);
+        const open = Math.max(before.lastIndexOf("<span"), before.lastIndexOf("<button"), before.lastIndexOf("<div"), before.lastIndexOf("<a "));
+        if (open === -1) continue;
+        const head = before.slice(open);
+        if (!/\bonClick=/.test(head) && !head.startsWith("<button")) continue;
+        // A glyph beside a word is decoration on a labelled control: "⌫ 3 gone",
+        // "▣ stash some files…". The label is the control, and it stays.
+        const after = text.slice(i + 1, i + 60);
+        if (/[A-Za-z0-9]/.test(after.split("<")[0] ?? "")) continue;
+        if (/[A-Za-z0-9]/.test(head.slice(head.lastIndexOf(">") + 1))) continue;
+        bad.push(`${rel}:${text.slice(0, i).split("\n").length} ${text[i]}`);
+      }
+    }
+    expect(bad, "draw it: an <svg> at ICON.xs or more, in a target of HIT").toEqual([]);
+  });
+});

--- a/web/test/menus-open-where-there-is-room.test.ts
+++ b/web/test/menus-open-where-there-is-room.test.ts
@@ -1,0 +1,55 @@
+/*
+ * A menu opens where there is room for it.
+ *
+ * `BasePicker` learned this the first time: a row at the bottom of a long list
+ * opened a list that ran off the screen, so the options at the end were the ones
+ * nobody could reach. `Select` — which is the app's replacement for every native
+ * dropdown — never did, and it always opened downward from the trigger.
+ *
+ * Reported on the ClickUp status picker: "este desplegable está mal, está como
+ * dentro del contenedor y no puedo ver todas las opciones, además debe abrirse
+ * para arriba, al estar tan cerca de la parte baja". Two faults in one sentence,
+ * and this file holds both halves of the answer — the control portals out of
+ * whatever clips it, and it flips when down does not fit.
+ *
+ * Source text: the decision is three lines of layout maths in a
+ * `useLayoutEffect`, and this repo has no DOM harness to open a menu in. What is
+ * asserted is the rule, at the place it is written.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const read = (f: string) => readFileSync(join(import.meta.dir, "..", "src", "components", f), "utf8");
+const SELECT = read("Select.tsx");
+const BASE = read("BasePicker.tsx");
+
+describe("Select", () => {
+  test("flips above the trigger when below does not fit and above is roomier", () => {
+    expect(SELECT).toContain("const up = below < 220 && above > below;");
+    // Anchored by its bottom when flipped, or the list would grow downward from
+    // a top computed for the other direction.
+    expect(SELECT).toContain("bottom: up ? window.innerHeight - r.top + 6 : undefined,");
+    expect(SELECT).toContain("...(pos.bottom == null ? { top: pos.top } : { bottom: pos.bottom }),");
+  });
+
+  test("takes its height from the room it actually has", () => {
+    /* `min(60vh, 420px)` is a guess about the window, not about this trigger:
+       a control 200px from the bottom got a list 400px tall whichever way it
+       opened. */
+    expect(SELECT).toContain("maxHeight: Math.max(180, Math.min(420, up ? above : below)),");
+    expect(SELECT).not.toContain('maxHeight: "min(60vh, 420px)"');
+  });
+
+  test("still leaves its container, which is the other half of the same bug", () => {
+    expect(SELECT).toContain("<Portal z={LAYER.menu}>");
+  });
+});
+
+describe("the rule is the one BasePicker already had", () => {
+  test("both menus decide it the same way", () => {
+    // Two menus that flip on different thresholds are two menus that feel
+    // different for no reason anybody could name.
+    expect(BASE).toContain("const up = below < 220 && above > below;");
+  });
+});

--- a/web/test/pending-review-surfacing.test.ts
+++ b/web/test/pending-review-surfacing.test.ts
@@ -1,0 +1,95 @@
+/*
+ * A review you started on the GitHub website, seen from here.
+ *
+ * GitHub lets you leave line comments from its own UI and never submit them.
+ * They are real — the next verdict you send from this app finishes THAT review
+ * and posts them — and until this change the app said the opposite twice: the
+ * file tree marked nothing, and the Review tab printed "No line comments queued
+ * here" over three of them.
+ *
+ * Reported as: a button to go straight to the pending comment on GitHub, a mark
+ * in the file list saying which files carry one, and something in the rail that
+ * says one exists without reprinting the whole message.
+ *
+ * The Edit link is the load-bearing part and the one worth explaining: no API
+ * edits a comment inside a pending review without submitting the review, so the
+ * only honest affordance is a way OUT to the page where it can be changed. If
+ * `url` ever stops being fetched, the button disappears silently — hence the
+ * assertion on the query itself.
+ */
+import { describe, expect, it } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { heldOn, type RailHeld } from "../src/lib/fileRail.ts";
+
+const ROOT = join(import.meta.dir, "..", "..");
+const read = (p: string) => readFileSync(join(ROOT, p), "utf8");
+
+describe("which pending comments belong to the file on screen", () => {
+  const held: RailHeld[] = [
+    { path: "src/pay.ts", line: 40, body: "second" },
+    { path: "src/other.ts", line: 1, body: "elsewhere" },
+    { path: "src/pay.ts", line: null, body: "outdated" },
+    { path: "src/pay.ts", line: 12, body: "first" },
+  ];
+
+  it("keeps this file's, in line order", () => {
+    expect(heldOn(held, "src/pay.ts").map((h) => h.body)).toEqual(["first", "second", "outdated"]);
+  });
+
+  it("puts the outdated ones last, because they have no row to sit beside", () => {
+    expect(heldOn(held, "src/pay.ts").at(-1)?.line).toBeNull();
+  });
+
+  it("says nothing when nothing is selected, and nothing when the caller cannot know", () => {
+    expect(heldOn(held, null)).toEqual([]);
+    expect(heldOn(undefined, "src/pay.ts")).toEqual([]);
+  });
+});
+
+describe("the address of a pending comment", () => {
+  it("is asked for from GitHub", () => {
+    // The whole feature hangs off this field being in the selection set.
+    const s = read("server/src/prs.ts");
+    expect(s).toContain("comments(first:100){nodes{url path line");
+    expect(s).toContain('url: typeof c.url === "string" ? c.url : ""');
+  });
+
+  it("survives the wire type, which is where it would be dropped in silence", () => {
+    const s = read("web/src/lib/api.ts");
+    expect(s).toContain('body: string; url: string }[] }>("/prs/pending-review"');
+  });
+});
+
+describe("the four places it now shows", () => {
+  it("offers a way to GitHub from the comment drawn on the line", () => {
+    const s = read("web/src/components/PrPanel.tsx");
+    // Both blocks: the one under its line, and the one under the file when the
+    // diff does not reach the line it was left on.
+    expect((s.match(/title="Edit this pending comment on GitHub"/g) ?? []).length).toBe(2);
+  });
+
+  it("marks the files that carry one in the tree", () => {
+    const s = read("web/src/components/PrPanel.tsx");
+    expect(s).toContain("const heldFor = (p: string) => held.filter((x) => x.path === p).length;");
+    expect(s).toContain("drafts={draftsFor} pending={heldFor}");
+    expect(s).toContain("drafted on GitHub in your unsubmitted review");
+  });
+
+  it("tells the rail, short, with the way out", () => {
+    const s = read("web/src/components/FileRail.tsx");
+    expect(s).toContain('<Sec title="Drafted on GitHub"');
+    expect(s).toContain('title="Edit this comment on GitHub"');
+    // Short: a preview, not the message. The Review tab is where they print whole.
+    expect(s).toContain("<Quote body={h.body} max={90} />");
+  });
+
+  it("stops the review box claiming nothing will be sent", () => {
+    const rail = read("web/src/components/FileRail.tsx");
+    /* The count the verdict line quotes has to include them, because submitting
+       from here finishes the review holding them. */
+    expect(rail).toContain("+ (held?.length ?? 0)");
+    const panel = read("web/src/components/PrPanel.tsx");
+    expect(panel).toContain("already drafted on GitHub, below.");
+  });
+});

--- a/web/test/pr-board-search.test.ts
+++ b/web/test/pr-board-search.test.ts
@@ -691,11 +691,22 @@ describe("assigning on GitHub, and the card on the other board", () => {
 });
 
 describe("the ClickUp half, as its own controls", () => {
-  it("reuses the card's own status pill and its dropdown", () => {
-    // A status has a colour its board gave it, and a row of bordered words
-    // throws that away — which is the one thing that makes the list readable.
-    expect(src).toContain("<StatusPill status={pick || card.status} color={statusColor(statuses, pick || card.status)} />");
-    expect(src).toContain("leave it where it is");
+  it("picks the status through the app's own Select, not a list in the flow", () => {
+    /*
+     * A status keeps the colour its board gave it — a row of bordered words
+     * throws away the one thing that makes seventeen of them scannable — so the
+     * options are pills.
+     *
+     * They go through `Select` because the list used to be drawn in the flow,
+     * inside a column that clips and scrolls with a Done button under it: it
+     * opened INSIDE the container, most of the statuses were unreachable, and
+     * near the bottom of the screen there was nowhere for it to go. `Select`
+     * portals out of the clipping and flips above the trigger.
+     */
+    expect(src).toContain("value={pick}");
+    expect(src).toContain("value: x.status, label: x.status, tint: x.color, pill: true,");
+    expect(src).toContain('{ value: "", label: "leave it where it is" }');
+    expect(src).not.toContain("setStOpen");
   });
 
   it("draws people as faces, with their own colour when there is no picture", () => {

--- a/web/test/pr-card-picker.test.ts
+++ b/web/test/pr-card-picker.test.ts
@@ -147,7 +147,21 @@ describe("the confirmation that came half true", () => {
   });
 
   it("claims a GitHub write only when there is one", () => {
-    expect(PICKER).toContain("{ghChanged > 0 && <div>· {title} on GitHub</div>}");
+    expect(PICKER).toContain("{ghChanged > 0 && (() => {");
+    expect(PICKER).toContain("<div>· {title} on GitHub</div>");
+  });
+
+  it("names who goes on and who comes off, with their face", () => {
+    /* The line was the picker's own title — "Request reviewers on GitHub" —
+       printed for a step that was taking a reviewer OFF. The ClickUp lines
+       under it named the person in both directions, so the one row that could
+       not be checked was the row about the write that is hardest to undo.
+       Reported as: it should say remove that user, with the avatar adding one
+       already has. */
+    expect(PICKER).toContain("const add = sel.filter((x) => !selected.includes(x));");
+    expect(PICKER).toContain("const gone = selected.filter((x) => !sel.includes(x));");
+    expect(PICKER).toContain("<Avatar login={o.avatar} size={14} />");
+    expect(PICKER).toContain('{on ? "+" : "−"}');
   });
 });
 

--- a/web/test/pr-filter-people.test.ts
+++ b/web/test/pr-filter-people.test.ts
@@ -46,7 +46,7 @@ describe("the free-text box", () => {
     const rows = [pr({ number: 30, title: "Cart totals" }), pr({ number: 31, title: "Ledger", author: "javidoe" })];
     expect(find(rows, "cart")).toEqual([30]);
     expect(find(rows, "31")).toEqual([31]);
-    expect(find(rows, "javier")).toEqual([31]);
+    expect(find(rows, "javid")).toEqual([31]);
   });
 
   it("does not match a person who is not on it", () => {

--- a/web/test/pr-filter-people.test.ts
+++ b/web/test/pr-filter-people.test.ts
@@ -1,0 +1,73 @@
+/*
+ * "Can the finder search by assignee name?"
+ *
+ * It could not. The box matched the number, the title and the AUTHOR — which
+ * answers "whose pull request is this" and never "where is Javi on this",
+ * while the card under the cursor said "Waiting on javidoe" in as many
+ * words. On a board of 389 open pull requests that is the question people
+ * actually type into it.
+ *
+ * Assignees and requested reviewers both. On this board they are one question
+ * wearing two hats — who owns it, and who is being waited on — and somebody
+ * looking for their own name does not care which column it landed in. The
+ * facets stay the exact filters they were; this is the free-text box, where a
+ * partial name is the point.
+ *
+ * Logins, not display names: a display name is not on a list row at all, so
+ * matching one would cost a fetch per row.
+ */
+import { describe, expect, it } from "bun:test";
+import { applyFilters, peopleMatched, parseQuery } from "../src/lib/prFilter.ts";
+import type { PrSummary } from "../../shared/types.ts";
+
+const pr = (over: Partial<PrSummary>): PrSummary => ({
+  number: 1, title: "Round prices at the cart boundary", author: "alexdoe", state: "OPEN",
+  isDraft: false, updatedAt: "2026-08-14T10:00:00Z", createdAt: "2026-08-01T10:00:00Z",
+  url: "https://github.com/acme/shop-api/pull/1", headRefName: "ORBIT-1042", baseRefName: "main",
+  additions: 1, deletions: 1, changedFiles: 1, labels: [], assignees: [], milestone: null,
+  checks: { state: "SUCCESS", total: 1, passed: 1, failed: 0, pending: 0 },
+  ...over,
+} as PrSummary);
+
+const find = (rows: PrSummary[], text: string) => applyFilters(rows, { ...parseQuery(""), text }).map((p) => p.number);
+
+describe("the free-text box", () => {
+  it("finds a pull request by the person assigned to it", () => {
+    const rows = [pr({ number: 10, assignees: ["javidoe"] }), pr({ number: 11 })];
+    expect(find(rows, "javi")).toEqual([10]);
+  });
+
+  it("finds one by who was asked to review it", () => {
+    const rows = [pr({ number: 20, reviewers: [{ login: "javidoe" }] }), pr({ number: 21 })];
+    expect(find(rows, "javi")).toEqual([20]);
+  });
+
+  it("still finds the old three: number, title and author", () => {
+    const rows = [pr({ number: 30, title: "Cart totals" }), pr({ number: 31, title: "Ledger", author: "javidoe" })];
+    expect(find(rows, "cart")).toEqual([30]);
+    expect(find(rows, "31")).toEqual([31]);
+    expect(find(rows, "javier")).toEqual([31]);
+  });
+
+  it("does not match a person who is not on it", () => {
+    expect(find([pr({ number: 40, assignees: ["alexdoe"] })], "javi")).toEqual([]);
+  });
+});
+
+describe("why the row is in the answer", () => {
+  it("names the person, when the person is the reason", () => {
+    const row = pr({ assignees: ["javidoe"], reviewers: [{ login: "javi-b" }] });
+    expect(peopleMatched(row, "javi")).toEqual(["javidoe", "javi-b"]);
+  });
+
+  it("says nothing when the title or the author already explains it", () => {
+    // A row that matched its own title is legible without help; a chip there is
+    // noise on every row of a title search.
+    expect(peopleMatched(pr({ title: "javi's refactor", assignees: ["javidoe"] }), "javi")).toEqual([]);
+    expect(peopleMatched(pr({ author: "javidoe", assignees: ["javidoe"] }), "javi")).toEqual([]);
+  });
+
+  it("says nothing when the box is empty", () => {
+    expect(peopleMatched(pr({ assignees: ["javidoe"] }), "")).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Adds a session picker to the terminal's bar, and closes the round of faults that a day of using the panels turned up.

Based on `feat/git-view`; merge that first.

**Resume any session in this project, from the bar.** By hand it is four steps — open a tab, start the agent, type `/resume`, find it in the list — and the fourth cannot be fixed by typing faster: the CLI's list is scoped to the directory the agent is running in, so a session from a worktree is not in the list you get from the main checkout, and those are usually the ones being looked for. The picker lists every checkout `git worktree list` reports, read from `~/.claude/projects` — the same transcripts `/resume` reads, so the two lists cannot disagree.

Each session is a card: the name somebody gave it, how it started, and where it got to. A name is read from the *tail* of the transcript, because `/rename` appends a `custom-title` line rather than rewriting the head — measured on a 5.8 MB transcript, the first such line sits at 18% of the file and the last at the very end. Two ways in per card, a tab or a split beside what is on screen, and a remembered checkbox for `--dangerously-skip-permissions` shown where the press happens.

A session that is already running is not offered: those cards are dimmed, name the window they are in, and offer the trip instead. The claim is checked twice — the pane must still have an agent running in the directory the note recorded, and in the one the session ran in — because tmux reuses pane ids, and an unchecked note points at whatever holds that id today.

**A new tab opens in the project on screen.** `new-window` with no `-c` starts in the session's directory, which is wherever the server was launched from; on a desktop build that is the install checkout, so every new tab landed there while the panel said otherwise.

**Nothing scrolls twice.** CSS has no one-axis overflow: `overflow-x: auto` computes `overflow-y: auto` as well, so every diff pane was also a vertical scroll container inside a column that already was one — two bars at the same edge, and the inner one apparently dead. Measured in headless Chrome against the running app, before and after.

**And the paint that stopped at the edge.** Scrolled sideways, a diff's row tint, its hunk bar and its line numbers all ran out: each hunk sized itself, and `position: sticky` on a grid item sticks to its own grid area — 4ch wide, nowhere to go. One box owns the width now, and the rows are flex so the gutter can pin to the pane. Line numbers are opaque and as wide as the file's biggest number, which four digits had been quietly overlapping.

**Plus:** a review left unsubmitted on GitHub is visible in the file tree, the rail and the review box, with a link to where it can be edited; the pull-request filter matches assignees and reviewers, not just the author; a lane opens the rest of itself in place; menus flip up when there is no room below; and the first row of a list is marked as the row being shown.

## How was it tested?

`bun run typecheck` and `bun test` in `web/` and `server/`, plus the production build.

**7 new suites.** The session reader is tested against a real repository with a worktree and real transcripts on disk, including the two cases that were wrong in the first version: a name that only exists at the end of the file, and a slash command as the first user message.

The scroll and paint work was measured rather than reasoned about, twice — the second time because the first reasoning was wrong. A probe drives the built app in headless Chrome to the Files tab, shrinks the window until things overflow, and prints every box with `overflow-y: auto|scroll` and its heights; after the change the only vertical scrollers left in that column are the column, the file tree and the rail.

Everything here was driven in the desktop app on this repository and on a monorepo with a dozen worktrees, which is where the pane-id reuse showed up: the picker offered "open in 1 fish" on a machine with two agent tabs and no split.
