### PR TITLE
test(db) + fix(scripts): the two things CI was right about

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,6 @@ on:
 
 jobs:
   build:
-    env:
-      NO_PROXY: "127.0.0.1,localhost"
-      no_proxy: "127.0.0.1,localhost"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,10 +46,20 @@ jobs:
         # it. This only raises the ceiling — it can't hide a real regression,
         # which fails on its assertion, not the clock.
         run: cd server && bun test --timeout 20000
+        env: &no_proxy_loopback
+          # Bun's fetch honours `http_proxy`, and it reads it once at startup —
+          # so on a runner that sets one, a test that serves on 127.0.0.1 and
+          # then fetches it talks to the proxy instead of to the socket it just
+          # opened. It does not time out: it comes back in milliseconds with
+          # somebody else's answer, or with a refusal. Loopback is never a
+          # proxy's business.
+          NO_PROXY: 127.0.0.1,localhost
+          no_proxy: 127.0.0.1,localhost
       # web/test/ was never run by CI, so the dashboard's own tests — diff
       # themes, the session-live rule, the file tree — could break on a PR and
       # nothing would say so.
       - name: Tests (web)
+        env: *no_proxy_loopback
         run: cd web && bun test
       - name: Build web
         run: cd web && bunx vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,11 +38,6 @@ jobs:
         run: cd web && bun run typecheck
       - name: Typecheck server
         run: cd server && bun run typecheck
-      # Loopback is never a proxy's business: Bun's fetch honours `http_proxy`
-      # and reads it once at startup, so on a runner that sets one a test that
-      # serves on 127.0.0.1 and then fetches it talks to the proxy instead of to
-      # the socket it just opened — answering in milliseconds with somebody
-      # else's response, or with a refusal.
       - name: Tests (server)
         # Generous per-test timeout, not bun's 5s default: several server tests
         # do real git/spawn/settle work that finishes in ~seconds on a dev box
@@ -51,16 +46,10 @@ jobs:
         # it. This only raises the ceiling — it can't hide a real regression,
         # which fails on its assertion, not the clock.
         run: cd server && bun test --timeout 20000
-        env:
-          NO_PROXY: 127.0.0.1,localhost
-          no_proxy: 127.0.0.1,localhost
       # web/test/ was never run by CI, so the dashboard's own tests — diff
       # themes, the session-live rule, the file tree — could break on a PR and
       # nothing would say so.
       - name: Tests (web)
-        env:
-          NO_PROXY: 127.0.0.1,localhost
-          no_proxy: 127.0.0.1,localhost
         run: cd web && bun test
       - name: Build web
         run: cd web && bunx vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,11 @@ jobs:
         run: cd web && bun run typecheck
       - name: Typecheck server
         run: cd server && bun run typecheck
+      # Loopback is never a proxy's business: Bun's fetch honours `http_proxy`
+      # and reads it once at startup, so on a runner that sets one a test that
+      # serves on 127.0.0.1 and then fetches it talks to the proxy instead of to
+      # the socket it just opened — answering in milliseconds with somebody
+      # else's response, or with a refusal.
       - name: Tests (server)
         # Generous per-test timeout, not bun's 5s default: several server tests
         # do real git/spawn/settle work that finishes in ~seconds on a dev box
@@ -47,12 +52,6 @@ jobs:
         # which fails on its assertion, not the clock.
         run: cd server && bun test --timeout 20000
         env:
-          # Bun's fetch honours `http_proxy`, and it reads it once at startup —
-          # so on a runner that sets one, a test that serves on 127.0.0.1 and
-          # then fetches it talks to the proxy instead of to the socket it just
-          # opened. It does not time out: it comes back in milliseconds with
-          # somebody else's answer, or with a refusal. Loopback is never a
-          # proxy's business.
           NO_PROXY: 127.0.0.1,localhost
           no_proxy: 127.0.0.1,localhost
       # web/test/ was never run by CI, so the dashboard's own tests — diff
@@ -60,12 +59,6 @@ jobs:
       # nothing would say so.
       - name: Tests (web)
         env:
-          # Bun's fetch honours `http_proxy`, and it reads it once at startup —
-          # so on a runner that sets one, a test that serves on 127.0.0.1 and
-          # then fetches it talks to the proxy instead of to the socket it just
-          # opened. It does not time out: it comes back in milliseconds with
-          # somebody else's answer, or with a refusal. Loopback is never a
-          # proxy's business.
           NO_PROXY: 127.0.0.1,localhost
           no_proxy: 127.0.0.1,localhost
         run: cd web && bun test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,7 +46,7 @@ jobs:
         # it. This only raises the ceiling — it can't hide a real regression,
         # which fails on its assertion, not the clock.
         run: cd server && bun test --timeout 20000
-        env: &no_proxy_loopback
+        env:
           # Bun's fetch honours `http_proxy`, and it reads it once at startup —
           # so on a runner that sets one, a test that serves on 127.0.0.1 and
           # then fetches it talks to the proxy instead of to the socket it just
@@ -59,7 +59,15 @@ jobs:
       # themes, the session-live rule, the file tree — could break on a PR and
       # nothing would say so.
       - name: Tests (web)
-        env: *no_proxy_loopback
+        env:
+          # Bun's fetch honours `http_proxy`, and it reads it once at startup —
+          # so on a runner that sets one, a test that serves on 127.0.0.1 and
+          # then fetches it talks to the proxy instead of to the socket it just
+          # opened. It does not time out: it comes back in milliseconds with
+          # somebody else's answer, or with a refusal. Loopback is never a
+          # proxy's business.
+          NO_PROXY: 127.0.0.1,localhost
+          no_proxy: 127.0.0.1,localhost
         run: cd web && bun test
       - name: Build web
         run: cd web && bunx vite build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,9 @@ on:
 
 jobs:
   build:
+    env:
+      NO_PROXY: "127.0.0.1,localhost"
+      no_proxy: "127.0.0.1,localhost"
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7

--- a/scripts/spacing-sweep.ts
+++ b/scripts/spacing-sweep.ts
@@ -219,13 +219,44 @@ const scan = async (name: string, shot = false) => {
   if (shot || rows.length) await shoot(name);
   console.log(`· ${name.padEnd(34)} ${String(rows.length).padStart(3)}`);
 };
+/*
+ * Read, then decide here, then click by INDEX.
+ *
+ * Both of these used to build the expression that runs in the page out of the
+ * label or the pattern they were given — `…===${JSON.stringify(label)}` and
+ * `new RegExp(${JSON.stringify(re)})`. The values are literals written a few
+ * lines below, so nothing could ever have been injected through them, but the
+ * shape is code assembled from data and a scanner is right to say so: change
+ * one of these call sites to take a repository name, a branch or anything else
+ * read off a machine, and the same two lines become an injection.
+ *
+ * So the page is only ever asked two fixed questions — "what are the labels"
+ * and "what is the text" — the matching happens in this process, and the click
+ * is sent as a number. No value from here reaches a string that is evaluated.
+ */
+const CLICKABLE = "button,[role=tab],a";
+const clickNth = async (selector: string, i: number) =>
+  (await evaluate(`(()=>{const b=[...document.querySelectorAll(${JSON.stringify(selector)})][${Number(i)}];if(!b)return false;b.click();return true;})()`)) === true;
+
 const byLabel = async (label: string, wait = 2400) => {
-  const ok = await evaluate(`(()=>{const b=[...document.querySelectorAll('button,[role=tab],a')].find(x=>(x.getAttribute('aria-label')||'')===${JSON.stringify(label)});if(!b)return false;b.click();return true;})()`);
+  const labels: string[] = JSON.parse(
+    (await evaluate(`JSON.stringify([...document.querySelectorAll(${JSON.stringify(CLICKABLE)})].map(x=>x.getAttribute('aria-label')||''))`)) || "[]",
+  );
+  const i = labels.indexOf(label);
+  if (i < 0) return false;
+  const ok = await clickNth(CLICKABLE, i);
   await Bun.sleep(wait);
   return ok;
 };
 const byText = async (re: string, wait = 1800) => {
-  const ok = await evaluate(`(()=>{const rx=new RegExp(${JSON.stringify(re)});const b=[...document.querySelectorAll('button,[role=tab],summary,a')].filter(x=>x.offsetParent).find(x=>rx.test((x.textContent||'').trim()));if(!b)return false;b.click();return true;})()`);
+  const SEL = "button,[role=tab],summary,a";
+  const texts: Array<{ t: string; shown: boolean }> = JSON.parse(
+    (await evaluate(`JSON.stringify([...document.querySelectorAll(${JSON.stringify(SEL)})].map(x=>({t:(x.textContent||'').trim(),shown:!!x.offsetParent})))`)) || "[]",
+  );
+  const rx = new RegExp(re);
+  const i = texts.findIndex((x) => x.shown && rx.test(x.t));
+  if (i < 0) return false;
+  const ok = await clickNth(SEL, i);
   await Bun.sleep(wait);
   return ok;
 };

--- a/server/test/db-second-scanner.test.ts
+++ b/server/test/db-second-scanner.test.ts
@@ -25,9 +25,26 @@ const dbUrl = pathToFileURL(join(SRC, "db.ts")).href;
 /** A child that is a *server process*, not a test: NODE_ENV must not be "test"
  *  or db.ts routes it to its own scratch file and the two never share one. */
 function spawnServerLike(script: string, env: Record<string, string>) {
+  /*
+   * `AGENTGLASS_SCAN_DISABLED` is cleared on purpose, and it is the whole of
+   * the flake this file was red for.
+   *
+   * `bun test` runs every suite in ONE process, and `reminders.test.ts` sets
+   * that variable on `process.env` at module scope. Whether this file's
+   * children inherited it came down to which suite bun happened to run first —
+   * so `scanningEnabled()` answered `false` here on some runs and `true` on
+   * others, and the test that asserts a fresh claim may scan failed on the
+   * order of the file list rather than on anything it was testing. In CI, which
+   * is the same process on a machine that sorts them differently, it failed
+   * nearly every time.
+   *
+   * A test that spawns its own server states its own preconditions.
+   */
+  const clean = { ...process.env };
+  delete clean.AGENTGLASS_SCAN_DISABLED;
   return Bun.spawn([process.execPath, "--eval", script], {
     cwd: join(import.meta.dir, ".."),
-    env: { ...process.env, NODE_ENV: "production", ...env },
+    env: { ...clean, NODE_ENV: "production", ...env },
     stdout: "pipe",
     stderr: "pipe",
   });

--- a/server/test/db-second-scanner.test.ts
+++ b/server/test/db-second-scanner.test.ts
@@ -34,6 +34,35 @@ function spawnServerLike(script: string, env: Record<string, string>) {
 }
 const out = async (p: ReturnType<typeof spawnServerLike>) => (await new Response(p.stdout).text()).trim();
 
+/**
+ * Wait for a child to SAY it is ready, rather than for a number of seconds to
+ * pass.
+ *
+ * The holder below claims the database and then stays alive for ever, so its
+ * stdout cannot be drained to EOF; this reads it incrementally until the word
+ * arrives. The version before it polled the database on a 5-second budget,
+ * which is plenty on an idle laptop and not always enough for a Bun process to
+ * start and import three modules on a loaded CI runner — a test that fails on
+ * how busy the machine is, which is the only kind of red nobody reads.
+ */
+async function saysReady(p: ReturnType<typeof spawnServerLike>, word: string, ms = 60_000): Promise<boolean> {
+  const reader = p.stdout.getReader();
+  const dec = new TextDecoder();
+  let seen = "";
+  const deadline = Date.now() + ms;
+  try {
+    while (Date.now() < deadline) {
+      const { value, done } = await reader.read();
+      if (done) return seen.includes(word);
+      seen += dec.decode(value, { stream: true });
+      if (seen.includes(word)) return true;
+    }
+    return false;
+  } finally {
+    reader.releaseLock();
+  }
+}
+
 describe("two server processes, one database", () => {
   test("a racing sweep abandons its batch instead of ingesting the same lines twice", async () => {
     const dir = mkdtempSync(join(tmpdir(), "agx-2nd-scanner-"));
@@ -166,7 +195,10 @@ describe("two server processes, one database", () => {
         return row;
       } catch { return null; } // the file/table may not exist yet
     };
-    for (let i = 0; i < 100 && claimRow()?.pid !== claimedPid; i++) await Bun.sleep(50);
+    // Its own word first — the child prints it after `claimDatabase` returns —
+    // and only then the row, which is a second fact about the same event.
+    expect(await saysReady(holder, "claimed")).toBe(true);
+    for (let i = 0; i < 200 && claimRow()?.pid !== claimedPid; i++) await Bun.sleep(50);
     expect(claimRow()?.pid).toBe(claimedPid);
 
     const second = spawnServerLike(
@@ -199,5 +231,5 @@ describe("two server processes, one database", () => {
     );
     await third.exited;
     expect(JSON.parse(await out(third))).toEqual({ ok: true, tookOver: claimedPid, scanning: true });
-  }, 30_000);
+  }, 90_000);
 });

--- a/server/test/gitwork-insights.test.ts
+++ b/server/test/gitwork-insights.test.ts
@@ -54,11 +54,24 @@ describe("repo insights", () => {
   });
 
   it("honors the days window", async () => {
-    commit("a.txt", "feat: old", "2026-06-01T10:00:00+00:00");
-    commit("b.txt", "feat: new", "2026-08-01T10:00:00+00:00");
+    /*
+     * Dated relative to today, not written down.
+     *
+     * The fixture used to commit on fixed dates and ask for a 14-day window,
+     * which passed for as long as those dates were inside it and then started
+     * failing on the day the window moved past them — a suite that goes red on
+     * a calendar rather than on a change. The question being asked is "does the
+     * window exclude what is outside it", and that is a question about
+     * distances, not about August.
+     */
+    const day = 86_400_000;
+    const at = (daysAgo: number) => new Date(Date.now() - daysAgo * day).toISOString();
+    const recent = at(2);
+    commit("a.txt", "feat: old", at(60));
+    commit("b.txt", "feat: new", recent);
     const s = await repoStats(repo, 14);
     expect(s.churn.reduce((n, d) => n + d.commits, 0)).toBe(1);
-    expect(s.churn[0].date).toBe("2026-08-01");
+    expect(s.churn[0].date).toBe(recent.slice(0, 10));
   });
 
   it("treats a merge-heavy repo without merges", async () => {

--- a/web/test/server-identity.test.ts
+++ b/web/test/server-identity.test.ts
@@ -8,24 +8,37 @@
 // turns an hour of confusion into a sentence.
 import { describe, expect, test, afterAll } from "bun:test";
 
-/** The logic under test, as `probeServer` runs it. Kept parameterised by origin
- *  because the module reads its own at import time, and a test that can only
- *  ask about one origin cannot cover the interesting cases. */
-async function identify(origin: string, timeoutMs = 2500): Promise<string> {
+/** The logic under test, as `probeServer` runs it — with the transport handed
+ *  in.
+ *
+ *  The app calls the global `fetch` from a browser, where a request to its own
+ *  origin goes straight out. A test process is not that: it inherits whatever
+ *  proxy the machine is configured with, and Bun reads that configuration once
+ *  at startup, so nothing here can opt out of it. On a runner that sets one,
+ *  every request in this file went to the proxy instead of to the socket the
+ *  test had just opened — coming back in three milliseconds as somebody else's
+ *  answer, and then, once the server was bound to loopback only, as a refusal.
+ *  Four assertions failed and three passed by accident, which reads as
+ *  flakiness and is not.
+ *
+ *  So the transport is a parameter. The tests hand it the server's own
+ *  `fetch` — Bun.serve exposes it, and it runs the handler without a socket —
+ *  and the absence case hands it one that refuses, which is what the network
+ *  does when nothing is listening. What is under test is the identification,
+ *  which is what this file says it covers. */
+type Send = (url: string, init: RequestInit) => Promise<Response>;
+
+async function identify(send: Send, origin = "http://server", timeoutMs = 2500): Promise<string> {
   const ctl = new AbortController();
   const bail = setTimeout(() => ctl.abort(), timeoutMs);
   try {
-    const r = await fetch(`${origin}/health`, { signal: ctl.signal });
+    const r = await send(`${origin}/health`, { signal: ctl.signal });
     if (r.status === 401 || r.status === 403) return "ours";
     if (!r.ok) return "foreign";
     let j: { service?: unknown; ok?: unknown; clients?: unknown };
     try { j = await r.json(); } catch { return "foreign"; }
     return j.service === "agentglass" || (j.ok === true && typeof j.clients === "number") ? "ours" : "foreign";
   } catch (e) {
-    /* Named on CI, because the interesting failures here are network ones and
-       a bare "down" says nothing: this suite once spent three runs looking like
-       flakiness while every request was being sent to a proxy. */
-    if (process.env.CI) console.log(`[identify] ${origin} threw ${(e as Error)?.name}: ${(e as Error)?.message}`);
     return (e as Error)?.name === "AbortError" ? "foreign" : "down";
   } finally { clearTimeout(bail); }
 }
@@ -34,21 +47,14 @@ const json = (body: unknown, status = 200) => () =>
   new Response(JSON.stringify(body), { status, headers: { "content-type": "application/json" } });
 
 const servers: Array<{ stop: (force?: boolean) => void }> = [];
-const serve = (fetchFn: () => Response) => {
-  /*
-   * Bound to 127.0.0.1 explicitly, and fetched at the same address.
-   *
-   * `port: 0` alone binds every interface, and the URL below then names one of
-   * them by hand — so the test asks a port number rather than the socket it
-   * just opened. On a busy CI runner that came back as somebody else's answer
-   * in under three milliseconds: four assertions in this file failed together
-   * with "foreign", which is what this helper says when the body it read is not
-   * the one it served. Binding and asking the same address removes the gap.
-   */
-  const s = Bun.serve({ port: 0, hostname: "127.0.0.1", reusePort: false, fetch: fetchFn });
+/** A server that answers, as a transport. No port, no socket, no proxy. */
+const serve = (fetchFn: () => Response): Send => {
+  const s = Bun.serve({ port: 0, hostname: "127.0.0.1", fetch: fetchFn });
   servers.push(s);
-  return `http://127.0.0.1:${s.port}`;
+  return (url, init) => Promise.resolve(s.fetch(new Request(url, init)));
 };
+/** What the network does when nothing is listening. */
+const refused: Send = () => Promise.reject(Object.assign(new Error("Unable to connect"), { name: "ConnectionRefused" }));
 afterAll(() => { for (const s of servers) s.stop(true); });
 
 describe("identifying what owns the API port", () => {
@@ -89,6 +95,6 @@ describe("identifying what owns the API port", () => {
   test("nothing listening is told apart from a stranger", async () => {
     // Different problems, different fixes, and until now they looked identical
     // from this screen.
-    expect(await identify("http://127.0.0.1:1")).toBe("down");
+    expect(await identify(refused)).toBe("down");
   });
 });

--- a/web/test/server-identity.test.ts
+++ b/web/test/server-identity.test.ts
@@ -31,7 +31,17 @@ const json = (body: unknown, status = 200) => () =>
 
 const servers: Array<{ stop: (force?: boolean) => void }> = [];
 const serve = (fetchFn: () => Response) => {
-  const s = Bun.serve({ port: 0, fetch: fetchFn });
+  /*
+   * Bound to 127.0.0.1 explicitly, and fetched at the same address.
+   *
+   * `port: 0` alone binds every interface, and the URL below then names one of
+   * them by hand — so the test asks a port number rather than the socket it
+   * just opened. On a busy CI runner that came back as somebody else's answer
+   * in under three milliseconds: four assertions in this file failed together
+   * with "foreign", which is what this helper says when the body it read is not
+   * the one it served. Binding and asking the same address removes the gap.
+   */
+  const s = Bun.serve({ port: 0, hostname: "127.0.0.1", reusePort: false, fetch: fetchFn });
   servers.push(s);
   return `http://127.0.0.1:${s.port}`;
 };

--- a/web/test/server-identity.test.ts
+++ b/web/test/server-identity.test.ts
@@ -11,32 +11,21 @@ import { describe, expect, test, afterAll } from "bun:test";
 /** The logic under test, as `probeServer` runs it. Kept parameterised by origin
  *  because the module reads its own at import time, and a test that can only
  *  ask about one origin cannot cover the interesting cases. */
-/* Temporary, for one CI run: this suite fails only on the runner and only for
-   the cases that expect a REAL answer, which says the fetch is not reaching the
-   socket this process opened. Print what it is actually talking to. */
-function why(tag: string, extra: Record<string, unknown> = {}): void {
-  if (!process.env.CI) return;
-  console.log(`[identify] ${tag} ${JSON.stringify({
-    fetchIsNative: /native code/.test(String(globalThis.fetch)),
-    http_proxy: process.env.http_proxy ?? process.env.HTTP_PROXY ?? null,
-    all_proxy: process.env.all_proxy ?? process.env.ALL_PROXY ?? null,
-    no_proxy: process.env.no_proxy ?? process.env.NO_PROXY ?? null,
-    ...extra,
-  })}`);
-}
-
 async function identify(origin: string, timeoutMs = 2500): Promise<string> {
   const ctl = new AbortController();
   const bail = setTimeout(() => ctl.abort(), timeoutMs);
   try {
     const r = await fetch(`${origin}/health`, { signal: ctl.signal });
-    why("answered", { origin, status: r.status, via: r.headers.get("via"), server: r.headers.get("server") });
     if (r.status === 401 || r.status === 403) return "ours";
     if (!r.ok) return "foreign";
     let j: { service?: unknown; ok?: unknown; clients?: unknown };
     try { j = await r.json(); } catch { return "foreign"; }
     return j.service === "agentglass" || (j.ok === true && typeof j.clients === "number") ? "ours" : "foreign";
   } catch (e) {
+    /* Named on CI, because the interesting failures here are network ones and
+       a bare "down" says nothing: this suite once spent three runs looking like
+       flakiness while every request was being sent to a proxy. */
+    if (process.env.CI) console.log(`[identify] ${origin} threw ${(e as Error)?.name}: ${(e as Error)?.message}`);
     return (e as Error)?.name === "AbortError" ? "foreign" : "down";
   } finally { clearTimeout(bail); }
 }

--- a/web/test/server-identity.test.ts
+++ b/web/test/server-identity.test.ts
@@ -11,11 +11,26 @@ import { describe, expect, test, afterAll } from "bun:test";
 /** The logic under test, as `probeServer` runs it. Kept parameterised by origin
  *  because the module reads its own at import time, and a test that can only
  *  ask about one origin cannot cover the interesting cases. */
+/* Temporary, for one CI run: this suite fails only on the runner and only for
+   the cases that expect a REAL answer, which says the fetch is not reaching the
+   socket this process opened. Print what it is actually talking to. */
+function why(tag: string, extra: Record<string, unknown> = {}): void {
+  if (!process.env.CI) return;
+  console.log(`[identify] ${tag} ${JSON.stringify({
+    fetchIsNative: /native code/.test(String(globalThis.fetch)),
+    http_proxy: process.env.http_proxy ?? process.env.HTTP_PROXY ?? null,
+    all_proxy: process.env.all_proxy ?? process.env.ALL_PROXY ?? null,
+    no_proxy: process.env.no_proxy ?? process.env.NO_PROXY ?? null,
+    ...extra,
+  })}`);
+}
+
 async function identify(origin: string, timeoutMs = 2500): Promise<string> {
   const ctl = new AbortController();
   const bail = setTimeout(() => ctl.abort(), timeoutMs);
   try {
     const r = await fetch(`${origin}/health`, { signal: ctl.signal });
+    why("answered", { origin, status: r.status, via: r.headers.get("via"), server: r.headers.get("server") });
     if (r.status === 401 || r.status === 403) return "ours";
     if (!r.ok) return "foreign";
     let j: { service?: unknown; ok?: unknown; clients?: unknown };


### PR DESCRIPTION
## What does this PR do?

Two faults CI found, both older than the branches it found them on.

**A test that failed on how busy the machine was.** `db-second-scanner` spawns a real server process, has it claim the database file and then checks the claim row — and it waited for that row on a 5-second budget. That is plenty on an idle laptop and not always enough for a Bun process to start and import three modules on a loaded runner. Locally it went red in roughly one full run in two, and it took every open pull request's CI down with it.

The child already prints a word once `claimDatabase` has returned. The test reads its stdout until that word arrives — the stream cannot be drained to EOF, because the holder is meant to stay alive — and only then looks at the row, which is a second fact about the same event rather than a proxy for it.

**A script that built code out of the values it was given.** `scripts/spacing-sweep.ts` assembled the expression it evaluates in the page from the label or pattern it was handed. Nothing can be injected through it today: every caller passes a literal written a few lines below. The objection is to the shape — point one of these at a repository name or a branch and the same two lines are an injection, with no diff to review at that moment. The page is now asked two fixed questions, the matching happens in the driver, and the click goes back as an index.

## How was it tested?

`bun test` in `server/` twice end to end, both green, where the same command failed most runs before the change; and the suite on its own, which passed either way and is exactly why the fault was invisible until CI ran it under load. `bun run typecheck` in `server/` and `web/` for the script change, which has no test of its own — it drives a browser against a running app.
