### PR TITLE
fix(build): the vendored binaries build on the release runners too

### DIFF
--- a/.github/workflows/desktop-binaries.yml
+++ b/.github/workflows/desktop-binaries.yml
@@ -81,6 +81,18 @@ jobs:
       # so a machine without tmux still gets tabs, splits and persistence — the
       # engine runs its own tmux; the user's is never involved. Windows skips:
       # the pane engine is POSIX-only and stays an honest "off" there.
+      # zig is the C compiler the Linux target builds against — musl static,
+      # cross-compiled from the same script a developer runs. Without it
+      # `configure` gets no compiler and answers "C compiler cannot create
+      # executables", which is what the first tag cut after the vendored
+      # binaries landed died on.
+      - name: zig, for the musl target
+        if: runner.os == 'Linux'
+        uses: mlugg/setup-zig@v2
+        with:
+          # The version this repository's own builds are made with.
+          version: 0.16.0
+
       - name: Build bundled tmux
         if: runner.os != 'Windows'
         shell: bash

--- a/scripts/build-task-static.sh
+++ b/scripts/build-task-static.sh
@@ -32,6 +32,14 @@
 # scripts/task-build-checksums.txt, and the build refuses to run without an
 # entry for every tarball: a binary the app ships is a supply-chain decision,
 # not a convenience.
+# `sha256sum` is GNU coreutils; macOS ships `shasum`. The release runners are
+# both, and the first tag cut after these scripts landed died on a macOS runner
+# with "sha256sum: command not found" — after downloading three tarballs.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -90,7 +98,7 @@ verify() { # file name
     echo "no pinned checksum for $name in $CHECKSUMS — refusing to build unverified" >&2
     exit 1
   fi
-  local got; got="$(sha256sum "$file" | awk '{print $1}')"
+  local got; got="$(sha256_of "$file")"
   if [ "$got" != "$want" ]; then
     echo "checksum mismatch for $name: got $got, want $want" >&2
     exit 1

--- a/scripts/build-tmux-static.sh
+++ b/scripts/build-tmux-static.sh
@@ -24,6 +24,14 @@
 # The result is statically linked (musl on Linux, full static on macOS) so the
 # bundled binary has no libevent/ncurses dependency on the host — that is what
 # makes "no tmux on the machine" irrelevant to the engine.
+# `sha256sum` is GNU coreutils; macOS ships `shasum`. The release runners are
+# both, and the first tag cut after these scripts landed died on a macOS runner
+# with "sha256sum: command not found" — after downloading three tarballs.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -89,7 +97,7 @@ verify() { # file name
     echo "no pinned checksum for $name in $CHECKSUMS — refusing to build unverified" >&2
     exit 1
   fi
-  local got; got="$(sha256sum "$file" | awk '{print $1}')"
+  local got; got="$(sha256_of "$file")"
   if [ "$got" != "$want" ]; then
     echo "checksum mismatch for $name: got $got, want $want" >&2
     exit 1

--- a/scripts/tmux-fill-checksums.sh
+++ b/scripts/tmux-fill-checksums.sh
@@ -6,6 +6,14 @@
 # this file, and every build after that verifies against it. A mismatch (the
 # version bumped, a mirror tampered) fails loudly. Idempotent: does nothing
 # once every pin exists, so CI can call it unconditionally.
+# `sha256sum` is GNU coreutils; macOS ships `shasum`. The release runners are
+# both, and the first tag cut after these scripts landed died on a macOS runner
+# with "sha256sum: command not found" — after downloading three tarballs.
+sha256_of() {
+  if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
+  else shasum -a 256 "$1" | awk '{print $1}'; fi
+}
+
 set -euo pipefail
 cd "$(dirname "$0")/.."
 
@@ -22,7 +30,7 @@ need() { # name url
   local tmp; tmp="$(mktemp /tmp/tmux-sha.XXXXXX)"
   trap 'rm -f "$tmp"' EXIT
   curl -fsSL -o "$tmp" "$url"
-  local sum; sum="$(sha256sum "$tmp" | awk '{print $1}')"
+  local sum; sum="$(sha256_of "$tmp")"
   printf '%s  %s\n' "$sum" "$name" >> "$CH"
   rm -f "$tmp"
   trap - EXIT

--- a/server/src/shelllog.ts
+++ b/server/src/shelllog.ts
@@ -45,7 +45,11 @@ export interface ShellRecord {
  * would put commands somebody ran by hand into an agent's transcript and its
  * cost. One id per server run keeps the shell's work grouped and separate.
  */
-const SESSION = `shell-${Math.random().toString(36).slice(2, 10)}`;
+/* `crypto`, not `Math.random`: this id is not a secret — it groups one server
+   run's shell work — but two runs colliding would merge two people's commands
+   into one session, and a scanner is right that a PRNG is the wrong tool for an
+   identifier. The cost is the same one call. */
+const SESSION = `shell-${crypto.randomUUID().slice(0, 8)}`;
 
 const base = (id: string, name: string, cwd: string | null) => ({
   source_app: "terminal",

--- a/web/test/view-chrome.test.ts
+++ b/web/test/view-chrome.test.ts
@@ -76,7 +76,10 @@ const EXEMPT: { file: string; match: string; why: string }[] = [
 /** Every `<button>` whose class list looks like a chip: rounded, with padding. */
 function chipButtons(src: string, exempt: string[] = []): { line: number; cls: string }[] {
   const out: { line: number; cls: string }[] = [];
-  for (const m of src.matchAll(/<button\b((?:[^>]|\n)*?)>/g)) {
+  // `[^>]` already matches a newline, so spelling the alternation out gave the
+  // engine two ways to consume one — which is the shape that backtracks
+  // exponentially on a tag that never closes.
+  for (const m of src.matchAll(/<button\b([^>]*?)>/g)) {
     const tag = m[1] ?? "";
     const cls = /className="([^"]*)"/.exec(tag)?.[1];
     // Every rounded shape, not only `rounded-lg`: the divergence that prompted


### PR DESCRIPTION
## What does this PR do?

The first tag cut since the vendored tmux and Taskwarrior landed took the desktop-binaries job down on all three unix targets, in two different ways. Both are about the machine, not the build.

**macOS has no `sha256sum`.** It ships `shasum`, so the checksum gate died with "command not found" — after downloading three tarballs. A two-line helper picks whichever the machine has; the check itself is unchanged and stays a refusal rather than a warning.

**The Linux target had no compiler.** It cross-compiles to musl with `zig cc`, and nothing on the runner installed zig, so `configure` answered "C compiler cannot create executables" and exited 77. The job installs it now, pinned to the version these builds are made with locally.

Windows is unaffected: it skips this step.

## How was it tested?

The scripts parse (`bash -n`) and the helper was exercised both ways on this machine — with `sha256sum` on PATH and with it hidden, so the `shasum` branch is the one that ran. The real proof is the run this unblocks: the same tag, rebuilt, which is what the next comment on this PR will carry.