### PR TITLE
fix(build): the vendored builds count the cores the machine has

### DIFF
--- a/scripts/build-task-static.sh
+++ b/scripts/build-task-static.sh
@@ -35,6 +35,14 @@
 # `sha256sum` is GNU coreutils; macOS ships `shasum`. The release runners are
 # both, and the first tag cut after these scripts landed died on a macOS runner
 # with "sha256sum: command not found" — after downloading three tarballs.
+# `nproc` is GNU; macOS has `sysctl -n hw.ncpu`. With neither, `make -j""` runs
+# with NO limit — which is how the first macOS release build died: ncurses'
+# makefiles raced and `make` reported "No rule to make target ../lib/libtinfo.a"
+# for a library its own tree had not finished writing yet.
+jobs_n() {
+  nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4
+}
+
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
   else shasum -a 256 "$1" | awk '{print $1}'; fi
@@ -120,7 +128,7 @@ build_uuid() {
     CC="$CC" ./configure ${TRIPLE:+--host="$TRIPLE"} --prefix="$WORK/prefix" \
       --disable-all-programs --enable-libuuid --disable-shared --enable-static \
       --without-python --without-systemd --without-udev >/dev/null
-    make -s -j"$(nproc)" && make -s install )
+    make -s -j"$(jobs_n)" && make -s install )
 }
 
 build_task() {
@@ -147,7 +155,7 @@ build_task() {
     # No `--target task`: 2.6.2 names its executable target differently from
     # the binary, and asking for one that does not exist ends with cmake
     # cheerfully doing nothing and the copy below failing on a missing file.
-    cmake --build build -j"$(nproc)" >/dev/null )
+    cmake --build build -j"$(jobs_n)" >/dev/null )
 }
 
 [ "$NEEDS_UUID" = "1" ] && [ "${SKIP_UUID:-0}" != "1" ] && build_uuid

--- a/scripts/build-tmux-static.sh
+++ b/scripts/build-tmux-static.sh
@@ -27,6 +27,14 @@
 # `sha256sum` is GNU coreutils; macOS ships `shasum`. The release runners are
 # both, and the first tag cut after these scripts landed died on a macOS runner
 # with "sha256sum: command not found" — after downloading three tarballs.
+# `nproc` is GNU; macOS has `sysctl -n hw.ncpu`. With neither, `make -j""` runs
+# with NO limit — which is how the first macOS release build died: ncurses'
+# makefiles raced and `make` reported "No rule to make target ../lib/libtinfo.a"
+# for a library its own tree had not finished writing yet.
+jobs_n() {
+  nproc 2>/dev/null || sysctl -n hw.ncpu 2>/dev/null || echo 4
+}
+
 sha256_of() {
   if command -v sha256sum >/dev/null 2>&1; then sha256sum "$1" | awk '{print $1}'
   else shasum -a 256 "$1" | awk '{print $1}'; fi
@@ -110,7 +118,7 @@ build_libevent() {
   tar -xzf "$t" -C "$WORK/src"
   ( cd "$WORK/src/libevent-${LIBEVENT_VERSION}-stable"
     CC="$CC" ./configure --host="$TRIPLE" --prefix="$WORK/prefix" --disable-shared --enable-static --disable-openssl --disable-samples --disable-libevent-regress >/dev/null
-    make -s -j"$(nproc)" && make -s install )
+    make -s -j"$(jobs_n)" && make -s install )
 }
 
 build_ncurses() {
@@ -126,7 +134,7 @@ build_ncurses() {
     # final link is the only thing that fails, looking for a file ncurses was
     # never asked to make.
     CC="$CC" CFLAGS="-O2" ./configure --host="$TRIPLE" --prefix="$WORK/prefix" --without-shared --without-progs --without-tests --without-manpages --without-ada --disable-db-install --enable-widec --with-termlib=tinfo >/dev/null
-    make -s -j"$(nproc)" && make -s install )
+    make -s -j"$(jobs_n)" && make -s install )
 }
 
 build_tmux() {
@@ -165,7 +173,7 @@ build_tmux() {
     LDFLAGS="-L$WORK/prefix/lib -static -s" \
     LIBS="-levent_core -levent -lncursesw -ltinfo -lm" \
     ./configure --host="$TRIPLE" --prefix="$WORK/prefix" >/dev/null
-    make -s -j"$(nproc)" )
+    make -s -j"$(jobs_n)" )
   file "$WORK/src/tmux-${TMUX_VERSION}/tmux"
 }
 


### PR DESCRIPTION
## What does this PR do?

`nproc` is GNU coreutils and macOS does not ship it, so on the release runner `make -s -j"$(nproc)"` became `make -j""` — parallelism with no limit. ncurses makefiles do not survive that: both macOS jobs died with "No rule to make target `../lib/libtinfo.a`" — a library its own build tree had not finished writing when another rule asked for it. Linux never saw it because `nproc` is there, which is also why the Linux target went green in the same run.

One helper in both build scripts: `nproc`, then `sysctl -n hw.ncpu`, then four.

## How was it tested?

Both scripts parse (`bash -n`), and the helper answers on this machine through each branch — with `nproc` on PATH and with it hidden. The proof that matters is the release run this unblocks: the two `.dmg` targets, which are the only assets v0.11.0 is still missing.