### PR TITLE
ci: use locked installs and local web build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
         with:
           bun-version: latest
       - name: Install
-        run: bun install
+        run: bun install --frozen-lockfile
       # The mark lives in seven places — a standalone SVG, the favicon, a React
       # component, the boot splash and three inlines in the landing page. They
       # drifted once and a fix shipped to six of them while the seventh kept
@@ -52,7 +52,7 @@ jobs:
       - name: Tests (web)
         run: cd web && bun test
       - name: Build web
-        run: cd web && bunx vite build
+        run: cd web && bun run build
       # Pinned rather than the runner's preinstalled Chrome: the ubuntu-latest
       # image has dropped and re-added browsers before, and this also keeps the
       # step working on container or self-hosted runners that ship none.
@@ -149,7 +149,7 @@ jobs:
       # the only job that runs the server outside `build`.
       - name: Install (workspace — the server those two suites boot)
         if: steps.phone.outputs.there == 'yes'
-        run: bun install
+        run: bun install --frozen-lockfile
       # Both configs: the app against React Native, the suites against
       # bun-types. `types` replaces rather than adds, so one file cannot hold
       # both — see mobile/tsconfig.test.json.


### PR DESCRIPTION
## What does this PR do?

Closes #470.

This makes the CI workflow use the repository's locked dependency graph more consistently:

- changes workspace installs to `bun install --frozen-lockfile`
- replaces the remaining `cd web && bunx vite build` with `cd web && bun run build`, so CI uses the repo-local Vite dependency declared in `web/package.json`

I intentionally left exact Bun/action SHA pinning out of this PR to keep the change small and reviewable.

## How was it tested?

Passed locally:

```bash
bun install --frozen-lockfile
cd web && bun run typecheck
cd web && bun run build
cd server && bun run typecheck
git diff --check
```

Additional local suite notes:

```bash
cd server && bun test --timeout 20000
```

This ran but failed in this macOS shell on environment-dependent tests, primarily missing `tmux`, process/machine introspection differences, and long-running desktop install/process cases. Many unrelated server tests passed before those failures.

```bash
cd web && bun test
```

This ran 2716 web tests: 2714 passed, 2 failed in `workspace chords` key-label expectations on this platform. The CI-targeted typecheck and production build both passed.
