### PR TITLE
fix(insights): a session id is only unique inside its app (#248)

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -9,8 +9,7 @@
 import type { Budget } from "../../shared/types.ts";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve, dirname, sep, delimiter, normalize } from "node:path";
-
+import { join, resolve, dirname, sep, delimiter } from "node:path";
 import { worktreeFamily } from "./worktree.ts";
 
 /**
@@ -371,13 +370,10 @@ export function workspaceRoot(): string | null {
  *  itself but never anything inside it there; every path in the project
  *  reads as out-of-scope. */
 export function isWithin(child: string, parent: string, s: string = sep): boolean {
-  const c = normalize(child);
-  const p = normalize(parent);
-  if (c === p) return true;
-  const prefix = p.endsWith(s) ? p : p + s;
-  return c.startsWith(prefix);
+  if (child === parent) return true;
+  const prefix = parent.endsWith(s) ? parent : parent + s;
+  return child.startsWith(prefix);
 }
-
 
 export function inScope(path: string | null | undefined, scope = workspaceRoot()): boolean {
   if (!scope) return true; // whole-machine: nothing to enforce

--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -9,7 +9,8 @@
 import type { Budget } from "../../shared/types.ts";
 import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
-import { join, resolve, dirname, sep, delimiter } from "node:path";
+import { join, resolve, dirname, sep, delimiter, normalize } from "node:path";
+
 import { worktreeFamily } from "./worktree.ts";
 
 /**
@@ -370,10 +371,13 @@ export function workspaceRoot(): string | null {
  *  itself but never anything inside it there; every path in the project
  *  reads as out-of-scope. */
 export function isWithin(child: string, parent: string, s: string = sep): boolean {
-  if (child === parent) return true;
-  const prefix = parent.endsWith(s) ? parent : parent + s;
-  return child.startsWith(prefix);
+  const c = normalize(child);
+  const p = normalize(parent);
+  if (c === p) return true;
+  const prefix = p.endsWith(s) ? p : p + s;
+  return c.startsWith(prefix);
 }
+
 
 export function inScope(path: string | null | undefined, scope = workspaceRoot()): boolean {
   if (!scope) return true; // whole-machine: nothing to enforce

--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -28,7 +28,7 @@ export function getInsights(): Insight[] {
        FROM events
        WHERE hook_event_type = 'PreToolUse' AND tool_name = 'Bash'
              AND cmd IS NOT NULL AND timestamp > ?${sc}
-       GROUP BY session_id, cmd
+       GROUP BY source_app, session_id, cmd
        HAVING n >= 6
        ORDER BY n DESC LIMIT 6`
     )
@@ -49,7 +49,7 @@ export function getInsights(): Insight[] {
   const spend = db
     .query<{ source_app: string; session_id: string; cost: number; last: number }, any[]>(
       `SELECT source_app, session_id, ROUND(SUM(cost_usd),2) cost, MAX(timestamp) last
-       FROM events WHERE timestamp > ?${sc} GROUP BY session_id
+       FROM events WHERE timestamp > ?${sc} GROUP BY source_app, session_id
        HAVING cost >= 15 ORDER BY cost DESC LIMIT 4`
     )
     .all(now - 15 * 60_000, ...sa);
@@ -77,7 +77,8 @@ export function getInsights(): Insight[] {
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') AND is_error = 1 THEN 1 ELSE 0 END) errs,
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) tools,
               MAX(timestamp) last
-       FROM events WHERE timestamp > ?${sc} GROUP BY session_id
+       FROM events WHERE timestamp > ?${sc} GROUP BY source_app, session_id
+
        HAVING tools >= 4 AND errs * 1.0 / tools > 0.3
        ORDER BY errs DESC LIMIT 4`
     )

--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -7,6 +7,12 @@ import { equivalentTokens } from "./pricing.ts";
 import { budgetStatus, budgetScopeLabel, periodLabel } from "./budget.ts";
 
 const key = (app: string, sid: string) => `${app}:${sid.slice(0, 8)}`;
+// The row identity the session-scoped queries group by. `key` is the label the
+// card shows: it shortens the session id to fit, and two rows are allowed to
+// render the same one. An id is a React key, so it carries the pair in full —
+// and escapes it, because an app `a:b` in session `c` and an app `a` in session
+// `b:c` are different rows that a plain join hands the same string.
+const rowId = (app: string, sid: string) => `${encodeURIComponent(app)}:${encodeURIComponent(sid)}`;
 const trim = (s: string, n = 64) => (s.length > n ? s.slice(0, n) + "…" : s);
 
 export function getInsights(): Insight[] {
@@ -35,7 +41,7 @@ export function getInsights(): Insight[] {
     .all(now - 30 * 60_000, ...sa);
   for (const l of loops) {
     out.push({
-      id: `loop:${l.session_id}:${l.cmd}`,
+      id: `loop:${rowId(l.source_app, l.session_id)}:${l.cmd}`,
       severity: l.n >= 15 ? "bad" : "warn",
       kind: "loop",
       title: `Possible loop · ${l.n}× identical command`,
@@ -55,7 +61,7 @@ export function getInsights(): Insight[] {
     .all(now - 15 * 60_000, ...sa);
   for (const s of spend) {
     out.push({
-      id: `spend:${s.session_id}`,
+      id: `spend:${rowId(s.source_app, s.session_id)}`,
       severity: s.cost >= 40 ? "bad" : "warn",
       kind: "spend",
       title: `Burning fast · $${s.cost.toFixed(2)} in 15m`,
@@ -78,7 +84,6 @@ export function getInsights(): Insight[] {
               SUM(CASE WHEN hook_event_type IN ('PostToolUse','PostToolUseFailure') THEN 1 ELSE 0 END) tools,
               MAX(timestamp) last
        FROM events WHERE timestamp > ?${sc} GROUP BY source_app, session_id
-
        HAVING tools >= 4 AND errs * 1.0 / tools > 0.3
        ORDER BY errs DESC LIMIT 4`
     )
@@ -86,7 +91,7 @@ export function getInsights(): Insight[] {
   for (const f of fails) {
     const pct = Math.round((f.errs / f.tools) * 100);
     out.push({
-      id: `errors:${f.session_id}`,
+      id: `errors:${rowId(f.source_app, f.session_id)}`,
       severity: pct >= 50 ? "bad" : "warn",
       kind: "errors",
       title: `High failure rate · ${pct}%`,

--- a/server/test/insights-group-app.test.ts
+++ b/server/test/insights-group-app.test.ts
@@ -1,3 +1,21 @@
+// A session id is only unique inside the app that issued it (#248). Two apps
+// working the same project can hold the same session id, and the insight
+// queries grouped by session id alone — so two fleets running `pytest test_a.py`
+// seven times each collapsed into one card, `Possible loop · 14× identical
+// command`, attributed to whichever source_app SQLite happened to return.
+//
+// The fix is the pair, and it has to hold in two places. `GROUP BY` splits the
+// rows; the `id` each row is keyed by has to split with them, or the cards are
+// separated in the server and merged again by `key={i.id}` in Alerts.tsx.
+//
+// The collision is what the fixture is for: one session id, one command, two
+// apps. Both halves are asserted, because each fails alone — dropping the
+// source_app from GROUP BY loses the second card, and dropping it from the id
+// makes two cards that React cannot tell apart.
+//
+// A third pair guards the id itself. `agentglass:web` in session `s1` and
+// `agentglass` in session `web:s1` are two rows that a plain join writes as one
+// string, so the id has to encode the pair rather than concatenate it.
 import { describe, expect, test, beforeAll } from "bun:test";
 import { mkdtempSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
@@ -10,16 +28,20 @@ process.env.AGENTGLASS_DB = join(dir, "insights-grp.db");
 process.env.AGENTGLASS_ROOT = ROOT;
 process.env.XDG_CONFIG_HOME = dir;
 
-let db: typeof import("../src/db.ts");
 let insights: typeof import("../src/insights.ts");
 
 const now = Date.now();
-const event = (app: string, session: string, cmd: string, i: number) => ({
+const SESSION = "s-shared"; // the same id in both apps — the whole point
+const CMD = "pytest test_a.py";
+const COLLIDING = ["app-alpha", "app-beta"];
+const AMBIGUOUS: [string, string][] = [["agentglass:web", "s1"], ["agentglass", "web:s1"]];
+
+const event = (app: string, session: string, over: Record<string, unknown>, i: number) => ({
   source_app: app,
   session_id: session,
   hook_event_type: "PreToolUse",
   tool_name: "Bash",
-  tool_use_id: `${session}-${i}`,
+  tool_use_id: `${app}-${session}-${i}`,
   agent_id: null,
   agent_type: null,
   model_name: "claude-opus-4-8",
@@ -29,33 +51,66 @@ const event = (app: string, session: string, cmd: string, i: number) => ({
   usage_is_cumulative: false,
   summary: "",
   timestamp: now - i * 1000,
-  payload: { project_path: ROOT, tool_input: { command: cmd } },
+  payload: { project_path: ROOT, tool_input: { command: CMD } },
   chat: null,
+  ...over,
 });
 
 beforeAll(async () => {
-  db = await import("../src/db.ts");
+  const db = await import("../src/db.ts");
   insights = await import("../src/insights.ts");
-  
-  // App 1 loop
-  for (let i = 0; i < 7; i++) {
-    db.insertEvent(event("app-alpha", "s-1", "pytest test_a.py", i) as any);
+  // Every session-scoped insight, for both apps, on the one shared session id.
+  for (const app of COLLIDING) {
+    let i = 0;
+    // Loop: >= 6 identical Bash commands in 30m.
+    for (let n = 0; n < 7; n++) db.insertEvent(event(app, SESSION, {}, i++) as any);
+    // Fast burn: >= $15 in 15m. Opus input is $5/M, so 2M tokens is $10 an event.
+    for (let n = 0; n < 2; n++) db.insertEvent(event(app, SESSION, {
+      hook_event_type: "PostToolUse",
+      usage: { input_tokens: 2_000_000, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0 },
+    }, i++) as any);
+    // High failure rate: 3 of 5 tool calls fail in an hour, which is over 30%.
+    for (let n = 0; n < 3; n++) db.insertEvent(event(app, SESSION, {
+      hook_event_type: "PostToolUseFailure", is_error: 1, error_text: "boom",
+    }, i++) as any);
   }
-  // App 2 loop with different app
-  for (let i = 0; i < 7; i++) {
-    db.insertEvent(event("app-beta", "s-2", "npm test", i) as any);
+  for (const [app, session] of AMBIGUOUS) {
+    for (let n = 0; n < 7; n++) db.insertEvent(event(app, session, {}, n) as any);
   }
 });
 
-describe("insights GROUP BY source_app", () => {
-  test("correctly attributes loops to their exact source_app", () => {
-    const list = insights.getInsights();
-    const alphaLoop = list.find((item) => item.session?.startsWith("app-alpha:"));
-    const betaLoop = list.find((item) => item.session?.startsWith("app-beta:"));
-    
-    expect(alphaLoop).toBeDefined();
-    expect(betaLoop).toBeDefined();
-    expect(alphaLoop?.detail).toBe("pytest test_a.py");
-    expect(betaLoop?.detail).toBe("npm test");
+const loopsFor = (prefix: string) =>
+  insights.getInsights().filter((i) => i.kind === "loop" && (i.session ?? "").startsWith(prefix));
+
+describe("two apps sharing one session id are two fleets, not one", () => {
+  test("each app gets its own card, counting only its own commands", () => {
+    const loops = loopsFor("app-");
+    const sessions = loops.map((l) => l.session);
+    expect(sessions).toContain(`app-alpha:${SESSION}`);
+    expect(sessions).toContain(`app-beta:${SESSION}`);
+    // 7 each. One merged card would say 14, and name only one of the two.
+    expect(loops.map((l) => l.title)).toEqual([
+      "Possible loop · 7× identical command",
+      "Possible loop · 7× identical command",
+    ]);
+    expect(loops.every((l) => l.detail === CMD)).toBe(true);
+  });
+
+  test("their cards are addressable apart, for every insight the pair keys", () => {
+    // `key={i.id}` in Alerts.tsx: an id shared by two cards renders one of them.
+    const ids = insights.getInsights().map((i) => i.id);
+    expect(new Set(ids).size).toBe(ids.length);
+    for (const kind of ["loop", "spend", "errors"]) {
+      expect(ids.filter((id) => id.startsWith(`${kind}:app-`))).toHaveLength(2);
+    }
+  });
+
+  test("a colon in an app name does not fold two rows into one id", () => {
+    const rows = loopsFor("agentglass");
+    expect(rows).toHaveLength(2);
+    // The label is allowed to collide — it is a label, and it truncates the
+    // session id anyway. The React key is not.
+    expect(new Set(rows.map((r) => r.session)).size).toBe(1);
+    expect(new Set(rows.map((r) => r.id)).size).toBe(2);
   });
 });

--- a/server/test/insights-group-app.test.ts
+++ b/server/test/insights-group-app.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-insights-group-"));
+const ROOT = join(dir, "proj");
+mkdirSync(ROOT, { recursive: true });
+process.env.AGENTGLASS_DB = join(dir, "insights-grp.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+let insights: typeof import("../src/insights.ts");
+
+const now = Date.now();
+const event = (app: string, session: string, cmd: string, i: number) => ({
+  source_app: app,
+  session_id: session,
+  hook_event_type: "PreToolUse",
+  tool_name: "Bash",
+  tool_use_id: `${session}-${i}`,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "",
+  timestamp: now - i * 1000,
+  payload: { project_path: ROOT, tool_input: { command: cmd } },
+  chat: null,
+});
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  insights = await import("../src/insights.ts");
+  
+  // App 1 loop
+  for (let i = 0; i < 7; i++) {
+    db.insertEvent(event("app-alpha", "s-1", "pytest test_a.py", i) as any);
+  }
+  // App 2 loop with different app
+  for (let i = 0; i < 7; i++) {
+    db.insertEvent(event("app-beta", "s-2", "npm test", i) as any);
+  }
+});
+
+describe("insights GROUP BY source_app", () => {
+  test("correctly attributes loops to their exact source_app", () => {
+    const list = insights.getInsights();
+    const alphaLoop = list.find((item) => item.session?.startsWith("app-alpha:"));
+    const betaLoop = list.find((item) => item.session?.startsWith("app-beta:"));
+    
+    expect(alphaLoop).toBeDefined();
+    expect(betaLoop).toBeDefined();
+    expect(alphaLoop?.detail).toBe("pytest test_a.py");
+    expect(betaLoop?.detail).toBe("npm test");
+  });
+});

--- a/server/test/insights-scope.test.ts
+++ b/server/test/insights-scope.test.ts
@@ -7,7 +7,7 @@
 import { describe, expect, test, beforeAll } from "bun:test";
 import { mkdtempSync, mkdirSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join } from "node:path";
+import { basename, join } from "node:path";
 
 const dir = mkdtempSync(join(tmpdir(), "agx-insights-scope-"));
 const SCOPED = join(dir, "scoped");
@@ -24,7 +24,7 @@ let insights: typeof import("../src/insights.ts");
 const now = Date.now();
 // One loop = >=6 identical Bash PreToolUse in a session within 30m.
 const loopEvent = (project: string, session: string, cmd: string, i: number, over: Record<string, unknown> = {}) => ({
-  source_app: project.split("/").pop()!,
+  source_app: basename(project),
   session_id: session,
   hook_event_type: "PreToolUse",
   tool_name: "Bash",
@@ -58,7 +58,7 @@ beforeAll(async () => {
     // cost is computed from usage at insert (opus input is $5/M), so 2M input
     // tokens ≈ $10/event; four events ≈ $40, over the $15 fast-burn threshold.
     for (let i = 0; i < 4; i++) db.insertEvent({
-      source_app: project.split("/").pop()!, session_id: session, hook_event_type: "PostToolUse",
+      source_app: basename(project), session_id: session, hook_event_type: "PostToolUse",
       tool_name: "Bash", tool_use_id: null, agent_id: null, agent_type: null, model_name: "claude-opus-4-8",
       is_error: 0, error_text: null,
       usage: { input_tokens: 2_000_000, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 0 },
@@ -74,20 +74,20 @@ const loopIds = () => insights.getInsights().filter((i) => i.kind === "loop").ma
 
 describe("insights are scoped to the project", () => {
   test("a loop in the scoped project surfaces", () => {
-    expect(loopIds().some((id) => id.startsWith("loop:s-in:"))).toBe(true);
+    expect(loopIds()).toContain("loop:scoped:s-in:npm run build");
   });
 
   test("a loop in ANOTHER project does not leak in", () => {
-    expect(loopIds().some((id) => id.startsWith("loop:s-out:"))).toBe(false);
+    expect(loopIds().some((id) => id.startsWith("loop:other:"))).toBe(false);
   });
 
   test("a loop whose turn ran inside the scope (via cwd) is included", () => {
-    expect(loopIds().some((id) => id.startsWith("loop:s-cwd:"))).toBe(true);
+    expect(loopIds()).toContain("loop:mono:s-cwd:npm run build");
   });
 
   test("a second insight kind (fast burn) is scoped too, not just loops", () => {
     const spendIds = insights.getInsights().filter((i) => i.kind === "spend").map((i) => i.id);
-    expect(spendIds).toContain("spend:b-in"); // in-scope fast burn surfaces
-    expect(spendIds).not.toContain("spend:b-out"); // another project's does not leak
+    expect(spendIds).toContain("spend:scoped:b-in"); // in-scope fast burn surfaces
+    expect(spendIds.some((id) => id.startsWith("spend:other:"))).toBe(false); // another project's does not leak
   });
 });


### PR DESCRIPTION
## What does this PR do?

Fixes the F18 part of #248. A session id is only unique inside the app that
issued it, and the insight queries grouped by session id alone — so two apps
working the same project, each running `pytest test_a.py` seven times, collapsed
into one card, `Possible loop · 14× identical command`, attributed to whichever
`source_app` SQLite happened to return.

`GROUP BY source_app, session_id[, cmd]` splits the rows. The `id` each card is
keyed by carries the pair too: without that, the two rows the grouping fix
correctly separates are handed to `key={i.id}` in `Alerts.tsx` as one, and the
UI merges them straight back. `rowId` encodes the pair rather than joining it,
because `source_app` is not constrained to exclude a colon.

The `isWithin`/`normalize()` change from the first revision is dropped. It is
platform-bound, and the one path shape that does fail today belongs in its own
PR with its failing case.

## How was it tested?

`server/test/insights-group-app.test.ts` is built around the collision — one
session id, one command, two apps — and asserts both halves, because each fails
alone:

| tree | result |
| --- | --- |
| base `26ef8bc` | 2 fail; the loop list holds only `app-alpha:s-shared` |
| `GROUP BY` fixed, ids untouched | 1 fail — 9 insights, 6 distinct ids |
| ids joined rather than encoded | 2 fail — 9 insights, 8 distinct ids |
| this branch | 3 pass |

The fixture carries all three session-scoped insights on the shared id, so the
uniqueness assertion covers `spend:` and `errors:` as well as `loop:`.

`server/test/insights-scope.test.ts` matched insight ids by prefix, which the new
id shape breaks. Its `source_app` came from splitting an OS path on `/`, which
does not split a Windows path, so it uses `basename` now and its four assertions
are exact.

Also run: `bun run typecheck` in `server/` and `web/`, `bunx vite build`, and the
full `server` suite on both `26ef8bc` and this branch — the five files that touch
insights fail identically on both, and this branch adds three passing tests.
