### PR TITLE
ci: pin bun, so the workflow measures the tree and not the week

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,9 +10,24 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
+      # Pinned, and this is the line that decides whether CI is measuring the
+      # tree or the week. `latest` resolved to bun 1.4.0 the moment it shipped
+      # — 2026-08-20 14:14 UTC — and main went red at 16:08 the same day, on a
+      # merge that had passed on its own branch. Nothing in the repository had
+      # changed: re-running the CI of a commit from the 17th, untouched, fails
+      # today and passed then.
+      #
+      # What breaks under 1.4.0 is nine tests in two files, all of them
+      # timeouts rather than wrong answers, and both files spawn child
+      # processes and share one `bun test` process between suites. That is a
+      # real thing to fix and it is not this change: this one stops the floor
+      # moving so the fix can be measured against something.
+      #
+      # 1.3.14 is not a guess. It is what `latest` meant on the 17th, which is
+      # the last run of this workflow that was green.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       - name: Install
         run: bun install --frozen-lockfile
       # The mark lives in seven places — a standalone SVG, the favicon, a React
@@ -124,9 +139,13 @@ jobs:
       # An action tag guessed wrong fails the job before a single step runs,
       # which is a worse trade than trusting the image for a version floor
       # nothing here is near.
+      # Pinned for the reason the build job above is, and to the same version.
+      # This job passes under 1.4.0 today, which is exactly why it is pinned:
+      # two jobs on two different bun versions is a difference nobody chose and
+      # nobody would think to look for.
       - uses: oven-sh/setup-bun@v2
         with:
-          bun-version: latest
+          bun-version: 1.3.14
       # `npm ci` and not `npm install`: the lockfile is the point. Its
       # postinstall runs scripts/build-terminal-engine.mjs and
       # build-terminal-font.mjs, which write src/terminal/engine.generated.ts


### PR DESCRIPTION
## What does this PR do?

Pins `bun-version` to `1.3.14` in both CI jobs, replacing `latest`. `main` has been red since 20 August and nothing in the tree caused it.

`latest` is resolved fresh on every run. bun 1.4.0 was published at **2026-08-20 14:14 UTC**; the first red run on `main` started at **16:08** the same day, under two hours later. The last green run of this workflow is the **17th**, when `latest` still meant 1.3.14.

`1.3.14` is not a preference — it is what `latest` meant on the last green run, which makes this a revert of an upgrade nobody asked for rather than a version somebody picked.

Both jobs are pinned, **including `mobile`, which is currently passing**. Two jobs on two bun versions is a difference nobody chose and nobody would think to look for when the next thing goes strange.

### What this does *not* do

It does not fix the nine failing tests, and is not meant to. They are all timeouts rather than wrong answers, in two files (`server/test/transcript-tail.test.ts`, `server/test/db-second-scanner.test.ts`) that spawn child processes and share one `bun test` process between suites — the shape of a latent race that a faster or slower runtime *exposes* rather than causes. Both files carry comments from earlier rounds of exactly that. Worth fixing on its own terms, against a floor that is holding still.

## How was it tested?

The control is what settles it, and it is a re-run rather than an argument:

- Re-ran the CI of **#531** — a commit from the 17th, not one byte changed, on the `ci.yml` of the time. It **passed on 17 August and fails today**, with the same nine tests, and the suite takes **383s against 292s** then. A commit cannot regress while sitting still.
- That control also clears **#529** (`ci: use locked installs and local web build`), which merged the same afternoon and is the obvious suspect: #531's branch predates it and uses the older workflow.
- The three open PRs (#531, #532, #534) are all red for this reason and none of them for their own diff.
- YAML re-parsed after the edit; both jobs confirmed resolving to `1.3.14`.

**Result: `build` is green here in 290s**, against 383s red on the same tree under 1.4.0 — and 292s on the last green run of 17 August. The nine tests pass untouched, which is the point: there was no regression to fix.