### PR TITLE
fix(build): re-sign the app after flipping its fuses

### DIFF
--- a/electron/package.json
+++ b/electron/package.json
@@ -29,6 +29,7 @@
       "output": "dist-app"
     },
     "electronFuses": {
+      "resetAdHocDarwinSignature": true,
       "runAsNode": false,
       "enableNodeCliInspectArguments": false,
       "enableNodeOptionsEnvironmentVariable": false

--- a/server/test/desktop-fuses.test.ts
+++ b/server/test/desktop-fuses.test.ts
@@ -51,11 +51,36 @@ const pkg = JSON.parse(readFileSync(resolve(ELECTRON_DIR, "package.json"), "utf8
 
 describe("electron fuses", () => {
   it("shuts the three doors that turn the app into a Node runtime", () => {
-    expect(pkg.build.electronFuses).toEqual({
+    // The signing directive below is not a door and is checked on its own; what
+    // is asserted here is that the doors are exactly these three and all shut,
+    // so a FOURTH one appearing still fails rather than passing unnoticed.
+    const { resetAdHocDarwinSignature: _resign, ...doors } = pkg.build.electronFuses;
+    expect(doors).toEqual({
       runAsNode: false,
       enableNodeCliInspectArguments: false,
       enableNodeOptionsEnvironmentVariable: false,
     });
+  });
+
+  it("re-signs the app after flipping them, or macOS arm64 will not start it", () => {
+    /*
+     * Shutting the doors is what BROKE the app on Apple Silicon for four
+     * releases (#517). Flipping a fuse rewrites bytes inside the Electron
+     * Framework, which invalidates the signature covering that page; Apple
+     * Silicon validates pages as they are first read, and the kernel kills the
+     * process. The crash was in `electron::fuses::IsRunAsNodeEnabled()` — it
+     * died reading the very fuse this file exists to set, before main.js ran.
+     *
+     * electron-builder signs after flipping, but skips signing entirely when
+     * there is no identity, and this project has none. This flag is what makes
+     * @electron/fuses re-apply an ad-hoc signature itself, and unset it does
+     * nothing at all.
+     *
+     * Pinned for the same reason as the fuses: it is invisible. Nothing about
+     * the config looks wrong without it, and the only symptom is on hardware
+     * neither CI nor most contributors have.
+     */
+    expect(pkg.build.electronFuses.resetAdHocDarwinSignature).toBe(true);
   });
 
   it("is built by a toolchain that understands the key", () => {


### PR DESCRIPTION
## What does this PR do?

One line: `resetAdHocDarwinSignature: true` in the `electronFuses` block.

**Refs #517, and deliberately does not close it.** Nobody has opened this build on an Apple Silicon machine — not CI, which can produce a dmg but cannot tell us it launches, and not me, diagnosing this from Linux. The issue stays open until somebody with the hardware confirms the app starts. A fix that closes the bug it has not been shown to fix is how this one got four releases deep.

The macOS arm64 desktop app has crashed on launch since **0.9.0**, and **0.11.0 is affected too** — the report predates it, but the config is identical. 0.8.0 is the last good one, and it is the release before `electronFuses` was added.

The crash report names the frame:

```
Exception Type:      EXC_BAD_ACCESS (SIGKILL (Code Signature Invalid))
Termination Reason:  Namespace CODESIGNING, Code 2, Invalid Page

0  Electron Framework  electron::fuses::IsRunAsNodeEnabled() + 4
1  agentglass
2  dyld                start + 6992
```

It dies *reading the fuse*, before `main.js` runs at all.

Flipping a fuse rewrites bytes inside the Electron Framework's `__TEXT`, which invalidates the signature covering that page. Apple Silicon validates pages as they are first read, and the kernel kills the process when one does not match — hence "Invalid Page". Intel does not enforce this, which is why it looked like an arm64 bug rather than a signing one. It is also why `xattr -dr com.apple.quarantine` did not help the reporter: that clears quarantine, not a broken signature.

electron-builder flips the fuses and then signs — its own comment says they *"MUST be flipped right before signing"* — but signing is skipped when there is no identity, and this project has none: `mac` sets only `target` and `icon`, no certificate is configured, and `desktop-binaries.yml` does not sign. So the rewritten binary keeps the stale signature it shipped with.

`resetAdHocDarwinSignature` exists for exactly that case. electron-builder passes the value straight through to `@electron/fuses`, which with it true runs `codesign --sign - --force --preserve-metadata=entitlements,requirements,flags,runtime --deep` over the bundle after the flip. Left unset it does nothing at all.

### Does anything else break the seal further along?

Worth asking, since the same failure could return one step later. It does not, and the ordering is the reason. From `platformPackager.js`:

```
copyFiles(extraResourceMatchers)   ← the sidecar, tmux, task, web/dist, hooks
copyFiles(extraFileMatchers)
sanityCheckPackage
doAddElectronFuses                 ← flip, then codesign --deep the whole .app
doSignAfterPack                    ← skipped: no identity
```

Everything the app bundles is already in place when the re-sign runs, so the same pass seals it, and `--deep` covers the nested frameworks including the one holding the fuse. Nothing modifies the bundle afterwards — building the dmg does not touch its contents. This matters more for 0.11.0 than for the versions in the report: 0.11.0 is the first release to bundle its own `tmux` and `task`, so it carries more nested code than anything the reporter tried.

## How was it tested?

**Not on hardware, and that is the caveat that matters.** This was diagnosed on Linux, from the crash report and from the two libraries' own source:

- `app-builder-lib@26.15.3` — confirmed it passes `resetAdHocDarwinSignature` through verbatim, and confirmed the pack ordering quoted above.
- `@electron/fuses` — confirmed the flag is what gates the `codesign` call, and read the exact argv it runs, `--deep` included.
- Confirmed the mac jobs run on `macos-14`, so `codesign` is present on the runner.
- Confirmed `v0.11.0`'s `electron/package.json` carries the same block with the flag absent.

`desktop-binaries.yml` has `workflow_dispatch`, so an arm64 dmg can be built from this branch and handed to somebody with the hardware before any release is cut. That is the step this needs, and CI going green here is not a substitute for it.