### PR TITLE
fix(build): the macOS desktop binaries build again

### DIFF
--- a/scripts/build-tmux-static.sh
+++ b/scripts/build-tmux-static.sh
@@ -187,12 +187,25 @@ verify() { # file name
   fi
 }
 
+# ARCHFLAG belongs here as much as it does to ncurses and tmux, and its absence
+# is what kept the x64 mac build red after everything else was fixed. That job
+# cross-builds for Intel on an arm64 runner: ncurses and tmux were told `-arch
+# x86_64` and libevent was not, so libevent came out arm64 while the tmux
+# linking against it came out x86_64. configure finds the header and then fails
+# the link test, and reports the confusing half of that:
+#
+#     configure:6014: checking for event2/event.h
+#     configure:6014: result: yes
+#     configure:6036: error: "libevent not found"
+#
+# The arm64 job never noticed, because there ARCHFLAG and the host agree and a
+# libevent built with no -arch at all comes out right by coincidence.
 build_libevent() {
   local t="$(fetch libevent.tar.gz "$LIBEVENT_URL")"
   verify "$t" "libevent-${LIBEVENT_VERSION}-stable.tar.gz"
   tar -xzf "$t" -C "$WORK/src"
   ( cd "$WORK/src/libevent-${LIBEVENT_VERSION}-stable"
-    CC="$CC" ./configure $HOSTFLAG --prefix="$WORK/prefix" --disable-shared --enable-static --disable-openssl --disable-samples --disable-libevent-regress >/dev/null
+    CC="$CC" CFLAGS="-O2 $ARCHFLAG" LDFLAGS="$ARCHFLAG" ./configure $HOSTFLAG --prefix="$WORK/prefix" --disable-shared --enable-static --disable-openssl --disable-samples --disable-libevent-regress >/dev/null
     make -s -j"$(jobs_n)" && make -s install )
 }
 

--- a/scripts/build-tmux-static.sh
+++ b/scripts/build-tmux-static.sh
@@ -101,7 +101,45 @@ WORK="$(mktemp -d /tmp/tmux-build.XXXXXX)"
 # cannot create executables" and puts the actual reason in config.log, which the
 # trap was deleting a millisecond later — two builds were guessed at before
 # anybody could read one.
-[ "${KEEP_WORK:-0}" = "1" ] || trap 'rm -rf "$WORK"' EXIT
+#
+# KEEP_WORK only helps somebody standing at the machine, and nobody is: this
+# runs on a CI runner that is destroyed either way. So on a failing exit the
+# reason is PRINTED, at the very end of the output, before anything is removed.
+# That end is the part a log reader can reach — the GitHub API returns the tail
+# of a job and nothing else, so a reason buried in the middle of a 2000-line
+# build is a reason nobody outside the web UI can read. Two rounds of this were
+# spent asking a human to copy the error out of a browser.
+dump_reason() {
+  status=$?
+  [ "$status" = "0" ] && return 0
+  echo "" >&2
+  echo "=== build failed (exit $status) — the last configure that ran ===" >&2
+  # Newest config.log under the work tree: the one that just failed. `find`
+  # rather than a fixed path because it may be libevent's, ncurses' or tmux's.
+  log="$(find "$WORK" -name config.log -type f 2>/dev/null | xargs ls -t 2>/dev/null | head -1)"
+  if [ -n "$log" ]; then
+    echo "--- $log ---" >&2
+    # The reason first, and by name. A config.log ENDS with the confdefs dump
+    # and `configure: exit 1`, so its tail is a list of HAVE_* defines and not
+    # the failure — printing forty lines of it says everything except why. The
+    # "configure: error:" line is where the failure actually is, and it sits in
+    # the middle, so go and get it with the lines that led up to it.
+    # `configure:1234: error: ...` — the line number sits in the middle, so the
+    # obvious pattern "configure: error" matches nothing. Found by testing this
+    # against a config.log shaped like a real one rather than by reading it.
+    if grep -qE "^configure:[0-9]+: error:" "$log"; then
+      grep -nE -B8 "^configure:[0-9]+: error:" "$log" | tail -30 >&2
+    else
+      echo "(no configure error line — the last 30 lines instead)" >&2
+      tail -30 "$log" >&2
+    fi
+  else
+    echo "(no config.log — it did not get as far as configure)" >&2
+  fi
+  echo "=== end of failure detail ===" >&2
+  return 0
+}
+[ "${KEEP_WORK:-0}" = "1" ] || trap 'dump_reason; rm -rf "$WORK"' EXIT
 echo "work dir: $WORK"
 mkdir -p "$WORK/src" "$WORK/prefix" "$WORK/bin"
 

--- a/scripts/build-tmux-static.sh
+++ b/scripts/build-tmux-static.sh
@@ -247,8 +247,41 @@ else
   echo "  cross-built for $TARGET — not run here"
 fi
 file "out/tmux-$TARGET" | sed 's/^/  /'
-case "$(file -b "out/tmux-$TARGET")" in
-  *"statically linked"*) ;;
-  *) echo "NOT STATIC — this would depend on the host's libc" >&2; exit 1 ;;
+
+# What "static enough" means, which is not the same sentence on both platforms.
+#
+# The property this build actually needs is that the binary runs on a machine
+# that has no tmux, no libevent and no ncurses — those three are built here as
+# .a archives and linked in. It is NOT "depends on nothing at all".
+#
+#   linux  — `-static` really does take libc too, and `file` says so. The string
+#            is the proof, and it stays the check.
+#   darwin — there is no static libSystem and the linker refuses to pretend
+#            otherwise, which is why LDMODE drops `-static` there (see the case
+#            near the top, and #531). `file` therefore never says "statically
+#            linked" on a Mach-O, and this check demanded it anyway: the mac
+#            builds compiled a working tmux, ran it, printed `tmux 3.5a`, and
+#            then failed on their own verification. So ask otool what is
+#            actually linked and require all of it to be the system's.
+case "$TARGET" in
+  *darwin*)
+    deps="$(otool -L "out/tmux-$TARGET" | tail -n +2 | awk '{print $1}')"
+    echo "$deps" | sed 's/^/  links: /'
+    # Anything outside /usr/lib and /System is a library the user would have to
+    # already have — libevent and ncursesw are the ones this script builds, and
+    # seeing either here means the .a archives were not the thing that got used.
+    stray="$(echo "$deps" | grep -vE '^(/usr/lib/|/System/Library/)' || true)"
+    if [ -n "$stray" ]; then
+      echo "NOT SELF-CONTAINED — links libraries the user may not have:" >&2
+      echo "$stray" | sed 's/^/  /' >&2
+      exit 1
+    fi
+    ;;
+  *)
+    case "$(file -b "out/tmux-$TARGET")" in
+      *"statically linked"*) ;;
+      *) echo "NOT STATIC — this would depend on the host's libc" >&2; exit 1 ;;
+    esac
+    ;;
 esac
 echo "built out/tmux-$TARGET"

--- a/scripts/build-tmux-static.sh
+++ b/scripts/build-tmux-static.sh
@@ -203,13 +203,26 @@ build_tmux() {
     #   -static on the linker line (not -static-libgcc): everything in, no
     #     dependency on the host's libc either. `-s` strips at link time — the
     #     unstripped binary carries megabytes of DWARF into the app's download.
+    #   --disable-utf8proc — darwin's configure refuses to guess and stops with
+    #     "must give --enable-utf8proc or --disable-utf8proc", which is where
+    #     both mac jobs of the v0.12.0 tag died once the ncurses fixes let them
+    #     reach it. Linux does not ask and settles on disabled anyway, so this
+    #     says out loud on every platform what one of them was already doing.
+    #     Enabling it would mean vendoring a third library.
+    #
+    #     It goes on the ./configure line and NOT here: every line in this block
+    #     ends in a backslash, so a comment placed among them is joined onto the
+    #     assignment above it and swallows the rest — configure then runs on its
+    #     own with none of these flags, finds neither libevent nor ncurses, and
+    #     the linux build that had been passing breaks. `bash -n` reads that as
+    #     valid, because it is; it is just not the command anybody wrote.
     ac_cv_search_forkpty="none required" \
     CC="$CC" \
     CFLAGS="-O2 $ARCHFLAG -I$WORK/prefix/include -I$WORK/prefix/include/ncursesw -DHAVE_PROC_PID" \
     CPPFLAGS="-I$WORK/prefix/include -I$WORK/prefix/include/ncursesw" \
     LDFLAGS="-L$WORK/prefix/lib $ARCHFLAG $LDMODE" \
     LIBS="-levent_core -levent -lncursesw $TINFO_LDLIB -lm" \
-    ./configure $HOSTFLAG --prefix="$WORK/prefix" >/dev/null
+    ./configure $HOSTFLAG --disable-utf8proc --prefix="$WORK/prefix" >/dev/null
     make -s -j"$(jobs_n)" )
   file "$WORK/src/tmux-${TMUX_VERSION}/tmux"
 }

--- a/server/test/shell-continuations.test.ts
+++ b/server/test/shell-continuations.test.ts
@@ -1,0 +1,68 @@
+/*
+ * No comment sits inside a backslash-continued command in the build scripts.
+ *
+ * This is a silent one, and it cost a working build. `build-tmux-static.sh`
+ * configures tmux with a long run of environment assignments, every line ending
+ * in a backslash:
+ *
+ *     CFLAGS="…" \
+ *     LIBS="…" \
+ *     ./configure … 
+ *
+ * A comment added among those lines does not document them. The backslash joins
+ * it onto the assignment above, the `#` swallows the rest of that line, and
+ * `./configure` is left to run on its own — with none of the flags, finding
+ * neither libevent nor ncurses. The linux build had been green for months and
+ * broke on exactly this, in a change whose only intent was to add one flag.
+ *
+ * `bash -n` does not see it, and that is the point of testing it here: the file
+ * is still valid shell. It simply is not the command anybody wrote, and nothing
+ * says so until a build that was passing stops.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+
+/** The scripts that build what the app ships. Named rather than globbed: a new
+ *  one should be added here deliberately, having been read. */
+const SCRIPTS = [
+  "scripts/build-tmux-static.sh",
+  "scripts/build-task-static.sh",
+];
+
+describe("build scripts", () => {
+  for (const rel of SCRIPTS) {
+    test(`${rel} has no comment inside a continued command`, () => {
+      const lines = readFileSync(join(ROOT, rel), "utf8").split("\n");
+      const bad: string[] = [];
+      for (let i = 1; i < lines.length; i++) {
+        const before = lines[i - 1] ?? "";
+        // A line continued with a backslash, followed by a comment: the two are
+        // one line by the time the shell reads them.
+        if (/\\\s*$/.test(before) && /^\s*#/.test(lines[i] ?? "")) {
+          bad.push(`${rel}:${i + 1}: ${(lines[i] ?? "").trim().slice(0, 60)}`);
+        }
+      }
+      expect(
+        bad,
+        "a comment here is joined onto the line above by its backslash and "
+        + "comments out the rest of the command. Put it above the whole block.",
+      ).toEqual([]);
+    });
+  }
+
+  test("the tmux configure still carries the flags it needs", () => {
+    // The failure above is invisible in the diff but very visible here: if the
+    // assignments stop reaching configure, these are what go missing.
+    const sh = readFileSync(join(ROOT, "scripts/build-tmux-static.sh"), "utf8");
+    const block = /ac_cv_search_forkpty=[\s\S]*?\.\/configure[^\n]*/.exec(sh)?.[0] ?? "";
+    expect(block, "the configure invocation was not found").not.toBe("");
+    for (const flag of ["CFLAGS=", "CPPFLAGS=", "LDFLAGS=", "LIBS=", "--prefix="]) {
+      expect(block, `${flag} no longer reaches configure`).toContain(flag);
+    }
+    // Darwin's configure stops without an explicit answer on this one.
+    expect(block).toContain("--disable-utf8proc");
+  });
+});

--- a/server/test/shell-continuations.test.ts
+++ b/server/test/shell-continuations.test.ts
@@ -53,6 +53,35 @@ describe("build scripts", () => {
     });
   }
 
+  test("every vendored library is built for the target architecture", () => {
+    /*
+     * The mac x64 job cross-builds for Intel on an arm64 runner, so each
+     * dependency has to be told `-arch x86_64` or it comes out as the host's.
+     * ncurses and tmux were told; libevent was not, so it built arm64 while the
+     * tmux linking against it built x86_64. What configure reports for that is
+     * the confusing half — the header is found and the link test fails:
+     *
+     *     checking for event2/event.h ... yes
+     *     error: "libevent not found"
+     *
+     * The arm64 job cannot catch this: there the host and the target agree, so
+     * a library built with no -arch at all is right by coincidence. Only the
+     * cross-build notices, and only at the link, three functions later.
+     */
+    const sh = readFileSync(join(ROOT, "scripts/build-tmux-static.sh"), "utf8");
+    const missing: string[] = [];
+    for (const line of sh.split("\n")) {
+      if (!/^\s*(CC=|CFLAGS=).*\.\/configure/.test(line)) continue;
+      if (!line.includes("$ARCHFLAG")) missing.push(line.trim().slice(0, 70));
+    }
+    expect(
+      missing,
+      "this configure runs without $ARCHFLAG, so on a cross-build it produces "
+      + "a library for the wrong architecture and the failure surfaces later, "
+      + "as a link error in something else.",
+    ).toEqual([]);
+  });
+
   test("the tmux configure still carries the flags it needs", () => {
     // The failure above is invisible in the diff but very visible here: if the
     // assignments stop reaching configure, these are what go missing.


### PR DESCRIPTION
## What does this PR do?

Gets the macOS half of `desktop-binaries.yml` building. It has been dead since before #531, which is why **v0.12.0 published with a linux AppImage, a deb and a windows nsis and no dmg at all** — including the one carrying #517's Apple Silicon crash fix, which cannot reach the people it is for while the mac build stops.

**All four jobs are green**, and all four artifacts exist: [run 32778674243](https://github.com/SirAllap/agentglass/actions/runs/32778674243).

Four faults, each hiding the next. Every one was found on a runner, because this script's downloads cannot be made from a container and `bash -n` sees none of them.

**1. `configure` on darwin declines to guess about utf8proc.**

```
configure: error: must give --enable-utf8proc or --disable-utf8proc
```

Disabled rather than enabled: the alternative is vendoring a third library to turn a red build green, against the wcwidth tmux already falls back to. Linux never asked and settles on disabled anyway, so the flag states on every platform what one of them was already doing.

**2. The static check asked darwin a question darwin cannot answer.**

With the flag in, both mac jobs compiled, linked and *ran* tmux — the log has `tmux 3.5a` in it, printed by the binary just built — and then failed on this script's own last assertion:

```
out/tmux-bun-darwin-arm64: Mach-O 64-bit executable arm64
NOT STATIC — this would depend on the host's libc
```

`file` never says "statically linked" about a Mach-O, and never will: there is no static libSystem, which is exactly why #531 dropped `-static` from `LDMODE` on darwin. The link was changed there and the proof of it was not.

It was also the wrong question. What this build needs is not "depends on nothing" but "runs on a machine with no tmux, no libevent and no ncurses" — those three are `.a` archives built here and linked in, and libSystem stays dynamic as it does for every binary on that platform. So darwin is asked with `otool` and required to link nothing outside `/usr/lib` and `/System/Library`. That is stricter than the string was: it names libevent or ncursesw if either appears as a dylib, which would mean the archives were not what got used.

**3. A failing build did not say why, anywhere a log reader could reach.**

The reason sits in the middle of a two-thousand-line build, and the API that reads job logs returns the tail — which is post-job git cleanup. Finding fault 2 cost two rounds of a person opening the job in a browser and copying the error out of it. On a non-zero exit the newest `config.log` under the work tree is now dumped to stderr before anything is removed, grepped for `configure:NNNN: error:` with the lines that led to it.

This fixes nothing on its own. It is what made fault 4 visible.

**4. libevent was built for the runner rather than the target.**

```
configure:6014: checking for event2/event.h
configure:6014: result: yes
configure:6036: error: "libevent not found"
```

Both halves true, and together they name it: the header is found, the link test is not. The x64 job cross-builds for Intel on an arm64 runner, so every dependency must be told `-arch x86_64`. ncurses was told. tmux was told. libevent took `$HOSTFLAG` and nothing else, so it compiled arm64 while the tmux linking against it compiled x86_64.

The arm64 job could never have caught this — there host and target agree, so a libevent built with no `-arch` is right by coincidence. That is precisely why one job went green and the other did not.

### Two guards, both proven against the fault

`server/test/shell-continuations.test.ts`:

- **No comment inside a backslash-continued command.** The first attempt at fault 1 put the explanatory comment among the assignments feeding `configure`. The backslash joins it onto the line above, the `#` swallows the rest, and configure ran with no `CFLAGS`, no `LDFLAGS` and no `LIBS` — **breaking the linux build that had been green for months.** `bash -n` reads that as valid, because it is; it is just not the command anybody wrote.
- **Every `./configure` here carries `$ARCHFLAG`**, so a fourth vendored dependency cannot repeat fault 4.

Both were verified by reintroducing the fault: `bash -n` passes each one, the tests do not.

## How was it tested?

On real runners, which is the only place any of this is visible:

- **Run 32778674243: all four jobs green.** Artifacts `agentglass-bun-darwin-arm64` (151.9 MB), `agentglass-bun-darwin-x64` (158.2 MB), `agentglass-bun-linux-x64`, `agentglass-bun-windows-x64`.
- The darwin `otool` check passed against a real Mach-O rather than against reasoning.
- Linux stayed green throughout, after the one commit that broke it was corrected — that regression is what the first guard exists to prevent.
- Locally: `bash -n`, and the two guards, including their negative cases.

**Not verified:** that the resulting app launches. That is #517's question, and it needs somebody with Apple Silicon to open the dmg. The arm64 artifact above is testable now, without merging anything.

### After this merges

v0.12.0 is already published without macOS assets. Either re-run `desktop-binaries` against the `v0.12.0` tag — the "Attach to release" step keys off the tag — or cut a v0.12.1. Worth deciding deliberately rather than by whichever happens first.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CukDHvByYbLYswQPPAz6sQ)_