### PR TITLE
The phone finishes the work instead of starting it

### DIFF
--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -34,7 +34,8 @@ import type { InboxGroup, InboxItem } from "../../src/model/inbox.ts";
 import {
   ChevronIcon, InboxIcon, IssuesIcon, PrsIcon, ReposIcon, TasksIcon, TerminalIcon,
 } from "../../src/nav/icons.tsx";
-import { BAR } from "../../src/nav/bar.ts";
+import { BAR, taskDestinations } from "../../src/nav/bar.ts";
+import { useTracksWork } from "../../src/state/use-tracks-work.ts";
 import { Card, Label, Note, TAP, groupEdge } from "../../src/ui.tsx";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
 
@@ -146,6 +147,11 @@ const DESTINATIONS = [
   { route: "repos" as const, label: "Source control" },
 ];
 
+/* Cards is dropped on a machine that tracks work nowhere — see
+   `taskDestinations` in src/nav/bar.ts for what "nowhere" means and why
+   unknown is not it. Nothing takes its place: this is a list, not the
+   five-slot bar it came from. */
+
 const ICONS = {
   prs: PrsIcon,
   terminal: TerminalIcon,
@@ -170,6 +176,10 @@ export default function InboxScreen(): React.ReactNode {
   const router = useRouter();
   const inbox = useInbox();
   const [pulling, setPulling] = useState(false);
+  /* Asked once per machine and held for a minute — the hook's own file says
+     why it is not a fetch inside this component. Null while it is unknown,
+     which draws every destination. */
+  const destinations = taskDestinations(DESTINATIONS, useTracksWork(host));
 
   const reload = inbox.reload;
   const onRefresh = useCallback((): void => {
@@ -329,7 +339,7 @@ export default function InboxScreen(): React.ReactNode {
           */}
           <View style={{ gap: SPACE.sm }}>
             <Label text="Go to" />
-            {DESTINATIONS.map((dest, i) => {
+            {destinations.map((dest, i) => {
               const Icon = ICONS[dest.route as keyof typeof ICONS];
               const count = COUNTS[dest.route]?.(inbox.counts);
               return (
@@ -339,7 +349,7 @@ export default function InboxScreen(): React.ReactNode {
                   accessibilityRole="button"
                   accessibilityLabel={dest.label ?? dest.route}
                   style={({ pressed }) => [
-                    groupEdge(i === 0, i === DESTINATIONS.length - 1),
+                    groupEdge(i === 0, i === destinations.length - 1),
                     {
                       flexDirection: "row", alignItems: "center", gap: SPACE.md,
                       paddingHorizontal: SPACE.lg, minHeight: TAP,
@@ -370,8 +380,13 @@ export default function InboxScreen(): React.ReactNode {
           <Card>
             <Label text="Clear" />
             <Note>
-              No pull request, issue or card is waiting on you. Anything an agent is doing is in
-              the terminal.
+              {/* The list of what was checked has to match what was actually
+                  checked. On a machine with no tracker there are no cards to
+                  have looked at, and naming them here is the same false
+                  reassurance the Cards screen used to give — it says something
+                  was searched that never existed. */}
+              No pull request{destinations.some((d) => d.route === "tasks") ? ", issue or card" : " or issue"} is
+              waiting on you. Anything an agent is doing is in the terminal.
             </Note>
           </Card>
         )

--- a/mobile/app/(tabs)/tasks.tsx
+++ b/mobile/app/(tabs)/tasks.tsx
@@ -21,6 +21,7 @@ import type { ProviderTask } from "../../../shared/providers.ts";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
+import { useTracksWork } from "../../src/state/use-tracks-work.ts";
 import { Card, HeaderPick, Label, Note, Segmented, Sheet, SheetRow, groupEdge } from "../../src/ui.tsx";
 import { dueIn } from "../../src/lib/dates.ts";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
@@ -111,6 +112,10 @@ export default function TasksScreen(): React.ReactNode {
   const [pulling, setPulling] = useState(false);
   const [said, setSaid] = useState<string | null>(null);
   const [openOnly, setOpenOnly] = useState(true);
+  /* Whether this machine tracks work anywhere. The Inbox uses the same answer
+     to decide whether to offer this screen at all; here it decides which of
+     three things an empty list means. */
+  const tracking = useTracksWork(host);
 
   useEffect(() => {
     if (!host) return;
@@ -211,9 +216,24 @@ export default function TasksScreen(): React.ReactNode {
         ListEmptyComponent={
           tasks === null ? null : (
             <Card>
-              <Label text={error ? "Cannot read the board" : "Nothing here"} />
+              {/*
+                Three states, where there were two.
+
+                "No board is connected" used to be drawn as "this view has no
+                cards that are still open", which asserts two things that are
+                both false on a machine with no tracker: that there is a board,
+                and that it is empty. Somebody reading it would go looking for
+                a filter.
+              */}
+              <Label
+                text={error ? "Cannot read the board" : tracking === false ? "No board here" : "Nothing here"}
+              />
               <Note tone={error ? "bad" : "quiet"}>
-                {error ?? "This view has no cards that are still open. The switch above shows the rest."}
+                {error
+                  ?? (tracking === false
+                    ? "This computer is not connected to a task tracker, so there are no cards to show. "
+                      + "It is connected at the computer, in Settings, not from here."
+                    : "This view has no cards that are still open. The switch above shows the rest.")}
               </Note>
             </Card>
           )

--- a/mobile/app/card/[id].tsx
+++ b/mobile/app/card/[id].tsx
@@ -14,6 +14,14 @@
  * answer gates does not get either. The controls are not drawn rather than
  * drawn and refused, which is the rule repos.tsx set.
  *
+ * ── the hand-off asks two things, and this is the second ─────────────────
+ * WHAT first, then WHERE. A card handed over used to carry one prompt — its id
+ * and its title — which is the right default and is not what you want most of
+ * the time: you have skills that take a card, and naming one is the difference
+ * between "here is a card" and "fix this card". They are matched rather than
+ * listed, in shared/cardSkills.ts, because a hand-kept list is wrong the first
+ * time somebody writes another one.
+ *
  * ── why the hand-off asks which checkout ─────────────────────────────────
  * A card is not a checkout. The desktop maps a ClickUp list to a local
  * repository with `rootForTask`, using where the panel is open as a hint —
@@ -28,12 +36,13 @@ import {
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
 import type { ProviderTask } from "../../../shared/providers.ts";
-import type { GitRepoRef } from "../../../shared/types.ts";
+import type { GitRepoRef, SkillInfo } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { requestHandoff } from "../../src/terminal/handoff.ts";
 import { mainCheckouts } from "../../src/model/prRows.ts";
+import { cardSkills, namedForIt, skillCommand, skillModes, windowName } from "../../../shared/cardSkills.ts";
 import { dueIn } from "../../src/lib/dates.ts";
 import { Btn, Card, Label, Note, Sheet, SheetRow, TAP, Toggle } from "../../src/ui.tsx";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
@@ -48,13 +57,6 @@ function statusInk(color?: string): string {
   return color && color !== "#ffffff" ? color : C.text3;
 }
 
-/** A tmux window name that says which card it is and survives `tmux ls`.
- *  tmux treats a dot as a pane separator in target strings, so a window named
- *  with one cannot be selected by name later. */
-function windowName(card: ProviderTask): string {
-  const raw = (card.customId || card.id).toLowerCase();
-  return raw.replace(/[^a-z0-9-]/g, "").slice(0, 24) || "card";
-}
 
 export default function CardScreen(): React.ReactNode {
   usePaletteTick(); // a scene repaints only if it asks — see use-palette.ts
@@ -70,6 +72,19 @@ export default function CardScreen(): React.ReactNode {
   const [said, setSaid] = useState<{ ok: boolean; text: string } | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
   const [handing, setHanding] = useState(false);
+  /*
+   * The skills that take a card, and which one was picked.
+   *
+   * Null until `/skills` answers; an empty array is a real answer and means
+   * this machine has none that mention a card, which is worth saying rather
+   * than showing an empty list. `picked` null means the old behaviour — the
+   * card's id and title as the prompt — and it stays the first row, because it
+   * is the right thing to send when you have not decided what to do yet.
+   */
+  const [skills, setSkills] = useState<SkillInfo[] | null>(null);
+  const [picking, setPicking] = useState(false);
+  const [picked, setPicked] = useState<{ skill: SkillInfo; mode?: string } | null>(null);
+  const [find, setFind] = useState("");
   const [say, setSay] = useState("");
 
   const load = useCallback(async (): Promise<void> => {
@@ -200,25 +215,73 @@ export default function CardScreen(): React.ReactNode {
     await load();
   }, [host, card, load]);
 
-  /** Leave the window request and go to the terminal. The text is the card —
-   *  its id and its title — which is what the desktop's own row hand-off
-   *  sends, and the id is the HUMAN one because that is what every skill,
-   *  branch name and commit message here is written against. */
+  /* Asked once the card is on screen, not on opening the sheet: the list is a
+     hundred-odd entries on a real machine and filtering it is instant, but
+     fetching it while somebody watches a sheet appear is a sheet that appears
+     empty. A failure leaves it null and the sheet says so — the plain hand-off
+     does not depend on this and stays available either way. */
+  useEffect(() => {
+    if (!host || !card) return;
+    let gone = false;
+    void (async () => {
+      const answer = await ask<{ skills?: SkillInfo[] }>(host, "/skills");
+      if (gone) return;
+      setSkills(answer.ok ? cardSkills(answer.value.skills ?? []) : null);
+    })();
+    return () => { gone = true; };
+  }, [host, card]);
+
+  /**
+   * Leave the window request and go to the terminal.
+   *
+   * The text is either the card — its id and its title, which is what the
+   * desktop's own row hand-off sends — or a skill invoked on it. The id is the
+   * HUMAN one in both cases, because that is what every skill, branch name and
+   * commit message here is written against, and handing over the internal id
+   * instead fails in the least useful way there is: the card exists and the
+   * tool cannot find it.
+   *
+   * `skillCommand` is shared with the desk rather than spelled again here. The
+   * shape of that line — `/name ID`, and a mode after it — is what the skills
+   * were written against and what their own descriptions quote.
+   */
   const hand = useCallback((repo: GitRepoRef): void => {
     if (!card) return;
     const label = card.customId || card.id;
+    const command = picked
+      ? `${skillCommand(picked.skill.name, card)}${picked.mode ? ` ${picked.mode}` : ""}`
+      : `${label} — ${card.title}`;
     requestHandoff({
       t: "tmux",
       cmd: "issue",
       cwd: repo.root,
       name: windowName(card),
-      prompt: `${label} — ${card.title}`,
+      prompt: command,
       agent: true,
       title: card.title,
     });
     setHanding(false);
+    setPicking(false);
     router.push("/terminal");
-  }, [card, router]);
+  }, [card, picked, router]);
+
+  /* The search, over name and description both — the same two fields the
+     matcher itself reads, so a skill found by its description is findable by
+     the same words here. */
+  const shownSkills = useMemo(() => {
+    const q = find.trim().toLowerCase();
+    if (!q) return skills ?? [];
+    return (skills ?? []).filter(
+      (s) => s.name.toLowerCase().includes(q) || (s.description ?? "").toLowerCase().includes(q),
+    );
+  }, [skills, find]);
+
+  /** The gears the picked skill advertises, if any. Read from its own
+   *  invocation line rather than from a list kept here — see cardSkills.ts. */
+  const pickedModes = useMemo(
+    () => (picked ? skillModes(picked.skill.argument_hint) : []),
+    [picked],
+  );
 
   const when = useMemo(() => (card ? dueIn(card.due, new Date()) : null), [card]);
   // A card is never moved to the status it is already in — the picker offers
@@ -386,9 +449,101 @@ export default function CardScreen(): React.ReactNode {
           paddingHorizontal: SPACE.lg, paddingTop: SPACE.md, paddingBottom: SPACE.lg,
           borderTopWidth: 1, borderTopColor: C.border, backgroundColor: C.bg2,
         }}>
-          <Btn label="✦ Hand to Claude" tone="primary" onPress={() => setHanding(true)} />
+          <Btn
+            label="✦ Hand to Claude"
+            tone="primary"
+            onPress={() => { setFind(""); setPicking(true); }}
+          />
         </View>
       ) : null}
+
+      {/* WHAT, before WHERE. The order is the point: the checkout is a detail of
+          running it and the instruction is the decision. */}
+      <Sheet open={picking} onClose={() => setPicking(false)} title="What should it do?">
+        <SheetRow
+          label="Just hand it the card"
+          sub={card ? `${card.customId || card.id} — ${card.title}` : undefined}
+          on={picked === null}
+          onPress={() => { setPicked(null); setPicking(false); setHanding(true); }}
+        />
+
+        {skills === null ? (
+          <View style={{ paddingTop: SPACE.md }}>
+            <Note>Reading your skills from the computer…</Note>
+          </View>
+        ) : null}
+
+        {skills?.length === 0 ? (
+          <View style={{ paddingTop: SPACE.md }}>
+            <Note>
+              No skill on that computer mentions a card. The row above still works, and so does
+              writing the instruction yourself once the window is open.
+            </Note>
+          </View>
+        ) : null}
+
+        {skills?.length ? (
+          <>
+            <View style={{ paddingTop: SPACE.md, paddingBottom: SPACE.sm }}>
+              <TextInput
+                value={find}
+                onChangeText={setFind}
+                placeholder={`Search ${skills.length} skills`}
+                placeholderTextColor={C.text4}
+                autoCapitalize="none"
+                autoCorrect={false}
+                style={{
+                  minHeight: TAP, borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.md,
+                  backgroundColor: C.bg, color: C.text, paddingHorizontal: SPACE.md, fontSize: T.body,
+                }}
+              />
+            </View>
+            {shownSkills.map((skill) => (
+              <SheetRow
+                key={skill.name}
+                label={`/${skill.name}`}
+                /* The description, because a name is not enough to choose by —
+                   and the group, because "named for a card" and "mentions one"
+                   are different levels of confidence and the menu should not
+                   pretend otherwise. */
+                sub={[namedForIt(skill) ? "takes a card" : "mentions cards", skill.description]
+                  .filter(Boolean).join(" · ")}
+                on={picked?.skill.name === skill.name}
+                onPress={() => {
+                  const modes = skillModes(skill.argument_hint);
+                  setPicked({ skill });
+                  // A skill with gears asks which one; one without goes
+                  // straight on to the checkout.
+                  if (!modes.length) { setPicking(false); setHanding(true); }
+                }}
+              />
+            ))}
+            {shownSkills.length === 0 ? (
+              <View style={{ paddingTop: SPACE.md }}><Note>Nothing matches that.</Note></View>
+            ) : null}
+          </>
+        ) : null}
+
+        {/* The gears a skill advertises, from its own invocation line. Shown
+            only once one is picked, because they belong to it. */}
+        {pickedModes.length ? (
+          <View style={{ paddingTop: SPACE.lg, gap: SPACE.xs }}>
+            <Label text={`How should /${picked!.skill.name} run?`} />
+            {["", ...pickedModes].map((mode) => (
+              <SheetRow
+                key={mode || "default"}
+                label={mode || "as it comes"}
+                on={(picked!.mode ?? "") === mode}
+                onPress={() => {
+                  setPicked({ skill: picked!.skill, mode: mode || undefined });
+                  setPicking(false);
+                  setHanding(true);
+                }}
+              />
+            ))}
+          </View>
+        ) : null}
+      </Sheet>
 
       <Sheet open={handing} onClose={() => setHanding(false)} title="Which checkout?">
         {repos.map((repo) => (
@@ -404,8 +559,13 @@ export default function CardScreen(): React.ReactNode {
             {/* Said out loud because a wrong answer here is expensive and looks
                 right: an agent opened in the wrong project is indistinguishable
                 from one opened in the right one until it edits something. */}
-            A card is not a checkout, so this has to be asked. The window opens in the one you pick,
-            with the card&apos;s id and title as the prompt.
+            A card is not a checkout, so this has to be asked. The window opens in the one you
+            pick, running{" "}
+            <Text style={{ fontFamily: MONO, color: C.text2 }}>
+              {card ? (picked
+                ? `${skillCommand(picked.skill.name, card)}${picked.mode ? ` ${picked.mode}` : ""}`
+                : `${card.customId || card.id} — ${card.title}`) : ""}
+            </Text>.
           </Note>
         </View>
       </Sheet>

--- a/mobile/app/card/[id].tsx
+++ b/mobile/app/card/[id].tsx
@@ -14,6 +14,14 @@
  * answer gates does not get either. The controls are not drawn rather than
  * drawn and refused, which is the rule repos.tsx set.
  *
+ * ── the card has a body, and this screen used to drop it ─────────────────
+ * `/clickup/task` answers with a whole TaskDetail — the description, the
+ * subtasks, the checklists and every comment — and this screen kept the one
+ * field the list rows already carry. It then explained the gap with a comment
+ * saying a card has no description, which was true of `ProviderTask` and false
+ * of what had just been fetched: the most expensive kind of wrong note, one
+ * that reads as a reason and stops anybody looking.
+ *
  * ── the hand-off asks two things, and this is the second ─────────────────
  * WHAT first, then WHERE. A card handed over used to carry one prompt — its id
  * and its title — which is the right default and is not what you want most of
@@ -35,7 +43,7 @@ import {
 } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
-import type { ProviderTask } from "../../../shared/providers.ts";
+import type { CardPr, ProviderTask, TaskDetail } from "../../../shared/providers.ts";
 import type { GitRepoRef, SkillInfo } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
@@ -43,9 +51,30 @@ import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { requestHandoff } from "../../src/terminal/handoff.ts";
 import { mainCheckouts } from "../../src/model/prRows.ts";
 import { cardSkills, namedForIt, skillCommand, skillModes, windowName } from "../../../shared/cardSkills.ts";
-import { dueIn } from "../../src/lib/dates.ts";
+import { dueIn, since } from "../../src/lib/dates.ts";
 import { Btn, Card, Label, Note, Sheet, SheetRow, TAP, Toggle } from "../../src/ui.tsx";
+import { ChevronIcon } from "../../src/nav/icons.tsx";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
+
+/** GitHub's three states, in the colours this app already uses for them.
+ *  Draft is grey rather than green: it is open and it is not asking to be
+ *  merged, which is a different thing to a reader deciding if work is done. */
+function prInk(pr: { state: string; draft?: boolean }): string {
+  if (pr.draft) return C.text4;
+  const state = (pr.state || "").toUpperCase();
+  if (state === "MERGED") return C.primary;
+  if (state === "CLOSED") return C.error;
+  if (state === "OPEN") return C.success;
+  // A pull request named by the card's own field is not searched for, so it
+  // arrives with no state at all. Grey says "we did not ask" rather than
+  // picking one of the three.
+  return C.text4;
+}
+
+/** How much description opens by default. 900 is about a screenful and a half
+ *  at this size — enough that most cards are shown whole and a specification is
+ *  visibly cut rather than silently truncated. */
+const BODY_CAP = 900;
 
 /** One status the card can be moved to, as the list defines it. */
 interface Status { status: string; color?: string; type?: string }
@@ -71,6 +100,24 @@ export default function CardScreen(): React.ReactNode {
   const [error, setError] = useState<string | null>(null);
   const [said, setSaid] = useState<{ ok: boolean; text: string } | null>(null);
   const [busy, setBusy] = useState<string | null>(null);
+  /** Everything on the card that is not the card's own row. Null until the
+   *  first read lands — an empty description and "not read yet" are different
+   *  things and the screen draws them differently. */
+  const [detail, setDetail] = useState<Omit<TaskDetail, "task"> | null>(null);
+  /** Whether the whole description is showing. A ClickUp description is often
+   *  a specification, and a screen that opens on eight hundred words has
+   *  buried the status and the buttons under them. */
+  const [wholeBody, setWholeBody] = useState(false);
+  /*
+   * The pull requests that belong to this card.
+   *
+   * Its own call, and deliberately not part of the card read: `/clickup/prs`
+   * shells out to `gh pr list --search`, which is seconds rather than
+   * milliseconds and fails entirely on a machine with no GitHub CLI. Folding it
+   * into the card read would make a card that cannot be seen at all because a
+   * search for its number timed out.
+   */
+  const [prs, setPrs] = useState<CardPr[] | null>(null);
   const [handing, setHanding] = useState(false);
   /*
    * The skills that take a card, and which one was picked.
@@ -87,9 +134,19 @@ export default function CardScreen(): React.ReactNode {
   const [find, setFind] = useState("");
   const [say, setSay] = useState("");
 
+  /*
+   * `/clickup/task` answers with a whole TaskDetail and this screen used to
+   * keep one field of it.
+   *
+   * The description, the subtasks, the checklists and the comments all arrived
+   * in the same response and were dropped on the floor — and the screen then
+   * carried a comment explaining that a card has no description, which was a
+   * true statement about `ProviderTask` and a false one about what had just
+   * been read. The board's own page was the only place to see any of it.
+   */
   const load = useCallback(async (): Promise<void> => {
     if (!host || !id) return;
-    const answer = await ask<{ ok?: boolean; task?: ProviderTask; error?: string }>(
+    const answer = await ask<{ ok?: boolean; error?: string } & Partial<TaskDetail>>(
       host, `/clickup/task?id=${encodeURIComponent(id)}`,
     );
     if (!answer.ok) { setError(answer.error); return; }
@@ -98,6 +155,12 @@ export default function CardScreen(): React.ReactNode {
       return;
     }
     setError(null);
+    setDetail({
+      description: answer.value.description ?? "",
+      subtasks: answer.value.subtasks ?? [],
+      checklists: answer.value.checklists ?? [],
+      comments: answer.value.comments ?? [],
+    });
     setCard(answer.value.task);
   }, [host, id]);
 
@@ -215,6 +278,23 @@ export default function CardScreen(): React.ReactNode {
     await load();
   }, [host, card, load]);
 
+  /* After the card, and only once it has an id to search for. A failure is
+     left as an empty list rather than an error on the screen: "no pull request
+     mentions this card" and "GitHub could not be asked" look the same to a
+     reader, so the section simply does not appear, and the card is still
+     readable on a machine with no `gh`. */
+  useEffect(() => {
+    if (!host || !card) return;
+    let gone = false;
+    void (async () => {
+      const query = `card=${encodeURIComponent(card.customId || card.id)}`;
+      const answer = await ask<{ ok: boolean; prs?: CardPr[] }>(host, `/clickup/prs?${query}`);
+      if (gone) return;
+      setPrs(answer.ok ? answer.value.prs ?? [] : []);
+    })();
+    return () => { gone = true; };
+  }, [host, card]);
+
   /* Asked once the card is on screen, not on opening the sheet: the list is a
      hundred-odd entries on a real machine and filtering it is instant, but
      fetching it while somebody watches a sheet appear is a sheet that appears
@@ -283,6 +363,27 @@ export default function CardScreen(): React.ReactNode {
     [picked],
   );
 
+  /* ClickUp writes an empty description as "" and sometimes as a lone newline,
+     so the emptiness test is on the trimmed text and the trimmed text is what
+     gets drawn. */
+  const body = (detail?.description ?? "").trim();
+
+  /* Subtasks and checklist items counted as one number, because they are one
+     question — what is left underneath this card. A subtask is done when the
+     board says its status is done; a checklist item when it is ticked. */
+  const under = useMemo(() => {
+    const subs = detail?.subtasks ?? [];
+    const items = (detail?.checklists ?? []).flatMap((c) => c.items);
+    return {
+      all: subs.length + items.length,
+      left: subs.filter((t) => t.statusKind !== "done").length + items.filter((i) => !i.done).length,
+    };
+  }, [detail]);
+  const allOver = under.all;
+  const leftOver = under.left;
+
+  const now = Date.now();
+
   const when = useMemo(() => (card ? dueIn(card.due, new Date()) : null), [card]);
   // A card is never moved to the status it is already in — the picker offers
   // the others, which is also what stops a no-op write.
@@ -331,10 +432,33 @@ export default function CardScreen(): React.ReactNode {
               <Note tone={said.ok ? "quiet" : "bad"}>{said.text}</Note>
             ) : null}
 
-            {/* No description: `ProviderTask` does not carry one. The board's
-                own page has it and the button at the bottom goes there — what
-                is shown here is everything the wire actually holds, rather
-                than an empty box where a body would be. */}
+            {/* Verbatim, and capped. Markdown is not rendered here for the
+                reason the pull request and issue screens both give: a
+                description is prose somebody wrote, and half-rendered markup
+                reads worse than none. The cap is because a ClickUp description
+                is regularly a specification, and a screen that opens on eight
+                hundred words has buried the status and the buttons under
+                them. */}
+            {body ? (
+              <Card>
+                <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 21 }}>
+                  {wholeBody ? body : body.slice(0, BODY_CAP)}
+                  {!wholeBody && body.length > BODY_CAP ? "…" : ""}
+                </Text>
+                {body.length > BODY_CAP ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => setWholeBody((was) => !was)}
+                    style={{ minHeight: TAP, justifyContent: "center" }}
+                  >
+                    <Text style={{ color: C.primary, fontSize: T.small, fontWeight: "600" }}>
+                      {wholeBody ? "Show less" : `Show all ${body.length} characters`}
+                    </Text>
+                  </Pressable>
+                ) : null}
+              </Card>
+            ) : null}
+
             <Card style={{ gap: SPACE.sm }}>
               <Label text="On the card" />
               {card.assignees.length ? (
@@ -430,6 +554,144 @@ export default function CardScreen(): React.ReactNode {
                   somebody was reading the request.
                 </Note>
               </Card>
+            ) : null}
+
+            {/* Work that hangs off this card. Subtasks and checklist items are
+                the same question asked two ways — what is left — so they are
+                counted together in the heading and listed apart, because the
+                board treats them differently and renaming somebody's workflow
+                is not ours to do. */}
+            {(detail?.subtasks.length || detail?.checklists.length) ? (
+              <View style={{ gap: SPACE.sm }}>
+                <Label text={`Underneath · ${leftOver} of ${allOver} left`} />
+                <Card style={{ gap: SPACE.xs }}>
+                  {detail.subtasks.map((sub) => (
+                    <Pressable
+                      key={sub.id}
+                      accessibilityRole="button"
+                      onPress={() => router.push({ pathname: "/card/[id]", params: { id: sub.id } })}
+                      style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm, minHeight: TAP }}
+                    >
+                      <Text style={{ color: statusInk(sub.statusColor), fontSize: T.eyebrow }}>
+                        {sub.statusKind === "done" ? "✓" : "○"}
+                      </Text>
+                      <Text
+                        numberOfLines={1}
+                        style={{
+                          color: sub.statusKind === "done" ? C.text4 : C.text2,
+                          fontSize: T.small, flex: 1,
+                        }}
+                      >{sub.title}</Text>
+                      <ChevronIcon color={C.text4} size={17} />
+                    </Pressable>
+                  ))}
+                  {detail.checklists.map((list) => (
+                    <View key={list.name} style={{ gap: 2, paddingTop: SPACE.xs }}>
+                      {list.name ? <Note>{list.name}</Note> : null}
+                      {list.items.map((item, i) => (
+                        <View
+                          key={`${list.name}-${i}`}
+                          /* No `minHeight`, and that is the point rather than an
+                             omission: a checklist item is not a target. The
+                             subtask rows above it navigate and take `TAP`; this
+                             one is read-only, so its height is its text and
+                             test/tap-floor.test.ts has nothing to weigh. */
+                          style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm, paddingVertical: 3 }}
+                        >
+                          <Text style={{ color: item.done ? C.success : C.text4, fontSize: T.eyebrow }}>
+                            {item.done ? "✓" : "○"}
+                          </Text>
+                          <Text
+                            style={{
+                              color: item.done ? C.text4 : C.text2, fontSize: T.small, flex: 1,
+                              textDecorationLine: item.done ? "line-through" : "none",
+                            }}
+                          >{item.name}</Text>
+                        </View>
+                      ))}
+                    </View>
+                  ))}
+                </Card>
+              </View>
+            ) : null}
+
+            {/* The pull requests. `stated` is marked because the two ways one
+                is found are not equally trustworthy: the card's own field NAMES
+                one, and a search of GitHub for the card's id is a good guess at
+                the rest. A reader deciding whether the work is done should know
+                which they are looking at. */}
+            {prs?.length ? (
+              <View style={{ gap: SPACE.sm }}>
+                <Label text={`Pull requests · ${prs.length}`} />
+                <Card style={{ gap: SPACE.xs }}>
+                  {prs.map((pr) => (
+                    <Pressable
+                      key={pr.number}
+                      accessibilityRole="button"
+                      onPress={() => { void Linking.openURL(pr.url); }}
+                      style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm, minHeight: TAP }}
+                    >
+                      <Text style={{ color: prInk(pr), fontSize: T.eyebrow, fontFamily: MONO, width: 52 }}>
+                        #{pr.number}
+                      </Text>
+                      <Text numberOfLines={1} style={{ color: C.text2, fontSize: T.small, flex: 1 }}>
+                        {pr.title || pr.url}
+                      </Text>
+                      <Text style={{ color: prInk(pr), fontSize: T.eyebrow }}>
+                        {pr.draft ? "draft" : pr.state.toLowerCase()}
+                      </Text>
+                    </Pressable>
+                  ))}
+                  {prs.some((pr) => !pr.stated) ? (
+                    <Note>
+                      Found by searching GitHub for this card&apos;s id, so one of these may belong to
+                      something else that mentions it.
+                    </Note>
+                  ) : null}
+                </Card>
+              </View>
+            ) : null}
+
+            {/* What was said on the board. Read-only here on purpose: the box
+                above posts a new one, and answering a specific comment is a
+                thread, which ClickUp models and this screen does not. */}
+            {detail?.comments.length ? (
+              <View style={{ gap: SPACE.sm }}>
+                <Label text={`Said on the board · ${detail.comments.length}`} />
+                <Card style={{ gap: SPACE.md }}>
+                  {detail.comments.map((c) => (
+                    <View key={c.id} style={{ gap: 2 }}>
+                      <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+                        <Text style={{ color: C.text, fontSize: T.small, fontWeight: "600" }}>{c.who}</Text>
+                        <Text style={{ color: C.text4, fontSize: T.eyebrow }}>{since(c.at, now)}</Text>
+                      </View>
+                      {c.text ? (
+                        <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 20 }}>{c.text}</Text>
+                      ) : (
+                        /* ClickUp comments can be an attachment and nothing
+                           else, which arrives as empty text. Saying so beats a
+                           blank row that reads as a rendering fault. */
+                        <Note>An attachment, with nothing written.</Note>
+                      )}
+                      {(c.replyList ?? []).map((r) => (
+                        <View key={r.id} style={{
+                          paddingLeft: SPACE.md, borderLeftWidth: 2, borderLeftColor: C.border,
+                          marginTop: SPACE.xs, gap: 2,
+                        }}>
+                          <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+                            <Text style={{ color: C.text2, fontSize: T.eyebrow, fontWeight: "600" }}>{r.who}</Text>
+                            <Text style={{ color: C.text4, fontSize: T.eyebrow }}>{since(r.at, now)}</Text>
+                          </View>
+                          <Text style={{ color: C.text3, fontSize: T.small, lineHeight: 18 }}>{r.text}</Text>
+                        </View>
+                      ))}
+                      {c.replies && !(c.replyList ?? []).length ? (
+                        <Note>{c.replies} {c.replies === 1 ? "reply" : "replies"}, on the board.</Note>
+                      ) : null}
+                    </View>
+                  ))}
+                </Card>
+              </View>
             ) : null}
 
             <View style={{ gap: SPACE.xs }}>

--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -261,6 +261,11 @@ export default function PrScreen(): React.ReactNode {
    *  it, and starts nothing. */
   const look = useCallback(async (recipe: ReviewRecipe): Promise<void> => {
     if (!host || !detail || !root) return;
+    /* The menu closes as this opens. `Sheet` is a react-native `Modal`, and two
+       visible at once is not a layout choice — presenting the second over the
+       first is unreliable on iOS and flickers on Android. Back from the preview
+       puts the menu back, so it still reads as a step rather than a jump. */
+    setHanding(false);
     setPreview({ recipe: recipe.id, title: recipe.title, state: "asking" });
     const answer = await ask<{ ok: boolean; prompt?: string; cwd?: string; error?: string }>(
       host, "/prs/review-prompt",
@@ -903,7 +908,11 @@ export default function PrScreen(): React.ReactNode {
       {/* What it would say, over the menu it was chosen from. A second sheet
           rather than a replaced one, so Back lands on the list and not on the
           pull request. */}
-      <Sheet open={!!preview} onClose={() => setPreview(null)} title={preview?.title ?? ""}>
+      <Sheet
+        open={!!preview}
+        onClose={() => { setPreview(null); setHanding(true); }}
+        title={preview?.title ?? ""}
+      >
         {preview?.state === "asking" ? (
           <Note>Building it on the computer…</Note>
         ) : null}
@@ -920,12 +929,13 @@ export default function PrScreen(): React.ReactNode {
 
         {preview?.state === "read" ? (
           <View style={{ gap: SPACE.md }}>
-            <ScrollView style={{ maxHeight: 320 }}>
-              <Text style={{
-                color: C.text2, fontSize: T.small, fontFamily: MONO, lineHeight: 18,
-                backgroundColor: C.bg, padding: SPACE.md, borderRadius: RADIUS.md,
-              }}>{preview.prompt}</Text>
-            </ScrollView>
+            {/* No ScrollView of its own. The sheet already scrolls and is
+                already capped at 75% of the screen; a second one nested inside
+                it is the arrangement react-native does not reliably scroll. */}
+            <Text style={{
+              color: C.text2, fontSize: T.small, fontFamily: MONO, lineHeight: 18,
+              backgroundColor: C.bg, padding: SPACE.md, borderRadius: RADIUS.md,
+            }}>{preview.prompt}</Text>
             {preview.cwd ? (
               <Text numberOfLines={1} ellipsizeMode="head" style={{
                 color: C.text4, fontSize: T.eyebrow, fontFamily: MONO,

--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -161,6 +161,27 @@ export default function PrScreen(): React.ReactNode {
   const [verdict, setVerdict] = useState<"approve" | "request_changes" | "comment" | null>(null);
   const [summary, setSummary] = useState("");
   const [sent, setSent] = useState<string | null>(null);
+  /*
+   * The review GitHub is already holding for you.
+   *
+   * A review can be STARTED anywhere — on github.com, at the desk, in an
+   * editor — and until it is submitted its line comments sit on GitHub,
+   * pending, visible to nobody. The phone could not see them, so the sheet
+   * said "no line comments" while three were queued, and sending a verdict
+   * from here submitted them along with it without ever having shown them.
+   *
+   * Null means "not asked yet", which is not the same as an empty list, and
+   * the sheet says which of the two it is.
+   */
+  const [pending, setPending] = useState<{ path: string; line: number | null; body: string }[] | null>(null);
+
+  /* A comment on the conversation, which is not a review and not a reply. It
+     is the only thing you can say on your OWN pull request — GitHub refuses a
+     review there, so the Review button is off and this is what is left. */
+  const [commenting, setCommenting] = useState(false);
+  const [comment, setComment] = useState("");
+  const [commentBusy, setCommentBusy] = useState(false);
+  const [commentErr, setCommentErr] = useState<string | null>(null);
 
   /* Merging. `method` is null until the detail lands, because the repository is
      what decides which three are on offer and opening on a guess is the bug
@@ -235,6 +256,26 @@ export default function PrScreen(): React.ReactNode {
   const key = `${root}#${number}`;
   const notes = draft(key);
 
+  /* Asked when the sheet opens rather than beside the detail: it is one more
+     round trip to GitHub for a question nobody has while they are reading the
+     files, and the answer is only ever looked at here. Re-asked on every
+     opening, because a review can be started elsewhere between two of them. */
+  useEffect(() => {
+    if (!host || !reviewing || !root || !number) return;
+    let gone = false;
+    void (async () => {
+      const answer = await ask<{ ok: boolean; comments?: { path: string; line: number | null; body: string }[] }>(
+        host, "/prs/pending-review", { method: "POST", body: { root, number: Number(number) } },
+      );
+      if (gone) return;
+      // A failure leaves it null — "could not ask" reads as "not asked", which
+      // is honest. Claiming zero would be the app inventing an answer about
+      // somebody else's queued comments.
+      setPending(answer.ok && answer.value.ok ? answer.value.comments ?? [] : null);
+    })();
+    return () => { gone = true; };
+  }, [host, reviewing, root, number]);
+
   /**
    * The verdict and every queued comment, in ONE call.
    *
@@ -258,8 +299,30 @@ export default function PrScreen(): React.ReactNode {
     setSummary("");
     setReviewing(false);
     setSent(null);
+    // Submitting takes the pending comments with it — that is what makes them
+    // pending — so what is held next time is a fresh question.
+    setPending(null);
     void load();
   }, [host, detail, root, summary, notes, key, load]);
+
+  /** One comment on the conversation. Posted on its own, because that is what
+   *  it is: not a verdict, not a remark about a line, and nothing GitHub
+   *  batches. */
+  const saySomething = useCallback(async (): Promise<void> => {
+    if (!host || !detail || !root || !comment.trim()) return;
+    setCommentBusy(true);
+    setCommentErr(null);
+    const answer = await ask<{ ok: boolean; error?: string }>(host, "/prs/comment", {
+      method: "POST",
+      body: { root, number: detail.number, body: comment.trim() },
+    });
+    setCommentBusy(false);
+    if (!answer.ok) { setCommentErr(answer.error); return; }
+    if (!answer.value.ok) { setCommentErr(answer.value.error ?? "GitHub refused that."); return; }
+    setComment("");
+    setCommenting(false);
+    void load();
+  }, [host, detail, root, comment, load]);
 
   /* Opened on what the repository would have checked, once — not on every
      render, or a tap on "Rebase" would be undone by the next repaint. */
@@ -461,16 +524,41 @@ export default function PrScreen(): React.ReactNode {
               </Card>
             </View>
 
-            {openThreads ? (
+            {(detail.threads ?? []).length ? (
               <View style={{ gap: SPACE.sm }}>
-                <Label text={`Open threads · ${openThreads}`} />
+                <Label text={`Threads · ${openThreads} open`} />
                 <Card>
-                  <Note>
-                    {openThreads === 1 ? "One conversation is" : `${openThreads} conversations are`}
-                    {" "}still unresolved. Reading them is on GitHub for now.
-                  </Note>
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => router.push({
+                      pathname: "/pr/threads",
+                      params: { number: String(number), root: root ?? "" },
+                    })}
+                    style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm, minHeight: TAP }}
+                  >
+                    <Text style={{ color: C.text2, fontSize: T.body, flex: 1 }}>
+                      {openThreads === 0
+                        ? "Every conversation is resolved"
+                        : openThreads === 1
+                          ? "One conversation is waiting on somebody"
+                          : `${openThreads} conversations are waiting on somebody`}
+                    </Text>
+                    <ChevronIcon color={C.text4} size={17} />
+                  </Pressable>
                 </Card>
               </View>
+            ) : null}
+
+            {/* Not in the pinned bar. The bar holds the three things you open a
+                pull request on a phone to DO — hand it over, review it, merge
+                it — and a fourth button there would be a fourth button in the
+                way of those. This is the thing you do on your own pull
+                request, where the other three are off. */}
+            {mayWrite ? (
+              <Btn
+                label="Comment on it"
+                onPress={() => { setCommentErr(null); setCommenting(true); }}
+              />
             ) : null}
 
             <Btn label="Open on GitHub" onPress={() => { void Linking.openURL(detail.url); }} />
@@ -526,6 +614,30 @@ export default function PrScreen(): React.ReactNode {
       ) : null}
 
       <Sheet open={reviewing} onClose={() => setReviewing(false)} title="Send your review">
+        {/* What GitHub is already holding, first — because it is the half you
+            did not write on this phone and would otherwise submit unseen. */}
+        {pending === null ? (
+          <View style={{ paddingBottom: SPACE.md }}>
+            <Note>Asking GitHub whether a review is already started…</Note>
+          </View>
+        ) : pending.length ? (
+          <View style={{ gap: SPACE.xs, paddingBottom: SPACE.md }}>
+            <Label text={`${pending.length} already on GitHub`} />
+            {pending.map((c, i) => (
+              <View key={`${c.path}:${c.line}:${i}`} style={{ paddingVertical: SPACE.xs }}>
+                <Text numberOfLines={2} style={{ color: C.text2, fontSize: T.small }}>{c.body}</Text>
+                <Text numberOfLines={1} style={{ color: C.text4, fontSize: T.eyebrow, fontFamily: MONO }}>
+                  {c.path}{c.line === null ? "" : `:${c.line}`}
+                </Text>
+              </View>
+            ))}
+            <Note>
+              Started somewhere else and never sent. Whichever verdict you press below submits
+              these too.
+            </Note>
+          </View>
+        ) : null}
+
         {notes.length ? (
           <View style={{ gap: SPACE.xs, paddingBottom: SPACE.md }}>
             <Label text={`${notes.length} ${notes.length === 1 ? "comment" : "comments"} queued`} />
@@ -540,7 +652,11 @@ export default function PrScreen(): React.ReactNode {
           </View>
         ) : (
           <View style={{ paddingBottom: SPACE.md }}>
-            <Note>No line comments. Open the files above to write one.</Note>
+            <Note>
+              {pending?.length
+                ? "Nothing written on this phone. Open the files above to add to it."
+                : "No line comments. Open the files above to write one."}
+            </Note>
           </View>
         )}
 
@@ -577,6 +693,35 @@ export default function PrScreen(): React.ReactNode {
                 being relied on. */}
             The verdict and every comment go in one call, so a dropped connection cannot leave half
             a review on GitHub.
+          </Note>
+        </View>
+      </Sheet>
+
+      <Sheet open={commenting} onClose={() => setCommenting(false)} title={`Comment on #${number}`}>
+        <TextInput
+          value={comment}
+          onChangeText={setComment}
+          placeholder="What do you want to say?"
+          placeholderTextColor={C.text4}
+          multiline
+          style={{
+            minHeight: 96, borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.md,
+            backgroundColor: C.bg, color: C.text, padding: SPACE.md, fontSize: T.body,
+          }}
+        />
+        <View style={{ paddingTop: SPACE.md, gap: SPACE.sm }}>
+          <Btn
+            label="Post it"
+            tone="primary"
+            busy={commentBusy}
+            disabled={!comment.trim() || commentBusy}
+            onPress={() => { void saySomething(); }}
+          />
+          {commentErr ? <Note tone="bad">{commentErr}</Note> : null}
+          {/* The distinction, said once and where it is being made. */}
+          <Note>
+            Goes on the conversation, on its own. A remark about a LINE belongs in the diff, where
+            it waits for a verdict and goes with it.
           </Note>
         </View>
       </Sheet>

--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -194,7 +194,9 @@ export default function PrScreen(): React.ReactNode {
    * Null means "not asked yet", which is not the same as an empty list, and
    * the sheet says which of the two it is.
    */
-  const [pending, setPending] = useState<{ path: string; line: number | null; body: string }[] | null>(null);
+  const [pending, setPending] = useState<
+    { path: string; line: number | null; body: string }[] | "asking" | "unknown"
+  >("unknown");
 
   /* A comment on the conversation, which is not a review and not a reply. It
      is the only thing you can say on your OWN pull request — GitHub refuses a
@@ -312,15 +314,18 @@ export default function PrScreen(): React.ReactNode {
   useEffect(() => {
     if (!host || !reviewing || !root || !number) return;
     let gone = false;
+    setPending("asking");
     void (async () => {
       const answer = await ask<{ ok: boolean; comments?: { path: string; line: number | null; body: string }[] }>(
         host, "/prs/pending-review", { method: "POST", body: { root, number: Number(number) } },
       );
       if (gone) return;
-      // A failure leaves it null — "could not ask" reads as "not asked", which
-      // is honest. Claiming zero would be the app inventing an answer about
-      // somebody else's queued comments.
-      setPending(answer.ok && answer.value.ok ? answer.value.comments ?? [] : null);
+      /* A failure ends at "unknown" and NOT at "asking". Leaving it on the
+         asking state was a spinner that never resolves — a screen saying it is
+         still working when it has stopped, which is the one thing a status
+         line must never do. Claiming zero would be worse still: the app
+         inventing an answer about somebody else's queued comments. */
+      setPending(answer.ok && answer.value.ok ? answer.value.comments ?? [] : "unknown");
     })();
     return () => { gone = true; };
   }, [host, reviewing, root, number]);
@@ -350,7 +355,7 @@ export default function PrScreen(): React.ReactNode {
     setSent(null);
     // Submitting takes the pending comments with it — that is what makes them
     // pending — so what is held next time is a fresh question.
-    setPending(null);
+    setPending("unknown");
     void load();
   }, [host, detail, root, summary, notes, key, load]);
 
@@ -665,9 +670,16 @@ export default function PrScreen(): React.ReactNode {
       <Sheet open={reviewing} onClose={() => setReviewing(false)} title="Send your review">
         {/* What GitHub is already holding, first — because it is the half you
             did not write on this phone and would otherwise submit unseen. */}
-        {pending === null ? (
+        {pending === "asking" ? (
           <View style={{ paddingBottom: SPACE.md }}>
             <Note>Asking GitHub whether a review is already started…</Note>
+          </View>
+        ) : pending === "unknown" ? (
+          <View style={{ paddingBottom: SPACE.md }}>
+            <Note>
+              Could not ask GitHub whether a review is already started here. If one is, whichever
+              verdict you press below submits it too.
+            </Note>
           </View>
         ) : pending.length ? (
           <View style={{ gap: SPACE.xs, paddingBottom: SPACE.md }}>
@@ -702,7 +714,7 @@ export default function PrScreen(): React.ReactNode {
         ) : (
           <View style={{ paddingBottom: SPACE.md }}>
             <Note>
-              {pending?.length
+              {Array.isArray(pending) && pending.length
                 ? "Nothing written on this phone. Open the files above to add to it."
                 : "No line comments. Open the files above to write one."}
             </Note>

--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -155,6 +155,27 @@ export default function PrScreen(): React.ReactNode {
    *  merged in. Null until it answers, which is why the sheet says so rather
    *  than drawing an empty list that reads as "no options". */
   const [catalogue, setCatalogue] = useState<ReviewRecipe[] | null>(null);
+  /*
+   * The prompt a recipe would send, read back before it is sent.
+   *
+   * ── this does NOT change what the socket carries ─────────────────────────
+   * `cmd: "review"` still carries a number, a directory and a recipe ID, and
+   * the words are still built on the computer from its own catalogue — the
+   * property src/model/reviewMenu.ts describes as load-bearing, which it is: a
+   * socket reachable from the UI must not be a way to choose what an agent is
+   * told. This is a separate, read-only call to `/prs/review-prompt`, which
+   * writes nothing and starts nothing. It answers "what am I about to ask" and
+   * the answer is not editable here, deliberately — an editable preview would
+   * be that socket by another route, and whether the phone should be allowed
+   * to send words of its own is a decision about what this app is, not a
+   * detail of a preview.
+   */
+  const [preview, setPreview] = useState<
+    | { recipe: string; title: string; state: "asking" }
+    | { recipe: string; title: string; state: "read"; prompt: string; cwd: string }
+    | { recipe: string; title: string; state: "failed"; error: string }
+    | null
+  >(null);
   /* Opened straight away when the diff sent you here with comments queued —
      `review=1` on the route. Otherwise it is the second button below. */
   const [reviewing, setReviewing] = useState(review === "1");
@@ -233,6 +254,33 @@ export default function PrScreen(): React.ReactNode {
     [detail, catalogue],
   );
 
+  /** Ask the computer what it would say, without asking it to say it. A GET in
+   *  everything but method: `prepareReviewPrompt` builds the text and returns
+   *  it, and starts nothing. */
+  const look = useCallback(async (recipe: ReviewRecipe): Promise<void> => {
+    if (!host || !detail || !root) return;
+    setPreview({ recipe: recipe.id, title: recipe.title, state: "asking" });
+    const answer = await ask<{ ok: boolean; prompt?: string; cwd?: string; error?: string }>(
+      host, "/prs/review-prompt",
+      { method: "POST", body: { root, number: detail.number, recipe: recipe.id } },
+    );
+    if (!answer.ok) {
+      setPreview({ recipe: recipe.id, title: recipe.title, state: "failed", error: answer.error });
+      return;
+    }
+    if (!answer.value.ok || !answer.value.prompt) {
+      setPreview({
+        recipe: recipe.id, title: recipe.title, state: "failed",
+        error: answer.value.error ?? "The computer could not build that prompt.",
+      });
+      return;
+    }
+    setPreview({
+      recipe: recipe.id, title: recipe.title, state: "read",
+      prompt: answer.value.prompt, cwd: answer.value.cwd ?? "",
+    });
+  }, [host, detail, root]);
+
   /**
    * Leave the request and go to the terminal.
    *
@@ -250,6 +298,7 @@ export default function PrScreen(): React.ReactNode {
       recipe,
     });
     setHanding(false);
+    setPreview(null);
     router.push("/terminal");
   }, [detail, root, router]);
 
@@ -823,21 +872,64 @@ export default function PrScreen(): React.ReactNode {
               recipe.skill ? recipe.skill.trim().split(/\s/)[0] : "",
             ].filter(Boolean).join(" · ") || undefined}
             on={recipe.id === menu?.suggested}
-            onPress={() => hand(recipe.id)}
+            onPress={() => { void look(recipe); }}
           />
         ))}
         <View style={{ paddingTop: SPACE.md, gap: SPACE.xs }}>
           <Note>
             Opens a tmux window on the computer with the agent already running, and takes you to it.
           </Note>
-          {/* Said out loud because it is the one thing that is not visible from
-              here: the words that reach the agent are the computer's, chosen by
-              the name above. This phone sends a number and an id. */}
+          {/* Still true, and now checkable: the words are the computer's, and
+              the next screen shows you which words before anything runs. */}
           <Note>
             The phone sends the number and which question to ask. The prompt itself is written on
-            the computer.
+            the computer — you see it before it goes.
           </Note>
         </View>
+      </Sheet>
+
+      {/* What it would say, over the menu it was chosen from. A second sheet
+          rather than a replaced one, so Back lands on the list and not on the
+          pull request. */}
+      <Sheet open={!!preview} onClose={() => setPreview(null)} title={preview?.title ?? ""}>
+        {preview?.state === "asking" ? (
+          <Note>Building it on the computer…</Note>
+        ) : null}
+
+        {preview?.state === "failed" ? (
+          <View style={{ gap: SPACE.sm }}>
+            <Note tone="bad">{preview.error}</Note>
+            <Note>
+              Nothing was started. The window opens only when you press Send below, and there is
+              nothing to send until this reads.
+            </Note>
+          </View>
+        ) : null}
+
+        {preview?.state === "read" ? (
+          <View style={{ gap: SPACE.md }}>
+            <ScrollView style={{ maxHeight: 320 }}>
+              <Text style={{
+                color: C.text2, fontSize: T.small, fontFamily: MONO, lineHeight: 18,
+                backgroundColor: C.bg, padding: SPACE.md, borderRadius: RADIUS.md,
+              }}>{preview.prompt}</Text>
+            </ScrollView>
+            {preview.cwd ? (
+              <Text numberOfLines={1} ellipsizeMode="head" style={{
+                color: C.text4, fontSize: T.eyebrow, fontFamily: MONO,
+              }}>in {preview.cwd}</Text>
+            ) : null}
+            <Btn label="Send it" tone="primary" onPress={() => hand(preview.recipe)} />
+            {/* The one thing a preview cannot show, said rather than implied:
+                what travels is the id above it, and the computer builds these
+                words again for itself. So this is a faithful reading of what
+                will be asked, not a copy that gets sent. */}
+            <Note>
+              Read from the computer, which writes it again when the window opens. The phone sends
+              the pull request number and the name of the question — never these words.
+            </Note>
+          </View>
+        ) : null}
       </Sheet>
     </View>
   );

--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -16,6 +16,15 @@
  * It is also the shape GitHub actually wants: a review IS a verdict plus its
  * comments, and posting them one at a time makes a thread per remark.
  *
+ * ── the lines the hunk cut off ───────────────────────────────────────────
+ * A hunk shows three lines of context and the question you have is usually
+ * about the twentieth. At a desk that is answered by the editor next to the
+ * browser; here there was no editor, so the answer was "open GitHub". The
+ * expanders between hunks fetch the real file from `/prs/file-slice`, one
+ * screen at a time. Those lines are context and cannot be commented on —
+ * GitHub only accepts a comment on a line the diff touches, and drawing them
+ * as pressable would be offering something that fails on send.
+ *
  * ── the whole diff arrives as one string ─────────────────────────────────
  * `/prs/diff` answers with the output of `gh pr diff`. Parsing it is
  * src/model/diffLines.ts, which is where the line-number arithmetic and its
@@ -34,6 +43,7 @@ import { usePaletteTick } from "../../src/state/use-palette.ts";
 import {
   commentableLine, fileLabel, parseDiff, type DiffFile, type DiffLine,
 } from "../../src/model/diffLines.ts";
+import { gapLabel, gapsIn, nextSlice, type Gap } from "../../src/model/expand.ts";
 import { draftCount, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
 import { Btn, Card, Label, Note, Sheet, SheetRow, TAP } from "../../src/ui.tsx";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
@@ -48,6 +58,51 @@ function lineFace(kind: DiffLine["kind"]): { bg: string; mark: string; ink: stri
   if (kind === "add") return { bg: "rgba(63,185,80,0.14)", mark: "+", ink: C.success };
   if (kind === "del") return { bg: "rgba(248,81,73,0.14)", mark: "−", ink: C.error };
   return { bg: "transparent", mark: " ", ink: C.text4 };
+}
+
+/** The lines fetched into a gap, drawn as context — no marker, no tint, and
+ *  deliberately not pressable: GitHub takes a comment only on a line the diff
+ *  touches, so a row that invited one here would fail on send. */
+function Context({ from, lines }: { from: number; lines: string[] }): React.ReactNode {
+  return (
+    <>
+      {lines.map((line, i) => (
+        <View key={from + i} style={{ flexDirection: "row", minHeight: 22 }}>
+          <Text style={{
+            width: 38, textAlign: "right", paddingRight: SPACE.sm,
+            color: C.text4, fontSize: 10.5, fontFamily: MONO, lineHeight: 20,
+          }}>{from + i}</Text>
+          <Text style={{ width: 10, fontSize: 10.5, fontFamily: MONO, lineHeight: 20 }}> </Text>
+          <Text style={{
+            flex: 1, color: C.text3, fontSize: 10.5, fontFamily: MONO,
+            lineHeight: 20, paddingRight: SPACE.sm,
+          }}>{line || " "}</Text>
+        </View>
+      ))}
+    </>
+  );
+}
+
+/** The bar that offers more, in the diff's own grey. Reads as part of the
+ *  file rather than as a control laid over it, which is what it is. */
+function Expander({ label, busy, onPress }: {
+  label: string; busy: boolean; onPress: () => void;
+}): React.ReactNode {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      onPress={onPress}
+      disabled={busy}
+      style={{
+        backgroundColor: C.bg3, minHeight: TAP, justifyContent: "center",
+        paddingHorizontal: SPACE.md, borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.border,
+      }}
+    >
+      <Text style={{ color: busy ? C.text4 : C.primary, fontSize: T.eyebrow, fontFamily: MONO }}>
+        {busy ? "…" : `⤢  ${label}`}
+      </Text>
+    </Pressable>
+  );
 }
 
 export default function DiffScreen(): React.ReactNode {
@@ -101,6 +156,72 @@ export default function DiffScreen(): React.ReactNode {
 
   const file: DiffFile | undefined = files[at];
 
+  /*
+   * The context fetched around this file's hunks, one entry per gap.
+   *
+   * Keyed by file path and gap, so moving between files does not carry one
+   * file's expansion onto another's line numbers — the fastest way to show
+   * somebody the wrong code. Each gap grows in ONE direction and stays a single
+   * contiguous run: the gap above the first hunk grows UPWARD from its bottom,
+   * and every other gap grows DOWNWARD from its top. Both start at the edge
+   * nearest the code that was being read, which is what the question is
+   * usually about.
+   */
+  const [shown, setShown] = useState<Record<string, { from: number; to: number; lines: string[] }>>({});
+  const [fetching, setFetching] = useState<string | null>(null);
+  const [slipped, setSlipped] = useState<{ key: string; text: string } | null>(null);
+
+  const gaps = useMemo(() => (file ? gapsIn(file) : []), [file]);
+
+  /** Which way a gap grows. Stated once, because the renderer and the fetcher
+   *  must agree — a gap drawn as growing up and fetched downward would append
+   *  lines to the wrong end of what is on screen. */
+  const dirOf = (gap: Gap): "up" | "down" => (gap.before === 0 ? "up" : "down");
+
+  const expand = useCallback(async (gap: Gap): Promise<void> => {
+    if (!host || !file || !number || !root) return;
+    const key = `${file.path}#${gap.before}`;
+    const have = shown[key];
+    const dir = dirOf(gap);
+    const edge = have ? (dir === "up" ? have.from : have.to) : null;
+    const want = nextSlice(gap, dir, edge);
+    if (!want) return;
+
+    setFetching(key);
+    setSlipped(null);
+    const query = new URLSearchParams({
+      root: String(root), number: String(number), path: file.path,
+      // RIGHT: the file as this pull request leaves it, which is the side the
+      // line numbers on screen belong to.
+      side: "RIGHT", from: String(want.from), to: String(want.to),
+    }).toString();
+    const answer = await ask<{ ok: boolean; lines?: string[]; binary?: boolean; error?: string }>(
+      host, `/prs/file-slice?${query}`,
+    );
+    setFetching(null);
+    if (!answer.ok) { setSlipped({ key, text: answer.error }); return; }
+    if (!answer.value.ok) { setSlipped({ key, text: answer.value.error || "Those lines could not be read." }); return; }
+    if (answer.value.binary) { setSlipped({ key, text: "That file is binary." }); return; }
+    const got = answer.value.lines ?? [];
+    /* The server clamps to the end of the file, so the tail gap can answer with
+       fewer lines than were asked for — or none, which is how "that was the
+       end" arrives. Trusting `want.to` here would draw blank numbered rows past
+       the end of the file. */
+    if (!got.length) { setSlipped({ key, text: "That is the end of the file." }); return; }
+    setShown((was) => {
+      const before = was[key];
+      if (!before) return { ...was, [key]: { from: want.from, to: want.from + got.length - 1, lines: got } };
+      return dir === "up"
+        ? { ...was, [key]: { from: want.from, to: before.to, lines: [...got, ...before.lines] } }
+        : { ...was, [key]: { from: before.from, to: want.from + got.length - 1, lines: [...before.lines, ...got] } };
+    });
+  }, [host, file, number, root, shown]);
+
+  /* Everything fetched belongs to the file it was fetched from. Kept as a
+     wholesale clear rather than a per-file map trim: it is one request to get
+     it back, and a stale entry here is wrong code under a right line number. */
+  useEffect(() => { setShown({}); setSlipped(null); }, [file?.path]);
+
   const add = useCallback((): void => {
     if (!writing || !writing.body.trim()) return;
     void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
@@ -112,6 +233,37 @@ export default function DiffScreen(): React.ReactNode {
     setQueued(takeDraft(key, (was) => [...was.filter((n) => !(n.path === note.path && n.line === note.line)), note]).length);
     setWriting(null);
   }, [writing, file, key]);
+
+  /** One gap: what has already been fetched into it, and the offer to fetch
+   *  more. Nothing at all when the file has no such gap, which is the ordinary
+   *  case for two hunks that touch. */
+  const gapBefore = (before: number): React.ReactNode => {
+    const gap = gaps.find((g) => g.before === before);
+    if (!gap || !file) return null;
+    const key = `${file.path}#${before}`;
+    const have = shown[key];
+    const dir = dirOf(gap);
+    const more = nextSlice(gap, dir, have ? (dir === "up" ? have.from : have.to) : null);
+    const label = gapLabel(gap, more);
+    const failed = slipped?.key === key ? slipped.text : null;
+    // Up-growing gaps put the offer ABOVE what they have already shown, so the
+    // control stays at the edge the next lines will appear at.
+    const bar = label ? (
+      <Expander label={label} busy={fetching === key} onPress={() => { void expand(gap); }} />
+    ) : null;
+    return (
+      <>
+        {dir === "up" ? bar : null}
+        {have ? <Context from={have.from} lines={have.lines} /> : null}
+        {dir === "down" ? bar : null}
+        {failed ? (
+          <Text style={{
+            color: C.text4, fontSize: T.eyebrow, paddingHorizontal: SPACE.md, paddingVertical: SPACE.xs,
+          }}>{failed}</Text>
+        ) : null}
+      </>
+    );
+  };
 
   return (
     <KeyboardAvoidingView style={{ flex: 1, backgroundColor: C.bg }} behavior="padding">
@@ -161,6 +313,7 @@ export default function DiffScreen(): React.ReactNode {
 
         {file?.hunks.map((hunk, h) => (
           <View key={`${hunk.header}-${h}`}>
+            {gapBefore(h)}
             {/* The header verbatim, including gh's trailing context — usually
                 the enclosing function, which is the most useful thing on
                 screen for saying where you are. */}
@@ -239,6 +392,11 @@ export default function DiffScreen(): React.ReactNode {
             })}
           </View>
         ))}
+
+        {/* The tail of the file, below the last hunk. Rendered outside the map
+            because it belongs to no hunk — `gapsIn` numbers it `hunks.length`
+            for exactly this. */}
+        {file && !file.binary ? gapBefore(file.hunks.length) : null}
 
         {file && !file.binary && file.hunks.length === 0 ? (
           <View style={{ padding: SPACE.lg }}>

--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -195,7 +195,7 @@ export default function DiffScreen(): React.ReactNode {
       // line numbers on screen belong to.
       side: "RIGHT", from: String(want.from), to: String(want.to),
     }).toString();
-    const answer = await ask<{ ok: boolean; lines?: string[]; binary?: boolean; error?: string }>(
+    const answer = await ask<{ ok: boolean; lines?: string[]; start?: number; binary?: boolean; error?: string }>(
       host, `/prs/file-slice?${query}`,
     );
     setFetching(null);
@@ -208,12 +208,18 @@ export default function DiffScreen(): React.ReactNode {
        end" arrives. Trusting `want.to` here would draw blank numbered rows past
        the end of the file. */
     if (!got.length) { setSlipped({ key, text: "That is the end of the file." }); return; }
+    /* And where it started is the SERVER's answer, not the number we asked
+       with. It clamps that too, and the two differing by one puts real lines
+       under wrong numbers — which on this screen is not a cosmetic fault: the
+       numbers beside expanded context are what a reader uses to say where
+       something is. */
+    const first = Number.isInteger(answer.value.start) ? (answer.value.start as number) : want.from;
     setShown((was) => {
       const before = was[key];
-      if (!before) return { ...was, [key]: { from: want.from, to: want.from + got.length - 1, lines: got } };
+      if (!before) return { ...was, [key]: { from: first, to: first + got.length - 1, lines: got } };
       return dir === "up"
-        ? { ...was, [key]: { from: want.from, to: before.to, lines: [...got, ...before.lines] } }
-        : { ...was, [key]: { from: before.from, to: want.from + got.length - 1, lines: [...before.lines, ...got] } };
+        ? { ...was, [key]: { from: first, to: before.to, lines: [...got, ...before.lines] } }
+        : { ...was, [key]: { from: before.from, to: first + got.length - 1, lines: [...before.lines, ...got] } };
     });
   }, [host, file, number, root, shown]);
 

--- a/mobile/app/pr/threads.tsx
+++ b/mobile/app/pr/threads.tsx
@@ -1,0 +1,403 @@
+/*
+ * The conversations on a pull request, answered from the phone.
+ *
+ * ── what this replaces ───────────────────────────────────────────────────
+ * A line on the detail screen that said "Reading them is on GitHub for now".
+ * That sentence was the honest description of a review you could start on the
+ * phone and could not finish: you could write remarks on the diff and send a
+ * verdict, but the moment somebody replied to one, the app had nothing to say
+ * and handed you to a browser, signed out, on a page built for a mouse.
+ *
+ * Three things happen here, and each is one call the server already served for
+ * the desk:
+ *
+ *   reply           `/prs/reply`            — into the thread, not as a new one
+ *   resolve         `/prs/thread-resolved`  — and unresolve, the same button
+ *   apply           `/prs/apply-suggestion` — commit the suggested lines
+ *
+ * ── replies post immediately, and the diff's comments do not ─────────────
+ * This looks like an inconsistency and is the opposite of one. A line comment
+ * is part of a REVIEW — a verdict plus its remarks, which GitHub takes in one
+ * call, and which reviewDraft.ts queues precisely so that a dropped connection
+ * cannot leave three observations with no conclusion. A reply is not part of
+ * anything: it is one message into a conversation that already exists, it
+ * stands on its own, and holding it back until some later verdict would be
+ * holding an answer somebody is waiting for.
+ *
+ * ── applying a suggestion writes a commit to somebody's branch ───────────
+ * So it asks first, and it says whose branch and which lines. The parsing —
+ * which block, which range — is `shared/suggestion.ts`, and the range comes
+ * from the THREAD rather than from anything in the block, because that is how
+ * GitHub defines it. An outdated thread offers no Apply at all: the lines it
+ * was written about are gone, and the number it still carries now points at
+ * something nobody was talking about.
+ */
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { ActivityIndicator, KeyboardAvoidingView, Linking, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { Stack, useLocalSearchParams } from "expo-router";
+import * as Haptics from "expo-haptics";
+import type { PrActionResult, PrDetail, PrThread } from "../../../shared/types.ts";
+import { suggestionRange, suggestionsIn } from "../../../shared/suggestion.ts";
+import { ask } from "../../src/lib/api.ts";
+import { useAgentglass } from "../../src/state/host-context.tsx";
+import { usePaletteTick } from "../../src/state/use-palette.ts";
+import { since } from "../../src/lib/dates.ts";
+import { Btn, Card, Label, Note, TAP } from "../../src/ui.tsx";
+import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
+
+/** Threads worth showing first: unresolved before resolved, and within each,
+ *  the file order the detail already sorted them into. Outdated ones sink —
+ *  they are about code that no longer exists and are usually safe to skip,
+ *  which is GitHub's own word for them. */
+function ordered(threads: PrThread[]): PrThread[] {
+  const rank = (t: PrThread): number => (t.isResolved ? 2 : t.isOutdated ? 1 : 0);
+  return [...threads].map((t, at) => ({ t, at }))
+    .sort((a, b) => rank(a.t) - rank(b.t) || a.at - b.at)
+    .map(({ t }) => t);
+}
+
+/** Where a thread is, in the shortest form that still identifies it. */
+function whereOf(thread: PrThread): string {
+  const line = thread.line ?? thread.originalLine;
+  const at = thread.startLine && line && thread.startLine !== line
+    ? `${thread.startLine}-${line}`
+    : line ?? "";
+  return at ? `${thread.path}:${at}` : thread.path;
+}
+
+/** The diff hunk GitHub kept with the comment, trimmed to what fits.
+ *  Kept because a reply written without seeing the code it is about is a reply
+ *  about the wrong thing — and on an outdated thread this is the ONLY copy of
+ *  those lines left anywhere in the app. */
+function Hunk({ text }: { text: string }): React.ReactNode {
+  const lines = text.split("\n").filter((l) => l.length);
+  // The tail, not the head: the last line of a hunk is the one the comment is
+  // anchored to, and the head is context leading up to it.
+  const shown = lines.slice(-8);
+  return (
+    <View style={{ backgroundColor: C.bg, borderRadius: RADIUS.sm, paddingVertical: SPACE.xs }}>
+      {lines.length > shown.length ? (
+        <Text style={{ color: C.text4, fontSize: 10, fontFamily: MONO, paddingHorizontal: SPACE.sm }}>⋯</Text>
+      ) : null}
+      {shown.map((line, i) => {
+        const add = line.startsWith("+");
+        const del = line.startsWith("-");
+        return (
+          <Text
+            key={i}
+            numberOfLines={1}
+            style={{
+              color: add ? C.success : del ? C.error : C.text3,
+              backgroundColor: add ? "rgba(63,185,80,0.12)" : del ? "rgba(248,81,73,0.12)" : "transparent",
+              fontSize: 10, fontFamily: MONO, lineHeight: 16, paddingHorizontal: SPACE.sm,
+            }}
+          >{line}</Text>
+        );
+      })}
+    </View>
+  );
+}
+
+export default function ThreadsScreen(): React.ReactNode {
+  usePaletteTick(); // a scene repaints only if it asks — see use-palette.ts
+  const { host } = useAgentglass();
+  const { number, root } = useLocalSearchParams<{ number: string; root: string }>();
+
+  const [detail, setDetail] = useState<PrDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+  /** Which thread has its reply box open, and what is in it. */
+  const [writing, setWriting] = useState<{ id: string; body: string } | null>(null);
+  /** The thread id something is in flight for, so one row can say it is busy
+   *  without freezing the whole screen. */
+  const [busy, setBusy] = useState<string | null>(null);
+  const [said, setSaid] = useState<{ id: string; text: string; bad: boolean } | null>(null);
+  /** A suggestion waiting to be confirmed. Applying one writes a commit to
+   *  somebody else's branch, which is not something a single tap should do. */
+  const [confirming, setConfirming] = useState<{ thread: PrThread; text: string } | null>(null);
+
+  const mayWrite = host?.scope === "full";
+
+  const load = useCallback(async (): Promise<void> => {
+    if (!host || !number || !root) return;
+    const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
+    const answer = await ask<{ ok: boolean; detail?: PrDetail; error?: string }>(host, `/prs/detail?${query}`);
+    if (!answer.ok) { setError(answer.error); return; }
+    if (!answer.value.ok || !answer.value.detail) {
+      setError(answer.value.error || "That pull request could not be read.");
+      return;
+    }
+    setError(null);
+    setDetail(answer.value.detail);
+  }, [host, number, root]);
+
+  useEffect(() => { void load(); }, [load]);
+
+  /*
+   * One write, and then a re-read.
+   *
+   * Never an optimistic update. What a thread looks like after a reply is
+   * GitHub's answer and not this app's guess — a resolve can be refused by a
+   * branch rule, and a reply can land while somebody else resolves the thread
+   * underneath it. Re-reading costs one request on an action that already cost
+   * one, and it is the difference between a screen that reports and a screen
+   * that hopes.
+   */
+  const act = useCallback(async (
+    id: string, path: string, body: unknown, done: string,
+  ): Promise<boolean> => {
+    if (!host) return false;
+    setBusy(id);
+    setSaid(null);
+    const answer = await ask<PrActionResult>(host, path, { method: "POST", body });
+    if (!answer.ok || !answer.value.ok) {
+      setBusy(null);
+      setSaid({ id, bad: true, text: (answer.ok ? answer.value.error : answer.error) || "GitHub refused that." });
+      return false;
+    }
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await load();
+    setBusy(null);
+    setSaid({ id, bad: false, text: done });
+    return true;
+  }, [host, load]);
+
+  const reply = useCallback(async (thread: PrThread): Promise<void> => {
+    const text = writing?.body.trim();
+    if (!text || writing?.id !== thread.id) return;
+    /*
+     * The REST reply endpoint takes the numeric id of a comment in the thread,
+     * and `PrThreadComment.id` is a GraphQL node id — the two are not
+     * interchangeable, which the shared type says out loud. Without a
+     * databaseId there is nothing to reply to, so the box is not offered.
+     */
+    const anchor = thread.comments.find((c) => typeof c.databaseId === "number")?.databaseId;
+    if (typeof anchor !== "number") {
+      setSaid({ id: thread.id, bad: true, text: "That thread carries no id to reply to." });
+      return;
+    }
+    const ok = await act(thread.id, "/prs/reply", { root, number: Number(number), commentId: anchor, body: text }, "Replied.");
+    if (ok) setWriting(null);
+  }, [act, writing, root, number]);
+
+  const setResolved = useCallback((thread: PrThread): void => {
+    void act(
+      thread.id, "/prs/thread-resolved",
+      { root, threadId: thread.id, resolved: !thread.isResolved },
+      thread.isResolved ? "Reopened." : "Resolved.",
+    );
+  }, [act, root]);
+
+  const applySuggestion = useCallback(async (): Promise<void> => {
+    if (!confirming) return;
+    const { thread, text } = confirming;
+    const range = suggestionRange(thread);
+    if (!range) return;
+    setConfirming(null);
+    await act(thread.id, "/prs/apply-suggestion", {
+      root, number: Number(number),
+      path: thread.path, startLine: range.startLine, line: range.line,
+      suggestion: text,
+      // Credited as a co-author on the commit, exactly as GitHub does it. The
+      // author of the SUGGESTION, which is the first comment in the thread and
+      // not whoever replied last.
+      author: thread.comments[0]?.author,
+    }, "Applied.");
+  }, [act, confirming, root, number]);
+
+  const threads = useMemo(() => ordered(detail?.threads ?? []), [detail]);
+  const open = threads.filter((t) => !t.isResolved).length;
+  const now = Date.now();
+
+  return (
+    /* `padding`, both platforms, never Platform-conditional — the measurement
+       is in test/keyboard-inset.test.ts. This screen takes typing. */
+    <KeyboardAvoidingView style={{ flex: 1, backgroundColor: C.bg }} behavior="padding">
+      <Stack.Screen options={{ title: `#${number} · threads` }} />
+
+      <ScrollView contentContainerStyle={{ padding: SPACE.lg, gap: SPACE.lg, paddingBottom: SPACE.xl }}>
+        {error ? (
+          <Card>
+            <Label text="Cannot read them" />
+            <Note tone="bad">{error}</Note>
+          </Card>
+        ) : null}
+
+        {!detail && !error ? <ActivityIndicator color={C.text3} /> : null}
+
+        {detail && threads.length === 0 ? (
+          <Card><Note>Nobody has commented on a line of this pull request.</Note></Card>
+        ) : null}
+
+        {threads.length ? (
+          <Label text={open ? `${open} open · ${threads.length} in all` : `${threads.length} resolved`} />
+        ) : null}
+
+        {threads.map((thread) => {
+          const range = suggestionRange(thread);
+          /* The FIRST suggestion in the thread, which is the one the range
+             belongs to. A later reply containing its own block is a different
+             proposal about the same lines, and applying it under the first
+             one's range would be applying something nobody chose. */
+          const suggestion = thread.comments
+            .flatMap((c) => suggestionsIn(c.body))
+            .at(0);
+          const canApply = mayWrite && !!suggestion && !!range && !thread.isResolved;
+          const canReply = mayWrite && thread.comments.some((c) => typeof c.databaseId === "number");
+          const note = said?.id === thread.id ? said : null;
+          const working = busy === thread.id;
+
+          return (
+            <Card key={thread.id} style={{ gap: SPACE.sm, opacity: thread.isResolved ? 0.6 : 1 }}>
+              <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+                <Text
+                  numberOfLines={1}
+                  ellipsizeMode="head"
+                  style={{ color: C.text2, fontSize: T.small, fontFamily: MONO, flex: 1 }}
+                >{whereOf(thread)}</Text>
+                {thread.isResolved ? (
+                  <Text style={{ color: C.success, fontSize: T.eyebrow }}>resolved</Text>
+                ) : thread.isOutdated ? (
+                  <Text style={{ color: C.text4, fontSize: T.eyebrow }}>outdated</Text>
+                ) : null}
+              </View>
+
+              {thread.diffHunk ? <Hunk text={thread.diffHunk} /> : null}
+
+              {thread.comments.map((comment) => (
+                <View key={comment.id} style={{ gap: 2, paddingTop: SPACE.xs }}>
+                  <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+                    <Text style={{ color: C.text, fontSize: T.small, fontWeight: "600" }}>
+                      {comment.author}{comment.isBot ? " · bot" : ""}
+                    </Text>
+                    <Text style={{ color: C.text4, fontSize: T.eyebrow }}>
+                      {since(comment.createdAt, now)}
+                    </Text>
+                  </View>
+                  <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 20 }}>{comment.body}</Text>
+                </View>
+              ))}
+
+              {writing?.id === thread.id ? (
+                <View style={{ gap: SPACE.sm, paddingTop: SPACE.xs }}>
+                  <TextInput
+                    value={writing.body}
+                    onChangeText={(body) => setWriting({ id: thread.id, body })}
+                    placeholder="Reply"
+                    placeholderTextColor={C.text4}
+                    multiline
+                    autoFocus
+                    style={{
+                      minHeight: 64, borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.sm,
+                      backgroundColor: C.bg, color: C.text, padding: SPACE.sm, fontSize: T.body,
+                    }}
+                  />
+                  <View style={{ flexDirection: "row", gap: SPACE.sm }}>
+                    <Btn
+                      label="Send reply"
+                      tone="primary"
+                      style={{ flex: 1 }}
+                      busy={working}
+                      disabled={!writing.body.trim() || working}
+                      onPress={() => { void reply(thread); }}
+                    />
+                    <Btn label="Cancel" onPress={() => setWriting(null)} />
+                  </View>
+                  {/* Said where the difference bites: this one goes now, and
+                      the remarks written on the diff do not. */}
+                  <Note>A reply is posted on its own, straight away.</Note>
+                </View>
+              ) : (
+                <View style={{ flexDirection: "row", gap: SPACE.sm, paddingTop: SPACE.xs }}>
+                  <Btn
+                    label="Reply"
+                    style={{ flex: 1 }}
+                    disabled={!canReply || working}
+                    onPress={() => { setSaid(null); setWriting({ id: thread.id, body: "" }); }}
+                  />
+                  <Btn
+                    label={thread.isResolved ? "Reopen" : "Resolve"}
+                    tone={thread.isResolved ? "plain" : "good"}
+                    style={{ flex: 1 }}
+                    busy={working}
+                    disabled={!mayWrite || working}
+                    onPress={() => setResolved(thread)}
+                  />
+                </View>
+              )}
+
+              {canApply ? (
+                <Btn
+                  label={`Apply suggestion · ${thread.path.split("/").pop()}:${
+                    range!.startLine === range!.line ? range!.line : `${range!.startLine}-${range!.line}`
+                  }`}
+                  disabled={working}
+                  onPress={() => { setSaid(null); setConfirming({ thread, text: suggestion!.text }); }}
+                />
+              ) : null}
+
+              {suggestion && !range ? (
+                <Note>
+                  This thread carries a suggestion, and the lines it was written about are gone.
+                  Applying it would change code nobody was talking about.
+                </Note>
+              ) : null}
+
+              {note ? <Note tone={note.bad ? "bad" : "quiet"}>{note.text}</Note> : null}
+
+              {thread.url ? (
+                <Pressable
+                  onPress={() => { void Linking.openURL(thread.url!); }}
+                  accessibilityRole="button"
+                  style={{ minHeight: TAP, justifyContent: "center" }}
+                >
+                  <Text style={{ color: C.primary, fontSize: T.small }}>Open the thread on GitHub</Text>
+                </Pressable>
+              ) : null}
+            </Card>
+          );
+        })}
+
+        {!mayWrite && threads.length ? (
+          <Note>
+            This phone is paired to read. Replying, resolving and applying a suggestion all write
+            to GitHub, so they are off until it is paired again with write access.
+          </Note>
+        ) : null}
+      </ScrollView>
+
+      {/* The confirmation, as a card over the list rather than a sheet: what it
+          is confirming is TEXT, and a sheet that has to scroll to show what you
+          are agreeing to is a sheet nobody reads to the bottom. */}
+      {confirming ? (
+        <View style={{
+          position: "absolute", left: 0, right: 0, bottom: 0, top: 0,
+          backgroundColor: "rgba(0,0,0,0.55)", justifyContent: "flex-end",
+        }}>
+          <View style={{
+            backgroundColor: C.bg2, borderTopLeftRadius: RADIUS.lg, borderTopRightRadius: RADIUS.lg,
+            padding: SPACE.lg, gap: SPACE.md, maxHeight: "80%",
+          }}>
+            <Label text="Commit this to the branch?" />
+            <Text style={{ color: C.text2, fontSize: T.small }}>
+              {whereOf(confirming.thread)} on {detail?.headRefName ?? "the head branch"}
+            </Text>
+            <ScrollView style={{ maxHeight: 220 }}>
+              <Text style={{
+                color: C.text, fontFamily: MONO, fontSize: 11, lineHeight: 17,
+                backgroundColor: C.bg, padding: SPACE.sm, borderRadius: RADIUS.sm,
+              }}>{confirming.text === "" ? "(removes those lines)" : confirming.text}</Text>
+            </ScrollView>
+            <Note>
+              It is committed through GitHub, credited to {confirming.thread.comments[0]?.author ?? "whoever wrote it"},
+              and refused if anybody has pushed since this was read.
+            </Note>
+            <View style={{ flexDirection: "row", gap: SPACE.sm }}>
+              <Btn label="Cancel" style={{ flex: 1 }} onPress={() => setConfirming(null)} />
+              <Btn label="Apply" tone="primary" style={{ flex: 1 }} onPress={() => { void applySuggestion(); }} />
+            </View>
+          </View>
+        </View>
+      ) : null}
+    </KeyboardAvoidingView>
+  );
+}

--- a/mobile/app/pr/threads.tsx
+++ b/mobile/app/pr/threads.tsx
@@ -42,41 +42,19 @@ import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { since } from "../../src/lib/dates.ts";
+import { hunkTail, ordered, replyAnchor, whereOf } from "../../src/model/threads.ts";
 import { Btn, Card, Label, Note, TAP } from "../../src/ui.tsx";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
-
-/** Threads worth showing first: unresolved before resolved, and within each,
- *  the file order the detail already sorted them into. Outdated ones sink —
- *  they are about code that no longer exists and are usually safe to skip,
- *  which is GitHub's own word for them. */
-function ordered(threads: PrThread[]): PrThread[] {
-  const rank = (t: PrThread): number => (t.isResolved ? 2 : t.isOutdated ? 1 : 0);
-  return [...threads].map((t, at) => ({ t, at }))
-    .sort((a, b) => rank(a.t) - rank(b.t) || a.at - b.at)
-    .map(({ t }) => t);
-}
-
-/** Where a thread is, in the shortest form that still identifies it. */
-function whereOf(thread: PrThread): string {
-  const line = thread.line ?? thread.originalLine;
-  const at = thread.startLine && line && thread.startLine !== line
-    ? `${thread.startLine}-${line}`
-    : line ?? "";
-  return at ? `${thread.path}:${at}` : thread.path;
-}
 
 /** The diff hunk GitHub kept with the comment, trimmed to what fits.
  *  Kept because a reply written without seeing the code it is about is a reply
  *  about the wrong thing — and on an outdated thread this is the ONLY copy of
  *  those lines left anywhere in the app. */
 function Hunk({ text }: { text: string }): React.ReactNode {
-  const lines = text.split("\n").filter((l) => l.length);
-  // The tail, not the head: the last line of a hunk is the one the comment is
-  // anchored to, and the head is context leading up to it.
-  const shown = lines.slice(-8);
+  const { lines: shown, clipped } = hunkTail(text);
   return (
     <View style={{ backgroundColor: C.bg, borderRadius: RADIUS.sm, paddingVertical: SPACE.xs }}>
-      {lines.length > shown.length ? (
+      {clipped ? (
         <Text style={{ color: C.text4, fontSize: 10, fontFamily: MONO, paddingHorizontal: SPACE.sm }}>⋯</Text>
       ) : null}
       {shown.map((line, i) => {
@@ -170,8 +148,8 @@ export default function ThreadsScreen(): React.ReactNode {
      * interchangeable, which the shared type says out loud. Without a
      * databaseId there is nothing to reply to, so the box is not offered.
      */
-    const anchor = thread.comments.find((c) => typeof c.databaseId === "number")?.databaseId;
-    if (typeof anchor !== "number") {
+    const anchor = replyAnchor(thread);
+    if (anchor === null) {
       setSaid({ id: thread.id, bad: true, text: "That thread carries no id to reply to." });
       return;
     }
@@ -242,7 +220,7 @@ export default function ThreadsScreen(): React.ReactNode {
             .flatMap((c) => suggestionsIn(c.body))
             .at(0);
           const canApply = mayWrite && !!suggestion && !!range && !thread.isResolved;
-          const canReply = mayWrite && thread.comments.some((c) => typeof c.databaseId === "number");
+          const canReply = mayWrite && replyAnchor(thread) !== null;
           const note = said?.id === thread.id ? said : null;
           const working = busy === thread.id;
 

--- a/mobile/scripts/qa.ts
+++ b/mobile/scripts/qa.ts
@@ -83,6 +83,10 @@ const ROUTES: { path: string; name: string; expect: RegExp; pane?: boolean }[] =
   // The job list, which is a `read` route — so unlike every other write on the
   // detail screens, this one has to hold under the default pairing scope.
   { path: "/pr/checks?number=0&root=%2Ftmp", name: "PR checks", expect: /Cannot read them|could not be read|out of scope|No jobs|not a git repository/i },
+  // Threads. Like the checks list it reads, so it must hold under the default
+  // pairing scope — the writes on it (reply, resolve, apply) are what needs
+  // `full`, and each is gated on its own.
+  { path: "/pr/threads?number=0&root=%2Ftmp", name: "PR threads", expect: /Cannot read them|could not be read|out of scope|not a git repository|commented on a line/i },
   // Walked at the workspace root rather than a nonsense one: this is a `read`
   // screen whose whole job is to LIST, and an empty listing would pass a check
   // that a broken one also passes. `bin` is in every checkout this repo has.

--- a/mobile/scripts/qa.ts
+++ b/mobile/scripts/qa.ts
@@ -74,7 +74,10 @@ const ROUTES: { path: string; name: string; expect: RegExp; pane?: boolean }[] =
   // which is the point: the failure this catches is the screen not mounting.
   { path: "/issues", name: "Issues", expect: /Mine|Nothing open|Cannot ask GitHub/i },
   { path: "/repos", name: "Repos", expect: /changed|Nothing changed/i },
-  { path: "/tasks", name: "Cards", expect: /hiding done|Nothing here|Cannot read the board/i },
+  /* Four things it may honestly say, and the third is the one this machine
+     shows: no tracker is connected here, so there is no board rather than an
+     empty one. The distinction is the point of the state existing. */
+  { path: "/tasks", name: "Cards", expect: /hiding done|Nothing here|No board here|Cannot read the board/i },
   // Both details walked with ids that exist nowhere, for the same reason as
   // the pull request's: what is asserted is that the screen mounts and says it
   // could not read it, rather than rendering a blank.

--- a/mobile/src/lib/dates.ts
+++ b/mobile/src/lib/dates.ts
@@ -38,12 +38,29 @@ export function dueIn(
   return { text: `in ${days}d`, late: false };
 }
 
-/** "3h", "2d" — how long since something last moved. Takes an ISO instant,
- *  which is what GitHub answers with, and is a genuine elapsed time rather than
- *  a calendar distance. */
-export function since(iso: string, now: number): string {
-  const at = Date.parse(iso);
-  if (!Number.isFinite(at)) return "";
+/**
+ * "3h", "2d" — how long since something last moved.
+ *
+ * A genuine elapsed time rather than a calendar distance, which is why it does
+ * not share `dueIn`'s machinery: a due date is a day somebody planned around
+ * and this is a duration.
+ *
+ * Two spellings of an instant, because the two services answer differently and
+ * neither is worth converting at the call site. GitHub sends an ISO string;
+ * ClickUp sends epoch milliseconds, which reach here as a number.
+ *
+ * Measured rather than assumed, because the obvious worry turned out to be the
+ * wrong one: `Date.parse("1787914800000")` is NaN, not a date in the year 1755
+ * — only a bare four-digit string reads as a year. So the failure this union
+ * prevents is not a wildly wrong duration, it is a SILENT one: every timestamp
+ * on the card screen quietly blank, which reads as "this app does not show
+ * those" rather than as a fault.
+ */
+export function since(when: string | number, now: number): string {
+  const at = typeof when === "number" ? when : Date.parse(when);
+  // Zero is ClickUp's "no date", not 1970. Both are useless to a reader and
+  // the empty string is what the screens already draw for "unknown".
+  if (!Number.isFinite(at) || at <= 0) return "";
   const minutes = Math.max(0, Math.round((now - at) / 60_000));
   if (minutes < 60) return `${minutes}m`;
   if (minutes < 1440) return `${Math.round(minutes / 60)}h`;

--- a/mobile/src/model/expand.ts
+++ b/mobile/src/model/expand.ts
@@ -1,0 +1,126 @@
+/*
+ * The lines a diff is NOT showing you, and which of them to ask for.
+ *
+ * A hunk header says `@@ -12,7 +12,9 @@` and the three lines of context around
+ * a change are all you get. On a desk that is usually enough, because the file
+ * is open in an editor two inches away. On a phone it is not: the question you
+ * actually have about a changed line — what calls this, what the branch above
+ * it tests — is answered by the twenty lines the hunk cut off, and today the
+ * only way to see them is to leave for GitHub.
+ *
+ * `/prs/file-slice` already serves them, by line range, from either side of the
+ * pull request. This module is the arithmetic: given the hunks that were
+ * parsed, where are the gaps, and what range does each expander ask for.
+ *
+ * ── it is arithmetic, so it is testable, so it is here ───────────────────
+ * The screen renders; this decides. Off-by-one in a diff is not a cosmetic
+ * bug — it is a comment anchored to the wrong line, which is a remark about
+ * code the author did not write. `diffLines.ts` makes the same argument for
+ * the same reason, and this is its neighbour.
+ */
+import type { DiffFile, DiffHunk } from "./diffLines.ts";
+
+/** How many lines one press asks for. Twenty is about a screen of code at the
+ *  10.5pt the diff draws at, and a whole screen is the unit somebody means when
+ *  they press "show more" — a smaller step turns reading into pressing. */
+export const STEP = 20;
+
+/** One place the file continues, between what two hunks show. */
+export interface Gap {
+  /** The hunk this expander sits ABOVE, by index. `hunks.length` means the
+   *  expander below the last hunk — the tail of the file. */
+  before: number;
+  /** First and last line NOT shown, on the new side, inclusive. `to` is null
+   *  at the tail, where how far the file goes is the server's to know. */
+  from: number;
+  to: number | null;
+}
+
+/** The new-side line numbers a hunk covers, or null when it carries none —
+ *  a pure deletion has no new side to speak of. */
+export function newSpan(hunk: DiffHunk): { first: number; last: number } | null {
+  let first: number | null = null;
+  let last: number | null = null;
+  for (const line of hunk.lines) {
+    if (line.newNo == null) continue;
+    if (first === null) first = line.newNo;
+    last = line.newNo;
+  }
+  return first === null || last === null ? null : { first, last };
+}
+
+/**
+ * Every gap in a file's diff, in file order.
+ *
+ * Includes the head of the file (above the first hunk) and its tail (below the
+ * last), because "what is at the top of this file" is one of the two questions
+ * a reviewer asks most and the diff never shows it.
+ *
+ * A file with no hunks gets nothing: there is no diff to expand around, and an
+ * expander on an empty screen offers to show a file the pull request did not
+ * change.
+ */
+export function gapsIn(file: Pick<DiffFile, "hunks">): Gap[] {
+  const spans = file.hunks.map(newSpan);
+  const out: Gap[] = [];
+  let prevLast = 0;
+  for (let i = 0; i < file.hunks.length; i++) {
+    const span = spans[i];
+    /* A hunk with no new side cannot bound a gap on the new side. Skipped
+       rather than treated as zero-length: `prevLast` stays where the last real
+       hunk left it, so the gap after a pure deletion is measured from the code
+       that is actually still there. */
+    if (!span) continue;
+    if (span.first > prevLast + 1) out.push({ before: i, from: prevLast + 1, to: span.first - 1 });
+    prevLast = Math.max(prevLast, span.last);
+  }
+  if (file.hunks.length) out.push({ before: file.hunks.length, from: prevLast + 1, to: null });
+  return out;
+}
+
+/**
+ * What one press on an expander should ask the server for.
+ *
+ * Two rules, and both of them are about not making somebody press twice for
+ * nothing:
+ *
+ *   A gap SMALLER than a step is asked for whole. Fetching 20 of the 6 lines
+ *   between two hunks and leaving a 0-line expander behind is the shape that
+ *   makes a control look broken.
+ *
+ *   Otherwise it grows from the end nearest the code you are reading —
+ *   downward from the top of a gap, upward from its bottom — because the lines
+ *   just past the edge of a hunk are the ones the question is about.
+ *
+ * `at` is the last line already shown from this gap, if the expander has been
+ * pressed before; null on the first press.
+ */
+export function nextSlice(gap: Gap, dir: "up" | "down", at: number | null): { from: number; to: number } | null {
+  if (gap.to !== null && gap.from > gap.to) return null;
+  if (dir === "down") {
+    const from = at === null ? gap.from : at + 1;
+    if (gap.to !== null && from > gap.to) return null;
+    const want = from + STEP - 1;
+    return { from, to: gap.to === null ? want : Math.min(want, gap.to) };
+  }
+  // Upward only has an end to count back from when the gap has one; the tail
+  // of a file is unbounded and is only ever read downward.
+  if (gap.to === null) return null;
+  const to = at === null ? gap.to : at - 1;
+  if (to < gap.from) return null;
+  return { from: Math.max(gap.from, to - STEP + 1), to };
+}
+
+/**
+ * How the expander reads.
+ *
+ * Says the size when it is known, because "37 lines" and "more lines" are
+ * different offers and only one of them is a decision. The tail of a file has
+ * no size until the server answers with one, so it says what it can.
+ */
+export function gapLabel(gap: Gap, slice: { from: number; to: number } | null): string {
+  if (!slice) return "";
+  const n = slice.to - slice.from + 1;
+  if (gap.to === null) return "Show more of the file";
+  return n === 1 ? "Show 1 more line" : `Show ${n} more lines`;
+}

--- a/mobile/src/model/taskProviders.ts
+++ b/mobile/src/model/taskProviders.ts
@@ -1,0 +1,66 @@
+/*
+ * Whether this machine tracks work anywhere, and what that costs the bar.
+ *
+ * ── the question is not "is ClickUp connected" ───────────────────────────
+ * ClickUp is one task provider of several. `shared/providers.ts` already lists
+ * them with a `kind`, and two of them — Taskwarrior and ClickUp — are tasks
+ * today, with nothing stopping a third. So the question this asks is the
+ * general one: does the person on the other end of this phone track work in
+ * SOMETHING. A check spelled `clickup` would be the app deciding that one
+ * workspace's tool is what a task is.
+ *
+ * ── and the answer changes the bar, which the desk's does not ────────────
+ * `web/src/lib/taskConnected.ts` answers the same question and reaches a
+ * different conclusion on purpose, so the difference is worth stating rather
+ * than looking like drift. Its rule is:
+ *
+ *   nothing set up   show every task source — this is a fresh install, and
+ *                    the bar is the only advertisement the feature has
+ *
+ * That argument holds at a desk because an unconnected tab there LINKS to the
+ * pane that connects it. It does not hold here, and the reason is a rule this
+ * app spends its scope on elsewhere: a phone cannot set a provider up. There
+ * is no Integrations pane on it, deliberately — the same refusal that makes
+ * Troubleshooting print an install line rather than run it. So an empty Cards
+ * tab on a phone advertises something you cannot act on from the device you
+ * are holding, and it spends a fifth of a five-item bar doing it.
+ *
+ * ── a broken provider still counts ───────────────────────────────────────
+ * Taken from the desk verbatim, because it is right there too: "ClickUp
+ * refused this token" is not the same as "you do not use ClickUp", and hiding
+ * the tab would remove the one surface that was going to say so.
+ */
+import { PROVIDERS, type ProviderState, type ProviderStatus } from "../../../shared/providers.ts";
+
+/** The ids that feed the work-you-owe half, read from the catalogue rather
+ *  than listed — a list here would be wrong the first time somebody adds a
+ *  provider, and wrong silently. */
+const TASK_IDS = new Set(PROVIDERS.filter((p) => p.kind === "task").map((p) => p.id));
+
+/**
+ * Whether a provider counts as "this person uses this".
+ *
+ * `connected` is the plain yes. `error` counts too: a refused token or a
+ * workspace that timed out is something you set up and that is failing.
+ *
+ * The two that mean no are the two that mean nobody ever did anything —
+ * `missing-tool` (the CLI is not installed) and `needs-auth` (installed, never
+ * signed in).
+ */
+const setUp = (state: ProviderState): boolean => state === "connected" || state === "error";
+
+/**
+ * Does this machine track work anywhere?
+ *
+ * `null` when it cannot be told — no answer yet, or an answer with no task
+ * provider mentioned in it at all. Null is NOT "no": a provider the server did
+ * not name is unknown rather than absent, and taking somebody's tab away on a
+ * missing answer is the one failure here with no way back from the device
+ * looking at it.
+ */
+export function tracksWork(statuses: ProviderStatus[] | null | undefined): boolean | null {
+  if (!statuses) return null;
+  const known = statuses.filter((p) => TASK_IDS.has(p.id));
+  if (!known.length) return null;
+  return known.some((p) => setUp(p.state));
+}

--- a/mobile/src/model/threads.ts
+++ b/mobile/src/model/threads.ts
@@ -1,0 +1,86 @@
+/*
+ * How a pull request's conversations are ordered and labelled.
+ *
+ * The screen renders; this decides — the same split diffLines.ts and expand.ts
+ * make, and here for a reason those two do not have. A thread screen can only
+ * be seen with real threads on it, which needs a GitHub the test machine does
+ * not have, so everything that can be decided without drawing is decided out
+ * here where a test can reach it. What is left in the screen is layout.
+ */
+import type { PrThread } from "../../../shared/types.ts";
+
+/**
+ * The order to read them in.
+ *
+ * Unresolved first, because they are the ones still asking something of
+ * somebody. Outdated next: GitHub's own word for a thread whose lines have
+ * changed underneath it, and usually safe to skip — but not hidden, because
+ * "usually" is not "always" and a remark about code that has since moved is
+ * still a remark somebody made.
+ *
+ * Resolved last, and kept. A resolved thread is the record of an argument that
+ * was had, which is exactly what you go looking for when the same line comes
+ * back a week later.
+ *
+ * Within each group, the order the detail already put them in — which is file
+ * order. A second sort here would be a second opinion about the same list.
+ */
+export function ordered(threads: PrThread[]): PrThread[] {
+  const rank = (t: PrThread): number => (t.isResolved ? 2 : t.isOutdated ? 1 : 0);
+  return threads
+    .map((t, at) => ({ t, at }))
+    .sort((a, b) => rank(a.t) - rank(b.t) || a.at - b.at)
+    .map(({ t }) => t);
+}
+
+/**
+ * Where a thread is, in the shortest form that still identifies it.
+ *
+ * `line` is null on an outdated thread — the lines it was written about are
+ * gone from the current diff — and `originalLine` is where it was written. For
+ * a LABEL that fallback is right and honest: it says where the conversation
+ * happened. It is emphatically not right for applying a suggestion, which is
+ * why `suggestionRange` refuses rather than falling back. The two questions
+ * look the same and are not.
+ */
+export function whereOf(thread: Pick<PrThread, "path" | "line" | "startLine" | "originalLine">): string {
+  const line = thread.line ?? thread.originalLine ?? null;
+  if (line === null) return thread.path;
+  const span = thread.startLine && thread.startLine !== line ? `${thread.startLine}-${line}` : `${line}`;
+  return `${thread.path}:${span}`;
+}
+
+/**
+ * The end of a diff hunk, which is the part worth showing.
+ *
+ * A comment is anchored to the LAST line of the hunk GitHub kept with it;
+ * everything above is context leading up to that line. On a phone there is
+ * room for about eight rows before the comment itself is pushed off screen, so
+ * the tail is what survives and the head is what goes.
+ *
+ * Blank lines are dropped first: `diffHunk` arrives with a trailing newline
+ * and sometimes two, and counting those as content spends the budget on
+ * nothing.
+ */
+export function hunkTail(text: string, rows = 8): { lines: string[]; clipped: boolean } {
+  const all = (text ?? "").split("\n").filter((l) => l.length > 0);
+  return { lines: all.slice(-rows), clipped: all.length > rows };
+}
+
+/**
+ * Can this thread be replied to, and with which id.
+ *
+ * The REST reply endpoint takes the NUMERIC id of a comment in the thread.
+ * `PrThreadComment.id` is a GraphQL node id and the two are not
+ * interchangeable — the shared type says so, and posting one where the other
+ * is expected fails with a 404 that reads like the thread does not exist.
+ *
+ * The FIRST comment carrying one, not the last: replying to a thread means
+ * `in_reply_to` its opening comment, and GitHub threads the rest itself.
+ */
+export function replyAnchor(thread: Pick<PrThread, "comments">): number | null {
+  for (const c of thread.comments) {
+    if (typeof c.databaseId === "number" && Number.isSafeInteger(c.databaseId)) return c.databaseId;
+  }
+  return null;
+}

--- a/mobile/src/nav/bar.ts
+++ b/mobile/src/nav/bar.ts
@@ -70,6 +70,38 @@ export const BAR: Destination[] = [
 ];
 
 /**
+ * The destinations the Inbox offers, given what this machine tracks work in.
+ *
+ * `BAR` is the claim about what this app is for and stays whole — it is the
+ * list, the test's subject, and the thing `index.tsx` draws from. This is the
+ * one question laid over it: a machine that tracks work NOWHERE has no cards,
+ * and a row that opens a screen which can only say "nothing is connected" is a
+ * row that costs a tap to learn nothing.
+ *
+ * ── why this removes rather than replaces ────────────────────────────────
+ * There is nothing to replace it with. When these five were a bottom bar the
+ * count had to stay odd or the star was not centred, and losing one meant
+ * promoting another; that bar is retired (src/nav/TabBar.tsx) and the Inbox
+ * draws a LIST, which has no such arithmetic. Source control was added to the
+ * list the moment the slot stopped existing, so the destination that would
+ * have been promoted is already here.
+ *
+ * ── unknown draws it ─────────────────────────────────────────────────────
+ * `null` is not "no". The same choice `visibleTaskSources` makes at the desk,
+ * and for the same reason: a spare row is recoverable by ignoring it, and a
+ * row that is missing because an answer never arrived is not recoverable at
+ * all from the device looking at the screen.
+ *
+ * ── a broken provider keeps its row ──────────────────────────────────────
+ * Decided in model/taskProviders.ts, which counts `error` as set up. "ClickUp
+ * refused this token" is not "you do not use ClickUp", and the row is the only
+ * surface that was going to say so.
+ */
+export function taskDestinations(all: Destination[], tracksWork: boolean | null): Destination[] {
+  return tracksWork === false ? all.filter((d) => d.route !== "tasks") : all;
+}
+
+/**
  * The routes that are still routes and are no longer tabs.
  *
  * Every one of them is a whole screen, mounted in the same navigator as the

--- a/mobile/src/state/use-tracks-work.ts
+++ b/mobile/src/state/use-tracks-work.ts
@@ -1,0 +1,61 @@
+/*
+ * One answer to "does this machine track work anywhere", shared by everything
+ * that asks.
+ *
+ * The bar mounts on every screen in the app, so this cannot be a fetch inside
+ * a component: that would be one request per navigation, forever, for an
+ * answer that changes when somebody connects a provider at their computer —
+ * which is to say, about twice.
+ *
+ * So it is a module-level cache with a hook over it, the shape
+ * `web/src/lib/taskConnected.ts` already uses at the desk. Held for a minute
+ * rather than forever, because connecting a provider should reach the phone
+ * without restarting the app; a failure is deliberately NOT cached, because
+ * the machine being unreachable for a moment must not take somebody's tab away
+ * for the next minute.
+ */
+import { useEffect, useState } from "react";
+import type { ProviderStatus } from "../../../shared/providers.ts";
+import { ask } from "../lib/api.ts";
+import type { Host } from "../lib/host.ts";
+import { tracksWork } from "../model/taskProviders.ts";
+
+const TTL = 60_000;
+let held: { at: number; origin: string; value: boolean | null } | null = null;
+let inflight: Promise<boolean | null> | null = null;
+
+/** Keyed by origin as well as time: pairing this phone to a second machine
+ *  must not carry the first one's answer over, and the two genuinely differ —
+ *  that is the whole point of the question. */
+const fresh = (origin: string): boolean | null | undefined =>
+  (held && held.origin === origin && Date.now() - held.at < TTL ? held.value : undefined);
+
+/** For a test, and for the moment a provider is connected. */
+export function forgetTracksWork(): void { held = null; inflight = null; }
+
+export function useTracksWork(host: Host | null): boolean | null {
+  const origin = host?.origin ?? "";
+  const [value, setValue] = useState<boolean | null>(() => fresh(origin) ?? null);
+
+  useEffect(() => {
+    if (!host) return;
+    const now = fresh(host.origin);
+    if (now !== undefined) { setValue(now); return; }
+    let live = true;
+    inflight ??= ask<{ providers?: ProviderStatus[] }>(host, "/providers")
+      .then((answer) => {
+        // Not an answer is not "no". `tracksWork` treats null as unknown and
+        // the bar draws everything on unknown, which is the direction with a
+        // way back: a spare tab is recoverable, a missing one is not.
+        const got = answer.ok ? tracksWork(answer.value.providers) : null;
+        held = { at: Date.now(), origin: host.origin, value: got };
+        return got;
+      })
+      .catch(() => null)
+      .finally(() => { inflight = null; });
+    void inflight.then((got) => { if (live) setValue(got); });
+    return () => { live = false; };
+  }, [host, origin]);
+
+  return value;
+}

--- a/mobile/test/due-date.test.ts
+++ b/mobile/test/due-date.test.ts
@@ -12,7 +12,7 @@
  * normalised the same way. The tests run the clock around a whole day to say so.
  */
 import { describe, expect, test } from "bun:test";
-import { dueIn } from "../src/lib/dates.ts";
+import { dueIn, since } from "../src/lib/dates.ts";
 
 /** A local date-time, built the way the device's own clock reports one. */
 const at = (iso: string): Date => new Date(iso);
@@ -53,5 +53,55 @@ describe("a due date, read as a distance", () => {
     for (const bad of [null, undefined, "", "someday", "2026-13-45x", "31/08/2026"]) {
       expect(dueIn(bad, at("2026-08-06T09:00:00")), String(bad)).toBeNull();
     }
+  });
+});
+
+/*
+ * "how long ago", from the two shapes an instant arrives in.
+ *
+ * GitHub answers with an ISO string and ClickUp with epoch milliseconds. The
+ * case worth a test is the second one going through the first one's parser.
+ * That fails quietly: a 13-digit epoch string is NaN to `Date.parse` —
+ * checked, because the guess was that it would read as the year 1755, and only
+ * a bare four-digit string does — so every time on the card screen would
+ * simply be blank, which reads as a screen that does not show times rather
+ * than as a broken one.
+ */
+describe("since", () => {
+  const now = Date.parse("2026-08-28T12:00:00Z");
+
+  test("reads an ISO instant, which is what GitHub sends", () => {
+    expect(since("2026-08-28T11:30:00Z", now)).toBe("30m");
+    expect(since("2026-08-28T09:00:00Z", now)).toBe("3h");
+    expect(since("2026-08-26T12:00:00Z", now)).toBe("2d");
+  });
+
+  test("reads epoch milliseconds, which is what ClickUp sends", () => {
+    expect(since(now - 30 * 60_000, now)).toBe("30m");
+    // 60 is not "60m": the minute branch is `< 60`, so the hour starts here.
+    expect(since(now - 60 * 60_000, now)).toBe("1h");
+    expect(since(now - 3 * 3_600_000, now)).toBe("3h");
+    expect(since(now - 2 * 86_400_000, now)).toBe("2d");
+  });
+
+  test("a number is never handed to the string parser", () => {
+    // The whole reason the signature takes both: the same instant, spelled the
+    // two ways, must not answer two different things — and the string spelling
+    // of an epoch is unparseable, so it answers with nothing at all.
+    const ms = Date.parse("2026-08-28T11:00:00Z");
+    expect(since(ms, now)).toBe("1h");
+    expect(since(String(ms) as unknown as string, now)).toBe("");
+  });
+
+  test("no date at all is blank rather than 1970", () => {
+    // ClickUp writes a missing date as 0, and "20500d" beside a comment is
+    // worse than nothing beside it.
+    expect(since(0, now)).toBe("");
+    expect(since("", now)).toBe("");
+    expect(since("not a date", now)).toBe("");
+  });
+
+  test("something dated in the future does not count backwards", () => {
+    expect(since(now + 60_000, now)).toBe("0m");
   });
 });

--- a/mobile/test/expand.test.ts
+++ b/mobile/test/expand.test.ts
@@ -1,0 +1,145 @@
+/*
+ * Where the diff stops and what one press asks for.
+ *
+ * The arithmetic, not the screen. A gap computed one line out shows context
+ * that overlaps the hunk above it — or worse, hides the line the reader was
+ * looking for and offers to fetch it again.
+ */
+import { describe, expect, test } from "bun:test";
+import { gapsIn, gapLabel, newSpan, nextSlice, STEP, type Gap } from "../src/model/expand.ts";
+import type { DiffHunk, DiffLine } from "../src/model/diffLines.ts";
+
+/** A hunk covering new-side lines [first, last], as a diff of context rows. */
+function hunk(first: number, last: number): DiffHunk {
+  const lines: DiffLine[] = [];
+  for (let n = first; n <= last; n++) lines.push({ kind: "ctx", text: `line ${n}`, oldNo: n, newNo: n });
+  return { header: `@@ -${first},${last - first + 1} +${first},${last - first + 1} @@`, lines };
+}
+
+/** A hunk that only removes: it has old-side numbers and no new-side ones. */
+function deletion(oldFrom: number, oldTo: number): DiffHunk {
+  const lines: DiffLine[] = [];
+  for (let n = oldFrom; n <= oldTo; n++) lines.push({ kind: "del", text: `gone ${n}`, oldNo: n, newNo: null });
+  return { header: "@@ -1,2 +0,0 @@", lines };
+}
+
+describe("newSpan", () => {
+  test("is the first and last new-side number in the hunk", () => {
+    expect(newSpan(hunk(12, 18))).toEqual({ first: 12, last: 18 });
+  });
+
+  test("is null when the hunk has no new side", () => {
+    expect(newSpan(deletion(4, 6))).toBe(null);
+  });
+});
+
+describe("gapsIn", () => {
+  test("a file with no hunks offers nothing to expand", () => {
+    expect(gapsIn({ hunks: [] })).toEqual([]);
+  });
+
+  test("the head of the file is a gap", () => {
+    const gaps = gapsIn({ hunks: [hunk(10, 14)] });
+    expect(gaps[0]).toEqual({ before: 0, from: 1, to: 9 });
+  });
+
+  test("a hunk starting at line 1 has no head gap", () => {
+    const gaps = gapsIn({ hunks: [hunk(1, 6)] });
+    expect(gaps.map((g) => g.before)).toEqual([1]); // the tail only
+  });
+
+  test("the space between two hunks is a gap", () => {
+    const gaps = gapsIn({ hunks: [hunk(1, 6), hunk(30, 36)] });
+    expect(gaps).toEqual([
+      { before: 1, from: 7, to: 29 },
+      { before: 2, from: 37, to: null },
+    ]);
+  });
+
+  test("touching hunks leave no gap between them", () => {
+    const gaps = gapsIn({ hunks: [hunk(1, 6), hunk(7, 9)] });
+    expect(gaps.map((g) => g.before)).toEqual([2]);
+  });
+
+  test("the tail is unbounded — only the server knows where the file ends", () => {
+    const gaps = gapsIn({ hunks: [hunk(1, 6)] });
+    expect(gaps.at(-1)).toEqual({ before: 1, from: 7, to: null });
+  });
+
+  test("a pure deletion does not move the boundary it cannot see", () => {
+    // The deletion has no new side. Measuring the next gap from it would start
+    // the gap at line 1 and offer to show code that is already on screen.
+    const gaps = gapsIn({ hunks: [hunk(1, 6), deletion(20, 22), hunk(40, 44)] });
+    expect(gaps[0]).toEqual({ before: 2, from: 7, to: 39 });
+  });
+});
+
+describe("nextSlice", () => {
+  const between: Gap = { before: 1, from: 7, to: 29 };
+  const head: Gap = { before: 0, from: 1, to: 9 };
+  const tail: Gap = { before: 2, from: 37, to: null };
+
+  test("downward starts at the top of the gap", () => {
+    expect(nextSlice(between, "down", null)).toEqual({ from: 7, to: 7 + STEP - 1 });
+  });
+
+  test("downward continues from where it left off", () => {
+    expect(nextSlice(between, "down", 26)).toEqual({ from: 27, to: 29 });
+  });
+
+  test("downward stops at the end of a bounded gap", () => {
+    expect(nextSlice(between, "down", 29)).toBe(null);
+  });
+
+  test("a gap smaller than a step is asked for whole", () => {
+    // Six lines, one press. Fetching twenty and leaving an expander showing
+    // nothing is what makes a control look broken.
+    expect(nextSlice({ before: 1, from: 7, to: 12 }, "down", null)).toEqual({ from: 7, to: 12 });
+  });
+
+  test("upward counts back from the bottom of the gap", () => {
+    expect(nextSlice(head, "up", null)).toEqual({ from: 1, to: 9 });
+    expect(nextSlice({ before: 1, from: 1, to: 100 }, "up", null)).toEqual({ from: 100 - STEP + 1, to: 100 });
+  });
+
+  test("upward continues above what it already showed", () => {
+    expect(nextSlice({ before: 1, from: 1, to: 100 }, "up", 81)).toEqual({ from: 80 - STEP + 1, to: 80 });
+  });
+
+  test("upward never runs off the top of the gap", () => {
+    expect(nextSlice(head, "up", 1)).toBe(null);
+  });
+
+  test("the tail of a file is only ever read downward", () => {
+    // There is no bottom to count back from: how far the file goes is the
+    // server's to know, and guessing it would ask for lines past the end.
+    expect(nextSlice(tail, "up", null)).toBe(null);
+    expect(nextSlice(tail, "down", null)).toEqual({ from: 37, to: 37 + STEP - 1 });
+  });
+
+  test("an empty gap offers nothing", () => {
+    expect(nextSlice({ before: 1, from: 10, to: 9 }, "down", null)).toBe(null);
+  });
+});
+
+describe("gapLabel", () => {
+  test("says how many when the count is known", () => {
+    const gap: Gap = { before: 1, from: 7, to: 12 };
+    expect(gapLabel(gap, nextSlice(gap, "down", null))).toBe("Show 6 more lines");
+  });
+
+  test("counts one line in the singular", () => {
+    const gap: Gap = { before: 1, from: 7, to: 7 };
+    expect(gapLabel(gap, nextSlice(gap, "down", null))).toBe("Show 1 more line");
+  });
+
+  test("the tail says what it can, because its size is not known yet", () => {
+    const gap: Gap = { before: 2, from: 37, to: null };
+    expect(gapLabel(gap, nextSlice(gap, "down", null))).toBe("Show more of the file");
+  });
+
+  test("nothing left to show is no label at all", () => {
+    const gap: Gap = { before: 1, from: 7, to: 12 };
+    expect(gapLabel(gap, nextSlice(gap, "down", 12))).toBe("");
+  });
+});

--- a/mobile/test/handoff-carries-an-id.test.ts
+++ b/mobile/test/handoff-carries-an-id.test.ts
@@ -1,0 +1,93 @@
+/*
+ * The one property the prompt preview must not quietly cost us.
+ *
+ * `src/model/reviewMenu.ts` states it as a rule: the socket carries an ID and
+ * never a prompt, so a socket reachable from the UI cannot become a way to
+ * choose what an agent is told. Until the preview existed, that rule was easy
+ * to keep by accident — the phone never held the words, so there was nothing
+ * to send even if somebody wanted to.
+ *
+ * Now it does hold them. `/prs/review-prompt` reads the built text back so it
+ * can be shown, and the words sit in state one line away from the call that
+ * opens the window. Turning that preview into what gets SENT is a two-word
+ * edit that would typecheck, pass every other test, and look like a feature.
+ *
+ * So it is checked here, by reading the screen rather than by running it: a
+ * behavioural test would have to reach into the socket, and the failure being
+ * guarded against is not a wrong value at runtime but a wrong SHAPE in the
+ * source. This is the same instrument web/test/pending-in-files.test.ts uses,
+ * for the same kind of claim.
+ */
+import { describe, expect, test } from "bun:test";
+
+const pr = await Bun.file(new URL("../app/pr/[number].tsx", import.meta.url)).text();
+const card = await Bun.file(new URL("../app/card/[id].tsx", import.meta.url)).text();
+
+/** The argument object of every `requestHandoff({...})` in a file. Matched on
+ *  the braces rather than parsed, which is enough: the call is written literally
+ *  at both sites and a version that was not would fail this loudly. */
+function frames(src: string): string[] {
+  return [...src.matchAll(/requestHandoff\(\{([\s\S]*?)\}\);/g)].map((m) => m[1] ?? "");
+}
+
+describe("what the review hand-off puts on the socket", () => {
+  const sent = frames(pr);
+
+  test("there is exactly one of them", () => {
+    // Two call sites is how the second one quietly grows a field the first
+    // does not have.
+    expect(sent.length).toBe(1);
+  });
+
+  test("it carries the recipe id", () => {
+    expect(sent[0]).toContain("cmd: \"review\"");
+    expect(sent[0]).toMatch(/\brecipe\b/);
+  });
+
+  test("it does NOT carry a prompt", () => {
+    /* The whole point. `prepareReviewPrompt` builds the text on the computer
+       and builds it again when the window opens; what this screen read back is
+       for a person to look at, and nothing else. A `prompt:` here would mean
+       the phone had started choosing the words. */
+    expect(sent[0]).not.toMatch(/\bprompt\s*:/);
+  });
+
+  test("the preview is read-only — nothing types into it", () => {
+    /* An editable preview is the same breach by another route, and it would
+       arrive as a TextInput bound to the prompt. Whether the phone should be
+       allowed to send words of its own is a decision about what this app is;
+       it is not something that should be able to appear in a diff about
+       layout. */
+    const preview = pr.slice(pr.indexOf("preview?.state === \"read\""));
+    expect(preview.slice(0, preview.indexOf("</Sheet>"))).not.toContain("TextInput");
+  });
+});
+
+describe("what the card hand-off puts on the socket", () => {
+  const sent = frames(card);
+
+  test("there is exactly one of them", () => {
+    expect(sent.length).toBe(1);
+  });
+
+  test("its prompt is built by the shared helper, not spelled here", () => {
+    /* A card hand-off DOES carry a prompt — it always has, and `cmd: "issue"`
+       is defined that way. What must not drift is the shape of the line: the
+       desk and the phone both invoke a skill as `/name ID`, from
+       shared/cardSkills.ts, because that is the string those skills were
+       written against. A second spelling here would work on the day it was
+       written and diverge from there. */
+    expect(sent[0]).toMatch(/\bprompt\b/);
+    expect(card).toContain("skillCommand(");
+    expect(card).toContain("shared/cardSkills.ts");
+  });
+
+  test("it does not ask the server to skip permission prompts", () => {
+    /* `yolo` buys exactly one flag — `--dangerously-skip-permissions` — and no
+       screen on this phone asks for it. A skill's own `[autonomous | yolo]`
+       modes are WORDS IN A PROMPT that the skill itself reads; they must never
+       be mistaken for the frame's boolean, which is a different thing with a
+       much longer reach. */
+    expect(sent[0]).not.toMatch(/\byolo\s*:/);
+  });
+});

--- a/mobile/test/suggestion.test.ts
+++ b/mobile/test/suggestion.test.ts
@@ -1,0 +1,88 @@
+/*
+ * The suggestion parser, against the shapes GitHub actually produces.
+ *
+ * Every case here is one somebody has written into a review comment. The two
+ * that matter most are the empty block — which means "delete these lines" and
+ * which a falsy check would silently drop — and the outdated thread, where the
+ * honest answer is "nowhere to apply this" rather than a line number that now
+ * points at something else.
+ */
+import { describe, expect, test } from "bun:test";
+import { suggestionsIn, suggestionRange } from "../../shared/suggestion.ts";
+
+describe("suggestionsIn", () => {
+  test("takes the body of a plain block", () => {
+    const got = suggestionsIn("Try this:\n\n```suggestion\nconst a = 1;\n```\n");
+    expect(got).toEqual([{ text: "const a = 1;" }]);
+  });
+
+  test("an empty block is a deletion, not an absence", () => {
+    const got = suggestionsIn("Drop it.\n\n```suggestion\n```\n");
+    expect(got.length).toBe(1);
+    expect(got[0]!.text).toBe("");
+  });
+
+  test("keeps every blank and every space inside the block", () => {
+    const got = suggestionsIn("```suggestion\nif (x) {\n\n  go();\n}\n```");
+    expect(got[0]!.text).toBe("if (x) {\n\n  go();\n}");
+  });
+
+  test("finds more than one, in order", () => {
+    const got = suggestionsIn("```suggestion\nfirst\n```\nand also\n```suggestion\nsecond\n```");
+    expect(got.map((s) => s.text)).toEqual(["first", "second"]);
+  });
+
+  test("ignores a fenced block that is not a suggestion", () => {
+    expect(suggestionsIn("```ts\nconst a = 1;\n```")).toEqual([]);
+    expect(suggestionsIn("```\nplain\n```")).toEqual([]);
+  });
+
+  test("an unclosed fence is dropped rather than guessed at", () => {
+    expect(suggestionsIn("```suggestion\nhalf a message")).toEqual([]);
+  });
+
+  test("strips the fence's own indent and no more", () => {
+    // Written inside a list item: the whole block is indented two, and the
+    // code's own nesting is four more that must survive.
+    const body = "- like so:\n  ```suggestion\n  if (x) {\n      deep();\n  }\n  ```";
+    expect(suggestionsIn(body)[0]!.text).toBe("if (x) {\n    deep();\n}");
+  });
+
+  test("a longer fence lets a suggestion contain a fence", () => {
+    const body = "````suggestion\n```\ninner\n```\n````";
+    expect(suggestionsIn(body)[0]!.text).toBe("```\ninner\n```");
+  });
+
+  test("says nothing about a body with no block at all", () => {
+    expect(suggestionsIn("just a remark")).toEqual([]);
+    expect(suggestionsIn("")).toEqual([]);
+  });
+});
+
+describe("suggestionRange", () => {
+  test("one line is a range of itself", () => {
+    expect(suggestionRange({ line: 42 })).toEqual({ startLine: 42, line: 42 });
+  });
+
+  test("a multi-line thread keeps both ends", () => {
+    expect(suggestionRange({ line: 48, startLine: 42 })).toEqual({ startLine: 42, line: 48 });
+  });
+
+  test("an outdated thread has nowhere to apply", () => {
+    // The lines it was written about are gone. `originalLine` still holds a
+    // number, and using it would edit whatever is at that line now.
+    expect(suggestionRange({ line: 42, isOutdated: true })).toBe(null);
+    expect(suggestionRange({ line: null, isOutdated: true })).toBe(null);
+  });
+
+  test("no line is no range", () => {
+    expect(suggestionRange({ line: null })).toBe(null);
+    expect(suggestionRange({ line: 0 })).toBe(null);
+  });
+
+  test("a start after the end is refused rather than swapped", () => {
+    // Swapping would apply the change somewhere plausible and wrong. The
+    // server refuses this too; agreeing with it here saves a round trip.
+    expect(suggestionRange({ line: 10, startLine: 20 })).toBe(null);
+  });
+});

--- a/mobile/test/task-providers.test.ts
+++ b/mobile/test/task-providers.test.ts
@@ -1,0 +1,102 @@
+/*
+ * Whether this machine tracks work anywhere, and what the Inbox does about it.
+ *
+ * The question this app was getting wrong is not "is ClickUp connected". It is
+ * the general one — ClickUp is one task provider of several, and a phone that
+ * offers a Cards row to somebody who tracks work in Taskwarrior, or in nothing
+ * at all, is showing them somebody else's product.
+ *
+ * Two failures are guarded here and they fail in opposite directions. Showing
+ * the row when there is no board costs a tap to learn nothing. HIDING it on an
+ * answer that never arrived costs the row itself, and there is no way to get it
+ * back from the phone: providers are connected at the computer.
+ */
+import { describe, expect, test } from "bun:test";
+import type { ProviderId, ProviderState, ProviderStatus } from "../../shared/providers.ts";
+import { tracksWork } from "../src/model/taskProviders.ts";
+import { BAR, taskDestinations, type Destination } from "../src/nav/bar.ts";
+
+const at = (id: ProviderId, state: ProviderState): ProviderStatus => ({ id, state });
+
+describe("tracksWork", () => {
+  test("a connected tracker is a yes", () => {
+    expect(tracksWork([at("clickup", "connected")])).toBe(true);
+    expect(tracksWork([at("taskwarrior", "connected")])).toBe(true);
+  });
+
+  test("any one of them is enough", () => {
+    // ClickUp is this workspace's tool and not the definition of a task.
+    expect(tracksWork([at("clickup", "needs-auth"), at("taskwarrior", "connected")])).toBe(true);
+  });
+
+  test("set up and broken still counts", () => {
+    /* "ClickUp refused this token" is not "you do not use ClickUp", and the
+       row is the only surface that was going to say so. */
+    expect(tracksWork([at("clickup", "error")])).toBe(true);
+  });
+
+  test("never set up is a no", () => {
+    // The two that mean nobody ever did anything.
+    expect(tracksWork([at("clickup", "needs-auth"), at("taskwarrior", "missing-tool")])).toBe(false);
+  });
+
+  test("review providers do not answer this question", () => {
+    // GitHub being signed in says nothing about where work is tracked.
+    expect(tracksWork([at("github", "connected"), at("clickup", "needs-auth")])).toBe(false);
+  });
+
+  test("no answer is unknown, not no", () => {
+    expect(tracksWork(null)).toBe(null);
+    expect(tracksWork(undefined)).toBe(null);
+  });
+
+  test("an answer naming no tracker at all is unknown", () => {
+    /* A server that did not mention a provider has not said it is absent. The
+       direction matters: unknown draws the row, and a row nobody needs is
+       recoverable by ignoring it. */
+    expect(tracksWork([])).toBe(null);
+    expect(tracksWork([at("github", "connected")])).toBe(null);
+  });
+});
+
+describe("taskDestinations", () => {
+  const all: Destination[] = [...BAR.filter((d) => d.route !== "index"), { route: "repos", label: "Source control" }];
+
+  test("keeps cards when something is tracked", () => {
+    expect(taskDestinations(all, true).map((d) => d.route)).toContain("tasks");
+  });
+
+  test("keeps cards while the answer is unknown", () => {
+    // The recoverable direction, and the same one the desk takes.
+    expect(taskDestinations(all, null).map((d) => d.route)).toContain("tasks");
+  });
+
+  test("drops cards when nothing is tracked", () => {
+    expect(taskDestinations(all, false).map((d) => d.route)).not.toContain("tasks");
+  });
+
+  test("drops cards and nothing else", () => {
+    /* There is nothing to promote in its place, and that is not an oversight:
+       the five-slot bar that made a removal need a replacement is retired, and
+       source control — the destination that would have been promoted — is
+       already in this list. */
+    const before = all.map((d) => d.route);
+    const after = taskDestinations(all, false).map((d) => d.route);
+    expect(after).toEqual(before.filter((r) => r !== "tasks"));
+  });
+
+  test("the order is never rearranged", () => {
+    for (const answer of [true, false, null]) {
+      const got = taskDestinations(all, answer).map((d) => d.route);
+      expect(got).toEqual(all.map((d) => d.route).filter((r) => got.includes(r)));
+    }
+  });
+
+  test("BAR itself is untouched — it is the claim, not the drawing", () => {
+    // Every other reader of BAR (the Inbox's own list, keyLayout's ordering)
+    // still sees the five this app is for.
+    taskDestinations(all, false);
+    expect(BAR.map((d) => d.route)).toContain("tasks");
+    expect(BAR.length).toBe(5);
+  });
+});

--- a/mobile/test/threads.test.ts
+++ b/mobile/test/threads.test.ts
@@ -1,0 +1,146 @@
+/*
+ * The decisions the threads screen makes before it draws anything.
+ *
+ * They live outside the screen because the screen cannot be seen here: showing
+ * it with real conversations on it needs a GitHub, and the QA walk that visits
+ * every route reaches only its "cannot read it" state. So the parts that can be
+ * wrong on their own are pulled out and checked on their own.
+ */
+import { describe, expect, test } from "bun:test";
+import type { PrThread, PrThreadComment } from "../../shared/types.ts";
+import { hunkTail, ordered, replyAnchor, whereOf } from "../src/model/threads.ts";
+
+function comment(over: Partial<PrThreadComment> = {}): PrThreadComment {
+  return {
+    id: "MDEy", author: "someone", isBot: false, body: "",
+    createdAt: "2026-08-01T00:00:00Z", ...over,
+  };
+}
+
+function thread(over: Partial<PrThread> = {}): PrThread {
+  return {
+    id: "T", path: "src/a.ts", line: 10, isResolved: false, isOutdated: false,
+    comments: [comment()], ...over,
+  };
+}
+
+describe("ordered", () => {
+  test("open threads come before resolved ones", () => {
+    const got = ordered([
+      thread({ id: "done", isResolved: true }),
+      thread({ id: "open" }),
+    ]);
+    expect(got.map((t) => t.id)).toEqual(["open", "done"]);
+  });
+
+  test("outdated sits between open and resolved", () => {
+    const got = ordered([
+      thread({ id: "resolved", isResolved: true }),
+      thread({ id: "outdated", isOutdated: true }),
+      thread({ id: "open" }),
+    ]);
+    expect(got.map((t) => t.id)).toEqual(["open", "outdated", "resolved"]);
+  });
+
+  test("nothing is hidden — a resolved thread is the record of an argument", () => {
+    const all = [thread({ id: "a", isResolved: true }), thread({ id: "b", isOutdated: true })];
+    expect(ordered(all).length).toBe(2);
+  });
+
+  test("within a group the detail's own order is kept", () => {
+    // File order, decided once on the server. Re-sorting here would be a
+    // second opinion about the same list.
+    const got = ordered([thread({ id: "1" }), thread({ id: "2" }), thread({ id: "3" })]);
+    expect(got.map((t) => t.id)).toEqual(["1", "2", "3"]);
+  });
+
+  test("the input is not reordered underneath the caller", () => {
+    const all = [thread({ id: "done", isResolved: true }), thread({ id: "open" })];
+    ordered(all);
+    expect(all.map((t) => t.id)).toEqual(["done", "open"]);
+  });
+
+  test("an empty list is an empty list", () => {
+    expect(ordered([])).toEqual([]);
+  });
+});
+
+describe("whereOf", () => {
+  test("one line", () => {
+    expect(whereOf({ path: "src/a.ts", line: 10, startLine: null, originalLine: null })).toBe("src/a.ts:10");
+  });
+
+  test("a range keeps both ends", () => {
+    expect(whereOf({ path: "src/a.ts", line: 18, startLine: 12, originalLine: null })).toBe("src/a.ts:12-18");
+  });
+
+  test("a start equal to the end is not a range", () => {
+    expect(whereOf({ path: "src/a.ts", line: 10, startLine: 10, originalLine: null })).toBe("src/a.ts:10");
+  });
+
+  test("an outdated thread is labelled where it was written", () => {
+    /* The label may fall back to originalLine and applying a suggestion may
+       not. Same two numbers, two different questions: this one says where the
+       conversation happened, and the other would edit the file. */
+    expect(whereOf({ path: "src/a.ts", line: null, startLine: null, originalLine: 42 })).toBe("src/a.ts:42");
+  });
+
+  test("no line anywhere is just the file", () => {
+    expect(whereOf({ path: "src/a.ts", line: null, startLine: null, originalLine: null })).toBe("src/a.ts");
+  });
+});
+
+describe("hunkTail", () => {
+  const lines = (n: number): string => Array.from({ length: n }, (_, i) => `line ${i + 1}`).join("\n");
+
+  test("keeps the end, because that is the line the comment is on", () => {
+    const got = hunkTail(lines(12), 3);
+    expect(got.lines).toEqual(["line 10", "line 11", "line 12"]);
+    expect(got.clipped).toBe(true);
+  });
+
+  test("a short hunk is shown whole and is not marked clipped", () => {
+    const got = hunkTail(lines(3), 8);
+    expect(got.lines.length).toBe(3);
+    expect(got.clipped).toBe(false);
+  });
+
+  test("trailing blanks do not eat the budget", () => {
+    // `diffHunk` arrives with a trailing newline, sometimes two. Counting them
+    // as content spends rows on nothing and pushes real lines off the top.
+    const got = hunkTail(`${lines(3)}\n\n`, 3);
+    expect(got.lines).toEqual(["line 1", "line 2", "line 3"]);
+    expect(got.clipped).toBe(false);
+  });
+
+  test("an absent hunk is nothing rather than a crash", () => {
+    expect(hunkTail("").lines).toEqual([]);
+    expect(hunkTail("" as unknown as string).clipped).toBe(false);
+  });
+});
+
+describe("replyAnchor", () => {
+  test("is the numeric id, never the node id", () => {
+    /* The two are not interchangeable, and posting the node id where the REST
+       endpoint wants the number fails with a 404 that reads like the thread
+       does not exist. */
+    expect(replyAnchor({ comments: [comment({ id: "PRRC_kwDO", databaseId: 991 })] })).toBe(991);
+  });
+
+  test("is the first comment that carries one", () => {
+    // `in_reply_to` the opening comment; GitHub threads the rest itself.
+    expect(replyAnchor({ comments: [comment({ databaseId: 1 }), comment({ databaseId: 2 })] })).toBe(1);
+  });
+
+  test("skips comments with no numeric id", () => {
+    expect(replyAnchor({ comments: [comment(), comment({ databaseId: 7 })] })).toBe(7);
+  });
+
+  test("a thread with nothing to reply to says so", () => {
+    // The screen does not offer a reply box in this case, rather than offering
+    // one that fails on send.
+    expect(replyAnchor({ comments: [comment()] })).toBe(null);
+    expect(replyAnchor({ comments: [] })).toBe(null);
+    expect(replyAnchor({ comments: [comment({ databaseId: null })] })).toBe(null);
+  });
+});

--- a/server/src/clickup.ts
+++ b/server/src/clickup.ts
@@ -20,7 +20,7 @@ import { singleFlight } from "./singleflight.ts";
 import { writesAllowed } from "./clickupviews.ts";
 import { secretFor, annotate, redacted, fingerprint } from "./credentials.ts";
 import type {
-  ListMember, TaskReply, ProviderTask, ClickUpUser, ClickUpWorkspace, ListStatus, ListField, ListPlace, TaskDetail } from "../../shared/providers.ts";
+  ListMember, TaskReply, ProviderTask, ClickUpUser, ClickUpWorkspace, ListStatus, ListField, ListPlace, TaskDetail, CardPr } from "../../shared/providers.ts";
 
 const CLICKUP_API = "https://api.clickup.com/api/v2";
 
@@ -1831,16 +1831,7 @@ export async function findCard(text: string, knownPrefix: string): Promise<CallR
  * request in another repository will never be found by searching this one.
  * Union of the two, the field first.
  */
-export interface CardPr {
-  number: number;
-  title: string;
-  /** OPEN | MERGED | CLOSED, as GitHub spells it. */
-  state: string;
-  draft?: boolean;
-  url: string;
-  /** True when it came from the card's own field rather than from a search. */
-  stated?: boolean;
-}
+export type { CardPr };
 
 /** A pull-request number out of a GitHub URL, and nothing else out of anything
  *  else. A bare number in that field would be ambiguous — issue or PR — so it

--- a/shared/cardSkills.ts
+++ b/shared/cardSkills.ts
@@ -11,8 +11,16 @@
  * specs, another sweeps a report stream — and both say in their own description
  * that they take a card. Matching only the name would hide exactly the two you
  * would never think to look for.
+ *
+ * ── in shared/ because two products ask the same question ────────────────
+ * It began in `web/src/lib/`, when the desk was the only place a card could be
+ * handed over. The phone now offers the same menu, and a second copy of this
+ * would be a second answer to "which skills take a card" — the menus would
+ * agree on the day they were written and drift from there. The regex, the
+ * grouping and the invocation line are one thing, in one file, and both
+ * products import it.
  */
-import type { SkillInfo } from "../../../shared/types.ts";
+import type { SkillInfo } from "./types.ts";
 
 /** `cu` on its own is a word in too many places; as a hyphenated part of a
  *  skill's name it is unambiguous, and that is how the ones here spell it. */

--- a/shared/providers.ts
+++ b/shared/providers.ts
@@ -551,6 +551,29 @@ export interface TaskDetail {
   }[];
 }
 
+/**
+ * A pull request that belongs to a card.
+ *
+ * Two ways one is found and they are not equally trustworthy, which is what
+ * `stated` records: the card's own field NAMES a pull request, and a search of
+ * GitHub for the card's id GUESSES at the rest — the id turns up in a branch
+ * name, a title or a commit, and which of those is not ours to assume. A stated
+ * one is right by construction; a found one is a good bet.
+ *
+ * Beside TaskDetail rather than inside the ClickUp module, because it is a wire
+ * type: it leaves the server on `/clickup/prs` and both clients draw it.
+ */
+export interface CardPr {
+  number: number;
+  title: string;
+  /** OPEN | MERGED | CLOSED, as GitHub spells it. */
+  state: string;
+  draft?: boolean;
+  url: string;
+  /** True when it came from the card's own field rather than from a search. */
+  stated?: boolean;
+}
+
 /** One reply in a comment thread. */
 export interface TaskReply {
   id: string;

--- a/shared/suggestion.ts
+++ b/shared/suggestion.ts
@@ -1,0 +1,101 @@
+/*
+ * The `suggestion` blocks inside a review comment.
+ *
+ * GitHub's suggestion is a fenced block with the word `suggestion` on the
+ * fence, and its meaning is positional rather than textual: the block replaces
+ * the lines the THREAD is anchored to, not lines named anywhere in the block.
+ * So a parser's whole job is to hand back the replacement text; the range comes
+ * from `PrThread.startLine`/`line` and from nowhere else.
+ *
+ * ── why this is shared and not written into a screen ─────────────────────
+ * `server/src/prs.ts` already owns the half that writes the commit —
+ * `applySuggestion` splices and calls `createCommitOnBranch`. What it does NOT
+ * do is find the suggestion in the first place: the desk reads the block out of
+ * the comment body it is drawing and posts the text. That reading is the part
+ * that can be wrong quietly — an empty block that means "delete these lines" is
+ * indistinguishable from "no suggestion here" if you get it wrong, and the
+ * difference is somebody's code.
+ *
+ * ── the empty block is real, and it is the interesting case ──────────────
+ * ```suggestion
+ * ```
+ * means "remove those lines", and GitHub applies it. `spliceLines` on the
+ * server takes `""` and produces exactly that. So the parser answers with an
+ * ARRAY of blocks and never with `""` meaning absent — a caller that treats
+ * falsiness as "none" would silently drop a deletion.
+ */
+
+/** One suggested replacement, in the order the blocks appear in the body. */
+export interface Suggestion {
+  /** The replacement text, newline-joined, with no trailing newline. Empty
+   *  string is a real value: it means "delete the lines this thread covers". */
+  text: string;
+}
+
+/*
+ * Fences are matched at any indent, because a suggestion nested inside a list
+ * item is indented and is still a suggestion. The closing fence must be at
+ * least as long as the opening one, which is CommonMark's own rule and the
+ * reason a suggestion CONTAINING a fenced block can be written at all:
+ *
+ *   ````suggestion
+ *   ```
+ *   still inside the suggestion
+ *   ```
+ *   ````
+ */
+const OPEN = /^(\s*)(`{3,})suggestion\s*$/;
+
+export function suggestionsIn(body: string): Suggestion[] {
+  const lines = (body ?? "").split("\n");
+  const out: Suggestion[] = [];
+  for (let i = 0; i < lines.length; i++) {
+    const open = OPEN.exec(lines[i] ?? "");
+    if (!open) continue;
+    const indent = (open[1] ?? "").length;
+    const fence = (open[2] ?? "```").length;
+    const held: string[] = [];
+    let closed = false;
+    for (let j = i + 1; j < lines.length; j++) {
+      const line = lines[j] ?? "";
+      const close = /^(\s*)(`{3,})\s*$/.exec(line);
+      if (close && (close[2] ?? "").length >= fence) { i = j; closed = true; break; }
+      /* The fence's own indent comes off every line, and only that much. A
+         suggestion written inside a list item is indented as a whole, and
+         keeping that indent would commit it into the file. Removing MORE than
+         the fence's indent would eat the code's own nesting, which is why this
+         is a slice and not a `trimStart`. */
+      held.push(line.slice(0, indent).trim() === "" ? line.slice(indent) : line);
+    }
+    /* An unclosed fence is dropped rather than guessed at. It happens when
+       somebody's comment was truncated, and applying the rest of the message
+       as code is the worst available reading of it. */
+    if (closed) out.push({ text: held.join("\n") });
+  }
+  return out;
+}
+
+/**
+ * The range a thread's suggestion replaces, as `applySuggestion` wants it.
+ *
+ * Its own function because the fallbacks are the whole content: a thread on one
+ * line has no `startLine`, and an OUTDATED thread has no `line` at all — the
+ * code it was written about is gone, so there is nothing to replace and the
+ * answer is null rather than a guess at `originalLine`. Committing a suggestion
+ * onto the line that number now points at would edit code nobody was talking
+ * about.
+ */
+export function suggestionRange(thread: {
+  line: number | null;
+  startLine?: number | null;
+  isOutdated?: boolean;
+}): { startLine: number; line: number } | null {
+  if (thread.isOutdated) return null;
+  const end = thread.line;
+  if (!Number.isInteger(end) || (end as number) <= 0) return null;
+  const start = Number.isInteger(thread.startLine) && (thread.startLine as number) > 0
+    ? (thread.startLine as number)
+    : (end as number);
+  if (start > (end as number)) return null;
+  return { startLine: start, line: end as number };
+}

--- a/web/src/components/TasksPanel.tsx
+++ b/web/src/components/TasksPanel.tsx
@@ -37,7 +37,7 @@ import { landingSource, rememberTaskSource } from "../lib/taskLanding.ts";
 import { externalUrl, openExternal } from "../lib/externalUrl.ts";
 import { LAYER } from "../lib/layers.ts";
 import { ContextMenu, MenuItem } from "./ContextMenu.tsx";
-import { cardSkills, skillCommand, windowName, skillModes, namedForIt, shortName } from "../lib/cardSkills.ts";
+import { cardSkills, skillCommand, windowName, skillModes, namedForIt, shortName } from "../../../shared/cardSkills.ts";
 import { subscribeReminders, liveReminders, nudgeReminders } from "../lib/reminderStore.ts";
 import { parseLocal, toLine, sortTasks, step, checkbox, toggleCheckbox, checkProgress, rootForTask, taskPrompt, lineWith, inUse, typingInto, dueBucket, bucketCounts, dueLabel, stamp, TASK_KEYS, SORTS, type SortMode, type Bucket } from "../lib/taskGrammar.ts";
 import { useSyncExternalStore } from "react";
@@ -3496,7 +3496,7 @@ function CardDetail({ t, today, statuses, fields, place, writable, repos, here, 
   repos: GitRepoRef[]; here: string;
   onOpenChatWith?: (cwd: string, prompt: string, title: string) => void;
   onAsk: (p: Pending) => void;
-  /** Only the skills that take a card — see lib/cardSkills.ts. */
+  /** Only the skills that take a card — see ../shared/cardSkills.ts. */
   skills: SkillInfo[];
   onNote: (text: string) => void;
   wide: boolean;

--- a/web/test/card-skills.test.ts
+++ b/web/test/card-skills.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "bun:test";
-import { cardSkills, skillCommand, windowName, skillModes } from "../src/lib/cardSkills.ts";
+import { cardSkills, skillCommand, windowName, skillModes } from "../../shared/cardSkills.ts";
 import type { SkillInfo } from "../../shared/types.ts";
 
 const mk = (name: string, description = ""): SkillInfo => ({
@@ -103,7 +103,7 @@ describe("the modes a skill advertises", () => {
 });
 
 describe("the short name a team uses", () => {
-  const { shortName } = require("../src/lib/cardSkills.ts") as typeof import("../src/lib/cardSkills.ts");
+  const { shortName } = require("../../shared/cardSkills.ts") as typeof import("../../shared/cardSkills.ts");
 
   it("takes the prefix the title already carries", () => {
     // "waiting on T2" is something to act on; "waiting on ABC-21016" is a


### PR DESCRIPTION
## What does this PR do?

Four things the phone could begin and could not finish, plus one thing it was assuming about everybody.

**A review can be finished.** You could read a diff, write remarks on lines and send a verdict — and the moment somebody replied to one, the app said "Reading them is on GitHub for now" and handed you to a browser. Threads are a screen now: reply, resolve, unresolve, apply a suggestion. The diff expands the context a hunk cut off. And the review sheet stops claiming there are no line comments while GitHub is holding three that were started somewhere else. Every one of these is a call the server already served for the desk.

**Work is handed over with intent.** The review hand-off shows the prompt before anything runs, and the card hand-off asks WHAT before it asks WHERE — a skill invoked on the card, rather than the card's id and title. What the socket carries has not changed and that is load-bearing: `cmd: "review"` still sends a number, a directory and a recipe id, the computer still writes the words, and the preview is deliberately not editable. `mobile/test/handoff-carries-an-id.test.ts` guards that.

**The card screen reads the card it already fetched.** `/clickup/task` answers with a whole `TaskDetail` and the screen kept one field of it, then carried a comment explaining that a card has no description — true of `ProviderTask`, false of what had just been read. Description, subtasks, checklists, comments with their replies, and the pull requests that mention the card.

**And it stops assuming everybody tracks work in ClickUp.** ClickUp is one task provider of several — `shared/providers.ts` lists Taskwarrior beside it — so the Cards row is offered only where something is actually set up, read from the catalogue rather than by naming a service. A provider that is set up and BROKEN keeps its row; an answer that has not arrived draws it. This is where the phone parts company with the desk, which shows every source on a fresh install because an unconnected tab there links to the pane that connects it: this app deliberately cannot set a provider up, so the row would advertise something you cannot act on from the device in your hand.

Two shared modules came out of it — `shared/suggestion.ts` and `shared/cardSkills.ts`, the second moved out of `web/src/lib/` because both products now ask it the same question, which also removed a `windowName` that existed twice byte for byte.

No new server routes. No change to any permission or scope rule.

## How was it tested?

- `bun test` and `npm run typecheck` in `mobile/` — 569 pass, 0 fail
- `bun test` in `web/` — 2716 pass, 0 fail; `tsc --noEmit` clean in `web/` and `server/`
- `bun scripts/qa.ts` — all 17 screens rendered in a real browser against a running server, 17/17
- The four guards in `handoff-carries-an-id.test.ts` were each verified by reintroducing the fault they name and watching that test, and only that test, fail
- The provider rule was checked end to end on a machine with no tracker connected: the Cards row is absent from the rendered Inbox and the Cards screen draws the new state. The QA walk caught its own expectation being out of date, which is the harness working

**Not tested, and worth saying:** the new screens have never been drawn with real data. This machine has no `gh` and no tracker connected, so the walk reaches their "cannot read it" states and stops there. Everything decidable without drawing was pulled into `src/model/` and tested — `expand.ts`, `threads.ts`, `suggestion.ts`, `taskProviders.ts` — and what is left in the components is layout, which needs a phone to judge.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CukDHvByYbLYswQPPAz6sQ)_