### PR TITLE
feat(mobile): Pane — the phone gets a design system of its own

### DIFF
--- a/mobile/app/(tabs)/now.tsx
+++ b/mobile/app/(tabs)/now.tsx
@@ -148,7 +148,7 @@ export default function NowScreen(): React.ReactNode {
       }
       ListHeaderComponent={
         <View style={{ gap: SPACE.xs, paddingBottom: SPACE.sm }}>
-          <Text style={{ color: C.text, fontSize: T.head, fontWeight: "700" }}>
+          <Text style={{ color: C.text, fontSize: T.display, fontWeight: "700", lineHeight: 31 }}>
             {waiting.length === 0
               ? "Nothing is waiting on you"
               : `${waiting.length} ${waiting.length === 1 ? "thing wants" : "things want"} you`}

--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -46,7 +46,7 @@ import {
 import { gapLabel, gapsIn, nextSlice, type Gap } from "../../src/model/expand.ts";
 import { draftCount, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
 import { Btn, Card, Label, Note, Sheet, SheetRow, TAP } from "../../src/ui.tsx";
-import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
+import { C, MONO, RADIUS, SPACE, T, tint } from "../../src/theme.ts";
 
 /** The two backgrounds a changed line takes.
  *
@@ -55,8 +55,8 @@ import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
  *  marker column carries the sign as well, so the distinction survives for
  *  anybody who cannot rely on the tint. */
 function lineFace(kind: DiffLine["kind"]): { bg: string; mark: string; ink: string } {
-  if (kind === "add") return { bg: "rgba(63,185,80,0.14)", mark: "+", ink: C.success };
-  if (kind === "del") return { bg: "rgba(248,81,73,0.14)", mark: "−", ink: C.error };
+  if (kind === "add") return { bg: tint(C.success, 0.14), mark: "+", ink: C.success };
+  if (kind === "del") return { bg: tint(C.error, 0.14), mark: "−", ink: C.error };
   return { bg: "transparent", mark: " ", ink: C.text4 };
 }
 

--- a/mobile/app/pr/threads.tsx
+++ b/mobile/app/pr/threads.tsx
@@ -44,7 +44,7 @@ import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { since } from "../../src/lib/dates.ts";
 import { hunkTail, ordered, replyAnchor, whereOf } from "../../src/model/threads.ts";
 import { Btn, Card, Label, Note, TAP } from "../../src/ui.tsx";
-import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
+import { C, MONO, RADIUS, SCRIM, SPACE, T, tint } from "../../src/theme.ts";
 
 /** The diff hunk GitHub kept with the comment, trimmed to what fits.
  *  Kept because a reply written without seeing the code it is about is a reply
@@ -66,7 +66,7 @@ function Hunk({ text }: { text: string }): React.ReactNode {
             numberOfLines={1}
             style={{
               color: add ? C.success : del ? C.error : C.text3,
-              backgroundColor: add ? "rgba(63,185,80,0.12)" : del ? "rgba(248,81,73,0.12)" : "transparent",
+              backgroundColor: add ? tint(C.success, 0.12) : del ? tint(C.error, 0.12) : "transparent",
               fontSize: 10, fontFamily: MONO, lineHeight: 16, paddingHorizontal: SPACE.sm,
             }}
           >{line}</Text>
@@ -349,7 +349,7 @@ export default function ThreadsScreen(): React.ReactNode {
       {confirming ? (
         <View style={{
           position: "absolute", left: 0, right: 0, bottom: 0, top: 0,
-          backgroundColor: "rgba(0,0,0,0.55)", justifyContent: "flex-end",
+          backgroundColor: SCRIM, justifyContent: "flex-end",
         }}>
           <View style={{
             backgroundColor: C.bg2, borderTopLeftRadius: RADIUS.lg, borderTopRightRadius: RADIUS.lg,

--- a/mobile/src/terminal/terminal-html.ts
+++ b/mobile/src/terminal/terminal-html.ts
@@ -24,7 +24,7 @@
  */
 import { XTERM_CSS, XTERM_JS } from "./engine.generated.ts";
 import { NERD_ICONS_RANGE, NERD_ICONS_WOFF2_B64 } from "./nerdfont.generated.ts";
-import { BASE, type Palette } from "../../../shared/palettes.ts";
+import { PANE, type Palette } from "../../../shared/palettes.ts";
 import { contrastRatio, deriveAnsi } from "../../../shared/termPalette.ts";
 
 export interface TerminalDocOptions {
@@ -112,7 +112,11 @@ export function terminalTheme(palette: Palette): Record<string, string> {
 export function counterTheme(palette: Palette): Record<string, string> {
   const isLight = contrastRatio(palette.bg, "#000000") > contrastRatio(palette.bg, "#ffffff");
   return terminalTheme({
-    ...BASE[isLight ? "dark" : "light"],
+    // PANE and not BASE: this is the phone's own furniture in the polarity it
+    // is not currently wearing, so it has to be the phone's other half. Reading
+    // BASE here would drop github-light's paper into an app that is nowhere
+    // else painted with it.
+    ...PANE[isLight ? "dark" : "light"],
     primary: palette.primary,
     primaryHover: palette.primaryHover,
   });

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -228,11 +228,21 @@ export function toneColor(tone: "crit" | "bad" | "good" | "plain"): string {
  * arm's length on a 27-inch monitor. Outdoors, in one hand, it does not.
  */
 export const T = {
+  /* Pane's ladder asks for 10.5 here and it does not get it. The rule above is
+     older and it wins: this is read outdoors, in one hand, by somebody deciding
+     whether a check failed. What makes an eyebrow an eyebrow is the tracking
+     and the caps, and Label already carries both — see ui.tsx. */
   eyebrow: 11,
   small: 12,
   body: 14,
-  title: 16,
+  title: 17,
   head: 20,
+  /* One line per screen, and only the line that says what the screen is FOR:
+     "3 things want you". It is not a title — a title names a thing and this
+     states a count, which is why the only place it appears is the top of Now.
+     A PR's own title is prose and stays at `head`, because 26pt of somebody
+     else's sentence is four lines before the screen has said anything. */
+  display: 26,
 } as const;
 
 export const SPACE = { xs: 4, sm: 8, md: 12, lg: 16, xl: 24 } as const;

--- a/mobile/src/theme.ts
+++ b/mobile/src/theme.ts
@@ -44,7 +44,7 @@
  * remember, which is exactly right.
  */
 import {
-  BASE, PHONE_ACCENTS, inkOn, paletteFor, polarityOf, sanitizeLook,
+  PANE, PHONE_ACCENTS, inkOn, paletteFor, polarityOf, sanitizeLook,
   type AccentId, type Look, type Palette, type Polarity, type ThemeMode,
 } from "../../shared/palettes.ts";
 
@@ -52,19 +52,27 @@ export type { AccentId, Look, Palette, Polarity, ThemeMode };
 export { PHONE_ACCENTS as ACCENTS };
 
 /*
- * Dark and blue, which is what this app looked like before it had a choice.
+ * Dark and teal, which is what this app looks like.
  *
- * Not System, and not Neutral, on purpose: both would repaint a phone that has
- * been in somebody's pocket for weeks the first time it updates. github-dark's
- * own primary was #58a6ff, so blue is the accent that leaves the app where it
- * was, and every change from here is one somebody made.
+ * It used to be dark and blue, and the reason given was that github-dark's own
+ * primary was #58a6ff, so blue left the app exactly where it was. That reason
+ * expired the moment the phone stopped wearing github-dark: it wears PANE now
+ * (see shared/palettes.ts), whose ground is darker, whose hairlines are quieter
+ * and whose default accent is the teal. Blue against that ground is the old app
+ * showing through the new one.
+ *
+ * Still not System and still not Neutral, and that half of the argument holds:
+ * both would repaint a phone that has been in a pocket for weeks the first time
+ * it updates, and a repaint nobody asked for is the one change a person cannot
+ * attribute to themselves. Anybody who chose an accent keeps it — `sanitizeLook`
+ * reads what was stored and this is only the fallback.
  */
-const SHIPPED: Look = { mode: "dark", accent: "blue" };
+const SHIPPED: Look = { mode: "dark", accent: "teal" };
 
 /** The live palette. Read it at render time — never destructure it into a
  *  module-level constant, which would freeze a screen in the palette that was
  *  current when its file was first evaluated. */
-export const C: Palette = { ...paletteFor("dark", SHIPPED.accent) };
+export const C: Palette = { ...paletteFor("dark", SHIPPED.accent, PANE) };
 
 let look: Look = { ...SHIPPED };
 let polarity: Polarity = "dark";
@@ -130,9 +138,9 @@ function systemIsDark(): boolean {
  */
 function paint(): void {
   polarity = polarityOf(look.mode, systemIsDark());
-  const next = paletteFor(polarity, look.accent);
+  const next = paletteFor(polarity, look.accent, PANE);
   let changed = false;
-  for (const key of Object.keys(BASE.dark) as (keyof Palette)[]) {
+  for (const key of Object.keys(PANE.dark) as (keyof Palette)[]) {
     if (C[key] !== next[key]) { C[key] = next[key]; changed = true; }
   }
   if (!changed) return; // a system event that resolved to the same surface
@@ -228,7 +236,60 @@ export const T = {
 } as const;
 
 export const SPACE = { xs: 4, sm: 8, md: 12, lg: 16, xl: 24 } as const;
-export const RADIUS = { sm: 6, md: 10, lg: 14 } as const;
+
+/*
+ * Corners, and the ladder is deliberately not even.
+ *
+ * `sm` and `md` sit two points apart on purpose. Small furniture — a key, a
+ * chip, a badge — is nearly a rectangle with the corner taken off, and a
+ * control is barely rounder. That is the whole of the shape language for
+ * everything you press: flat, quiet, and not competing with the words in it.
+ * A phone screen at 393 points is mostly small furniture, and a ladder that
+ * separates each rung visibly ends up with eight different corners on one
+ * screen, which reads as several apps stacked.
+ *
+ * Then there is exactly ONE round thing, and `pill` is it: a capsule, for the
+ * one surface per screen that is a place to type or a single filter. Being far
+ * away from the rest is the point — one round shape among rectangles is a
+ * signal, and three sizes of round is decoration.
+ *
+ * `lg` is the middle: cards, sheets and grouped rows. It went 14 → 16 when `sm`
+ * went 6 → 8, because it is the container those small things sit inside and a
+ * container whose corner is tighter than its contents' looks like a mistake.
+ */
+export const RADIUS = { sm: 8, md: 10, lg: 16, pill: 22 } as const;
+
+/**
+ * A palette colour at low opacity, as a wash behind text.
+ *
+ * Eight-digit hex rather than `rgba(…)` with the channels written out, because
+ * the channels are the point: a literal freezes whichever palette was current
+ * when somebody typed it, and the two places this is used — the diff's added
+ * and removed rows — carried github-dark's green and red long after the phone
+ * stopped wearing github-dark. The red had drifted a whole hue away from the
+ * `C.error` printed on the same row.
+ *
+ * Call it at render time. A tint hoisted to module scope is the same bug in a
+ * new place: it would hold the shipped palette through every theme change.
+ */
+export function tint(hex: string, alpha: number): string {
+  const pct = Math.round(Math.min(1, Math.max(0, alpha)) * 255);
+  return `${hex}${pct.toString(16).padStart(2, "0")}`;
+}
+
+/**
+ * The veil behind a sheet.
+ *
+ * A constant and not a palette entry, because a scrim's job is to darken what
+ * is behind it and that job does not change in Light — a pale veil over a pale
+ * page is a sheet with no edge. It is PANE's own ground at 55%, so the dark
+ * mode's dimmed background is the colour the app is already made of.
+ *
+ * One constant because there were two: a sheet dimmed to `rgba(1,4,9,.55)` and
+ * a modal on another screen to `rgba(0,0,0,.55)`, which are visibly different
+ * greys on the same phone thirty seconds apart.
+ */
+export const SCRIM = "rgba(10,12,16,0.55)";
 
 /** A monospace face that exists on Android, for a command or a branch name. */
 export const MONO = "monospace";

--- a/mobile/src/ui.tsx
+++ b/mobile/src/ui.tsx
@@ -14,7 +14,7 @@ import {
   type StyleProp, type TextStyle, type ViewStyle,
 } from "react-native";
 import { useSafeAreaInsets } from "react-native-safe-area-context";
-import { C, RADIUS, SPACE, T, ink } from "./theme.ts";
+import { C, RADIUS, SCRIM, SPACE, T, ink } from "./theme.ts";
 
 /**
  * The floor for anything you tap.
@@ -418,14 +418,16 @@ export function Sheet({ open, onClose, title, children }: {
         accessibilityRole="button"
         accessibilityLabel={`Close ${title}`}
         onPress={onClose}
-        style={{ flex: 1, backgroundColor: "rgba(1,4,9,0.55)" }}
+        style={{ flex: 1, backgroundColor: SCRIM }}
       />
       <View style={{
         backgroundColor: C.bg2,
         borderTopWidth: 1,
         borderTopColor: C.border2,
-        borderTopLeftRadius: RADIUS.lg + 6,
-        borderTopRightRadius: RADIUS.lg + 6,
+        // The capsule radius, because a sheet's top edge IS the round thing on
+        // the screen it covers — same reason and same number as the composer.
+        borderTopLeftRadius: RADIUS.pill,
+        borderTopRightRadius: RADIUS.pill,
         paddingTop: SPACE.md,
         // The gesture bar, paid once. Nothing else in the sheet knows about it.
         paddingBottom: insets.bottom + SPACE.md,

--- a/mobile/test/look.test.ts
+++ b/mobile/test/look.test.ts
@@ -10,9 +10,10 @@ import { describe, expect, test } from "bun:test";
 import { readdirSync, readFileSync, statSync } from "node:fs";
 import { join } from "node:path";
 import {
-  ACCENTS, BASE, PHONE_ACCENTS, accentFor, cssVars, inkOn, paletteFor, polarityOf, sanitizeLook,
+  ACCENTS, BASE, PANE, PHONE_ACCENTS, accentFor, cssVars, inkOn, paletteFor, polarityOf, sanitizeLook,
   type AccentId, type Palette, type Polarity,
 } from "../../shared/palettes.ts";
+import { tint } from "../src/theme.ts";
 
 const POLARITIES: Polarity[] = ["dark", "light"];
 const IDS = PHONE_ACCENTS.map((a) => a.id);
@@ -78,8 +79,11 @@ describe("the accent, laid over a base", () => {
     expect(PHONE_ACCENTS[0]?.id).toBe("neutral");
     expect(new Set(IDS).size).toBe(IDS.length);
     // The desk's six, unchanged and all present — this file adds an axis to the
-    // phone, it takes nothing off the desk.
-    expect(IDS.slice(1)).toEqual(["blue", "violet", "green", "amber", "rose", "cyan"]);
+    // phone, it takes nothing off the desk. Teal is the seventh and it is in
+    // ACCENTS rather than in a phone-only list on purpose: the rule above is
+    // that an accent named the same in both products IS the same hex, and a
+    // colour only one of them can spell would be the first exception to it.
+    expect(IDS.slice(1)).toEqual(["blue", "violet", "green", "amber", "rose", "cyan", "teal"]);
   });
 
   test("an accent nobody has heard of paints the base rather than throwing", () => {
@@ -87,6 +91,16 @@ describe("the accent, laid over a base", () => {
     // file says "purple" is worse than a phone with a blue cursor.
     const stray = accentFor("dark", "purple" as AccentId);
     expect(stray.primary).toBe(BASE.dark.primary);
+  });
+
+  test("the base it falls back to is the caller's, not this file's", () => {
+    /* The phone does not wear BASE any more, so this fallback is the one place
+       an unreadable preference could put the desk's blue on a PANE ground.
+       Reading the module constant here instead of the argument would do exactly
+       that, and it would only ever show on somebody's phone. */
+    const stray = accentFor("dark", "purple" as AccentId, PANE);
+    expect(stray.primary).toBe(PANE.dark.primary);
+    expect(stray.hover).toBe(PANE.dark.primaryHover);
   });
 });
 
@@ -201,5 +215,40 @@ describe("the bases are the desk's, not new colours", () => {
       // text3 is the note under a control — the smallest type on the screen.
       expect(contrast(base.text3, base.bg)).toBeGreaterThan(4.5);
     }
+  });
+});
+
+describe("tint", () => {
+  test("appends the alpha as two hex digits", () => {
+    // React Native reads #RRGGBBAA. Eight digits and not seven: a single digit
+    // makes a seven-character string, which RN silently draws as transparent.
+    expect(tint("#3fb950", 0.14)).toBe("#3fb95024");
+    expect(tint("#3fb950", 0.14).length).toBe(9);
+  });
+
+  test("a small alpha still gets two digits", () => {
+    // 0.02 * 255 rounds to 5, which is "5" before padding. This is the case the
+    // padStart exists for.
+    expect(tint("#000000", 0.02)).toBe("#00000005");
+  });
+
+  test("the ends are the ends", () => {
+    expect(tint("#ffffff", 0)).toBe("#ffffff00");
+    expect(tint("#ffffff", 1)).toBe("#ffffffff");
+  });
+
+  test("an alpha outside 0..1 is clamped rather than wrapped", () => {
+    /* Wrapping would be the worst failure available here: 1.2 * 255 is 306,
+       which is 0x132 — three digits, a ten-character colour, and RN draws
+       nothing. Clamping makes an out-of-range alpha merely wrong. */
+    expect(tint("#ffffff", 1.2)).toBe("#ffffffff");
+    expect(tint("#ffffff", -1)).toBe("#ffffff00");
+  });
+
+  test("it follows the live palette rather than a frozen hex", () => {
+    // The whole reason it exists: the diff's washes used to be github-dark's
+    // green and red written out as rgba(), on a phone that wears PANE.
+    expect(tint(PANE.dark.error, 0.14).startsWith(PANE.dark.error)).toBe(true);
+    expect(tint(PANE.light.error, 0.14).startsWith(PANE.light.error)).toBe(true);
   });
 });

--- a/mobile/test/term-ansi.test.ts
+++ b/mobile/test/term-ansi.test.ts
@@ -22,7 +22,7 @@
  * reason look.test.ts does it.
  */
 import { describe, expect, test } from "bun:test";
-import { PHONE_ACCENTS, paletteFor, type Polarity } from "../../shared/palettes.ts";
+import { PANE, PHONE_ACCENTS, paletteFor, type AccentId, type Polarity } from "../../shared/palettes.ts";
 import { deriveAnsi } from "../../shared/termPalette.ts";
 import { counterTheme, terminalDocument, terminalTheme } from "../src/terminal/terminal-html.ts";
 
@@ -50,11 +50,18 @@ const FLOOR = 4.5;
 
 const POLARITIES: Polarity[] = ["dark", "light"];
 
+/** What the app actually paints with. Every palette below composes on PANE and
+ *  not on the module default, because these are contrast floors: measuring them
+ *  against a ground this app no longer wears would pass a terminal nobody can
+ *  read on the one it does. */
+const phone = (polarity: Polarity, accent: AccentId): ReturnType<typeof paletteFor> =>
+  paletteFor(polarity, accent, PANE);
+
 describe("every ANSI colour is readable on the surface it is painted on", () => {
   for (const polarity of POLARITIES) {
     for (const accent of PHONE_ACCENTS) {
       test(`${polarity} + ${accent.id}`, () => {
-        const p = paletteFor(polarity, accent.id);
+        const p = phone(polarity, accent.id);
         const theme = terminalTheme(p);
         for (const slot of ANSI) {
           const ratio = contrast(theme[slot]!, p.bg);
@@ -84,7 +91,7 @@ describe("sixteen slots hold sixteen colours", () => {
   for (const polarity of POLARITIES) {
     for (const accent of PHONE_ACCENTS) {
       test(`${polarity} + ${accent.id}`, () => {
-        const theme = terminalTheme(paletteFor(polarity, accent.id));
+        const theme = terminalTheme(phone(polarity, accent.id));
         const hexes = ANSI.map((slot) => theme[slot]!.toLowerCase());
         expect(new Set(hexes).size, hexes.join(" ")).toBe(16);
       });
@@ -96,7 +103,7 @@ describe("sixteen slots hold sixteen colours", () => {
     // reader lost: a cyan directory listing that was blue, an emphasised line
     // that was the same white as the rest, and a black that was the background.
     for (const polarity of POLARITIES) {
-      const p = paletteFor(polarity, "blue");
+      const p = phone(polarity, "blue");
       const theme = terminalTheme(p);
       expect(theme.cyan).not.toBe(theme.blue);
       expect(theme.brightWhite).not.toBe(theme.white);
@@ -112,7 +119,7 @@ describe("one derivation, not a second copy of it", () => {
      * desk and the phone are one product showing one machine's screens. This is
      * the assertion that keeps the rule in shared/ rather than beside it.
      */
-    const p = paletteFor("dark", "violet");
+    const p = phone("dark", "violet");
     const theme = terminalTheme(p);
     const ansi = deriveAnsi({
       bg: p.bg, text: p.text, primary: p.primary,
@@ -125,8 +132,8 @@ describe("one derivation, not a second copy of it", () => {
 describe("the other surface, carried in the page beside this one", () => {
   test("the counter set is the opposite polarity wearing the same accent", () => {
     for (const polarity of POLARITIES) {
-      const p = paletteFor(polarity, "amber");
-      const other = paletteFor(polarity === "dark" ? "light" : "dark", "amber");
+      const p = phone(polarity, "amber");
+      const other = phone(polarity === "dark" ? "light" : "dark", "amber");
       const counter = counterTheme(p);
       expect(counter.background).toBe(other.bg);
       expect(counter.foreground).toBe(other.text);
@@ -138,7 +145,7 @@ describe("the other surface, carried in the page beside this one", () => {
 
   test("and it is readable on its own background", () => {
     for (const polarity of POLARITIES) {
-      const counter = counterTheme(paletteFor(polarity, "blue"));
+      const counter = counterTheme(phone(polarity, "blue"));
       for (const slot of ANSI) {
         const min = slot === "black" && luminance(counter.background!) < 0.4 ? 2.5 : FLOOR;
         expect(contrast(counter[slot]!, counter.background!), `${slot} ${counter[slot]}`).toBeGreaterThanOrEqual(min);
@@ -155,7 +162,7 @@ describe("the other surface, carried in the page beside this one", () => {
      * dim by construction and this background is lighter than the one they were
      * derived for. Worst non-black at #1e1e1e is brightBlack at 4.78.
      */
-    const dark = terminalTheme(paletteFor("dark", "blue"));
+    const dark = terminalTheme(phone("dark", "blue"));
     for (const slot of ANSI) {
       const min = slot === "black" ? 2.2 : FLOOR;
       expect(contrast(dark[slot]!, "#1e1e1e"), `${slot} ${dark[slot]} on #1e1e1e`).toBeGreaterThanOrEqual(min);
@@ -166,9 +173,9 @@ describe("the other surface, carried in the page beside this one", () => {
     // Structural: the page picks between them by measuring the pane (see the
     // browser tests in pane-line.test.ts), and it cannot pick one it was never
     // given. Cheap, and it catches the counter being dropped on the way in.
-    const doc = terminalDocument({ palette: paletteFor("light", "blue"), columns: 80 });
-    expect(doc).toContain(JSON.stringify(terminalTheme(paletteFor("light", "blue"))));
-    expect(doc).toContain(JSON.stringify(counterTheme(paletteFor("light", "blue"))));
+    const doc = terminalDocument({ palette: phone("light", "blue"), columns: 80 });
+    expect(doc).toContain(JSON.stringify(terminalTheme(phone("light", "blue"))));
+    expect(doc).toContain(JSON.stringify(counterTheme(phone("light", "blue"))));
     expect(doc).toContain("var OWN = ");
   });
 });

--- a/shared/palettes.ts
+++ b/shared/palettes.ts
@@ -59,7 +59,68 @@ export const BASE: Record<Polarity, Palette> = {
   },
 };
 
-export type AccentId = "neutral" | "blue" | "violet" | "green" | "amber" | "rose" | "cyan";
+/*
+ * The phone's own ground and ink, which are no longer the desk's.
+ *
+ * `BASE` above is github-dark and github-light, and it stays that on the desk:
+ * a browser tab beside GitHub's own should not argue with it about what a
+ * surface is. A phone has no such neighbour. It is held in one hand, in the
+ * dark, at arm's length, and the two things it is mostly showing are a terminal
+ * and a list of rows — so it is worth its own values.
+ *
+ * What changed and why, rather than "we picked nicer greys":
+ *
+ *   The ground goes DARKER and slightly cooler (#0a0c10 against #0d1117).
+ *   github-dark is tuned to sit beside white browser chrome; a phone at night
+ *   has nothing beside it, and the darker ground is what stops a full-screen
+ *   terminal glowing in a dark room.
+ *
+ *   The hairline goes QUIETER (#232833 against #30363d) and the raised surface
+ *   goes UP (#1a1f27 against #21262d). The desk separates things with borders
+ *   because it has the pixels; the phone separates them with surface, because
+ *   at 393 points a visible border around every row is most of what you see.
+ *
+ *   The mid ink goes UP (#a6b0bd against #c9d1d9 for secondary), because a
+ *   phone is read outdoors and github-dark's third and fourth inks are close
+ *   enough to disappear in sunlight.
+ *
+ * The light half is not github-light either, and not a photographic negative of
+ * the dark one: it is warm where the dark one is cool. A cool near-white reads
+ * as a screen that has been left on; a warm one reads as paper, which is what
+ * a light mode is for.
+ *
+ * ── info stays a blue, and that is not an oversight ──────────────────────
+ * The obvious move is to set `info` to the teal, since the teal is what this
+ * palette is. It is wrong twice. In the UI it collapses two meanings into one
+ * hex — an informational tone and a button you press stop being tellable apart,
+ * and `info` is a semantic slot for the same reason `error` is. In the terminal
+ * it is worse and it is silent: `deriveAnsi` picks ANSI blue by HUE, taking
+ * `info` when it is near 220 and falling through to `primary` when it is not.
+ * Teal is 171, so ANSI blue would become the accent — and on the NEUTRAL accent
+ * the accent is the body text, which put the same hex in two of the sixteen
+ * slots and made a `ls` colour vanish. Sixteen distinct slots is asserted in
+ * mobile/test/term-ansi.test.ts, which is how this was found.
+ */
+export const PANE: Record<Polarity, Palette> = {
+  dark: {
+    bg: "#0a0c10", bg2: "#12161d", bg3: "#1a1f27", bg4: "#232833",
+    text: "#e8ecf1", text2: "#a6b0bd", text3: "#7b8593", text4: "#6b7683",
+    border: "#232833", border2: "#2f3540",
+    // Replaced by the chosen accent — see paletteFor. These are what the shipped
+    // one resolves to, so a palette read before a choice is made is not blue.
+    primary: "#4dd6c1", primaryHover: "#7ce4d4",
+    success: "#3fb950", warning: "#d9a441", error: "#f0776c", info: "#6aa9f5",
+  },
+  light: {
+    bg: "#faf9f7", bg2: "#f2f0ed", bg3: "#e8e5e0", bg4: "#dbd7d1",
+    text: "#16181c", text2: "#4a4e56", text3: "#6d727b", text4: "#8b9099",
+    border: "#e2ded8", border2: "#cdc8c1",
+    primary: "#0f9b88", primaryHover: "#0c8071",
+    success: "#1a7f4b", warning: "#9a6a00", error: "#c2402f", info: "#1a63c8",
+  },
+};
+
+export type AccentId = "neutral" | "blue" | "violet" | "green" | "amber" | "rose" | "cyan" | "teal";
 
 export interface Accent { id: AccentId; name: string; primary: string; hover: string }
 
@@ -79,6 +140,13 @@ export const ACCENTS: Accent[] = [
   { id: "amber", name: "Amber", primary: "#f59e0b", hover: "#fbbf24" },
   { id: "rose", name: "Rose", primary: "#f43f5e", hover: "#fb7185" },
   { id: "cyan", name: "Cyan", primary: "#06b6d4", hover: "#22d3ee" },
+  /* Teal is the phone's default and is not cyan with a nudge: cyan is a blue
+     that has warmed up, and against a near-black ground it reads as another
+     GitHub blue. This one is far enough round the wheel to be its own colour,
+     and far enough from `success` green that a filled button is never mistaken
+     for a passing check — the one confusion an accent on this app must not
+     have. */
+  { id: "teal", name: "Teal", primary: "#4dd6c1", hover: "#7ce4d4" },
 ];
 
 /**
@@ -106,16 +174,24 @@ export const PHONE_ACCENTS: Accent[] = [
  * own near-white, Porcelain's is its own near-black — so this is that idea
  * rather than a fourth constant nobody would keep in step.
  */
-export function accentFor(polarity: Polarity, id: AccentId): { primary: string; hover: string } {
+export function accentFor(
+  polarity: Polarity, id: AccentId, base: Record<Polarity, Palette> = BASE,
+): { primary: string; hover: string } {
   if (id === "neutral") {
-    const base = BASE[polarity];
-    return { primary: base.text, hover: polarity === "dark" ? "#ffffff" : "#000000" };
+    // The ink of THIS page, which is why the base is a parameter: the phone's
+    // near-white is not the desk's, and a neutral accent resolved against the
+    // wrong one is an accent that does not match the text beside it.
+    const surface = base[polarity];
+    return { primary: surface.text, hover: polarity === "dark" ? "#ffffff" : "#000000" };
   }
   const accent = ACCENTS.find((a) => a.id === id);
   // An unknown id paints the base's own primary rather than throwing: this
   // value arrives from storage, and a phone that will not start because a
   // preference file says "purple" is worse than a phone with a blue cursor.
-  if (!accent) return { primary: BASE[polarity].primary, hover: BASE[polarity].primaryHover };
+  // The BASE it falls back to is the caller's, not this file's — reading the
+  // module constant here would answer a phone on PANE with the desk's blue,
+  // which is the one case where the fallback is visible.
+  if (!accent) return { primary: base[polarity].primary, hover: base[polarity].primaryHover };
   return { primary: accent.primary, hover: accent.hover };
 }
 
@@ -126,9 +202,9 @@ export function accentFor(polarity: Polarity, id: AccentId): { primary: string; 
  * warning, error and info stay the base's. Same rule as the desk's applyAccent:
  * an accent is a taste, and a red that means "this failed" is not.
  */
-export function paletteFor(polarity: Polarity, accent: AccentId): Palette {
-  const { primary, hover } = accentFor(polarity, accent);
-  return { ...BASE[polarity], primary, primaryHover: hover };
+export function paletteFor(polarity: Polarity, accent: AccentId, base: Record<Polarity, Palette> = BASE): Palette {
+  const { primary, hover } = accentFor(polarity, accent, base);
+  return { ...base[polarity], primary, primaryHover: hover };
 }
 
 /** The mode as a surface. `systemIsDark` is asked for rather than read here


### PR DESCRIPTION
## What does this PR do?

The phone stops wearing github-dark and gets a palette, a corner ladder and a type scale of its own — **Pane**. The desk is untouched: `paletteFor` and `accentFor` now take the base palette as an argument instead of reading the module constant, so one product changing its skin is a parameter rather than a fork.

**Colour.** PANE is not github-dark tuned. Its ground is darker (`#0a0c10`), its hairlines are quieter and its raised surfaces come *up* instead — a desk separates rows with borders because it has the pixels, a phone at 393 points separates them with surface. The mid inks go up, because a phone is read outdoors. The light half is warm rather than a negative of the dark one: a cool near-white reads as a screen left on, a warm one reads as paper. Teal is the shipped accent and lives in `ACCENTS` beside the other six, so the desk gains the row too — deliberately, since the rule that file already argues is that an accent named the same in both products *is* the same hex.

**Corners.** 8 / 10 / 16, plus a separate `pill` at 22. `sm` and `md` sit two points apart on purpose: everything you press is nearly a rectangle, and there is exactly one round thing per screen. The sheet's top edge stops being `RADIUS.lg + 6` and becomes that pill.

**Type.** Title 16 → 17, and Now's opening line gets a size of its own at 26. That line is the only Display in the app because it states a count — "3 things want you" — and is what the screen is for; a pull request's own title stays at 20, since 26pt of somebody else's prose is four lines before the screen has said anything. The eyebrow keeps 11 rather than dropping to the design's 10.5: this is read outdoors, in one hand, by somebody deciding whether a check failed, and what makes an eyebrow read as one is the tracking and the caps, which `Label` has carried all along.

**No font files.** Pane wants one family for prose and code, which means bundling IBM Plex through `expo-font`, a load-before-render step and ~400 KB of APK for a difference nobody on a phone reads as a family choice. The ladder, the tracking and the mono/prose split all work on the system face, which is where the idea actually lives.

Three faults were found while wiring it, each of which would have shipped:

- `setLook` composed the live repaint on `BASE`. The app would have looked like Pane until the first time anybody opened Settings, and then snapped back to github-dark for good.
- `accentFor`'s unknown-id fallback read the module `BASE` instead of its own argument, so an unreadable preference file put the desk's blue on a Pane ground.
- `info` was set to the teal, matching the accent. Wrong twice: in the UI it collapses "informational" and "press me" into one hex, and in the terminal `deriveAnsi` picks ANSI blue by *hue* — teal is 171°, so blue fell through to `primary`, and on the neutral accent `primary` **is** the body text. Two of the sixteen slots held the same colour and an `ls` colour vanished.

Two hardcoded colours went with it. The diff's added and removed rows carried github's green and red written out as `rgba()` long after the phone stopped wearing them — with the red a whole hue from the `C.error` printed on the same row — and now derive from the live palette via `tint()`. The two scrims (`rgba(1,4,9,.55)` on one screen, `rgba(0,0,0,.55)` on another) became one `SCRIM`.

No server routes, no permission or scope changes, no `shared/types.ts` contract change.

## How was it tested?

- `npx tsc --noEmit` in `mobile/` — clean.
- `bun test` in `mobile/` — 579 pass, 0 fail, 40 skip across 44 files.
- `bun test` in `web/` — 2716 pass, 0 fail across 210 files, confirming the desk is unchanged by the shared/palettes.ts edits.
- The `info` fault above was caught by `mobile/test/term-ansi.test.ts` once its palettes were composed on what the app actually paints rather than on the module default — that file now builds every palette through a `phone()` helper, so its WCAG floors are measured against the real ground.
- New coverage: `tint()` is checked for two-digit padding (a one-digit alpha makes a seven-character colour that RN silently draws as transparent), clamping at both ends, and following the live palette; `accentFor`'s fallback is checked against a caller-supplied base.

Not exercised on a device — no phone attached to this environment. The palette, radius and type changes are declarative and covered by the suites above, but a visual pass on a real screen is worth doing before merge.

## CI

`build` is red on the **Tests (server)** step, and it is not this branch's — see the comment below: `main`'s own last green run, re-run today unchanged, fails identically.