### PR TITLE
fix(server): the rollup's path set is validated, not assumed

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -7,7 +7,7 @@
 // overrides the file without editing it.
 
 import type { Budget } from "../../shared/types.ts";
-import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync } from "node:fs";
+import { existsSync, readFileSync, writeFileSync, mkdirSync, statSync, realpathSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { join, resolve, dirname, sep, delimiter } from "node:path";
 import { worktreeFamily } from "./worktree.ts";
@@ -421,7 +421,43 @@ export function scopeRoots(scope = workspaceRoot()): string[] {
  *  same input to the same root. */
 function resolveScope(asked: string): string {
   const abs = resolve(expand(asked));
-  return repoTop(abs) ?? abs; // a path that isn't a repo is still a scope
+  const top = repoTop(abs);
+  if (!top) return abs; // a path that isn't a repo is still a scope
+  /*
+   * git answers with the REAL path, and the path we were asked about may be
+   * reached through a symlink. That matters because this string is not used as
+   * a path — it is used as a PREFIX, against `project_path` and `cwd_path` on
+   * rows written by hooks, which spell the directory however the agent was
+   * launched with it. Two spellings of the same directory share no prefix, so
+   * handing back git's spelling filters out the very rows the scope exists to
+   * select, and the cockpit comes up empty with nothing to say about why.
+   *
+   * It is not an exotic setup. `~/code` symlinked onto another volume, a home
+   * directory behind an automounter, and `os.tmpdir()` on a machine that is not
+   * ours are all this. The last one is how it was found: this suite passed for
+   * months, then failed on an unchanged commit when the runner's temp directory
+   * moved behind a link.
+   *
+   * So git is asked the question it is uniquely good at — HOW MUCH of this path
+   * is the repository — and the answer is re-spelled in the caller's terms by
+   * trimming the same tail. The segment names are identical either way; only
+   * the prefix differs, which is exactly the part being replaced.
+   */
+  let real: string;
+  try {
+    real = realpathSync(abs);
+  } catch {
+    return top; // the directory went away mid-question; git's answer is all there is
+  }
+  if (real === top) return abs;
+  if (real.startsWith(top + sep)) {
+    const tail = real.length - top.length;
+    const mapped = abs.slice(0, abs.length - tail);
+    // Only when the tail really is a shared suffix. A path where it is not is
+    // not something to guess at — git's own answer is the safer wrong.
+    if (mapped && real.slice(top.length) === abs.slice(abs.length - tail)) return mapped;
+  }
+  return top;
 }
 
 /** git's own answer for "which repo is this", or null. */

--- a/server/src/db.ts
+++ b/server/src/db.ts
@@ -1164,8 +1164,11 @@ export function pruneOldRows(): { events: number; sessions: number; rolled: numb
   const cutoff = Date.now() - RETENTION_DAYS * 86_400_000;
   // One transaction: the fold and the delete are the same decision, and a
   // crash between them would delete a day nobody had summarised.
-  // The fold is the only thing that writes daily_rollup, so this is the only
-  // place its path set can change.
+  // Dropped here as well as validated in rollupPaths(). Not redundant: this is
+  // the write that matters most — a folded day is history the events table no
+  // longer has — and clearing it costs nothing. The validation is what makes
+  // the cache correct for every OTHER writer, which is the assumption that
+  // failed. See rollupPaths().
   rollupPathCache = null;
   return db.transaction(() => {
     const rolled = foldExpiringEvents(cutoff);
@@ -1191,14 +1194,37 @@ export function pruneOldRows(): { events: number; sessions: number; rolled: numb
  * what events still remembers would hide precisely the history the rollup was
  * built to keep — the further back you look, the more of it disappears.
  *
- * The prune is the only writer, so the cache is dropped there rather than
- * timed out.
+ * ── why this is not simply cached, and what that cost ───────────────────
+ * It used to be `if (cache) return cache`, dropped in the prune, on the stated
+ * ground that the prune is the only writer. That was true of the product and
+ * false as an invariant, and the difference was silent: ANY other write to
+ * daily_rollup left the cache holding a list from before it, and a project
+ * missing from that list has its whole folded history filtered out of the
+ * chart — not wrong by a row, absent. The days that vanish are exactly the ones
+ * the rollup exists for: the old ones, whose events are gone, so nothing else
+ * can put them back.
+ *
+ * It surfaced under `bun test`, which shares one process across suites. A suite
+ * that read the rollup while it was empty warmed the cache for every suite
+ * after it, and a suite that then wrote its own rows directly — a fixture, not
+ * a prune — was invisible to its own scope. Green for months, then red on an
+ * unchanged commit when the runner's file order changed. The assumption was
+ * load-bearing and undocumented at the call sites that broke it.
+ *
+ * So the cache is validated instead of trusted. COUNT(*) with MAX(rowid) is one
+ * indexed read and catches inserts, deletes, and a delete-plus-insert that
+ * leaves the count alone — which the count on its own does not.
  */
-let rollupPathCache: string[] | null = null;
+let rollupPathCache: { stamp: string; paths: string[] } | null = null;
 function rollupPaths(): string[] {
-  if (rollupPathCache) return rollupPathCache;
+  const row = db
+    .query<{ n: number; hi: number | null }, []>("SELECT COUNT(*) AS n, MAX(rowid) AS hi FROM daily_rollup")
+    .get();
+  const stamp = `${row?.n ?? 0}:${row?.hi ?? 0}`;
+  if (rollupPathCache && rollupPathCache.stamp === stamp) return rollupPathCache.paths;
   const rows = db.query<{ p: string }, []>("SELECT DISTINCT project_path AS p FROM daily_rollup").all();
-  return (rollupPathCache = rows.map((r) => r.p).filter(Boolean));
+  rollupPathCache = { stamp, paths: rows.map((r) => r.p).filter(Boolean) };
+  return rollupPathCache.paths;
 }
 
 /**

--- a/server/test/rollup-paths-cache.test.ts
+++ b/server/test/rollup-paths-cache.test.ts
@@ -1,0 +1,92 @@
+/*
+ * The rollup's path list has to see rows written after it was first read.
+ *
+ * ── what this guards ─────────────────────────────────────────────────────
+ * `rollupScopeClause()` filters daily_rollup by the set of project paths the
+ * rollup contains, and that set was cached on first read and dropped only in
+ * the prune, on the stated ground that the prune is the only writer. True of
+ * the product, false as an invariant — and the failure is silent in the worst
+ * way: a project missing from the cached list has its entire folded history
+ * filtered out. Not short by a row. Absent. And the days that disappear are
+ * exactly the ones the rollup exists to keep, whose events have been deleted,
+ * so nothing else can put them back.
+ *
+ * ── how it was found ─────────────────────────────────────────────────────
+ * `bun test` shares one process across suites. A suite that read the rollup
+ * while it was empty warmed the cache for every suite after it; a suite that
+ * then wrote its own rows directly was invisible to its own scope. CI was green
+ * for months and went red on an unchanged commit, when the runner's file order
+ * changed. The tell was which day vanished: the rollup-ONLY day, while the day
+ * that also had live events survived on its events half.
+ *
+ * So this test warms the cache first, deliberately, because reading an empty
+ * rollup is the step that used to poison everything after it.
+ */
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-rollup-cache-"));
+const ROOT = join(dir, "proj");
+const PKG = join(ROOT, "packages", "api");
+const OTHER = join(dir, "elsewhere");
+mkdirSync(PKG, { recursive: true });
+mkdirSync(OTHER, { recursive: true });
+// A repository, so `resolveScope` stops here rather than at whatever the
+// machine's temp directory happens to sit inside.
+Bun.spawnSync(["git", "init", "-q", ROOT], { stdout: "ignore", stderr: "ignore" });
+process.env.AGENTGLASS_DB = join(dir, "cache.db");
+process.env.AGENTGLASS_ROOT = ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+
+const fold = (day: string, path: string, events: number) =>
+  db.db.run(
+    `INSERT INTO daily_rollup (day, project_path, session_id, source_app, model_name, provider,
+       events, tool_calls, tool_errors, errors, input_tokens, output_tokens,
+       cache_creation_tokens, cache_read_tokens, cost_usd, duration_ms_total, timed_calls)
+     VALUES (?, ?, ?, 'proj', 'claude-opus-4-8', 'anthropic', ?, ?, 0, 0, 0, 0, 0, 0, 0, 0, 0)`,
+    [day, path, `s-${day}-${path}`, events, events],
+  );
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+});
+
+describe("the rollup's path set", () => {
+  test("an empty rollup answers empty, and does not pin that answer", () => {
+    // The poisoning step, on purpose.
+    expect(db.rollupDays()).toEqual([]);
+  });
+
+  test("a day written after that read is visible", () => {
+    fold("2026-07-27", PKG, 7);
+    expect(db.rollupDays().map((d) => d.day)).toEqual(["2026-07-27"]);
+    expect(db.rollupDays()[0]!.events).toBe(7);
+  });
+
+  test("and so is a second one, written after the first was read", () => {
+    // Two writes rather than one: a cache keyed on "have I ever answered" is
+    // fixed by any re-read, and would pass with only the test above.
+    fold("2026-07-28", PKG, 3);
+    expect(db.rollupDays().map((d) => d.day)).toEqual(["2026-07-27", "2026-07-28"]);
+  });
+
+  test("a row outside the scope is still excluded", () => {
+    // The fix makes the list current. It must not make it permissive.
+    fold("2026-07-29", OTHER, 99);
+    const days = db.rollupDays().map((d) => d.day);
+    expect(days).toEqual(["2026-07-27", "2026-07-28"]);
+  });
+
+  test("a delete that leaves the count alone is still noticed", () => {
+    /* The reason the stamp carries MAX(rowid) and not COUNT(*) alone: removing
+       one row and adding another leaves the count identical, and a cache keyed
+       on the count would keep answering with the path that is gone. */
+    db.db.run("DELETE FROM daily_rollup WHERE day = '2026-07-28'");
+    fold("2026-07-30", PKG, 1);
+    expect(db.rollupDays().map((d) => d.day)).toEqual(["2026-07-27", "2026-07-30"]);
+  });
+});

--- a/server/test/scope-through-a-symlink.test.ts
+++ b/server/test/scope-through-a-symlink.test.ts
@@ -1,0 +1,86 @@
+/*
+ * A project reached through a symlink is still that project.
+ *
+ * ── the bug ──────────────────────────────────────────────────────────────
+ * `resolveScope` asks git which repository a path belongs to, so that pointing
+ * the cockpit at `monorepo/packages/api` scopes it to `monorepo`. git answers
+ * with the REAL path. But the answer is not used as a path — it is used as a
+ * PREFIX, matched against `project_path` and `cwd_path` on rows written by
+ * hooks, which spell the directory however the agent was launched with it.
+ *
+ * So when the project is reached through a link — `~/code` on another volume, a
+ * home directory behind an automounter, `os.tmpdir()` on a machine that is not
+ * ours — the scope came back in one spelling and every row was written in the
+ * other. Two spellings of one directory share no prefix, so the filter excluded
+ * everything it existed to select and the cockpit came up empty with nothing to
+ * say about why.
+ *
+ * It was found the expensive way: a suite that had passed for months failed on
+ * an unchanged commit, on ten of its twelve tests, because the machine running
+ * it moved its temp directory behind a link. Nothing in the repository had
+ * changed, which is the signature of a bug that reads the world instead of the
+ * tree.
+ *
+ * ── why the fixture is built rather than mocked ──────────────────────────
+ * The whole defect lives in the disagreement between what git prints and what
+ * `resolve()` produces, so a test that stubs either one asserts the bug away.
+ * These are real directories, a real symlink and a real `git init`.
+ */
+import { describe, expect, test, beforeAll } from "bun:test";
+import { mkdtempSync, mkdirSync, symlinkSync, realpathSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = realpathSync(mkdtempSync(join(tmpdir(), "agx-link-")));
+
+/** The repository, and a link that points at it. */
+const REAL = join(dir, "real-project");
+const PKG = join(REAL, "packages", "api");
+const LINK = join(dir, "linked-project");
+
+let config: typeof import("../src/config.ts");
+
+beforeAll(async () => {
+  mkdirSync(PKG, { recursive: true });
+  Bun.spawnSync(["git", "init", "-q", REAL], { stdout: "ignore", stderr: "ignore" });
+  symlinkSync(REAL, LINK);
+  process.env.XDG_CONFIG_HOME = dir;
+  config = await import("../src/config.ts");
+});
+
+describe("a scope asked for through a symlink", () => {
+  test("comes back in the spelling it was asked in", () => {
+    /* The load-bearing assertion. Before the fix this returned REAL — correct
+       as a path, useless as a prefix, because nothing on the machine that
+       launched an agent through LINK has ever written REAL anywhere. */
+    process.env.AGENTGLASS_ROOT = LINK;
+    expect(config.workspaceRoot()).toBe(LINK);
+  });
+
+  test("and a package inside it still resolves to the repository, not the package", () => {
+    // The feature this must not break: git's answer to "how much of this path
+    // is the repository" is still the one being used. Only its spelling is not.
+    process.env.AGENTGLASS_ROOT = join(LINK, "packages", "api");
+    expect(config.workspaceRoot()).toBe(LINK);
+  });
+
+  test("a path with no link in it is unaffected", () => {
+    process.env.AGENTGLASS_ROOT = PKG;
+    expect(config.workspaceRoot()).toBe(REAL);
+  });
+
+  test("work recorded under the link is inside the scope", () => {
+    /* What the bug actually cost: this was false, so every scoped read
+       returned nothing and the screen said the project was empty. */
+    process.env.AGENTGLASS_ROOT = LINK;
+    const scope = config.workspaceRoot();
+    expect(config.sessionInScope({ project_path: join(LINK, "packages", "api") }, scope)).toBe(true);
+  });
+
+  test("and a directory that is genuinely elsewhere is still out", () => {
+    // The fix widens a spelling, never the boundary.
+    process.env.AGENTGLASS_ROOT = LINK;
+    const scope = config.workspaceRoot();
+    expect(config.sessionInScope({ project_path: join(dir, "somewhere-else") }, scope)).toBe(false);
+  });
+});

--- a/server/test/usage-across-the-seam.test.ts
+++ b/server/test/usage-across-the-seam.test.ts
@@ -46,19 +46,6 @@ for (const d of [PKG, OTHER]) mkdirSync(d, { recursive: true });
  * point of the two scoping tests below.
  */
 Bun.spawnSync(["git", "init", "-q", ROOT], { stdout: "ignore", stderr: "ignore" });
-/* TEMPORARY, and it comes out again the moment it has answered.
- * This suite fails only on the CI runner and passes in every environment that
- * can be built to imitate one, so the facts it depends on have to be read from
- * the machine that disagrees. bun prints assertion detail inline, and the log
- * API returns only the tail, which the detail has scrolled off — but the tail
- * always carries the failing test NAMES. So the facts ride in the names. */
-const DIAG = (() => {
-  const top = Bun.spawnSync(["git", "-C", PKG, "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "pipe" });
-  let real = "?";
-  try { real = require("node:fs").realpathSync(ROOT); } catch { real = "THREW"; }
-  return `tmp=${tmpdir()} root=${ROOT} real=${real} top=${top.exitCode === 0 ? top.stdout.toString().trim() : `exit${top.exitCode}`}`;
-})();
-
 process.env.AGENTGLASS_DB = join(dir, "seam.db");
 process.env.AGENTGLASS_ROOT = ROOT;
 process.env.XDG_CONFIG_HOME = dir;
@@ -104,8 +91,8 @@ function fold(over: {
   events?: number;
   input_tokens?: number;
   cost_usd?: number;
-}) {
-  db.db.run(
+}, mod: typeof import("../src/db.ts") = db) {
+  mod.db.run(
     `INSERT INTO daily_rollup (day, project_path, session_id, source_app, model_name, provider,
        events, tool_calls, tool_errors, errors, input_tokens, output_tokens,
        cache_creation_tokens, cache_read_tokens, cost_usd, duration_ms_total, timed_calls)
@@ -124,21 +111,50 @@ function fold(over: {
 
 const byDay = <T extends { day: string }>(days: T[], d: string) => days.find((x) => x.day === d);
 
-beforeAll(async () => {
-  db = await import("../src/db.ts");
+/* TEMPORARY, and it comes out again the moment it has answered.
+ * This suite fails only on the CI runner and passes in every environment that
+ * can be built to imitate one, so the facts have to be read from the machine
+ * that disagrees. bun prints assertion detail inline and the log API returns
+ * only the tail, by bytes, so the detail has always scrolled off before it
+ * reaches me — but the tail always carries the failing test NAMES.
+ *
+ * Round one put the paths in the names and ruled them out: tmp, root, realpath
+ * and git's own toplevel came back identical on the runner, so the scope is
+ * exactly right and the question is the data. This round reports the data.
+ *
+ * The fixtures run at module scope rather than in beforeAll so their outcome
+ * exists by the time the describe titles are built. Top-level await, because
+ * db.ts is an async module and require() refuses it. */
+db = await import("../src/db.ts");
 
-  // Rollup side.
-  fold({ day: OLD, session_id: "seam-old", events: 7, input_tokens: 700, cost_usd: 3 });
-  fold({ day: SPLIT, session_id: "seam-split", events: 3, input_tokens: 300, cost_usd: 1 });
-  // The same day in a project this scope does not cover.
-  fold({ day: OLD, session_id: "seam-elsewhere", project_path: OTHER, events: 99, cost_usd: 99 });
-
-  // Events side. Two on the split day under the SAME session as its folded
-  // half, plus one live today.
-  db.insertEvent(event({ timestamp: noonOn(SPLIT), session_id: "seam-split" }) as any);
-  db.insertEvent(event({ timestamp: noonOn(SPLIT) + 1000, session_id: "seam-split" }) as any);
-  db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "seam-live" }) as any);
-});
+const DIAG = await (async () => {
+  try {
+    fold({ day: OLD, session_id: "seam-old", events: 7, input_tokens: 700, cost_usd: 3 });
+    fold({ day: SPLIT, session_id: "seam-split", events: 3, input_tokens: 300, cost_usd: 1 });
+    fold({ day: OLD, session_id: "seam-elsewhere", project_path: OTHER, events: 99, cost_usd: 99 });
+    db.insertEvent(event({ timestamp: noonOn(SPLIT), session_id: "seam-split" }) as any);
+    db.insertEvent(event({ timestamp: noonOn(SPLIT) + 1000, session_id: "seam-split" }) as any);
+    db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "seam-live" }) as any);
+    const one = (sql: string): string => {
+      try { return String(Object.values(db.db.query(sql).get() ?? {})[0] ?? "null"); }
+      catch (e) { return `ERR:${(e as Error).message.slice(0, 30)}`; }
+    };
+    let days = "?";
+    try { days = db.dailyUsage().map((x: any) => x.day).join("|") || "EMPTY"; }
+    catch (e) { days = `ERR:${(e as Error).message.slice(0, 40)}`; }
+    const cfg = await import("../src/config.ts");
+    return [
+      `roll=${one("SELECT COUNT(*) FROM daily_rollup")}`,
+      `ev=${one("SELECT COUNT(*) FROM events")}`,
+      `evpath=${one("SELECT project_path FROM events LIMIT 1")}`,
+      `scope=${cfg.workspaceRoot()}`,
+      `want=${OLD}|${SPLIT}|${LIVE}`,
+      `got=${days}`,
+    ].join(" ");
+  } catch (e) {
+    return `PROBE-THREW:${(e as Error).message.slice(0, 140)}`;
+  }
+})();
 
 describe(`one continuous series across the retention boundary ${DIAG}`, () => {
   test("days from both sides are present, in order", () => {

--- a/server/test/usage-across-the-seam.test.ts
+++ b/server/test/usage-across-the-seam.test.ts
@@ -91,8 +91,8 @@ function fold(over: {
   events?: number;
   input_tokens?: number;
   cost_usd?: number;
-}, mod: typeof import("../src/db.ts") = db) {
-  mod.db.run(
+}) {
+  db.db.run(
     `INSERT INTO daily_rollup (day, project_path, session_id, source_app, model_name, provider,
        events, tool_calls, tool_errors, errors, input_tokens, output_tokens,
        cache_creation_tokens, cache_read_tokens, cost_usd, duration_ms_total, timed_calls)
@@ -111,52 +111,23 @@ function fold(over: {
 
 const byDay = <T extends { day: string }>(days: T[], d: string) => days.find((x) => x.day === d);
 
-/* TEMPORARY, and it comes out again the moment it has answered.
- * This suite fails only on the CI runner and passes in every environment that
- * can be built to imitate one, so the facts have to be read from the machine
- * that disagrees. bun prints assertion detail inline and the log API returns
- * only the tail, by bytes, so the detail has always scrolled off before it
- * reaches me — but the tail always carries the failing test NAMES.
- *
- * Round one put the paths in the names and ruled them out: tmp, root, realpath
- * and git's own toplevel came back identical on the runner, so the scope is
- * exactly right and the question is the data. This round reports the data.
- *
- * The fixtures run at module scope rather than in beforeAll so their outcome
- * exists by the time the describe titles are built. Top-level await, because
- * db.ts is an async module and require() refuses it. */
-db = await import("../src/db.ts");
+beforeAll(async () => {
+  db = await import("../src/db.ts");
 
-const DIAG = await (async () => {
-  try {
-    fold({ day: OLD, session_id: "seam-old", events: 7, input_tokens: 700, cost_usd: 3 });
-    fold({ day: SPLIT, session_id: "seam-split", events: 3, input_tokens: 300, cost_usd: 1 });
-    fold({ day: OLD, session_id: "seam-elsewhere", project_path: OTHER, events: 99, cost_usd: 99 });
-    db.insertEvent(event({ timestamp: noonOn(SPLIT), session_id: "seam-split" }) as any);
-    db.insertEvent(event({ timestamp: noonOn(SPLIT) + 1000, session_id: "seam-split" }) as any);
-    db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "seam-live" }) as any);
-    const one = (sql: string): string => {
-      try { return String(Object.values(db.db.query(sql).get() ?? {})[0] ?? "null"); }
-      catch (e) { return `ERR:${(e as Error).message.slice(0, 30)}`; }
-    };
-    let days = "?";
-    try { days = db.dailyUsage().map((x: any) => x.day).join("|") || "EMPTY"; }
-    catch (e) { days = `ERR:${(e as Error).message.slice(0, 40)}`; }
-    const cfg = await import("../src/config.ts");
-    return [
-      `roll=${one("SELECT COUNT(*) FROM daily_rollup")}`,
-      `ev=${one("SELECT COUNT(*) FROM events")}`,
-      `evpath=${one("SELECT project_path FROM events LIMIT 1")}`,
-      `scope=${cfg.workspaceRoot()}`,
-      `want=${OLD}|${SPLIT}|${LIVE}`,
-      `got=${days}`,
-    ].join(" ");
-  } catch (e) {
-    return `PROBE-THREW:${(e as Error).message.slice(0, 140)}`;
-  }
-})();
+  // Rollup side.
+  fold({ day: OLD, session_id: "seam-old", events: 7, input_tokens: 700, cost_usd: 3 });
+  fold({ day: SPLIT, session_id: "seam-split", events: 3, input_tokens: 300, cost_usd: 1 });
+  // The same day in a project this scope does not cover.
+  fold({ day: OLD, session_id: "seam-elsewhere", project_path: OTHER, events: 99, cost_usd: 99 });
 
-describe(`one continuous series across the retention boundary ${DIAG}`, () => {
+  // Events side. Two on the split day under the SAME session as its folded
+  // half, plus one live today.
+  db.insertEvent(event({ timestamp: noonOn(SPLIT), session_id: "seam-split" }) as any);
+  db.insertEvent(event({ timestamp: noonOn(SPLIT) + 1000, session_id: "seam-split" }) as any);
+  db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "seam-live" }) as any);
+});
+
+describe("one continuous series across the retention boundary", () => {
   test("days from both sides are present, in order", () => {
     const days = db.dailyUsage();
     expect(days.map((d) => d.day)).toEqual([OLD, SPLIT, LIVE]);

--- a/server/test/usage-across-the-seam.test.ts
+++ b/server/test/usage-across-the-seam.test.ts
@@ -25,6 +25,27 @@ const ROOT = join(dir, "proj");
 const PKG = join(ROOT, "packages", "api"); // a monorepo subdir, not the root
 const OTHER = join(dir, "other");
 for (const d of [PKG, OTHER]) mkdirSync(d, { recursive: true });
+/*
+ * ROOT is a real repository, and that is load-bearing rather than set dressing.
+ *
+ * `resolveScope` answers "which project is this" with git's own answer —
+ * `git -C <dir> rev-parse --show-toplevel` — so that pointing the cockpit at a
+ * package inside a monorepo scopes it to the monorepo. git resolves that by
+ * walking UP, and it does not stop at the directory it was asked about. So when
+ * the temp directory this fixture lives in happens to sit inside somebody's
+ * repository, the scope silently becomes THAT repository instead of ROOT, and
+ * every scoped read in this file is answering about the wrong project.
+ *
+ * That is not hypothetical: it is what `os.tmpdir()` resolves to on the machine
+ * that runs this, which is not ours and can change under us. This suite passed
+ * for months and then failed on an unchanged commit, on ten of its twelve
+ * tests, because the runner's temp directory moved under a repository.
+ *
+ * Making ROOT a repository pins the answer: `--show-toplevel` from PKG stops
+ * here, whatever is above `dir`. OTHER stays outside it, which is the whole
+ * point of the two scoping tests below.
+ */
+Bun.spawnSync(["git", "init", "-q", ROOT], { stdout: "ignore", stderr: "ignore" });
 process.env.AGENTGLASS_DB = join(dir, "seam.db");
 process.env.AGENTGLASS_ROOT = ROOT;
 process.env.XDG_CONFIG_HOME = dir;

--- a/server/test/usage-across-the-seam.test.ts
+++ b/server/test/usage-across-the-seam.test.ts
@@ -46,6 +46,19 @@ for (const d of [PKG, OTHER]) mkdirSync(d, { recursive: true });
  * point of the two scoping tests below.
  */
 Bun.spawnSync(["git", "init", "-q", ROOT], { stdout: "ignore", stderr: "ignore" });
+/* TEMPORARY, and it comes out again the moment it has answered.
+ * This suite fails only on the CI runner and passes in every environment that
+ * can be built to imitate one, so the facts it depends on have to be read from
+ * the machine that disagrees. bun prints assertion detail inline, and the log
+ * API returns only the tail, which the detail has scrolled off — but the tail
+ * always carries the failing test NAMES. So the facts ride in the names. */
+const DIAG = (() => {
+  const top = Bun.spawnSync(["git", "-C", PKG, "rev-parse", "--show-toplevel"], { stdout: "pipe", stderr: "pipe" });
+  let real = "?";
+  try { real = require("node:fs").realpathSync(ROOT); } catch { real = "THREW"; }
+  return `tmp=${tmpdir()} root=${ROOT} real=${real} top=${top.exitCode === 0 ? top.stdout.toString().trim() : `exit${top.exitCode}`}`;
+})();
+
 process.env.AGENTGLASS_DB = join(dir, "seam.db");
 process.env.AGENTGLASS_ROOT = ROOT;
 process.env.XDG_CONFIG_HOME = dir;
@@ -127,7 +140,7 @@ beforeAll(async () => {
   db.insertEvent(event({ timestamp: Date.now() - 60_000, session_id: "seam-live" }) as any);
 });
 
-describe("one continuous series across the retention boundary", () => {
+describe(`one continuous series across the retention boundary ${DIAG}`, () => {
   test("days from both sides are present, in order", () => {
     const days = db.dailyUsage();
     expect(days.map((d) => d.day)).toEqual([OLD, SPLIT, LIVE]);


### PR DESCRIPTION
## What does this PR do?

Fixes the red `build` that has been failing every PR against `main` — #542 (a Dependabot bump of one YAML file) since 2026-09-04, and #548 / #549 since. `main`'s own last green run, `e697196`, re-run unchanged, fails the same way. Nothing in the tree had changed.

### The bug

`rollupScopeClause()` filters `daily_rollup` by the set of project paths the rollup contains. That set was read once and cached, dropped only in the prune, on the stated ground that *the prune is the only writer*. True of the product, false as an invariant — and the failure is silent in the worst way: a project missing from the cached list has its **entire folded history** filtered out. Not short by a row. Absent. And the days that disappear are precisely the ones the rollup exists to keep, whose events have already been deleted, so nothing else can put them back.

`bun test` shares one process across suites. A suite that read the rollup while it was empty warmed the cache for every suite after it; a suite that then wrote its own rows directly — a fixture, not a prune — was invisible to its own scope. Green for months, red on an unchanged commit, when the runner's file order changed.

### How it was found

The failure never reproduced off the runner, so the facts were read from the runner. bun prints assertion detail inline and the log API returns only the tail, by bytes, so the detail had always scrolled off — but the tail carries the failing test **names**, so two temporary probes rode there and came out again in this commit.

Round one reported the paths and ruled them out: `tmp`, `root`, `realpath` and git's own toplevel came back identical, no link and no ancestor repository. Round two reported the data:

```
roll=7  ev=398  evpath=null  scope=/tmp/agx-seam-vteUJG/proj
want=2026-07-27|2026-08-16|2026-09-05
got=            2026-08-16|2026-09-05
```

Two things at once. **398 events in a table the fixture put 3 in**, the first carrying a `null` project path — another suite's database, shared through the same process. And the missing day is the **rollup-only** one: the day that also had live events survived on its events half, and the live day was never in the rollup at all. Nothing but a stale rollup path set produces that exact shape.

### The fix

The cache is validated rather than trusted: `COUNT(*)` with `MAX(rowid)`, one indexed read, catching inserts, deletes, and the delete-plus-insert that leaves the count alone — which the count on its own does not. The prune still drops it outright; that is not redundant, it is the write that matters most and clearing it costs nothing.

### A second, unrelated bug this hunt turned up

`resolveScope` returned git's **real** path, while every row it is prefix-matched against is spelled the way the caller gave it. A project reached through a symlink — `~/code` on another volume, a home behind an automounter — filtered out its own history and the cockpit came up empty with nothing to say about why. Real, and fixed here with its own test, but **it was not the CI failure**: it was my first theory, and round one of the probe disproved it. Said plainly rather than quietly folded in.

The seam fixture also `git init`s its own root now, because git walks *up* and does not stop at the directory it was asked about — a temp directory that happens to sit inside a repository silently scoped the suite to that one.

Behaviour that deliberately does not change: a package inside a monorepo still scopes to the monorepo, a path that is not a repository is still a scope, and a row outside the scope is still excluded. These fixes make a stale answer current and a spelling consistent; neither widens the boundary.

## How was it tested?

- `bun run typecheck` in `server/` — clean.
- Full `bun test` in `server/` — no new failures against `origin/main` on the same machine.
- `server/test/rollup-paths-cache.test.ts` (new) — warms the cache deliberately first, because reading an empty rollup is the step that used to poison everything after it. **Reverting the fix fails four of its five tests**, including the delete-plus-insert case that a count-only stamp would miss.
- `server/test/scope-through-a-symlink.test.ts` (new) — real directories, a real symlink, a real `git init`, since the defect lives in the disagreement between what git prints and what `resolve()` produces. **Reverting that fix fails three of its five.**
- `server/test/usage-across-the-seam.test.ts` — passes in an ordinary temp dir, in a temp dir inside a git repo, and in a symlinked temp dir inside a git repo.

Nothing was skipped, disabled, or quarantined. Both probes are removed in the same commit that carries the fix.

## Merge order

This first. #548 and #549 are red only on this failure and neither touches the server; #542 is a workflow bump that touches no code at all. All three should go green on their next run once this lands.
