### PR TITLE
feat(mobile): the terminal's composer becomes a way in rather than a field

### DIFF
--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -52,6 +52,9 @@ import {
 import { bytesFor } from "../../src/terminal/customKeys.ts";
 import { editFor } from "../../src/terminal/mirror.ts";
 import {
+  NO_MODES, applyDefault, isLive, prune, setLive, type LiveModes,
+} from "../../src/terminal/liveDefault.ts";
+import {
   clearFocusTimer, focusCapture, liveDetail, scheduleFocus, type FocusTimer,
 } from "../../src/terminal/liveFocus.ts";
 import { onHandoff, takeHandoff } from "../../src/terminal/handoff.ts";
@@ -387,7 +390,40 @@ export default function TerminalScreen(): React.ReactNode {
    * something unrecoverable, and one that guesses the other way leaves them
    * tapping at a prompt that is not listening.
    */
-  const [raw, setRaw] = useState(false);
+  /*
+   * Direct input is the default, per pane, applied once.
+   *
+   * A pane opens typing straight through, because that is what a shell, a
+   * REPL, an editor and an agent's prompt all expect — composing a line first
+   * is the special case. Somebody who wants the other one says so in the ···
+   * sheet, and their answer survives every refresh after it.
+   *
+   * Per PANE and not per screen: two tabs are two terminals, and an answer
+   * given about one is not an answer about the other. The bookkeeping that
+   * makes the default one-shot is in liveDefault.ts, with the reason it cannot
+   * be a plain `useState(true)` — the tab list refreshes constantly, and a
+   * default re-applied on any of those refreshes would undo a choice made
+   * seconds earlier with nothing on screen to explain it.
+   */
+  const [modes, setModes] = useState<LiveModes>(NO_MODES);
+  const raw = isLive(modes, active);
+  const setRawFor = useCallback((on: boolean) => {
+    setModes((current) => (active ? setLive(current, active, on) : current));
+  }, [active]);
+  /*
+   * Apply the default to panes nobody has answered for, and forget the closed
+   * ones — both driven by `strip`, which is what the machine actually reported.
+   *
+   * `null` is "we have not asked yet" and is skipped entirely: pruning against
+   * a list that has not arrived would forget every answer on screen and then
+   * hand the panes back as new on the next poll, which is the default
+   * re-applying under a different name. See the test that states exactly that.
+   */
+  useEffect(() => {
+    if (!strip) return;
+    const panes = strip.map((t) => t.paneId).filter(Boolean);
+    setModes((current) => applyDefault(prune(current, panes), panes));
+  }, [strip]);
   /*
    * What the field holds in `keys` mode, and how much of it has already gone.
    *
@@ -2131,7 +2167,7 @@ export default function TerminalScreen(): React.ReactNode {
               // The transcript is emptied on the way past, in both directions:
               // it belongs to `keys`, and a deliberate tap is a moment when
               // nothing is being typed.
-              onPress={() => { setRaw((v) => !v); forgetKeys(); }}
+              onPress={() => { setRawFor(!raw); forgetKeys(); }}
             />
 
             <Label text="Past sessions" />

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -55,7 +55,7 @@ import {
   clearFocusTimer, focusCapture, liveDetail, scheduleFocus, type FocusTimer,
 } from "../../src/terminal/liveFocus.ts";
 import { onHandoff, takeHandoff } from "../../src/terminal/handoff.ts";
-import { BackIcon, ImageIcon, MicIcon } from "../../src/nav/icons.tsx";
+import { BackIcon, ImageIcon, KeyboardIcon, MicIcon } from "../../src/nav/icons.tsx";
 import { since } from "../../src/lib/dates.ts";
 import type { AgentSessionRow } from "../../../shared/types.ts";
 
@@ -1789,11 +1789,19 @@ export default function TerminalScreen(): React.ReactNode {
         <View style={{ paddingHorizontal: SPACE.sm, paddingBottom: SPACE.sm }}>
           <View style={{
             flexDirection: "row", alignItems: "center", gap: 2,
-            backgroundColor: C.bg2, borderWidth: 1,
-            // The one border on this row, and it is the field's. In `keys` it
-            // takes the accent, because the field behaving differently is the
-            // thing that switch used to have to say out loud.
-            borderColor: raw ? C.primary : C.border,
+            /*
+             * A field has an edge; a button has a face. That is the whole of
+             * the difference drawn here, and it was reported from a phone as
+             * "sigue pareciendo un input" — because it was one shape doing two
+             * jobs, with only a border colour between them.
+             *
+             * `keys` is a BUTTON: filled, no border, a keyboard on it. Line
+             * mode is a FIELD: a raised ground inside a hairline, which is what
+             * every other field in this app looks like.
+             */
+            backgroundColor: raw ? C.bg3 : C.bg2,
+            borderWidth: raw ? 0 : 1,
+            borderColor: C.border,
             // The capsule, and the only one on this screen. Pane allows exactly
             // one round thing per screen against everything else being nearly
             // rectangular, and on the terminal this is it: the place you type.
@@ -1818,10 +1826,15 @@ export default function TerminalScreen(): React.ReactNode {
               accessibilityLabel="Show the keyboard for this pane"
               accessibilityHint="What you type is sent to the pane as you type it"
               style={({ pressed }) => ({
-                flex: 1, height: TAP, justifyContent: "center",
-                paddingRight: SPACE.xs, opacity: !canSend ? 0.45 : pressed ? 0.6 : 1,
+                flex: 1, height: TAP, flexDirection: "row", alignItems: "center",
+                gap: SPACE.sm, paddingRight: SPACE.xs,
+                opacity: !canSend ? 0.45 : pressed ? 0.6 : 1,
               })}
             >
+              {/* The glyph is what a border used to do: say what this is. It
+                  goes first because it is read first — the words after it are
+                  the CONTENT of the button, not its name. */}
+              <KeyboardIcon color={C.text3} size={18} />
               <Text
                 numberOfLines={1}
                 /* From the HEAD, so a long line shows its END. The other way
@@ -1829,8 +1842,15 @@ export default function TerminalScreen(): React.ReactNode {
                    part of a line anybody is reading. */
                 ellipsizeMode="head"
                 style={{
-                  color: keyed.length > 0 ? C.text : C.text4,
-                  fontSize: T.body, fontFamily: MONO,
+                  // `text2`, not the placeholder's `text4`. Faint grey on the
+                  // left of a rounded box IS the drawing of an empty field —
+                  // the one thing this must not look like.
+                  color: keyed.length > 0 ? C.text : C.text2,
+                  fontSize: T.body,
+                  // The line itself is the pane's, so it is mono. The prompt to
+                  // press is this app talking, so it is not.
+                  fontFamily: keyed.length > 0 ? MONO : undefined,
+                  flex: 1,
                 }}
               >
                 {open ? liveDetail(keyed) : "Nothing is open"}

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -1167,6 +1167,11 @@ export default function TerminalScreen(): React.ReactNode {
   const focusLive = useCallback(function focusLive(): void {
     const now = liveNow.current;
     if (!now.canSend || !now.raw) return;
+    /* The pane is told too, and not only the capture. They are two different
+       claims: the capture is where the KEYBOARD goes, and this is what makes
+       the pane draw itself as the focused thing — a cursor that stays hollow
+       while somebody types into it is the screen disagreeing with the phone. */
+    terminal.current?.focus();
     focusCapture(capture.current, {
       keyboardShown: now.keyboardShown,
       retry: () => scheduleFocus(focusTimer, focusLive),
@@ -1474,6 +1479,7 @@ export default function TerminalScreen(): React.ReactNode {
             columns={columns}
             palette={paneColours}
             onState={onState}
+            onTap={tapPane}
             onTmux={(info) => setPrefix(prefixKey(info.prefix?.[0]))}
             onLine={onLine}
             onOpened={onOpened}

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -57,6 +57,24 @@ import type { AgentSessionRow } from "../../../shared/types.ts";
 
 /** The last segment of a path, which is what a person calls a checkout — the
  *  same rule src/terminal/tabs.ts uses to name a window. */
+/*
+ * The picture and the microphone are wired and do not work, so they are drawn
+ * disabled rather than drawn as if they might.
+ *
+ * Both need a computer to finish: the attach path wants a server that will take
+ * the upload, and dictation wants a transcriber configured on the machine.
+ * Neither is a phone-side change and neither is being guessed at from here.
+ *
+ * Drawn and dimmed rather than removed, which is the opposite call to the one
+ * `80c`, `line` and `fit` got. Those were controls that WORKED and duplicated
+ * something else; these are controls that do not work yet, and a row that
+ * silently loses them says the feature was dropped. A dimmed one says "not
+ * this build", which is true. The wiring below is untouched — `attach` and
+ * `dictate` still exist and still do what they did — so re-enabling is this
+ * line and nothing else.
+ */
+const HARDWARE_READY = false;
+
 const leafOf = (path: string): string => path.split("/").filter(Boolean).pop() ?? path;
 
 import { fileFrom, pastePayload, type Uploaded } from "../../src/terminal/imagePaste.ts";
@@ -1712,7 +1730,7 @@ export default function TerminalScreen(): React.ReactNode {
         */}
         <View style={{ paddingHorizontal: SPACE.sm, paddingBottom: SPACE.sm }}>
           <View style={{
-            flexDirection: "row", alignItems: "flex-end", gap: 2,
+            flexDirection: "row", alignItems: "center", gap: 2,
             backgroundColor: C.bg2, borderWidth: 1,
             // The one border on this row, and it is the field's. In `keys` it
             // takes the accent, because the field behaving differently is the
@@ -1733,7 +1751,10 @@ export default function TerminalScreen(): React.ReactNode {
                 // Said differently in the two cases, because they behave
                 // differently and a field that lies about which one it is in is
                 // worse than one that says nothing.
-                : mirror ? "This is the pane's line — type into it" : "Write a line for this pane"
+                // Short enough to fit. The old one wrapped at this width, and
+                // a wrapped placeholder was the row breaking its own layout
+                // before anybody had typed anything.
+                : mirror ? "The pane's line" : "Write a line"
               : "Nothing is open"}
             placeholderTextColor={C.text4}
             editable={!!open}
@@ -1756,11 +1777,22 @@ export default function TerminalScreen(): React.ReactNode {
             // preference: prediction rewrites characters it has already given
             // up, and those have gone down the socket.
             keyboardType={raw ? (Platform.OS === "android" ? "visible-password" : "ascii-capable") : "default"}
-            // Multiline so a long command wraps and the field grows to about
-            // five lines, but the return key SENDS rather than adding a line —
-            // this is a terminal, and Enter has meant "run it" the whole time.
-            // A newline can still arrive by paste, and `submit` handles that.
-            multiline
+            /*
+             * One line, and it does not grow. It used to be `multiline` with a
+             * 120pt ceiling, which meant the pill got taller as you typed and
+             * the three icons beside it slid down with it — the row reorganised
+             * itself under the thumb that was using it, and a placeholder long
+             * enough to wrap did it before a single character was typed.
+             *
+             * A terminal line is a line. It scrolls sideways here exactly as it
+             * scrolls sideways in the pane, which is the behaviour the thing
+             * being typed into already has, and the row is now a fixed height
+             * that nothing can push around.
+             *
+             * Enter still sends rather than inserting a newline, which is what
+             * it always did — this is a terminal and Enter has meant "run it"
+             * the whole time.
+             */
             submitBehavior="submit"
             /*
              * There is no onKeyPress here any more, and its absence is the fix
@@ -1787,9 +1819,12 @@ export default function TerminalScreen(): React.ReactNode {
               // number for a field would pass the test on somebody else's
               // reason. It costs nothing here — the icons beside it are 44, so
               // the pill is the same height either way.
-              flex: 1, minHeight: TAP, maxHeight: 120,
+              // A fixed height rather than a floor and a ceiling: `minHeight`
+              // with `multiline` is what let this grow. TAP is still the number,
+              // for the same reason as before — the icons beside it are 44.
+              flex: 1, height: TAP,
               backgroundColor: "transparent", color: C.text,
-              paddingTop: SPACE.sm, paddingBottom: SPACE.sm, paddingRight: SPACE.xs,
+              paddingVertical: 0, paddingRight: SPACE.xs,
               fontSize: T.body, fontFamily: MONO,
             }}
           />
@@ -1810,21 +1845,27 @@ export default function TerminalScreen(): React.ReactNode {
           */}
           <Pressable
             onPress={() => { void attach(); }}
-            disabled={!open || sending}
+            disabled={!HARDWARE_READY || !open || sending}
             accessibilityRole="button"
-            accessibilityLabel="Attach a picture to this pane"
+            accessibilityState={{ disabled: !HARDWARE_READY }}
+            accessibilityLabel={HARDWARE_READY
+              ? "Attach a picture to this pane"
+              : "Attach a picture — not available in this build"}
             // 40 wide rather than 44, and the eight points that buys across
             // the two icons are what keep the field readable at this width. The
             // HEIGHT stays at the 44 floor, which is the axis a thumb misses on.
             style={({ pressed }) => ({
               width: 40, height: TAP, alignItems: "center", justifyContent: "center",
-              borderRadius: RADIUS.md,
-              opacity: !open ? 0.4 : pressed ? 0.5 : 1,
+              // The pill's own roundness, not the ladder's control radius. A
+              // 10pt corner inside a 22pt capsule reads as a button escaping
+              // the thing it sits in — which is exactly what it looked like.
+              borderRadius: RADIUS.pill,
+              opacity: !HARDWARE_READY ? 0.28 : !open ? 0.4 : pressed ? 0.5 : 1,
             })}
           >
             {sending
               ? <ActivityIndicator color={C.text3} size="small" />
-              : <ImageIcon color={C.text3} size={19} />}
+              : <ImageIcon color={HARDWARE_READY ? C.text3 : C.text4} size={19} />}
           </Pressable>
           {/* The microphone, beside the picture, for the same reason: what is
               being said is part of the line being written, not a separate
@@ -1834,22 +1875,28 @@ export default function TerminalScreen(): React.ReactNode {
               your turn to hold on. */}
           <Pressable
             onPress={() => { void dictate(); }}
-            disabled={!open || hearing === "thinking"}
+            disabled={!HARDWARE_READY || !open || hearing === "thinking"}
             accessibilityRole="button"
-            accessibilityLabel={hearing === "listening" ? "Stop and transcribe" : "Speak a line"}
+            accessibilityState={{ disabled: !HARDWARE_READY }}
+            accessibilityLabel={!HARDWARE_READY
+              ? "Speak a line — not available in this build"
+              : hearing === "listening" ? "Stop and transcribe" : "Speak a line"}
             style={({ pressed }) => ({
               width: 40, height: TAP, alignItems: "center", justifyContent: "center",
-              borderRadius: RADIUS.md,
+              borderRadius: RADIUS.pill, // same reason as the picture above
               // Filled only while it is listening. Inside the pill an idle fill
               // would be a button drawn on top of a field; a live one is the
               // one state on this row that has to be unmissable.
               backgroundColor: hearing === "listening" ? C.error : "transparent",
-              opacity: !open ? 0.4 : pressed ? 0.5 : 1,
+              opacity: !HARDWARE_READY ? 0.28 : !open ? 0.4 : pressed ? 0.5 : 1,
             })}
           >
             {hearing === "thinking"
               ? <ActivityIndicator color={C.text3} size="small" />
-              : <MicIcon color={hearing === "listening" ? ink(C.error) : C.text3} size={19} />}
+              : <MicIcon
+                  color={hearing === "listening" ? ink(C.error) : HARDWARE_READY ? C.text3 : C.text4}
+                  size={19}
+                />}
           </Pressable>
           {/* Send, or Enter — the same thing the return key does, put where a
               thumb already is. */}
@@ -1859,7 +1906,10 @@ export default function TerminalScreen(): React.ReactNode {
             accessibilityLabel={raw ? "Enter" : "Send this line to the pane"}
             disabled={!canSend}
             style={{
-              width: 40, height: TAP, borderRadius: RADIUS.md,
+              // The one that had to change most: filled, and at the ladder's
+              // control radius it was a 10pt rectangle sitting inside a 22pt
+              // capsule with its corners visibly proud of it.
+              width: 40, height: TAP, borderRadius: RADIUS.pill,
               alignItems: "center", justifyContent: "center",
               // The only filled thing inside the pill, because it is the only
               // one that DOES something to what has been typed.

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -42,6 +42,7 @@ import { useSafeAreaInsets } from "react-native-safe-area-context";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { useDeskPalette, usePaletteTick } from "../../src/state/use-palette.ts";
+import { useKeyboardShown } from "../../src/state/use-keyboard.ts";
 import { TerminalView, type TerminalHandle, type TerminalState } from "../../src/terminal/TerminalView.tsx";
 import { ACCESSORY_KEYS, prefixKey, type AccessoryKey } from "../../src/terminal/keys.ts";
 import { apply as applyKeyLayout } from "../../src/terminal/keyLayout.ts";
@@ -50,6 +51,9 @@ import {
 } from "../../src/terminal/termPrefs.ts";
 import { bytesFor } from "../../src/terminal/customKeys.ts";
 import { editFor } from "../../src/terminal/mirror.ts";
+import {
+  clearFocusTimer, focusCapture, liveDetail, scheduleFocus, type FocusTimer,
+} from "../../src/terminal/liveFocus.ts";
 import { onHandoff, takeHandoff } from "../../src/terminal/handoff.ts";
 import { BackIcon, ImageIcon, MicIcon } from "../../src/nav/icons.tsx";
 import { since } from "../../src/lib/dates.ts";
@@ -1133,6 +1137,54 @@ export default function TerminalScreen(): React.ReactNode {
   // Something to send it to, and something to send — which in `keys` is the
   // return key, so the button is live there as soon as a pane is attached.
   const canSend = !!open && (raw || draft.length > 0);
+
+  /*
+   * `keys` mode stops drawing a field at all.
+   *
+   * What it draws is a button that reports the line, and behind it a 1×1
+   * transparent TextInput that actually holds the keyboard. Every keystroke
+   * still goes down as bytes exactly as it did — `typed`, `editFor` and
+   * `keyed` are untouched — but nothing on this row can grow any more, because
+   * the thing the text is in is not the thing being measured.
+   *
+   * The reason it is a button and not a smaller field: a field grows with what
+   * is in it, and a terminal line has no length limit. This was reported from
+   * a phone as the row rearranging itself under the thumb using it, and a
+   * one-line field with a ceiling only moves where the breakage happens.
+   *
+   * See liveFocus.ts for the two ways asking for a keyboard fails quietly.
+   */
+  const capture = useRef<TextInput | null>(null);
+  const focusTimer = useRef<ReturnType<typeof setTimeout> | null>(null) as FocusTimer;
+  const keyboardShown = useKeyboardShown();
+  // Read through a ref so the callbacks below do not need rebuilding on every
+  // keyboard event — and so a scheduled focus reads the state at the moment it
+  // FIRES rather than the moment it was queued, which is the whole point of
+  // deferring it.
+  const liveNow = useRef({ canSend, raw, keyboardShown });
+  liveNow.current = { canSend, raw, keyboardShown };
+
+  const focusLive = useCallback(function focusLive(): void {
+    const now = liveNow.current;
+    if (!now.canSend || !now.raw) return;
+    focusCapture(capture.current, {
+      keyboardShown: now.keyboardShown,
+      retry: () => scheduleFocus(focusTimer, focusLive),
+    });
+  }, []);
+
+  /* A tap on the pane opens the keyboard, which is the gesture this mode is
+     for: the terminal is the thing you are looking at, so it is the thing you
+     should be able to type into. Deferred, because the WebView still owns the
+     keyboard while it is reporting the touch. */
+  const tapPane = useCallback(() => {
+    if (!liveNow.current.raw) return;
+    scheduleFocus(focusTimer, focusLive);
+  }, [focusLive]);
+
+  // A retained route must not carry a pending focus across a navigation, and a
+  // capture left focused behind another screen is a keyboard nobody asked for.
+  useEffect(() => () => { clearFocusTimer(focusTimer); capture.current?.blur(); }, []);
   /*
    * Whether this phone is the widest thing looking at the window — see `grid`.
    *
@@ -1742,7 +1794,45 @@ export default function TerminalScreen(): React.ReactNode {
             borderRadius: RADIUS.pill, paddingLeft: SPACE.md, paddingRight: 3,
             paddingVertical: 3,
           }}>
+          {raw ? (
+            /*
+             * `keys` mode: a button, and the keyboard lives behind it.
+             *
+             * Everything typed goes to the pane as bytes the moment it is
+             * typed, so there is nothing here to edit and nothing to submit —
+             * which is exactly why a field was the wrong shape. What somebody
+             * needs from this row is a way to get the keyboard back and a
+             * reading of what has gone down the wire, and both fit on one line
+             * that cannot grow.
+             */
+            <Pressable
+              onPress={focusLive}
+              disabled={!canSend}
+              accessibilityRole="button"
+              accessibilityLabel="Show the keyboard for this pane"
+              accessibilityHint="What you type is sent to the pane as you type it"
+              style={({ pressed }) => ({
+                flex: 1, height: TAP, justifyContent: "center",
+                paddingRight: SPACE.xs, opacity: !canSend ? 0.45 : pressed ? 0.6 : 1,
+              })}
+            >
+              <Text
+                numberOfLines={1}
+                /* From the HEAD, so a long line shows its END. The other way
+                   round hides the cursor's own neighbourhood, which is the only
+                   part of a line anybody is reading. */
+                ellipsizeMode="head"
+                style={{
+                  color: keyed.length > 0 ? C.text : C.text4,
+                  fontSize: T.body, fontFamily: MONO,
+                }}
+              >
+                {open ? liveDetail(keyed) : "Nothing is open"}
+              </Text>
+            </Pressable>
+          ) : null}
           <TextInput
+            ref={capture}
             value={raw ? keyed : draft}
             onChangeText={typed}
             placeholder={open
@@ -1813,20 +1903,32 @@ export default function TerminalScreen(): React.ReactNode {
             // No border and no fill of its own: the pill around it is the
             // field's edge now, so drawing a second one inside it was the
             // box-within-a-box that made this row read as five controls.
-            style={{
-              // TAP, not 40. The key bar's 40 is argued in tap-floor.test.ts and
-              // the argument is about KEYS reaching the fold; borrowing that
-              // number for a field would pass the test on somebody else's
-              // reason. It costs nothing here — the icons beside it are 44, so
-              // the pill is the same height either way.
-              // A fixed height rather than a floor and a ceiling: `minHeight`
-              // with `multiline` is what let this grow. TAP is still the number,
-              // for the same reason as before — the icons beside it are 44.
-              flex: 1, height: TAP,
-              backgroundColor: "transparent", color: C.text,
-              paddingVertical: 0, paddingRight: SPACE.xs,
-              fontSize: T.body, fontFamily: MONO,
-            }}
+            style={raw
+              ? {
+                  /*
+                   * In `keys` this is the capture: 1×1 and transparent, behind
+                   * the button above, holding the keyboard and nothing else.
+                   * Not `display: none` and not unmounted — a field that is not
+                   * laid out cannot take focus, and taking focus is its whole
+                   * job. Absolute so its one point does not sit in the row.
+                   */
+                  position: "absolute", opacity: 0, width: 1, height: 1,
+                  color: C.text,
+                }
+              : {
+                  // TAP, not 40. The key bar's 40 is argued in tap-floor.test.ts
+                  // and the argument is about KEYS reaching the fold; borrowing
+                  // that number for a field would pass the test on somebody
+                  // else's reason. It costs nothing here — the icons beside it
+                  // are 44, so the pill is the same height either way.
+                  //
+                  // A fixed height rather than a floor and a ceiling:
+                  // `minHeight` with `multiline` is what let this grow.
+                  flex: 1, height: TAP,
+                  backgroundColor: "transparent", color: C.text,
+                  paddingVertical: 0, paddingRight: SPACE.xs,
+                  fontSize: T.body, fontFamily: MONO,
+                }}
           />
           {/*
             A picture, beside the field rather than behind a menu.

--- a/mobile/src/nav/icons.tsx
+++ b/mobile/src/nav/icons.tsx
@@ -242,6 +242,30 @@ export function MicIcon({ color, size = 20 }: IconProps): React.ReactNode {
   );
 }
 
+/**
+ * A keyboard: the case and four keys, one of them the space bar.
+ *
+ * On the live-input bar, where the whole job is to say "this is not a field,
+ * it is the way to get the keyboard". A field's cue is a border and a caret;
+ * this has neither, and the glyph is what replaces them.
+ *
+ * Four keys rather than a full row of twelve. At 18px a real layout is grey
+ * mush — what survives is the outline plus enough marks to read as keys, and
+ * the wide one at the bottom is the whole of why it is a keyboard and not a
+ * calculator.
+ */
+export function KeyboardIcon({ color, size = 20 }: IconProps): React.ReactNode {
+  return (
+    <Svg {...line} {...box(size)} color={color}>
+      <Path d="M3.2 6.2h17.6a1.4 1.4 0 0 1 1.4 1.4v8.8a1.4 1.4 0 0 1-1.4 1.4H3.2a1.4 1.4 0 0 1-1.4-1.4V7.6a1.4 1.4 0 0 1 1.4-1.4z" />
+      <Path d="M6 9.6h1.6" />
+      <Path d="M11.2 9.6h1.6" />
+      <Path d="M16.4 9.6h1.6" />
+      <Path d="M7.6 14.2h8.8" />
+    </Svg>
+  );
+}
+
 /** The way back out of a screen the bar cannot return you to — Now and
  *  Settings, which are tabs with no tab. A chevron rather than "‹", which is
  *  the character problem this whole file exists to avoid. */

--- a/mobile/src/terminal/TerminalView.tsx
+++ b/mobile/src/terminal/TerminalView.tsx
@@ -51,6 +51,16 @@ interface Props {
   root?: string;
   /** Reflow the tmux window to this client. See attachArgvFor on the server. */
   fit?: boolean;
+  /**
+   * A finger touched the pane and did not drag it.
+   *
+   * Decided inside the page, because the WebView swallows the gesture and a
+   * Pressable wrapped around it would take the drag away from the scroller.
+   * What arrives is the intent and never a coordinate — the screen above uses
+   * it to hand the keyboard over, which is the only thing a tap on something
+   * you are reading can reasonably mean here.
+   */
+  onTap?: () => void;
   /** How many columns to show. See terminal-html.ts — this is what decides
    *  whether you see the pane or the left-hand corner of it. */
   columns: number;
@@ -117,7 +127,7 @@ interface Props {
 const ptyFrame = (frame: PtyClientFrame): string => JSON.stringify(frame);
 
 export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalView(
-  { host, pane, root, fit, columns, palette, onState, onTmux, onLine, onGrid, onPane, onOpened }, ref,
+  { host, pane, root, fit, columns, palette, onState, onTmux, onLine, onGrid, onPane, onOpened, onTap }, ref,
 ) {
   const webview = useRef<WebView>(null);
   const socket = useRef<WebSocket | null>(null);
@@ -186,8 +196,8 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
    * none of them, which is the shape this needs: the socket's lifetime belongs
    * to the pane, not to whoever happens to be listening.
    */
-  const handlers = useRef({ onState, onTmux, onLine, onGrid, onPane, onOpened });
-  handlers.current = { onState, onTmux, onLine, onGrid, onPane, onOpened };
+  const handlers = useRef({ onState, onTmux, onLine, onGrid, onPane, onOpened, onTap });
+  handlers.current = { onState, onTmux, onLine, onGrid, onPane, onOpened, onTap };
 
   const inject = useCallback((js: string): void => {
     webview.current?.injectJavaScript(`${js};true;`);
@@ -406,6 +416,7 @@ export const TerminalView = forwardRef<TerminalHandle, Props>(function TerminalV
       if (waiting.length) inject(`window.AGX.writeMany(${JSON.stringify(waiting)})`);
       return;
     }
+    if (message.t === "tap") { handlers.current.onTap?.(); return; }
     if (message.t === "in" && typeof message.d === "string") {
       if (ws && ws.readyState === 1) ws.send(ptyFrame({ t: "in", d: message.d }));
       return;

--- a/mobile/src/terminal/liveDefault.ts
+++ b/mobile/src/terminal/liveDefault.ts
@@ -1,0 +1,94 @@
+/*
+ * Which panes type straight through, and which ones were asked.
+ *
+ * ── the default, and why it is not just `useState(true)` ─────────────────
+ * A pane opens in direct mode: what you type reaches it as you type it. That
+ * is the mode a shell, a REPL, an editor and an agent's prompt all expect, and
+ * composing a line first is the special case rather than the normal one. Orca
+ * reached the same conclusion and wrote down the reason it is worth the
+ * bookkeeping: the default has to be applied ONCE per pane, not on every
+ * render and not on every refresh of the tab list.
+ *
+ * Because the tab list refreshes constantly. It refreshes when a pane is
+ * opened, when tmux is polled, when the desk takes a window back. A default
+ * re-applied on any of those would undo the choice somebody made ten seconds
+ * ago, silently, and the only symptom would be a mode that "keeps changing
+ * back" — which reads as a bug in the toggle rather than as a default being
+ * re-run.
+ *
+ * So two sets rather than one. `live` is which panes are in direct mode.
+ * `defaulted` is which panes have already had the question answered for them,
+ * and it is what makes the default one-shot: a pane that has been turned OFF
+ * stays in `defaulted`, so nothing puts it back.
+ *
+ * ── why a module and not three useStates ─────────────────────────────────
+ * The whole of the difficulty is in the merge, and a merge is a function. The
+ * screen it belongs to cannot be rendered on a machine with no phone, so the
+ * rule that says "seen before" would otherwise be the one part of this with no
+ * way to check it.
+ */
+
+export interface LiveModes {
+  /** Panes whose keystrokes go straight to the pty. */
+  readonly live: ReadonlySet<string>;
+  /** Panes the default has already been applied to, whatever the answer was. */
+  readonly defaulted: ReadonlySet<string>;
+}
+
+export const NO_MODES: LiveModes = { live: new Set(), defaulted: new Set() };
+
+/**
+ * Turn direct mode on for panes that have never been asked about.
+ *
+ * Everything already in `defaulted` is left exactly as it is — that is the
+ * one-shot rule, and it is the whole reason this takes a second set. Returns
+ * the SAME object when nothing changed, so a caller storing this in state does
+ * not re-render on every poll that found the same tabs.
+ */
+export function applyDefault(state: LiveModes, panes: readonly string[]): LiveModes {
+  const fresh = panes.filter((id) => id && !state.defaulted.has(id));
+  if (!fresh.length) return state;
+  const live = new Set(state.live);
+  const defaulted = new Set(state.defaulted);
+  for (const id of fresh) { live.add(id); defaulted.add(id); }
+  return { live, defaulted };
+}
+
+/**
+ * Somebody answered for themselves.
+ *
+ * The pane is marked `defaulted` either way, including when it is turned ON by
+ * hand: the question has been answered, and a later refresh must not treat it
+ * as new. Turning it on by hand and having the default turn it on again is
+ * harmless today and would stop being harmless the day the default flips.
+ */
+export function setLive(state: LiveModes, pane: string, on: boolean): LiveModes {
+  if (!pane) return state;
+  const live = new Set(state.live);
+  if (on) live.add(pane); else live.delete(pane);
+  const defaulted = new Set(state.defaulted);
+  defaulted.add(pane);
+  return { live, defaulted };
+}
+
+/** Is this pane typing straight through? An absent pane is not, which is the
+ *  safe answer: line mode cannot send anything nobody pressed Return on. */
+export const isLive = (state: LiveModes, pane: string | null | undefined): boolean =>
+  !!pane && state.live.has(pane);
+
+/**
+ * Forget panes that no longer exist.
+ *
+ * Driven by the authoritative list of panes and by nothing else. A tab
+ * snapshot can lag a pane that was just created or just closed, and pruning
+ * from a lagging list would drop a live pane's mode and then hand it back as
+ * "never seen" on the next poll — the default re-applying under a different
+ * name. So this is called with what tmux actually reported, or not at all.
+ */
+export function prune(state: LiveModes, alive: readonly string[]): LiveModes {
+  const keep = new Set(alive);
+  const live = new Set([...state.live].filter((id) => keep.has(id)));
+  const defaulted = new Set([...state.defaulted].filter((id) => keep.has(id)));
+  if (live.size === state.live.size && defaulted.size === state.defaulted.size) return state;
+  return { live, defaulted };
+}

--- a/mobile/src/terminal/liveFocus.ts
+++ b/mobile/src/terminal/liveFocus.ts
@@ -1,0 +1,100 @@
+/*
+ * Opening the keyboard for a field nobody can see.
+ *
+ * ── what this is for ─────────────────────────────────────────────────────
+ * In `keys` mode the composer is not a field. It is a button that reports the
+ * line and, when pressed, hands the keyboard to a 1×1 transparent TextInput
+ * sitting behind it — every keystroke goes to the pane as bytes and nothing on
+ * screen grows. Orca's mobile client is built the same way and calls it live
+ * input; the two problems below are the ones that arrangement creates, and
+ * both of them fail silently, which is why they are here with tests rather
+ * than inline with a comment.
+ *
+ * ── one: the WebView has not let go yet ──────────────────────────────────
+ * The tap that should open the keyboard lands on the terminal, which is a
+ * WebView, and the WebView still owns the keyboard at the moment it tells us
+ * the touch ended. Focusing inside that notification is a no-op — the tap does
+ * nothing at all, which reads as the app being broken rather than as a race.
+ * So a focus is scheduled rather than performed, and a pending one is replaced
+ * rather than queued: two quick taps during a route change would otherwise
+ * focus a field that has since been unmounted.
+ *
+ * ── two: Android keeps a hidden field focused after the IME is gone ───────
+ * Dismiss the keyboard with the back gesture and the field is still, as far as
+ * it is concerned, focused. `focus()` on an already-focused field does
+ * nothing, so the keyboard never comes back and the only way out is to leave
+ * the screen. The fix is to notice the disagreement — the keyboard is down and
+ * the field says it is focused — and force a new focus session by blurring
+ * first. That is the whole reason this takes `keyboardShown`: it is not
+ * decoration, it is the only evidence that the two disagree.
+ */
+
+/** What the module needs from a TextInput. Narrow on purpose: this is unit
+ *  tested with plain objects, and a full ref would drag react-native into a
+ *  suite that has no phone to render on. */
+export interface FocusTarget {
+  focus: () => void;
+  blur: () => void;
+  isFocused?: () => boolean;
+}
+
+/** A mutable box holding the pending timer, owned by the caller's `useRef`. */
+export interface FocusTimer { current: ReturnType<typeof setTimeout> | null }
+
+/** Drop a pending focus. Called on unmount and before scheduling another. */
+export function clearFocusTimer(timer: FocusTimer): void {
+  if (timer.current === null) return;
+  clearTimeout(timer.current);
+  timer.current = null;
+}
+
+/**
+ * Focus, but not yet.
+ *
+ * 50ms is Orca's number and it is a settling time rather than a guess at how
+ * long the WebView takes: it has to outlast the touch notification and stay
+ * under what a person reads as lag. Replacing a pending call rather than
+ * queueing another is the load-bearing half — see the note above about a route
+ * change between the tap and the timer.
+ */
+export function scheduleFocus(timer: FocusTimer, focus: () => void, delayMs = 50): void {
+  clearFocusTimer(timer);
+  timer.current = setTimeout(() => {
+    timer.current = null;
+    focus();
+  }, delayMs);
+}
+
+/**
+ * Ask for the keyboard, and notice when asking is not enough.
+ *
+ * `keyboardShown` false with `isFocused()` true is the Android state described
+ * above. Blurring makes the next focus a new session, and the retry goes
+ * through the caller's scheduler so it is subject to the same cancellation as
+ * every other pending focus.
+ */
+export function focusCapture(
+  target: FocusTarget | null | undefined,
+  { keyboardShown, retry }: { keyboardShown: boolean; retry: () => void },
+): void {
+  if (!target) return;
+  if (!keyboardShown && target.isFocused?.()) {
+    target.blur();
+    retry();
+    return;
+  }
+  target.focus();
+}
+
+/**
+ * What the bar says under its title.
+ *
+ * The captured line, or an instruction when there is none. `ellipsizeMode`
+ * cannot be expressed here — the caller sets it to `head`, so a long line
+ * shows its END, which is the part being typed. Truncating the other way would
+ * hide the cursor's own neighbourhood, which is the only part anybody is
+ * looking at.
+ */
+export function liveDetail(captured: string, idle = "Tap to show keyboard"): string {
+  return captured.length > 0 ? captured : idle;
+}

--- a/mobile/src/terminal/terminal-html.ts
+++ b/mobile/src/terminal/terminal-html.ts
@@ -994,6 +994,21 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
   };
 
   var lastY = null, carry = 0, vel = 0, lastT = 0, burstY = 0, burstT = 0;
+  /*
+   * A tap, told apart from a scroll by how far the finger went.
+   *
+   * The pane is the thing being read, so it should be the thing you can type
+   * into — and on a phone the only way to say "I want the keyboard" is to
+   * touch what you are looking at. RN cannot see this: the WebView swallows
+   * the gesture, and wrapping it in a Pressable would take the drag away from
+   * the scroller above.
+   *
+   * So it is decided here, where the drag is already being measured, and sent
+   * as an intent rather than as coordinates. SLOP is generous because a thumb
+   * on glass is never still, and the time limit keeps a long press — which is
+   * the selection gesture — from counting.
+   */
+  var tapT = 0, tapMoved = 0, TAP_SLOP = 12, TAP_MS = 400;
   var probe = null;      // a notch out on its own, waiting to be measured
   var calibrate = false; // this gesture has not probed yet
   var probes = 0;
@@ -1179,6 +1194,8 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
     if (e.touches.length !== 1) { lastY = null; return; }
     lastY = e.touches[0].clientY;
     lastT = clockOf(e);
+    tapT = clockOf(e);
+    tapMoved = 0;
     carry = 0;
     vel = 0;
     burstY = 0;
@@ -1198,6 +1215,9 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
     // suggests, which is why it is written out.
     var dy = lastY - y;
     var dt = now - lastT;
+    // Distance travelled, unsigned: a finger that goes down and comes back is
+    // not still, and the carry above cannot answer it: the scroller eats it.
+    tapMoved += Math.abs(dy);
     lastY = y;
     lastT = now;
     carry += dy;
@@ -1225,10 +1245,13 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
     drain();
     if (e.cancelable) e.preventDefault();
   }, { passive: false });
-  surface.addEventListener('touchend', function () {
+  surface.addEventListener('touchend', function (e) {
     lastY = null;
     if (Math.abs(vel) > FLICK) coast(vel);
     vel = 0;
+    // Short and still: somebody meant to touch the pane, not move it.
+    if (tapT && tapMoved <= TAP_SLOP && clockOf(e) - tapT <= TAP_MS) post({ t: 'tap' });
+    tapT = 0;
   }, { passive: true });
   // Cancelled is the gesture being taken away, not released: no coast.
   surface.addEventListener('touchcancel', function () { lastY = null; vel = 0; }, { passive: true });

--- a/mobile/test/live-default.test.ts
+++ b/mobile/test/live-default.test.ts
@@ -1,0 +1,118 @@
+/*
+ * The default is applied once per pane, and never again.
+ *
+ * The failure this guards is not a crash. It is a mode that "keeps changing
+ * back": somebody turns direct input off, the tab list refreshes a second
+ * later — which it does constantly, on every poll and every open — and the
+ * default puts it back. Nothing is logged, nothing throws, and the toggle gets
+ * the blame.
+ *
+ * The merge is the whole of the difficulty and the screen cannot be rendered
+ * on a machine with no phone, so it is checked here instead.
+ */
+import { describe, expect, test } from "bun:test";
+import {
+  applyDefault, isLive, NO_MODES, prune, setLive, type LiveModes,
+} from "../src/terminal/liveDefault.ts";
+
+const ids = (s: ReadonlySet<string>): string[] => [...s].sort();
+
+describe("the one-shot default", () => {
+  test("a pane nobody has seen starts typing straight through", () => {
+    const after = applyDefault(NO_MODES, ["%1"]);
+    expect(isLive(after, "%1")).toBe(true);
+    expect(ids(after.defaulted)).toEqual(["%1"]);
+  });
+
+  test("turning it off sticks, even though the pane is still listed", () => {
+    /* The bug in one test. The pane is still in every tab snapshot after this,
+       so the default runs again — and must do nothing. */
+    let state = applyDefault(NO_MODES, ["%1"]);
+    state = setLive(state, "%1", false);
+    state = applyDefault(state, ["%1"]);
+    expect(isLive(state, "%1")).toBe(false);
+  });
+
+  test("and it stays off across many refreshes, not just the next one", () => {
+    let state = setLive(applyDefault(NO_MODES, ["%1"]), "%1", false);
+    for (let i = 0; i < 20; i++) state = applyDefault(state, ["%1"]);
+    expect(isLive(state, "%1")).toBe(false);
+  });
+
+  test("a pane discovered later still gets the default", () => {
+    // The one-shot is per pane, not per app. Opening a second tab must not
+    // inherit the first tab's answer.
+    let state = setLive(applyDefault(NO_MODES, ["%1"]), "%1", false);
+    state = applyDefault(state, ["%1", "%2"]);
+    expect(isLive(state, "%1")).toBe(false);
+    expect(isLive(state, "%2")).toBe(true);
+  });
+
+  test("turning it ON by hand also counts as answered", () => {
+    /* Harmless today, because the default is on. It stops being harmless the
+       day the default flips, and this is the assertion that would notice. */
+    const state = setLive(NO_MODES, "%9", true);
+    expect(ids(state.defaulted)).toEqual(["%9"]);
+  });
+
+  test("nothing new means the same object, so no render", () => {
+    const first = applyDefault(NO_MODES, ["%1"]);
+    expect(applyDefault(first, ["%1"])).toBe(first);
+  });
+
+  test("an empty list changes nothing", () => {
+    expect(applyDefault(NO_MODES, [])).toBe(NO_MODES);
+  });
+
+  test("a pane with no id is not a pane", () => {
+    const state = applyDefault(NO_MODES, [""]);
+    expect(state).toBe(NO_MODES);
+    expect(setLive(NO_MODES, "", true)).toBe(NO_MODES);
+  });
+
+  test("no pane open is not live", () => {
+    // The safe answer: line mode cannot send what nobody pressed Return on.
+    const state = applyDefault(NO_MODES, ["%1"]);
+    expect(isLive(state, null)).toBe(false);
+    expect(isLive(state, undefined)).toBe(false);
+  });
+});
+
+describe("forgetting closed panes", () => {
+  test("a pane that is gone is dropped from both sets", () => {
+    let state = applyDefault(NO_MODES, ["%1", "%2"]);
+    state = prune(state, ["%2"]);
+    expect(ids(state.live)).toEqual(["%2"]);
+    expect(ids(state.defaulted)).toEqual(["%2"]);
+  });
+
+  test("a pane that is still there keeps the answer it was given", () => {
+    let state = setLive(applyDefault(NO_MODES, ["%1", "%2"]), "%1", false);
+    state = prune(state, ["%1", "%2"]);
+    expect(isLive(state, "%1")).toBe(false);
+    expect(isLive(state, "%2")).toBe(true);
+  });
+
+  test("dropping and re-seeing a pane defaults it again, which is why the caller must not prune from a lagging list", () => {
+    /* Stated as a test because it is the trap: prune from a snapshot that has
+       not caught up and the mode comes back as if the pane were new. The rule
+       is that only the authoritative list may prune, and this is what the rule
+       is protecting. */
+    let state = setLive(applyDefault(NO_MODES, ["%1"]), "%1", false);
+    state = prune(state, []);
+    state = applyDefault(state, ["%1"]);
+    expect(isLive(state, "%1")).toBe(true);
+  });
+
+  test("nothing to forget means the same object", () => {
+    const state = applyDefault(NO_MODES, ["%1"]);
+    expect(prune(state, ["%1"])).toBe(state);
+  });
+
+  test("the input sets are not mutated underneath the caller", () => {
+    const before: LiveModes = applyDefault(NO_MODES, ["%1", "%2"]);
+    prune(before, ["%1"]);
+    setLive(before, "%1", false);
+    expect(ids(before.live)).toEqual(["%1", "%2"]);
+  });
+});

--- a/mobile/test/live-focus.test.ts
+++ b/mobile/test/live-focus.test.ts
@@ -1,0 +1,140 @@
+/*
+ * The two ways "tap to type" fails silently.
+ *
+ * Both were paid for once already — Orca's mobile client carries the same two
+ * workarounds — and both share a shape that makes them expensive to find: the
+ * tap does nothing, no error is raised, and the only symptom is somebody
+ * pressing the bar again. So they are pulled out of the screen and checked
+ * here, where a plain object can stand in for a TextInput and the disagreement
+ * that causes each one can be stated directly.
+ */
+import { describe, expect, mock, test } from "bun:test";
+import {
+  clearFocusTimer, focusCapture, liveDetail, scheduleFocus,
+  type FocusTarget, type FocusTimer,
+} from "../src/terminal/liveFocus.ts";
+
+function target(over: Partial<FocusTarget> & { focused?: boolean } = {}): FocusTarget & {
+  focus: ReturnType<typeof mock>; blur: ReturnType<typeof mock>;
+} {
+  let focused = over.focused ?? false;
+  return {
+    focus: mock(() => { focused = true; }),
+    blur: mock(() => { focused = false; }),
+    isFocused: () => focused,
+  } as never;
+}
+
+const timer = (): FocusTimer => ({ current: null });
+
+describe("scheduling a focus past the WebView", () => {
+  test("does not focus in the same tick the tap arrives in", async () => {
+    /* The whole point. The WebView still owns the keyboard while it is telling
+       us the touch ended, so focusing there is a no-op and the tap silently
+       does nothing. */
+    const t = timer();
+    const focus = mock(() => {});
+    scheduleFocus(t, focus, 5);
+    expect(focus).not.toHaveBeenCalled();
+    await new Promise((r) => setTimeout(r, 20));
+    expect(focus).toHaveBeenCalledTimes(1);
+  });
+
+  test("a second tap replaces the first rather than focusing twice", async () => {
+    // Queueing would focus a field that a route change may have unmounted
+    // between the two taps.
+    const t = timer();
+    const first = mock(() => {});
+    const second = mock(() => {});
+    scheduleFocus(t, first, 5);
+    scheduleFocus(t, second, 5);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(first).not.toHaveBeenCalled();
+    expect(second).toHaveBeenCalledTimes(1);
+  });
+
+  test("clearing stops a pending one, which is what unmount does", async () => {
+    const t = timer();
+    const focus = mock(() => {});
+    scheduleFocus(t, focus, 5);
+    clearFocusTimer(t);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(focus).not.toHaveBeenCalled();
+    expect(t.current).toBe(null);
+  });
+
+  test("clearing nothing is not an error", () => {
+    const t = timer();
+    expect(() => clearFocusTimer(t)).not.toThrow();
+  });
+
+  test("the box is emptied once it has fired, so a later clear is a no-op", async () => {
+    const t = timer();
+    scheduleFocus(t, () => {}, 5);
+    await new Promise((r) => setTimeout(r, 20));
+    expect(t.current).toBe(null);
+  });
+});
+
+describe("asking Android twice", () => {
+  test("an ordinary focus is just a focus", () => {
+    const el = target({ focused: false });
+    const retry = mock(() => {});
+    focusCapture(el, { keyboardShown: false, retry });
+    expect(el.focus).toHaveBeenCalledTimes(1);
+    expect(el.blur).not.toHaveBeenCalled();
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  test("keyboard down but the field says focused: blur first, then retry", () => {
+    /* Android's state after the back gesture dismisses the IME. focus() on an
+       already-focused field does nothing, so without this the keyboard never
+       comes back and leaving the screen is the only way out. */
+    const el = target({ focused: true });
+    const retry = mock(() => {});
+    focusCapture(el, { keyboardShown: false, retry });
+    expect(el.blur).toHaveBeenCalledTimes(1);
+    expect(retry).toHaveBeenCalledTimes(1);
+    expect(el.focus).not.toHaveBeenCalled();
+  });
+
+  test("keyboard already up needs no such trick", () => {
+    // The two do not disagree here, so blurring would close a keyboard
+    // somebody is using.
+    const el = target({ focused: true });
+    const retry = mock(() => {});
+    focusCapture(el, { keyboardShown: true, retry });
+    expect(el.focus).toHaveBeenCalledTimes(1);
+    expect(el.blur).not.toHaveBeenCalled();
+    expect(retry).not.toHaveBeenCalled();
+  });
+
+  test("no field yet is nothing rather than a crash", () => {
+    // The ref is null for the first render and after unmount, and a tap can
+    // land in both.
+    expect(() => focusCapture(null, { keyboardShown: false, retry: () => {} })).not.toThrow();
+    expect(() => focusCapture(undefined, { keyboardShown: true, retry: () => {} })).not.toThrow();
+  });
+
+  test("a target that cannot answer isFocused is focused rather than skipped", () => {
+    // isFocused is optional on the platform. Unknown is not "already focused".
+    const el = { focus: mock(() => {}), blur: mock(() => {}) };
+    focusCapture(el, { keyboardShown: false, retry: () => {} });
+    expect(el.focus).toHaveBeenCalledTimes(1);
+  });
+});
+
+describe("what the bar says", () => {
+  test("the captured line when there is one", () => {
+    expect(liveDetail("git status")).toBe("git status");
+  });
+
+  test("and an instruction when there is not", () => {
+    // The bar is a button. A button with nothing written on it is furniture.
+    expect(liveDetail("")).toBe("Tap to show keyboard");
+  });
+
+  test("a line of spaces is a line — it is what was typed", () => {
+    expect(liveDetail(" ")).toBe(" ");
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Reported from a phone, with screenshots, about the composer that shipped in #549: the row rearranged itself while it was being used, a filled button sat visibly proud of the capsule around it, and two controls that do not work were drawn as if they might. Then, after using Orca: its terminal input is more intuitive than ours, and it is.

### What was wrong, in the order it was found

- **The icons were `RADIUS.md`** — a 10pt corner inside a 22pt capsule. On the send button, the only filled one, that read as a rectangle escaping the thing it is inside. All three take the pill's own roundness now.
- **The field was `multiline` with a 120pt ceiling**, so the capsule grew as you typed and the three icons slid down with it. Worse, the placeholder was long enough to wrap at this width, so it did that before a single character was typed. One line now, fixed height, scrolling sideways as the pane it types into does.
- **The picture and the microphone do not work** and need a computer to finish — a server that takes the upload, a transcriber on the machine. They are dimmed and unpressable behind one flag, wiring untouched, so re-enabling is that line and nothing else. Drawn rather than removed, which is the opposite call to the one `80c`, `line` and `fit` got in #549: those worked and duplicated something else; a row that silently loses these says the feature was dropped, where a dimmed one says "not this build".

### And then the shape of the thing

In direct mode every character reaches the pane as it is typed, so there is nothing on that row to edit and nothing to submit — which is what made a text field the wrong shape for it. It is a **button** now, with a 1×1 transparent capture behind it holding the keyboard. Nothing on the row can grow, because the thing the text is in is not the thing being measured.

It also had to *look* like one. It was a `Pressable` already and still read as a field: same capsule, same hairline, same faint grey monospaced text on the left — three separate cues all drawing an empty input. A field has an edge; a button has a face. Direct mode is filled with no border and carries a keyboard glyph; line mode keeps the hairline every other field in this app wears.

**A tap on the pane is a request for the keyboard**, decided inside the page where the drag is already measured — under 12 points, under 400ms — because the WebView swallows the gesture and a `Pressable` around it would take the scroll away from the scroller. What crosses is the intent, never a coordinate.

**A pane opens in direct mode**, per pane, applied once. That is Orca's default and the reason is theirs too: a shell, a REPL, an editor and an agent's prompt all expect keystrokes to land immediately, and composing a line first is the special case.

### The parts that are easy to get wrong, and are in their own modules

`liveFocus.ts` — two ways asking for a keyboard fails **silently**:
- The tap lands on the WebView, which still owns the keyboard while reporting the touch ended. Focusing there is a no-op, so the tap does nothing at all and reads as the app being broken. Focus is scheduled instead, and a pending one is replaced rather than queued.
- Android keeps a hidden field focused after the IME is dismissed by the back gesture. `focus()` on an already-focused field does nothing, so the keyboard never returns. The disagreement — keyboard down, field says focused — is the evidence, and a blur first makes the next focus a new session.

`liveDefault.ts` — why the default cannot be `useState(true)`: the tab list refreshes constantly, and a default re-applied on any of those undoes a choice made seconds earlier with nothing on screen to explain it. The symptom is a mode that keeps changing back and a toggle that gets the blame. Two sets: which panes are live, and which have already been answered for. Pruning is driven only by what the machine reported — forgetting a pane that is merely late means the default re-applies under a different name.

Both are per **pane**. Two tabs are two terminals, and the old single boolean carried the previous pane's mode across a tab switch.

## How was it tested?

- `npx tsc --noEmit` in `mobile/` — clean.
- `bun test` in `mobile/` — **646 pass, 0 fail**, including 27 new ones across the two modules above. They are unit tests because the screen they belong to cannot be rendered on a machine with no phone.
- **`scripts/qa.ts` drove the built web target in Chromium** against a real agentglass server and a real tmux pane with a client attached: **17/17 screens**, 187 characters actually drawn on the pane, and the bar photographed in both modes. The final run needed no toggling — the button is what a plain walk now photographs, which is the default working.
- A synthetic touch was fired at the pane itself to prove the route from the page's `touchend` through to the screen is connected.

Two existing guards caught mistakes on the way and both earned their keep: `terminal-socket-lifetime.test.ts` refused `onTap` in the message callback's dependencies (every callback prop goes through a ref so a parent re-render cannot re-open the socket), and `terminal-html.ts` may hold no backtick even inside a comment — one in a prose aside closed the template literal and broke the file thirty lines further down.

**Not verified here:** that the soft keyboard actually appears. Chromium has none. The code and its tests are in; the phone is what confirms it.

No server changes, no permission or scope changes, no `shared/types.ts` change. No version bump and no release notes — a separate release is being cut today and will pick this up.
