### PR TITLE
fix: the download page tells the truth, the rail fits a short window, and a refusal is not a stack trace

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -3060,7 +3060,7 @@ ccT.textContent = STEPS[0].title; ccB.textContent = STEPS[0].body;
       <p class="dlb-na" data-na="mac-arm" hidden></p>
       <a class="dlb" data-dl="mac-x64" target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass/releases/latest">Intel <span class="sz" data-size="mac-x64">.dmg</span></a>
       <p class="dlb-na" data-na="mac-x64" hidden></p>
-      <p class="dlc-f"><b>First run.</b> The build is unsigned, so Gatekeeper quarantines it and reports the app as <i>damaged</i>. It is not. Right-click the app ▸ <b>Open</b>, or clear the flag:</p>
+      <p class="dlc-f"><b>First run.</b> The build is unsigned, so Gatekeeper quarantines it and reports the app as <i>damaged</i>. It is not. On Apple silicon right-click ▸ <b>Open</b> does not clear this variant — run this once, then open it normally:</p>
       <code class="dlc-c">xattr -dr com.apple.quarantine /Applications/agentglass.app</code>
     </article>
 
@@ -3081,6 +3081,13 @@ sudo apt install ./agentglass_*.deb</code>
       <p class="dlb-na" data-na="win-exe" hidden></p>
       <p class="dlc-f"><b>First run.</b> Unsigned, so SmartScreen warns: <b>More info</b> ▸ <b>Run anyway</b>.</p>
       <p class="dlc-f"><b>Known gap.</b> The terminal panel is POSIX-only and does not work here yet (<a target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass/issues/98">#98</a>). Everything else runs.</p>
+    </article>
+
+    <article class="dlc" data-os="android">
+      <header class="dlc-h"><span class="dlc-os">Android</span><span class="dlc-you">your phone</span></header>
+      <a class="dlb pri" data-dl="android" target="_blank" rel="noopener" href="https://github.com/SirAllap/agentglass/releases/latest">Companion app <span class="sz" data-size="android">.apk</span></a>
+      <p class="dlb-na" data-na="android" hidden></p>
+      <p class="dlc-f"><b>First run.</b> Sideloaded, so Android asks you to allow installs from your browser once. Pair it with the desktop app by scanning a code — it reaches your machine over your own network, not through a server of ours.</p>
     </article>
   </div>
 

--- a/scripts/landing-release.mjs
+++ b/scripts/landing-release.mjs
@@ -127,6 +127,7 @@ const PICKS = {
   "linux-appimage": [/\.AppImage$/i],
   "linux-deb": [/\.deb$/i],
   "win-exe": [/\.exe$/i, /\.msi$/i],
+  android: [/\.apk$/i],
 };
 
 /**
@@ -145,6 +146,7 @@ const NAMES = {
   "linux-appimage": "AppImage",
   "linux-deb": ".deb",
   "win-exe": "Windows installer",
+  android: "the Android app",
 };
 
 /** Bytes as something a human reads before clicking a 150 MB link. */

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -178,7 +178,7 @@ import { fetchCatalogue } from "./plugin-catalogue.ts";
 import {
   openStub, settleLedger, recordDecision, recordFence, scorecard,
   setMode, halt, setEnabled, enabled as understudyEnabled, sealSituation,
-  consent, setAllowed, addExtraSource, removeExtraSource, setNever, termsStatus,
+  consent, setAllowed, addExtraSource, SourceRefused, removeExtraSource, setNever, termsStatus,
   precedentCount, precedentsByClass,
   proposeScope, setProposeScope, quarantinedEver, openProjectNameAllowed,
   judgeEnabled, setJudge, isOpenProjectPath, OPEN_PARTITION, openProjectName, setOpenProject,
@@ -1346,7 +1346,7 @@ async function runOneSuiteWithRetry(cwd: string, timeoutMs: number, suite: { dir
     out: `${second.out.slice(-4000)}\n\n--- the first run of this suite was red and the second was green, unchanged. Treated as a flake, and the queue kept going. ---${named}`,
   };
 }
-import { ingest, policySummary } from "./understudy-ingest.ts";
+import { ingest, IngestRefused, policySummary } from "./understudy-ingest.ts";
 import { predictSealed } from "./understudy-predict.ts";
 import { ask, compiledRules } from "./understudy-ask.ts";
 import * as Shift from "./understudy-shift.ts";
@@ -3399,7 +3399,16 @@ const server = Bun.serve<WsData>({
       if (!p) return json({ ok: false, error: "not a path we can read" }, 400);
       let id: string;
       try { id = addExtraSource(p, b?.label, b?.kind); }
-      catch (e) { return json({ ok: false, error: String((e as Error)?.message ?? e) }, 400); }
+      catch (e) {
+        /* Only our own refusal reaches the caller. Anything else — a
+           filesystem error, a database error — is logged here and answered
+           with a fixed sentence: that text carries absolute paths and
+           internals, and a reader on the other end of the wire is owed the
+           decision, not the plumbing. */
+        if (e instanceof SourceRefused) return json({ ok: false, error: e.message }, 400);
+        console.error("[understudy] source/add:", e);
+        return json({ ok: false, error: "that path could not be added" }, 400);
+      }
       setAllowed(id, true);
       const { allow, extra } = consent();
       return json({ ok: true, id, sources: listSources(allow, extra) });
@@ -3491,7 +3500,12 @@ const server = Bun.serve<WsData>({
         broadcast({ type: "understudy", data: scorecard() });
         return json({ ok: true, learned: r });
       } catch (e) {
-        return json({ ok: false, error: String(e instanceof Error ? e.message : e) }, 409);
+        // Same rule as /understudy/source/add: our refusal by name, and
+        // nothing else. `IngestRefused` is the "no private-terms list" answer,
+        // which the screen shows and acts on.
+        if (e instanceof IngestRefused) return json({ ok: false, error: e.message }, 409);
+        console.error("[understudy] learn:", e);
+        return json({ ok: false, error: "it could not read the sources" }, 409);
       }
     }
 
@@ -3531,7 +3545,8 @@ const server = Bun.serve<WsData>({
           banked: bankByPartition(),
         });
       } catch (e) {
-        return json({ ok: false, error: String(e instanceof Error ? e.message : e) }, 400);
+        console.error("[understudy] ask:", e);
+        return json({ ok: false, error: "it could not answer that" }, 400);
       }
     }
     /*

--- a/server/src/understudy.ts
+++ b/server/src/understudy.ts
@@ -384,9 +384,16 @@ export function setAllowed(id: string, allowed: boolean): void {
  * "an id, then allow it", and an id for something not registered would be
  * allowed into nothing while the panel said it worked.
  */
+/** A path this app will not read, refused by rule. Its message is ours. */
+export class SourceRefused extends Error {}
+
 export function addExtraSource(path: string, label?: string, kind?: "rules" | "precedents"): string {
   const refused = extraSourceError(path);
-  if (refused) throw new Error(refused);
+  /* Its own type, so a route can tell "this path is not one we read" — a
+     sentence written here, safe to show — from a filesystem or database error,
+     whose text carries absolute paths and internals a caller has no business
+     seeing. */
+  if (refused) throw new SourceRefused(refused);
   const st = load();
   const id = `added:${sha256(path).slice(0, 12)}`;
   if (st.extra.some((e) => e.id === id)) return id;

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -323,7 +323,7 @@ export function ViewRail({
           "put it at the bottom of the top group", and a container sized to its
           contents would have quietly refused. */}
       <div
-        className="flex-1 flex flex-col gap-1"
+        className="flex-1 min-h-0 flex flex-col gap-1"
         onDragOver={(e) => overDrawer(e, "work")}
         onDrop={commit}
       >
@@ -349,7 +349,11 @@ export function ViewRail({
         {dragging && !base.utility.length && !at(slot, "utility", 0) && <div className="h-6" />}
       </div>
 
-      <div className="flex flex-col gap-1">
+      {/* `shrink-0`: this cluster is the way back — Ports, Resources, Settings —
+          and it is the one thing on the rail that must never be the part that
+          gets pushed off the bottom. Reported from a short window: the
+          Resources button "looks cutoff". */}
+      <div className="shrink-0 flex flex-col gap-1">
         {/* A second hairline, because everything below is not a view at all:
             these open OVER whatever you are in and hand it straight back. A
             divider is the cheapest way to say "these do not change where you
@@ -398,7 +402,7 @@ export function ViewRail({
             data-tip={dragging
               ? "Drop to take it off the rail — it comes back from here"
               : `Hidden views · ${hiddenViews.length} put away`}
-            className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+            className="agw-tip relative h-10 min-h-[30px] shrink w-full grid place-items-center rounded-[10px] transition-colors"
             style={{
               color: aimingHidden ? "var(--error)" : restoreAt ? "var(--primary-hover)" : "var(--text4)",
               // Only while something is in the air. A dashed outline the rest of
@@ -424,7 +428,7 @@ export function ViewRail({
           onClick={() => onMachine("ports")}
           aria-label="Ports"
           data-tip="Ports · what is listening, and from which checkout"
-          className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+          className="agw-tip relative h-10 min-h-[30px] shrink w-full grid place-items-center rounded-[10px] transition-colors"
           style={{ color: "var(--text4)" }}
         >
           <PortsIcon size={ICON.rail} />
@@ -433,7 +437,7 @@ export function ViewRail({
           onClick={() => onMachine("resources")}
           aria-label="Resources"
           data-tip="Resources · CPU, memory and disk, by checkout"
-          className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+          className="agw-tip relative h-10 min-h-[30px] shrink w-full grid place-items-center rounded-[10px] transition-colors"
           style={{ color: "var(--text4)" }}
         >
           <ResourcesIcon size={ICON.rail} />
@@ -442,7 +446,7 @@ export function ViewRail({
           onClick={onSettings}
           aria-label="Settings"
           data-tip="Settings · preferences, exports, shortcuts"
-          className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+          className="agw-tip relative h-10 min-h-[30px] shrink w-full grid place-items-center rounded-[10px] transition-colors"
           style={{ color: "var(--text4)" }}
         >
           <RailGear size={ICON.rail} />
@@ -454,7 +458,7 @@ export function ViewRail({
           onClick={onSkills}
           aria-label="Skills catalog"
           data-tip="Skills catalog · what this fleet can do"
-          className="agw-tip relative h-10 w-full grid place-items-center rounded-[10px] transition-colors"
+          className="agw-tip relative h-10 min-h-[30px] shrink w-full grid place-items-center rounded-[10px] transition-colors"
           style={{ color: "var(--text4)" }}
         >
           <SkillsIcon size={ICON.rail} />

--- a/web/test/rail-fits-a-short-window.test.ts
+++ b/web/test/rail-fits-a-short-window.test.ts
@@ -1,0 +1,44 @@
+/*
+ * The rail must not push its own way out of the window.
+ *
+ * Reported from a short window (#466): the Resources button "looks cutoff".
+ * The rail is a column of fixed-height buttons with no scroller — it cannot
+ * have one, because the tooltips are `::after` pseudo-elements that escape
+ * horizontally and any overflow container clips both axes. So the fix is the
+ * other direction: the buttons give up height before the column overflows,
+ * and the cluster below the hairline — Ports, Resources, Settings, the way
+ * back from anywhere — never gives up any.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const src = readFileSync(join(new URL(".", import.meta.url).pathname, "..", "src", "components", "workspace", "ViewRail.tsx"), "utf8");
+
+describe("the rail in a window shorter than its icons", () => {
+  test("every rail button may compress, and none below a legible floor", () => {
+    const buttons = src.match(/className="agw-tip relative [^"]*"/g) ?? [];
+    expect(buttons.length, "the rail still has its buttons").toBeGreaterThan(3);
+    for (const cls of buttons) {
+      expect(cls, `a rail button that cannot shrink: ${cls}`).toContain("shrink");
+      expect(cls, `a rail button with no floor: ${cls}`).toContain("min-h-[30px]");
+    }
+  });
+
+  test("the group that holds the views may shrink below its content", () => {
+    // Without `min-h-0` a flex child refuses to go under its content height,
+    // and the column grows past the window instead of compressing.
+    expect(src).toContain('className="flex-1 min-h-0 flex flex-col gap-1"');
+  });
+
+  test("the cluster below the hairline keeps its height, whatever happens above", () => {
+    expect(src).toContain('className="shrink-0 flex flex-col gap-1"');
+  });
+
+  test("the rail itself is still not a scroller, because the tooltips leave it", () => {
+    // `overflow-y: auto` would make overflow-x compute to auto as well, and a
+    // 200px tooltip beside a 52px rail would be clipped to the rail.
+    expect(src).toContain("overflow-visible");
+    expect(src).not.toMatch(/className="[^"]*w-\[52px\][^"]*overflow-(y-)?(auto|scroll)/);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Four small things a fresh visitor or a fresh alert found, none of them related except by that.

**The macOS download card told people the wrong thing.** It said right-click ▸ Open. On Apple silicon that does not clear the "damaged" quarantine variant — only `xattr -dr com.apple.quarantine` does, which `docs/INSTALL.md` has said all along. Somebody hit exactly this and gave up. The card now says what works, and the same paragraph is on the v0.15.0 release page, which is where they had downloaded from.

**The Android APK was built, attached, and unreachable.** Every tag ships one and the site offered three cards: macOS, Linux, Windows. There is a fourth now, and `scripts/landing-release.mjs` knows the slot, so it carries the real size and a direct link like the others do.

**The view rail could not fit a short window** (#466). The column of fixed-height buttons simply grew past the bottom edge and the last ones went with it. It cannot become a scroller: the tooltips are `::after` elements that escape sideways, and an overflow container clips both axes. So the buttons give up height instead, down to a floor that keeps the icon legible, and the cluster below the hairline — Ports, Resources, Settings, the way back from anywhere — gives up none.

**Three routes handed the caller the text of whatever exception they caught.** CodeQL read it as a stack trace reaching the user (`js/stack-trace-exposure`, alert #55) and in practice it leaks absolute paths and internals. A refusal this app decided is now its own type and reaches the caller by name; anything else is logged on the server and answered with a fixed sentence.

## How was it tested?

`make ci` on this commit: server 5048 / web 4297 / mobile 719 tests, lint, typechecks, smoke over all 11 views, perf budget — green. The release stamper was run against the edited page and fills the new Android slot with the real asset (127 MB) and its direct URL. The rail change is pinned by `web/test/rail-fits-a-short-window.test.ts`, which also asserts the rail did not quietly become a scroller.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0185QQ4QAbp2DViEueUCedWh
