### PR TITLE
fix(security): an exception's text is not an answer

### DIFF
--- a/server/src/bench.ts
+++ b/server/src/bench.ts
@@ -20,6 +20,7 @@
  * the app's own data directory, keyed by the checkout's path.
  */
 import { createHash } from "node:crypto";
+import { failed } from "./refused.ts";
 import { mkdirSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join } from "node:path";
@@ -101,7 +102,7 @@ export function writeNote(rootIn: unknown, textIn: unknown): NoteReport {
     writeFileSync(file, text, { mode: 0o600 });
     return { ok: true, text, at: Date.now() };
   } catch (e) {
-    return { ok: false, text: "", error: String(e) };
+    return { ok: false, text: "", error: failed("bench/note", e, "the note could not be saved") };
   }
 }
 

--- a/server/src/browse.ts
+++ b/server/src/browse.ts
@@ -20,6 +20,7 @@
  * new room.
  */
 import { readdirSync, statSync, lstatSync, readFileSync, realpathSync } from "node:fs";
+import { failed } from "./refused.ts";
 import { basename, dirname, extname, join, resolve } from "node:path";
 import { diskAllows, diskRoots } from "./disk.ts";
 import { safeAbs } from "./git.ts";
@@ -493,6 +494,6 @@ export function openInDesktop(pathIn: unknown): { ok: boolean; with?: string; er
     });
     return { ok: true, with: basename(opener) };
   } catch (e) {
-    return { ok: false, error: String(e) };
+    return { ok: false, error: failed("preview/open", e, "the desktop could not open that file") };
   }
 }

--- a/server/src/files.ts
+++ b/server/src/files.ts
@@ -17,6 +17,7 @@
 // `../../../etc` is a file server for the whole machine.
 
 import { mkdtempSync, readdirSync, readFileSync, statSync, writeFileSync } from "node:fs";
+import { failed } from "./refused.ts";
 import { tmpdir } from "node:os";
 import { join, resolve, relative, sep } from "node:path";
 import { git, safeAbs } from "./git.ts";
@@ -138,7 +139,7 @@ export function fileTree(rootIn: unknown, relIn: unknown): TreeReport {
   if ("error" in at) return { ok: false, root: "", rel: "", entries: [], error: at.error };
 
   let names: string[];
-  try { names = readdirSync(at.abs); } catch (e) { return { ok: false, root: at.root, rel: at.rel, entries: [], error: String(e) }; }
+  try { names = readdirSync(at.abs); } catch (e) { return { ok: false, root: at.root, rel: at.rel, entries: [], error: failed("files/tree", e, "that directory could not be read") }; }
 
   const marks = statusMarks(at.root);
   const entries: FileEntry[] = [];
@@ -492,7 +493,7 @@ export function fileText(rootIn: unknown, relIn: unknown, refIn?: unknown): File
   if (st.isDirectory()) return { ok: false, rel: at.rel, text: "", bytes: 0, error: "that is a directory" };
 
   let buf: Buffer;
-  try { buf = readFileSync(at.abs); } catch (e) { return { ok: false, rel: at.rel, text: "", bytes: 0, error: String(e) }; }
+  try { buf = readFileSync(at.abs); } catch (e) { return { ok: false, rel: at.rel, text: "", bytes: 0, error: failed("files/text", e, "that file could not be read") }; }
 
   const head = buf.subarray(0, 8192);
   if (head.includes(0)) return { ok: false, rel: at.rel, text: "", bytes: st.size, error: "that file is binary" };

--- a/server/src/gitlocks.ts
+++ b/server/src/gitlocks.ts
@@ -22,6 +22,7 @@
 // message.
 
 import { existsSync, readFileSync, readdirSync, rmSync, statSync } from "node:fs";
+import { failed } from "./refused.ts";
 import { dirname, join, resolve, sep } from "node:path";
 import { ownedByMe, cwdOf } from "./machine.ts";
 
@@ -323,6 +324,6 @@ export function removeStaleLock(pathIn: unknown, roots: string[]): { ok: boolean
     rmSync(target);
     return { ok: true, detail: `removed ${found.name}` };
   } catch (e) {
-    return { ok: false, error: String(e) };
+    return { ok: false, error: failed("git/lock", e, "the lock file could not be removed") };
   }
 }

--- a/server/src/issues.ts
+++ b/server/src/issues.ts
@@ -18,6 +18,7 @@
 // checkouts and no idea which is which.
 
 import { mkdirSync, readFileSync, writeFileSync } from "node:fs";
+import { failed } from "./refused.ts";
 import { existsSync } from "node:fs";
 import { homedir } from "node:os";
 import { dirname, join, basename } from "node:path";
@@ -211,7 +212,7 @@ export async function listIssues(rootIn: unknown, opts: { state?: string; assign
     const rows = (JSON.parse(r.stdout) as any[]).map((x) => normalise(x, repo, work));
     return { ok: true, issues: rows };
   } catch (e) {
-    return { ok: false, issues: [], error: String(e) };
+    return { ok: false, issues: [], error: failed("issues/list", e, "the issues could not be read") };
   }
 }
 
@@ -238,7 +239,7 @@ export async function issueDetail(rootIn: unknown, numberIn: unknown): Promise<{
       },
     };
   } catch (e) {
-    return { ok: false, error: String(e) };
+    return { ok: false, error: failed("issues/detail", e, "that issue could not be read") };
   }
 }
 

--- a/server/src/machine.ts
+++ b/server/src/machine.ts
@@ -17,6 +17,7 @@
 // only ever touch a process this user owns.
 
 import { existsSync, readdirSync, readFileSync, readlinkSync, statSync, statfsSync } from "node:fs";
+import { failed } from "./refused.ts";
 
 /** One listening TCP socket. */
 export interface PortEntry {
@@ -269,7 +270,7 @@ export function killPort(pidIn: unknown): { ok: boolean; error?: string; detail?
     process.kill(pid, "SIGTERM");
     return { ok: true, detail: `Asked ${pid} to stop` };
   } catch (e) {
-    return { ok: false, error: String(e) };
+    return { ok: false, error: failed("machine/kill", e, "that process could not be stopped") };
   }
 }
 

--- a/server/src/notifications.ts
+++ b/server/src/notifications.ts
@@ -19,6 +19,7 @@
  */
 
 import { spawn, type Subprocess } from "bun";
+import { failed } from "./refused.ts";
 import { existsSync } from "node:fs";
 
 export type SystemNote = {
@@ -317,7 +318,7 @@ export function openNote(id: unknown): { ok: boolean; error?: string } {
     spawn({ cmd, stdout: "ignore", stderr: "ignore", stdin: "ignore" }).unref();
     return { ok: true };
   } catch (e) {
-    return { ok: false, error: String(e) };
+    return { ok: false, error: failed("notify/open", e, "that note could not be opened") };
   }
 }
 

--- a/server/src/prs.ts
+++ b/server/src/prs.ts
@@ -15,6 +15,7 @@
 //    so every mutation goes through `writeGuard` and the irreversible ones are
 //    named separately from the rest.
 import { existsSync, mkdirSync, mkdtempSync, readFileSync, writeFileSync } from "node:fs";
+import { failed } from "./refused.ts";
 import { homedir, tmpdir } from "node:os";
 import { dirname, join, resolve } from "node:path";
 import { gitAsync, safeAbs, repoRootOf } from "./git.ts";
@@ -1784,7 +1785,7 @@ function refreshList(repo: PrRepoId, filter: PrFilter, state: PrState, after?: s
         for (const r of page.rows) noteTalk(repo, r);
       }
     } catch (e) {
-      listCache.set(key, keep({ loading: false, checksPending: false, error: String(e) }));
+      listCache.set(key, keep({ loading: false, checksPending: false, error: failed("prs/list", e, "the pull requests could not be read") }));
     } finally {
       inflight.delete(key);
     }

--- a/server/src/refused.ts
+++ b/server/src/refused.ts
@@ -1,0 +1,36 @@
+/*
+ * WHAT A CALLER IS TOLD WHEN SOMETHING THREW.
+ *
+ * `String(e)` reads like the honest thing to return and is not. A caught
+ * exception carries the plumbing: absolute paths on this machine, the shape of
+ * a directory tree, the argv of a command, sometimes a stack. None of that is
+ * the caller's business, and on a machine reachable from a phone the caller is
+ * not always the person sitting at it — CodeQL reads the same flow as
+ * `js/stack-trace-exposure` and it is right to.
+ *
+ * The distinction this module draws is between a refusal and a failure.
+ *
+ * A REFUSAL is a decision this app made and can spell out: "that path is not
+ * in the open project", "a note is text". Those sentences are written here, in
+ * this repository, and they are exactly what the caller needs. They do not go
+ * through this module at all — they are returned as themselves.
+ *
+ * A FAILURE is the other kind: the write threw, the command was not there, the
+ * disk is full. The caller needs to know the operation did not happen, and
+ * nothing else. The real error goes to this process's stderr, where the person
+ * running the app can read it, and the caller gets a sentence naming what
+ * failed in the app's own vocabulary.
+ */
+
+/**
+ * Log the real error, return the sentence the caller gets.
+ *
+ * `where` is a short tag for the log line, so a maintainer reading stderr can
+ * find the call site without a stack. `said` is the sentence, and it should
+ * name the operation rather than the mechanism: "the note could not be saved",
+ * not "writeFileSync failed".
+ */
+export function failed(where: string, e: unknown, said: string): string {
+  console.error(`[${where}]`, e);
+  return said;
+}

--- a/server/src/spend.ts
+++ b/server/src/spend.ts
@@ -30,6 +30,7 @@
 // panel can say which part of the number it is sure of instead of rounding the
 // doubt away. See PrPanel's spend chip for the wording that comes out of it.
 import { resolve } from "node:path";
+import { failed } from "./refused.ts";
 import { db, scopeClause, RETENTION_DAYS, retentionSeamDay, spendBetween } from "./db.ts";
 import { isWithin } from "./config.ts";
 import { gitAsync } from "./git.ts";
@@ -310,7 +311,7 @@ export async function repoSpend(rootIn: unknown): Promise<RepoSpend> {
   } catch (e) {
     // A failure here is a missing number on a chip, never a broken board — so
     // it is reported as one rather than thrown at the route.
-    return { ok: false, error: String(e), since, seamDay, beforeSeamUsd: 0, branches: [], worktrees: [] };
+    return { ok: false, error: failed("spend/repo", e, "the spend for this repository could not be read"), since, seamDay, beforeSeamUsd: 0, branches: [], worktrees: [] };
   }
   if (cache.size > 32) cache.clear();
   cache.set(root, { at: Date.now(), value });

--- a/server/src/themesync.ts
+++ b/server/src/themesync.ts
@@ -17,6 +17,7 @@
 // it would put our update cycle in a fight with their local edits forever.
 
 import { mkdirSync, writeFileSync, readFileSync, existsSync } from "node:fs";
+import { failed } from "./refused.ts";
 import { homedir, tmpdir } from "node:os";
 import { join, dirname } from "node:path";
 import { liveNvimSockets } from "./editor.ts";
@@ -563,7 +564,7 @@ export async function syncTheme(vars: Record<string, unknown>, themeName: string
     writeFileSync(jsonThemePath(), `${JSON.stringify({ name: themeName, vars: v }, null, 2)}\n`);
     wrote.push(jsonThemePath());
   } catch (e) {
-    return { ok: false, wrote, reloaded, error: String(e) };
+    return { ok: false, wrote, reloaded, error: failed("theme/sync", e, "the theme could not be written to every tool") };
   }
 
   /*

--- a/server/test/no-raw-exception-to-the-caller.test.ts
+++ b/server/test/no-raw-exception-to-the-caller.test.ts
@@ -1,0 +1,57 @@
+/*
+ * An exception's text is not an answer.
+ *
+ * `String(e)` in a catch reads like honesty and is not: a caught error carries
+ * absolute paths on this machine, the shape of a directory tree, the argv of a
+ * command, sometimes a stack — and on a machine a phone can reach, the caller
+ * is not always the person sitting at it. CodeQL read one of these as
+ * `js/stack-trace-exposure` (alert #55, `bench.ts` through `/bench/note`) and
+ * there were eleven more of the same shape it had not traced.
+ *
+ * The rule now: a refusal this app decided is returned as itself, because the
+ * sentence is written in this repository. A failure goes through `failed()`,
+ * which logs the real error to this process's stderr and hands the caller a
+ * sentence naming the operation.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const dir = join(new URL(".", import.meta.url).pathname, "..", "src");
+
+/** `error: String(e)` and its spellings, anywhere a value is handed back. */
+const RAW = /\berror:\s*String\(\s*(e|err|ex|error)\s*\)/;
+
+describe("what a caller is told when something threw", () => {
+  test("no module hands back the text of a caught exception", () => {
+    const offenders: string[] = [];
+    for (const f of readdirSync(dir)) {
+      if (!f.endsWith(".ts")) continue;
+      readFileSync(join(dir, f), "utf8").split("\n").forEach((line, i) => {
+        if (RAW.test(line)) offenders.push(`${f}:${i + 1}`);
+      });
+    }
+    expect(
+      offenders,
+      "use failed(where, e, said) from refused.ts: it logs the real error and answers with a sentence",
+    ).toEqual([]);
+  });
+
+  test("failed() logs the real error and returns only the sentence", async () => {
+    const { failed } = await import("../src/refused.ts");
+    const saw: unknown[] = [];
+    const real = console.error;
+    console.error = (...a: unknown[]) => { saw.push(a); };
+    try {
+      const said = failed("a/probe", new Error("ENOENT /home/somebody/.ssh/id_rsa"), "that file could not be read");
+      expect(said).toBe("that file could not be read");
+      expect(said).not.toContain("/home/");
+      expect(saw.length, "the real error reaches stderr").toBe(1);
+      // The Error itself, not a string of it: an Error JSON-stringifies to
+      // `{}`, so the assertion has to look at the object that was logged.
+      const logged = (saw[0] as unknown[])[1];
+      expect(logged, "and it is the whole error, not the sentence").toBeInstanceOf(Error);
+      expect((logged as Error).message).toContain("ENOENT");
+    } finally { console.error = real; }
+  });
+});


### PR DESCRIPTION
## What does this PR do?

CodeQL alert #55 (`js/stack-trace-exposure`) stayed open after the last pass. The previous fix closed three routes in `index.ts`; the flow CodeQL had actually traced ran through `server/src/bench.ts`, where a failed note write returned `String(e)` and `/bench/note` handed it straight to the caller.

Grepping for that shape found eleven more of it: preview, git locks, issues (twice), machine, notifications, spend, theme sync, pull requests, and both file readers. All the same class — a caught exception answered with its own text, which is absolute paths on this machine, the shape of a directory tree, the argv of a command, and sometimes a stack. On a machine a phone can reach, the caller is not always the person sitting at it.

`server/src/refused.ts` draws the line the code was missing. A **refusal** this app decided — "that path is not in the open project", "a note is text" — is a sentence written in this repository, and is returned as itself; it does not go through the helper at all. A **failure** goes through `failed(where, e, said)`, which logs the real error to this process's stderr, where the person running the app can read it, and answers the caller with a sentence naming the operation rather than the mechanism.

## How was it tested?

`make ci` green on this commit: server 5050 / web 4297 / mobile 719, lint, typechecks, smoke over all 11 views, perf budget.

`server/test/no-raw-exception-to-the-caller.test.ts` walks every module in `server/src` and fails on the shape coming back, and exercises `failed()` itself: the sentence it returns carries no path, and the whole Error — not a string of it — reaches stderr.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
