### PR TITLE
feat(insights): price expired cache rebuilds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,9 @@ Where this is going — themes, not dates. The living version is the issue track
 - Tasks per project, and a decision log mined from transcripts — [#12](https://github.com/SirAllap/agentglass/issues/12), [#13](https://github.com/SirAllap/agentglass/issues/13)
 - Voice input in chat — [#92](https://github.com/SirAllap/agentglass/issues/92)
 
+**Built since v0.15.0**
+- Cache rebuild insights identify a large prompt cache recreated after expiry, keep model and main/subagent lineages separate, and price only the cache-write premium over a cache read — [#293](https://github.com/SirAllap/agentglass/issues/293)
+
 
 ## Released
 

--- a/server/src/insights.ts
+++ b/server/src/insights.ts
@@ -3,7 +3,7 @@
 // Computed from the full event history (better than the live buffer for loops).
 import type { Insight } from "../../shared/types.ts";
 import { db, scopeClause } from "./db.ts";
-import { equivalentTokens } from "./pricing.ts";
+import { cacheRebuildPenaltyUsd, equivalentTokens } from "./pricing.ts";
 import { budgetStatus, budgetScopeLabel, periodLabel } from "./budget.ts";
 
 const key = (app: string, sid: string) => `${app}:${sid.slice(0, 8)}`;
@@ -14,6 +14,14 @@ const key = (app: string, sid: string) => `${app}:${sid.slice(0, 8)}`;
 // `b:c` are different rows that a plain join hands the same string.
 const rowId = (app: string, sid: string) => `${encodeURIComponent(app)}:${encodeURIComponent(sid)}`;
 const trim = (s: string, n = 64) => (s.length > n ? s.slice(0, n) + "…" : s);
+const USD = new Intl.NumberFormat("en-US", { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+
+// The bundled cache-write rates describe five-minute prompt caches. A smaller
+// creation is usually normal turn churn; keep this signal for prefixes large
+// enough to be useful rather than announcing pennies on every resumed chat.
+export const CACHE_REBUILD_WINDOW_MS = 5 * 60_000;
+export const CACHE_REBUILD_LOOKBACK_MS = 24 * 60 * 60_000;
+export const CACHE_REBUILD_MIN_TOKENS = 10_000;
 
 export function getInsights(): Insight[] {
   const now = Date.now();
@@ -71,7 +79,65 @@ export function getInsights(): Insight[] {
     });
   }
 
-  // 3) High failure rate — errors relative to tool calls in the last hour.
+  // 3) Cache rebuilds — a sizeable cache creation after the previous
+  // cache-bearing turn in the same model/agent lineage has expired. The query
+  // starts from recent creations, then asks the session index for the one prior
+  // cache-bearing event. That keeps this 15-second poll proportional to recent
+  // candidates rather than rescanning the whole retention window.
+  const rebuildRows = db
+    .query<{
+      source_app: string; session_id: string; model_name: string | null;
+      cache_creation_tokens: number; timestamp: number; previous_at: number | null;
+    }, any[]>(
+      `SELECT e.source_app, e.session_id, e.model_name,
+              e.cache_creation_tokens, e.timestamp,
+              (SELECT MAX(p.timestamp)
+                 FROM events p
+                WHERE p.source_app = e.source_app
+                  AND p.session_id = e.session_id
+                  AND p.model_name IS e.model_name
+                  AND COALESCE(NULLIF(p.agent_id, ''), 'main') =
+                      COALESCE(NULLIF(e.agent_id, ''), 'main')
+                  AND (p.timestamp < e.timestamp OR (p.timestamp = e.timestamp AND p.id < e.id))
+                  AND (p.cache_creation_tokens > 0 OR p.cache_read_tokens > 0)
+              ) previous_at
+         FROM events e
+        WHERE e.timestamp > ? AND e.cache_creation_tokens >= ?${sc}
+        ORDER BY e.timestamp DESC`
+    )
+    .all(now - CACHE_REBUILD_LOOKBACK_MS, CACHE_REBUILD_MIN_TOKENS, ...sa);
+  const rebuilds = new Map<string, {
+    source_app: string; session_id: string; count: number; tokens: number;
+    penalty: number; last: number;
+  }>();
+  for (const r of rebuildRows) {
+    if (r.previous_at === null || r.timestamp - r.previous_at <= CACHE_REBUILD_WINDOW_MS) continue;
+    const penalty = cacheRebuildPenaltyUsd(r.cache_creation_tokens, r.model_name);
+    if (!(penalty > 0)) continue;
+    const id = rowId(r.source_app, r.session_id);
+    const a = rebuilds.get(id) ?? {
+      source_app: r.source_app, session_id: r.session_id,
+      count: 0, tokens: 0, penalty: 0, last: 0,
+    };
+    a.count++;
+    a.tokens += r.cache_creation_tokens;
+    a.penalty += penalty;
+    a.last = Math.max(a.last, r.timestamp);
+    rebuilds.set(id, a);
+  }
+  for (const [id, r] of rebuilds) {
+    out.push({
+      id: `cache:${id}`,
+      severity: r.penalty >= 5 ? "warn" : "info",
+      kind: "cache",
+      title: `Rebuilt expired cache · ${r.count}× · $${USD.format(r.penalty)}`,
+      detail: `${Math.round(r.tokens / 1000)}k tokens paid at cache-write instead of cache-read rates`,
+      session: key(r.source_app, r.session_id),
+      ts: r.last,
+    });
+  }
+
+  // 4) High failure rate — errors relative to tool calls in the last hour.
   const fails = db
     .query<{ source_app: string; session_id: string; errs: number; tools: number; last: number }, any[]>(
       // errs counts only tool failures, because tools is the denominator. It
@@ -101,7 +167,7 @@ export function getInsights(): Insight[] {
     });
   }
 
-  // 4) Budgets — a number the user chose, which beats every constant above it.
+  // 5) Budgets — a number the user chose, which beats every constant above it.
   //
   //    Only when one is set. With none, everything here behaves exactly as it
   //    did, because a fixed threshold is a reasonable default and taking it
@@ -127,7 +193,7 @@ export function getInsights(): Insight[] {
     });
   }
 
-  // 5) Spend velocity — overall $/hr over the last hour (context, info-level).
+  // 6) Spend velocity — overall $/hr over the last hour (context, info-level).
   /*
    * Grouped by model so the token figure can be weighted.
    *

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -202,6 +202,20 @@ export function costUsd(usage: TokenUsage, modelName: string | null | undefined)
 }
 
 /**
+ * Extra dollars paid when tokens that could have been cache reads are written
+ * again. Unknown models and tables where writes are no dearer than reads do not
+ * produce a confident penalty.
+ */
+export function cacheRebuildPenaltyUsd(
+  cacheCreationTokens: number,
+  modelName: string | null | undefined,
+): number {
+  const p = priceFor(modelName);
+  if (!p || !Number.isFinite(cacheCreationTokens) || cacheCreationTokens <= 0) return 0;
+  return cacheCreationTokens * Math.max(0, p.cache_write - p.cache_read) / 1_000_000;
+}
+
+/**
  * What one token of each class costs, in uncached input tokens.
  *
  * A token is not a token. On Opus an output token costs five uncached input

--- a/server/test/cache-rebuild-insight.test.ts
+++ b/server/test/cache-rebuild-insight.test.ts
@@ -1,0 +1,121 @@
+/*
+ * A cache creation is ordinary until the same model/agent lineage had already
+ * established a cache and then sat beyond the five-minute window. These cases
+ * pin both sides of that inference so the insight cannot price a model switch,
+ * another subagent's work, or normal within-window churn as avoidable spend.
+ */
+import { beforeAll, describe, expect, test } from "bun:test";
+import { mkdtempSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+const dir = mkdtempSync(join(tmpdir(), "agx-cache-rebuild-"));
+process.env.AGENTGLASS_DB = join(dir, "cache-rebuild.db");
+delete process.env.AGENTGLASS_ROOT;
+process.env.XDG_CONFIG_HOME = dir;
+
+let db: typeof import("../src/db.ts");
+let insights: typeof import("../src/insights.ts");
+const now = Date.now();
+
+const event = (
+  session_id: string,
+  at: number,
+  cache_creation_tokens: number,
+  over: Record<string, unknown> = {},
+) => ({
+  source_app: "orbit",
+  session_id,
+  hook_event_type: "Stop",
+  tool_name: null,
+  tool_use_id: null,
+  agent_id: null,
+  agent_type: null,
+  model_name: "claude-opus-4-8",
+  is_error: 0,
+  error_text: null,
+  usage: { input_tokens: 0, output_tokens: 0, cache_creation_tokens, cache_read_tokens: 0 },
+  usage_is_cumulative: false,
+  summary: "",
+  timestamp: at,
+  payload: { project_path: "/work/orbit" },
+  chat: null,
+  ...over,
+});
+
+const pair = (
+  session: string,
+  gapMs: number,
+  previous: Record<string, unknown> = {},
+  current: Record<string, unknown> = {},
+) => {
+  db.insertEvent(event(session, now - gapMs - 60_000, 100_000, previous) as any);
+  db.insertEvent(event(session, now - 60_000, 100_000, current) as any);
+};
+
+beforeAll(async () => {
+  db = await import("../src/db.ts");
+  insights = await import("../src/insights.ts");
+
+  pair("expired-main", 9 * 60_000);
+  db.insertEvent(event("repeated", now - 15 * 60_000, 100_000) as any);
+  db.insertEvent(event("repeated", now - 8 * 60_000, 100_000) as any);
+  db.insertEvent(event("repeated", now - 60_000, 100_000) as any);
+  pair("still-live", 4 * 60_000);
+  pair("model-switch", 9 * 60_000, {}, { model_name: "claude-sonnet-4-8" });
+  pair("agent-switch", 9 * 60_000, {}, { agent_id: "agent-a", agent_type: "subagent" });
+  pair("same-agent", 9 * 60_000,
+    { agent_id: "agent-a", agent_type: "subagent" },
+    { agent_id: "agent-a", agent_type: "subagent" });
+  pair("different-agent", 9 * 60_000,
+    { agent_id: "agent-a", agent_type: "subagent" },
+    { agent_id: "agent-b", agent_type: "subagent" });
+  pair("small-rebuild", 9 * 60_000, {}, {
+    usage: { input_tokens: 0, output_tokens: 0, cache_creation_tokens: 9_999, cache_read_tokens: 0 },
+  });
+  pair("unknown-model", 9 * 60_000,
+    { model_name: "private-model" },
+    { model_name: "private-model" });
+  db.insertEvent(event("prior-read", now - 10 * 60_000, 0, {
+    usage: { input_tokens: 0, output_tokens: 0, cache_creation_tokens: 0, cache_read_tokens: 100_000 },
+  }) as any);
+  db.insertEvent(event("prior-read", now - 60_000, 100_000) as any);
+});
+
+const caches = () => insights.getInsights().filter((i) => i.kind === "cache");
+const cache = (session: string) => caches().find((i) => i.id === `cache:orbit:${session}`);
+
+describe("expired prompt cache insight", () => {
+  test("prices the write/read premium after the five-minute window", () => {
+    const i = cache("expired-main");
+    expect(i?.title).toBe("Rebuilt expired cache · 1× · $0.58");
+    expect(i?.detail).toBe("100k tokens paid at cache-write instead of cache-read rates");
+  });
+
+  test("accepts a prior cache read as evidence that the prefix existed", () => {
+    expect(cache("prior-read")).toBeDefined();
+  });
+
+  test("aggregates repeated rebuilds and their write premium", () => {
+    expect(cache("repeated")?.title).toBe("Rebuilt expired cache · 2× · $1.15");
+  });
+
+  test("does not flag ordinary within-window cache creation", () => {
+    expect(cache("still-live")).toBeUndefined();
+  });
+
+  test("keeps model and agent lineages separate", () => {
+    expect(cache("model-switch")).toBeUndefined();
+    expect(cache("agent-switch")).toBeUndefined();
+    expect(cache("different-agent")).toBeUndefined();
+    expect(cache("same-agent")).toBeDefined();
+  });
+
+  test("ignores creations below the useful-signal floor", () => {
+    expect(cache("small-rebuild")).toBeUndefined();
+  });
+
+  test("does not invent a penalty for an unpriced model", () => {
+    expect(cache("unknown-model")).toBeUndefined();
+  });
+});

--- a/server/test/insights-scope.test.ts
+++ b/server/test/insights-scope.test.ts
@@ -68,6 +68,22 @@ beforeAll(async () => {
   };
   burn(SCOPED, "b-in");
   burn(OTHER, "b-out");
+
+  // Cache rebuilds use a correlated lookup for the prior cache-bearing turn.
+  // The candidate still has to obey the project boundary; otherwise the new
+  // card would reintroduce the exact cross-project leak this file guards.
+  const cache = (project: string, session: string) => {
+    for (const timestamp of [now - 10 * 60_000, now - 1000]) db.insertEvent({
+      source_app: basename(project), session_id: session, hook_event_type: "Stop",
+      tool_name: null, tool_use_id: null, agent_id: null, agent_type: null, model_name: "claude-opus-4-8",
+      is_error: 0, error_text: null,
+      usage: { input_tokens: 0, output_tokens: 0, cache_creation_tokens: 100_000, cache_read_tokens: 0 },
+      usage_is_cumulative: false, summary: "", timestamp,
+      payload: { project_path: project }, chat: null,
+    } as any);
+  };
+  cache(SCOPED, "c-in");
+  cache(OTHER, "c-out");
 });
 
 const loopIds = () => insights.getInsights().filter((i) => i.kind === "loop").map((i) => i.id);
@@ -89,5 +105,11 @@ describe("insights are scoped to the project", () => {
     const spendIds = insights.getInsights().filter((i) => i.kind === "spend").map((i) => i.id);
     expect(spendIds).toContain("spend:scoped:b-in"); // in-scope fast burn surfaces
     expect(spendIds.some((id) => id.startsWith("spend:other:"))).toBe(false); // another project's does not leak
+  });
+
+  test("cache rebuilds obey the same scope, including their prior-turn lookup", () => {
+    const cacheIds = insights.getInsights().filter((i) => i.kind === "cache").map((i) => i.id);
+    expect(cacheIds).toContain("cache:scoped:c-in");
+    expect(cacheIds.some((id) => id.startsWith("cache:other:"))).toBe(false);
   });
 });

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -794,7 +794,7 @@ export interface SearchHit {
 export interface Insight {
   id: string;
   severity: "info" | "warn" | "bad";
-  kind: "loop" | "spend" | "errors" | "burn";
+  kind: "loop" | "spend" | "errors" | "burn" | "cache";
   title: string;
   detail: string;
   session: string | null; // "source_app:session8"

--- a/web/src/components/Alerts.tsx
+++ b/web/src/components/Alerts.tsx
@@ -16,7 +16,7 @@ const LEVEL: Record<Alert["level"], { color: string; icon: string }> = {
   info: { color: "var(--info)", icon: "ℹ" },
 };
 const SEV: Record<Insight["severity"], string> = { bad: "var(--error)", warn: "var(--warning)", info: "var(--info)" };
-const KIND_ICON: Record<Insight["kind"], string> = { loop: "↻", spend: "🔥", errors: "✕", burn: "⚡" };
+const KIND_ICON: Record<Insight["kind"], string> = { loop: "↻", spend: "🔥", errors: "✕", burn: "⚡", cache: "↥" };
 
 export function Alerts({ alerts, agents = [], onSelectApp, bump, active = true }: { alerts: Alert[]; agents?: AgentCard[]; onSelectApp?: (app: string) => void; bump?: number; active?: boolean }) {
   const [insights, setInsights] = useState<Insight[]>([]);


### PR DESCRIPTION
Closes #293.

Adds a 24-hour cache-rebuild insight for large creations after the five-minute cache window. Detection stays within the same session, model, and main/subagent lineage, and prices only the cache-write premium over a read.

Validation:
- 20 focused insight and scope tests
- server and web type checks
- lint, production build, and performance budget
- web suite: 4,274 passed; 23 unrelated existing keyboard/layout failures
- server suite: changed tests passed; unrelated host/tmux fixtures failed
- smoke mounted the app; the existing workspace-shortcut invariant failed

