### PR TITLE
feat(pricing): refresh rates from LiteLLM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Where this is going — themes, not dates. The living version is the issue track
 - Per-project gate policies and hook profiles — [#14](https://github.com/SirAllap/agentglass/issues/14)
 - Keep model prices fresh without hand-editing the table — [#9](https://github.com/SirAllap/agentglass/issues/9)
 
+The optional LiteLLM price refresh now updates exact model rates at boot and daily, keeps bundled offline fallback, preserves user overrides, and reports its provenance in Statistics.
+
 **Later / exploring**
 - An API panel to exercise the endpoints the fleet is building — [#170](https://github.com/SirAllap/agentglass/issues/170)
 - Tasks per project, and a decision log mined from transcripts — [#12](https://github.com/SirAllap/agentglass/issues/12), [#13](https://github.com/SirAllap/agentglass/issues/13)

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -114,6 +114,7 @@ are:
 | `AGENTGLASS_SCAN_DISABLED` | — | `1` → turn off the machine-wide transcript scanner (rely on hooks / OTel only). |
 | `AGENTGLASS_RETENTION_DAYS` | `8` | Days of **raw events** to keep (pruned hourly, with resolved gates and answered reminders). Covers the full 7d stats window. Expiring days are folded into a daily rollup first, so spend history outlives the rows. `0` = keep events for ever, and also keep the Clone's shifts, acts and runs for ever. It does **not** move the Clone's and Lantern's own windows (30 and 90 days, fixed) — see SECURITY.md, *What agentglass stores*. |
 | `AGENTGLASS_PRICING` | — | Path to a JSON pricing override (see `server/src/pricing.ts`). |
+| `AGENTGLASS_PRICING_REFRESH` | — | `1` (or `true`/`yes`/`on`) → refresh exact model prices from LiteLLM at boot and daily. The bundled table remains the offline fallback; `AGENTGLASS_PRICING` disables the refresh and stays authoritative. |
 | `AGENTGLASS_WEBHOOK` | — | POST `{text}` here (a Slack/Discord-shaped incoming webhook) for alerts, Lantern watch notices and PR nudges sent with `send: true`. Loopback and the two hosts it exists for (`hooks.slack.com`, `discord.com`) work directly; any other destination requires `AGENTGLASS_ALLOW_REMOTE=1`. The host it resolved to is logged once at boot — the host, never the path, which is where a webhook URL keeps its credential. What travels is the notification's title and body — agent names, a checkout's base name, a PR's number, title, URL and reviewer logins — never a transcript, a diff or a token. Blanked out of every Clone run. |
 | `AGENTGLASS_NOTIFY` | — | `1` → fire desktop alerts. A connected client (browser or desktop app) raises a **native OS notification** on any platform; `notify-send` is the fallback for a headless server with nothing attached to show it. Does **not** gate the phone, which hears every alert on the socket it already holds and decides for itself — see [Alerts on the phone](WORKSPACE.md#alerts-on-the-phone-and-what-they-honestly-cover). |
 | `AGENTGLASS_SERVER` | `http://127.0.0.1:4000` | Used by the hook/seed scripts. Refused unless it points at this machine — see the next row. A `localhost` value is accepted and rewritten to `127.0.0.1` before connecting: the server binds IPv4-only, so on a host that resolves `localhost` to `::1` first, every event pays a refused connect before falling back. |
@@ -179,9 +180,10 @@ matter for a desktop-launched app, which inherits no shell environment and so
 cannot be configured by `export` at all.
 
 > **Pricing is a user-editable default.** Numbers in `pricing.ts` are per 1M
-> tokens and matched against `model_name` by substring. Anthropic (Claude) rates
-> are verified; other providers are marked *approx* — verify current rates and
-> tune, or point `AGENTGLASS_PRICING` at your own JSON.
+> tokens and matched against `model_name` by substring. Set
+> `AGENTGLASS_PRICING_REFRESH=1` to prefer validated exact-model rates from
+> LiteLLM, with the bundled table retained for offline and unmatched models.
+> `AGENTGLASS_PRICING` remains the final authority when you supply one.
 
 ### Every other `AGENTGLASS_*` the code reads
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -5,6 +5,7 @@ import type { ServerWebSocket } from "bun";
 import type { IngestBody, WsFrame, WorkingTree, PanesResponse, AgentSessionRow } from "../../shared/types.ts";
 import { slackReachable } from "./slackreach.ts";
 import { normalize, detectError, clampIngestTimestamp, externalIngestError } from "./ingest.ts";
+import { pricingProvenance, startPricingRefresh } from "./pricing.ts";
 import { db } from "./db.ts";
 import {
   insertEvent,
@@ -7320,6 +7321,7 @@ const server = Bun.serve<WsData>({
         ),
         server_started_at: STARTED_AT,
         retention_days: RETENTION_DAYS,
+        pricing: pricingProvenance(),
       });
     }
     /*
@@ -8129,6 +8131,7 @@ console.log(`   POST events → http://localhost:${server.port}/ingest`);
 console.log(`   WebSocket   → ws://localhost:${server.port}/stream`);
 console.log(`   Stats API   → http://localhost:${server.port}/stats`);
 console.log(`   Retention   → ${RETENTION_DAYS ? `${RETENTION_DAYS} days` : "unlimited"}`);
+startPricingRefresh();
 const ws = workspaceRoot();
 console.log(ws ? `   Project     → ${ws} (this project only)` : "   Project     → every project on this machine");
 // Only meaningful once a project is open — see startAutoFetch().

--- a/server/src/pricing.ts
+++ b/server/src/pricing.ts
@@ -1,3 +1,5 @@
+import type { StatsSummary } from "../../shared/types.ts";
+
 // Model pricing, USD per 1,000,000 tokens.
 //
 // These are user-editable defaults. Whatever source feeds agentglass (Claude
@@ -135,7 +137,89 @@ export const PRICE_TABLE: ModelPrice[] = [
   { match: ["command"], label: "Command", input: 0.5, output: 1.5, cache_write: 0, cache_read: 0 },
 ];
 
-let table = PRICE_TABLE;
+type PricingProvenance = NonNullable<StatsSummary["pricing"]>;
+
+export const LITELLM_PRICING_URL =
+  "https://raw.githubusercontent.com/BerriAI/litellm/main/model_prices_and_context_window.json";
+const BUNDLED_UPDATED_AT = "2026-07-28";
+const LITELLM_MAX_BYTES = 5 * 1024 * 1024;
+const LITELLM_MIN_MODELS = 100;
+const REFRESH_MS = 24 * 60 * 60 * 1000;
+type PricingFetch = (input: string | URL | Request, init?: RequestInit) => Promise<Response>;
+
+function matchTable(table: ModelPrice[], model: string): ModelPrice | null {
+  for (const p of table) {
+    const exact = p.exact?.some((id) => model === id || model.startsWith(`${id}[`));
+    if (exact || p.match.some((frag) => model.includes(frag))) return p;
+  }
+  return null;
+}
+
+function perMillion(value: unknown, optional = false): number | null {
+  if (value === undefined && optional) return 0;
+  if (typeof value !== "number" || !Number.isFinite(value) || value < 0) return null;
+  return value * 1_000_000;
+}
+
+/** Validate the remote shape before any of it can replace the active catalogue. */
+export function mapLiteLlmPricing(raw: unknown): Map<string, ModelPrice> {
+  if (!raw || typeof raw !== "object" || Array.isArray(raw)) throw new Error("price catalogue is not an object");
+  const mapped = new Map<string, ModelPrice>();
+  for (const [rawName, value] of Object.entries(raw)) {
+    if (!rawName.trim() || !value || typeof value !== "object" || Array.isArray(value)) continue;
+    const row = value as Record<string, unknown>;
+    const input = perMillion(row.input_cost_per_token);
+    const output = perMillion(row.output_cost_per_token);
+    const cacheWrite = perMillion(row.cache_creation_input_token_cost, true);
+    const cacheRead = perMillion(row.cache_read_input_token_cost, true);
+    if (input === null || output === null || cacheWrite === null || cacheRead === null) continue;
+    const name = rawName.toLowerCase();
+    mapped.set(name, {
+      match: [],
+      exact: [name],
+      label: rawName,
+      input,
+      output,
+      cache_write: cacheWrite,
+      cache_read: cacheRead,
+    });
+  }
+  return mapped;
+}
+
+/** A catalogue swaps remote data atomically and always retains bundled fallback. */
+export class PricingCatalog {
+  private live = new Map<string, ModelPrice>();
+  private liveAt: string | null = null;
+
+  constructor(
+    private readonly bundled: ModelPrice[],
+    private readonly user: ModelPrice[] | null = null,
+    private readonly userLoadedAt = new Date().toISOString().slice(0, 10),
+  ) {}
+
+  priceFor(modelName: string | null | undefined): ModelPrice | null {
+    if (!modelName) return null;
+    const model = modelName.toLowerCase();
+    if (this.user) return matchTable(this.user, model);
+    const exact = model.replace(/\[[^\]]+\]$/, "");
+    return this.live.get(exact) ?? matchTable(this.bundled, model);
+  }
+
+  installLive(prices: Map<string, ModelPrice>, updatedAt: string): void {
+    if (prices.size < LITELLM_MIN_MODELS) throw new Error(`price catalogue has only ${prices.size} usable models`);
+    this.live = new Map(prices);
+    this.liveAt = updatedAt;
+  }
+
+  provenance(): PricingProvenance {
+    if (this.user) return { source: "user", updated_at: this.userLoadedAt };
+    if (this.liveAt) return { source: "live", provider: "litellm", updated_at: this.liveAt };
+    return { source: "bundled", updated_at: BUNDLED_UPDATED_AT };
+  }
+}
+
+let userTable: ModelPrice[] | null = null;
 
 // Allow a JSON override file so users tune prices without editing source.
 try {
@@ -144,20 +228,68 @@ try {
     const f = Bun.file(path);
     // top-level await is fine in Bun module scope
     const custom = (await f.json()) as ModelPrice[];
-    if (Array.isArray(custom) && custom.length) table = custom;
+    if (Array.isArray(custom) && custom.length) userTable = custom;
   }
 } catch (e) {
   console.warn("[pricing] failed to load AGENTGLASS_PRICING, using defaults:", e);
 }
 
-export function priceFor(modelName: string | null | undefined): ModelPrice | null {
-  if (!modelName) return null;
-  const m = modelName.toLowerCase();
-  for (const p of table) {
-    const exact = p.exact?.some((id) => m === id || m.startsWith(`${id}[`));
-    if (exact || p.match.some((frag) => m.includes(frag))) return p;
+const catalog = new PricingCatalog(PRICE_TABLE, userTable);
+
+export function pricingProvenance(): PricingProvenance {
+  return catalog.provenance();
+}
+
+export async function refreshLiteLlmPricing(
+  target: PricingCatalog = catalog,
+  fetcher: PricingFetch = fetch,
+  now = Date.now(),
+): Promise<boolean> {
+  try {
+    const response = await fetcher(LITELLM_PRICING_URL, {
+      headers: { accept: "application/json" },
+      signal: AbortSignal.timeout(10_000),
+      redirect: "error",
+    });
+    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    const declared = Number(response.headers.get("content-length") ?? 0);
+    if (declared > LITELLM_MAX_BYTES) throw new Error(`response exceeds ${LITELLM_MAX_BYTES} bytes`);
+    if (!response.body) throw new Error("response has no body");
+    const reader = response.body.getReader();
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      total += value.byteLength;
+      if (total > LITELLM_MAX_BYTES) {
+        try { await reader.cancel(); } catch { /* the size refusal is the useful error */ }
+        throw new Error(`response exceeds ${LITELLM_MAX_BYTES} bytes`);
+      }
+      chunks.push(value);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) { bytes.set(chunk, offset); offset += chunk.byteLength; }
+    const prices = mapLiteLlmPricing(JSON.parse(new TextDecoder().decode(bytes)));
+    target.installLive(prices, new Date(now).toISOString().slice(0, 10));
+    return true;
+  } catch (e) {
+    console.warn("[pricing] LiteLLM refresh failed; keeping current prices:", e);
+    return false;
   }
-  return null;
+}
+
+let refreshStarted = false;
+export function startPricingRefresh(): void {
+  if (refreshStarted || userTable || !/^(1|true|yes|on)$/i.test(process.env.AGENTGLASS_PRICING_REFRESH ?? "")) return;
+  refreshStarted = true;
+  void refreshLiteLlmPricing();
+  setInterval(() => void refreshLiteLlmPricing(), REFRESH_MS).unref?.();
+}
+
+export function priceFor(modelName: string | null | undefined): ModelPrice | null {
+  return catalog.priceFor(modelName);
 }
 
 export interface TokenUsage {

--- a/server/test/pricing-refresh.test.ts
+++ b/server/test/pricing-refresh.test.ts
@@ -1,0 +1,106 @@
+import { describe, expect, test } from "bun:test";
+import {
+  PRICE_TABLE,
+  PricingCatalog,
+  mapLiteLlmPricing,
+  refreshLiteLlmPricing,
+} from "../src/pricing.ts";
+
+function remoteRows(count = 100): Record<string, Record<string, number>> {
+  return Object.fromEntries(Array.from({ length: count }, (_, i) => [
+    `community/model-${i}`,
+    {
+      input_cost_per_token: (i + 1) / 1_000_000,
+      output_cost_per_token: (i + 2) / 1_000_000,
+      cache_read_input_token_cost: 0.25 / 1_000_000,
+    },
+  ]));
+}
+
+describe("LiteLLM pricing refresh", () => {
+  test("maps only complete, non-negative token rates into exact model prices", () => {
+    const mapped = mapLiteLlmPricing({
+      "vendor/model": {
+        input_cost_per_token: 0.000_003,
+        output_cost_per_token: 0.000_015,
+        cache_creation_input_token_cost: 0.000_00375,
+        cache_read_input_token_cost: 0.000_0003,
+      },
+      "vendor/missing-output": { input_cost_per_token: 0.000_003 },
+      "vendor/negative": { input_cost_per_token: -1, output_cost_per_token: 1 },
+    });
+
+    expect(mapped.size).toBe(1);
+    expect(mapped.get("vendor/model")).toMatchObject({
+      exact: ["vendor/model"],
+      input: 3,
+      output: 15,
+      cache_write: 3.75,
+      cache_read: 0.3,
+    });
+  });
+
+  test("live exact rates win while unmatched models retain bundled fallback", () => {
+    const catalog = new PricingCatalog(PRICE_TABLE);
+    const mapped = mapLiteLlmPricing(remoteRows());
+    mapped.set("claude-sonnet-4", {
+      match: [], exact: ["claude-sonnet-4"], label: "claude-sonnet-4",
+      input: 4, output: 20, cache_write: 5, cache_read: 0.4,
+    });
+    catalog.installLive(mapped, "2026-09-07");
+
+    expect(catalog.priceFor("claude-sonnet-4")?.input).toBe(4);
+    expect(catalog.priceFor("claude-sonnet-4[1m]")?.output).toBe(20);
+    expect(catalog.priceFor("claude-opus-4")?.label).toBe("Opus");
+    expect(catalog.provenance()).toEqual({ source: "live", provider: "litellm", updated_at: "2026-09-07" });
+  });
+
+  test("a user table remains authoritative even after a live install", () => {
+    const user = [{ match: ["private-model"], label: "Private", input: 9, output: 10, cache_write: 0, cache_read: 0 }];
+    const catalog = new PricingCatalog(PRICE_TABLE, user, "2026-09-06");
+    catalog.installLive(mapLiteLlmPricing(remoteRows()), "2026-09-07");
+
+    expect(catalog.priceFor("private-model-v2")?.label).toBe("Private");
+    expect(catalog.priceFor("claude-sonnet-4")).toBeNull();
+    expect(catalog.provenance()).toEqual({ source: "user", updated_at: "2026-09-06" });
+  });
+
+  test("a failed refresh retains the last complete live catalogue", async () => {
+    const catalog = new PricingCatalog(PRICE_TABLE);
+    const ok = await refreshLiteLlmPricing(
+      catalog,
+      async () => new Response(JSON.stringify(remoteRows())),
+      Date.parse("2026-09-07T03:00:00Z"),
+    );
+    const failed = await refreshLiteLlmPricing(
+      catalog,
+      async () => new Response("unavailable", { status: 503 }),
+    );
+
+    expect(ok).toBe(true);
+    expect(failed).toBe(false);
+    expect(catalog.priceFor("community/model-4")?.input).toBe(5);
+    expect(catalog.provenance()).toEqual({ source: "live", provider: "litellm", updated_at: "2026-09-07" });
+  });
+
+  test("an incomplete response cannot replace a complete catalogue", () => {
+    const catalog = new PricingCatalog(PRICE_TABLE);
+    catalog.installLive(mapLiteLlmPricing(remoteRows()), "2026-09-07");
+
+    expect(() => catalog.installLive(mapLiteLlmPricing(remoteRows(99)), "2026-09-08")).toThrow("only 99 usable models");
+    expect(catalog.priceFor("community/model-99")?.input).toBe(100);
+    expect(catalog.provenance().updated_at).toBe("2026-09-07");
+  });
+
+  test("a declared oversized response is refused before it can replace fallback", async () => {
+    const catalog = new PricingCatalog(PRICE_TABLE);
+    const ok = await refreshLiteLlmPricing(
+      catalog,
+      async () => new Response(JSON.stringify(remoteRows()), { headers: { "content-length": "6000000" } }),
+    );
+
+    expect(ok).toBe(false);
+    expect(catalog.provenance().source).toBe("bundled");
+    expect(catalog.priceFor("claude-sonnet-4")?.label).toBe("Sonnet");
+  });
+});

--- a/shared/types.ts
+++ b/shared/types.ts
@@ -331,6 +331,12 @@ export interface StatsSummary {
   /** Wall-clock ms when the server process started — what the header's
    *  uptime counts from. Absent in demo mode, where nothing is "up". */
   server_started_at?: number;
+  /** The price catalogue currently used for locally estimated spend. */
+  pricing?: {
+    source: "bundled" | "live" | "user";
+    updated_at: string;
+    provider?: "litellm";
+  };
   /**
    * AGENTGLASS_RETENTION_DAYS, so the window chips can tell the truth.
    *

--- a/web/src/components/StatsModal.tsx
+++ b/web/src/components/StatsModal.tsx
@@ -299,9 +299,14 @@ export function StatsModal({ open, onClose, stats, windowMs }: { open: boolean; 
                     initial={{ opacity: 0, y: -8 }} animate={{ opacity: 1, y: 0 }}
                     className="flex items-center justify-between mb-4 px-1"
                   >
-                    <div className="flex items-baseline gap-2.5">
+                    <div className="flex flex-wrap items-baseline gap-2.5">
                       <span className="text-[17px] font-semibold" style={{ color: "var(--text)" }}>Statistics</span>
                       <span className="chip" style={{ color: "var(--primary-hover)", background: "color-mix(in srgb, var(--primary) 18%, transparent)", borderColor: "color-mix(in srgb, var(--primary) 45%, transparent)" }}>{windowLabel(windowMs)}</span>
+                      {stats?.pricing && (
+                        <span className="text-[10px] t-dim2">
+                          prices: {stats.pricing.source}{stats.pricing.provider ? ` · ${stats.pricing.provider}` : ""} · updated {stats.pricing.updated_at}
+                        </span>
+                      )}
                     </div>
                     <CloseButton onClick={onClose} hit={32} className="rounded-full" style={{ background: "color-mix(in srgb, white 8%, transparent)", backdropFilter: "blur(10px)", border: "1px solid color-mix(in srgb, white 12%, transparent)" }} />
                   </motion.div>


### PR DESCRIPTION
## What does this PR do?

Fixes #9. `AGENTGLASS_PRICING_REFRESH=1` now loads validated exact-model rates from LiteLLM at boot and daily, while bundled prices remain the offline fallback and user overrides remain authoritative. Statistics shows the active price source and update date.

## How was it tested?

Focused pricing tests (77 pass), all three typechecks, lint, production build, a live LiteLLM fetch, an isolated `/stats` smoke, and the performance budget (p99 5ms / 120ms) pass.
