### PR TITLE
fix(theme): keep an unasked repaint inside the engine's socket, and give `make perf` a database with rows in it

### DIFF
--- a/scripts/perfbudget.ts
+++ b/scripts/perfbudget.ts
@@ -71,34 +71,62 @@ const port = 4960 + Math.floor(Math.random() * 30);
 const S = `http://127.0.0.1:${port}`;
 const R = encodeURIComponent(repo);
 
+/**
+ * The database this run measures against.
+ *
+ * Half of what the panels poll reads `events`, and the cost of those queries is
+ * in the rows. An empty database made every one of them look free: a query that
+ * walks the table per candidate row measured 11ms here and 46 seconds against a
+ * day of real turns, and this check passed it. `loadtest.ts` already said as
+ * much — "an empty DB is why `make perf` never reproduced the stutter" — but it
+ * works from a copy of a real 186MB database, so it is not a check a
+ * contributor can run. This one now seeds its own.
+ *
+ * `AGX_PERF_EVENTS=0` skips it, for a run that only cares about the git side.
+ */
+const SEED_EVENTS = Number(process.env.AGX_PERF_EVENTS ?? 20_000);
+/** The environment both children get: the seeder writes the database the server
+ *  then opens, so every isolation knob below has to be the same for both. */
+const childEnv = {
+  ...process.env,
+  AGENTGLASS_PORT: String(port),
+  AGENTGLASS_ROOT: repo,
+  AGENTGLASS_DB: join(home, "perf.db"),
+  XDG_CONFIG_HOME: join(home, "config"),
+  XDG_DATA_HOME: join(home, "data"),
+  XDG_CACHE_HOME: join(home, "cache"),
+  // And the state dir, which is where the engine's generated tmux.conf lives:
+  // isolating the config alone let a throwaway run rewrite the conf the
+  // operator's own engine runs on. See server/test/tmux-conf-isolation.
+  AGENTGLASS_STATE_DIR: join(home, "state"),
+  // Its own tmux socket directory, beside the config/data/cache above and
+  // for the same reason: this child is a SERVER, and a server with no
+  // TMUX_TMPDIR sweeps and lists /tmp/tmux-<uid> — the sessions the user is
+  // working in. See scripts/tmuxTmp.ts for what was measured reaching them.
+  TMUX_TMPDIR: privateTmuxDir(home),
+  AGENTGLASS_TOKEN: "",
+  // The transcript sweep reads whatever is in the operator's ~/.claude, which
+  // is neither this app's doing nor reproducible on a CI runner.
+  AGENTGLASS_SCAN_DISABLED: "1",
+  // Arm the server's parent-death watchdog. The finally below kills it on a
+  // clean exit, but if this script is SIGKILLed the server is reparented to
+  // init and would otherwise linger holding the port — the watchdog reaps it.
+  AGENTGLASS_DIE_WITH_PARENT: "1",
+};
+
+if (SEED_EVENTS > 0) {
+  const seed = spawnSync("bun", [join(ROOT, "scripts", "seedEvents.ts"), join(home, "perf.db"), repo, String(SEED_EVENTS)],
+    { encoding: "utf8", env: childEnv });
+  if (seed.status !== 0) {
+    console.log(`✗ perf: could not seed the fixture database\n${seed.stderr ?? ""}`);
+    process.exit(1);
+  }
+  process.stdout.write(seed.stdout ?? "");
+}
+
 const server = spawn({
   cmd: ["bun", join(ROOT, "server", "src", "index.ts")],
-  env: {
-    ...process.env,
-    AGENTGLASS_PORT: String(port),
-    AGENTGLASS_ROOT: repo,
-    AGENTGLASS_DB: join(home, "perf.db"),
-    XDG_CONFIG_HOME: join(home, "config"),
-    XDG_DATA_HOME: join(home, "data"),
-    XDG_CACHE_HOME: join(home, "cache"),
-    // And the state dir, which is where the engine's generated tmux.conf lives:
-    // isolating the config alone let a throwaway run rewrite the conf the
-    // operator's own engine runs on. See server/test/tmux-conf-isolation.
-    AGENTGLASS_STATE_DIR: join(home, "state"),
-    // Its own tmux socket directory, beside the config/data/cache above and
-    // for the same reason: this child is a SERVER, and a server with no
-    // TMUX_TMPDIR sweeps and lists /tmp/tmux-<uid> — the sessions the user is
-    // working in. See scripts/tmuxTmp.ts for what was measured reaching them.
-    TMUX_TMPDIR: privateTmuxDir(home),
-    AGENTGLASS_TOKEN: "",
-    // The transcript sweep reads whatever is in the operator's ~/.claude, which
-    // is neither this app's doing nor reproducible on a CI runner.
-    AGENTGLASS_SCAN_DISABLED: "1",
-    // Arm the server's parent-death watchdog. The finally below kills it on a
-    // clean exit, but if this script is SIGKILLed the server is reparented to
-    // init and would otherwise linger holding the port — the watchdog reaps it.
-    AGENTGLASS_DIE_WITH_PARENT: "1",
-  },
+  env: childEnv,
   stdout: "ignore",
   stderr: "inherit",
 });
@@ -132,8 +160,29 @@ const POLLED = [
   `/events/filter-options`,
   `/sessions?limit=100`,
   `/stats?window=3600000`,
+  // The alerts panel polls this every 15s whenever it is open, and it is served
+  // inline off the same synchronous SQLite handle as everything else — so a
+  // slow insight is the whole server not answering, terminal included.
+  `/insights`,
   `/skills`,
 ];
+
+/**
+ * Per-route timings, so a failure can name the endpoint instead of only the
+ * symptom. Wall time under concurrency, not a clean per-route measurement — a
+ * route that queued behind a slow neighbour looks slow too — which is why this
+ * reports and the loop delay decides. A route ceiling of its own would fire on
+ * a legitimately large repo under AGX_PERF_ROOT, and a check that cries about
+ * those gets muted.
+ */
+const routeMs = new Map<string, number[]>();
+const hit = async (path: string) => {
+  const a = performance.now();
+  try { await fetch(S + path).then((r) => r.text()); } catch { /* between requests */ }
+  const took = performance.now() - a;
+  const seen = routeMs.get(path);
+  if (seen) seen.push(took); else routeMs.set(path, [took]);
+};
 
 let failed = false;
 try {
@@ -156,7 +205,7 @@ try {
   const MEASURE_MS = 6_000;
   let rounds = 0;
   while (performance.now() - t0 < MEASURE_MS) {
-    await Promise.all(POLLED.map((p) => fetch(S + p).then((r) => r.text()).catch(() => "")));
+    await Promise.all(POLLED.map(hit));
     rounds++;
     await Bun.sleep(400);
   }
@@ -167,6 +216,17 @@ try {
   const p = (q: number) => ms[Math.min(ms.length - 1, Math.floor((q / 100) * ms.length))] ?? 0;
   console.log(`served ${POLLED.length} endpoints × ${rounds} rounds over ${((performance.now() - t0) / 1000).toFixed(1)}s`);
   console.log(`loop meanwhile: ${ms.length} samples · p50 ${p(50).toFixed(1)}ms · p95 ${p(95).toFixed(1)}ms · p99 ${p(99).toFixed(1)}ms · max ${(ms.at(-1) ?? 0).toFixed(0)}ms`);
+
+  // The three worst endpoints, always — a green run shows what is closest to
+  // the line, and a red one shows where to look first.
+  const worst = [...routeMs.entries()]
+    .map(([path, xs]) => {
+      const sorted = [...xs].sort((a, b) => a - b);
+      return { path, p99: sorted[Math.min(sorted.length - 1, Math.floor(0.99 * sorted.length))] ?? 0 };
+    })
+    .sort((a, b) => b.p99 - a.p99)
+    .slice(0, 3);
+  console.log(`slowest routes: ${worst.map((w) => `${w.path.split("?")[0]} ${w.p99.toFixed(0)}ms`).join(" · ")}`);
 
   if (ms.length < 50) {
     console.log(`\n✗ perf: only ${ms.length} samples — the probe never got going, so this proved nothing`);

--- a/scripts/seedEvents.ts
+++ b/scripts/seedEvents.ts
@@ -1,0 +1,95 @@
+#!/usr/bin/env bun
+/**
+ * Fill a scratch database with a plausible day of events.
+ *
+ * `perfbudget.ts` was careful about one half of its fixture and blind to the
+ * other: `buildRepo` makes eight worktrees because "a single-checkout fixture
+ * would pass this check with the bugs still in", while the database it measured
+ * against was empty every run. Half the routes the panels poll read `events`,
+ * so their cost — the part that scales with what a real desk accumulates — was
+ * never on the clock. A query that walks the table per candidate row measured
+ * 11ms against that empty database and 46 seconds against a day of turns.
+ *
+ * So: rows, before anything is measured. Written as its own process rather than
+ * an import, because the harness then holds no database handle of its own — the
+ * child closes everything by exiting, and the server it spawns next opens the
+ * file cleanly.
+ *
+ *   bun scripts/seedEvents.ts <db path> <project path> [count]
+ *
+ * The shape matters as much as the count. Several apps, several models, several
+ * sessions per app, main and subagent lineages side by side, a minority of
+ * events in another project so a scope filter has something to exclude, and
+ * tool calls paired with their results the way the ingest path writes them. One
+ * session with one model would leave a per-lineage query looking linear.
+ */
+import { insertEvent, db } from "../server/src/db.ts";
+
+const [dbPath, projectPath, countArg] = process.argv.slice(2);
+if (!dbPath || !projectPath) {
+  console.error("usage: bun scripts/seedEvents.ts <db path> <project path> [count]");
+  process.exit(2);
+}
+if (process.env.AGENTGLASS_DB !== dbPath) {
+  console.error(`[seed] AGENTGLASS_DB must be ${dbPath} in this process's environment`);
+  process.exit(2);
+}
+
+const COUNT = Math.max(0, Number(countArg ?? 20_000) || 0);
+const APPS = ["orbit", "atlas", "relay"];
+const MODELS = ["claude-opus-4-8", "claude-sonnet-4-5", "gpt-5.1-codex"];
+const TOOLS = ["Bash", "Read", "Edit", "Grep", "Write", "WebFetch"];
+/** A minority elsewhere, so `scopeClause` has rows to leave out rather than a
+ *  table that happens to be entirely in scope. */
+const OTHER_PROJECT = "/tmp/agx-perf-other";
+const SESSIONS_PER_APP = 8;
+const DAY = 24 * 60 * 60_000;
+
+const now = Date.now();
+let written = 0;
+
+const seed = db.transaction(() => {
+  for (let i = 0; i < COUNT; i++) {
+    const app = APPS[i % APPS.length]!;
+    const session = `${app}-session-${Math.floor(i / APPS.length) % SESSIONS_PER_APP}`;
+    const model = MODELS[Math.floor(i / 7) % MODELS.length]!;
+    // Every fifth event belongs to a subagent, and there are two of them: the
+    // lineage split is what a per-agent query has to walk past.
+    const sub = i % 5 === 0 ? `agent-${i % 2}` : null;
+    const tool = i % 3 === 0 ? TOOLS[i % TOOLS.length]! : null;
+    // Most of the history inside the last day — that is the window the insight
+    // and stats queries scan — with a tail behind it, because retention is 8
+    // days and a real table is not all "today".
+    const age = i % 9 === 0 ? DAY + (i % 7) * DAY : Math.floor((i / COUNT) * DAY);
+    insertEvent({
+      source_app: app,
+      session_id: session,
+      hook_event_type: tool ? (i % 6 === 0 ? "PreToolUse" : "PostToolUse") : "Stop",
+      tool_name: tool,
+      tool_use_id: tool ? `tu-${i}` : null,
+      agent_id: sub,
+      agent_type: sub ? "subagent" : null,
+      model_name: model,
+      is_error: i % 47 === 0 ? 1 : 0,
+      error_text: i % 47 === 0 ? "command failed with exit code 1" : null,
+      usage: {
+        input_tokens: 400 + (i % 900),
+        output_tokens: 120 + (i % 400),
+        // Cache-bearing on most turns, which is what a warm agent actually does
+        // — and what makes a cache-lineage query expensive.
+        cache_creation_tokens: i % 4 === 0 ? 12_000 + (i % 9_000) : 0,
+        cache_read_tokens: i % 4 === 0 ? 0 : 40_000 + (i % 20_000),
+      },
+      usage_is_cumulative: false,
+      summary: tool ? `${tool} on src/module-${i % 120}.ts` : "turn complete",
+      timestamp: now - age,
+      payload: { project_path: i % 11 === 0 ? OTHER_PROJECT : projectPath },
+      chat: null,
+    } as Parameters<typeof insertEvent>[0]);
+    written++;
+  }
+});
+
+seed();
+db.close();
+console.log(`[seed] ${written} events across ${APPS.length} apps × ${SESSIONS_PER_APP} sessions, ${MODELS.length} models`);

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -85,7 +85,7 @@ import { watchLoop, entered, stalls, backoff } from "./loopwatch.ts";
 import { spawnPoolStats } from "./spawnpool.ts";
 import { singleFlight, inflightCount } from "./singleflight.ts";
 import { openInEditor, editorTarget, editorCapability, HAS_NVIM } from "./editor.ts";
-import { syncTheme, snippetStatus, SNIPPETS, tmuxThemePath, repairTmuxTheme, currentTheme } from "./themesync.ts";
+import { syncTheme, snippetStatus, SNIPPETS, tmuxThemePath, repairTmuxTheme, currentTheme, automatedThemeClient } from "./themesync.ts";
 import { existsSync as fsExists, readFileSync as fsRead, writeFileSync as fsWrite, mkdtempSync } from "node:fs";
 import { completePath, FS_BROWSE_ENABLED } from "./fsbrowse.ts";
 import { listPorts, listResources, spaceFor, killPort } from "./machine.ts";
@@ -5065,6 +5065,14 @@ const server = Bun.serve<WsData>({
     if (pathname === "/theme/current") return json({ theme: currentTheme() });
     if (pathname === "/theme/sync" && req.method === "POST") {
       if (!trustedCaller(req, from)) return csrfBlocked();
+      /* This route writes files a person's tmux and nvim read, so an automated
+         page load must not reach it — see #455, where a harness that loaded the
+         cockpit left the machine's terminals white. The browser refuses first
+         (navigator.webdriver in web/src/lib/themes.ts), and that check cannot
+         see a plain CDP attach, which is what every script in scripts/ is. */
+      if (automatedThemeClient(req.headers.get("user-agent"))) {
+        return json({ ok: false, wrote: [], reloaded: [], error: "automated client: a theme reaches tmux and nvim only from a browser someone is using" });
+      }
       let b: any = {};
       try { b = await req.json(); } catch { return json({ ok: false, error: "invalid json" }, 400); }
       return json(await syncTheme(b.vars ?? {}, String(b.name ?? "custom")));

--- a/server/src/themesync.ts
+++ b/server/src/themesync.ts
@@ -23,7 +23,7 @@ import { join, dirname } from "node:path";
 import { liveNvimSockets } from "./editor.ts";
 // One rule for "may a tmux command reach this socket", not a second copy of it
 // here. tmuxctl.ts does not import this file, so the edge is one-way.
-import { tmuxSocketAllowed, tmuxSocketConfined } from "./tmuxctl.ts";
+import { socketPath, tmuxSocketAllowed, tmuxSocketConfined } from "./tmuxctl.ts";
 import { resolveTmuxBin, tmuxSocket } from "./tmuxbin.ts";
 
 /*
@@ -542,6 +542,43 @@ export function themeTmuxTarget(): string[] {
   return ["-L", tmuxSocket()];
 }
 
+/** Is this socket the engine's own — the one furniture this app draws lives on? */
+export function themeEngineSocket(socket: string[]): boolean {
+  return socketPath(socket) === socketPath(themeTmuxTarget());
+}
+
+/**
+ * May a repaint reach this tmux server without anybody asking for it?
+ *
+ * The engine's socket, always: those panes are drawn by this app. Any other
+ * server is the user's, and the answer is whatever they already told us by
+ * pasting `SNIPPETS.tmux` into their own config — an opt-in they wrote, that we
+ * only ever read.
+ */
+export function themeRepaintAllowed(socket: string[]): boolean {
+  return themeEngineSocket(socket) || snippetStatus().tmux;
+}
+
+/**
+ * Does this request come from a browser that nobody is sitting at?
+ *
+ * The browser-side check in `web/src/lib/themes.ts` reads `navigator.webdriver`,
+ * which WebDriver sets and a plain CDP attach does not — and every harness in
+ * `scripts/` is a plain CDP attach: measured, `navigator.webdriver === false`
+ * for a Chrome launched `--headless=new --remote-debugging-port=…`. The same
+ * browser announces itself in the one field it cannot hide from us:
+ *
+ *   Mozilla/5.0 (X11; Linux x86_64) … HeadlessChrome/141.0.0.0 Safari/537.36
+ *
+ * So this is the fence #455 asked for, on the server, beside the `NODE_ENV=test`
+ * one — the client-side check stays as the cheaper first line. A real browser
+ * driven by a person never carries these tokens; a harness would have to forge
+ * a User-Agent to get past it, which is no longer an accident.
+ */
+export function automatedThemeClient(userAgent: string | null | undefined): boolean {
+  return /headless|phantomjs|puppeteer|playwright|selenium|webdriver/i.test(userAgent ?? "");
+}
+
 /**
  * Write both files and nudge whatever is running to pick them up.
  *
@@ -672,17 +709,33 @@ export function tmuxConfPath(): string {
 /**
  * Push the generated theme into one specific tmux server.
  *
- * `syncTheme` already does this on the default socket when the palette changes,
- * which covers "the user picked a new theme". It does not cover the other
- * direction: a tmux *server* that started after the last sync — a reboot, a
- * `kill-server`, or a tmux-continuum restore — comes up with none of it, and
- * everything the panel does not draw itself (the message row, the prompt, the
- * pane borders) falls back to whatever tmux ships with. That is a black bar in
- * the middle of a themed panel, and nothing in the app explains why.
+ * `syncTheme` repaints the engine's own socket when the palette changes, which
+ * covers "the user picked a new theme" for the panes this app draws. It does
+ * not cover the other direction: a tmux *server* that started after the last
+ * sync — a reboot, a `kill-server`, or a tmux-continuum restore — comes up with
+ * none of it, and everything the panel does not draw itself (the message row,
+ * the prompt, the pane borders) falls back to whatever tmux ships with. That is
+ * a black bar in the middle of a themed panel, and nothing in the app explains
+ * why.
  *
  * Sourcing our own generated file is the same act the theme switch already
  * performs, at the moment it is actually needed, and `-q` makes it silent when
  * the file is not there yet.
+ *
+ * WHOSE server, though, is the question #455 was really about. The panel calls
+ * this from `followSession` (`terminal.ts`) every time it follows a session,
+ * and the socket it passes comes from `socketOf()` off a real client's argv —
+ * `[]` for the ordinary spellings, which is the user's own server. Repainting
+ * the engine's socket is this app dressing its own furniture; repainting the
+ * user's server is the white-out they filed, and it is worse after the sync
+ * boundary moved, because the file on disk is no longer kept current for that
+ * socket: what lands is the palette last written, not the one on screen.
+ *
+ * So the user's own server is opt-in, and the opt-in already exists and is
+ * theirs to give: the `source-file` line in SNIPPETS, pasted into their own
+ * tmux.conf. `snippetStatus().tmux` reads it, never writes it. With the
+ * snippet, this file is what their config asked for and a repaint is what they
+ * signed up for; without it, we stay inside the engine's socket.
  */
 export function applyThemeTo(socket: string[]): boolean {
   const TMUX_THEME = tmuxThemePath();
@@ -705,6 +758,7 @@ export function applyThemeTo(socket: string[]): boolean {
    * then covers the child that cannot see NODE_ENV at all — see its note.
    */
   if (isTest() || !tmuxSocketAllowed(socket) || !tmuxSocketConfined(socket)) return false;
+  if (!themeRepaintAllowed(socket)) return false;
   if (!existsSync(TMUX_THEME)) return false;
   try {
     const p = Bun.spawnSync(["tmux", ...socket, "source-file", "-q", TMUX_THEME], {

--- a/server/test/themesync-nondestructive.test.ts
+++ b/server/test/themesync-nondestructive.test.ts
@@ -137,6 +137,80 @@ describe("syncTheme never edits the user's own config", () => {
     }
   });
 
+  /*
+   * #455, the route #564 did not close: `followSession` in terminal.ts calls
+   * applyThemeTo on whatever socket the panel is following, which for the
+   * ordinary `tmux attach` spellings is the user's own server — no pick, no
+   * gesture, and after the sync boundary moved, a palette that is no longer
+   * kept current for that socket. The engine's own socket stays automatic;
+   * the user's server waits for the opt-in they write themselves.
+   */
+  describe("an unasked repaint stays inside the engine's socket", () => {
+    const xdgTmux = join(config, "tmux", "tmux.conf");
+    const withConf = (body: string | null, run: () => void) => {
+      const saved = existsSync(xdgTmux) ? readFileSync(xdgTmux, "utf8") : null;
+      try {
+        if (body === null) { mkdirSync(join(config, "tmux"), { recursive: true }); writeFileSync(xdgTmux, "# nothing of ours\n"); }
+        else { mkdirSync(join(config, "tmux"), { recursive: true }); writeFileSync(xdgTmux, body); }
+        run();
+      } finally {
+        if (saved === null) writeFileSync(xdgTmux, "# nothing of ours\n"); else writeFileSync(xdgTmux, saved);
+      }
+    };
+
+    test("the engine's own socket is repainted with no opt-in at all", () => {
+      withConf(null, () => {
+        expect(ts.themeEngineSocket(ts.themeTmuxTarget())).toBe(true);
+        expect(ts.themeRepaintAllowed(ts.themeTmuxTarget())).toBe(true);
+      });
+    });
+
+    test("the user's own server is not — a bare socket is exactly what terminal.ts passes", () => {
+      withConf(null, () => {
+        expect(ts.themeEngineSocket([])).toBe(false);
+        expect(ts.themeRepaintAllowed([])).toBe(false);
+        expect(ts.themeRepaintAllowed(["-L", "someone-elses"])).toBe(false);
+      });
+    });
+
+    test("and is, once they have pasted the snippet into their own config", () => {
+      withConf(`set -g mouse on\n${ts.SNIPPETS.tmux}\n`, () => {
+        expect(ts.themeRepaintAllowed([])).toBe(true);
+      });
+    });
+  });
+
+  /*
+   * The browser-side fence in web/src/lib/themes.ts reads navigator.webdriver,
+   * which a plain CDP attach leaves false — measured on a Chrome launched the
+   * way every script in scripts/ launches it. The User-Agent it sends is the
+   * part it cannot keep to itself, and #455 asked for the refusal to live here,
+   * on the server, beside the NODE_ENV=test one.
+   */
+  describe("an automated browser is refused server-side", () => {
+    const HEADLESS = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36";
+    const CHROME = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36";
+
+    test("headless Chrome — the exact User-Agent our own harnesses send", () => {
+      expect(ts.automatedThemeClient(HEADLESS)).toBe(true);
+    });
+
+    test("the other automation stacks that announce themselves", () => {
+      for (const ua of ["Playwright/1.4", "python-selenium/4", "WebDriver", "PhantomJS/2.1", "puppeteer"]) {
+        expect(ts.automatedThemeClient(ua)).toBe(true);
+      }
+    });
+
+    test("a browser someone is sitting at is not refused", () => {
+      expect(ts.automatedThemeClient(CHROME)).toBe(false);
+      expect(ts.automatedThemeClient("Mozilla/5.0 (iPhone; CPU iPhone OS 18_0 like Mac OS X) Safari/605.1.15")).toBe(false);
+      // Absent is not automated: a phone or a CLI may send nothing, and the
+      // route is already behind the token and the origin gate.
+      expect(ts.automatedThemeClient(null)).toBe(false);
+      expect(ts.automatedThemeClient("")).toBe(false);
+    });
+  });
+
   test("snippetStatus reports opt-in state read-only, without editing anything", () => {
     // os.homedir() ignores $HOME on POSIX, so tmuxConfPath() resolves against the
     // real home — which is exactly why the guarantee matters: snippetStatus only


### PR DESCRIPTION
Closes #567.

## What does this PR do?

The two follow-ups from reviewing #564 and #565, both of which were mine rather than the contributor's.

**The third route in #455.** #564 confined `syncTheme` to explicit picks and to agentglass's own tmux socket. `applyThemeTo` was still repainting the user's own server with nobody asking: `followSession` (`terminal.ts:1047`) calls it every time the panel follows a session, with the socket `socketOf()` read off a real client's argv — `[]` for the ordinary `attach` spellings, which is their server. Worse after the boundary moved, because the generated conf is no longer kept current for that socket, so what landed was the palette last written rather than the one on screen.

The engine's socket stays automatic — those panes are ours to dress. Any other server now waits for the opt-in that already existed and is the user's to give: the `source-file` line in `SNIPPETS`, in their own `tmux.conf`, which `snippetStatus()` reads and never writes.

This also adds the server-side half of #455's third bullet. The browser refuses first on `navigator.webdriver`, and that flag is `false` for a plain CDP attach — measured on a Chrome launched the way every script in `scripts/` launches it (`--headless=new --remote-debugging-port=…`). The User-Agent is the part it does not get to keep quiet (`… HeadlessChrome/141.0.0.0 …`), so `POST /theme/sync` now refuses that, beside the `NODE_ENV=test` fence. The docstring above `applyThemeTo` claimed `syncTheme` covers the default socket; it has not since #564, and that sentence was the justification for the function.

**`make perf` measured an empty database.** `buildRepo` makes eight worktrees because "a single-checkout fixture would pass this check with the bugs still in" — and the database was new every run with the transcript sweep off, so every `events` query in the app was timed against zero rows. Half of what the panels poll reads that table and the cost is in the rows: on #565's branch `getInsights()` takes 11 ms against an empty database and 46 seconds against a day of turns, on a route the alerts panel polls every fifteen seconds, served inline off the same synchronous SQLite handle as everything else. `make perf` passed it. `loadtest.ts` already knew — *"an empty DB is why `make perf` never reproduced the stutter"* — but it works from a copy of a real 186 MB database, so it is not a check a contributor can run.

So `scripts/seedEvents.ts` builds one: 20k events over three apps, three models, eight sessions each, main and subagent lineages side by side, and a minority in another project so a scope filter has rows to exclude. Four seconds; `AGX_PERF_EVENTS=` to change it, `0` to skip. `/insights` joins the polled set, and the report names the three slowest routes so a red run says where to look.

No per-route failure line, deliberately: the loop budget already fails on exactly this shape, and a route ceiling would fire on a legitimately large repo under `AGX_PERF_ROOT` — a check that cries about those gets muted.

## How was it tested?

- `bunx tsc --noEmit` in `server/` — clean. `bunx oxlint` on the touched files — no new warnings (`mkdirSync` has been imported unused in `perfbudget.ts` since before this branch; left alone).
- `bun test server/test/themesync-nondestructive.test.ts server/test/themesync.test.ts web/test/theme-boot-sync.test.ts web/test/theme-mode.test.ts` — **38 pass, 0 fail**, including six new ones: the engine socket repaints with no opt-in, a bare socket and someone else's `-L` do not, both do once the snippet is in the user's config, and the User-Agent fence against the exact string headless Chrome sends, the other automation stacks, a real browser, and absent.
- `make perf` against this branch: passes, p99 loop delay 15 ms, budget 120 ms.
- The one that matters — #565 merged into this branch and `make perf` run again:

```
⏱  event loop blocked 1425ms by GET /insights — the terminal was frozen for that long
loop meanwhile: 78 samples · p50 0.7ms · p95 1348.2ms · p99 1410.4ms · max 1410ms
✗ perf: p99 loop delay 1410ms is over the 120ms budget
```

The failure this harness exists for, caught, with the server's own watchdog naming the route. That merge was for verification only and is not in this branch.