### PR TITLE
Windows: run the sidecar there in CI, stop leaking process trees on it, and fix the fixture that hid one reason to

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,6 +137,47 @@ jobs:
           curl -sf http://localhost:4123/health
           kill $SVPID
 
+  # Windows and macOS have never run a line of this in CI.
+  #
+  # `electron/package.json` has declared an `nsis` target and a `dmg` target for
+  # five releases and neither has ever been executed — not here, not anywhere
+  # the history shows (#193). An audit of an NSIS install on Windows 11 found
+  # roughly a dozen breakages, every one a first-ten-minutes failure of the kind
+  # this job catches in ninety seconds: an env var split on the wrong character,
+  # a prefix test with a hardcoded `/`, a shell that does not exist there. The
+  # cost was never the bugs. It was that they accumulated across five releases
+  # and were found by a person installing the app.
+  #
+  # It does not build an installer. Booting the sidecar and asking it four
+  # questions catches everything in that audit but the packaging provenance, and
+  # waiting for a signed artifact would have kept this from landing at all.
+  #
+  # Not `fail-fast`: a red Windows must not hide a green macOS, which is the
+  # whole reason both are here rather than one.
+  platform:
+    name: Sidecar (${{ matrix.os }})
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [windows-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: 1.3.14 # pinned — see the note in `build`
+      - name: Install
+        run: bun install --frozen-lockfile
+      # One bun script rather than shell steps, and that is the point: the
+      # shells differ exactly where the bugs are. `windows-latest` runs
+      # PowerShell, where `&` does not background, `curl` is an alias for
+      # Invoke-WebRequest and `seq` does not exist — so a shell-written version
+      # of this job would have to be written twice, and the half nobody reads
+      # would rot. See scripts/platformsmoke.ts for what it asserts and why the
+      # terminal check accepts two different answers.
+      - name: The sidecar boots and answers here
+        run: bun scripts/platformsmoke.ts
+
   # The phone had no CI at all: 29 suites and two tsconfigs that only ran when
   # somebody remembered, while mobile/README.md and mobile/.npmrc both described
   # a `npm ci` in CI that did not exist. A reader concluded the app was covered.

--- a/scripts/platformsmoke.ts
+++ b/scripts/platformsmoke.ts
@@ -27,6 +27,7 @@ import { spawn } from "bun";
 import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
+import { privateTmuxDir } from "./tmuxTmp.ts";
 
 const ROOT = resolve(import.meta.dir, "..");
 const home = mkdtempSync(join(tmpdir(), "agx-platform-"));
@@ -43,6 +44,13 @@ const server = spawn({
     XDG_DATA_HOME: join(home, "data"),
     XDG_CACHE_HOME: join(home, "cache"),
     AGENTGLASS_STATE_DIR: join(home, "state"),
+    // Its own socket directory. This child is a SERVER: it runs the boot sweep
+    // at module scope and resolves tmux against `$TMUX_TMPDIR/tmux-<uid>`, so
+    // with no TMUX_TMPDIR it reaches into /tmp/tmux-<uid> — the sockets holding
+    // the sessions somebody is working in. See scripts/tmuxTmp.ts, and
+    // server/test/tmux-test-isolation.test.ts, which fails the build for any
+    // file that spawns the server without this and duly failed for this one.
+    TMUX_TMPDIR: privateTmuxDir(home),
     AGENTGLASS_TOKEN: "",
     // The transcript sweep reads the operator's own ~/.claude, which is neither
     // this app's doing nor reproducible on a runner.

--- a/scripts/platformsmoke.ts
+++ b/scripts/platformsmoke.ts
@@ -1,0 +1,153 @@
+#!/usr/bin/env bun
+/**
+ * Does the sidecar come up, and answer, on THIS operating system?
+ *
+ * `electron/package.json` has declared an `nsis` target for Windows and a `dmg`
+ * for macOS for five releases, and neither has ever been executed — not by CI,
+ * not by anyone (#193). What that cost was not the bugs: it was that a dozen
+ * of them accumulated invisibly and were found by a person installing the app,
+ * which is the most expensive detector there is. Every one was a
+ * first-ten-minutes failure of the kind a boot and four requests would have
+ * caught: an env var split on the wrong character, a prefix test with a
+ * hardcoded `/`, a shell that does not exist there.
+ *
+ * So this boots the server and asks it four questions. It does not build an
+ * installer — that is strictly better and much slower, and this should not wait
+ * for it.
+ *
+ * A bun script rather than shell steps, because the shells differ exactly where
+ * the bugs are: `windows-latest` runs PowerShell, `&` does not background,
+ * `curl` is an alias for `Invoke-WebRequest`, and `$(seq 1 30)` is nothing at
+ * all. A workflow written twice is a workflow where the Windows half rots
+ * quietly, which is the failure this file exists to end.
+ *
+ *   bun scripts/platformsmoke.ts
+ */
+import { spawn } from "bun";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+const ROOT = resolve(import.meta.dir, "..");
+const home = mkdtempSync(join(tmpdir(), "agx-platform-"));
+const port = 4870 + Math.floor(Math.random() * 40);
+const S = `http://127.0.0.1:${port}`;
+
+const server = spawn({
+  cmd: ["bun", join(ROOT, "server", "src", "index.ts")],
+  env: {
+    ...process.env,
+    AGENTGLASS_PORT: String(port),
+    AGENTGLASS_DB: join(home, "platform.db"),
+    XDG_CONFIG_HOME: join(home, "config"),
+    XDG_DATA_HOME: join(home, "data"),
+    XDG_CACHE_HOME: join(home, "cache"),
+    AGENTGLASS_STATE_DIR: join(home, "state"),
+    AGENTGLASS_TOKEN: "",
+    // The transcript sweep reads the operator's own ~/.claude, which is neither
+    // this app's doing nor reproducible on a runner.
+    AGENTGLASS_SCAN_DISABLED: "1",
+    AGENTGLASS_DIE_WITH_PARENT: "1",
+  },
+  stdout: "inherit",
+  stderr: "inherit",
+});
+
+type Result = { name: string; ok: boolean; detail: string };
+const results: Result[] = [];
+const record = (name: string, ok: boolean, detail: string) => {
+  results.push({ name, ok, detail });
+  console.log(`${ok ? "✓" : "✗"} ${name} — ${detail}`);
+};
+
+/** A route answers 200 with the JSON shape the panels read. */
+async function endpoint(name: string, path: string, shape: (body: any) => string | null) {
+  try {
+    const r = await fetch(S + path);
+    if (r.status !== 200) return record(name, false, `HTTP ${r.status}`);
+    const body = await r.json();
+    const wrong = shape(body);
+    record(name, !wrong, wrong ?? "200, and the shape the panel expects");
+  } catch (e) {
+    record(name, false, `no answer: ${e instanceof Error ? e.message : String(e)}`);
+  }
+}
+
+/**
+ * The terminal either works or says it does not — never a crash, never a hang.
+ *
+ * Two honest answers, one per platform. Where a PTY exists the socket opens and
+ * the first control frame is `ready`. On Windows there is no POSIX PTY backend,
+ * and the route refuses before the upgrade with `403` and a reason in the body
+ * — the same contract one layer earlier, and the shape #98 will change when it
+ * lands as ConPTY or as a deliberate disable. What fails this check is a 500, a
+ * socket that opens and dies with `fatal`, or silence.
+ */
+async function terminalContract(): Promise<void> {
+  const name = "GET /terminal/pty (the terminal works, or says it does not)";
+  let refusal: { status: number; body: string } | null = null;
+  try {
+    const probe = await fetch(`${S}/terminal/pty`, { headers: { upgrade: "websocket" } });
+    if (probe.status === 403) refusal = { status: 403, body: (await probe.text()).slice(0, 200) };
+    else if (probe.status >= 500) return record(name, false, `HTTP ${probe.status} — a refusal is fine, a crash is not`);
+  } catch { /* an upgrade the fetch client will not follow; the socket below is the real test */ }
+
+  if (refusal) {
+    const said = /disabled|not available/i.test(refusal.body);
+    return record(name, said, said
+      ? `refused cleanly: ${refusal.body}`
+      : `403 with no reason a user could act on: ${refusal.body}`);
+  }
+
+  await new Promise<void>((done) => {
+    const ws = new WebSocket(`${S.replace("http", "ws")}/terminal/pty`);
+    const settle = (ok: boolean, detail: string) => {
+      clearTimeout(timer);
+      record(name, ok, detail);
+      try { ws.close(); } catch { /* already gone */ }
+      done();
+    };
+    const timer = setTimeout(() => settle(false, "no frame within 15s — neither working nor saying so"), 15_000);
+    ws.onmessage = (ev) => {
+      const raw = typeof ev.data === "string" ? ev.data : "";
+      let frame: any;
+      try { frame = JSON.parse(raw); } catch { return; } // shell output, not a control frame
+      if (frame?.t === "ready") settle(true, `socket opened, shell ${frame.shell ?? "?"} in ${frame.cwd ?? "?"}`);
+      else if (frame?.t === "fatal") settle(false, `socket opened then died: ${frame.error}`);
+    };
+    ws.onerror = () => settle(false, "socket error before any frame");
+    ws.onclose = (ev) => { if (ev.code !== 1000) settle(false, `socket closed early (${ev.code} ${ev.reason || "no reason"})`); };
+  });
+}
+
+let failed = false;
+try {
+  let up = false;
+  for (let i = 0; i < 60; i++) {
+    try { if ((await fetch(`${S}/health`)).ok) { up = true; break; } } catch { /* booting */ }
+    await Bun.sleep(500);
+  }
+  if (!up) {
+    console.log(`\n✗ platform: the sidecar never answered /health on ${process.platform} — nothing below could run`);
+    process.exit(1);
+  }
+  record("GET /health", true, `the sidecar boots on ${process.platform}/${process.arch}`);
+
+  await endpoint("GET /stats", "/stats?window=3600000",
+    (b) => (b && typeof b === "object" && "totals" in b ? null : "200, but no totals in the body"));
+  await endpoint("GET /projects", "/projects",
+    (b) => (Array.isArray(b) || (b && typeof b === "object") ? null : "200, but neither a list nor an object"));
+  await endpoint("GET /git/repos?all=1", "/git/repos?all=1",
+    (b) => (Array.isArray(b) || (b && typeof b === "object") ? null : "200, but neither a list nor an object"));
+  await terminalContract();
+
+  failed = results.some((r) => !r.ok);
+  console.log(failed
+    ? `\n✗ platform: ${results.filter((r) => !r.ok).length} of ${results.length} checks failed on ${process.platform}`
+    : `\n✓ platform: ${results.length} checks pass on ${process.platform}/${process.arch}`);
+} finally {
+  try { server.kill(); } catch { /* already gone */ }
+  rmSync(home, { recursive: true, force: true });
+}
+
+process.exit(failed ? 1 : 0);

--- a/scripts/platformsmoke.ts
+++ b/scripts/platformsmoke.ts
@@ -24,7 +24,7 @@
  *   bun scripts/platformsmoke.ts
  */
 import { spawn } from "bun";
-import { mkdtempSync, rmSync } from "node:fs";
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join, resolve } from "node:path";
 
@@ -120,6 +120,52 @@ async function terminalContract(): Promise<void> {
   });
 }
 
+/**
+ * Can this platform launch a CLI installed the way npm installs one? (#195)
+ *
+ * `chat.ts` finds its CLI with `Bun.which("claude")` and launches it with
+ * `Bun.spawn`, and on Windows an npm install lands as a `claude.cmd` shim
+ * rather than an executable — so both steps were open questions that could not
+ * be answered from a Linux machine, and a wrong answer means the chat panel is
+ * dead at the first turn rather than degraded. This asks the same two questions
+ * of a shim we write ourselves, through the same two functions.
+ *
+ * It runs everywhere: on POSIX the shim is a `#!/bin/sh` script, which keeps
+ * the probe itself honest on the machine where it was written.
+ */
+async function cliShimContract(): Promise<void> {
+  const name = "Bun.which + Bun.spawn on an npm-style shim (#195)";
+  const dir = mkdtempSync(join(tmpdir(), "agx-shim-"));
+  const windows = process.platform === "win32";
+  const shim = join(dir, windows ? "agxprobe.cmd" : "agxprobe");
+  try {
+    if (windows) writeFileSync(shim, "@echo off\r\necho agx-shim-ok\r\n");
+    else { writeFileSync(shim, "#!/bin/sh\necho agx-shim-ok\n"); chmodSync(shim, 0o755); }
+
+    // An explicit PATH, because `Bun.which` does not read a `process.env.PATH`
+    // mutated after start — measured here: the ambient form answers null and
+    // the explicit one finds the file. Production is unaffected, since the
+    // server inherits its PATH at boot, but a probe that mutated and asked
+    // would have reported a failure that does not exist.
+    const PATH = `${dir}${windows ? ";" : ":"}${process.env.PATH ?? ""}`;
+    {
+      const found = Bun.which("agxprobe", { PATH });
+      if (!found) return record(name, false, "Bun.which did not resolve the shim — a CLI installed this way is invisible");
+      const proc = Bun.spawn([found], { stdout: "pipe", stderr: "pipe", env: { ...process.env, PATH } });
+      const out = await new Response(proc.stdout).text();
+      await proc.exited;
+      const ran = out.includes("agx-shim-ok");
+      record(name, ran, ran
+        ? `resolved ${found.replace(dir, "…")} and ran it`
+        : `resolved it, but the spawn produced ${JSON.stringify(out.slice(0, 120))} — a shim that needs a shell`);
+    }
+  } catch (e) {
+    record(name, false, `probe failed: ${e instanceof Error ? e.message : String(e)}`);
+  } finally {
+    rmSync(dir, { recursive: true, force: true });
+  }
+}
+
 let failed = false;
 try {
   let up = false;
@@ -140,6 +186,7 @@ try {
   await endpoint("GET /git/repos?all=1", "/git/repos?all=1",
     (b) => (Array.isArray(b) || (b && typeof b === "object") ? null : "200, but neither a list nor an object"));
   await terminalContract();
+  await cliShimContract();
 
   failed = results.some((r) => !r.ok);
   console.log(failed

--- a/server/src/antigravity.ts
+++ b/server/src/antigravity.ts
@@ -30,6 +30,7 @@ import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
 import { inScope, chatBypassAllowed } from "./config.ts";
 import { startKeepalive, drainStderr, MODEL_RE, SESSION_RE } from "./chat.ts";
 import type { AgentModel, IngestBody } from "../../shared/types.ts";
+import { stopTree } from "./proctree.ts";
 
 const agyBin = () => Bun.which("agy");
 /*
@@ -472,10 +473,7 @@ export function antigravityStream(
               || `agy produced no output in ${STARTUP_TIMEOUT_MS / 1000}s — it is probably waiting for a login it can't ask for here. Run \`agy\` in a terminal and sign in, then try again.`,
           }) + "\n"));
         } catch { /* the client already went away */ }
-        try {
-          if (setsid) process.kill(-proc.pid, "SIGTERM");
-          else proc.kill();
-        } catch { /* gone */ }
+        stopTree(proc, !!setsid); // the tree, not just the CLI
       }, STARTUP_TIMEOUT_MS);
       try {
         for (;;) {
@@ -502,10 +500,7 @@ export function antigravityStream(
     },
     cancel() {
       cancelled = true;
-      try {
-        if (setsid) process.kill(-proc.pid, "SIGTERM"); // the group, not just agy
-        else proc.kill();
-      } catch { /* gone */ }
+      stopTree(proc, !!setsid); // the tree, not just the CLI
     },
   });
 

--- a/server/src/chat.ts
+++ b/server/src/chat.ts
@@ -17,6 +17,7 @@ import { paneTurnStream, paneEngineCapability } from "./chatpane.ts";
 import type { Scope } from "./devices.ts";
 import { CHAT_EFFORTS } from "../../shared/types.ts";
 import type { ChatImage, ChatImageMediaType, ChatEffort } from "../../shared/types.ts";
+import { stopTree } from "./proctree.ts";
 
 const claudeBin = () => Bun.which("claude");
 export const CHAT_ENABLED = !!claudeBin();
@@ -550,10 +551,7 @@ function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
               || `claude produced no output in ${STARTUP_TIMEOUT_MS / 1000}s — it is probably waiting for a login it can't ask for here. Run \`claude\` once in a terminal to sign in, then try again.`,
           }) + "\n"));
         } catch { /* the client already went away */ }
-        try {
-          if (setsid) process.kill(-proc.pid, "SIGTERM");
-          else proc.kill();
-        } catch { /* gone */ }
+        stopTree(proc, !!setsid);
       }, STARTUP_TIMEOUT_MS);
       const dec = new TextDecoder();
       try {
@@ -591,10 +589,7 @@ function chatStreamPlanned(plan: Extract<TurnPlan, { ok: true }>): Response {
     cancel() {
       cancelled = true;
       release();
-      try {
-        if (setsid) process.kill(-proc.pid, "SIGTERM"); // the group, not just claude
-        else proc.kill();
-      } catch { /* gone */ }
+      stopTree(proc, !!setsid); // the tree, not just claude
     },
   });
 

--- a/server/src/codex.ts
+++ b/server/src/codex.ts
@@ -23,6 +23,7 @@ import { safeAbs, repoRootOf, gitCapability } from "./git.ts";
 import { inScope, chatBypassAllowed } from "./config.ts";
 import { startKeepalive, drainStderr, MODEL_RE, SESSION_RE } from "./chat.ts";
 import type { CodexModel, TimelineEntry } from "../../shared/types.ts";
+import { stopTree } from "./proctree.ts";
 
 const codexBin = () => Bun.which("codex");
 /*
@@ -484,10 +485,7 @@ export function codexStream(cwd: unknown, message: unknown, model: unknown, resu
               || `codex produced no output in ${STARTUP_TIMEOUT_MS / 1000}s — it is probably waiting for a login it can't ask for here. Run \`codex login\` in a terminal, then try again.`,
           }) + "\n"));
         } catch { /* the client already went away */ }
-        try {
-          if (setsid) process.kill(-proc.pid, "SIGTERM");
-          else proc.kill();
-        } catch { /* gone */ }
+        stopTree(proc, !!setsid); // the tree, not just the CLI
       }, STARTUP_TIMEOUT_MS);
       /*
        * The only thing read out of this stream on the way past: the id Codex
@@ -534,10 +532,7 @@ export function codexStream(cwd: unknown, message: unknown, model: unknown, resu
     },
     cancel() {
       cancelled = true;
-      try {
-        if (setsid) process.kill(-proc.pid, "SIGTERM"); // the group, not just codex
-        else proc.kill();
-      } catch { /* gone */ }
+      stopTree(proc, !!setsid); // the tree, not just the CLI
     },
   });
 

--- a/server/src/proctree.ts
+++ b/server/src/proctree.ts
@@ -1,0 +1,63 @@
+/**
+ * Stopping a turn has to reach the whole job tree, on every platform.
+ *
+ * `claude`, `codex` and `agy` all spawn work of their own — a test run, a dev
+ * server, a build — and the promise the Stop button makes is that pressing it
+ * ends the job, not just the CLI that launched it. On POSIX that is what the
+ * `setsid` prefix at each spawn site buys: the child leads its own process
+ * group, so one signal to `-pid` reaches everything it started.
+ *
+ * `setsid` does not exist on Windows, and the fallback there killed only the
+ * direct child (#195). Everything below it survived, still holding the CPU, the
+ * port, or the lock — and nothing on screen said so, because the CLI it was
+ * launched by had gone. `taskkill /T` is the equivalent that does exist:
+ * `/T` walks the tree, `/F` does not ask twice.
+ *
+ * One place rather than three, because it was written three times — chat.ts,
+ * codex.ts, antigravity.ts, each with the same comment about the group and the
+ * same Windows hole underneath it.
+ */
+
+export interface Stoppable {
+  readonly pid: number;
+  kill(): void;
+}
+
+/** Injected in tests so the Windows branch can be asserted from any host. */
+export type Runner = (cmd: string[]) => { exitCode: number | null };
+
+const defaultRunner: Runner = (cmd) => {
+  const r = Bun.spawnSync(cmd, { stdout: "ignore", stderr: "ignore" });
+  return { exitCode: r.exitCode };
+};
+
+/**
+ * End a spawned turn and everything it started.
+ *
+ * `grouped` is whether the process was launched under `setsid` — the caller
+ * knows, because it is the one that decided. A process that is not grouped can
+ * only be killed directly, which is the honest limit of that spawn rather than
+ * something to paper over here.
+ *
+ * Best-effort by design: a tree that has already exited is the normal case at
+ * every one of these call sites, and a stop that throws because the job it was
+ * stopping had finished would turn a success into an error.
+ */
+export function stopTree(
+  proc: Stoppable,
+  grouped: boolean,
+  platform: string = process.platform,
+  run: Runner = defaultRunner,
+): void {
+  if (platform === "win32") {
+    // The direct kill first, so a missing taskkill (Windows Nano, a stripped
+    // container image) still stops the CLI itself rather than nothing at all.
+    try { proc.kill(); } catch { /* already gone */ }
+    try { run(["taskkill", "/T", "/F", "/PID", String(proc.pid)]); } catch { /* no taskkill; the direct kill above stands */ }
+    return;
+  }
+  try {
+    if (grouped) process.kill(-proc.pid, "SIGTERM"); // the group, not just the CLI
+    else proc.kill();
+  } catch { /* gone */ }
+}

--- a/server/test/insights-scope.test.ts
+++ b/server/test/insights-scope.test.ts
@@ -50,7 +50,12 @@ beforeAll(async () => {
   };
   loop(SCOPED, "s-in"); // in scope
   loop(OTHER, "s-out"); // out of scope — must not leak
-  loop(MONO, "s-cwd", { cwd: SCOPED + "/wt/x" }); // in scope via the cwd the turn ran in
+  // join, not `SCOPED + "/wt/x"`: `isWithin` compares with the platform's own
+  // separator, so on Windows the concatenated form is `C:\…\scoped/wt/x` and
+  // fails a prefix test against `C:\…\scoped\` — the fixture would sit outside
+  // the scope it exists to prove is inside it, and this assertion would pass by
+  // testing nothing (#569).
+  loop(MONO, "s-cwd", { cwd: join(SCOPED, "wt", "x") }); // in scope via the cwd the turn ran in
 
   // A second, differently-shaped query (SUM(cost)/HAVING) — a fast-burn session
   // over $15 in 15m — to prove the scope guard covers more than the loop query.

--- a/server/test/proctree.test.ts
+++ b/server/test/proctree.test.ts
@@ -1,0 +1,105 @@
+/*
+ * Stopping a turn has to end the job, not just the CLI that launched it (#195).
+ *
+ * The POSIX case is exercised for real — a process group with a grandchild in
+ * it, stopped, then asked whether the grandchild is still there — because that
+ * is the property the Stop button promises and a mock of it would prove
+ * nothing. The Windows case is exercised through an injected platform and
+ * runner, because `taskkill` does not exist here; what is asserted there is the
+ * command, which is the whole of what this module decides.
+ */
+import { describe, expect, test } from "bun:test";
+import { stopTree, type Runner } from "../src/proctree.ts";
+
+/**
+ * Is this pid a process that is still doing something?
+ *
+ * Not `process.kill(pid, 0)`, which answers true for a zombie — and a zombie is
+ * exactly what a killed grandchild is for the moment between dying and being
+ * reaped. Measured while writing this: the group SIGTERM lands, the `sleep`
+ * goes to state `Z`, and `kill(pid, 0)` still succeeds for a second or two
+ * afterwards because the parent shell died first and init has not collected it
+ * yet. A test on that signal would have failed while the code worked.
+ */
+const alive = (pid: number): boolean => {
+  const stat = Bun.spawnSync(["ps", "-o", "stat=", "-p", String(pid)]).stdout.toString().trim();
+  return stat.length > 0 && !stat.startsWith("Z");
+};
+
+const settle = () => Bun.sleep(300);
+
+describe("stopping a turn on Windows", () => {
+  const fake = () => {
+    const cmds: string[][] = [];
+    let killed = 0;
+    const run: Runner = (cmd) => { cmds.push(cmd); return { exitCode: 0 }; };
+    return { cmds, run, killed: () => killed, proc: { pid: 4321, kill: () => { killed++; } } };
+  };
+
+  test("walks the tree with taskkill, since setsid does not exist there", () => {
+    const f = fake();
+    stopTree(f.proc, false, "win32", f.run);
+    expect(f.cmds).toEqual([["taskkill", "/T", "/F", "/PID", "4321"]]);
+  });
+
+  test("kills the CLI itself first, so a machine with no taskkill still stops something", () => {
+    const f = fake();
+    stopTree(f.proc, false, "win32", f.run);
+    expect(f.killed()).toBe(1);
+  });
+
+  test("a taskkill that is not installed is not an error — the turn is over either way", () => {
+    const f = fake();
+    const throws: Runner = () => { throw new Error("spawn taskkill ENOENT"); };
+    expect(() => stopTree(f.proc, false, "win32", throws)).not.toThrow();
+    expect(f.killed()).toBe(1);
+  });
+
+  test("`grouped` is meaningless there and changes nothing", () => {
+    const a = fake(); const b = fake();
+    stopTree(a.proc, true, "win32", a.run);
+    stopTree(b.proc, false, "win32", b.run);
+    expect(a.cmds).toEqual(b.cmds);
+  });
+});
+
+describe("stopping a turn on this machine", () => {
+  test("a grouped turn takes its grandchildren with it", async () => {
+    const setsid = Bun.which("setsid");
+    if (!setsid) return; // no process groups to test — the Windows branch above covers that shape
+
+    // A shell that starts a long sleep and reports its pid, then waits: the
+    // sleep is the "test run the agent kicked off" this feature exists for.
+    const proc = Bun.spawn([setsid, "sh", "-c", "sleep 60 & echo $!; wait"], { stdout: "pipe", stderr: "ignore" });
+    // One read, not `new Response(...).text()`: that waits for the stream to
+    // close, and the shell is still holding it open — which is the point of the
+    // fixture. The pid arrives on the first chunk.
+    const reader = (proc.stdout as ReadableStream<Uint8Array>).getReader();
+    const first = await reader.read();
+    const grandchild = Number(new TextDecoder().decode(first.value ?? new Uint8Array()).trim().split("\n")[0]);
+    try { await reader.cancel(); } catch { /* the shell is about to go anyway */ }
+    expect(Number.isFinite(grandchild) && grandchild > 0).toBe(true);
+    expect(alive(grandchild)).toBe(true);
+
+    stopTree(proc, true);
+    await settle();
+
+    expect(alive(grandchild)).toBe(false);
+    expect(alive(proc.pid)).toBe(false);
+  }, 15_000);
+
+  test("an ungrouped turn stops the process it was given", async () => {
+    const proc = Bun.spawn(["sh", "-c", "sleep 60"], { stdout: "ignore", stderr: "ignore" });
+    expect(alive(proc.pid)).toBe(true);
+
+    stopTree(proc, false);
+    await settle();
+
+    expect(alive(proc.pid)).toBe(false);
+  }, 15_000);
+
+  test("stopping something already gone is not an error", () => {
+    const proc = Bun.spawn(["sh", "-c", "exit 0"], { stdout: "ignore", stderr: "ignore" });
+    expect(() => { stopTree(proc, true); stopTree(proc, false); }).not.toThrow();
+  });
+});


### PR DESCRIPTION
Closes #193. Closes #569. Closes #195.

## What does this PR do?

Three Windows-shaped holes, and the first one is what found the others.

**Windows and macOS have never run a line of this in CI (#193).** The `nsis` and `dmg` targets in `electron/package.json` have been declared for five releases and never executed. An audit of an NSIS install on Windows 11 found roughly a dozen breakages, every one a first-ten-minutes failure — an env var split on the wrong character, a prefix test with a hardcoded `/`, a shell that does not exist there. The cost was never the bugs; it was that they accumulated across five releases and were found by a person installing the app.

There is now a `platform` job on `windows-latest` and `macos-latest` that boots the sidecar and asks it four questions: 200 with the expected shape on `/stats`, `/projects` and `/git/repos?all=1`, then the contract that matters — **the terminal either works or says it does not.** That check takes either honest answer: where a PTY exists the socket opens and the first control frame is `ready`; on Windows there is no POSIX backend, so `/terminal/pty` refuses *before* the upgrade with `403` and a reason in the body — the same contract one layer earlier than the issue described, and the shape #98 will change when it lands. What fails is a 500, a socket that opens and dies with `fatal`, or silence.

It is one bun script rather than shell steps, deliberately: on `windows-latest` `&` does not background, `curl` is an alias for `Invoke-WebRequest`, and `seq` does not exist. A workflow written twice is one where the Windows half rots, which is the failure this job exists to end. `fail-fast: false`, so a red Windows cannot hide a green macOS.

**Stopping a turn left the job running on Windows (#195).** `claude`, `codex` and `agy` are each spawned under `setsid` so that Stop reaches the whole tree — the CLI starts tools of its own, a test run, a dev server. `setsid` does not exist on Windows and the fallback killed only the direct child, so everything below it survived, still holding the CPU, the port or the lock, with nothing on screen to say so. `taskkill /T /F` is the equivalent that does. It was written three times with the same comment and the same hole under it, so it is one place now — `stopTree()` in `proctree.ts` — and the direct kill runs first there, so a machine without `taskkill` still stops the CLI rather than nothing.

The same issue asked two things nobody could answer from Linux: does `Bun.which("claude")` resolve an npm-installed `claude.cmd` shim, and does `Bun.spawn` run it without `cmd.exe /c`? The platform smoke now writes a shim of its own and asks both, through the same two functions `chat.ts` uses — so `windows-latest` answers it on every run rather than once.

**A fixture that was quietly proving nothing (#569).** Reported by @snowyukitty, the separate finding they said they'd file when the platform-bound half was dropped from #532. `insights-scope.test.ts` built the in-scope cwd as `SCOPED + "/wt/x"` while `isWithin` compares against the platform's own separator, so on Windows the case that exists to prove a turn is in scope *through the directory it ran in* was testing a path outside it. Fixture only; `join` was already imported.

## How was it tested?

The first CI run of this branch already answered the oldest question in the issue — **the sidecar boots on Windows and answers everything asked of it**:

```
✓ GET /terminal/pty (the terminal works, or says it does not) — refused cleanly: {"error":"terminal is disabled"}
✓ platform: 5 checks pass on win32/x64
```

macOS passed in the same run. This push adds the shim probe, so this run answers the spawn half too.

Locally:

- `bun scripts/platformsmoke.ts` — **6/6 on linux**, and the terminal contract exercised on both branches: with a PTY (`ready`, `bash`) and with `AGENTGLASS_TERMINAL_DISABLED=1` (`403 {"error":"terminal is disabled"}`).
- `bun test server/test/proctree.test.ts` — **7 pass**, including a real process group with a grandchild in it, stopped, then checked. Writing that turned up a trap worth recording: a killed grandchild is a **zombie** until reaped, and `process.kill(pid, 0)` answers "alive" for a zombie — so the obvious liveness check fails for a second or two while the code is working. The test reads the process state instead.
- The eight suites that touch the three drivers (`antigravity`, `chat-allowlist`, `chat-effort`, `chat-images`, `chat-keepalive`, `chat-scope`, `chat-stderr`, `codex-usage`) — **91 pass, 0 fail**.
- `bun test server/test/insights-scope.test.ts` — **5 pass**; and the reporter's reduced win32 probe reproduces exactly: `false` concatenated, `true` joined, `false` control.
- `bunx oxlint` on every new and changed file — clean. `bunx tsc --noEmit` in `server/` — clean.

Also measured, and noted in the probe: `Bun.which` does not see a `process.env.PATH` mutated after start — the ambient form answers `null` where an explicit `{ PATH }` finds the file. Production is unaffected (the server inherits its PATH at boot); a probe that mutated and asked would have reported a failure that does not exist.