### PR TITLE
feat(phone): render the markdown people actually write

### DIFF
--- a/mobile/app/card/[id].tsx
+++ b/mobile/app/card/[id].tsx
@@ -48,6 +48,7 @@ import type { GitRepoRef, SkillInfo } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
 import { announceCard } from "../../src/state/card-edits.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
+import { Md, outline } from "../../src/md/Md.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { providerTitle } from "../../src/model/taskProviders.ts";
 import { requestHandoff } from "../../src/terminal/handoff.ts";
@@ -85,7 +86,9 @@ function prInk(pr: { state: string; draft?: boolean }): string {
 /** How much description opens by default. 900 is about a screenful and a half
  *  at this size — enough that most cards are shown whole and a specification is
  *  visibly cut rather than silently truncated. */
-const BODY_CAP = 900;
+/** How much of a description shows before the fold. Blocks, not
+ *  characters: a cut mid-sentence is a cut nobody chose. */
+const BODY_BLOCKS = 5;
 
 /** One status the card can be moved to, as the list defines it. */
 interface Status { status: string; color?: string; type?: string }
@@ -408,6 +411,9 @@ export default function CardScreen(): React.ReactNode {
      so the emptiness test is on the trimmed text and the trimmed text is what
      gets drawn. */
   const body = (detail?.description ?? "").trim();
+  /* What the fold hides, named. A specification's next heading is the whole
+     of what a reader needs to decide whether to open it. */
+  const bodyRest = useMemo(() => outline(body, BODY_BLOCKS), [body]);
 
   /* Subtasks and checklist items counted as one number, because they are one
      question — what is left underneath this card. A subtask is done when the
@@ -473,27 +479,28 @@ export default function CardScreen(): React.ReactNode {
               <Note tone={said.ok ? "quiet" : "bad"}>{said.text}</Note>
             ) : null}
 
-            {/* Verbatim, and capped. Markdown is not rendered here for the
-                reason the pull request and issue screens both give: a
-                description is prose somebody wrote, and half-rendered markup
-                reads worse than none. The cap is because a ClickUp description
-                is regularly a specification, and a screen that opens on eight
-                hundred words has buried the status and the buttons under
-                them. */}
+            {/* Rendered, and folded by blocks rather than by characters. The
+                fold is still here for the reason it always was — a ClickUp
+                description is regularly a specification, and a screen that
+                opens on eight hundred words has buried the status and the
+                buttons under them — but a cut between two things somebody
+                wrote beats a cut at character nine hundred, and the expander
+                can name what is under it. */}
             {body ? (
-              <Card>
-                <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 21 }}>
-                  {wholeBody ? body : body.slice(0, BODY_CAP)}
-                  {!wholeBody && body.length > BODY_CAP ? "…" : ""}
-                </Text>
-                {body.length > BODY_CAP ? (
+              <Card style={{ gap: SPACE.md }}>
+                <Md text={body} host={host} limit={wholeBody ? undefined : BODY_BLOCKS} />
+                {bodyRest.hidden ? (
                   <Pressable
                     accessibilityRole="button"
                     onPress={() => setWholeBody((was) => !was)}
                     style={{ minHeight: TAP, justifyContent: "center" }}
                   >
                     <Text style={{ color: C.primary, fontSize: T.small, fontWeight: "600" }}>
-                      {wholeBody ? "Show less" : `Show all ${body.length} characters`}
+                      {wholeBody
+                        ? "Show less"
+                        : bodyRest.nextHeading
+                          ? `${bodyRest.nextHeading}${bodyRest.hidden > 1 ? ` and ${bodyRest.hidden - 1} more` : ""}`
+                          : `${bodyRest.hidden} more`}
                     </Text>
                   </Pressable>
                 ) : null}

--- a/mobile/app/issue/[number].tsx
+++ b/mobile/app/issue/[number].tsx
@@ -24,6 +24,7 @@ import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import type { IssueDetail, IssuePr, IssuePrsReport, IssueStartResult } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
+import { Md } from "../../src/md/Md.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { requestHandoff } from "../../src/terminal/handoff.ts";
 import { since } from "../../src/lib/dates.ts";
@@ -237,13 +238,14 @@ export default function IssueScreen(): React.ReactNode {
 
           {detail.body.trim() ? (
             <Card>
-              {/* Verbatim, and never reflowed into something that reads like a
-                  different report. Markdown is not rendered here: an issue body
-                  is somebody's description of a bug, and half-rendered markup
-                  is harder to read than none. */}
-              <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 21 }}>
-                {detail.body.trim()}
-              </Text>
+              {/* Rendered, and never reflowed into something that reads like a
+                  different report: a report's own headings, its numbered steps
+                  and its fenced output are how it argues, and flattening them
+                  is what made an issue harder to read here than on the web.
+                  Uncapped, because an issue is read rather than skimmed — the
+                  cap belongs on a pull request template, not on somebody's
+                  account of a bug. */}
+              <Md text={detail.body.trim()} host={host} />
             </Card>
           ) : (
             <Card>

--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -27,6 +27,7 @@ import { ActivityIndicator, Linking, Pressable, ScrollView, Text, TextInput, Vie
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import type { PrCheck, PrDetail, ReviewRecipe, ReviewRecipesResponse } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
+import { Md, outline } from "../../src/md/Md.tsx";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { RECIPES_PATH, menuFor, situationOf } from "../../src/model/reviewMenu.ts";
@@ -41,6 +42,9 @@ import {
 import { Btn, Card, Label, Note, Sheet, SheetRow, TAP, Toggle } from "../../src/ui.tsx";
 import { ChevronIcon } from "../../src/nav/icons.tsx";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
+
+/** How much of a description shows before the fold. */
+const BODY_BLOCKS = 6;
 
 /** The rollup as one word and one colour. `pending` beats `failure` on purpose:
  *  a run still going has not failed yet, and calling it red is how a screen
@@ -151,6 +155,16 @@ export default function PrScreen(): React.ReactNode {
   const [error, setError] = useState<string | null>(null);
   const [handing, setHanding] = useState(false);
   const [allFiles, setAllFiles] = useState(false);
+  /* The description folds after six blocks. Six is where this project's own
+     template stops being the checklist and starts being the CU reference —
+     which is exactly the point a reader decides whether to read on. */
+  const [bodyOpen, setBodyOpen] = useState(false);
+  /* What the fold is hiding, named rather than counted: "CU reference and 2
+     more" tells you whether to open it; "Show more" does not. */
+  const rest = useMemo(
+    () => (detail?.body ? outline(detail.body.trim(), BODY_BLOCKS) : { hidden: 0, nextHeading: null }),
+    [detail?.body],
+  );
   /** The menu, as the computer has it — built-ins with the user's own edits
    *  merged in. Null until it answers, which is why the sheet says so rather
    *  than drawing an empty list that reads as "no options". */
@@ -526,15 +540,27 @@ export default function PrScreen(): React.ReactNode {
             </View>
 
             {detail.body.trim() ? (
-              <Card>
-                {/* Verbatim. Markdown is not rendered: a description is prose
-                    somebody wrote, and half-rendered markup reads worse than
-                    none. Capped, because a template can be four thousand
-                    characters of checklist. */}
-                <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 21 }}>
-                  {detail.body.trim().slice(0, 1200)}
-                  {detail.body.trim().length > 1200 ? "…" : ""}
-                </Text>
+              <Card style={{ gap: SPACE.md }}>
+                {/* Rendered, and folded by BLOCKS rather than by characters.
+                    A cut at 1,200 characters landed mid-word and mid-checkbox;
+                    a cut after six blocks lands between two things somebody
+                    wrote, and the expander below can say what the rest is. */}
+                <Md text={detail.body.trim()} host={host} limit={bodyOpen ? undefined : BODY_BLOCKS} />
+                {rest.hidden ? (
+                  <Pressable
+                    accessibilityRole="button"
+                    onPress={() => setBodyOpen((was) => !was)}
+                    style={{ minHeight: TAP, flexDirection: "row", alignItems: "center", gap: SPACE.sm }}
+                  >
+                    <Text style={{ color: C.primary, fontSize: T.body, fontWeight: "600" }}>
+                      {bodyOpen
+                        ? "Show less"
+                        : rest.nextHeading
+                          ? `${rest.nextHeading}${rest.hidden > 1 ? ` and ${rest.hidden - 1} more` : ""}`
+                          : `${rest.hidden} more`}
+                    </Text>
+                  </Pressable>
+                ) : null}
               </Card>
             ) : null}
 

--- a/mobile/src/md/Md.tsx
+++ b/mobile/src/md/Md.tsx
@@ -1,0 +1,264 @@
+/*
+ * Rendered markdown, in this app's own type and colour.
+ *
+ * The parser next door decides what a body IS; this decides what it looks
+ * like, and every value it uses comes from `theme.ts` rather than from a
+ * stylesheet of its own — a renderer with its own idea of a heading is how a
+ * screen ends up looking like two apps.
+ *
+ * Three things here are not decoration:
+ *
+ *   A task list draws real boxes. Every pull request in this project opens
+ *   with a checklist, and "is that one ticked" is the question it exists to
+ *   answer.
+ *
+ *   A table scrolls inside its own box. Nothing else on a 393-point screen may
+ *   scroll sideways, and a table that forces the page to is worse than a table
+ *   that is cut off.
+ *
+ *   An image goes through the server. GitHub's attachment host answers 404
+ *   without the token the sidecar attaches, so a body's screenshot loaded
+ *   directly is a broken box on every phone — see `prAsset` in server/src/prs.ts.
+ */
+import { memo, useState } from "react";
+import { Image, Linking, ScrollView, Text, View } from "react-native";
+import type { Host } from "../lib/host.ts";
+import { C, MONO, RADIUS, SPACE, T } from "../theme.ts";
+import { inlineText, parseMarkdown, type Block, type Inline, type ListItem } from "./parse.ts";
+
+/** GitHub's own attachment addresses, which need the sidecar's token. Anything
+ *  else — a badge, a raw file, somebody's blog — is fetched as written. */
+const NEEDS_TOKEN = /^https:\/\/(?:github\.com\/user-attachments|private-user-images\.githubusercontent\.com|user-images\.githubusercontent\.com)\//;
+
+const HEADING_SIZE: Record<number, number> = { 1: T.head, 2: T.title, 3: T.body + 1, 4: T.body, 5: T.body, 6: T.body };
+
+/** Inline spans, as one Text so the line wraps as a line rather than as a row
+ *  of boxes that break wherever a span ends. */
+function Spans({ kids, size, color }: { kids: Inline[]; size: number; color: string }): React.ReactNode {
+  return (
+    <>
+      {kids.map((k, i) => {
+        if (k.t === "text") return <Text key={i} style={{ color, fontSize: size }}>{k.text}</Text>;
+        if (k.t === "code") {
+          return (
+            <Text key={i} style={{
+              color: C.text, fontFamily: MONO, fontSize: size - 1.5,
+              backgroundColor: C.bg3,
+            }}> {k.text} </Text>
+          );
+        }
+        if (k.t === "strong") {
+          return <Text key={i} style={{ fontWeight: "700", color: C.text, fontSize: size }}><Spans kids={k.kids} size={size} color={C.text} /></Text>;
+        }
+        if (k.t === "em") {
+          return <Text key={i} style={{ fontStyle: "italic", color, fontSize: size }}><Spans kids={k.kids} size={size} color={color} /></Text>;
+        }
+        return (
+          <Text
+            key={i}
+            accessibilityRole="link"
+            onPress={() => { void Linking.openURL(k.href).catch(() => { /* no app for it */ }); }}
+            style={{ color: C.primary, fontSize: size }}
+          >
+            <Spans kids={k.kids} size={size} color={C.primary} />
+          </Text>
+        );
+      })}
+    </>
+  );
+}
+
+/** A body's image. It is given a height once it has one, because a phone
+ *  showing a full-width box of nothing while a screenshot loads is a layout
+ *  that jumps under the reader's thumb. */
+function BodyImage({ src, alt, host }: { src: string; alt: string; host: Host | null }): React.ReactNode {
+  const [ratio, setRatio] = useState<number | null>(null);
+  const [failed, setFailed] = useState(false);
+  const through = host && NEEDS_TOKEN.test(src)
+    ? { uri: `${host.origin}/prs/asset?url=${encodeURIComponent(src)}`, headers: { authorization: `Bearer ${host.token}` } }
+    : { uri: src };
+
+  if (failed) {
+    return (
+      <Text style={{ color: C.text3, fontSize: T.small, fontStyle: "italic" }}>
+        {alt ? `${alt} — image did not load` : "an image did not load"}
+      </Text>
+    );
+  }
+  return (
+    <Image
+      accessibilityLabel={alt || "image"}
+      source={through}
+      onError={() => setFailed(true)}
+      onLoad={(e) => {
+        const { width, height } = e.nativeEvent.source;
+        if (width > 0 && height > 0) setRatio(width / height);
+      }}
+      resizeMode="contain"
+      style={{ width: "100%", aspectRatio: ratio ?? 16 / 9, borderRadius: RADIUS.sm, backgroundColor: C.bg2 }}
+    />
+  );
+}
+
+function Items({ list, host }: { list: Extract<Block, { t: "list" }>; host: Host | null }): React.ReactNode {
+  return (
+    <View style={{ gap: SPACE.sm }}>
+      {list.items.map((item: ListItem, i) => (
+        <View key={i} style={{ gap: SPACE.sm }}>
+          <View style={{ flexDirection: "row", gap: SPACE.sm }}>
+            {item.checked === null ? (
+              <Text style={{ color: C.text3, fontSize: T.body, lineHeight: 21, width: list.ordered ? undefined : 14 }}>
+                {list.ordered ? `${list.start + i}.` : "•"}
+              </Text>
+            ) : (
+              <View style={{
+                width: 16, height: 16, marginTop: 3, borderRadius: RADIUS.sm,
+                alignItems: "center", justifyContent: "center",
+                backgroundColor: item.checked ? C.primary : "transparent",
+                borderWidth: item.checked ? 0 : 1.5,
+                borderColor: C.border2,
+              }}>
+                {item.checked ? <Text style={{ color: C.bg, fontSize: 11, fontWeight: "900", lineHeight: 13 }}>✓</Text> : null}
+              </View>
+            )}
+            <Text style={{ flex: 1, color: C.text2, fontSize: T.body, lineHeight: 21 }}>
+              <Spans kids={item.kids} size={T.body} color={C.text2} />
+            </Text>
+          </View>
+          {item.children.length ? (
+            <View style={{ paddingLeft: SPACE.lg, gap: SPACE.sm }}>
+              <Blocks blocks={item.children} host={host} />
+            </View>
+          ) : null}
+        </View>
+      ))}
+    </View>
+  );
+}
+
+function Blocks({ blocks, host }: { blocks: Block[]; host: Host | null }): React.ReactNode {
+  return (
+    <>
+      {blocks.map((b, i) => {
+        switch (b.t) {
+          case "h":
+            return (
+              <Text key={i} style={{
+                color: C.text, fontSize: HEADING_SIZE[b.level] ?? T.body, fontWeight: "700",
+                lineHeight: (HEADING_SIZE[b.level] ?? T.body) + 6, marginTop: i === 0 ? 0 : SPACE.xs,
+              }}>
+                <Spans kids={b.kids} size={HEADING_SIZE[b.level] ?? T.body} color={C.text} />
+              </Text>
+            );
+          case "p":
+            return (
+              <Text key={i} style={{ color: C.text2, fontSize: T.body, lineHeight: 21 }}>
+                <Spans kids={b.kids} size={T.body} color={C.text2} />
+              </Text>
+            );
+          case "code":
+            return (
+              /* Scrolled rather than wrapped, and this is the one place that
+                 differs from the diff: a diff line is short enough to wrap
+                 with a hanging indent, but a pasted block is often a table or
+                 a stack trace where a broken line is a wrong line. React
+                 Native has no text-indent to hang it with either. */
+              <ScrollView key={i} horizontal showsHorizontalScrollIndicator={false} style={{
+                backgroundColor: C.bg2, borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.sm,
+              }}>
+                <Text style={{ color: C.text2, fontFamily: MONO, fontSize: T.small, lineHeight: 18, padding: SPACE.md }}>
+                  {b.text}
+                </Text>
+              </ScrollView>
+            );
+          case "quote":
+            return (
+              <View key={i} style={{
+                borderLeftWidth: 3, borderLeftColor: C.border2,
+                paddingLeft: SPACE.md, gap: SPACE.sm,
+              }}>
+                <Blocks blocks={b.blocks} host={host} />
+              </View>
+            );
+          case "list":
+            return <Items key={i} list={b} host={host} />;
+          case "hr":
+            return <View key={i} style={{ height: 1, backgroundColor: C.border }} />;
+          case "image":
+            return <BodyImage key={i} src={b.src} alt={b.alt} host={host} />;
+          case "table":
+            return (
+              <ScrollView key={i} horizontal showsHorizontalScrollIndicator={false}
+                style={{ borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.sm, backgroundColor: C.bg2 }}
+              >
+                <View>
+                  <View style={{ flexDirection: "row", backgroundColor: C.bg3 }}>
+                    {b.head.map((cell, c) => (
+                      <Text key={c} style={{
+                        minWidth: 96, maxWidth: 220, padding: SPACE.sm,
+                        color: C.text, fontSize: T.small, fontWeight: "700",
+                      }}>
+                        <Spans kids={cell} size={T.small} color={C.text} />
+                      </Text>
+                    ))}
+                  </View>
+                  {b.rows.map((row, r) => (
+                    <View key={r} style={{ flexDirection: "row", borderTopWidth: 1, borderTopColor: C.border }}>
+                      {row.map((cell, c) => (
+                        <Text key={c} style={{
+                          minWidth: 96, maxWidth: 220, padding: SPACE.sm,
+                          color: C.text2, fontSize: T.small,
+                        }}>
+                          <Spans kids={cell} size={T.small} color={C.text2} />
+                        </Text>
+                      ))}
+                    </View>
+                  ))}
+                </View>
+              </ScrollView>
+            );
+        }
+      })}
+    </>
+  );
+}
+
+/**
+ * A body, rendered.
+ *
+ * `limit` caps how many blocks are drawn — a coverage table pasted into a
+ * comment is 46,551 characters at the desk, and text layout is what React
+ * Native spends its time on. The caller decides what "the rest" looks like,
+ * because only the caller knows whether there is room for an expander.
+ */
+export const Md = memo(function Md({ text, host, limit }: {
+  text: string;
+  host: Host | null;
+  limit?: number;
+}): React.ReactNode {
+  const blocks = parseMarkdown(text);
+  const shown = limit && blocks.length > limit ? blocks.slice(0, limit) : blocks;
+  if (!shown.length) return null;
+  return (
+    <View style={{ gap: SPACE.md }}>
+      <Blocks blocks={shown} host={host} />
+    </View>
+  );
+});
+
+/**
+ * What is behind the fold, so a caller can name it.
+ *
+ * A collapsed section has to give the reader enough to decide whether to open
+ * it; "Show more" under a hard cut does not. The next heading is the best
+ * single word for that, and the count covers a body with no headings at all.
+ */
+export function outline(text: string, limit: number): { hidden: number; nextHeading: string | null } {
+  const blocks = parseMarkdown(text);
+  const rest = blocks.slice(limit);
+  const heading = rest.find((b) => b.t === "h");
+  return {
+    hidden: rest.length,
+    nextHeading: heading && heading.t === "h" ? inlineText(heading.kids) : null,
+  };
+}

--- a/mobile/src/md/parse.ts
+++ b/mobile/src/md/parse.ts
@@ -57,14 +57,57 @@ const HTML_COMMENT = /<!--[\s\S]*?-->/g;
 
 const FENCE = /^(\s*)(```+|~~~+)\s*([^\s`]*)/;
 const HEADING = /^(#{1,6})\s+(.*)$/;
-const RULE = /^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/;
+/**
+ * `---`, `***`, `___` — three or more of one mark, spaces allowed between.
+ *
+ * A loop rather than `(?:\s*\1){2,}`, which is the same quadratic shape as the
+ * table rule above: a repeated group with an optional-space run inside it.
+ */
+function isBreak(line: string): boolean {
+  const body = line.trim();
+  if (body.length < 3) return false;
+  const mark = body[0]!;
+  if (mark !== "-" && mark !== "*" && mark !== "_") return false;
+  let seen = 0;
+  for (const ch of body) {
+    if (ch === mark) seen++;
+    else if (ch !== " " && ch !== "\t") return false;
+  }
+  return seen >= 3;
+}
 const QUOTE = /^\s{0,3}>\s?(.*)$/;
 const BULLET = /^(\s*)([-*+])\s+(.*)$/;
 const ORDERED = /^(\s*)(\d{1,9})[.)]\s+(.*)$/;
 const TASK = /^\[([ xX])\]\s+(.*)$/;
-/** A table's second row: `---`, `:--`, `--:` or `:-:`, per column. */
-const TABLE_RULE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)+\|?\s*$/;
+/** One column of a table's rule row: `---`, `:--`, `--:` or `:-:`. Anchored,
+ *  with a single quantifier and nothing ambiguous around it. */
+const RULE_CELL = /^:?-+:?$/;
+
+/**
+ * Is this the `| --- | --- |` row under a table's header?
+ *
+ * Split and checked rather than matched by one expression. The expression this
+ * replaced repeated a group that contained `\s*` on both sides of a `-{1,}`,
+ * which backtracks quadratically on a long line of dashes — and every line here
+ * comes from a pull request body, which is text a stranger wrote. Splitting on
+ * the pipes is linear whatever the line is.
+ */
+function isTableRule(line: string): boolean {
+  const cells = line.trim().replace(/^\|/, "").replace(/\|$/, "").split("|");
+  if (cells.length < 2) return false;
+  return cells.every((cell) => RULE_CELL.test(cell.trim()));
+}
 const IMAGE_ONLY = /^!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)$/;
+
+/** Does this line close a fence opened with `marker`? At least as many of the
+ *  same character, and nothing else. Built by hand rather than by compiling a
+ *  regex per line out of text somebody else wrote. */
+function closesFence(line: string, marker: string): boolean {
+  const body = line.trim();
+  if (body.length < marker.length) return false;
+  for (const ch of body) if (ch !== marker[0]) return false;
+  return true;
+}
 
 /** How far in a line is, with a tab counted as the four spaces a phone shows. */
 const indentOf = (s: string): number => {
@@ -108,7 +151,7 @@ function parseLines(lines: string[]): Block[] {
       const lang = fence[3] ? fence[3] : null;
       const body: string[] = [];
       i++;
-      while (i < lines.length && !new RegExp(`^\\s*${marker[0]}{${marker.length},}\\s*$`).test(lines[i]!)) {
+      while (i < lines.length && !closesFence(lines[i]!, marker)) {
         body.push(lines[i]!);
         i++;
       }
@@ -117,7 +160,7 @@ function parseLines(lines: string[]): Block[] {
       continue;
     }
 
-    if (RULE.test(line)) { out.push({ t: "hr" }); i++; continue; }
+    if (isBreak(line)) { out.push({ t: "hr" }); i++; continue; }
 
     const heading = HEADING.exec(line);
     if (heading) {
@@ -151,7 +194,7 @@ function parseLines(lines: string[]): Block[] {
 
     // A table is only a table with its rule row under the header; without one,
     // a line of pipes is a sentence about pipes.
-    if (line.includes("|") && i + 1 < lines.length && TABLE_RULE.test(lines[i + 1]!)) {
+    if (line.includes("|") && i + 1 < lines.length && isTableRule(lines[i + 1]!)) {
       const head = splitRow(line);
       const rows: Inline[][][] = [];
       i += 2;
@@ -172,7 +215,7 @@ function parseLines(lines: string[]): Block[] {
     const para: string[] = [];
     while (i < lines.length && lines[i]!.trim()) {
       const at = lines[i]!;
-      if (para.length && (HEADING.test(at) || RULE.test(at) || FENCE.test(at) || QUOTE.test(at)
+      if (para.length && (HEADING.test(at) || isBreak(at) || FENCE.test(at) || QUOTE.test(at)
         || BULLET.test(at) || ORDERED.test(at))) break;
       para.push(at.trim());
       i++;
@@ -260,9 +303,12 @@ const LINK = /^\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/;
 const IMAGE_INLINE = /^!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/;
 const AUTOLINK = /^<((?:https?):\/\/[^>\s]+)>/;
 /** A bare address, which is how the CU reference is written in this project's
- *  own template. Stops before trailing punctuation so a URL at the end of a
- *  sentence does not swallow the full stop. */
-const BARE_URL = /^(https?:\/\/[^\s<]+[^\s<.,:;!?)\]}"'])/;
+ *  own template. One quantifier and no lookahead: the two adjacent character
+ *  classes this used to end with overlap, which is the third quadratic shape in
+ *  this file. The trailing punctuation is trimmed below instead. */
+const BARE_URL = /^https?:\/\/[^\s<]+/;
+/** What a URL at the end of a sentence should not swallow. */
+const URL_TAIL = ".,:;!?)]}\"'";
 const STRONG = /^(\*\*|__)(?=\S)([\s\S]*?\S)\1/;
 const EM = /^(\*|_)(?=\S)([\s\S]*?\S)\1/;
 
@@ -317,9 +363,13 @@ export function parseInline(src: string): Inline[] {
     if (rest[0] === "h") {
       const bare = BARE_URL.exec(rest);
       if (bare) {
+        let href = bare[0];
+        while (href.length > "https://".length && URL_TAIL.includes(href[href.length - 1]!)) {
+          href = href.slice(0, -1);
+        }
         flush();
-        out.push({ t: "link", href: bare[1]!, kids: [{ t: "text", text: bare[1]! }] });
-        i += bare[0].length;
+        out.push({ t: "link", href, kids: [{ t: "text", text: href }] });
+        i += href.length;
         continue;
       }
     }

--- a/mobile/src/md/parse.ts
+++ b/mobile/src/md/parse.ts
@@ -50,10 +50,39 @@ export type Block =
   | { t: "table"; head: Inline[][]; rows: Inline[][][] }
   | { t: "image"; src: string; alt: string };
 
-/** `<!-- pr-template-nudge -->` opens a bot comment this app shows every day.
- *  Dropped rather than escaped: it is addressed to a machine, and printing it
- *  would be printing the one thing the author meant to hide. */
-const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+/**
+ * Drop HTML comments.
+ *
+ * `<!-- pr-template-nudge -->` opens a bot comment this app shows every day.
+ * Dropped rather than escaped: it is addressed to a machine, and printing it
+ * would be printing the one thing the author meant to hide.
+ *
+ * A scanner rather than a pattern. The obvious `/<!--[\s\S]*?-->/g` agrees with
+ * a browser on the comment a bot writes and disagrees on every short one: HTML
+ * ends a comment at `<!-->` and at `<!--->` before it has begun, and at `--!>`
+ * as well as at `-->`. A filter that misses those leaves the reader looking at
+ * markup the author hid, so this follows the parser browsers follow.
+ */
+function stripComments(src: string): string {
+  let out = "";
+  let at = 0;
+  for (;;) {
+    const open = src.indexOf("<!--", at);
+    if (open < 0) return out + src.slice(at);
+    out += src.slice(at, open);
+    let i = open + 4;
+    // `<!-->` and `<!--->` are a whole comment, empty and already closed.
+    if (src.startsWith(">", i)) { at = i + 1; continue; }
+    if (src.startsWith("->", i)) { at = i + 2; continue; }
+    for (;;) {
+      const dash = src.indexOf("--", i);
+      if (dash < 0) return out;          // unterminated: the rest is comment
+      if (src.startsWith("-->", dash)) { at = dash + 3; break; }
+      if (src.startsWith("--!>", dash)) { at = dash + 4; break; }
+      i = dash + 2;
+    }
+  }
+}
 
 const FENCE = /^(\s*)(```+|~~~+)\s*([^\s`]*)/;
 const HEADING = /^(#{1,6})\s+(.*)$/;
@@ -129,7 +158,7 @@ const indentOf = (s: string): number => {
  * same wherever it appears.
  */
 export function parseMarkdown(src: string): Block[] {
-  const text = (src ?? "").replace(HTML_COMMENT, "");
+  const text = stripComments(src ?? "");
   const lines = text.replace(/\r\n?/g, "\n").split("\n");
   return parseLines(lines);
 }

--- a/mobile/src/md/parse.ts
+++ b/mobile/src/md/parse.ts
@@ -1,0 +1,345 @@
+/*
+ * The markdown a pull request actually contains, and nothing else.
+ *
+ * Three screens used to print a body verbatim with a note saying markdown was
+ * not rendered because "half-rendered markup reads worse than what somebody
+ * wrote". That was true of half a renderer. What it cost was a checklist —
+ * every pull request in this project opens with one — read as a wall of
+ * `- [x]` and a description cut off at 1,200 characters.
+ *
+ * So this is deliberately not CommonMark. It is the constructs that turn up in
+ * a body, an issue and a card description, parsed line by line the way
+ * `model/diffLines.ts` parses a diff, and everything else kept as the text
+ * somebody typed. An unknown construct renders as itself; nothing is ever
+ * swallowed. That rule is what makes a bounded parser honest rather than
+ * lossy — the failure mode of a big one is a blank where a paragraph was.
+ *
+ * What is here: headings, paragraphs, bullet/ordered/task lists with nesting,
+ * fenced code, blockquotes, rules, tables, images, and inline code, links,
+ * bold and italic.
+ *
+ * What is not, on purpose: raw HTML (dropped, see below), footnotes,
+ * definition lists, setext headings, reference links, nested blockquotes
+ * inside lists. None of them has appeared in a body this app has shown, and
+ * each is a rule that can only be wrong in a way nobody would notice.
+ */
+
+export type Inline =
+  | { t: "text"; text: string }
+  | { t: "code"; text: string }
+  | { t: "link"; href: string; kids: Inline[] }
+  | { t: "strong"; kids: Inline[] }
+  | { t: "em"; kids: Inline[] };
+
+export interface ListItem {
+  /** `null` for an ordinary bullet; a task list carries its state. */
+  checked: boolean | null;
+  kids: Inline[];
+  /** A nested list under this item. One level is common in a checklist; the
+   *  parser allows any depth because refusing at two would be arbitrary. */
+  children: Block[];
+}
+
+export type Block =
+  | { t: "p"; kids: Inline[] }
+  | { t: "h"; level: number; kids: Inline[] }
+  | { t: "code"; text: string; lang: string | null }
+  | { t: "quote"; blocks: Block[] }
+  | { t: "list"; ordered: boolean; start: number; items: ListItem[] }
+  | { t: "hr" }
+  | { t: "table"; head: Inline[][]; rows: Inline[][][] }
+  | { t: "image"; src: string; alt: string };
+
+/** `<!-- pr-template-nudge -->` opens a bot comment this app shows every day.
+ *  Dropped rather than escaped: it is addressed to a machine, and printing it
+ *  would be printing the one thing the author meant to hide. */
+const HTML_COMMENT = /<!--[\s\S]*?-->/g;
+
+const FENCE = /^(\s*)(```+|~~~+)\s*([^\s`]*)/;
+const HEADING = /^(#{1,6})\s+(.*)$/;
+const RULE = /^\s{0,3}([-*_])(?:\s*\1){2,}\s*$/;
+const QUOTE = /^\s{0,3}>\s?(.*)$/;
+const BULLET = /^(\s*)([-*+])\s+(.*)$/;
+const ORDERED = /^(\s*)(\d{1,9})[.)]\s+(.*)$/;
+const TASK = /^\[([ xX])\]\s+(.*)$/;
+/** A table's second row: `---`, `:--`, `--:` or `:-:`, per column. */
+const TABLE_RULE = /^\s*\|?\s*:?-{1,}:?\s*(\|\s*:?-{1,}:?\s*)+\|?\s*$/;
+const IMAGE_ONLY = /^!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)$/;
+
+/** How far in a line is, with a tab counted as the four spaces a phone shows. */
+const indentOf = (s: string): number => {
+  let n = 0;
+  for (const ch of s) {
+    if (ch === " ") n += 1;
+    else if (ch === "\t") n += 4;
+    else break;
+  }
+  return n;
+};
+
+/**
+ * Turn a body into blocks.
+ *
+ * Line-based and single-pass, with one lookahead for a table's rule row. The
+ * only recursion is into a blockquote and into a nested list, both of which
+ * re-enter here with the outer marker stripped — so a construct behaves the
+ * same wherever it appears.
+ */
+export function parseMarkdown(src: string): Block[] {
+  const text = (src ?? "").replace(HTML_COMMENT, "");
+  const lines = text.replace(/\r\n?/g, "\n").split("\n");
+  return parseLines(lines);
+}
+
+function parseLines(lines: string[]): Block[] {
+  const out: Block[] = [];
+  let i = 0;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+
+    if (!line.trim()) { i++; continue; }
+
+    // Fenced code first: everything inside it is text, including what would
+    // otherwise be a heading or a list.
+    const fence = FENCE.exec(line);
+    if (fence) {
+      const marker = fence[2]!;
+      const lang = fence[3] ? fence[3] : null;
+      const body: string[] = [];
+      i++;
+      while (i < lines.length && !new RegExp(`^\\s*${marker[0]}{${marker.length},}\\s*$`).test(lines[i]!)) {
+        body.push(lines[i]!);
+        i++;
+      }
+      i++; // the closing fence, or the end of the text
+      out.push({ t: "code", text: body.join("\n"), lang });
+      continue;
+    }
+
+    if (RULE.test(line)) { out.push({ t: "hr" }); i++; continue; }
+
+    const heading = HEADING.exec(line);
+    if (heading) {
+      out.push({ t: "h", level: heading[1]!.length, kids: parseInline(heading[2]!.replace(/\s+#+\s*$/, "")) });
+      i++;
+      continue;
+    }
+
+    const quote = QUOTE.exec(line);
+    if (quote) {
+      const body: string[] = [];
+      while (i < lines.length) {
+        const q = QUOTE.exec(lines[i]!);
+        if (q) { body.push(q[1]!); i++; continue; }
+        // A blank line ends the quote; a plain line does not, because GitHub's
+        // "lazy continuation" lets a wrapped sentence lose its `>`.
+        if (!lines[i]!.trim()) break;
+        body.push(lines[i]!);
+        i++;
+      }
+      out.push({ t: "quote", blocks: parseLines(body) });
+      continue;
+    }
+
+    if (BULLET.test(line) || ORDERED.test(line)) {
+      const [list, next] = parseList(lines, i);
+      out.push(list);
+      i = next;
+      continue;
+    }
+
+    // A table is only a table with its rule row under the header; without one,
+    // a line of pipes is a sentence about pipes.
+    if (line.includes("|") && i + 1 < lines.length && TABLE_RULE.test(lines[i + 1]!)) {
+      const head = splitRow(line);
+      const rows: Inline[][][] = [];
+      i += 2;
+      while (i < lines.length && lines[i]!.includes("|") && lines[i]!.trim()) {
+        rows.push(splitRow(lines[i]!));
+        i++;
+      }
+      out.push({ t: "table", head, rows });
+      continue;
+    }
+
+    const image = IMAGE_ONLY.exec(line.trim());
+    if (image) { out.push({ t: "image", alt: image[1]!, src: image[2]! }); i++; continue; }
+
+    // A paragraph runs to the blank line, or to the first line that starts
+    // something else — otherwise a list written straight under a sentence, which
+    // is how people write them, is eaten by the sentence.
+    const para: string[] = [];
+    while (i < lines.length && lines[i]!.trim()) {
+      const at = lines[i]!;
+      if (para.length && (HEADING.test(at) || RULE.test(at) || FENCE.test(at) || QUOTE.test(at)
+        || BULLET.test(at) || ORDERED.test(at))) break;
+      para.push(at.trim());
+      i++;
+    }
+    out.push({ t: "p", kids: parseInline(para.join(" ")) });
+  }
+
+  return out;
+}
+
+/** One list, and where it ends. Items at a deeper indent belong to the item
+ *  above them and are parsed as their own blocks. */
+function parseList(lines: string[], from: number): [Block, number] {
+  const first = BULLET.exec(lines[from]!) ?? ORDERED.exec(lines[from]!);
+  const ordered = !BULLET.test(lines[from]!);
+  const baseIndent = indentOf(lines[from]!);
+  const start = ordered ? Number(first![2]) : 1;
+  const items: ListItem[] = [];
+  let i = from;
+
+  while (i < lines.length) {
+    const line = lines[i]!;
+    if (!line.trim()) {
+      // A blank line inside a list is only a break if what follows is not a
+      // deeper line: `- a\n\n- b` is one list to every reader.
+      const nextAt = lines[i + 1];
+      if (!nextAt || (!BULLET.test(nextAt) && !ORDERED.test(nextAt))) break;
+      i++;
+      continue;
+    }
+    const m = BULLET.exec(line) ?? ORDERED.exec(line);
+    if (!m) break;
+    const indent = indentOf(line);
+    if (indent < baseIndent) break;
+    if (indent > baseIndent) {
+      // Deeper: everything at this indent or more belongs to the last item.
+      const nested: string[] = [];
+      while (i < lines.length && (indentOf(lines[i]!) > baseIndent || !lines[i]!.trim())) {
+        if (!lines[i]!.trim() && !(lines[i + 1] && indentOf(lines[i + 1]!) > baseIndent)) break;
+        nested.push(lines[i]!.slice(baseIndent + 1));
+        i++;
+      }
+      const owner = items[items.length - 1];
+      if (owner) owner.children.push(...parseLines(nested));
+      continue;
+    }
+    // An ordered list cannot become a bullet list halfway down; that is a new
+    // list and the caller will pick it up.
+    if (ordered !== !BULLET.test(line)) break;
+
+    const rest = m[3]!;
+    const task = TASK.exec(rest);
+    items.push({
+      checked: task ? task[1]!.toLowerCase() === "x" : null,
+      kids: parseInline(task ? task[2]! : rest),
+      children: [],
+    });
+    i++;
+  }
+
+  return [{ t: "list", ordered, start, items }, i];
+}
+
+/** The cells of one table row, without the outer pipes. */
+function splitRow(line: string): Inline[][] {
+  const trimmed = line.trim().replace(/^\|/, "").replace(/\|$/, "");
+  // Split on pipes that are not inside a code span, so `| a \| b |` and
+  // `` `a|b` `` both survive.
+  const cells: string[] = [];
+  let cell = "";
+  let code = false;
+  for (let i = 0; i < trimmed.length; i++) {
+    const ch = trimmed[i]!;
+    if (ch === "\\" && trimmed[i + 1] === "|") { cell += "|"; i++; continue; }
+    if (ch === "`") code = !code;
+    if (ch === "|" && !code) { cells.push(cell); cell = ""; continue; }
+    cell += ch;
+  }
+  cells.push(cell);
+  return cells.map((c) => parseInline(c.trim()));
+}
+
+const CODE_SPAN = /^(`+)([\s\S]*?)\1/;
+const LINK = /^\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/;
+const IMAGE_INLINE = /^!\[([^\]]*)\]\(([^)\s]+)(?:\s+"[^"]*")?\)/;
+const AUTOLINK = /^<((?:https?):\/\/[^>\s]+)>/;
+/** A bare address, which is how the CU reference is written in this project's
+ *  own template. Stops before trailing punctuation so a URL at the end of a
+ *  sentence does not swallow the full stop. */
+const BARE_URL = /^(https?:\/\/[^\s<]+[^\s<.,:;!?)\]}"'])/;
+const STRONG = /^(\*\*|__)(?=\S)([\s\S]*?\S)\1/;
+const EM = /^(\*|_)(?=\S)([\s\S]*?\S)\1/;
+
+/**
+ * The spans inside a line.
+ *
+ * Code first, always: what is inside a code span is text, and a glob written
+ * with two stars in one would otherwise turn the rest of the sentence bold.
+ */
+export function parseInline(src: string): Inline[] {
+  const out: Inline[] = [];
+  let text = "";
+  let i = 0;
+
+  const flush = (): void => { if (text) { out.push({ t: "text", text }); text = ""; } };
+
+  while (i < src.length) {
+    const rest = src.slice(i);
+
+    if (rest[0] === "\\" && rest.length > 1) { text += rest[1]; i += 2; continue; }
+
+    const code = CODE_SPAN.exec(rest);
+    if (code) { flush(); out.push({ t: "code", text: code[2]!.trim() }); i += code[0].length; continue; }
+
+    // An inline image is rare and cannot be laid out inside a sentence, so it
+    // reads as its alt text linked to the file — which is what a reader wants
+    // from `![build status](…)` anyway.
+    const img = IMAGE_INLINE.exec(rest);
+    if (img) {
+      flush();
+      out.push({ t: "link", href: img[2]!, kids: [{ t: "text", text: img[1] || img[2]! }] });
+      i += img[0].length;
+      continue;
+    }
+
+    const link = LINK.exec(rest);
+    if (link) {
+      flush();
+      out.push({ t: "link", href: link[2]!, kids: parseInline(link[1]!) });
+      i += link[0].length;
+      continue;
+    }
+
+    const auto = AUTOLINK.exec(rest);
+    if (auto) {
+      flush();
+      out.push({ t: "link", href: auto[1]!, kids: [{ t: "text", text: auto[1]! }] });
+      i += auto[0].length;
+      continue;
+    }
+
+    if (rest[0] === "h") {
+      const bare = BARE_URL.exec(rest);
+      if (bare) {
+        flush();
+        out.push({ t: "link", href: bare[1]!, kids: [{ t: "text", text: bare[1]! }] });
+        i += bare[0].length;
+        continue;
+      }
+    }
+
+    const strong = STRONG.exec(rest);
+    if (strong) { flush(); out.push({ t: "strong", kids: parseInline(strong[2]!) }); i += strong[0].length; continue; }
+
+    const em = EM.exec(rest);
+    if (em) { flush(); out.push({ t: "em", kids: parseInline(em[2]!) }); i += em[0].length; continue; }
+
+    text += rest[0];
+    i++;
+  }
+
+  flush();
+  return out;
+}
+
+/** The plain text of a run of spans — for a row that has one line to give a
+ *  thread, and for tests that care about what was kept rather than how. */
+export function inlineText(kids: Inline[]): string {
+  return kids.map((k) => (k.t === "text" || k.t === "code" ? k.text : inlineText(k.kids))).join("");
+}

--- a/mobile/test/fleet-shapes.test.ts
+++ b/mobile/test/fleet-shapes.test.ts
@@ -33,6 +33,18 @@ const get = async <T,>(path: string): Promise<T> => {
   return (await response.json()) as T;
 };
 
+/**
+ * Boots the sidecar and waits for it to answer.
+ *
+ * The wait below budgets twenty seconds for a cold server; the hook around it
+ * had bun's default five, so on a loaded runner the boot was still going when
+ * the hook was killed and every test in this file went with it — measured on
+ * ubuntu-latest as `(fail) (unnamed) [5000.53ms] — a beforeEach/afterEach hook
+ * timed out for this test`, with nothing in it naming the file. The same
+ * failure `pane-line.test.ts` carries a comment about, and the same fix: the
+ * hook outlasts its own wait, so a boot that really is broken fails with the
+ * sentence at the end rather than as an unnamed timeout.
+ */
 beforeAll(async () => {
   dir = mkdtempSync(join(tmpdir(), "agx-shapes-"));
   server = Bun.spawn(["bun", "run", "src/index.ts"], {
@@ -61,7 +73,7 @@ beforeAll(async () => {
     await Bun.sleep(250);
   }
   throw new Error(`the server never answered ${ORIGIN}/health`);
-});
+}, 45_000);
 
 afterAll(async () => {
   server?.kill();

--- a/mobile/test/md-parse.test.ts
+++ b/mobile/test/md-parse.test.ts
@@ -1,0 +1,169 @@
+/*
+ * The markdown parser, tested on the bodies this app actually shows.
+ *
+ * Every fixture below is the shape of something real: this project's own pull
+ * request template, a review bot's finding with a table, a description with a
+ * screenshot in it. A parser tested on invented markdown passes and then meets
+ * a checklist it renders as a wall of `- [x]`.
+ */
+import { describe, expect, test } from "bun:test";
+import { inlineText, parseInline, parseMarkdown, type Block } from "../src/md/parse.ts";
+
+const md = (...lines: string[]): string => lines.join("\n");
+
+const only = <T extends Block["t"]>(blocks: Block[], t: T): Extract<Block, { t: T }>[] =>
+  blocks.filter((b): b is Extract<Block, { t: T }> => b.t === t);
+
+describe("the checklist every pull request here opens with", () => {
+  const body = md(
+    "## Checklist",
+    "Please check the following items before submitting your PR:",
+    "",
+    "- [x] I have followed the [Checks before submitting a Pull Request](https://github.com/x/y/blob/master/docs/submit.md) document.",
+    "- [x] I have added the necessary tests for this feature, if needed.",
+    "- [ ] I have updated the documentation accordingly, if needed.",
+    "- [ ] If there are changes in prompts, I have added the `Evals` label so CI runs the eval suite.",
+    "",
+    "## CU reference",
+    "",
+    "https://app.clickup.com/t/14295188/PROJ-18040",
+  );
+
+  const blocks = parseMarkdown(body);
+
+  test("the boxes are state, not text", () => {
+    const [list] = only(blocks, "list");
+    expect(list!.items.map((i) => i.checked)).toEqual([true, true, false, false]);
+  });
+
+  test("an item keeps its link and its code span", () => {
+    const [list] = only(blocks, "list");
+    expect(list!.items[0]!.kids.some((k) => k.t === "link")).toBe(true);
+    expect(inlineText(list!.items[3]!.kids)).toContain("Evals");
+    expect(list!.items[3]!.kids.some((k) => k.t === "code" && k.text === "Evals")).toBe(true);
+  });
+
+  test("both headings survive, at their own level", () => {
+    expect(only(blocks, "h").map((h) => [h.level, inlineText(h.kids)]))
+      .toEqual([[2, "Checklist"], [2, "CU reference"]]);
+  });
+
+  test("the bare CU address is a link — it is written without brackets", () => {
+    const last = blocks[blocks.length - 1]!;
+    expect(last.t).toBe("p");
+    expect(last.t === "p" && last.kids[0]!.t === "link").toBe(true);
+    expect(last.t === "p" && last.kids[0]!.t === "link" && last.kids[0]!.href)
+      .toBe("https://app.clickup.com/t/14295188/PROJ-18040");
+  });
+
+  test("a sentence directly above a list stays a sentence", () => {
+    const [para] = only(blocks, "p");
+    expect(inlineText(para!.kids)).toBe("Please check the following items before submitting your PR:");
+  });
+});
+
+describe("what a review bot writes", () => {
+  const body = md(
+    "<!-- pr-template-nudge -->",
+    "**[High]** `tasks.py` — a second join can be scheduled alongside the first.",
+    "",
+    "| Alert | Package | Patched |",
+    "| --- | --- | --- |",
+    "| #2 | `image-size` | none exists |",
+    "| #5 | `query-string` | 0.5.0 |",
+    "",
+    "```python",
+    "# not a heading, and not a list",
+    "- cache.set(key, True, timeout=300)",
+    "```",
+  );
+
+  const blocks = parseMarkdown(body);
+
+  test("the machine-addressed comment is dropped, not printed", () => {
+    expect(JSON.stringify(blocks)).not.toContain("pr-template-nudge");
+  });
+
+  test("the table keeps its header and every row", () => {
+    const [table] = only(blocks, "table");
+    expect(table!.head.map(inlineText)).toEqual(["Alert", "Package", "Patched"]);
+    expect(table!.rows).toHaveLength(2);
+    expect(table!.rows[0]!.map(inlineText)).toEqual(["#2", "image-size", "none exists"]);
+  });
+
+  test("a fence is text, whatever it looks like inside", () => {
+    const [code] = only(blocks, "code");
+    expect(code!.lang).toBe("python");
+    expect(code!.text).toContain("- cache.set(key, True, timeout=300)");
+    expect(only(blocks, "list")).toHaveLength(0);
+  });
+
+  test("severity stays bold and the file stays code", () => {
+    const [para] = only(blocks, "p");
+    expect(para!.kids[0]!.t).toBe("strong");
+    expect(para!.kids.some((k) => k.t === "code" && k.text === "tasks.py")).toBe(true);
+  });
+});
+
+describe("nesting, quotes and images", () => {
+  test("a sub-list belongs to the item above it, not to the list", () => {
+    const [list] = only(parseMarkdown(md(
+      "- Reproduced on three calls",
+      "  - all Spanish",
+      "  - all redacted",
+      "- The pro's inbox shows no attachment",
+    )), "list");
+    expect(list!.items).toHaveLength(2);
+    const [nested] = only(list!.items[0]!.children, "list");
+    expect(nested!.items.map((i) => inlineText(i.kids))).toEqual(["all Spanish", "all redacted"]);
+  });
+
+  test("a numbered list keeps the number it started at", () => {
+    const [list] = only(parseMarkdown(md("3. third", "4. fourth")), "list");
+    expect(list!.ordered).toBe(true);
+    expect(list!.start).toBe(3);
+  });
+
+  test("a quote is its own blocks, and a wrapped line stays in it", () => {
+    const [quote] = only(parseMarkdown(md("> Measured rather than argued,", "and the answer is cost.")), "quote");
+    expect(inlineText(only(quote!.blocks, "p")[0]!.kids)).toBe("Measured rather than argued, and the answer is cost.");
+  });
+
+  test("a screenshot on its own line is an image, with its source kept whole", () => {
+    const [image] = only(parseMarkdown("![the pro's empty inbox](https://github.com/user-attachments/assets/9f2c.png)"), "image");
+    expect(image!.alt).toBe("the pro's empty inbox");
+    expect(image!.src).toBe("https://github.com/user-attachments/assets/9f2c.png");
+  });
+
+  test("a rule is a rule, and three dashes under text are not", () => {
+    expect(only(parseMarkdown("---"), "hr")).toHaveLength(1);
+    expect(only(parseMarkdown(md("Heading", "---")), "hr")).toHaveLength(1);
+  });
+});
+
+describe("nothing is swallowed", () => {
+  test("an unknown construct survives as the text somebody typed", () => {
+    const [para] = only(parseMarkdown("A footnote[^1] and <kbd>Ctrl</kbd> stay readable."), "p");
+    expect(inlineText(para!.kids)).toBe("A footnote[^1] and <kbd>Ctrl</kbd> stay readable.");
+  });
+
+  test("an unclosed fence takes the rest of the body rather than losing it", () => {
+    const [code] = only(parseMarkdown(md("```", "still here")), "code");
+    expect(code!.text).toBe("still here");
+  });
+
+  test("an escaped marker is a character, not emphasis", () => {
+    expect(inlineText(parseInline("2 \\* 3 \\* 4"))).toBe("2 * 3 * 4");
+  });
+
+  test("a path inside code does not turn the sentence bold", () => {
+    const kids = parseInline("`**/*.ts` and then plain text");
+    expect(kids[0]!.t).toBe("code");
+    expect(kids.some((k) => k.t === "strong")).toBe(false);
+  });
+
+  test("an empty body is no blocks rather than an empty paragraph", () => {
+    expect(parseMarkdown("")).toEqual([]);
+    expect(parseMarkdown("\n\n  \n")).toEqual([]);
+  });
+});

--- a/mobile/test/md-parse.test.ts
+++ b/mobile/test/md-parse.test.ts
@@ -105,6 +105,43 @@ describe("what a review bot writes", () => {
   });
 });
 
+describe("an HTML comment is hidden the way a browser hides it", () => {
+  const gone = (body: string, marker = "secret"): void => {
+    expect(JSON.stringify(parseMarkdown(body))).not.toContain(marker);
+  };
+
+  test("the ordinary one, on its own line and inline", () => {
+    gone("<!-- secret -->");
+    gone("before <!-- secret --> after");
+    expect(inlineText(only(parseMarkdown("before <!-- secret --> after"), "p")[0]!.kids))
+      .toBe("before  after");
+  });
+
+  test("the short forms a browser closes early", () => {
+    // `<!-->` and `<!--->` are whole comments; what follows them is text.
+    expect(inlineText(only(parseMarkdown("<!-->secret is text"), "p")[0]!.kids)).toBe("secret is text");
+    expect(inlineText(only(parseMarkdown("<!--->secret is text"), "p")[0]!.kids)).toBe("secret is text");
+  });
+
+  test("`--!>` closes one too, so what follows is not left hidden", () => {
+    expect(inlineText(only(parseMarkdown("<!-- x --!>shown"), "p")[0]!.kids)).toBe("shown");
+  });
+
+  test("dashes inside a comment do not close it", () => {
+    gone("<!-- secret --- still secret -->");
+    expect(parseMarkdown("<!-- a --- b -->post")[0]).toEqual({ t: "p", kids: [{ t: "text", text: "post" }] });
+  });
+
+  test("an unterminated comment takes the rest, rather than printing it", () => {
+    gone(md("intro", "<!-- secret", "secret too"));
+    expect(inlineText(only(parseMarkdown(md("intro", "<!-- secret")), "p")[0]!.kids)).toBe("intro");
+  });
+
+  test("a lone `<!--` in a code span is still hidden — and nothing throws", () => {
+    expect(() => parseMarkdown("`<!--` and `-->`")).not.toThrow();
+  });
+});
+
 describe("nesting, quotes and images", () => {
   test("a sub-list belongs to the item above it, not to the list", () => {
     const [list] = only(parseMarkdown(md(
@@ -193,5 +230,7 @@ describe("a hostile body cannot hang the screen", () => {
   under("an address with a tail of punctuation", `https://x.example/${"a".repeat(6000)}.....`);
   under("a run of backticks that closes nothing", `${"`".repeat(4000)}text`);
   under("emphasis that is never closed", `**${"a ".repeat(4000)}`);
+  under("a thousand comment openings that never close", `${"<!--".repeat(1000)}text`);
+  under("a comment full of dashes", `<!-- ${"-".repeat(8000)} -->tail`);
   under("four hundred lines of shifting indent", Array.from({ length: 400 }, (_, i) => `${" ".repeat(i % 20)}- item`).join("\n"));
 });

--- a/mobile/test/md-parse.test.ts
+++ b/mobile/test/md-parse.test.ts
@@ -167,3 +167,31 @@ describe("nothing is swallowed", () => {
     expect(parseMarkdown("\n\n  \n")).toEqual([]);
   });
 });
+
+/*
+ * A body is text a stranger wrote, so the parser's cost has to stay linear in
+ * its length. Three of these lines used to be quadratic: a table's rule row and
+ * a thematic break both repeated a group with an optional-space run inside it,
+ * and a bare address ended in two overlapping character classes. CodeQL called
+ * the first one on the way in.
+ *
+ * The bound is deliberately loose. It is not a benchmark — it is the difference
+ * between milliseconds and a phone that stops answering, and a tight number
+ * here would fail on a busy runner while proving nothing extra.
+ */
+describe("a hostile body cannot hang the screen", () => {
+  const under = (name: string, body: string): void => {
+    test(name, () => {
+      const started = performance.now();
+      parseMarkdown(body);
+      expect(performance.now() - started).toBeLessThan(1000);
+    });
+  };
+
+  under("a rule row of four thousand dashes", `| ${"-".repeat(4000)}${" ".repeat(200)}${"|".repeat(200)}`);
+  under("four thousand dashes and spaces", "- ".repeat(4000));
+  under("an address with a tail of punctuation", `https://x.example/${"a".repeat(6000)}.....`);
+  under("a run of backticks that closes nothing", `${"`".repeat(4000)}text`);
+  under("emphasis that is never closed", `**${"a ".repeat(4000)}`);
+  under("four hundred lines of shifting indent", Array.from({ length: 400 }, (_, i) => `${" ".repeat(i % 20)}- item`).join("\n"));
+});


### PR DESCRIPTION
## What does this PR do?

Three screens printed a body verbatim, each with a comment saying why: markdown was not rendered because *"half-rendered markup reads worse than what somebody wrote"*. That is true of half a renderer, and what it cost is specific — the checklist every pull request in this project opens with, read as a wall of `- [x]`, and a description cut off at character 1,200, mid-word, with no way to see the rest.

So this adds a parser for the constructs that actually turn up in a body, an issue and a card description, and a view that draws them in the app's own type and colour.

It is deliberately not CommonMark. It is line-based, the way `model/diffLines.ts` parses a diff, and its rule is that **nothing is ever swallowed**: an unknown construct renders as the text somebody typed. The failure mode of a large parser is a blank where a paragraph was, which is worse than the markup it was meant to fix.

Three things in the view are not decoration:

- **A task list draws real boxes.** "Is that one ticked" is the question a checklist exists to answer.
- **A table scrolls inside its own box, and so does a fenced block.** Those two scroll sideways; the page never does.
- **An image goes through `/prs/asset`.** GitHub's attachment host answers 404 without the token the sidecar attaches, so a screenshot loaded directly is a broken box on every phone.

The fold changes from characters to **blocks**, and the expander names what is behind it — "CU reference and 2 more" rather than "Show more" — because a collapsed section has to give the reader enough to decide whether to open it. The issue screen keeps no cap at all: an issue is read, not skimmed.

## A body is text a stranger wrote

Two rounds of that, both raised by CodeQL on the way in and both real.

**Backtracking.** Three patterns were quadratic — a table's rule row and a thematic break each repeated a group with an optional-space run inside it, and a bare address ended in two overlapping character classes. They are linear scanners now, and the closing fence stopped being a regex compiled per line out of somebody else's text. Six tests pin the property rather than the patterns: four thousand dashes, a run of backticks that closes nothing, emphasis that is never closed, four hundred lines of shifting indent. Each parses in under 8ms today and the bound is a second, because this is the difference between milliseconds and a phone that stops answering, not a benchmark.

**`js/bad-tag-filter`.** `/<!--[\s\S]*?-->/g` agrees with a browser on the comment a review bot writes and disagrees on every short one. `<!-->` and `<!--->` are whole comments, already closed — the pattern reads on and swallows the paragraphs after them. `--!>` closes a comment too, and the pattern does not stop there, so text the author meant to be read stays hidden. An unterminated `<!--` is a comment to the end of the input, and the pattern matches nothing and prints the markup instead. It is a scanner now, following the rules a browser follows, with no regex left for the rule to fire on.

## And one test that was not this change's

The `mobile` job failed here with `(fail) (unnamed) [5000.53ms] — a beforeEach/afterEach hook timed out for this test`, one line with nothing in it naming a file. It is `fleet-shapes.test.ts`: its `beforeAll` spawns a real sidecar and polls `/health` for twenty seconds, inside a hook bun gives five. On a loaded runner the boot was still going at five, so all five of that file's tests were lost — the shapes check that exists because a wrapper mismatch took the whole app down. `pane-line.test.ts` already carries a comment about the same symptom, and this is the same fix: the hook outlasts its own wait, so a server that really does not come up fails with the sentence the loop throws.

## How was it tested?

- `bun test` in `mobile/` — **714 pass, 41 skip, 0 fail** across 55 files, including 33 parser tests.
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on every touched file — clean.
- The parser fixtures are the shape of real things rather than invented markdown: this project's own PR template with its checklist and bare CU address, a review bot's finding with a table and an HTML comment, a body with a screenshot, a fence containing what looks like a list, an unclosed fence, and a sub-list under an item.

Bodies render at their real size on device — I have not run this on a handset, so the case worth a second pair of eyes is a very long description, where the block cap is the only thing standing between the screen and a few hundred text nodes.