### PR TITLE
feat(phone): put the conversation on the line it is about

### DIFF
--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -25,18 +25,35 @@
  * GitHub only accepts a comment on a line the diff touches, and drawing them
  * as pressable would be offering something that fails on send.
  *
+ * ── what has already been said, on the line it was said about ────────────
+ * A conversation lives on a line, and until this it lived on another screen:
+ * you read the code here, and the remark about it two taps away, with nothing
+ * on the diff to say there was one. So the threads are drawn where they
+ * belong — one line each, opened by a tap into the same card the threads
+ * screen draws, answered and resolved from here.
+ *
+ * Your own queued remarks are drawn the same way, in the review's colour
+ * rather than a thread's: they are not a conversation yet and nobody else can
+ * see them. Before this they vanished into a counter, which is how a remark
+ * gets written twice.
+ *
+ * A thread whose lines have changed underneath it has no line to sit on —
+ * GitHub clears it — and goes above the file rather than onto whatever now
+ * carries that number.
+ *
  * ── the whole diff arrives as one string ─────────────────────────────────
  * `/prs/diff` answers with the output of `gh pr diff`. Parsing it is
  * src/model/diffLines.ts, which is where the line-number arithmetic and its
  * tests live — a comment anchored to the wrong line is a remark about code the
  * author did not write.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   ActivityIndicator, KeyboardAvoidingView, Pressable, ScrollView, Text, TextInput, View,
 } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
+import type { PrDetail } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
@@ -44,7 +61,12 @@ import {
   commentableLine, fileLabel, parseDiff, type DiffFile, type DiffLine,
 } from "../../src/model/diffLines.ts";
 import { gapLabel, gapsIn, nextSlice, type Gap } from "../../src/model/expand.ts";
-import { draftCount, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
+import { draft, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
+import { threadsOnFile } from "../../src/model/threads.ts";
+import { ApplyConfirm } from "../../src/review/ApplyConfirm.tsx";
+import { ThreadCard } from "../../src/review/ThreadCard.tsx";
+import { ThreadMarker } from "../../src/review/ThreadMarker.tsx";
+import { useThreadActions } from "../../src/review/useThreadActions.ts";
 import { Btn, Card, Label, Note, Sheet, SheetRow, TAP } from "../../src/ui.tsx";
 import { C, MONO, RADIUS, SPACE, T, tint } from "../../src/theme.ts";
 
@@ -119,30 +141,82 @@ export default function DiffScreen(): React.ReactNode {
   const [picking, setPicking] = useState(false);
   /** The line a comment is being written against, and what has been typed. */
   const [writing, setWriting] = useState<{ line: number; body: string } | null>(null);
-  /** Only to repaint the counter — the draft itself lives in the module, so it
-   *  survives this screen being left and come back to. */
-  const [queued, setQueued] = useState(0);
+  /** A copy of the draft, only so this screen repaints — the draft itself
+   *  lives in the module, so it survives leaving here and coming back.
+   *
+   *  The whole list rather than its count, because a remark you have written
+   *  and cannot see is a remark you write twice. They are drawn on their own
+   *  lines below. */
+  const [queued, setQueued] = useState<LineNote[]>([]);
 
   const key = `${root}#${number}`;
 
-  useEffect(() => { setQueued(draftCount(key)); }, [key]);
+  useEffect(() => { setQueued(draft(key)); }, [key]);
 
-  useEffect(() => {
+  /** Which read is the current one. Two can be in flight — the first on
+   *  arrival, a second after a suggestion is committed — and the answer that
+   *  arrives last is not necessarily the one that was asked for last. */
+  const diffRead = useRef(0);
+
+  const loadDiff = useCallback(async (): Promise<void> => {
     if (!host || !number || !root) return;
-    let gone = false;
-    void (async () => {
-      const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
-      const answer = await ask<{ ok: boolean; text?: string; error?: string }>(
-        host, `/prs/diff?${query}`,
-      );
-      if (gone) return;
-      if (!answer.ok) { setError(answer.error); return; }
-      if (!answer.value.ok) { setError(answer.value.error || "That diff could not be read."); return; }
-      setError(null);
-      setText(answer.value.text ?? "");
-    })();
-    return () => { gone = true; };
+    const mine = ++diffRead.current;
+    const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
+    const answer = await ask<{ ok: boolean; text?: string; error?: string }>(
+      host, `/prs/diff?${query}`,
+    );
+    if (mine !== diffRead.current) return;
+    if (!answer.ok) { setError(answer.error); return; }
+    if (!answer.value.ok) { setError(answer.value.error || "That diff could not be read."); return; }
+    setError(null);
+    setText(answer.value.text ?? "");
   }, [host, number, root]);
+
+  useEffect(() => { void loadDiff(); }, [loadDiff]);
+
+  /*
+   * The conversations, from the same detail the threads screen reads.
+   *
+   * A second request on this screen and not a shared one, because the two
+   * answers have different lifetimes: `/prs/diff` is the change and does not
+   * move while you read it, and a thread does — somebody replies, somebody
+   * resolves — and every write below re-reads exactly this. The server serves
+   * both stale-while-revalidate, so the cost of asking here is one cached
+   * answer, not one round trip to GitHub.
+   */
+  const [detail, setDetail] = useState<PrDetail | null>(null);
+
+  const loadThreads = useCallback(async (): Promise<void> => {
+    if (!host || !number || !root) return;
+    const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
+    const answer = await ask<{ ok: boolean; detail?: PrDetail; error?: string }>(host, `/prs/detail?${query}`);
+    // Deliberately quiet. The diff is the reason to be here; a pull request
+    // whose detail cannot be read still shows its change, with no markers.
+    if (answer.ok && answer.value.ok && answer.value.detail) setDetail(answer.value.detail);
+  }, [host, number, root]);
+
+  useEffect(() => { void loadThreads(); }, [loadThreads]);
+
+  /*
+   * After a write, both halves of the screen are re-read.
+   *
+   * The threads for the obvious reason — a reply has to appear, a resolve has
+   * to take. The DIFF because one of these three writes a commit: applying a
+   * suggestion changes the very lines under the card, and leaving them on
+   * screen as they were is showing code that no longer exists, directly above
+   * the conversation that just replaced it.
+   */
+  const reload = useCallback(async (): Promise<void> => {
+    await Promise.all([loadThreads(), loadDiff()]);
+  }, [loadThreads, loadDiff]);
+
+  const actions = useThreadActions({
+    host, root: root ?? "", number: number ?? "", reload,
+  });
+
+  /** Which thread is open. One at a time: two cards expanded in a diff is a
+   *  screen with no code left on it. */
+  const [reading, setReading] = useState<string | null>(null);
 
   const files = useMemo(() => parseDiff(text ?? ""), [text]);
 
@@ -155,6 +229,86 @@ export default function DiffScreen(): React.ReactNode {
   }, [path, files]);
 
   const file: DiffFile | undefined = files[at];
+
+  /** This file's conversations: the ones with a line to sit on, and the ones
+   *  whose lines have gone. */
+  const onFile = useMemo(
+    () => threadsOnFile(detail?.threads ?? [], file?.path ?? ""),
+    [detail, file],
+  );
+
+  /** How many are still open, per file — the number the picker needs so you
+   *  can find the file somebody is waiting on without opening all eleven. */
+  const openByPath = useMemo(() => {
+    const counts = new Map<string, number>();
+    for (const t of detail?.threads ?? []) {
+      if (t.isResolved) continue;
+      counts.set(t.path, (counts.get(t.path) ?? 0) + 1);
+    }
+    return counts;
+  }, [detail]);
+
+  /** One expanded card belongs to the file it was opened on. Moving to
+   *  another file leaves it behind rather than carrying it across. */
+  useEffect(() => { setReading(null); }, [at]);
+
+  /** What you have already written on this line, waiting to go with the
+   *  verdict. In the review's own colour rather than a thread's: it is not a
+   *  conversation yet, and nobody else can see it. */
+  const yoursOn = (line: number | null): React.ReactNode => {
+    if (line === null || !file) return null;
+    const mine = queued.filter((n) => n.path === file.path && n.line === line);
+    if (!mine.length) return null;
+    return mine.map((note, i) => (
+      <View
+        key={`${note.line}-${i}`}
+        style={{
+          marginLeft: 38, paddingLeft: SPACE.sm, paddingRight: SPACE.md, paddingVertical: SPACE.sm,
+          gap: SPACE.xs, backgroundColor: C.bg3,
+          borderLeftWidth: 3, borderLeftColor: C.warning,
+        }}
+      >
+        <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+          <Text style={{ color: C.warning, fontSize: T.eyebrow, fontWeight: "700", flex: 1 }}>
+            Yours · not sent yet
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel={`Remove your comment on line ${note.line}`}
+            onPress={() => drop(note)}
+            style={{ minHeight: TAP, justifyContent: "center", paddingLeft: SPACE.md }}
+          >
+            <Text style={{ color: C.text3, fontSize: T.eyebrow }}>Remove</Text>
+          </Pressable>
+        </View>
+        <Text style={{ color: C.text2, fontSize: T.small, lineHeight: 18 }}>{note.body}</Text>
+      </View>
+    ));
+  };
+
+  /** The markers under one line of code, and the card when one is open. */
+  const threadsOn = (line: number | null): React.ReactNode => {
+    if (line === null) return null;
+    const here = onFile.byLine.get(line);
+    if (!here?.length) return null;
+    return here.map((thread) => (
+      <View key={thread.id}>
+        <ThreadMarker
+          thread={thread}
+          open={reading === thread.id}
+          onPress={() => setReading((was) => (was === thread.id ? null : thread.id))}
+        />
+        {reading === thread.id ? (
+          <View style={{ padding: SPACE.md }}>
+            {/* No path header and no hunk: the file is in the bar above and
+                the code is the row this card is hanging from. Printing either
+                again pushes the words themselves off the screen. */}
+            <ThreadCard thread={thread} host={host} actions={actions} where={false} hunk={false} />
+          </View>
+        ) : null}
+      </View>
+    ));
+  };
 
   /*
    * The context fetched around this file's hunks, one entry per gap.
@@ -236,9 +390,15 @@ export default function DiffScreen(): React.ReactNode {
       line: writing.line,
       body: writing.body.trim(),
     };
-    setQueued(takeDraft(key, (was) => [...was.filter((n) => !(n.path === note.path && n.line === note.line)), note]).length);
+    setQueued(takeDraft(key, (was) => [...was.filter((n) => !(n.path === note.path && n.line === note.line)), note]));
     setWriting(null);
   }, [writing, file, key]);
+
+  /** Take one back. A queued remark is not on GitHub yet, so this is the whole
+   *  of undoing it — no call, and nothing to tell anybody. */
+  const drop = useCallback((note: LineNote): void => {
+    setQueued(takeDraft(key, (was) => was.filter((n) => !(n.path === note.path && n.line === note.line))));
+  }, [key]);
 
   /** One gap: what has already been fetched into it, and the offer to fetch
    *  more. Nothing at all when the file has no such gap, which is the ordinary
@@ -317,6 +477,23 @@ export default function DiffScreen(): React.ReactNode {
           </View>
         ) : null}
 
+        {/* The conversations this file has that no line can hold. GitHub
+            clears a thread's line when the code under it changes, and hanging
+            one on whatever now carries that number would be a remark about
+            code nobody was talking about — so they sit above the file, with
+            the hunk they were written against, which is the only copy of
+            those lines left anywhere. */}
+        {onFile.adrift.length ? (
+          <View style={{ padding: SPACE.lg, gap: SPACE.md }}>
+            <Label text={onFile.adrift.length === 1
+              ? "One conversation about lines that have changed"
+              : `${onFile.adrift.length} conversations about lines that have changed`} />
+            {onFile.adrift.map((thread) => (
+              <ThreadCard key={thread.id} thread={thread} host={host} actions={actions} />
+            ))}
+          </View>
+        ) : null}
+
         {file?.hunks.map((hunk, h) => (
           <View key={`${hunk.header}-${h}`}>
             {gapBefore(h)}
@@ -361,6 +538,9 @@ export default function DiffScreen(): React.ReactNode {
                       }}
                     >{line.text || " "}</Text>
                   </Pressable>
+
+                  {yoursOn(line.newNo ?? null)}
+                  {threadsOn(line.newNo ?? null)}
 
                   {open ? (
                     <View style={{
@@ -427,9 +607,9 @@ export default function DiffScreen(): React.ReactNode {
           disabled={at === 0}
           onPress={() => { setWriting(null); setAt((n) => Math.max(0, n - 1)); }}
         />
-        {queued > 0 ? (
+        {queued.length > 0 ? (
           <Btn
-            label={`Review · ${queued}`}
+            label={`Review · ${queued.length}`}
             tone="primary"
             style={{ flex: 1 }}
             onPress={() => router.push({
@@ -446,12 +626,29 @@ export default function DiffScreen(): React.ReactNode {
         />
       </View>
 
+      {actions.confirming ? (
+        <ApplyConfirm
+          thread={actions.confirming.thread}
+          text={actions.confirming.text}
+          branch={detail?.headRefName}
+          onCancel={actions.cancelApply}
+          onApply={() => { void actions.apply(); }}
+        />
+      ) : null}
+
       <Sheet open={picking} onClose={() => setPicking(false)} title="Files">
         {files.map((f, i) => (
           <SheetRow
             key={`${f.path}-${i}`}
             label={fileLabel(f)}
-            sub={f.binary ? "binary" : `+${f.additions} −${f.deletions}`}
+            sub={[
+              f.binary ? "binary" : `+${f.additions} −${f.deletions}`,
+              // The number that decides which file to open next, on the row
+              // that opens it.
+              openByPath.get(f.path)
+                ? `${openByPath.get(f.path)} open`
+                : null,
+            ].filter(Boolean).join(" · ")}
             on={i === at}
             onPress={() => { setAt(i); setWriting(null); setPicking(false); }}
           />

--- a/mobile/app/pr/threads.tsx
+++ b/mobile/app/pr/threads.tsx
@@ -8,12 +8,12 @@
  * verdict, but the moment somebody replied to one, the app had nothing to say
  * and handed you to a browser, signed out, on a page built for a mouse.
  *
- * Three things happen here, and each is one call the server already served for
- * the desk:
- *
- *   reply           `/prs/reply`            — into the thread, not as a new one
- *   resolve         `/prs/thread-resolved`  — and unresolve, the same button
- *   apply           `/prs/apply-suggestion` — commit the suggested lines
+ * ── this is the list; the diff has the same thing on the line ────────────
+ * A conversation is answered here or under the row of code it is about, and
+ * both draw `review/ThreadCard.tsx` and act through `useThreadActions` — the
+ * three writes and the re-read after them live there. What is left in this
+ * file is the list: which threads, in what order, and what to say when there
+ * are none.
  *
  * ── replies post immediately, and the diff's comments do not ─────────────
  * This looks like an inconsistency and is the opposite of one. A line comment
@@ -23,58 +23,20 @@
  * anything: it is one message into a conversation that already exists, it
  * stands on its own, and holding it back until some later verdict would be
  * holding an answer somebody is waiting for.
- *
- * ── applying a suggestion writes a commit to somebody's branch ───────────
- * So it asks first, and it says whose branch and which lines. The parsing —
- * which block, which range — is `shared/suggestion.ts`, and the range comes
- * from the THREAD rather than from anything in the block, because that is how
- * GitHub defines it. An outdated thread offers no Apply at all: the lines it
- * was written about are gone, and the number it still carries now points at
- * something nobody was talking about.
  */
 import { useCallback, useEffect, useMemo, useState } from "react";
-import { ActivityIndicator, KeyboardAvoidingView, Linking, Pressable, ScrollView, Text, TextInput, View } from "react-native";
+import { ActivityIndicator, KeyboardAvoidingView, ScrollView } from "react-native";
 import { Stack, useLocalSearchParams } from "expo-router";
-import * as Haptics from "expo-haptics";
-import type { PrActionResult, PrDetail, PrThread } from "../../../shared/types.ts";
-import { suggestionRange, suggestionsIn } from "../../../shared/suggestion.ts";
+import type { PrDetail } from "../../../shared/types.ts";
 import { ask } from "../../src/lib/api.ts";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
-import { since } from "../../src/lib/dates.ts";
-import { hunkTail, ordered, replyAnchor, whereOf } from "../../src/model/threads.ts";
-import { Btn, Card, Label, Note, TAP } from "../../src/ui.tsx";
-import { C, MONO, RADIUS, SCRIM, SPACE, T, tint } from "../../src/theme.ts";
-
-/** The diff hunk GitHub kept with the comment, trimmed to what fits.
- *  Kept because a reply written without seeing the code it is about is a reply
- *  about the wrong thing — and on an outdated thread this is the ONLY copy of
- *  those lines left anywhere in the app. */
-function Hunk({ text }: { text: string }): React.ReactNode {
-  const { lines: shown, clipped } = hunkTail(text);
-  return (
-    <View style={{ backgroundColor: C.bg, borderRadius: RADIUS.sm, paddingVertical: SPACE.xs }}>
-      {clipped ? (
-        <Text style={{ color: C.text4, fontSize: 10, fontFamily: MONO, paddingHorizontal: SPACE.sm }}>⋯</Text>
-      ) : null}
-      {shown.map((line, i) => {
-        const add = line.startsWith("+");
-        const del = line.startsWith("-");
-        return (
-          <Text
-            key={i}
-            numberOfLines={1}
-            style={{
-              color: add ? C.success : del ? C.error : C.text3,
-              backgroundColor: add ? tint(C.success, 0.12) : del ? tint(C.error, 0.12) : "transparent",
-              fontSize: 10, fontFamily: MONO, lineHeight: 16, paddingHorizontal: SPACE.sm,
-            }}
-          >{line}</Text>
-        );
-      })}
-    </View>
-  );
-}
+import { ordered } from "../../src/model/threads.ts";
+import { ApplyConfirm } from "../../src/review/ApplyConfirm.tsx";
+import { ThreadCard } from "../../src/review/ThreadCard.tsx";
+import { useThreadActions } from "../../src/review/useThreadActions.ts";
+import { Card, Label, Note } from "../../src/ui.tsx";
+import { C, SPACE } from "../../src/theme.ts";
 
 export default function ThreadsScreen(): React.ReactNode {
   usePaletteTick(); // a scene repaints only if it asks — see use-palette.ts
@@ -83,17 +45,6 @@ export default function ThreadsScreen(): React.ReactNode {
 
   const [detail, setDetail] = useState<PrDetail | null>(null);
   const [error, setError] = useState<string | null>(null);
-  /** Which thread has its reply box open, and what is in it. */
-  const [writing, setWriting] = useState<{ id: string; body: string } | null>(null);
-  /** The thread id something is in flight for, so one row can say it is busy
-   *  without freezing the whole screen. */
-  const [busy, setBusy] = useState<string | null>(null);
-  const [said, setSaid] = useState<{ id: string; text: string; bad: boolean } | null>(null);
-  /** A suggestion waiting to be confirmed. Applying one writes a commit to
-   *  somebody else's branch, which is not something a single tap should do. */
-  const [confirming, setConfirming] = useState<{ thread: PrThread; text: string } | null>(null);
-
-  const mayWrite = host?.scope === "full";
 
   const load = useCallback(async (): Promise<void> => {
     if (!host || !number || !root) return;
@@ -110,77 +61,7 @@ export default function ThreadsScreen(): React.ReactNode {
 
   useEffect(() => { void load(); }, [load]);
 
-  /*
-   * One write, and then a re-read.
-   *
-   * Never an optimistic update. What a thread looks like after a reply is
-   * GitHub's answer and not this app's guess — a resolve can be refused by a
-   * branch rule, and a reply can land while somebody else resolves the thread
-   * underneath it. Re-reading costs one request on an action that already cost
-   * one, and it is the difference between a screen that reports and a screen
-   * that hopes.
-   */
-  const act = useCallback(async (
-    id: string, path: string, body: unknown, done: string,
-  ): Promise<boolean> => {
-    if (!host) return false;
-    setBusy(id);
-    setSaid(null);
-    const answer = await ask<PrActionResult>(host, path, { method: "POST", body });
-    if (!answer.ok || !answer.value.ok) {
-      setBusy(null);
-      setSaid({ id, bad: true, text: (answer.ok ? answer.value.error : answer.error) || "GitHub refused that." });
-      return false;
-    }
-    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
-    await load();
-    setBusy(null);
-    setSaid({ id, bad: false, text: done });
-    return true;
-  }, [host, load]);
-
-  const reply = useCallback(async (thread: PrThread): Promise<void> => {
-    const text = writing?.body.trim();
-    if (!text || writing?.id !== thread.id) return;
-    /*
-     * The REST reply endpoint takes the numeric id of a comment in the thread,
-     * and `PrThreadComment.id` is a GraphQL node id — the two are not
-     * interchangeable, which the shared type says out loud. Without a
-     * databaseId there is nothing to reply to, so the box is not offered.
-     */
-    const anchor = replyAnchor(thread);
-    if (anchor === null) {
-      setSaid({ id: thread.id, bad: true, text: "That thread carries no id to reply to." });
-      return;
-    }
-    const ok = await act(thread.id, "/prs/reply", { root, number: Number(number), commentId: anchor, body: text }, "Replied.");
-    if (ok) setWriting(null);
-  }, [act, writing, root, number]);
-
-  const setResolved = useCallback((thread: PrThread): void => {
-    void act(
-      thread.id, "/prs/thread-resolved",
-      { root, threadId: thread.id, resolved: !thread.isResolved },
-      thread.isResolved ? "Reopened." : "Resolved.",
-    );
-  }, [act, root]);
-
-  const applySuggestion = useCallback(async (): Promise<void> => {
-    if (!confirming) return;
-    const { thread, text } = confirming;
-    const range = suggestionRange(thread);
-    if (!range) return;
-    setConfirming(null);
-    await act(thread.id, "/prs/apply-suggestion", {
-      root, number: Number(number),
-      path: thread.path, startLine: range.startLine, line: range.line,
-      suggestion: text,
-      // Credited as a co-author on the commit, exactly as GitHub does it. The
-      // author of the SUGGESTION, which is the first comment in the thread and
-      // not whoever replied last.
-      author: thread.comments[0]?.author,
-    }, "Applied.");
-  }, [act, confirming, root, number]);
+  const actions = useThreadActions({ host, root: root ?? "", number: number ?? "", reload: load });
 
   const threads = useMemo(() => ordered(detail?.threads ?? []), [detail]);
   const open = threads.filter((t) => !t.isResolved).length;
@@ -210,132 +91,11 @@ export default function ThreadsScreen(): React.ReactNode {
           <Label text={open ? `${open} open · ${threads.length} in all` : `${threads.length} resolved`} />
         ) : null}
 
-        {threads.map((thread) => {
-          const range = suggestionRange(thread);
-          /* The FIRST suggestion in the thread, which is the one the range
-             belongs to. A later reply containing its own block is a different
-             proposal about the same lines, and applying it under the first
-             one's range would be applying something nobody chose. */
-          const suggestion = thread.comments
-            .flatMap((c) => suggestionsIn(c.body))
-            .at(0);
-          const canApply = mayWrite && !!suggestion && !!range && !thread.isResolved;
-          const canReply = mayWrite && replyAnchor(thread) !== null;
-          const note = said?.id === thread.id ? said : null;
-          const working = busy === thread.id;
+        {threads.map((thread) => (
+          <ThreadCard key={thread.id} thread={thread} host={host} actions={actions} now={now} />
+        ))}
 
-          return (
-            <Card key={thread.id} style={{ gap: SPACE.sm, opacity: thread.isResolved ? 0.6 : 1 }}>
-              <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
-                <Text
-                  numberOfLines={1}
-                  ellipsizeMode="head"
-                  style={{ color: C.text2, fontSize: T.small, fontFamily: MONO, flex: 1 }}
-                >{whereOf(thread)}</Text>
-                {thread.isResolved ? (
-                  <Text style={{ color: C.success, fontSize: T.eyebrow }}>resolved</Text>
-                ) : thread.isOutdated ? (
-                  <Text style={{ color: C.text4, fontSize: T.eyebrow }}>outdated</Text>
-                ) : null}
-              </View>
-
-              {thread.diffHunk ? <Hunk text={thread.diffHunk} /> : null}
-
-              {thread.comments.map((comment) => (
-                <View key={comment.id} style={{ gap: 2, paddingTop: SPACE.xs }}>
-                  <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
-                    <Text style={{ color: C.text, fontSize: T.small, fontWeight: "600" }}>
-                      {comment.author}{comment.isBot ? " · bot" : ""}
-                    </Text>
-                    <Text style={{ color: C.text4, fontSize: T.eyebrow }}>
-                      {since(comment.createdAt, now)}
-                    </Text>
-                  </View>
-                  <Text style={{ color: C.text2, fontSize: T.body, lineHeight: 20 }}>{comment.body}</Text>
-                </View>
-              ))}
-
-              {writing?.id === thread.id ? (
-                <View style={{ gap: SPACE.sm, paddingTop: SPACE.xs }}>
-                  <TextInput
-                    value={writing.body}
-                    onChangeText={(body) => setWriting({ id: thread.id, body })}
-                    placeholder="Reply"
-                    placeholderTextColor={C.text4}
-                    multiline
-                    autoFocus
-                    style={{
-                      minHeight: 64, borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.sm,
-                      backgroundColor: C.bg, color: C.text, padding: SPACE.sm, fontSize: T.body,
-                    }}
-                  />
-                  <View style={{ flexDirection: "row", gap: SPACE.sm }}>
-                    <Btn
-                      label="Send reply"
-                      tone="primary"
-                      style={{ flex: 1 }}
-                      busy={working}
-                      disabled={!writing.body.trim() || working}
-                      onPress={() => { void reply(thread); }}
-                    />
-                    <Btn label="Cancel" onPress={() => setWriting(null)} />
-                  </View>
-                  {/* Said where the difference bites: this one goes now, and
-                      the remarks written on the diff do not. */}
-                  <Note>A reply is posted on its own, straight away.</Note>
-                </View>
-              ) : (
-                <View style={{ flexDirection: "row", gap: SPACE.sm, paddingTop: SPACE.xs }}>
-                  <Btn
-                    label="Reply"
-                    style={{ flex: 1 }}
-                    disabled={!canReply || working}
-                    onPress={() => { setSaid(null); setWriting({ id: thread.id, body: "" }); }}
-                  />
-                  <Btn
-                    label={thread.isResolved ? "Reopen" : "Resolve"}
-                    tone={thread.isResolved ? "plain" : "good"}
-                    style={{ flex: 1 }}
-                    busy={working}
-                    disabled={!mayWrite || working}
-                    onPress={() => setResolved(thread)}
-                  />
-                </View>
-              )}
-
-              {canApply ? (
-                <Btn
-                  label={`Apply suggestion · ${thread.path.split("/").pop()}:${
-                    range!.startLine === range!.line ? range!.line : `${range!.startLine}-${range!.line}`
-                  }`}
-                  disabled={working}
-                  onPress={() => { setSaid(null); setConfirming({ thread, text: suggestion!.text }); }}
-                />
-              ) : null}
-
-              {suggestion && !range ? (
-                <Note>
-                  This thread carries a suggestion, and the lines it was written about are gone.
-                  Applying it would change code nobody was talking about.
-                </Note>
-              ) : null}
-
-              {note ? <Note tone={note.bad ? "bad" : "quiet"}>{note.text}</Note> : null}
-
-              {thread.url ? (
-                <Pressable
-                  onPress={() => { void Linking.openURL(thread.url!); }}
-                  accessibilityRole="button"
-                  style={{ minHeight: TAP, justifyContent: "center" }}
-                >
-                  <Text style={{ color: C.primary, fontSize: T.small }}>Open the thread on GitHub</Text>
-                </Pressable>
-              ) : null}
-            </Card>
-          );
-        })}
-
-        {!mayWrite && threads.length ? (
+        {!actions.mayWrite && threads.length ? (
           <Note>
             This phone is paired to read. Replying, resolving and applying a suggestion all write
             to GitHub, so they are off until it is paired again with write access.
@@ -343,38 +103,14 @@ export default function ThreadsScreen(): React.ReactNode {
         ) : null}
       </ScrollView>
 
-      {/* The confirmation, as a card over the list rather than a sheet: what it
-          is confirming is TEXT, and a sheet that has to scroll to show what you
-          are agreeing to is a sheet nobody reads to the bottom. */}
-      {confirming ? (
-        <View style={{
-          position: "absolute", left: 0, right: 0, bottom: 0, top: 0,
-          backgroundColor: SCRIM, justifyContent: "flex-end",
-        }}>
-          <View style={{
-            backgroundColor: C.bg2, borderTopLeftRadius: RADIUS.lg, borderTopRightRadius: RADIUS.lg,
-            padding: SPACE.lg, gap: SPACE.md, maxHeight: "80%",
-          }}>
-            <Label text="Commit this to the branch?" />
-            <Text style={{ color: C.text2, fontSize: T.small }}>
-              {whereOf(confirming.thread)} on {detail?.headRefName ?? "the head branch"}
-            </Text>
-            <ScrollView style={{ maxHeight: 220 }}>
-              <Text style={{
-                color: C.text, fontFamily: MONO, fontSize: 11, lineHeight: 17,
-                backgroundColor: C.bg, padding: SPACE.sm, borderRadius: RADIUS.sm,
-              }}>{confirming.text === "" ? "(removes those lines)" : confirming.text}</Text>
-            </ScrollView>
-            <Note>
-              It is committed through GitHub, credited to {confirming.thread.comments[0]?.author ?? "whoever wrote it"},
-              and refused if anybody has pushed since this was read.
-            </Note>
-            <View style={{ flexDirection: "row", gap: SPACE.sm }}>
-              <Btn label="Cancel" style={{ flex: 1 }} onPress={() => setConfirming(null)} />
-              <Btn label="Apply" tone="primary" style={{ flex: 1 }} onPress={() => { void applySuggestion(); }} />
-            </View>
-          </View>
-        </View>
+      {actions.confirming ? (
+        <ApplyConfirm
+          thread={actions.confirming.thread}
+          text={actions.confirming.text}
+          branch={detail?.headRefName}
+          onCancel={actions.cancelApply}
+          onApply={() => { void actions.apply(); }}
+        />
       ) : null}
     </KeyboardAvoidingView>
   );

--- a/mobile/src/model/threads.ts
+++ b/mobile/src/model/threads.ts
@@ -84,3 +84,73 @@ export function replyAnchor(thread: Pick<PrThread, "comments">): number | null {
   }
   return null;
 }
+
+/**
+ * The threads that belong on a file of the diff, and where each one sits.
+ *
+ * `line` is the thread's position in the file as this pull request leaves it —
+ * the RIGHT side, which is the side the numbers on the diff screen belong to.
+ * That makes the anchor a lookup and not arithmetic.
+ *
+ * A thread with no `line` is adrift, and that is not an error: GitHub clears
+ * it when the lines the conversation was about have changed underneath it. It
+ * cannot be drawn against a row of code that no longer says what it said, so
+ * it is handed back separately and the screen puts it at the top of the file,
+ * where it reads as "about this file, once" rather than as a remark about
+ * whatever line happens to be there now.
+ *
+ * Resolved threads are kept, and grouped like the rest. A resolved thread on a
+ * line is the record of an argument that was had about it, which is the thing
+ * you go looking for when the same line comes back a week later — the screen
+ * draws it collapsed rather than dropping it.
+ */
+export function threadsOnFile(threads: PrThread[], path: string): {
+  byLine: Map<number, PrThread[]>;
+  adrift: PrThread[];
+} {
+  const byLine = new Map<number, PrThread[]>();
+  const adrift: PrThread[] = [];
+  for (const thread of ordered(threads)) {
+    if (thread.path !== path) continue;
+    const line = thread.line;
+    if (typeof line !== "number") { adrift.push(thread); continue; }
+    const at = byLine.get(line);
+    if (at) at.push(thread);
+    else byLine.set(line, [thread]);
+  }
+  return { byLine, adrift };
+}
+
+/**
+ * The one line an unopened thread gets on the diff.
+ *
+ * A marker under a row of code has room for a name, a state and a few words,
+ * and those few words have to be enough to decide whether to open it. So it is
+ * the FIRST comment — the remark itself, not the last reply, which out of
+ * context is usually "done" — flattened to one line, with the number of
+ * replies after it.
+ */
+export function threadDigest(thread: PrThread): {
+  who: string;
+  gist: string;
+  replies: number;
+  state: "open" | "outdated" | "resolved";
+} {
+  const first = thread.comments[0];
+  /* Fenced blocks stand aside for the word "code": a marker is one line, and a
+     stack trace flattened into it says nothing while filling all of it. Split
+     on the fence rather than matched with a pattern — the segments between a
+     pair of fences are the odd ones, which is the whole rule. */
+  const parts = (first?.body ?? "").split("```");
+  const gist = parts
+    .filter((_, i) => i % 2 === 0)
+    .join(" code ")
+    .replace(/\s+/g, " ")
+    .trim();
+  return {
+    who: first?.author ?? "somebody",
+    gist,
+    replies: Math.max(0, thread.comments.length - 1),
+    state: thread.isResolved ? "resolved" : thread.isOutdated ? "outdated" : "open",
+  };
+}

--- a/mobile/src/review/ApplyConfirm.tsx
+++ b/mobile/src/review/ApplyConfirm.tsx
@@ -1,0 +1,56 @@
+/*
+ * "Commit this to the branch?" — the one question in the review flow that has
+ * to be asked out loud.
+ *
+ * Applying a suggestion writes a commit to somebody else's branch. Everything
+ * else here can be undone by saying something; that cannot, so it names whose
+ * branch, which lines, and who gets the credit, and it shows the text itself.
+ *
+ * A card over the screen rather than a sheet: what it is confirming is TEXT,
+ * and a sheet you have to scroll to see what you are agreeing to is a sheet
+ * nobody reads to the bottom.
+ */
+import { ScrollView, Text, View } from "react-native";
+import type { PrThread } from "../../../shared/types.ts";
+import { whereOf } from "../model/threads.ts";
+import { Btn, Label, Note } from "../ui.tsx";
+import { C, MONO, RADIUS, SCRIM, SPACE, T } from "../theme.ts";
+
+export function ApplyConfirm({ thread, text, branch, onCancel, onApply }: {
+  thread: PrThread;
+  text: string;
+  branch: string | null | undefined;
+  onCancel: () => void;
+  onApply: () => void;
+}): React.ReactNode {
+  return (
+    <View style={{
+      position: "absolute", left: 0, right: 0, bottom: 0, top: 0,
+      backgroundColor: SCRIM, justifyContent: "flex-end",
+    }}>
+      <View style={{
+        backgroundColor: C.bg2, borderTopLeftRadius: RADIUS.lg, borderTopRightRadius: RADIUS.lg,
+        padding: SPACE.lg, gap: SPACE.md, maxHeight: "80%",
+      }}>
+        <Label text="Commit this to the branch?" />
+        <Text style={{ color: C.text2, fontSize: T.small }}>
+          {whereOf(thread)} on {branch ?? "the head branch"}
+        </Text>
+        <ScrollView style={{ maxHeight: 220 }}>
+          <Text style={{
+            color: C.text, fontFamily: MONO, fontSize: 11, lineHeight: 17,
+            backgroundColor: C.bg, padding: SPACE.sm, borderRadius: RADIUS.sm,
+          }}>{text === "" ? "(removes those lines)" : text}</Text>
+        </ScrollView>
+        <Note>
+          It is committed through GitHub, credited to {thread.comments[0]?.author ?? "whoever wrote it"},
+          and refused if anybody has pushed since this was read.
+        </Note>
+        <View style={{ flexDirection: "row", gap: SPACE.sm }}>
+          <Btn label="Cancel" style={{ flex: 1 }} onPress={onCancel} />
+          <Btn label="Apply" tone="primary" style={{ flex: 1 }} onPress={onApply} />
+        </View>
+      </View>
+    </View>
+  );
+}

--- a/mobile/src/review/ThreadCard.tsx
+++ b/mobile/src/review/ThreadCard.tsx
@@ -1,0 +1,196 @@
+/*
+ * One conversation on a line, drawn the same wherever it appears.
+ *
+ * The threads screen lists these; the diff screen puts one under the row of
+ * code it is about. That is the whole reason this is a component and not part
+ * of a screen — a reply box that looks and behaves differently depending on
+ * which way you arrived at the same thread is two apps.
+ *
+ * Bodies go through the markdown renderer. A review comment is where a
+ * suggestion block lives, and a ```suggestion fence printed verbatim is the
+ * single worst thing this app used to show: five lines of markup wrapped at
+ * eleven points, with the code the person is proposing hidden inside it.
+ */
+import { Linking, Pressable, Text, TextInput, View } from "react-native";
+import type { PrThread } from "../../../shared/types.ts";
+import { suggestionRange, suggestionsIn } from "../../../shared/suggestion.ts";
+import { since } from "../lib/dates.ts";
+import type { Host } from "../lib/host.ts";
+import { Md } from "../md/Md.tsx";
+import { hunkTail, replyAnchor, whereOf } from "../model/threads.ts";
+import { Btn, Card, Note, TAP } from "../ui.tsx";
+import { C, MONO, RADIUS, SPACE, T, tint } from "../theme.ts";
+import type { ThreadActions } from "./useThreadActions.ts";
+
+/** The diff hunk GitHub kept with the comment, trimmed to what fits.
+ *  Kept because a reply written without seeing the code it is about is a reply
+ *  about the wrong thing — and on an outdated thread this is the ONLY copy of
+ *  those lines left anywhere in the app. */
+export function Hunk({ text }: { text: string }): React.ReactNode {
+  const { lines: shown, clipped } = hunkTail(text);
+  return (
+    <View style={{ backgroundColor: C.bg, borderRadius: RADIUS.sm, paddingVertical: SPACE.xs }}>
+      {clipped ? (
+        <Text style={{ color: C.text4, fontSize: 10, fontFamily: MONO, paddingHorizontal: SPACE.sm }}>⋯</Text>
+      ) : null}
+      {shown.map((line, i) => {
+        const add = line.startsWith("+");
+        const del = line.startsWith("-");
+        return (
+          <Text
+            key={i}
+            numberOfLines={1}
+            style={{
+              color: add ? C.success : del ? C.error : C.text3,
+              backgroundColor: add ? tint(C.success, 0.12) : del ? tint(C.error, 0.12) : "transparent",
+              fontSize: 10, fontFamily: MONO, lineHeight: 16, paddingHorizontal: SPACE.sm,
+            }}
+          >{line}</Text>
+        );
+      })}
+    </View>
+  );
+}
+
+/**
+ * @param where  Draw the `path:line` header. On the threads screen that is how
+ *               you know which file you are reading about; on the diff it is
+ *               the line you are already looking at, so it is off there.
+ * @param hunk   Draw the hunk GitHub kept. Same argument: on the diff the code
+ *               is directly above, and printing it again pushes the words off
+ *               the screen.
+ */
+export function ThreadCard({ thread, host, actions, where = true, hunk = true, now = Date.now() }: {
+  thread: PrThread;
+  host: Host | null;
+  actions: ThreadActions;
+  where?: boolean;
+  hunk?: boolean;
+  now?: number;
+}): React.ReactNode {
+  const range = suggestionRange(thread);
+  /* The FIRST suggestion in the thread, which is the one the range belongs to.
+     A later reply containing its own block is a different proposal about the
+     same lines, and applying it under the first one's range would be applying
+     something nobody chose. */
+  const suggestion = thread.comments.flatMap((c) => suggestionsIn(c.body)).at(0);
+  const canApply = actions.mayWrite && !!suggestion && !!range && !thread.isResolved;
+  const canReply = actions.mayWrite && replyAnchor(thread) !== null;
+  const note = actions.said?.id === thread.id ? actions.said : null;
+  const working = actions.busy === thread.id;
+  const writing = actions.writing?.id === thread.id ? actions.writing : null;
+
+  return (
+    <Card style={{ gap: SPACE.sm, opacity: thread.isResolved ? 0.6 : 1 }}>
+      {where || thread.isResolved || thread.isOutdated ? (
+        <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+          {where ? (
+            <Text
+              numberOfLines={1}
+              ellipsizeMode="head"
+              style={{ color: C.text2, fontSize: T.small, fontFamily: MONO, flex: 1 }}
+            >{whereOf(thread)}</Text>
+          ) : <View style={{ flex: 1 }} />}
+          {thread.isResolved ? (
+            <Text style={{ color: C.success, fontSize: T.eyebrow }}>resolved</Text>
+          ) : thread.isOutdated ? (
+            <Text style={{ color: C.text4, fontSize: T.eyebrow }}>outdated</Text>
+          ) : null}
+        </View>
+      ) : null}
+
+      {hunk && thread.diffHunk ? <Hunk text={thread.diffHunk} /> : null}
+
+      {thread.comments.map((comment) => (
+        <View key={comment.id} style={{ gap: 2, paddingTop: SPACE.xs }}>
+          <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm }}>
+            <Text style={{ color: C.text, fontSize: T.small, fontWeight: "600" }}>
+              {comment.author}{comment.isBot ? " · bot" : ""}
+            </Text>
+            <Text style={{ color: C.text4, fontSize: T.eyebrow }}>
+              {since(comment.createdAt, now)}
+            </Text>
+          </View>
+          <Md text={comment.body} host={host} />
+        </View>
+      ))}
+
+      {writing ? (
+        <View style={{ gap: SPACE.sm, paddingTop: SPACE.xs }}>
+          <TextInput
+            value={writing.body}
+            onChangeText={actions.type}
+            placeholder="Reply"
+            placeholderTextColor={C.text4}
+            multiline
+            autoFocus
+            style={{
+              minHeight: 64, borderWidth: 1, borderColor: C.border, borderRadius: RADIUS.sm,
+              backgroundColor: C.bg, color: C.text, padding: SPACE.sm, fontSize: T.body,
+            }}
+          />
+          <View style={{ flexDirection: "row", gap: SPACE.sm }}>
+            <Btn
+              label="Send reply"
+              tone="primary"
+              style={{ flex: 1 }}
+              busy={working}
+              disabled={!writing.body.trim() || working}
+              onPress={() => { void actions.reply(thread); }}
+            />
+            <Btn label="Cancel" onPress={actions.cancel} />
+          </View>
+          {/* Said where the difference bites: this one goes now, and the
+              remarks written on the diff do not. */}
+          <Note>A reply is posted on its own, straight away.</Note>
+        </View>
+      ) : (
+        <View style={{ flexDirection: "row", gap: SPACE.sm, paddingTop: SPACE.xs }}>
+          <Btn
+            label="Reply"
+            style={{ flex: 1 }}
+            disabled={!canReply || working}
+            onPress={() => actions.begin(thread)}
+          />
+          <Btn
+            label={thread.isResolved ? "Reopen" : "Resolve"}
+            tone={thread.isResolved ? "plain" : "good"}
+            style={{ flex: 1 }}
+            busy={working}
+            disabled={!actions.mayWrite || working}
+            onPress={() => actions.setResolved(thread)}
+          />
+        </View>
+      )}
+
+      {canApply ? (
+        <Btn
+          label={`Apply suggestion · ${thread.path.split("/").pop()}:${
+            range!.startLine === range!.line ? range!.line : `${range!.startLine}-${range!.line}`
+          }`}
+          disabled={working}
+          onPress={() => actions.askApply(thread, suggestion!.text)}
+        />
+      ) : null}
+
+      {suggestion && !range ? (
+        <Note>
+          This thread carries a suggestion, and the lines it was written about are gone.
+          Applying it would change code nobody was talking about.
+        </Note>
+      ) : null}
+
+      {note ? <Note tone={note.bad ? "bad" : "quiet"}>{note.text}</Note> : null}
+
+      {thread.url ? (
+        <Pressable
+          onPress={() => { void Linking.openURL(thread.url!); }}
+          accessibilityRole="button"
+          style={{ minHeight: TAP, justifyContent: "center" }}
+        >
+          <Text style={{ color: C.primary, fontSize: T.small }}>Open the thread on GitHub</Text>
+        </Pressable>
+      ) : null}
+    </Card>
+  );
+}

--- a/mobile/src/review/ThreadMarker.tsx
+++ b/mobile/src/review/ThreadMarker.tsx
@@ -1,0 +1,63 @@
+/*
+ * A conversation, unopened, under the line it is about.
+ *
+ * The diff is eleven-point monospace at 22 points a row, and a thread card
+ * dropped into the middle of it unasked would bury the code the thread is
+ * about. So it starts as one line: who said it, roughly what, and how many
+ * replies came after — enough to decide whether to open it, which is the only
+ * decision a marker is for.
+ *
+ * It takes the full 44-point target even though the rows around it are 22.
+ * The line under it is a line of code and has the argument written in
+ * test/tap-floor.test.ts; this is a control, and a mis-tap on a control that
+ * expands a card is a card that covers what you were reading.
+ */
+import { Pressable, Text } from "react-native";
+import type { PrThread } from "../../../shared/types.ts";
+import { threadDigest } from "../model/threads.ts";
+import { TAP } from "../ui.tsx";
+import { C, SPACE, T, tint } from "../theme.ts";
+
+const FACE: Record<"open" | "outdated" | "resolved", string> = {
+  open: C.primary,
+  outdated: C.text4,
+  resolved: C.success,
+};
+
+export function ThreadMarker({ thread, open, onPress }: {
+  thread: PrThread;
+  open: boolean;
+  onPress: () => void;
+}): React.ReactNode {
+  const { who, gist, replies, state } = threadDigest(thread);
+  const accent = FACE[state];
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={`${state} thread from ${who}${replies ? `, ${replies} replies` : ""}`}
+      onPress={onPress}
+      style={{
+        flexDirection: "row", alignItems: "center", gap: SPACE.sm,
+        minHeight: TAP, paddingRight: SPACE.md, paddingLeft: SPACE.sm,
+        // Indented past the number column, so the strip starts where the code
+        // does and reads as hanging off that line rather than off the file.
+        marginLeft: 38,
+        backgroundColor: tint(accent, 0.1),
+        borderLeftWidth: 3, borderLeftColor: accent,
+      }}
+    >
+      <Text style={{ color: C.text, fontSize: T.eyebrow, fontWeight: "700" }} numberOfLines={1}>
+        {who}
+      </Text>
+      <Text style={{ color: C.text3, fontSize: T.eyebrow, flex: 1 }} numberOfLines={1}>
+        {state === "resolved" ? "resolved · " : state === "outdated" ? "outdated · " : ""}{gist}
+      </Text>
+      {replies ? (
+        <Text style={{ color: C.text4, fontSize: T.eyebrow }}>
+          {replies === 1 ? "1 reply" : `${replies} replies`}
+        </Text>
+      ) : null}
+      <Text style={{ color: C.text4, fontSize: T.eyebrow }}>{open ? "⌄" : "›"}</Text>
+    </Pressable>
+  );
+}

--- a/mobile/src/review/useThreadActions.ts
+++ b/mobile/src/review/useThreadActions.ts
@@ -1,0 +1,151 @@
+/*
+ * Answering a thread: the three writes, and the bookkeeping around them.
+ *
+ * This used to live inside the threads screen, which was fine while the
+ * threads screen was the only place a conversation could be answered. It is
+ * not any more — the diff draws them on the line they are about — and two
+ * copies of "reply, resolve, apply" is how one of them quietly stops
+ * re-reading after a write.
+ *
+ *   reply     `/prs/reply`            — into the thread, not as a new one
+ *   resolve   `/prs/thread-resolved`  — and unresolve, the same button
+ *   apply     `/prs/apply-suggestion` — commit the suggested lines
+ *
+ * The caller owns the fetch and passes `reload`, because the two screens read
+ * different things: the threads screen wants the detail, and the diff wants
+ * the detail AND keeps its own parsed text. Both must re-read after a write.
+ */
+import { useCallback, useState } from "react";
+import * as Haptics from "expo-haptics";
+import type { PrActionResult, PrThread } from "../../../shared/types.ts";
+import { suggestionRange } from "../../../shared/suggestion.ts";
+import { ask } from "../lib/api.ts";
+import type { Host } from "../lib/host.ts";
+import { replyAnchor } from "../model/threads.ts";
+
+/** What a row is being told, and about which thread. `bad` is GitHub refusing
+ *  rather than this app failing — both are shown, in different colours. */
+export interface ThreadSaid { id: string; text: string; bad: boolean }
+
+export interface ThreadActions {
+  /** Off entirely on a phone paired to read: all three of these write. */
+  mayWrite: boolean;
+  /** The thread id something is in flight for, so one row can say it is busy
+   *  without freezing the screen around it. */
+  busy: string | null;
+  said: ThreadSaid | null;
+  writing: { id: string; body: string } | null;
+  confirming: { thread: PrThread; text: string } | null;
+  begin: (thread: PrThread) => void;
+  type: (body: string) => void;
+  cancel: () => void;
+  reply: (thread: PrThread) => Promise<void>;
+  setResolved: (thread: PrThread) => void;
+  askApply: (thread: PrThread, text: string) => void;
+  cancelApply: () => void;
+  apply: () => Promise<void>;
+}
+
+export function useThreadActions({ host, root, number, reload }: {
+  host: Host | null;
+  root: string;
+  number: string;
+  reload: () => Promise<void>;
+}): ThreadActions {
+  const [busy, setBusy] = useState<string | null>(null);
+  const [said, setSaid] = useState<ThreadSaid | null>(null);
+  const [writing, setWriting] = useState<{ id: string; body: string } | null>(null);
+  /** A suggestion waiting to be confirmed. Applying one writes a commit to
+   *  somebody else's branch, which is not something a single tap should do. */
+  const [confirming, setConfirming] = useState<{ thread: PrThread; text: string } | null>(null);
+
+  const mayWrite = host?.scope === "full";
+
+  /*
+   * One write, and then a re-read.
+   *
+   * Never an optimistic update. What a thread looks like after a reply is
+   * GitHub's answer and not this app's guess — a resolve can be refused by a
+   * branch rule, and a reply can land while somebody else resolves the thread
+   * underneath it. Re-reading costs one request on an action that already cost
+   * one, and it is the difference between a screen that reports and a screen
+   * that hopes.
+   */
+  const act = useCallback(async (
+    id: string, path: string, body: unknown, done: string,
+  ): Promise<boolean> => {
+    if (!host) return false;
+    setBusy(id);
+    setSaid(null);
+    const answer = await ask<PrActionResult>(host, path, { method: "POST", body });
+    if (!answer.ok || !answer.value.ok) {
+      setBusy(null);
+      setSaid({ id, bad: true, text: (answer.ok ? answer.value.error : answer.error) || "GitHub refused that." });
+      return false;
+    }
+    void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
+    await reload();
+    setBusy(null);
+    setSaid({ id, bad: false, text: done });
+    return true;
+  }, [host, reload]);
+
+  const reply = useCallback(async (thread: PrThread): Promise<void> => {
+    const text = writing?.body.trim();
+    if (!text || writing?.id !== thread.id) return;
+    /*
+     * The REST reply endpoint takes the numeric id of a comment in the thread,
+     * and `PrThreadComment.id` is a GraphQL node id — the two are not
+     * interchangeable, which the shared type says out loud. Without a
+     * databaseId there is nothing to reply to, so the box is not offered.
+     */
+    const anchor = replyAnchor(thread);
+    if (anchor === null) {
+      setSaid({ id: thread.id, bad: true, text: "That thread carries no id to reply to." });
+      return;
+    }
+    const ok = await act(
+      thread.id, "/prs/reply",
+      { root, number: Number(number), commentId: anchor, body: text },
+      "Replied.",
+    );
+    if (ok) setWriting(null);
+  }, [act, writing, root, number]);
+
+  const setResolved = useCallback((thread: PrThread): void => {
+    void act(
+      thread.id, "/prs/thread-resolved",
+      { root, threadId: thread.id, resolved: !thread.isResolved },
+      thread.isResolved ? "Reopened." : "Resolved.",
+    );
+  }, [act, root]);
+
+  const apply = useCallback(async (): Promise<void> => {
+    if (!confirming) return;
+    const { thread, text } = confirming;
+    const range = suggestionRange(thread);
+    if (!range) return;
+    setConfirming(null);
+    await act(thread.id, "/prs/apply-suggestion", {
+      root, number: Number(number),
+      path: thread.path, startLine: range.startLine, line: range.line,
+      suggestion: text,
+      // Credited as a co-author on the commit, exactly as GitHub does it. The
+      // author of the SUGGESTION, which is the first comment in the thread and
+      // not whoever replied last.
+      author: thread.comments[0]?.author,
+    }, "Applied.");
+  }, [act, confirming, root, number]);
+
+  return {
+    mayWrite, busy, said, writing, confirming,
+    begin: (thread) => { setSaid(null); setWriting({ id: thread.id, body: "" }); },
+    type: (body) => { setWriting((was) => (was ? { id: was.id, body } : was)); },
+    cancel: () => setWriting(null),
+    reply,
+    setResolved,
+    askApply: (thread, text) => { setSaid(null); setConfirming({ thread, text }); },
+    cancelApply: () => setConfirming(null),
+    apply,
+  };
+}

--- a/mobile/test/threads.test.ts
+++ b/mobile/test/threads.test.ts
@@ -8,7 +8,7 @@
  */
 import { describe, expect, test } from "bun:test";
 import type { PrThread, PrThreadComment } from "../../shared/types.ts";
-import { hunkTail, ordered, replyAnchor, whereOf } from "../src/model/threads.ts";
+import { hunkTail, ordered, replyAnchor, threadDigest, threadsOnFile, whereOf } from "../src/model/threads.ts";
 
 function comment(over: Partial<PrThreadComment> = {}): PrThreadComment {
   return {
@@ -142,5 +142,92 @@ describe("replyAnchor", () => {
     expect(replyAnchor({ comments: [comment()] })).toBe(null);
     expect(replyAnchor({ comments: [] })).toBe(null);
     expect(replyAnchor({ comments: [comment({ databaseId: null })] })).toBe(null);
+  });
+});
+
+/*
+ * Which line a conversation belongs on.
+ *
+ * The diff screen draws one file at a time and looks up each row by its
+ * new-side number, so this is the lookup it does — and the case that matters
+ * is the one where there is nothing to look up: an outdated thread has no
+ * line, and hanging it on the row that now holds that number would be a
+ * remark attached to code nobody was talking about.
+ */
+describe("threadsOnFile", () => {
+  test("only this file's threads, keyed by the line they sit on", () => {
+    const { byLine, adrift } = threadsOnFile([
+      thread({ id: "here", path: "src/a.ts", line: 12 }),
+      thread({ id: "elsewhere", path: "src/b.ts", line: 12 }),
+    ], "src/a.ts");
+    expect([...byLine.keys()]).toEqual([12]);
+    expect(byLine.get(12)!.map((t) => t.id)).toEqual(["here"]);
+    expect(adrift).toEqual([]);
+  });
+
+  test("two conversations on one line both stay on it, open first", () => {
+    const { byLine } = threadsOnFile([
+      thread({ id: "done", line: 40, isResolved: true }),
+      thread({ id: "asking", line: 40 }),
+    ], "src/a.ts");
+    expect(byLine.get(40)!.map((t) => t.id)).toEqual(["asking", "done"]);
+  });
+
+  test("a thread with no line is adrift rather than hung on a number", () => {
+    const { byLine, adrift } = threadsOnFile([
+      thread({ id: "moved", line: null, originalLine: 12, isOutdated: true }),
+      thread({ id: "still", line: 12 }),
+    ], "src/a.ts");
+    expect(adrift.map((t) => t.id)).toEqual(["moved"]);
+    expect(byLine.get(12)!.map((t) => t.id)).toEqual(["still"]);
+  });
+
+  test("a resolved thread is kept — it is the record of the argument", () => {
+    const { byLine } = threadsOnFile([thread({ id: "done", line: 3, isResolved: true })], "src/a.ts");
+    expect(byLine.get(3)!.map((t) => t.id)).toEqual(["done"]);
+  });
+
+  test("nothing on this file is two empties, not a crash", () => {
+    const { byLine, adrift } = threadsOnFile([], "src/a.ts");
+    expect(byLine.size).toBe(0);
+    expect(adrift).toEqual([]);
+  });
+});
+
+describe("threadDigest", () => {
+  test("the first comment is the gist — the last one is usually 'done'", () => {
+    const got = threadDigest(thread({
+      comments: [
+        comment({ author: "ana", body: "This drops the error." }),
+        comment({ author: "me", body: "Done." }),
+      ],
+    }));
+    expect(got.who).toBe("ana");
+    expect(got.gist).toBe("This drops the error.");
+    expect(got.replies).toBe(1);
+    expect(got.state).toBe("open");
+  });
+
+  test("a fenced block stands aside for the word code", () => {
+    expect(threadDigest(thread({
+      comments: [comment({ body: "Try\n```ts\nconst a = 1;\n```\ninstead." })],
+    })).gist).toBe("Try code instead.");
+  });
+
+  test("newlines collapse — a marker is one line", () => {
+    expect(threadDigest(thread({
+      comments: [comment({ body: "one\n\ntwo   three" })],
+    })).gist).toBe("one two three");
+  });
+
+  test("the state is the one the screen colours by", () => {
+    expect(threadDigest(thread({ isResolved: true })).state).toBe("resolved");
+    expect(threadDigest(thread({ isOutdated: true })).state).toBe("outdated");
+  });
+
+  test("a thread with no comments still names somebody", () => {
+    const got = threadDigest(thread({ comments: [] }));
+    expect(got.who).toBe("somebody");
+    expect(got.replies).toBe(0);
   });
 });


### PR DESCRIPTION
## What does this PR do?

Reviewing a pull request on the phone meant reading the code on one screen and the remark about it on another. Nothing on the diff said a remark existed — you found out somebody had objected to line 148 by opening a list of threads and reading the path in each header.

Now a thread sits under its line: one strip — who, roughly what, how many replies — and a tap opens the same card the threads screen draws, with **Reply**, **Resolve** and **Apply suggestion** on it. The threads screen stays: "what is still open on this pull request" is a real question, and a diff is a bad way to ask it.

The first commit is the part with no visible change: the card, the confirmation and the three writes came out of the threads screen into `src/review/`, because two copies of "reply, resolve, apply" is how one of them quietly stops re-reading after a write. That screen went from 381 lines to 117, and what is left in it is the list. One thing does change while passing through: a comment body now goes through the markdown renderer that landed in #574 — a ` ```suggestion ` fence printed verbatim was the worst thing this app showed, five lines of markup wrapped at eleven points with the proposed code hidden inside them.

Three decisions in the second commit worth stating:

- **A thread with no line is not hung on a number.** GitHub clears `line` when the code underneath has changed, and the row carrying that number now is code nobody was talking about. Those go above the file, with the hunk they were written against — which by then is the only copy of those lines left anywhere in the app.
- **Your own queued remarks are drawn too**, in the review's colour rather than a thread's, with Remove beside them. Before this they vanished into a counter, which is how a remark gets written twice.
- **Applying a suggestion re-reads the diff as well as the threads.** It writes a commit to those very lines, and leaving them on screen as they were is showing code that no longer exists directly above the conversation that replaced it.

The file picker also carries the count of open threads per file, so the file somebody is waiting on can be found without opening all eleven.

## How was it tested?

- `bun test` in `mobile/` — **724 pass, 41 skip, 0 fail** across 55 files, including 10 new tests on `threadsOnFile` and `threadDigest`.
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on every touched file — clean.
- The two decisions that can be wrong without being drawn are the ones under test: which line a thread lands on (including the outdated one that must land on none), and what a marker's single line says. The rest is layout, and the same argument `model/threads.ts` already opens with applies — a thread screen cannot be seen here without a GitHub.

Not exercised on a handset. The case worth a second pair of eyes is a file with several conversations on nearby lines, where the markers and an expanded card share the screen with the code.

---
_Generated by [Claude Code](https://claude.ai/code/session_01SBUZ5PGpAbFxitwt9zq63V)_