### PR TITLE
fix(phone): the button stops holding the message after it is sent

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,44 @@
+# Working in this repository
+
+Rules that cost something the day they were broken. They are short because
+each one is a scar, not a preference.
+
+## This repository is public
+
+Everything below follows from that one fact.
+
+- **No private conversation ever reaches a file, a commit message, a pull
+  request body, or a comment on one.** Not quoted, not translated, not
+  paraphrased with "reported by". A comment owes the next reader the defect and
+  how it was measured; who mentioned it, and in what words, is not
+  documentation. Write "the strip did not follow the computer", never "somebody
+  said the strip did not follow the computer".
+- **No real names.** Not in a comment, not in an example, not in test data.
+  Chat notifications and task boards carry other people's names — replace them
+  with a placeholder before the example goes in.
+- **No links to an assistant session.** They are private URLs and they belong
+  in nobody's git history. The GitHub tooling can append one to a pull request
+  body when the pull request is CREATED: after opening one, read the body back
+  and strip it. Editing a body never adds one.
+- **One signature per pull request body, at most.** Two is what happens when a
+  footer is written by hand and appended by a tool as well.
+- **Nothing in the tree that is not the change.** No design notes, no scratch
+  files, no implementation plans, no screenshots of a conversation. A working
+  document lives outside the repository.
+
+`bun test` in `server/` runs `test/private-content.test.ts`, which scans the
+tree for the first three. It fails the build rather than trusting anybody to
+remember.
+
+## Commits
+
+- End the message with `Co-Authored-By:` and nothing else. No session trailer.
+- One reason per commit, and the message says why rather than what — the diff
+  already says what.
+
+## Tests
+
+- A test's fixture should be the shape of something real, and its comment
+  should say what went wrong without saying who it went wrong for.
+- Prefer pulling a decision out of a screen and testing it there. There is no
+  renderer in this project, and a rule about source is asserted against source.

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -55,7 +55,7 @@ import {
   NO_MODES, applyDefault, isLive, prune, setLive, type LiveModes,
 } from "../../src/terminal/liveDefault.ts";
 import {
-  clearFocusTimer, focusCapture, liveDetail, scheduleFocus, type FocusTimer,
+  clearFocusTimer, endsTheLine, focusCapture, liveDetail, scheduleFocus, type FocusTimer,
 } from "../../src/terminal/liveFocus.ts";
 import { onHandoff, takeHandoff } from "../../src/terminal/handoff.ts";
 import { BackIcon, ImageIcon, KeyboardIcon, MicIcon } from "../../src/nav/icons.tsx";
@@ -929,8 +929,12 @@ function TerminalPane(): React.ReactNode {
     // the field, so what `onPane` holds describes a screen that no longer
     // exists. Dropped rather than refreshed — the next report seeds it again.
     onPane.current = null;
+    // The line has run, so the transcript of it is over. Without this the
+    // button along the bottom keeps the message that was just sent, which is
+    // how a button ends up looking like a field with your line still in it.
+    if (endsTheLine(bytes)) forgetKeys();
     terminal.current?.send(bytes);
-  }, []);
+  }, [forgetKeys]);
 
   /**
    * Deliver whatever another screen left in the letterbox.
@@ -1131,7 +1135,15 @@ function TerminalPane(): React.ReactNode {
     if (text.endsWith("\n")) {
       const body = text.replace(/\n+$/, "");
       typedBody(body);
-      commit(body);
+      /*
+       * In `keys` the body has already gone down the wire, character by
+       * character, as it was typed — so what is left to send is the return
+       * itself. `commit` would send the whole line AGAIN, which is the same
+       * double-run `onPane` exists to stop, and it is `onKey` that drops the
+       * transcript afterwards.
+       */
+      if (raw) onKey("\r");
+      else commit(body);
       return;
     }
     typedBody(text);

--- a/mobile/app/(tabs)/terminal.tsx
+++ b/mobile/app/(tabs)/terminal.tsx
@@ -50,7 +50,7 @@ import {
   customKeys, keyLayout, onTermPrefs, setTermColumns, termAssist, termColumns,
 } from "../../src/terminal/termPrefs.ts";
 import { bytesFor } from "../../src/terminal/customKeys.ts";
-import { editFor } from "../../src/terminal/mirror.ts";
+import { echoOfSent, editFor, type JustSent } from "../../src/terminal/mirror.ts";
 import {
   NO_MODES, applyDefault, isLive, prune, setLive, type LiveModes,
 } from "../../src/terminal/liveDefault.ts";
@@ -370,14 +370,23 @@ function TerminalPane(): React.ReactNode {
    *
    * Treating that as `shadow = null`, which is what happened before this
    * existed, is what makes the phone send a line the pane already has. Measured
-   * on the emulator: `esto es una linea larga escrita en el ordenador para ver
-   * si el movil la` was typed at the computer, the phone's field went empty and
-   * became a composer, and one word typed into it submitted
-   * "…si el movil la hola2" — the desk's line and the phone's word, run as one
-   * prompt. Holding what the pane has is what lets Send know there is nothing
-   * to send but a carriage return.
+   * on the emulator: a long line typed at the computer left the phone's field
+   * empty and turned it into a composer, and one word typed into that field
+   * submitted the tail of the desk's line with the word appended — the two of
+   * them run as one prompt. Holding what the pane has is what lets Send know
+   * there is nothing to send but a carriage return.
    */
   const onPane = useRef<string | null>(null);
+  /*
+   * The line that was just submitted from here, and when.
+   *
+   * A pane goes on showing a prompt for a beat after it is submitted — an
+   * agent keeps it in its box until it takes it — and the read of that line
+   * arrives here as an ordinary report, which puts the message straight back
+   * into a field that had just been emptied. `echoOfSent` is where the rule
+   * and its expiry are written.
+   */
+  const justSent = useRef<JustSent | null>(null);
   /*
    * Whether somebody has started a line here, and therefore owns it.
    *
@@ -1022,6 +1031,16 @@ function TerminalPane(): React.ReactNode {
    */
   const onLine = useCallback((text: string | null, exact = true): void => {
     if (claimed.current) return;
+    /*
+     * The pane still showing the line that was just sent is not news.
+     *
+     * Without this the field emptied on send and filled again a beat later
+     * with the same message — reported from a phone as the message staying
+     * written along the bottom of the screen. See `echoOfSent`, which is also
+     * where the reason it expires is written.
+     */
+    if (echoOfSent(justSent.current, text, Date.now())) return;
+    justSent.current = null;
     // Editable only when the read is exact. An inexact one still fills the
     // field — that is the whole point, the two sides are meant to show the same
     // thing — but it is remembered as the pane's rather than as ours, so
@@ -1052,6 +1071,7 @@ function TerminalPane(): React.ReactNode {
       terminal.current?.send("\r");
       // Cleared here rather than waiting for the pane to say so: the field is
       // empty the instant Enter is pressed, everywhere else in the world.
+      justSent.current = { text, at: Date.now() };
       shadow.current = "";
       onPane.current = null;
       // The line is gone, so nobody owns it any more and the pane may seed the
@@ -1074,6 +1094,7 @@ function TerminalPane(): React.ReactNode {
     if (onPane.current !== null) {
       void Haptics.impactAsync(Haptics.ImpactFeedbackStyle.Light);
       terminal.current?.send("\r");
+      justSent.current = { text: onPane.current, at: Date.now() };
       onPane.current = null;
       claimed.current = false;
       setDraft("");
@@ -1091,6 +1112,7 @@ function TerminalPane(): React.ReactNode {
      * here; `submitBehavior` below spends the return key on sending.
      */
     terminal.current?.send(`${text.replace(/\n/g, "\r")}\r`);
+    justSent.current = { text, at: Date.now() };
     setDraft("");
   }, []);
 

--- a/mobile/src/terminal/liveFocus.ts
+++ b/mobile/src/terminal/liveFocus.ts
@@ -102,11 +102,11 @@ export function liveDetail(captured: string, idle = "Tap to show keyboard"): str
 /**
  * Does this key end the line the button is showing?
  *
- * Reported from a phone: send a message, and it stays written along the bottom
- * of the screen. That row is a BUTTON in `keys` mode — its text is a reading
- * of what has gone down the wire, not a field somebody is still editing — and
- * a button that keeps the last message reads as a field with your message
- * still in it, which is the one thing it must not look like.
+ * A message sent used to stay written along the bottom of the screen. That row
+ * is a BUTTON in `keys` mode — its text is a reading of what has gone down the
+ * wire, not a field somebody is still editing — and a button that keeps the
+ * last message reads as a field with that message still in it, which is the
+ * one thing it must not look like.
  *
  * Enter is where a line stops being anything: it has run. So the transcript is
  * dropped on it, whichever route the key took — the bar's ⏎, the keyboard's

--- a/mobile/src/terminal/liveFocus.ts
+++ b/mobile/src/terminal/liveFocus.ts
@@ -98,3 +98,25 @@ export function focusCapture(
 export function liveDetail(captured: string, idle = "Tap to show keyboard"): string {
   return captured.length > 0 ? captured : idle;
 }
+
+/**
+ * Does this key end the line the button is showing?
+ *
+ * Reported from a phone: send a message, and it stays written along the bottom
+ * of the screen. That row is a BUTTON in `keys` mode — its text is a reading
+ * of what has gone down the wire, not a field somebody is still editing — and
+ * a button that keeps the last message reads as a field with your message
+ * still in it, which is the one thing it must not look like.
+ *
+ * Enter is where a line stops being anything: it has run. So the transcript is
+ * dropped on it, whichever route the key took — the bar's ⏎, the keyboard's
+ * return, or an IME that commits the newline as text.
+ *
+ * CR and LF both, because the bar sends CR and a pasted line arrives as LF.
+ * Nothing else clears it: Tab completes the line, up replaces it, Ctrl+C
+ * throws it away — all of which change the line without ending it, and the
+ * pane is the thing that knows what it looks like afterwards.
+ */
+export function endsTheLine(bytes: string): boolean {
+  return bytes === "\r" || bytes === "\n" || bytes === "\r\n";
+}

--- a/mobile/src/terminal/mirror.ts
+++ b/mobile/src/terminal/mirror.ts
@@ -64,3 +64,44 @@ export function editFor(was: string, next: string): string {
   // counts array entries rather than `was.length`.
   return DEL.repeat(a.length - same) + b.slice(same).join("");
 }
+
+/** A line that has just been submitted from the phone, and the moment it was. */
+export interface JustSent { text: string; at: number }
+
+/**
+ * Is what the pane is showing just the line we sent a moment ago?
+ *
+ * A message sent used to stay written along the bottom of the screen. In line
+ * mode the field IS the pane's line — everything above this explains why — so
+ * the pane holding the submitted prompt in its box for a beat puts it straight
+ * back into a field that had just been emptied. The field is not wrong, it is
+ * honest; but "I pressed send and my message is still sitting there" is the
+ * reading, and the reading is what matters.
+ *
+ * So a report equal to what was just sent is ignored, and the field stays
+ * empty until the pane says something else — which it does the instant the
+ * agent takes the line.
+ *
+ * ── why it expires ────────────────────────────────────────────────────────
+ * Because "the pane still shows it" and "the pane has a line on it again that
+ * happens to be the same" are the same read, and only time tells them apart. A
+ * TUI that keeps the submitted line on its prompt is not echoing, it is
+ * holding a line somebody may want to edit — and after the hold it mirrors
+ * again, one blink late, rather than leaving a field that never fills.
+ *
+ * Compared trimmed: a pane pads its box to the width of the frame, and a line
+ * that differs from the one we sent by the spaces around it is the line we
+ * sent. An empty submission is never an echo — there was nothing on the line
+ * to hold.
+ */
+export function echoOfSent(
+  sent: JustSent | null,
+  line: string | null,
+  now: number,
+  holdMs = 3000,
+): boolean {
+  if (!sent || line === null) return false;
+  if (!sent.text.trim()) return false;
+  if (now - sent.at >= holdMs) return false;
+  return line.trim() === sent.text.trim();
+}

--- a/mobile/test/live-focus.test.ts
+++ b/mobile/test/live-focus.test.ts
@@ -140,14 +140,13 @@ describe("what the bar says", () => {
 });
 
 /*
- * Reported from a phone, with a screenshot: "cuando envío un mensaje se queda
- * escrito aquí abajo y aquí no debería escribirse nada — es un botón y ya no
- * un input".
+ * The button along the bottom, after the line it was showing has run.
  *
- * It was right, and the cause was that nothing dropped the transcript. In
- * `keys` the row along the bottom reads back what has gone down the wire, and
- * a line that has RUN has nothing left to read back — so it kept the message
- * and read as a field with your message still in it.
+ * In `keys` that row reads back what has gone down the wire, and nothing ever
+ * dropped the transcript: not the bar's return, not the keyboard's. A line
+ * that has RUN has nothing left to read back, so the row kept the message and
+ * read as a field with that message still in it — which is the one thing a
+ * button must not look like.
  */
 describe("when the button stops showing a line", () => {
   test("the return key ends it, by either spelling", () => {

--- a/mobile/test/live-focus.test.ts
+++ b/mobile/test/live-focus.test.ts
@@ -10,7 +10,7 @@
  */
 import { describe, expect, mock, test } from "bun:test";
 import {
-  clearFocusTimer, focusCapture, liveDetail, scheduleFocus,
+  clearFocusTimer, endsTheLine, focusCapture, liveDetail, scheduleFocus,
   type FocusTarget, type FocusTimer,
 } from "../src/terminal/liveFocus.ts";
 
@@ -136,5 +136,45 @@ describe("what the bar says", () => {
 
   test("a line of spaces is a line — it is what was typed", () => {
     expect(liveDetail(" ")).toBe(" ");
+  });
+});
+
+/*
+ * Reported from a phone, with a screenshot: "cuando envío un mensaje se queda
+ * escrito aquí abajo y aquí no debería escribirse nada — es un botón y ya no
+ * un input".
+ *
+ * It was right, and the cause was that nothing dropped the transcript. In
+ * `keys` the row along the bottom reads back what has gone down the wire, and
+ * a line that has RUN has nothing left to read back — so it kept the message
+ * and read as a field with your message still in it.
+ */
+describe("when the button stops showing a line", () => {
+  test("the return key ends it, by either spelling", () => {
+    expect(endsTheLine("\r")).toBe(true);
+    expect(endsTheLine("\n")).toBe(true);
+    expect(endsTheLine("\r\n")).toBe(true);
+  });
+
+  test("the keys that change a line without ending it do not", () => {
+    // Tab completes it, up replaces it, Ctrl+C throws it away. All of them
+    // leave a line on the pane, and the pane is what knows what it says
+    // afterwards.
+    for (const key of ["\t", "\u001b[A", "\u001b[B", "\u0003", "\u0004"]) {
+      expect(endsTheLine(key), JSON.stringify(key)).toBe(false);
+    }
+  });
+
+  test("a line that merely contains a return is not the return key", () => {
+    // A paste. It goes to the pane as bytes, and what it leaves behind is a
+    // line the pane is still holding.
+    expect(endsTheLine("git status\r")).toBe(false);
+    expect(endsTheLine("")).toBe(false);
+  });
+
+  test("and then the bar is back to asking for the keyboard", () => {
+    // The pair, stated together: this is the state the screen is left in after
+    // the clear, and it is the whole of what the report asked for.
+    expect(liveDetail("")).toBe("Tap to show keyboard");
   });
 });

--- a/mobile/test/mirror.test.ts
+++ b/mobile/test/mirror.test.ts
@@ -13,7 +13,7 @@
 import { describe, expect, test } from "bun:test";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
-import { editFor } from "../src/terminal/mirror.ts";
+import { echoOfSent, editFor } from "../src/terminal/mirror.ts";
 import { announce, built } from "./generated-artifacts.ts";
 import { C } from "../src/theme.ts";
 
@@ -244,9 +244,9 @@ describe("the field's claim on the line", () => {
  *   1. the phone's field went EMPTY while the pane held the whole line, which
  *      is "one shows the text and the other does not";
  *   2. and the field, now a composer, sent its contents on top of what was
- *      already there. Captured: `esto es una linea larga escrita en el
- *      ordenador para ver si el movil la` typed at the computer plus `hola2`
- *      typed on the phone ran as one prompt, concatenated.
+ *      already there. Measured: a long line typed at the computer, plus one
+ *      word typed on the phone, ran as one prompt — the two of them
+ *      concatenated.
  */
 describe("a line the field could read but cannot edit", () => {
   const screen = readFileSync(join(import.meta.dir, "..", "app", "(tabs)", "terminal.tsx"), "utf8");
@@ -455,5 +455,59 @@ describe("what a burst of typing puts on the pane", () => {
     expect(paneAfter(["hello", "hell", "hel"])).toBe("hel");
     // And it must not retype the tail it kept.
     expect(editFor("hello", "hell")).toBe("\x7f");
+  });
+});
+
+/*
+ * The other half of "my message stays written after I send it".
+ *
+ * In line mode the field is the pane's line, so the pane still holding the
+ * submitted prompt in its box puts it straight back into a field that had just
+ * been emptied. That read is honest and the reading of it is not, so a report
+ * equal to what was just sent is ignored — for a while.
+ */
+describe("the pane still showing what was just sent", () => {
+  const at = 1_000_000;
+
+  test("the same line, a moment later, is the echo and not news", () => {
+    expect(echoOfSent({ text: "deploy the thing", at }, "deploy the thing", at + 200)).toBe(true);
+  });
+
+  test("padding around it is still the same line — a box pads to its frame", () => {
+    expect(echoOfSent({ text: "deploy the thing", at }, "  deploy the thing   ", at + 200)).toBe(true);
+  });
+
+  test("anything else is the pane talking, and the field follows it", () => {
+    expect(echoOfSent({ text: "deploy the thing", at }, "deploy the thin", at + 200)).toBe(false);
+    expect(echoOfSent({ text: "deploy the thing", at }, "", at + 200)).toBe(false);
+    expect(echoOfSent({ text: "deploy the thing", at }, null, at + 200)).toBe(false);
+  });
+
+  test("it expires, because only time tells a held line from an echo", () => {
+    // A TUI that keeps the submitted line on its prompt is not echoing — it is
+    // holding a line somebody may want to edit. After the hold the field
+    // mirrors it again, one blink late.
+    expect(echoOfSent({ text: "deploy the thing", at }, "deploy the thing", at + 3000)).toBe(false);
+    expect(echoOfSent({ text: "deploy the thing", at }, "deploy the thing", at + 2999)).toBe(true);
+  });
+
+  test("an empty submission is never an echo", () => {
+    // There was nothing on the line to hold, and an empty read is exactly the
+    // one this must not swallow: it is how the field learns the line is gone.
+    expect(echoOfSent({ text: "", at }, "", at + 10)).toBe(false);
+    expect(echoOfSent({ text: "   ", at }, "", at + 10)).toBe(false);
+  });
+
+  test("nothing was sent, so nothing is an echo", () => {
+    expect(echoOfSent(null, "anything at all", at)).toBe(false);
+  });
+
+  test("the screen remembers the line on every route that sends one", () => {
+    // Three ways a line leaves this app — the mirror's Enter, the read-only
+    // line's Enter, and a plain send — and the guard is worth nothing if it is
+    // wired to two of them.
+    const screen = readFileSync(join(import.meta.dir, "..", "app", "(tabs)", "terminal.tsx"), "utf8");
+    expect(screen.match(/justSent\.current = \{ text/g)?.length).toBe(3);
+    expect(screen).toContain("if (echoOfSent(justSent.current, text, Date.now())) return;");
   });
 });

--- a/mobile/test/terminal-poll.test.ts
+++ b/mobile/test/terminal-poll.test.ts
@@ -2,13 +2,12 @@
  * The strip keeps up with the computer on its own, and costs nothing when the
  * computer stands still.
  *
- * Reported from a phone: "cuando tengo la app de movil abierta y en el pc en
- * una tab que solo tiene un pane meto uno mas… tengo que refresh para que se
- * haga, no es un auto sync como tiene que ser." Measured, and he was exactly
- * right: `load()` ran once on mount and after that only from the two refresh
- * buttons. The desk does not have the problem because the server sweeps tmux
- * twice a second and pushes it a `t:"tmux"` frame; the phone's socket carries
- * `events`, `notify` and pty bytes and nothing that says the panes moved.
+ * Open a pane at the computer with the phone watching, and the phone's strip
+ * did not know until you pulled it down: measured, `load()` ran once on mount
+ * and after that only from the two refresh buttons. The desk does not have the
+ * problem because the server sweeps tmux twice a second and pushes it a
+ * `t:"tmux"` frame; the phone's socket carries `events`, `notify` and pty bytes
+ * and nothing that says the panes moved.
  *
  * The fix is a poll while the screen is focused, and a poll has one dangerous
  * half: the answer is a fresh array every couple of seconds, so adopting it

--- a/server/src/clickupwatch.ts
+++ b/server/src/clickupwatch.ts
@@ -404,7 +404,7 @@ export function stopCardWatch(): void {
 /**
  * ClickUp's own desktop notification, matched back to a card.
  *
- * The desktop app posts "Alejandro set the status to: READY FOR QA" with the
+ * The desktop app posts "<somebody> set the status to: READY FOR QA" with the
  * task's TITLE as the summary and nothing else — no id, no url, and a D-Bus
  * monitor cannot invoke the notification's own action to find out. So the row
  * behind the bell had nowhere to go but ClickUp's website, which is the one

--- a/server/test/private-content.test.ts
+++ b/server/test/private-content.test.ts
@@ -1,0 +1,96 @@
+/*
+ * The repository is public, and three things kept getting into it.
+ *
+ * A private message, quoted verbatim in a comment. A real person's name, out
+ * of a chat notification that happened to be open. A link to an assistant
+ * session, appended to a pull request body by tooling.
+ *
+ * All three were fixed by hand more than once, which is the definition of a
+ * thing that needs a lock rather than a promise. So this reads the tree the
+ * way `mobile/test/tap-floor.test.ts` reads it — source is a fact, and a fact
+ * is testable — and fails the build before the next one ships.
+ *
+ * It lives in server/ because that is what `make test` and CI's build job run,
+ * and it scans every workspace rather than this one.
+ */
+import { describe, expect, test } from "bun:test";
+import { readdirSync, readFileSync, statSync } from "node:fs";
+import { join } from "node:path";
+
+const ROOT = join(import.meta.dir, "..", "..");
+
+/** Everything a person writes. Not lockfiles, not generated files, and not
+ *  `node_modules` — a dependency's own prose is not ours to police. */
+const SKIP_DIR = new Set([
+  "node_modules", ".git", "dist", "build", "coverage", ".expo", "android", "ios",
+  "web-shims", "static", "vendor",
+]);
+const TEXT = /\.(ts|tsx|js|jsx|mjs|cjs|md|json|ya?ml|html|css|sh)$/;
+
+function files(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    if (SKIP_DIR.has(entry)) continue;
+    const path = join(dir, entry);
+    if (statSync(path).isDirectory()) { out.push(...files(path)); continue; }
+    if (!TEXT.test(entry) || /\.generated\./.test(entry)) continue;
+    if (entry === "bun.lock" || entry === "package-lock.json") continue;
+    out.push(path);
+  }
+  return out;
+}
+
+const tree = files(ROOT).map((path) => ({
+  path: path.slice(ROOT.length + 1),
+  text: readFileSync(path, "utf8"),
+}));
+
+/** This file quotes the very patterns it bans, so it cannot scan itself. */
+const scanned = tree.filter((f) => !f.path.endsWith("test/private-content.test.ts"));
+
+const hits = (re: RegExp): string[] =>
+  scanned.flatMap(({ path, text }) => {
+    const found = text.match(re);
+    return found ? [`${path}: ${found[0].slice(0, 60)}`] : [];
+  });
+
+describe("nothing private is in the tree", () => {
+  test("there is a tree to read at all", () => {
+    // A scan that stops finding files is a test that passes for the wrong
+    // reason. The number is a floor, not a count.
+    expect(scanned.length).toBeGreaterThan(200);
+  });
+
+  test("no link to an assistant session", () => {
+    // Written clean and appended by tooling on pull request CREATION, which is
+    // why the rule in CLAUDE.md is to read the body back afterwards.
+    expect(hits(/claude\.ai\/code\/session[_/][A-Za-z0-9]+/)).toEqual([]);
+  });
+
+  test("no session trailer in a committed template or script", () => {
+    expect(hits(/Claude-Session:\s*https?:\/\//)).toEqual([]);
+  });
+
+  test("a comment does not quote a message somebody sent", () => {
+    /*
+     * The heuristic is language. This codebase is written in English, and every
+     * one of these got in as a quoted Spanish sentence — so a Spanish function
+     * word between quotes is the shape of the thing, and it is nearly free of
+     * false positives: a real Spanish string in the product would be a
+     * translation file, and there is none.
+     *
+     * Deliberately narrow. It is a tripwire for the mistake that was actually
+     * made, not a language detector; the rule it protects is written in
+     * CLAUDE.md and a person reading a failure here should go and read it.
+     */
+    const SPANISH = /(?:"|«|`)[^"«`\n]{0,120}\b(?:cuando|porque|entonces|debería|deberia|tengo que|puedas|para que|movil|móvil|gracias|vale)\b[^"«`\n]{0,120}(?:"|»|`)/i;
+    expect(hits(SPANISH)).toEqual([]);
+  });
+
+  test("and the rules it enforces are written down", () => {
+    // A lock with no explanation beside it is a lock somebody deletes.
+    const rules = readFileSync(join(ROOT, "CLAUDE.md"), "utf8");
+    expect(rules).toContain("This repository is public");
+    expect(rules).toContain("test/private-content.test.ts");
+  });
+});

--- a/server/test/review-recipes.test.ts
+++ b/server/test/review-recipes.test.ts
@@ -67,8 +67,8 @@ describe("the placeholders", () => {
  * personal, so the wording that actually goes out lives in the user's own file.
  * What is pinned here is the frame's two halves, because losing either is how
  * the feature failed the first time it was used — style copied from the channel
- * with no floor under the content produced a one-line "cuando puedas <link>",
- * and content with no style rule reads like an app wrote it.
+ * with no floor under the content produced a bare "when you can, <link>", and
+ * content with no style rule reads like an app wrote it.
  */
 describe("the prompt that asks somebody for a review", () => {
   const ping = () => C.BUILT_IN_RECIPES.find((r) => r.id === "ready-for-review")!;

--- a/server/test/tmux-move-window.test.ts
+++ b/server/test/tmux-move-window.test.ts
@@ -60,7 +60,7 @@ describe("dragging a tab", () => {
   });
 
   it("dropped leftwards, lands where the line was and pushes the rest along", () => {
-    // His words: "muevo la 7 al 3, entonces el 3 pasa a ser 4".
+    // The rule, stated as a drag: move 7 onto 3, and 3 becomes 4.
     move("w5", 2);
     expect(strip()).toBe("1:w1 2:w5 3:w2 4:w3 5:w4");
   });

--- a/web/src/components/NoteToasts.tsx
+++ b/web/src/components/NoteToasts.tsx
@@ -6,8 +6,8 @@
 // has listed them — but the only thing that *interrupted* was a line of 10px
 // text in the middle of the top bar, which loses its slot to the "needs you"
 // chip the moment anything is held, and which cannot carry a message anyway.
-// "Slack — New message from Alejandro García" is two lines of prose, not a
-// caption.
+// "Slack — New message from <somebody>" plus the message itself is two lines
+// of prose, not a caption.
 //
 // So mirrored notifications get the surface they always needed: a card, in a
 // stack, over everything. Deliberately separate from the bar's lane, which keeps

--- a/web/src/components/TopBarNotes.tsx
+++ b/web/src/components/TopBarNotes.tsx
@@ -190,9 +190,9 @@ export function useAmbientNotes(): { note: Note | null; behind: number; ahead: n
   // The lane is one slot in the middle of the bar, and the "needs you" chip owns
   // that slot whenever anything is held — so the mirrored ping arrived exactly
   // when it was least likely to be shown. And a caption cannot carry someone
-  // else's message: "New message from Alejandro García / Avisa cuando lo tengas"
-  // is prose, and truncating prose to 10px of bar is how you end up opening
-  // Slack to find out what Slack already told you.
+  // else's message: a chat notification is a name and a sentence of prose, and
+  // truncating prose to 10px of bar is how you end up opening Slack to find
+  // out what Slack already told you.
   //
   // Our own events keep the lane, because they genuinely are captions.
 

--- a/web/src/lib/cardActivity.ts
+++ b/web/src/lib/cardActivity.ts
@@ -162,8 +162,8 @@ export const NO_AUTHOR_NOTE =
  * name appears — and a name deserves the same face the creation row gets.
  *
  * Split on the verb rather than on the first word: names have two and three
- * parts ("Alejandro Garcia assigned this task to you"), and a first-word rule
- * would put "Alejandro" beside a face belonging to somebody else.
+ * parts ("A B C assigned this task to you"), and a first-word rule would put
+ * the first of them beside a face belonging to somebody else.
  */
 const SEEN_VERBS = [
   "assigned", "unassigned", "set", "moved", "commented", "mentioned", "added",

--- a/web/src/lib/sysNotify.ts
+++ b/web/src/lib/sysNotify.ts
@@ -796,7 +796,7 @@ function scheduleReopen() {
  * A ClickUp notification, pointed at the board in this app.
  *
  * ClickUp's desktop app posts the task's title and the sentence that happened to
- * it — "Alejandro set the status to: READY FOR QA" — and nothing else: no id, no
+ * it — "<somebody> set the status to: READY FOR QA" — and nothing else: no id, no
  * url, and a D-Bus monitor cannot invoke the notification's own action to ask.
  * So these rows were the only ones behind the bell that could not be opened, and
  * clicking the desktop pop-up went to ClickUp's website, which is the one place


### PR DESCRIPTION
## What does this PR do?

In `keys` mode the row along the bottom is a **button** whose text reads back what has gone down the wire, and nothing ever dropped that transcript — not the bar's ⏎, not the keyboard's return. A line that has *run* has nothing left to read back, so what was left on screen was the message just sent, sitting in a rounded box at the bottom: the exact drawing of a field with a message still in it, which is the one thing that row must not look like.

Enter clears it now, whichever route the key took. **Only** enter: Tab completes a line, up replaces it, Ctrl+C throws it away — all three change the line without ending it, and the pane is what knows what it says afterwards.

The same path had a second bug of the same age. An IME that commits the return as *text* rather than as an editor action lands the newline in the field, and that route called `commit`, which sends the whole line. In `keys` the line has already gone through character by character, so it would have run **twice** — the same double-run the `onPane` machinery exists elsewhere to prevent. It sends the return alone now, which is what the bar's own route has always done.

The other half, in line mode: there the field **is** the pane's line, so a pane that keeps the submitted prompt in its box for a beat puts it straight back into a field that had just been emptied. A report equal to the line just sent is now ignored until the pane says something else — and the guard expires after three seconds, because "the pane still shows it" and "the pane has that line on it again" are the same read and only time separates them. A TUI that legitimately holds the line still mirrors it, one blink later.

## How was it tested?

- `bun test` in `mobile/` — 0 fail, including new tests on `endsTheLine` and `echoOfSent` (the echo's window, its expiry, padding, and the empty submission that must never be swallowed).
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on every touched file — clean.
- Both decisions are predicates in `src/terminal/` rather than conditions inside the screen, for the reason those files already give: a terminal screen cannot be seen in a test here, so what can be decided outside it is. The wiring that cannot be tested that way — that all three send routes record the line — is asserted against the source, the same technique `mirror.test.ts` already uses.

Not exercised on a handset.