### PR TITLE
feat(phone): the work item a pull request came from, whoever tracks it

### DIFF
--- a/mobile/app/(tabs)/tasks.tsx
+++ b/mobile/app/(tabs)/tasks.tsx
@@ -24,7 +24,7 @@
  */
 import { useCallback, useEffect, useLayoutEffect, useMemo, useState } from "react";
 import { FlatList, Linking, Pressable, RefreshControl, Text, View } from "react-native";
-import { useNavigation, useRouter } from "expo-router";
+import { useLocalSearchParams, useNavigation, useRouter } from "expo-router";
 import * as Clipboard from "expo-clipboard";
 import * as Haptics from "expo-haptics";
 import type { ClickUpBoards, ProviderTask } from "../../../shared/providers.ts";
@@ -35,7 +35,8 @@ import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { useTaskProvider } from "../../src/state/use-tracks-work.ts";
 import { localMeta, visibleLocal } from "../../src/model/localTasks.ts";
-import { Card, HeaderPick, Label, Note, Segmented, Sheet, SheetRow, groupEdge } from "../../src/ui.tsx";
+import { matchesQuery } from "../../../shared/taskref.ts";
+import { Card, HeaderPick, Label, Note, Segmented, Sheet, SheetRow, TAP, groupEdge } from "../../src/ui.tsx";
 import { dueIn } from "../../src/lib/dates.ts";
 import { C, MONO, RADIUS, SPACE, T } from "../../src/theme.ts";
 
@@ -182,6 +183,23 @@ export default function TasksScreen(): React.ReactNode {
      until it is known, because fetching ClickUp's board on a Taskwarrior
      machine is the bug this screen had. */
   const provider = useTaskProvider(host);
+  /*
+   * An id handed over from somewhere else — today, the chip on a pull request
+   * that names the item it came from.
+   *
+   * It filters what this screen already has rather than asking the tracker,
+   * and that is the whole reason it works for everybody: the rows are whatever
+   * the connected provider returned, and "every word appears somewhere in the
+   * row" is a question that can be asked of a card, a Taskwarrior task, or
+   * whatever comes next. Nothing here knows which one it is looking at.
+   *
+   * Dismissed rather than sticky: it arrives with a navigation and the screen
+   * is a tab somebody comes back to, so it must not still be filtering
+   * tomorrow.
+   */
+  const { q } = useLocalSearchParams<{ q?: string }>();
+  const [finding, setFinding] = useState<string | null>(null);
+  useEffect(() => { setFinding(q && q.trim() ? q.trim() : null); }, [q]);
   const board = provider?.id === "clickup";
   const localList = !!provider && !board;
 
@@ -224,10 +242,16 @@ export default function TasksScreen(): React.ReactNode {
     // Done cards are the bulk of any board and none of them are work you owe.
     // Kept behind a switch rather than dropped, because "did I close that?" is
     // a real question somebody asks from a sofa.
-    () => (tasks ?? []).filter((t) => (openOnly ? t.statusKind !== "done" : true)),
-    [tasks, openOnly],
+    () => (tasks ?? [])
+      .filter((t) => (openOnly ? t.statusKind !== "done" : true))
+      .filter((t) => !finding || matchesQuery([t.title, t.customId, t.id, t.list], finding)),
+    [tasks, openOnly, finding],
   );
-  const shownLocal = useMemo(() => visibleLocal(local, openOnly), [local, openOnly]);
+  const shownLocal = useMemo(
+    () => visibleLocal(local, openOnly)
+      .filter((t) => !finding || matchesQuery([t.description, t.project, ...t.tags], finding)),
+    [local, openOnly, finding],
+  );
 
   const onRefresh = useCallback((): void => {
     setPulling(true);
@@ -309,6 +333,29 @@ export default function TasksScreen(): React.ReactNode {
         name no product. `undefined` — still asking — draws nothing, because
         the wrong empty state for a second reads as a flash of a lie.
       */}
+      {/* Said out loud, with the way out beside it. A list quietly showing
+          three of forty rows is the same screen as a tracker that lost
+          everything, and the difference has to be on screen. */}
+      {finding ? (
+        <View style={{
+          flexDirection: "row", alignItems: "center", gap: SPACE.sm,
+          paddingHorizontal: SPACE.lg, paddingVertical: SPACE.sm,
+          borderBottomWidth: 1, borderBottomColor: C.border, backgroundColor: C.bg2,
+        }}>
+          <Text numberOfLines={1} style={{ color: C.text2, fontSize: T.small, flex: 1 }}>
+            Showing what matches <Text style={{ color: C.text, fontFamily: MONO }}>{finding}</Text>
+          </Text>
+          <Pressable
+            accessibilityRole="button"
+            accessibilityLabel="Show everything again"
+            onPress={() => setFinding(null)}
+            style={{ minHeight: TAP, justifyContent: "center", paddingLeft: SPACE.md }}
+          >
+            <Text style={{ color: C.primary, fontSize: T.small, fontWeight: "600" }}>Clear</Text>
+          </Pressable>
+        </View>
+      ) : null}
+
       {provider === null ? (
         <View style={{ padding: SPACE.lg }}>
           <Card>

--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -30,6 +30,8 @@ import { ask } from "../../src/lib/api.ts";
 import { Md, outline } from "../../src/md/Md.tsx";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
+import { useTracksWork } from "../../src/state/use-tracks-work.ts";
+import { TaskChip } from "../../src/review/TaskChip.tsx";
 import { RECIPES_PATH, menuFor, situationOf } from "../../src/model/reviewMenu.ts";
 import { requestHandoff } from "../../src/terminal/handoff.ts";
 import { clearDraft, draft, forWire } from "../../src/model/reviewDraft.ts";
@@ -141,6 +143,10 @@ function CheckRow({ check, onOpen }: {
 export default function PrScreen(): React.ReactNode {
   usePaletteTick(); // a scene repaints only if it asks — see use-palette.ts
   const { host } = useAgentglass();
+  /* Whether this machine tracks work in ANYTHING — the catalogue's question,
+     not a product's. It decides only whether an id read from a branch may be
+     offered as something to look up; an address in the body opens either way. */
+  const tracked = useTracksWork(host);
   const router = useRouter();
   const { number, root, review } = useLocalSearchParams<{
     number: string; root: string; review?: string;
@@ -500,6 +506,15 @@ export default function PrScreen(): React.ReactNode {
                 style={{ color: C.text3, fontSize: T.eyebrow, fontFamily: MONO }}
               >{detail.headRefName} → {detail.baseRefName}</Text>
               <View style={{ flexDirection: "row", alignItems: "center", gap: SPACE.sm, flexWrap: "wrap" }}>
+                {/* First, because it is the only chip that says what this pull
+                    request is ABOUT — the rest say what state it is in. It
+                    draws nothing at all on a machine that tracks work nowhere,
+                    or on a pull request that names no item. */}
+                <TaskChip
+                  pr={detail}
+                  tracked={tracked}
+                  onFind={(query) => router.push({ pathname: "/(tabs)/tasks", params: { q: query } })}
+                />
                 {detail.isDraft ? (
                   <View style={{
                     paddingHorizontal: SPACE.sm, paddingVertical: 2,

--- a/mobile/src/review/TaskChip.tsx
+++ b/mobile/src/review/TaskChip.tsx
@@ -1,0 +1,56 @@
+/*
+ * The work item a pull request came from, as four characters at the top of it.
+ *
+ * The rule for whether it may be shown at all — and what a tap is entitled to
+ * do — is `shared/taskref.ts`, shared with the desk so the two cannot drift.
+ * What is decided here is only how it looks, and one thing that is not
+ * decoration: a chip that opens somewhere ELSE carries the mark saying so.
+ * Every other chip on this row is a fact about the pull request; this one is a
+ * door, and a door that looks like a label is a tap nobody makes.
+ *
+ * On a machine that tracks work nowhere, and on a pull request that names
+ * nothing, this renders null — no chip, no gap, no placeholder. That case is
+ * the majority and it has to feel deliberate rather than broken.
+ */
+import { useMemo } from "react";
+import { Linking, Pressable, Text } from "react-native";
+import { chipFor, readTaskRef } from "../../../shared/taskref.ts";
+import { C, RADIUS, SPACE, T } from "../theme.ts";
+
+export function TaskChip({ pr, tracked, onFind }: {
+  pr: { headRefName?: string; title?: string; body?: string; url?: string };
+  /** Whether anything is connected that could resolve a bare id — from the
+   *  provider catalogue, never from a product name. Null while unknown. */
+  tracked: boolean | null;
+  onFind: (query: string, label: string) => void;
+}): React.ReactNode {
+  const ref = useMemo(
+    () => readTaskRef(pr),
+    [pr.headRefName, pr.title, pr.body, pr.url],
+  );
+  const go = useMemo(() => chipFor(ref, tracked), [ref, tracked]);
+  if (!ref || !go) return null;
+
+  const away = "open" in go;
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityLabel={away
+        ? `Open ${ref.label}, the item this pull request came from`
+        : `Find ${ref.label} in the cards on this machine`}
+      onPress={() => {
+        if ("open" in go) void Linking.openURL(go.open).catch(() => { /* no app for it */ });
+        else onFind(go.find, ref.label);
+      }}
+      style={({ pressed }) => ({
+        flexDirection: "row", alignItems: "center", gap: 4,
+        paddingHorizontal: SPACE.sm, paddingVertical: 2,
+        borderRadius: RADIUS.sm, borderWidth: 1, borderColor: C.primary,
+        opacity: pressed ? 0.6 : 1,
+      })}
+    >
+      <Text style={{ color: C.primary, fontSize: T.eyebrow, fontWeight: "600" }}>{ref.label}</Text>
+      {away ? <Text style={{ color: C.primary, fontSize: T.eyebrow }}>↗</Text> : null}
+    </Pressable>
+  );
+}

--- a/mobile/test/task-ref.test.ts
+++ b/mobile/test/task-ref.test.ts
@@ -1,0 +1,222 @@
+/*
+ * Which work item a pull request is about, on a machine that may track work in
+ * anything or in nothing at all.
+ *
+ * The failure this guards against is not a missing chip. It is a chip that is
+ * confidently wrong: a Jira shop shown a ClickUp mark, a Renovate branch given
+ * an id it does not have, or a link to a page that does not exist. So most of
+ * what is pinned here is what the reader REFUSES to say.
+ */
+import { describe, expect, test } from "bun:test";
+import { chipFor, matchesQuery, readTaskRef, taskRefTitle } from "../../shared/taskref.ts";
+
+const PR = "https://github.com/acme/widget/pull/91";
+
+describe("an address in the body is certain", () => {
+  test("a ticket, named by the tracker whose address it is", () => {
+    const ref = readTaskRef({
+      body: "Rewrites the retry loop.\n\nhttps://acme.atlassian.net/browse/WEB-1042",
+      url: PR,
+    });
+    expect(ref).toMatchObject({ label: "WEB-1042", query: "WEB-1042", tracker: "jira", from: "url" });
+    expect(ref!.url).toBe("https://acme.atlassian.net/browse/WEB-1042");
+  });
+
+  test("each shape reads, and none of them is guessed from an id", () => {
+    const of = (line: string) => readTaskRef({ body: `Body.\n\n${line}`, url: PR });
+    expect(of("https://linear.app/acme/issue/ENG-88/retry-loop")!.tracker).toBe("linear");
+    expect(of("https://app.shortcut.com/acme/story/4471")!.tracker).toBe("shortcut");
+    expect(of("https://trello.com/c/aB9xQ2Zk")!.tracker).toBe("trello");
+    expect(of("https://app.asana.com/0/1200/1209")!.tracker).toBe("asana");
+    expect(of("https://dev.azure.com/acme/Widget/_workitems/edit/771")!.tracker).toBe("azure");
+    expect(of("https://gitlab.com/acme/widget/-/issues/12")!.tracker).toBe("gitlab");
+  });
+
+  test("a workspace segment is not the item", () => {
+    // `/t/<team>/<id>` — the last one is the task. The first is the workspace,
+    // and handing that to a lookup asks for an item whose id is a team number.
+    expect(readTaskRef({ body: "https://app.clickup.com/t/900100/ORBIT-1042" })!.query).toBe("ORBIT-1042");
+    expect(readTaskRef({ body: "https://clickup.com/t/8ab12cd34" })!.query).toBe("8ab12cd34");
+  });
+
+  test("a link to the tracker's front page is not a ticket", () => {
+    // Anchored on a path segment that means "an item", not on the host. A link
+    // to somebody's board is not the thing this pull request is about.
+    expect(readTaskRef({ body: "See https://acme.atlassian.net/jira/software/projects/WEB" })).toBeNull();
+    expect(readTaskRef({ body: "Board: https://app.clickup.com/9001/v/li/900200" })).toBeNull();
+  });
+
+  test("the branch's id is preferred as the LABEL, the address as the query", () => {
+    // People say "ORBIT-1042" out loud; a lookup wants the id that cannot be
+    // ambiguous.
+    const ref = readTaskRef({
+      headRefName: "feat/ORBIT-1042-retry",
+      body: "https://clickup.com/t/8ab12cd34",
+    });
+    expect(ref).toMatchObject({ label: "ORBIT-1042", query: "8ab12cd34" });
+  });
+});
+
+describe("a template's own links are not this pull request's item", () => {
+  const TEMPLATE = [
+    "## Checklist",
+    "- [x] I have read the [contributing guide](https://acme.atlassian.net/browse/WEB-1).",
+    "- [ ] Trial only — see [WEB-3306](https://acme.atlassian.net/browse/WEB-3306).",
+    "",
+    "## Reference",
+    "",
+    "https://acme.atlassian.net/browse/WEB-1042",
+  ].join("\n");
+
+  test("only the one written on a line of its own survives", () => {
+    expect(readTaskRef({ body: TEMPLATE })!.query).toBe("WEB-1042");
+  });
+
+  test("a quoted address is somebody else's too", () => {
+    expect(readTaskRef({ body: "> https://acme.atlassian.net/browse/WEB-9\n\nAgreed." })).toBeNull();
+  });
+
+  test("two different items means it cannot tell, so it says nothing", () => {
+    const two = "https://acme.atlassian.net/browse/WEB-1042\n\nhttps://trello.com/c/aB9xQ2Zk";
+    expect(readTaskRef({ body: two })).toBeNull();
+  });
+
+  test("the same item twice is still one item", () => {
+    const twice = "https://acme.atlassian.net/browse/WEB-1042\n\nAgain: https://acme.atlassian.net/browse/WEB-1042";
+    expect(readTaskRef({ body: twice })!.query).toBe("WEB-1042");
+  });
+});
+
+describe("the issue a pull request says it closes", () => {
+  test("the host's own syntax, which needs no tracker connected", () => {
+    const ref = readTaskRef({ body: "Fixes #12", url: PR });
+    expect(ref).toMatchObject({ label: "#12", from: "url", tracker: "github" });
+    expect(ref!.url).toBe("https://github.com/acme/widget/issues/12");
+  });
+
+  test("another repository's issue keeps that repository", () => {
+    expect(readTaskRef({ body: "Closes acme/other#7", url: PR })!.url)
+      .toBe("https://github.com/acme/other/issues/7");
+  });
+
+  test("a merge request resolves against its own host", () => {
+    expect(readTaskRef({ body: "Resolves #5", url: "https://gitlab.com/acme/widget/-/merge_requests/3" })!.url)
+      .toBe("https://gitlab.com/acme/widget/-/issues/5");
+  });
+
+  test("a bare number is not a reference", () => {
+    // Bodies are full of `#12`, and as often as not it is another pull request.
+    expect(readTaskRef({ body: "Same as #12, but for the phone.", url: PR })).toBeNull();
+  });
+
+  test("a linked ticket beats a closing keyword", () => {
+    // Somebody who did both means the ticket; the issue is housekeeping.
+    const ref = readTaskRef({ body: "https://linear.app/acme/issue/ENG-88\n\nFixes #12", url: PR });
+    expect(ref!.query).toBe("ENG-88");
+  });
+
+  test("with no pull request address there is nowhere to send it", () => {
+    expect(readTaskRef({ body: "Fixes #12" })).toBeNull();
+  });
+});
+
+describe("an id by convention", () => {
+  test("is read from the branch, and named by nobody", () => {
+    const ref = readTaskRef({ headRefName: "feat/ORBIT-1042-retry" });
+    expect(ref).toMatchObject({ label: "ORBIT-1042", from: "branch", tracker: null });
+    expect(ref!.url).toBeUndefined();
+  });
+
+  test("falls back to the title, which people type by hand", () => {
+    expect(readTaskRef({ title: "[WEB-1042] retry the loop" })).toMatchObject({ from: "title" });
+  });
+
+  test("the branch names every release tool cuts are not ids", () => {
+    for (const branch of [
+      "fix/UTF-8-decode",
+      "release/v2-1409",
+      "dependabot/npm_and_yarn/types/node-22-10-1",
+      "claude/phone-threads-on-the-line",
+      "agent-v2",
+    ]) {
+      expect(readTaskRef({ headRefName: branch }), branch).toBeNull();
+    }
+  });
+});
+
+describe("what the chip may do with it", () => {
+  const byUrl = readTaskRef({ body: "https://trello.com/c/aB9xQ2Zk" })!;
+  const byBranch = readTaskRef({ headRefName: "feat/ORBIT-1042-retry" })!;
+
+  test("a URL opens, whether or not anything is connected here", () => {
+    expect(chipFor(byUrl, false)).toEqual({ open: "https://trello.com/c/aB9xQ2Zk" });
+    expect(chipFor(byUrl, null)).toEqual({ open: "https://trello.com/c/aB9xQ2Zk" });
+  });
+
+  test("a bare id is handed to whatever IS connected", () => {
+    expect(chipFor(byBranch, true)).toEqual({ find: "ORBIT-1042" });
+  });
+
+  test("and shown to nobody when nothing can resolve it", () => {
+    // The rule that keeps this feature honest on a machine that tracks work
+    // nowhere: it is not a chip that fails on tap, it is no chip.
+    expect(chipFor(byBranch, false)).toBeNull();
+    expect(chipFor(null, true)).toBeNull();
+  });
+
+  test("nor while the answer has not arrived", () => {
+    // Null is "not yet", and a chip that appears a second late is better than
+    // one that appears and vanishes.
+    expect(chipFor(byBranch, null)).toBeNull();
+  });
+
+  test("the long form says which evidence it rests on", () => {
+    expect(taskRefTitle(byUrl)).toContain("linked from the description");
+    expect(taskRefTitle(byBranch)).toContain("convention rather than a link");
+  });
+});
+
+/*
+ * Handing that id to the Cards tab.
+ *
+ * The tab filters the rows it already has rather than asking the tracker, which
+ * is what makes it work for everybody: the rows are whatever the connected
+ * provider returned, and this question can be asked of a card, a Taskwarrior
+ * task, or whatever comes next. Nothing here knows which one it is looking at,
+ * and that is the property under test.
+ */
+describe("finding that item among rows of any shape", () => {
+  test("a card answers on its custom id, its internal id or its title", () => {
+    const card = ["Retry the loop", "ORBIT-1042", "8ab12cd34", "In review"];
+    expect(matchesQuery(card, "ORBIT-1042")).toBe(true);
+    expect(matchesQuery(card, "8ab12cd34")).toBe(true);
+    expect(matchesQuery(card, "retry")).toBe(true);
+    expect(matchesQuery(card, "WEB-9")).toBe(false);
+  });
+
+  test("a local task answers on the fields a local task has", () => {
+    // No ids, no lists — a description, a project and tags. The matcher is
+    // shape-free precisely so this row needs no special case.
+    const task = ["Retry the loop on 429", "widget", "phone", "review"];
+    expect(matchesQuery(task, "retry loop")).toBe(true);
+    expect(matchesQuery(task, "widget")).toBe(true);
+    expect(matchesQuery(task, "ORBIT-1042")).toBe(false);
+  });
+
+  test("every word has to appear, in any of the fields", () => {
+    expect(matchesQuery(["Retry the loop", "widget"], "retry widget")).toBe(true);
+    expect(matchesQuery(["Retry the loop", "widget"], "retry gadget")).toBe(false);
+  });
+
+  test("case does not matter, and neither do missing fields", () => {
+    expect(matchesQuery(["Retry", null, undefined, "ORBIT-1042"], "orbit-1042")).toBe(true);
+  });
+
+  test("an empty query matches nothing, so a caller cannot filter by accident", () => {
+    // The screen reads it from a route parameter. Empty there means "show what
+    // you were showing", and that decision belongs to the screen — not to a
+    // matcher that would otherwise quietly return everything or nothing.
+    expect(matchesQuery(["anything"], "")).toBe(false);
+    expect(matchesQuery(["anything"], "   ")).toBe(false);
+  });
+});

--- a/server/src/clickup.ts
+++ b/server/src/clickup.ts
@@ -18,6 +18,7 @@
  */
 import { singleFlight } from "./singleflight.ts";
 import { cardIdDigits, mentionsCardId } from "../../shared/cardRef.ts";
+import { matchesQuery } from "../../shared/taskref.ts";
 import * as Index from "./clickupindex.ts";
 import { writesAllowed } from "./clickupviews.ts";
 import { secretFor, annotate, redacted, fingerprint } from "./credentials.ts";
@@ -815,10 +816,10 @@ async function sweepWorkspace(
  *  this is a list somebody is scanning, and a fuzzy hit they cannot see the
  *  reason for reads as noise. */
 export function matchesText(t: Pick<ProviderTask, "title" | "customId" | "id" | "list">, q: string): boolean {
-  const words = q.toLowerCase().split(/\s+/).filter(Boolean);
-  if (!words.length) return false;
-  const hay = `${t.title} ${t.customId ?? ""} ${t.id} ${t.list ?? ""}`.toLowerCase();
-  return words.every((w) => hay.includes(w));
+  // The rule itself is in shared/, because the phone asks the same question of
+  // a row it already has and two copies of "every word appears somewhere"
+  // drift the day one of them learns about a new field.
+  return matchesQuery([t.title, t.customId, t.id, t.list], q);
 }
 
 /**

--- a/shared/taskref.ts
+++ b/shared/taskref.ts
@@ -1,0 +1,266 @@
+/*
+ * The work item a pull request came from, whoever tracks it.
+ *
+ * A pull request usually exists BECAUSE of something — a card, a ticket, an
+ * issue. Standing on the pull request, that link is worth four characters of
+ * chrome: it is how you tell two similarly-titled pull requests apart, and how
+ * you get from a review back to what was actually asked for.
+ *
+ * ── it must work for somebody who has never heard of any of these ────────
+ * Most people running this have no ClickUp. Some have Jira, some have Linear,
+ * plenty have nothing but GitHub issues, and plenty have nothing at all. So
+ * this reads what a pull request CARRIES and never assumes which product wrote
+ * it, and the three answers it can give are:
+ *
+ *   nothing              null. No chip, no gap, no placeholder — the row is
+ *                        simply one thing shorter. This is the common case and
+ *                        the one that has to feel deliberate.
+ *   an address           certain. The body named a tracker's own URL, and a
+ *                        URL opens without anybody's credentials or setup.
+ *   an id by convention  shown only when the caller says something is
+ *                        connected that could resolve it, and never dressed in
+ *                        a particular tracker's colours: `WEB-1042` is a shape
+ *                        half the trackers in the world use, and being
+ *                        confidently wrong about which one owns an id sends
+ *                        people to a page that does not exist.
+ *
+ * ── what it deliberately does not do ─────────────────────────────────────
+ * Guess a provider from the shape of an id. A tracker is named only when its
+ * own address was in the body; otherwise `tracker` is null and stays null.
+ */
+
+/** The trackers whose addresses can be read without ambiguity. Not a list of
+ *  what is supported — nothing here needs supporting — but of URL shapes that
+ *  cannot be mistaken for somebody else's. */
+export type TrackerId =
+  | "clickup" | "jira" | "linear" | "shortcut" | "asana" | "trello"
+  | "github" | "gitlab" | "azure";
+
+export type Evidence = "url" | "branch" | "title";
+
+export interface TaskRef {
+  /** What the chip says, because it is what people say out loud. */
+  label: string;
+  /** What a finder is handed. Not always the label: an address carries an
+   *  unambiguous id, and using it skips a custom-id lookup entirely. */
+  query: string;
+  /** Present only when the body carried a real address. Without one there is
+   *  nowhere honest to send a click. */
+  url?: string;
+  from: Evidence;
+  /** Named ONLY by its own address. Never inferred from an id's shape. */
+  tracker: TrackerId | null;
+}
+
+/**
+ * One tracker's address, and which capture is the item.
+ *
+ * Every pattern is anchored on a host AND a path segment that means "an item"
+ * — `/t/`, `/browse/`, `/issue/`, `/issues/`. A host alone is not enough: a
+ * link to somebody's Jira dashboard is not a ticket, and a chip that opens one
+ * is a chip that lied.
+ */
+const ADDRESSES: { tracker: TrackerId; re: RegExp; pick?: (m: RegExpExecArray) => string }[] = [
+  // Two shapes in the wild: `/t/<id>` and `/t/<team>/<id>`, the second being a
+  // workspace with custom ids switched on. When there are two segments the LAST
+  // is the task — the first is the workspace, and handing that to a lookup asks
+  // for an item whose id is a team number.
+  {
+    tracker: "clickup",
+    re: /https?:\/\/(?:[\w-]+\.)*clickup\.com\/t\/([\w-]+)(?:\/([\w-]+))?/i,
+    pick: (m) => m[2] ?? m[1]!,
+  },
+  { tracker: "jira", re: /https?:\/\/[\w-]+\.atlassian\.net\/browse\/([A-Z][A-Z0-9]+-\d+)/i },
+  { tracker: "linear", re: /https?:\/\/linear\.app\/[\w-]+\/issue\/([A-Z][A-Z0-9]+-\d+)/i },
+  { tracker: "shortcut", re: /https?:\/\/app\.shortcut\.com\/[\w-]+\/story\/(\d+)/i },
+  { tracker: "asana", re: /https?:\/\/app\.asana\.com\/\d+\/\d+\/(\d+)/i },
+  { tracker: "trello", re: /https?:\/\/trello\.com\/c\/([\w-]+)/i },
+  { tracker: "github", re: /https?:\/\/github\.com\/[\w.-]+\/[\w.-]+\/issues\/(\d+)/i },
+  { tracker: "gitlab", re: /https?:\/\/(?:[\w-]+\.)*gitlab\.[\w.]+\/[\w./-]+?\/-\/issues\/(\d+)/i },
+  { tracker: "azure", re: /https?:\/\/dev\.azure\.com\/[\w-]+\/[\w%-]+\/_workitems\/edit\/(\d+)/i },
+];
+
+/**
+ * The item addresses a body MEANS, which is not every address in it.
+ *
+ * Lines that are a list item or a quotation are skipped. That is where a
+ * template puts its own links and where a reply quotes somebody else's, and
+ * both are in the body of every pull request the template made rather than in
+ * the one you are reading. Measured on real pull requests before this rule
+ * existed: most of them resolved to the same item, because the checklist they
+ * are all written from links an item of its own. What survives is a reference
+ * somebody wrote for THIS pull request — on its own line, bare or as a link.
+ */
+function addresses(body: string): { id: string; url: string; tracker: TrackerId }[] {
+  const found = new Map<string, { id: string; url: string; tracker: TrackerId }>();
+  for (const line of (body || "").split(/\r?\n/)) {
+    if (/^\s*(?:[-*+>]|\d+[.)])\s/.test(line)) continue;
+    for (const { tracker, re, pick } of ADDRESSES) {
+      const m = re.exec(line);
+      if (!m) continue;
+      const id = pick ? pick(m) : m[1]!;
+      found.set(`${tracker}:${id}`, { id, url: m[0], tracker });
+    }
+  }
+  return [...found.values()];
+}
+
+/**
+ * A human item id: capitals, a hyphen, digits.
+ *
+ * Every bound is doing one job — keeping ordinary branch names out of a chip.
+ * None of them are hypothetical:
+ *
+ *   fix/UTF-8-decode                    one digit, so not an id
+ *   release/v2-1409                     lower case, and a digit in the prefix
+ *   .../types/node-22-10-1              lower case — this is the one that bites
+ *
+ * Capitals is the load-bearing rule, and it is not arbitrary: an id is a proper
+ * noun and gets written as one, by every tracker's own "create branch", by
+ * every template, and by anybody copying it out of an address bar. Somebody who
+ * lower-cases theirs loses the chip on the branch and keeps it via the address
+ * in the body, which is where most of them come from anyway.
+ *
+ * It must start the string or follow a separator, so `agent-v2` cannot lend its
+ * tail to something that looks like an id. What follows may be a hyphen — a
+ * branch is `ORBIT-1042-what-it-was-about` — but not a word character, so a
+ * number is never matched half-way.
+ */
+const HUMAN_ID = /(?:^|[/_\-\s[(])([A-Z]{2,10})-(\d{2,})(?!\w)/;
+
+const human = (s: string): string | null => {
+  const m = HUMAN_ID.exec(s || "");
+  return m ? `${m[1]}-${m[2]}` : null;
+};
+
+/**
+ * The issue this pull request says it closes, in the host's own syntax.
+ *
+ * `Fixes #12`, `Closes owner/repo#12`. This is the one every public repository
+ * has and no tracker needs to be connected for — GitHub and GitLab both write
+ * it, both act on it, and the number is meaningful against the pull request's
+ * own repository.
+ *
+ * Skipped inside list items and quotations for the same reason as an address,
+ * and a bare `#12` with no keyword is NOT read: pull request bodies are full of
+ * them, referring to other pull requests as often as to issues.
+ */
+const CLOSES = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\s+(?:([\w.-]+\/[\w.-]+))?#(\d+)\b/i;
+
+function closesIssue(body: string): { label: string; query: string; repo?: string } | null {
+  for (const line of (body || "").split(/\r?\n/)) {
+    if (/^\s*(?:[-*+>]|\d+[.)])\s/.test(line)) continue;
+    const m = CLOSES.exec(line);
+    if (m) return { label: `#${m[2]}`, query: m[2]!, repo: m[1] };
+  }
+  return null;
+}
+
+/**
+ * What item this pull request is about, as far as it is willing to say.
+ *
+ * `repoUrl` is the pull request's own address, used only to build the URL of an
+ * issue it says it closes — `…/pull/91` and `…/issues/12` differ by one
+ * segment, and without it that reference has a label and nowhere to go.
+ *
+ * Two different addresses surviving means the body names two items and this
+ * cannot tell which is the one. It says so by returning neither: a chip that
+ * opens the wrong thing is worse than no chip, because it is believed.
+ */
+export function readTaskRef(
+  pr: { headRefName?: string; title?: string; body?: string; url?: string },
+): TaskRef | null {
+  // The label people recognise, wherever it turns up. Branch first: it is
+  // written by the tool that cut it, so it is the id far more often than a
+  // title somebody typed.
+  const branch = human(pr.headRefName ?? "");
+  const named = branch ?? human(pr.title ?? "");
+  const [only, ...rest] = addresses(pr.body ?? "");
+
+  if (only && !rest.length) {
+    return { label: named ?? only.id, query: only.id, url: only.url, from: "url", tracker: only.tracker };
+  }
+  // An address beats a closing keyword: somebody who linked a ticket AND wrote
+  // "fixes #12" means the ticket, and the issue is the housekeeping.
+  if (!only) {
+    const issue = closesIssue(pr.body ?? "");
+    if (issue) {
+      const url = issueUrl(pr.url, issue.repo, issue.query);
+      // Without an address this is still certain — the host resolves the
+      // number itself — but it is only useful if it can be opened.
+      if (url) return { label: issue.label, query: issue.query, url, from: "url", tracker: hostOf(pr.url) };
+    }
+  }
+  if (!named) return null;
+  return { label: named, query: named, from: branch ? "branch" : "title", tracker: null };
+}
+
+/** `…/owner/repo/pull/91` → `…/owner/repo/issues/12`, and the same for a
+ *  GitLab merge request. Null when the pull request's own address is unknown or
+ *  is not one of those two shapes — a guessed URL is the thing this file exists
+ *  to avoid. */
+function issueUrl(prUrl: string | undefined, repo: string | undefined, number: string): string | undefined {
+  if (!prUrl) return undefined;
+  const gh = /^(https?:\/\/[^/]*github\.[^/]+)\/([\w.-]+\/[\w.-]+)\/pull\/\d+/i.exec(prUrl);
+  if (gh) return `${gh[1]}/${repo ?? gh[2]}/issues/${number}`;
+  const gl = /^(https?:\/\/[^/]*gitlab\.[^/]+)\/([\w./-]+?)\/-\/merge_requests\/\d+/i.exec(prUrl);
+  if (gl) return `${gl[1]}/${repo ?? gl[2]}/-/issues/${number}`;
+  return undefined;
+}
+
+function hostOf(prUrl: string | undefined): TrackerId | null {
+  if (!prUrl) return null;
+  if (/github\./i.test(prUrl)) return "github";
+  if (/gitlab\./i.test(prUrl)) return "gitlab";
+  return null;
+}
+
+/**
+ * What a chip may DO with a reference, as one decision rather than a condition
+ * spread across some JSX.
+ *
+ * `tracked` is the caller's answer to "is anything connected that could resolve
+ * a bare id" — on both clients that comes from the provider catalogue and never
+ * from a product name. Null while the answer has not arrived: saying nothing
+ * until it has is what stops a chip appearing and then vanishing.
+ *
+ *   null          say nothing — an id from a tracker nothing here can resolve
+ *   { open }      a URL, which needs nobody's credentials
+ *   { find }      hand the id to whatever tracker is connected
+ */
+export function chipFor(
+  ref: TaskRef | null,
+  tracked: boolean | null,
+): { open: string } | { find: string } | null {
+  if (!ref) return null;
+  if (ref.url) return { open: ref.url };
+  if (tracked === true) return { find: ref.query };
+  return null;
+}
+
+/** What the chip says when there is room to explain it — where the honesty
+ *  about evidence lives, since the chip itself is a few characters. */
+export function taskRefTitle(ref: TaskRef): string {
+  return ref.from === "url"
+    ? `${ref.label} — linked from the description`
+    : `${ref.label} — read from the ${ref.from}, which is a convention rather than a link`;
+}
+
+/**
+ * Does this row answer that query?
+ *
+ * Every word must appear somewhere in the row's own text. Shape-free on
+ * purpose — the caller passes the fields, because a ClickUp card, a Taskwarrior
+ * task and whatever comes next do not agree on what they are called, and a
+ * matcher that knew would be a matcher that has to be edited per tracker.
+ *
+ * An empty query matches nothing rather than everything: it is asked by a
+ * screen that has been handed an id, and "no id" there means "show what you
+ * were showing", which the caller decides — not this.
+ */
+export function matchesQuery(fields: (string | null | undefined)[], q: string): boolean {
+  const words = q.toLowerCase().split(/\s+/).filter(Boolean);
+  if (!words.length) return false;
+  const hay = fields.filter(Boolean).join(" ").toLowerCase();
+  return words.every((w) => hay.includes(w));
+}


### PR DESCRIPTION
## What does this PR do?

A pull request usually exists **because** of something — a card, a ticket, an issue — and standing on the pull request the phone said nothing about what. The desk has a chip for it, but its reader is `web/src/lib/cardRef.ts`, and that file says out loud what it is: a ClickUp reader. Most people running agentglass have no ClickUp, plenty have nothing but GitHub issues, and plenty have nothing at all.

So the rule moves to `shared/taskref.ts` and stops naming a product.

**An address in the body** — certain, and named by whose address it is: ClickUp, Jira, Linear, Shortcut, Asana, Trello, GitHub, GitLab, Azure Boards. Every pattern is anchored on a host **and** a path segment that means "an item" (`/browse/`, `/issue/`, `/t/`, `/issues/`), because a link to somebody's board is not a ticket and a chip that opens one has lied.

**`Fixes #12`** — the one every public repository has and no tracker needs to be connected for. Resolved against the pull request's own address, so `…/pull/91` gives `…/issues/12`, and `Closes acme/other#7` keeps that repository. A bare `#12` is deliberately not read: bodies are full of them and as often as not they mean another pull request.

**An id in the branch** — a convention, shown only when something is connected that could resolve it, and never dressed in a tracker's colours. `WEB-1042` is a shape half the trackers in the world use, and being confidently wrong about which one owns an id sends people to a page that does not exist.

The two rules that were measured on real pull requests are kept: a template's own links are skipped by shape — they live inside checklist items, a real reference is a line of its own — and a body naming two different items means the reader cannot tell, so it returns neither.

### On the phone

Four characters at the head of the pull request screen, first in the chip row, because it is the only chip that says what the pull request is *about* rather than what state it is in.

- Carried an address → it opens, with the `↗` that says the tap leaves. No tracker, no token.
- Only an id, and this machine tracks work somewhere → the Cards tab, filtered to it. **The tab filters the rows it already has**, so it works for whatever provider answered — a ClickUp card by its custom id, a Taskwarrior task by its text — and nothing along that path knows which one it is looking at.
- Anything else → no chip. Not a chip that fails on tap, not an empty slot: the row is one thing shorter. That is the majority case and it should feel deliberate.

The filter says out loud what it is doing, with Clear beside it — a list quietly showing three of forty rows is the same screen as a tracker that lost everything — and it is dropped when the tab is left, because a tab you come back to must not still be filtering tomorrow.

`matchesQuery` is shape-free: the caller passes the fields, because a card, a Taskwarrior task and whatever comes next do not agree on what they are called. The server's `matchesText` delegates to it rather than keeping a second copy of "every word appears somewhere".

## How was it tested?

- `bun test` in `mobile/` — **763 pass, 41 skip, 0 fail**, including 28 new tests. Most of them pin what the reader **refuses** to say: a Renovate branch, a release branch, `fix/UTF-8-decode`, a link to a Jira dashboard, a quoted address, a body naming two items, a bare `#12`.
- `bun test` in `server/` — the failure count is unchanged from `main` on this machine (tmux, D-Bus and keychain are not available in this container); the ClickUp suites that cover the moved matcher are green, 169 pass.
- `npm run typecheck` in `mobile/`, `bun run typecheck` in `server/` and `web/` — clean. `bunx oxlint` on every touched file — clean, bar one warning that predates this branch.

Not exercised on a handset. The case worth a second pair of eyes is a machine with no tracker at all, where the intended result is that nothing new appears anywhere.