### PR TITLE
feat(phone): mark what changed inside a line, not just which line changed

### DIFF
--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -63,6 +63,7 @@ import {
 import { gapLabel, gapsIn, nextSlice, type Gap } from "../../src/model/expand.ts";
 import { draft, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
 import { threadsOnFile } from "../../src/model/threads.ts";
+import { inlineSpans, pairsIn, type Span } from "../../src/model/tokens.ts";
 import { ApplyConfirm } from "../../src/review/ApplyConfirm.tsx";
 import { ThreadCard } from "../../src/review/ThreadCard.tsx";
 import { ThreadMarker } from "../../src/review/ThreadMarker.tsx";
@@ -229,6 +230,32 @@ export default function DiffScreen(): React.ReactNode {
   }, [path, files]);
 
   const file: DiffFile | undefined = files[at];
+
+  /*
+   * What changed INSIDE each line, for the pairs that are an edit.
+   *
+   * Computed once per file rather than per row: it is pure, the file does not
+   * change under it, and a row that recomputed its own would do so on every
+   * repaint of a screen that repaints on every tap. Keyed by hunk and index
+   * because that is what the renderer has in hand.
+   *
+   * Bounded twice over in `tokens.ts` — a pair too dissimilar to be an edit
+   * gets nothing, and a middle too long for the table is marked coarsely — so
+   * a file of minified JavaScript costs a pass over its lines and stops.
+   */
+  const marks = useMemo(() => {
+    const out = new Map<string, Span[]>();
+    if (!file) return out;
+    file.hunks.forEach((hunk, h) => {
+      for (const [del, add] of pairsIn(hunk.lines)) {
+        const both = inlineSpans(hunk.lines[del]!.text, hunk.lines[add]!.text);
+        if (!both) continue;
+        out.set(`${h}:${del}`, both.before);
+        out.set(`${h}:${add}`, both.after);
+      }
+    });
+    return out;
+  }, [file]);
 
   /** This file's conversations: the ones with a line to sit on, and the ones
    *  whose lines have gone. */
@@ -536,7 +563,22 @@ export default function DiffScreen(): React.ReactNode {
                         flex: 1, color: line.kind === "meta" ? C.text4 : C.text2,
                         fontSize: 10.5, fontFamily: MONO, lineHeight: 20, paddingRight: SPACE.sm,
                       }}
-                    >{line.text || " "}</Text>
+                    >
+                      {/* The words that actually changed, when this line is a
+                          rewrite of the one above or below it. A hunk that
+                          renames one identifier used to be two full-width
+                          bands and a game of spot-the-difference at eleven
+                          points; the band still says which side you are on,
+                          and this says where to look. */}
+                      {marks.get(`${h}:${i}`)?.map((span, s) => (
+                        <Text
+                          key={s}
+                          style={span.changed
+                            ? { color: C.text, backgroundColor: tint(face.ink, 0.34), fontWeight: "600" }
+                            : undefined}
+                        >{span.text}</Text>
+                      )) ?? (line.text || " ")}
+                    </Text>
                   </Pressable>
 
                   {yoursOn(line.newNo ?? null)}

--- a/mobile/src/model/tokens.ts
+++ b/mobile/src/model/tokens.ts
@@ -1,0 +1,172 @@
+/*
+ * What actually changed INSIDE a line.
+ *
+ * A hunk that renames one identifier draws two full-width bands, one red and
+ * one green, and leaves the reader to play spot-the-difference on eleven-point
+ * monospace. On a 393-point screen that is most of the work of reading a diff,
+ * and it is work a machine can do: the two lines are right there.
+ *
+ * ── which lines are a pair ───────────────────────────────────────────────
+ * A run of deletions immediately followed by a run of additions is an edit,
+ * and the nth of each is the same line before and after. That is the rule
+ * every diff viewer uses and it is right far more often than it is wrong —
+ * but only when the runs are the same length. Three lines deleted and one
+ * added is not three edits, it is a deletion and an insertion, and pairing
+ * them would draw a relationship that is not there.
+ *
+ * ── and when a pair is too different to be one ───────────────────────────
+ * Two lines that share almost nothing are not an edit of each other; they are
+ * a line that went and a line that came. Highlighting them token by token
+ * would mark nearly everything, which is the same as marking nothing while
+ * costing the reader a second to work that out. So a pair below a similarity
+ * floor gets no intra-line marks at all and stays two plain bands.
+ *
+ * ── the cost, which is the reason for the shape below ────────────────────
+ * A diff is text a stranger wrote and a line has no length limit — a minified
+ * bundle is one line of 300kB. Common prefix and suffix are trimmed first, in
+ * one pass each, which is what most real edits are made of. Only what is left
+ * in the middle goes through the quadratic part, and only when both middles
+ * are short enough for it to be free; past that the whole middle is marked,
+ * which is coarser and never slower than the reader's patience.
+ */
+import type { DiffLine } from "./diffLines.ts";
+
+/** A run of text, and whether it is part of what changed. */
+export interface Span { text: string; changed: boolean }
+
+/**
+ * Words, punctuation and runs of space, kept separately.
+ *
+ * Token granularity rather than character: a renamed identifier is ONE thing
+ * that changed, and marking it letter by letter — `agentglas`|`s` — is how a
+ * highlight becomes confetti. Whitespace is its own token so that indentation
+ * changes show as indentation changing.
+ */
+export function tokens(line: string): string[] {
+  return line.match(/[A-Za-z0-9_$]+|\s+|[^A-Za-z0-9_$\s]/g) ?? [];
+}
+
+/** Both middles longer than this and the pair keeps the coarse marking. 64×64
+ *  comparisons is nothing; the guard is against the line that is a whole file. */
+const LCS_LIMIT = 64;
+
+/** Below this share of tokens in common, two lines are not an edit of each
+ *  other. Half is deliberately generous: a line whose right-hand side was
+ *  rewritten still shares its declaration, and that is worth marking. */
+const SIMILAR = 0.3;
+
+/**
+ * The spans to draw for one pair of lines, or null when there is no pair worth
+ * drawing.
+ *
+ * Null is a real answer and the caller must handle it: it means "these two are
+ * not an edit of each other", and the honest drawing then is the two plain
+ * bands this app already had.
+ */
+export function inlineSpans(before: string, after: string): { before: Span[]; after: Span[] } | null {
+  if (before === after) return null;
+  const a = tokens(before);
+  const b = tokens(after);
+  if (!a.length || !b.length) return null;
+
+  // The head and tail the two lines agree on, in tokens. Most edits are a
+  // change in the middle of a line that is otherwise identical, so this alone
+  // usually leaves a middle of two or three tokens.
+  let head = 0;
+  while (head < a.length && head < b.length && a[head] === b[head]) head++;
+  let tail = 0;
+  while (
+    tail < a.length - head && tail < b.length - head
+    && a[a.length - 1 - tail] === b[b.length - 1 - tail]
+  ) tail++;
+
+  const midA = a.slice(head, a.length - tail);
+  const midB = b.slice(head, b.length - tail);
+  const shared = head + tail;
+  if (shared / Math.max(a.length, b.length) < SIMILAR) return null;
+
+  const marks = midA.length <= LCS_LIMIT && midB.length <= LCS_LIMIT
+    ? viaLcs(midA, midB)
+    : { a: midA.map(() => true), b: midB.map(() => true) };
+
+  return {
+    before: assemble(a, head, tail, marks.a),
+    after: assemble(b, head, tail, marks.b),
+  };
+}
+
+/**
+ * Which of the middle tokens are NOT in the longest common subsequence.
+ *
+ * The textbook table, on a middle that has already been trimmed and bounded.
+ * It is here rather than a prefix rule because the case it buys is common and
+ * visible: `foo(a, b)` becoming `foo(a, c, b)` marks `c` and nothing else,
+ * where a prefix-only rule marks `c, b` and reads as though two things moved.
+ */
+function viaLcs(a: string[], b: string[]): { a: boolean[]; b: boolean[] } {
+  const n = a.length;
+  const m = b.length;
+  const table: number[][] = Array.from({ length: n + 1 }, () => Array.from<number>({ length: m + 1 }).fill(0));
+  for (let i = n - 1; i >= 0; i--) {
+    for (let j = m - 1; j >= 0; j--) {
+      table[i]![j] = a[i] === b[j]
+        ? table[i + 1]![j + 1]! + 1
+        : Math.max(table[i + 1]![j]!, table[i]![j + 1]!);
+    }
+  }
+  const markA = Array.from<boolean>({ length: n }).fill(true);
+  const markB = Array.from<boolean>({ length: m }).fill(true);
+  let i = 0;
+  let j = 0;
+  while (i < n && j < m) {
+    if (a[i] === b[j]) { markA[i] = false; markB[j] = false; i++; j++; }
+    else if (table[i + 1]![j]! >= table[i]![j + 1]!) i++;
+    else j++;
+  }
+  return { a: markA, b: markB };
+}
+
+/** The whole line as spans: the agreed head, the marked middle, the agreed
+ *  tail — with neighbours of the same kind joined, because one `<Text>` per
+ *  token is a paragraph the layout engine has to measure word by word. */
+function assemble(all: string[], head: number, tail: number, marks: boolean[]): Span[] {
+  const flags = [
+    ...Array.from<boolean>({ length: head }).fill(false),
+    ...marks,
+    ...Array.from<boolean>({ length: tail }).fill(false),
+  ];
+  const out: Span[] = [];
+  for (let i = 0; i < all.length; i++) {
+    const changed = flags[i] ?? false;
+    const last = out[out.length - 1];
+    if (last && last.changed === changed) last.text += all[i]!;
+    else out.push({ text: all[i]!, changed });
+  }
+  return out;
+}
+
+/**
+ * The pairs in a hunk: which deleted line each added line is a rewrite of.
+ *
+ * Keyed by index into the hunk's own lines, because that is what the renderer
+ * has in hand while it draws. A run only pairs when the two sides are the same
+ * length — see the note at the top about three deleted and one added.
+ */
+export function pairsIn(lines: DiffLine[]): Map<number, number> {
+  const pairs = new Map<number, number>();
+  let i = 0;
+  while (i < lines.length) {
+    if (lines[i]!.kind !== "del") { i++; continue; }
+    let dels = i;
+    while (dels < lines.length && lines[dels]!.kind === "del") dels++;
+    let adds = dels;
+    while (adds < lines.length && lines[adds]!.kind === "add") adds++;
+    const removed = dels - i;
+    const added = adds - dels;
+    if (removed > 0 && removed === added) {
+      for (let k = 0; k < removed; k++) pairs.set(i + k, dels + k);
+    }
+    i = adds > dels ? adds : dels;
+  }
+  return pairs;
+}

--- a/mobile/test/tokens.test.ts
+++ b/mobile/test/tokens.test.ts
@@ -1,0 +1,182 @@
+/*
+ * What changed inside a line, and — mostly — when not to claim anything did.
+ *
+ * The value of this is a reader not playing spot-the-difference on eleven-point
+ * monospace. The RISK of it is a highlight that marks the wrong half of a line,
+ * which is worse than the two plain bands it replaced: a mark is read as a
+ * fact, and a wrong fact about a diff sends somebody looking at code that did
+ * not change. So most of what is pinned here is a refusal.
+ */
+import { describe, expect, test } from "bun:test";
+import { inlineSpans, pairsIn, tokens } from "../src/model/tokens.ts";
+import type { DiffLine } from "../src/model/diffLines.ts";
+
+/** The changed text of a side, which is the whole question a reader has. */
+const marked = (spans: { text: string; changed: boolean }[] | undefined): string =>
+  (spans ?? []).filter((s) => s.changed).map((s) => s.text).join("");
+
+/** And the whole line back, which must be exactly what went in — a renderer
+ *  that drops a character is a diff that lies. */
+const whole = (spans: { text: string }[] | undefined): string =>
+  (spans ?? []).map((s) => s.text).join("");
+
+describe("one identifier renamed", () => {
+  const both = inlineSpans(
+    "  const answer = await ask(host, `/prs/diff?${query}`);",
+    "  const answer = await ask(host, `/prs/detail?${query}`);",
+  )!;
+
+  test("only the word that changed is marked, on each side", () => {
+    expect(marked(both.before)).toBe("diff");
+    expect(marked(both.after)).toBe("detail");
+  });
+
+  test("and the line comes back whole", () => {
+    expect(whole(both.before)).toBe("  const answer = await ask(host, `/prs/diff?${query}`);");
+    expect(whole(both.after)).toBe("  const answer = await ask(host, `/prs/detail?${query}`);");
+  });
+
+  test("neighbouring tokens of the same kind are one span", () => {
+    // One `<Text>` per token is a paragraph the layout engine measures word by
+    // word, on every row of a diff that can be four hundred rows long.
+    expect(both.before.length).toBeLessThan(6);
+  });
+});
+
+describe("an insertion in the middle", () => {
+  test("marks what was inserted and nothing either side of it", () => {
+    // The case a prefix-only rule gets wrong: it would mark `c, b` and read as
+    // though two things moved.
+    const both = inlineSpans("foo(a, b)", "foo(a, c, b)")!;
+    expect(marked(both.before)).toBe("");
+    expect(marked(both.after)).toBe("c, ");
+  });
+
+  test("a token appended at the end is the only mark", () => {
+    const both = inlineSpans("await load()", "await load(host)")!;
+    expect(marked(both.after)).toBe("host");
+  });
+
+  test("indentation changing is visible as indentation changing", () => {
+    // Whitespace is its own token, so this is not "the whole line changed".
+    const both = inlineSpans("  return null;", "      return null;")!;
+    expect(marked(both.before)).toBe("  ");
+    expect(marked(both.after)).toBe("      ");
+  });
+});
+
+describe("what it refuses to mark", () => {
+  test("two lines that share almost nothing are not an edit of each other", () => {
+    // A line that went and a line that came. Marking them token by token marks
+    // nearly everything, which is the same as marking nothing and costs the
+    // reader a second to work out.
+    expect(inlineSpans("import { readFileSync } from 'node:fs';", "export const TAP = 44;")).toBeNull();
+  });
+
+  test("identical lines have nothing to say", () => {
+    expect(inlineSpans("same", "same")).toBeNull();
+  });
+
+  test("an empty side is not a rewrite", () => {
+    // A line emptied or a line born is a deletion and an addition; the bands
+    // already say so.
+    expect(inlineSpans("", "something")).toBeNull();
+    expect(inlineSpans("something", "")).toBeNull();
+  });
+});
+
+describe("a line with no length limit", () => {
+  const under = (name: string, before: string, after: string): void => {
+    test(name, () => {
+      const started = performance.now();
+      inlineSpans(before, after);
+      // Loose on purpose. It is not a benchmark — it is the difference between
+      // a scroll and a phone that stops answering, and a tight number here
+      // would fail on a busy runner while proving nothing extra.
+      expect(performance.now() - started).toBeLessThan(500);
+    });
+  };
+
+  const long = "x".repeat(4000);
+  under("a minified line that changed at the end", `${long} a`, `${long} b`);
+  under("two long lines that differ throughout",
+    Array.from({ length: 2000 }, (_, i) => `t${i}`).join(" "),
+    Array.from({ length: 2000 }, (_, i) => `u${i}`).join(" "));
+  under("a long line with a long common middle",
+    `head ${long} tail`, `HEAD ${long} TAIL`);
+
+  test("past the bound it is coarse rather than slow", () => {
+    // A line the two sides mostly agree on, whose disagreement is longer than
+    // the table is allowed to be: the whole middle is marked. Coarser than the
+    // truth, and never slower than the reader's patience.
+    const same = Array.from({ length: 400 }, (_, i) => `k${i}`).join(" ");
+    const a = `${same} ${Array.from({ length: 300 }, (_, i) => `a${i}`).join(" ")} ${same}`;
+    const b = `${same} ${Array.from({ length: 300 }, (_, i) => `b${i}`).join(" ")} ${same}`;
+    const both = inlineSpans(a, b)!;
+    expect(whole(both.before)).toBe(a);
+    expect(marked(both.before)).toContain("a0");
+    expect(marked(both.before)).not.toContain("k0");
+  });
+
+  test("and a pair with nothing much in common is refused before any of that", () => {
+    // The similarity floor comes first, so the expensive path is never even
+    // reached for two lines that are not an edit of each other.
+    const a = Array.from({ length: 300 }, (_, i) => `a${i}`).join(" ");
+    const b = Array.from({ length: 300 }, (_, i) => `b${i}`).join(" ");
+    expect(inlineSpans(a, b)).toBeNull();
+  });
+});
+
+describe("which lines are a pair", () => {
+  const line = (kind: DiffLine["kind"], text: string): DiffLine =>
+    ({ kind, text, oldNo: null, newNo: null });
+
+  test("a run of deletions followed by as many additions", () => {
+    const pairs = pairsIn([
+      line("ctx", "before"),
+      line("del", "one"), line("del", "two"),
+      line("add", "ONE"), line("add", "TWO"),
+      line("ctx", "after"),
+    ]);
+    expect([...pairs]).toEqual([[1, 3], [2, 4]]);
+  });
+
+  test("uneven runs are a deletion and an insertion, not edits", () => {
+    // Three lines deleted and one added is not three rewrites, and pairing
+    // them would draw a relationship that is not there.
+    expect(pairsIn([
+      line("del", "a"), line("del", "b"), line("del", "c"),
+      line("add", "z"),
+    ]).size).toBe(0);
+  });
+
+  test("additions with no deletion above them pair with nothing", () => {
+    expect(pairsIn([line("ctx", "x"), line("add", "new")]).size).toBe(0);
+  });
+
+  test("two separate edits in one hunk are both found", () => {
+    const pairs = pairsIn([
+      line("del", "a"), line("add", "A"),
+      line("ctx", "-"),
+      line("del", "b"), line("add", "B"),
+    ]);
+    expect([...pairs]).toEqual([[0, 1], [3, 4]]);
+  });
+
+  test("context between the two runs breaks the pairing", () => {
+    // The runs have to be adjacent: a deletion, then unchanged code, then an
+    // addition is two separate things that happen to be in one hunk.
+    expect(pairsIn([line("del", "a"), line("ctx", "x"), line("add", "A")]).size).toBe(0);
+  });
+});
+
+describe("tokens", () => {
+  test("words, punctuation and runs of space, kept apart", () => {
+    expect(tokens("a.b(1)")).toEqual(["a", ".", "b", "(", "1", ")"]);
+    expect(tokens("  two words")).toEqual(["  ", "two", " ", "words"]);
+  });
+
+  test("an identifier is one token, so a rename is one mark", () => {
+    expect(tokens("agentglass_2")).toEqual(["agentglass_2"]);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

A hunk that renames one identifier drew two full-width bands, one red and one green, and left the reader to play spot-the-difference on eleven-point monospace. On a 393-point screen that is most of the work of reading a diff — and it is work a machine can do, because both lines are right there.

So a deleted line and the added line that replaced it are compared token by token, and only the tokens that differ are marked. The band still says which side you are on; the marks say where to look.

Three refusals, and they are the point — a mark is read as a fact, and a wrong fact about a diff sends somebody looking at code that did not change:

- **Uneven runs are not edits.** Three lines deleted and one added is a deletion and an insertion; pairing them draws a relationship that does not exist. Only equal-length adjacent runs pair, nth with nth.
- **Two lines sharing less than a third of their tokens are not a rewrite of each other.** Marking those marks nearly everything, which is the same as marking nothing while costing the reader a second to work that out. They stay two plain bands.
- **A middle longer than the table is allowed to be is marked whole.** Coarser than the truth, and never slower than the reader's patience.

Token granularity rather than character: a renamed identifier is one thing that changed, and marking it letter by letter (`agentglas`|`s`) is confetti. Whitespace is its own token, so an indentation change reads as an indentation change.

## How was it tested?

- `bun test` in `mobile/` — **784 pass, 41 skip, 0 fail**, including 21 new tests. Most of them are the refusals above, plus the invariant that matters for a renderer: the spans concatenate back to exactly the line that went in.
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on every touched file — clean.
- **Measured**, on a real 35-file, 3,619-line diff of this repository: **3.6ms** for the whole file set — 50 pairs found, 28 of them marked. A 200kB minified line changed at its end: **4.2ms**, because the common prefix and suffix are trimmed in one pass each before anything quadratic is considered. The marks are computed once per file and memoised, not per row.

Not exercised on a handset. The case worth a second pair of eyes is a hunk of moved code, where the intended result is no intra-line marks at all rather than confident ones.