### PR TITLE
perf(phone): the diff draws what is on screen, not the whole file

### DIFF
--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -49,7 +49,7 @@
  */
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
-  ActivityIndicator, KeyboardAvoidingView, Pressable, ScrollView, Text, TextInput, View,
+  ActivityIndicator, FlatList, KeyboardAvoidingView, Pressable, Text, TextInput, View,
 } from "react-native";
 import { Stack, useLocalSearchParams, useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
@@ -63,6 +63,7 @@ import {
 import { gapLabel, gapsIn, nextSlice, type Gap } from "../../src/model/expand.ts";
 import { draft, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
 import { threadsOnFile } from "../../src/model/threads.ts";
+import { FIRST_ROWS, rowsOf } from "../../src/model/diffRows.ts";
 import { inlineSpans, pairsIn, type Span } from "../../src/model/tokens.ts";
 import { ApplyConfirm } from "../../src/review/ApplyConfirm.tsx";
 import { ThreadCard } from "../../src/review/ThreadCard.tsx";
@@ -354,6 +355,10 @@ export default function DiffScreen(): React.ReactNode {
 
   const gaps = useMemo(() => (file ? gapsIn(file) : []), [file]);
 
+  /** The file as a flat list of rows, which is what lets the list window it —
+   *  see model/diffRows.ts for why a column of nested maps could not be. */
+  const rows = useMemo(() => rowsOf(file), [file]);
+
   /** Which way a gap grows. Stated once, because the renderer and the fetcher
    *  must agree — a gap drawn as growing up and fetched downward would append
    *  lines to the wrong end of what is on screen. */
@@ -458,6 +463,98 @@ export default function DiffScreen(): React.ReactNode {
     );
   };
 
+  /**
+   * One line of the diff, with whatever hangs off it.
+   *
+   * A FUNCTION that returns elements, and deliberately not a component defined
+   * here. A component declared inside a render is a new type on every repaint,
+   * and React unmounts a subtree whose type changed — which for this row means
+   * the comment box losing focus on the keystroke that opened it, every time.
+   * Called rather than rendered, the elements keep their identity and the row
+   * is just what was inside the map before.
+   */
+  const lineRow = (h: number, i: number, line: DiffLine): React.ReactNode => {
+    const face = lineFace(line.kind);
+    const can = commentableLine(line);
+    const open = writing?.line === can && can !== null;
+    return (
+      <View>
+        <Pressable
+          disabled={can === null}
+          onPress={() => setWriting(can === null ? null : { line: can, body: "" })}
+          style={{ flexDirection: "row", backgroundColor: face.bg, minHeight: 22 }}
+        >
+          {/* The new-side number, which is the one a comment anchors to. The
+              old side is deliberately not drawn: two columns of digits on a
+              393-point screen is a third of the width spent on something you
+              look at once. */}
+          <Text style={{
+            width: 38, textAlign: "right", paddingRight: SPACE.sm,
+            color: C.text4, fontSize: 10.5, fontFamily: MONO, lineHeight: 20,
+          }}>{line.newNo ?? line.oldNo ?? ""}</Text>
+          <Text style={{
+            width: 10, color: face.ink, fontSize: 10.5, fontFamily: MONO, lineHeight: 20,
+          }}>{face.mark}</Text>
+          <Text
+            style={{
+              flex: 1, color: line.kind === "meta" ? C.text4 : C.text2,
+              fontSize: 10.5, fontFamily: MONO, lineHeight: 20, paddingRight: SPACE.sm,
+            }}
+          >
+            {/* The words that actually changed, when this line is a rewrite of
+                the one above or below it. A hunk that renames one identifier
+                used to be two full-width bands and a game of
+                spot-the-difference at eleven points; the band still says which
+                side you are on, and this says where to look. */}
+            {marks.get(`${h}:${i}`)?.map((span, s) => (
+              <Text
+                key={s}
+                style={span.changed
+                  ? { color: C.text, backgroundColor: tint(face.ink, 0.34), fontWeight: "600" }
+                  : undefined}
+              >{span.text}</Text>
+            )) ?? (line.text || " ")}
+          </Text>
+        </Pressable>
+
+        {yoursOn(line.newNo ?? null)}
+        {threadsOn(line.newNo ?? null)}
+
+        {open ? (
+          <View style={{
+            margin: SPACE.md, borderWidth: 1, borderColor: C.primary,
+            borderRadius: RADIUS.md, padding: SPACE.md, gap: SPACE.sm,
+          }}>
+            <Label text={`Comment on line ${writing!.line}`} />
+            <TextInput
+              value={writing!.body}
+              onChangeText={(body) => setWriting({ line: writing!.line, body })}
+              placeholder="What is wrong with it?"
+              placeholderTextColor={C.text4}
+              multiline
+              autoFocus
+              style={{
+                minHeight: 64, borderWidth: 1, borderColor: C.border,
+                borderRadius: RADIUS.sm, backgroundColor: C.bg,
+                color: C.text, padding: SPACE.sm, fontSize: T.body,
+              }}
+            />
+            <View style={{ flexDirection: "row", gap: SPACE.sm }}>
+              <Btn
+                label="Add to review"
+                tone="primary"
+                style={{ flex: 1 }}
+                disabled={!writing!.body.trim()}
+                onPress={add}
+              />
+              <Btn label="Cancel" onPress={() => setWriting(null)} />
+            </View>
+          </View>
+        ) : null}
+      </View>
+    );
+  };
+
   return (
     <KeyboardAvoidingView style={{ flex: 1, backgroundColor: C.bg }} behavior="padding">
       <Stack.Screen options={{ title: file ? fileLabel(file).split("/").pop() ?? "Diff" : "Diff" }} />
@@ -484,159 +581,103 @@ export default function DiffScreen(): React.ReactNode {
         </Text>
       </View>
 
-      <ScrollView contentContainerStyle={{ paddingBottom: SPACE.xl }}>
-        {error ? (
-          <View style={{ padding: SPACE.lg }}>
-            <Card>
-              <Label text="Cannot read it" />
-              <Note tone="bad">{error}</Note>
-            </Card>
-          </View>
-        ) : null}
+      {/*
+        A windowed list, not a column.
 
-        {text === null && !error ? (
-          <View style={{ padding: SPACE.xl }}><ActivityIndicator color={C.text3} /></View>
-        ) : null}
+        Every row of the open file used to be mounted before the first one was
+        on screen — four hundred rows of three text nodes each on a big file,
+        measured up front and measured again on every repaint, which on this
+        screen is every tap. `rowsOf` flattens the same content into rows with
+        stable keys so the list can mount what is near the viewport and drop
+        the rest.
 
-        {file?.binary ? (
-          <View style={{ padding: SPACE.lg }}>
-            <Card><Note>This file is binary — there is nothing to show.</Note></Card>
-          </View>
-        ) : null}
+        `removeClippedSubviews` stays off deliberately: a row here can hold a
+        text input and a thread's buttons, and clipping those on Android is how
+        a control stops answering after a scroll. The window is what buys the
+        cost back; clipping would only buy memory this screen does not need.
+      */}
+      <FlatList
+        data={rows}
+        keyExtractor={(row) => row.key}
+        contentContainerStyle={{ paddingBottom: SPACE.xl }}
+        /* The comment box lives inside a row, so a tap must reach the row
+           while the keyboard is up rather than being spent dismissing it. */
+        keyboardShouldPersistTaps="handled"
+        initialNumToRender={FIRST_ROWS}
+        maxToRenderPerBatch={FIRST_ROWS}
+        windowSize={7}
+        removeClippedSubviews={false}
+        ListHeaderComponent={
+          <>
+            {error ? (
+              <View style={{ padding: SPACE.lg }}>
+                <Card>
+                  <Label text="Cannot read it" />
+                  <Note tone="bad">{error}</Note>
+                </Card>
+              </View>
+            ) : null}
 
-        {/* The conversations this file has that no line can hold. GitHub
-            clears a thread's line when the code under it changes, and hanging
-            one on whatever now carries that number would be a remark about
-            code nobody was talking about — so they sit above the file, with
-            the hunk they were written against, which is the only copy of
-            those lines left anywhere. */}
-        {onFile.adrift.length ? (
-          <View style={{ padding: SPACE.lg, gap: SPACE.md }}>
-            <Label text={onFile.adrift.length === 1
-              ? "One conversation about lines that have changed"
-              : `${onFile.adrift.length} conversations about lines that have changed`} />
-            {onFile.adrift.map((thread) => (
-              <ThreadCard key={thread.id} thread={thread} host={host} actions={actions} />
-            ))}
-          </View>
-        ) : null}
+            {text === null && !error ? (
+              <View style={{ padding: SPACE.xl }}><ActivityIndicator color={C.text3} /></View>
+            ) : null}
 
-        {file?.hunks.map((hunk, h) => (
-          <View key={`${hunk.header}-${h}`}>
-            {gapBefore(h)}
-            {/* The header verbatim, including gh's trailing context — usually
-                the enclosing function, which is the most useful thing on
-                screen for saying where you are. */}
-            <View style={{
-              backgroundColor: C.bg3, paddingHorizontal: SPACE.md, paddingVertical: SPACE.xs,
-              borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.border,
-            }}>
-              <Text numberOfLines={1} style={{ color: C.text3, fontSize: T.eyebrow, fontFamily: MONO }}>
-                {hunk.header}
-              </Text>
+            {file?.binary ? (
+              <View style={{ padding: SPACE.lg }}>
+                <Card><Note>This file is binary — there is nothing to show.</Note></Card>
+              </View>
+            ) : null}
+
+            {/* The conversations this file has that no line can hold. GitHub
+                clears a thread's line when the code under it changes, and
+                hanging one on whatever now carries that number would be a
+                remark about code nobody was talking about — so they sit above
+                the file, with the hunk they were written against, which is the
+                only copy of those lines left anywhere. */}
+            {onFile.adrift.length ? (
+              <View style={{ padding: SPACE.lg, gap: SPACE.md }}>
+                <Label text={onFile.adrift.length === 1
+                  ? "One conversation about lines that have changed"
+                  : `${onFile.adrift.length} conversations about lines that have changed`} />
+                {onFile.adrift.map((thread) => (
+                  <ThreadCard key={thread.id} thread={thread} host={host} actions={actions} />
+                ))}
+              </View>
+            ) : null}
+          </>
+        }
+        ListEmptyComponent={
+          file && !file.binary && file.hunks.length === 0 ? (
+            <View style={{ padding: SPACE.lg }}>
+              <Card>
+                <Note>
+                  No lines changed in this file — it was {file.status}
+                  {file.from ? ` from ${file.from}` : ""}.
+                </Note>
+              </Card>
             </View>
-
-            {hunk.lines.map((line, i) => {
-              const face = lineFace(line.kind);
-              const can = commentableLine(line);
-              const open = writing?.line === can && can !== null;
-              return (
-                <View key={i}>
-                  <Pressable
-                    disabled={can === null}
-                    onPress={() => setWriting(can === null ? null : { line: can, body: "" })}
-                    style={{ flexDirection: "row", backgroundColor: face.bg, minHeight: 22 }}
-                  >
-                    {/* The new-side number, which is the one a comment anchors
-                        to. The old side is deliberately not drawn: two columns
-                        of digits on a 393-point screen is a third of the width
-                        spent on something you look at once. */}
-                    <Text style={{
-                      width: 38, textAlign: "right", paddingRight: SPACE.sm,
-                      color: C.text4, fontSize: 10.5, fontFamily: MONO, lineHeight: 20,
-                    }}>{line.newNo ?? line.oldNo ?? ""}</Text>
-                    <Text style={{
-                      width: 10, color: face.ink, fontSize: 10.5, fontFamily: MONO, lineHeight: 20,
-                    }}>{face.mark}</Text>
-                    <Text
-                      style={{
-                        flex: 1, color: line.kind === "meta" ? C.text4 : C.text2,
-                        fontSize: 10.5, fontFamily: MONO, lineHeight: 20, paddingRight: SPACE.sm,
-                      }}
-                    >
-                      {/* The words that actually changed, when this line is a
-                          rewrite of the one above or below it. A hunk that
-                          renames one identifier used to be two full-width
-                          bands and a game of spot-the-difference at eleven
-                          points; the band still says which side you are on,
-                          and this says where to look. */}
-                      {marks.get(`${h}:${i}`)?.map((span, s) => (
-                        <Text
-                          key={s}
-                          style={span.changed
-                            ? { color: C.text, backgroundColor: tint(face.ink, 0.34), fontWeight: "600" }
-                            : undefined}
-                        >{span.text}</Text>
-                      )) ?? (line.text || " ")}
-                    </Text>
-                  </Pressable>
-
-                  {yoursOn(line.newNo ?? null)}
-                  {threadsOn(line.newNo ?? null)}
-
-                  {open ? (
-                    <View style={{
-                      margin: SPACE.md, borderWidth: 1, borderColor: C.primary,
-                      borderRadius: RADIUS.md, padding: SPACE.md, gap: SPACE.sm,
-                    }}>
-                      <Label text={`Comment on line ${writing!.line}`} />
-                      <TextInput
-                        value={writing!.body}
-                        onChangeText={(body) => setWriting({ line: writing!.line, body })}
-                        placeholder="What is wrong with it?"
-                        placeholderTextColor={C.text4}
-                        multiline
-                        autoFocus
-                        style={{
-                          minHeight: 64, borderWidth: 1, borderColor: C.border,
-                          borderRadius: RADIUS.sm, backgroundColor: C.bg,
-                          color: C.text, padding: SPACE.sm, fontSize: T.body,
-                        }}
-                      />
-                      <View style={{ flexDirection: "row", gap: SPACE.sm }}>
-                        <Btn
-                          label="Add to review"
-                          tone="primary"
-                          style={{ flex: 1 }}
-                          disabled={!writing!.body.trim()}
-                          onPress={add}
-                        />
-                        <Btn label="Cancel" onPress={() => setWriting(null)} />
-                      </View>
-                    </View>
-                  ) : null}
-                </View>
-              );
-            })}
-          </View>
-        ))}
-
-        {/* The tail of the file, below the last hunk. Rendered outside the map
-            because it belongs to no hunk — `gapsIn` numbers it `hunks.length`
-            for exactly this. */}
-        {file && !file.binary ? gapBefore(file.hunks.length) : null}
-
-        {file && !file.binary && file.hunks.length === 0 ? (
-          <View style={{ padding: SPACE.lg }}>
-            <Card>
-              <Note>
-                No lines changed in this file — it was {file.status}
-                {file.from ? ` from ${file.from}` : ""}.
-              </Note>
-            </Card>
-          </View>
-        ) : null}
-      </ScrollView>
+          ) : null
+        }
+        renderItem={({ item }) => {
+          if (item.t === "gap") return <>{gapBefore(item.before)}</>;
+          if (item.t === "hunk") {
+            return (
+              /* The header verbatim, including gh's trailing context — usually
+                 the enclosing function, which is the most useful thing on
+                 screen for saying where you are. */
+              <View style={{
+                backgroundColor: C.bg3, paddingHorizontal: SPACE.md, paddingVertical: SPACE.xs,
+                borderTopWidth: 1, borderBottomWidth: 1, borderColor: C.border,
+              }}>
+                <Text numberOfLines={1} style={{ color: C.text3, fontSize: T.eyebrow, fontFamily: MONO }}>
+                  {item.header}
+                </Text>
+              </View>
+            );
+          }
+          return <>{lineRow(item.h, item.i, item.line)}</>;
+        }}
+      />
 
       <View style={{
         flexDirection: "row", gap: SPACE.sm,

--- a/mobile/src/model/diffRows.ts
+++ b/mobile/src/model/diffRows.ts
@@ -1,0 +1,71 @@
+/*
+ * A file's diff, flattened into the rows a list draws.
+ *
+ * ── why a list and not a column ──────────────────────────────────────────
+ * The screen used to put every hunk of the open file inside one ScrollView,
+ * which means React Native lays out and keeps mounted every row of it before
+ * the first one is on screen. A four-hundred-line file is four hundred rows of
+ * three text nodes each, measured up front, and the cost is paid again on
+ * every repaint — a tap on a line, a thread opening, a comment being typed.
+ *
+ * A windowed list mounts what is near the viewport and drops the rest, which
+ * it can only do if the content is a flat array of rows with stable keys. That
+ * is the whole of what this file makes: the shape the renderer already draws,
+ * as data instead of as nesting.
+ *
+ * ── it is deliberately dumb ──────────────────────────────────────────────
+ * No decisions live here beyond the order of things. Which lines can carry a
+ * comment is `commentableLine`, where the gaps are is `gapsIn`, what changed
+ * inside a line is `tokens.ts`. This only says: the gap before hunk 0, then
+ * hunk 0's header, then its lines, then the gap before hunk 1 — and the tail
+ * gap after the last one, which belongs to no hunk and is numbered
+ * `hunks.length` for exactly that reason.
+ */
+import type { DiffFile, DiffLine } from "./diffLines.ts";
+import { gapsIn } from "./expand.ts";
+
+export type DiffRow =
+  /** The expander for the gap before hunk `before`, and whatever has been
+   *  fetched into it. `before === hunks.length` is the tail of the file. */
+  | { t: "gap"; key: string; before: number }
+  | { t: "hunk"; key: string; at: number; header: string }
+  | { t: "line"; key: string; h: number; i: number; line: DiffLine };
+
+/**
+ * The rows, in the order they are read.
+ *
+ * Keys are the position in the file rather than the content: two identical
+ * lines are two rows, and a key made of text would make them one — which a
+ * virtualised list expresses by drawing the same row twice and losing a
+ * comment box that was open on one of them.
+ *
+ * A gap row is emitted only where there IS a gap, so the list has no rows that
+ * draw nothing. A binary file has no hunks and gets no rows at all; the screen
+ * says why in its place.
+ */
+export function rowsOf(file: Pick<DiffFile, "hunks" | "binary"> | undefined): DiffRow[] {
+  if (!file || file.binary) return [];
+  const gaps = new Set(gapsIn(file).map((g) => g.before));
+  const rows: DiffRow[] = [];
+  file.hunks.forEach((hunk, h) => {
+    if (gaps.has(h)) rows.push({ t: "gap", key: `gap:${h}`, before: h });
+    rows.push({ t: "hunk", key: `hunk:${h}`, at: h, header: hunk.header });
+    hunk.lines.forEach((line, i) => {
+      rows.push({ t: "line", key: `line:${h}:${i}`, h, i, line });
+    });
+  });
+  if (gaps.has(file.hunks.length)) {
+    rows.push({ t: "gap", key: `gap:${file.hunks.length}`, before: file.hunks.length });
+  }
+  return rows;
+}
+
+/**
+ * How many rows to draw before the list is handed the rest.
+ *
+ * A phone is 393 by about 750 points of content, and a diff row is 22 — so a
+ * screenful is 34. Rendering a screenful and a half up front means the first
+ * paint is a full screen with something already below the fold to scroll into,
+ * and everything past it arrives while the thumb is moving.
+ */
+export const FIRST_ROWS = 50;

--- a/mobile/test/diff-rows.test.ts
+++ b/mobile/test/diff-rows.test.ts
@@ -1,0 +1,156 @@
+/*
+ * The diff as a flat list of rows, which is what lets it be windowed.
+ *
+ * Two things can go wrong here and both are invisible in a screenshot: a row
+ * missing (a hunk header, the expander for the tail of the file) and a key
+ * repeated. The second is the nastier one — a virtualised list with two rows
+ * under one key draws one of them twice, so a comment box opened on line 40
+ * appears on line 12 as well.
+ */
+import { describe, expect, test } from "bun:test";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { rowsOf } from "../src/model/diffRows.ts";
+import { parseDiff } from "../src/model/diffLines.ts";
+
+const DIFF = [
+  "diff --git a/src/a.ts b/src/a.ts",
+  "--- a/src/a.ts",
+  "+++ b/src/a.ts",
+  "@@ -10,3 +10,4 @@ function one() {",
+  " keep",
+  "-was",
+  "+is",
+  "+added",
+  "@@ -80,2 +81,2 @@ function two() {",
+  " context",
+  "-gone",
+  "+here",
+].join("\n");
+
+const file = parseDiff(DIFF)[0]!;
+const rows = rowsOf(file);
+
+describe("the order things are read in", () => {
+  test("a gap, its hunk, then that hunk's lines", () => {
+    expect(rows.slice(0, 3).map((r) => r.t)).toEqual(["gap", "hunk", "line"]);
+  });
+
+  test("every line of every hunk is a row, and nothing else is", () => {
+    const lines = file.hunks.reduce((n, h) => n + h.lines.length, 0);
+    expect(rows.filter((r) => r.t === "line")).toHaveLength(lines);
+    expect(rows.filter((r) => r.t === "hunk")).toHaveLength(2);
+  });
+
+  test("the gap between two hunks is between them", () => {
+    const at = rows.findIndex((r) => r.t === "gap" && r.before === 1);
+    const second = rows.findIndex((r) => r.t === "hunk" && r.at === 1);
+    expect(at).toBeGreaterThan(0);
+    expect(at).toBeLessThan(second);
+  });
+
+  test("the tail of the file gets the gap that belongs to no hunk", () => {
+    // Numbered `hunks.length` for exactly this reason — the code after the
+    // last hunk is still code somebody may want to see.
+    const last = rows[rows.length - 1]!;
+    expect(last).toMatchObject({ t: "gap", before: 2 });
+  });
+
+  test("a line row carries where it is, not what it says", () => {
+    const row = rows.find((r) => r.t === "line")!;
+    expect(row).toMatchObject({ t: "line", h: 0, i: 0 });
+  });
+});
+
+describe("keys", () => {
+  test("no two rows share one", () => {
+    const keys = rows.map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+
+  test("two identical lines are still two rows", () => {
+    // A key made of the text would make them one, and a windowed list would
+    // then draw the same row twice.
+    const twice = parseDiff([
+      "diff --git a/x b/x",
+      "--- a/x",
+      "+++ b/x",
+      "@@ -1,2 +1,2 @@",
+      "-same",
+      "-same",
+      "+same",
+      "+same",
+    ].join("\n"))[0]!;
+    const keys = rowsOf(twice).map((r) => r.key);
+    expect(new Set(keys).size).toBe(keys.length);
+  });
+});
+
+describe("files with nothing to draw", () => {
+  test("a binary file has no rows — the screen says why instead", () => {
+    expect(rowsOf({ hunks: [], binary: true })).toEqual([]);
+  });
+
+  test("a file with no hunks has no rows, and no tail gap either", () => {
+    // A rename with no content change. There is no code to expand into.
+    expect(rowsOf({ hunks: [], binary: false })).toEqual([]);
+  });
+
+  test("no file at all is no rows rather than a crash", () => {
+    expect(rowsOf(undefined)).toEqual([]);
+  });
+});
+
+describe("a hunk that starts at line 1", () => {
+  test("has no gap above it, so no row draws an empty expander", () => {
+    const top = parseDiff([
+      "diff --git a/x b/x",
+      "--- a/x",
+      "+++ b/x",
+      "@@ -1,2 +1,2 @@",
+      " one",
+      "-two",
+      "+TWO",
+    ].join("\n"))[0]!;
+    const first = rowsOf(top)[0]!;
+    expect(first.t).toBe("hunk");
+  });
+});
+
+/*
+ * Two things about the screen that no assertion about data can reach, and both
+ * of which put back the defect this file exists for.
+ *
+ * Source, not render: there is no renderer in this project, and both of these
+ * are facts about how the screen is written. Same technique, and the same
+ * reason, as mirror.test.ts and tap-floor.test.ts.
+ */
+describe("the screen actually windows it", () => {
+  const screen = readFileSync(join(import.meta.dir, "..", "app", "pr", "diff.tsx"), "utf8");
+
+  test("the diff is a list, not a column of everything", () => {
+    expect(screen).toContain("<FlatList");
+    expect(screen).toContain("data={rows}");
+    expect(screen).toContain("keyExtractor={(row) => row.key}");
+    // The whole point: a ScrollView here mounts every row before the first is
+    // on screen, which is what this replaced.
+    expect(screen).not.toContain("<ScrollView contentContainerStyle={{ paddingBottom: SPACE.xl }}>");
+  });
+
+  test("a row is CALLED, never declared as a component in the render", () => {
+    /*
+     * A component declared inside a render is a new type on every repaint, and
+     * React unmounts a subtree whose type changed. The row holds the comment
+     * box, so that costs the keyboard its focus on the keystroke that opened
+     * it — every time, and invisibly to every test that reads data.
+     */
+    expect(screen).toContain("lineRow(item.h, item.i, item.line)");
+    expect(screen).not.toMatch(/const [A-Z]\w+ = \(\{[^}]*\}: \{[^}]*\}\): React\.ReactNode =>/);
+  });
+
+  test("taps still land while the keyboard is up", () => {
+    // The comment box is inside a row; without this a tap is spent dismissing
+    // the keyboard instead of reaching the control under the thumb.
+    expect(screen).toContain('keyboardShouldPersistTaps="handled"');
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Every row of the open file was mounted before the first one was visible. A `ScrollView` lays out and keeps all of its children, so a four-hundred-line file is four hundred rows of three text nodes each, measured up front — and measured again on every repaint, which on this screen is every tap: a line opening a comment box, a thread expanding, a character typed into a remark.

It is a windowed list now. `rowsOf` flattens the same content into rows with stable keys — the gap before a hunk, the hunk's header, its lines, and the tail gap that belongs to no hunk — which is the shape a list can mount near the viewport and drop behind.

Two decisions in here are not the mechanical part:

- **`removeClippedSubviews` stays off.** A row can hold a text input and a thread's buttons, and clipping those on Android is how a control stops answering after a scroll. The window is what buys the cost back; clipping would only buy memory this screen does not need.
- **The row is a function that returns elements, not a component declared in the render.** A component declared there is a new type on every repaint, and React unmounts a subtree whose type changed — which for this row means the comment box losing focus on the keystroke that opened it, every time. It is invisible to any test that reads data, so it is pinned against the source.

## How was it tested?

- `bun test` in `mobile/` — **798 pass, 41 skip, 0 fail**, including 14 new tests: the row order, the tail gap that belongs to no hunk, a binary file having no rows, and the key property that matters for a virtualised list — two identical lines are two rows, because a key made of the text would make a list draw one of them twice and carry an open comment box with it.
- Three of those read the screen's source rather than data, the same technique `mirror.test.ts` and `tap-floor.test.ts` already use: that the diff is a `FlatList` over `rows`, that the row is called rather than mounted as a fresh component type, and that taps still land while the keyboard is up.
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on every touched file — clean.
- **Measured** over this week's diff of `mobile/`: 27 files flatten in **0.7ms**, and the largest is **426 rows of which 50 are mounted at the first paint**.

Not exercised on a handset. The thing worth a second pair of eyes is scrolling back to a line with an expanded thread on it, where a windowed list is at its least forgiving.