### PR TITLE
refactor: one intra-line diff, shared — and it was wrong on both sides

### DIFF
--- a/mobile/app/pr/diff.tsx
+++ b/mobile/app/pr/diff.tsx
@@ -64,7 +64,7 @@ import { gapLabel, gapsIn, nextSlice, type Gap } from "../../src/model/expand.ts
 import { draft, takeDraft, type LineNote } from "../../src/model/reviewDraft.ts";
 import { threadsOnFile } from "../../src/model/threads.ts";
 import { FIRST_ROWS, rowsOf } from "../../src/model/diffRows.ts";
-import { inlineSpans, pairsIn, type Span } from "../../src/model/tokens.ts";
+import { pairsIn, tokenDiff, type Seg } from "../../../shared/tokenDiff.ts";
 import { ApplyConfirm } from "../../src/review/ApplyConfirm.tsx";
 import { ThreadCard } from "../../src/review/ThreadCard.tsx";
 import { ThreadMarker } from "../../src/review/ThreadMarker.tsx";
@@ -240,19 +240,21 @@ export default function DiffScreen(): React.ReactNode {
    * repaint of a screen that repaints on every tap. Keyed by hunk and index
    * because that is what the renderer has in hand.
    *
-   * Bounded twice over in `tokens.ts` — a pair too dissimilar to be an edit
-   * gets nothing, and a middle too long for the table is marked coarsely — so
-   * a file of minified JavaScript costs a pass over its lines and stops.
+   * Bounded twice over in `shared/tokenDiff.ts` — a pair too dissimilar to be
+   * an edit gets nothing, and a middle too long for the table is marked
+   * coarsely — so a file of minified JavaScript costs a pass over its lines
+   * and stops. Shared with the desk, because one reader on two screens must
+   * not be told two different things about the same line.
    */
   const marks = useMemo(() => {
-    const out = new Map<string, Span[]>();
+    const out = new Map<string, Seg[]>();
     if (!file) return out;
     file.hunks.forEach((hunk, h) => {
       for (const [del, add] of pairsIn(hunk.lines)) {
-        const both = inlineSpans(hunk.lines[del]!.text, hunk.lines[add]!.text);
+        const both = tokenDiff(hunk.lines[del]!.text, hunk.lines[add]!.text);
         if (!both) continue;
-        out.set(`${h}:${del}`, both.before);
-        out.set(`${h}:${add}`, both.after);
+        out.set(`${h}:${del}`, both.left);
+        out.set(`${h}:${add}`, both.right);
       }
     });
     return out;

--- a/mobile/test/token-diff.test.ts
+++ b/mobile/test/token-diff.test.ts
@@ -8,7 +8,7 @@
  * not change. So most of what is pinned here is a refusal.
  */
 import { describe, expect, test } from "bun:test";
-import { inlineSpans, pairsIn, tokens } from "../src/model/tokens.ts";
+import { pairsIn, tokenDiff, tokens } from "../../shared/tokenDiff.ts";
 import type { DiffLine } from "../src/model/diffLines.ts";
 
 /** The changed text of a side, which is the whole question a reader has. */
@@ -21,25 +21,25 @@ const whole = (spans: { text: string }[] | undefined): string =>
   (spans ?? []).map((s) => s.text).join("");
 
 describe("one identifier renamed", () => {
-  const both = inlineSpans(
+  const both = tokenDiff(
     "  const answer = await ask(host, `/prs/diff?${query}`);",
     "  const answer = await ask(host, `/prs/detail?${query}`);",
   )!;
 
   test("only the word that changed is marked, on each side", () => {
-    expect(marked(both.before)).toBe("diff");
-    expect(marked(both.after)).toBe("detail");
+    expect(marked(both.left)).toBe("diff");
+    expect(marked(both.right)).toBe("detail");
   });
 
   test("and the line comes back whole", () => {
-    expect(whole(both.before)).toBe("  const answer = await ask(host, `/prs/diff?${query}`);");
-    expect(whole(both.after)).toBe("  const answer = await ask(host, `/prs/detail?${query}`);");
+    expect(whole(both.left)).toBe("  const answer = await ask(host, `/prs/diff?${query}`);");
+    expect(whole(both.right)).toBe("  const answer = await ask(host, `/prs/detail?${query}`);");
   });
 
   test("neighbouring tokens of the same kind are one span", () => {
     // One `<Text>` per token is a paragraph the layout engine measures word by
     // word, on every row of a diff that can be four hundred rows long.
-    expect(both.before.length).toBeLessThan(6);
+    expect(both.left.length).toBeLessThan(6);
   });
 });
 
@@ -47,21 +47,21 @@ describe("an insertion in the middle", () => {
   test("marks what was inserted and nothing either side of it", () => {
     // The case a prefix-only rule gets wrong: it would mark `c, b` and read as
     // though two things moved.
-    const both = inlineSpans("foo(a, b)", "foo(a, c, b)")!;
-    expect(marked(both.before)).toBe("");
-    expect(marked(both.after)).toBe("c, ");
+    const both = tokenDiff("foo(a, b)", "foo(a, c, b)")!;
+    expect(marked(both.left)).toBe("");
+    expect(marked(both.right)).toBe("c, ");
   });
 
   test("a token appended at the end is the only mark", () => {
-    const both = inlineSpans("await load()", "await load(host)")!;
-    expect(marked(both.after)).toBe("host");
+    const both = tokenDiff("await load()", "await load(host)")!;
+    expect(marked(both.right)).toBe("host");
   });
 
   test("indentation changing is visible as indentation changing", () => {
     // Whitespace is its own token, so this is not "the whole line changed".
-    const both = inlineSpans("  return null;", "      return null;")!;
-    expect(marked(both.before)).toBe("  ");
-    expect(marked(both.after)).toBe("      ");
+    const both = tokenDiff("  return null;", "      return null;")!;
+    expect(marked(both.left)).toBe("  ");
+    expect(marked(both.right)).toBe("      ");
   });
 });
 
@@ -70,18 +70,18 @@ describe("what it refuses to mark", () => {
     // A line that went and a line that came. Marking them token by token marks
     // nearly everything, which is the same as marking nothing and costs the
     // reader a second to work out.
-    expect(inlineSpans("import { readFileSync } from 'node:fs';", "export const TAP = 44;")).toBeNull();
+    expect(tokenDiff("import { readFileSync } from 'node:fs';", "export const TAP = 44;")).toBeNull();
   });
 
   test("identical lines have nothing to say", () => {
-    expect(inlineSpans("same", "same")).toBeNull();
+    expect(tokenDiff("same", "same")).toBeNull();
   });
 
   test("an empty side is not a rewrite", () => {
     // A line emptied or a line born is a deletion and an addition; the bands
     // already say so.
-    expect(inlineSpans("", "something")).toBeNull();
-    expect(inlineSpans("something", "")).toBeNull();
+    expect(tokenDiff("", "something")).toBeNull();
+    expect(tokenDiff("something", "")).toBeNull();
   });
 });
 
@@ -89,7 +89,7 @@ describe("a line with no length limit", () => {
   const under = (name: string, before: string, after: string): void => {
     test(name, () => {
       const started = performance.now();
-      inlineSpans(before, after);
+      tokenDiff(before, after);
       // Loose on purpose. It is not a benchmark — it is the difference between
       // a scroll and a phone that stops answering, and a tight number here
       // would fail on a busy runner while proving nothing extra.
@@ -112,10 +112,10 @@ describe("a line with no length limit", () => {
     const same = Array.from({ length: 400 }, (_, i) => `k${i}`).join(" ");
     const a = `${same} ${Array.from({ length: 300 }, (_, i) => `a${i}`).join(" ")} ${same}`;
     const b = `${same} ${Array.from({ length: 300 }, (_, i) => `b${i}`).join(" ")} ${same}`;
-    const both = inlineSpans(a, b)!;
-    expect(whole(both.before)).toBe(a);
-    expect(marked(both.before)).toContain("a0");
-    expect(marked(both.before)).not.toContain("k0");
+    const both = tokenDiff(a, b)!;
+    expect(whole(both.left)).toBe(a);
+    expect(marked(both.left)).toContain("a0");
+    expect(marked(both.left)).not.toContain("k0");
   });
 
   test("and a pair with nothing much in common is refused before any of that", () => {
@@ -123,7 +123,7 @@ describe("a line with no length limit", () => {
     // reached for two lines that are not an edit of each other.
     const a = Array.from({ length: 300 }, (_, i) => `a${i}`).join(" ");
     const b = Array.from({ length: 300 }, (_, i) => `b${i}`).join(" ");
-    expect(inlineSpans(a, b)).toBeNull();
+    expect(tokenDiff(a, b)).toBeNull();
   });
 });
 
@@ -141,13 +141,24 @@ describe("which lines are a pair", () => {
     expect([...pairs]).toEqual([[1, 3], [2, 4]]);
   });
 
-  test("uneven runs are a deletion and an insertion, not edits", () => {
-    // Three lines deleted and one added is not three rewrites, and pairing
-    // them would draw a relationship that is not there.
-    expect(pairsIn([
+  test("uneven runs pair as far as the shorter one goes", () => {
+    /*
+     * Three deleted and one added usually IS one line rewritten and two
+     * removed. Refusing the whole block would throw away the marks on the pair
+     * that is right; the similarity floor in `tokenDiff` is what stops the
+     * guess being painted when it is wrong, and it is measured rather than
+     * assumed — see the pair below, which pairs and then marks nothing.
+     */
+    expect([...pairsIn([
       line("del", "a"), line("del", "b"), line("del", "c"),
       line("add", "z"),
-    ]).size).toBe(0);
+    ])]).toEqual([[0, 3]]);
+  });
+
+  test("and a pairing that was a bad guess is marked by nobody", () => {
+    // The two halves working together: positional pairing is a guess, and the
+    // floor is what keeps a wrong guess off the screen.
+    expect(tokenDiff("import { readFileSync } from 'node:fs';", "})")).toBeNull();
   });
 
   test("additions with no deletion above them pair with nothing", () => {

--- a/shared/tokenDiff.ts
+++ b/shared/tokenDiff.ts
@@ -1,25 +1,31 @@
 /*
  * What actually changed INSIDE a line.
  *
- * A hunk that renames one identifier draws two full-width bands, one red and
- * one green, and leaves the reader to play spot-the-difference on eleven-point
- * monospace. On a 393-point screen that is most of the work of reading a diff,
- * and it is work a machine can do: the two lines are right there.
+ * Shared because two clients ask the same question of the same diff and must
+ * not answer it differently. They did: the desk had this, the phone grew its
+ * own a week later, and the two disagreed about when a deleted line and an
+ * added one are a rewrite of each other — which is a difference a reader would
+ * see as one screen marking a word and the other marking nothing.
+ *
+ * ── the value, and the risk ──────────────────────────────────────────────
+ * A hunk that renames one identifier draws two full-width bands and leaves the
+ * reader to play spot-the-difference. That is work a machine can do; both
+ * lines are right there. But a mark is READ AS A FACT, and a wrong fact about
+ * a diff sends somebody looking at code that did not change — so most of what
+ * is below is about refusing to mark.
  *
  * ── which lines are a pair ───────────────────────────────────────────────
  * A run of deletions immediately followed by a run of additions is an edit,
- * and the nth of each is the same line before and after. That is the rule
- * every diff viewer uses and it is right far more often than it is wrong —
- * but only when the runs are the same length. Three lines deleted and one
- * added is not three edits, it is a deletion and an insertion, and pairing
- * them would draw a relationship that is not there.
+ * and the nth of each is the same line before and after. Pairing is positional
+ * and therefore a guess, which is exactly why the similarity floor below is
+ * not optional: unrelated lines land opposite each other all the time.
  *
  * ── and when a pair is too different to be one ───────────────────────────
  * Two lines that share almost nothing are not an edit of each other; they are
  * a line that went and a line that came. Highlighting them token by token
- * would mark nearly everything, which is the same as marking nothing while
- * costing the reader a second to work that out. So a pair below a similarity
- * floor gets no intra-line marks at all and stays two plain bands.
+ * marks nearly everything, which is the same as marking nothing while costing
+ * the reader a second to work that out. Below the floor: no marks, two plain
+ * bands.
  *
  * ── the cost, which is the reason for the shape below ────────────────────
  * A diff is text a stranger wrote and a line has no length limit — a minified
@@ -29,10 +35,10 @@
  * are short enough for it to be free; past that the whole middle is marked,
  * which is coarser and never slower than the reader's patience.
  */
-import type { DiffLine } from "./diffLines.ts";
 
 /** A run of text, and whether it is part of what changed. */
-export interface Span { text: string; changed: boolean }
+export interface Seg { text: string; changed: boolean }
+
 
 /**
  * Words, punctuation and runs of space, kept separately.
@@ -50,10 +56,10 @@ export function tokens(line: string): string[] {
  *  comparisons is nothing; the guard is against the line that is a whole file. */
 const LCS_LIMIT = 64;
 
-/** Below this share of tokens in common, two lines are not an edit of each
- *  other. Half is deliberately generous: a line whose right-hand side was
+/** Below this share of their characters in common, two lines are not an edit
+ *  of each other. Deliberately generous: a line whose right-hand side was
  *  rewritten still shares its declaration, and that is worth marking. */
-const SIMILAR = 0.3;
+const SIMILAR = 0.4;
 
 /**
  * The spans to draw for one pair of lines, or null when there is no pair worth
@@ -63,7 +69,7 @@ const SIMILAR = 0.3;
  * not an edit of each other", and the honest drawing then is the two plain
  * bands this app already had.
  */
-export function inlineSpans(before: string, after: string): { before: Span[]; after: Span[] } | null {
+export function tokenDiff(before: string, after: string): { left: Seg[]; right: Seg[] } | null {
   if (before === after) return null;
   const a = tokens(before);
   const b = tokens(after);
@@ -82,16 +88,36 @@ export function inlineSpans(before: string, after: string): { before: Span[]; af
 
   const midA = a.slice(head, a.length - tail);
   const midB = b.slice(head, b.length - tail);
-  const shared = head + tail;
-  if (shared / Math.max(a.length, b.length) < SIMILAR) return null;
 
-  const marks = midA.length <= LCS_LIMIT && midB.length <= LCS_LIMIT
+  /*
+   * The middle, and then the floor — in that order, which is not an
+   * optimisation but the difference between right and wrong.
+   *
+   * Measuring similarity from the trimmed head and tail ALONE says a line
+   * changed at both of its ends has nothing in common with itself:
+   * `const total = sum(items, seed);` against
+   * `let total = sum(items, base);` shares its whole middle and agrees on two
+   * tokens at the end, and a head-and-tail count calls that 14% and refuses to
+   * mark it. So what counts is everything the two lines actually keep,
+   * including what the table matched in the middle.
+   *
+   * In characters rather than tokens, because it is a claim about what a
+   * reader sees: one long identifier kept is worth more than three brackets.
+   */
+  const fits = midA.length <= LCS_LIMIT && midB.length <= LCS_LIMIT;
+  const marks = fits
     ? viaLcs(midA, midB)
     : { a: midA.map(() => true), b: midB.map(() => true) };
 
+  let kept = 0;
+  for (let i = 0; i < head; i++) kept += a[i]!.length;
+  for (let i = 0; i < tail; i++) kept += a[a.length - 1 - i]!.length;
+  if (fits) for (let i = 0; i < midA.length; i++) if (!marks.a[i]) kept += midA[i]!.length;
+  if ((2 * kept) / (before.length + after.length) < SIMILAR) return null;
+
   return {
-    before: assemble(a, head, tail, marks.a),
-    after: assemble(b, head, tail, marks.b),
+    left: assemble(a, head, tail, marks.a),
+    right: assemble(b, head, tail, marks.b),
   };
 }
 
@@ -129,13 +155,13 @@ function viaLcs(a: string[], b: string[]): { a: boolean[]; b: boolean[] } {
 /** The whole line as spans: the agreed head, the marked middle, the agreed
  *  tail — with neighbours of the same kind joined, because one `<Text>` per
  *  token is a paragraph the layout engine has to measure word by word. */
-function assemble(all: string[], head: number, tail: number, marks: boolean[]): Span[] {
+function assemble(all: string[], head: number, tail: number, marks: boolean[]): Seg[] {
   const flags = [
     ...Array.from<boolean>({ length: head }).fill(false),
     ...marks,
     ...Array.from<boolean>({ length: tail }).fill(false),
   ];
-  const out: Span[] = [];
+  const out: Seg[] = [];
   for (let i = 0; i < all.length; i++) {
     const changed = flags[i] ?? false;
     const last = out[out.length - 1];
@@ -146,26 +172,29 @@ function assemble(all: string[], head: number, tail: number, marks: boolean[]): 
 }
 
 /**
- * The pairs in a hunk: which deleted line each added line is a rewrite of.
+ * The pairs in a run of rows: which deleted line each added line rewrites.
  *
- * Keyed by index into the hunk's own lines, because that is what the renderer
- * has in hand while it draws. A run only pairs when the two sides are the same
- * length — see the note at the top about three deleted and one added.
+ * Keyed by index into the rows themselves, because that is what both callers
+ * have in hand while they draw. A block of deletions pairs with the block of
+ * additions immediately after it, nth with nth, and never across a line of
+ * context — a context line is git saying the change block ended.
+ *
+ * Uneven blocks pair as far as the shorter one goes rather than not at all.
+ * Three deleted and one added usually IS one line rewritten and two removed,
+ * and the similarity floor in `tokenDiff` is what stops the guess being
+ * painted when it is wrong. Refusing the whole block instead would throw away
+ * the marks on the pair that is right.
  */
-export function pairsIn(lines: DiffLine[]): Map<number, number> {
+export function pairsIn(rows: { kind: string }[]): Map<number, number> {
   const pairs = new Map<number, number>();
   let i = 0;
-  while (i < lines.length) {
-    if (lines[i]!.kind !== "del") { i++; continue; }
+  while (i < rows.length) {
+    if (rows[i]!.kind !== "del") { i++; continue; }
     let dels = i;
-    while (dels < lines.length && lines[dels]!.kind === "del") dels++;
+    while (dels < rows.length && rows[dels]!.kind === "del") dels++;
     let adds = dels;
-    while (adds < lines.length && lines[adds]!.kind === "add") adds++;
-    const removed = dels - i;
-    const added = adds - dels;
-    if (removed > 0 && removed === added) {
-      for (let k = 0; k < removed; k++) pairs.set(i + k, dels + k);
-    }
+    while (adds < rows.length && rows[adds]!.kind === "add") adds++;
+    for (let k = 0; k < Math.min(dels - i, adds - dels); k++) pairs.set(i + k, dels + k);
     i = adds > dels ? adds : dels;
   }
   return pairs;

--- a/web/src/components/diff/DiffLines.tsx
+++ b/web/src/components/diff/DiffLines.tsx
@@ -17,6 +17,7 @@ import { createContext, Fragment, memo, useContext, useEffect, useMemo, useRef, 
 import type { CSSProperties, MouseEvent as ReactMouseEvent, ReactNode, RefObject, WheelEvent as ReactWheelEvent } from "react";
 import { HiliteCtx } from "../../lib/diffHighlight.ts";
 import type { DiffHunk, FileChange } from "../../../../shared/types.ts";
+import { pairsIn, tokenDiff, type Seg } from "../../../../shared/tokenDiff.ts";
 
 // --- shared type + style vocabulary ------------------------------------------
 
@@ -78,8 +79,9 @@ export const SCROLLBAR_CSS = '.agx-scroll{scrollbar-width:thin;scrollbar-color:c
 // --- the row model (pure; everything below the components depends on it) -----
 
 export type DiffKind = "ctx" | "del" | "add";
-/** A run of a line's text, `hi` when the intra-line diff says it changed. */
-export type Seg = { text: string; hi: boolean };
+/** A run of a line's text, `changed` when the intra-line diff says it did.
+ *  Re-exported so the components below keep their own vocabulary. */
+export type { Seg } from "../../../../shared/tokenDiff.ts";
 /** One unified row: at most one of the two gutters carries a number. */
 export type URow = { oldN: number | null; newN: number | null; text: string; kind: DiffKind; segs?: Seg[] | null };
 /** One side of one split row. Absent (`null` in `SplitRow`) means the other
@@ -116,66 +118,27 @@ function parseLine(line: string): { kind: DiffKind; text: string } | null {
 
 // --- intra-line (token-level) diff --------------------------------------------
 
-// Whitespace runs, identifier runs, and every other character on its own: the
-// three alternatives cover any string, so the tokens of a line always
-// reconstruct it exactly. Callers rely on that — a segment list that lost a
-// character would render code the file does not contain.
-const WORD_RE = /\s+|[A-Za-z0-9_]+|[^\sA-Za-z0-9_]/g;
-const tokenize = (s: string): string[] => s.match(WORD_RE) ?? [];
-
-/**
- * Token LCS between two lines → highlighted segments per side, or null when the
- * lines are too dissimilar to be "the same line, modified".
+/*
+ * The rule itself is `shared/tokenDiff.ts`, and it is shared for a reason that
+ * had already happened: the phone grew its own a week after this one, and the
+ * two disagreed about when a deleted line and an added one are a rewrite of
+ * each other. One reader, two screens, two answers.
  *
- * The null cases are the point. Removals and additions are paired by position,
- * which is a guess, so two unrelated lines regularly land opposite each other;
- * without the similarity floor the guess gets painted as a word-level change
- * and the reader is told to look at noise. The size caps exist because the DP
- * table is O(n·m) and a minified bundle in a diff is one line of 200k.
+ * What moved out is the whole of it — the tokeniser, the similarity floor, the
+ * bounded table — and what came back is a better bound than this file had. It
+ * used to give up entirely on a pair longer than 4,000 characters; the shared
+ * one trims the common prefix and suffix first, so a minified line changed at
+ * its end is still marked at its end.
  */
-export function tokenDiff(a: string, b: string): { left: Seg[]; right: Seg[] } | null {
-  if (!a || !b || a === b || a.length + b.length > 4000) return null;
-  const ta = tokenize(a), tb = tokenize(b);
-  const n = ta.length, m = tb.length;
-  if (n + m > 600) return null;
-  const dp = Array.from({ length: n + 1 }, () => new Array<number>(m + 1).fill(0));
-  for (let i = n - 1; i >= 0; i--)
-    for (let j = m - 1; j >= 0; j--)
-      dp[i][j] = ta[i] === tb[j] ? dp[i + 1][j + 1] + 1 : Math.max(dp[i + 1][j], dp[i][j + 1]);
-  const left: Seg[] = [], right: Seg[] = [];
-  // Adjacent runs of the same verdict are merged as they are pushed, so the
-  // renderer emits one <span> per visible change instead of one per token.
-  const push = (arr: Seg[], text: string, hi: boolean) => {
-    const last = arr[arr.length - 1];
-    if (last && last.hi === hi) last.text += text; else arr.push({ text, hi });
-  };
-  let i = 0, j = 0, eq = 0;
-  while (i < n && j < m) {
-    if (ta[i] === tb[j]) { push(left, ta[i], false); push(right, tb[j], false); eq += ta[i].length; i++; j++; }
-    else if (dp[i + 1][j] >= dp[i][j + 1]) push(left, ta[i++], true);
-    else push(right, tb[j++], true);
-  }
-  while (i < n) push(left, ta[i++], true);
-  while (j < m) push(right, tb[j++], true);
-  if ((2 * eq) / (a.length + b.length) < 0.4) return null; // too different → render plain
-  return { left, right };
-}
 
 /** In a unified row list, pair each removal with the addition at the same offset
  *  in the following add block, and attach token segments to those pairs. Blocks
  *  are matched in order and never across a context line, because a context line
  *  is git telling us the change block ended. */
 export function attachTokenDiff(rows: URow[]): void {
-  let i = 0;
-  while (i < rows.length) {
-    if (rows[i].kind !== "del") { i++; continue; }
-    let d = i; while (d < rows.length && rows[d].kind === "del") d++;
-    let a = d; while (a < rows.length && rows[a].kind === "add") a++;
-    for (let k = 0; k < Math.min(d - i, a - d); k++) {
-      const td = tokenDiff(rows[i + k].text, rows[d + k].text);
-      if (td) { rows[i + k].segs = td.left; rows[d + k].segs = td.right; }
-    }
-    i = a;
+  for (const [del, add] of pairsIn(rows)) {
+    const td = tokenDiff(rows[del].text, rows[add].text);
+    if (td) { rows[del].segs = td.left; rows[add].segs = td.right; }
   }
 }
 
@@ -266,7 +229,7 @@ function gutterWidth(maxLine: number): string {
 
 function Marked({ segs, kind }: { segs: Seg[]; kind: "del" | "add" }) {
   const bg = kind === "del" ? "color-mix(in srgb, var(--error) 22%, transparent)" : "color-mix(in srgb, var(--success) 22%, transparent)";
-  return <>{segs.map((s, i) => (s.hi ? <span key={i} style={{ background: bg, borderRadius: "2px" }}>{s.text}</span> : <span key={i}>{s.text}</span>))}</>;
+  return <>{segs.map((s, i) => (s.changed ? <span key={i} style={{ background: bg, borderRadius: "2px" }}>{s.text}</span> : <span key={i}>{s.text}</span>))}</>;
 }
 
 /** Segment list → character ranges, so the token diff can be re-applied on top
@@ -275,7 +238,7 @@ function changedRanges(segs?: Seg[] | null): Array<[number, number]> {
   const out: Array<[number, number]> = [];
   if (!segs) return out;
   let off = 0;
-  for (const s of segs) { if (s.hi) out.push([off, off + s.text.length]); off += s.text.length; }
+  for (const s of segs) { if (s.changed) out.push([off, off + s.text.length]); off += s.text.length; }
   return out;
 }
 

--- a/web/test/diff-lines.test.ts
+++ b/web/test/diff-lines.test.ts
@@ -9,7 +9,8 @@
 // what is tested here.
 import { test, expect } from "bun:test";
 import type { DiffHunk } from "../../shared/types.ts";
-import { unifiedRows, splitRows, tokenDiff, attachTokenDiff, type URow } from "../src/components/diff/DiffLines.tsx";
+import { unifiedRows, splitRows, attachTokenDiff, type URow } from "../src/components/diff/DiffLines.tsx";
+import { tokenDiff } from "../../shared/tokenDiff.ts";
 
 const hunk = (over: Partial<DiffHunk> & Pick<DiffHunk, "lines">): DiffHunk =>
   ({ oldStart: 1, oldLines: 0, newStart: 1, newLines: 0, ...over });
@@ -101,8 +102,8 @@ test("the token diff runs on the stripped text, not on the CR", () => {
   // it a silent partner in the similarity score and in every segment length.
   expect(del.segs!.map((s) => s.text).join("")).toBe("const b = 2;");
   expect(add.segs!.map((s) => s.text).join("")).toBe("const b = 3;");
-  expect(del.segs!.filter((s) => s.hi).map((s) => s.text)).toEqual(["2"]);
-  expect(add.segs!.filter((s) => s.hi).map((s) => s.text)).toEqual(["3"]);
+  expect(del.segs!.filter((s) => s.changed).map((s) => s.text)).toEqual(["2"]);
+  expect(add.segs!.filter((s) => s.changed).map((s) => s.text)).toEqual(["3"]);
 });
 
 // --- a one-line file ---------------------------------------------------------
@@ -211,8 +212,8 @@ test("a line changed at both ends is reconstructed exactly by its segments", () 
   // order. Anything else paints code the file does not contain.
   expect(td.left.map((s) => s.text).join("")).toBe(a);
   expect(td.right.map((s) => s.text).join("")).toBe(b);
-  expect(td.left.filter((s) => s.hi).map((s) => s.text)).toEqual(["const", "seed"]);
-  expect(td.right.filter((s) => s.hi).map((s) => s.text)).toEqual(["let", "base"]);
+  expect(td.left.filter((s) => s.changed).map((s) => s.text)).toEqual(["const", "seed"]);
+  expect(td.right.filter((s) => s.changed).map((s) => s.text)).toEqual(["let", "base"]);
   // Adjacent runs of the same verdict are merged, so the untouched middle is
   // one span rather than one per token.
   expect(td.left).toHaveLength(4);
@@ -233,8 +234,8 @@ test("attachTokenDiff pairs by offset within a block and never across context", 
     { oldN: 3, newN: null, text: "const c = 4;", kind: "del" },
   ];
   attachTokenDiff(rows);
-  expect(rows[0]!.segs!.filter((s) => s.hi).map((s) => s.text)).toEqual(["1"]);
-  expect(rows[1]!.segs!.filter((s) => s.hi).map((s) => s.text)).toEqual(["2"]);
+  expect(rows[0]!.segs!.filter((s) => s.changed).map((s) => s.text)).toEqual(["1"]);
+  expect(rows[1]!.segs!.filter((s) => s.changed).map((s) => s.text)).toEqual(["2"]);
   expect(rows[2]!.segs).toBeUndefined();
   // A removal with no addition opposite it has nothing to be compared against —
   // it must not borrow the context line above or the block before it.


### PR DESCRIPTION
## What does this PR do?

The desk has had a token diff since the diff panel was written. The phone grew its own last night, in #578. Two implementations of "which words in this line changed", and they disagreed — which a reader meets as one screen marking a word and the other marking nothing about the same line.

So there is one now, in `shared/tokenDiff.ts`. Putting the two side by side found a defect in **each**.

**The phone's.** A line changed at *both* ends got no marks at all. Similarity was measured from the common head and tail alone, so:

```
const total = sum(items, seed);
let   total = sum(items, base);
```

counted as 14% alike — it shares its entire middle, and none of that was being counted. It is measured now from everything the two lines actually keep, the table's matches included, and in characters rather than tokens, because it is a claim about what a reader sees: one long identifier kept is worth more than three brackets. **The desk's own test is what caught it**, and it had been asserting that case since the day it was written.

**The desk's.** It gave up entirely on a pair longer than 4,000 characters, so a minified line changed at its end was two plain bands. The shared one trims the common prefix and suffix before anything quadratic is considered, so that line is marked at its end for the cost of two linear passes.

The **pairing rule** is the desk's. The phone's was the stricter of the two for no good reason: three lines deleted and one added usually *is* one line rewritten and two removed, and refusing the whole block throws away the marks on the pair that is right. What stops a bad guess being painted is the similarity floor, which is measured — not the shape of the block, which is assumed.

`Seg.hi` is `Seg.changed`. It is read in four places, and "hi" is not a word.

## How was it tested?

- `bun test` in `web/` — the diff suite is green, including the both-ends case that found the phone's bug and the `attachTokenDiff` test that pins pairing never crossing a context line. (One unrelated palette test fails in this container both with and without this branch.)
- `bun test` in `mobile/` — **799 pass, 41 skip, 0 fail**. The phone's suite moves to `token-diff.test.ts` and its pairing test now asserts the shared rule, with a companion test showing the floor refusing the bad guess that rule allows through.
- `bun run typecheck` in `web/` and `server/`, `npm run typecheck` in `mobile/` — clean. `bunx oxlint` on every touched file — clean.

No behaviour change on the desk beyond the long-line case gaining marks it did not have, and none on the phone beyond the both-ends case gaining the same.