### PR TITLE
feat(phone): the three screens with no tab, on every header

### DIFF
--- a/mobile/app/(tabs)/_layout.tsx
+++ b/mobile/app/(tabs)/_layout.tsx
@@ -16,13 +16,14 @@
  * src/nav/icons.tsx. Nothing about that reasoning was dropped, it stopped
  * living in a layout file that had grown into three files' worth of it.
  */
-import { Pressable } from "react-native";
-import { Tabs, useRouter } from "expo-router";
+import { useState } from "react";
+import { Pressable, Text } from "react-native";
+import { Tabs, usePathname, useRouter } from "expo-router";
 import { TabBar } from "../../src/nav/TabBar.tsx";
-import { BackIcon, SettingsIcon } from "../../src/nav/icons.tsx";
+import { BackIcon } from "../../src/nav/icons.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
 import { C, SPACE, T } from "../../src/theme.ts";
-import { TAP } from "../../src/ui.tsx";
+import { Sheet, SheetRow, TAP } from "../../src/ui.tsx";
 
 /** A header button, at the tap target the rest of the app holds itself to.
  *  Square, because both of the two are a single glyph. */
@@ -56,6 +57,32 @@ export default function TabsLayout(): React.ReactNode {
    *  navigator goes to the first route, which is Home — and Home is the only
    *  place either of these two can be opened from, so it is also the right
    *  answer. */
+  /*
+   * The three screens with no tab, behind one control on every header.
+   *
+   * They used to be behind a gear on the Inbox and nowhere else, which meant
+   * that reaching Settings from a pull request was: back to the Inbox, gear,
+   * and then find your way home again. Three screens that the bar cannot hold
+   * and that you may want from anywhere is what a More menu is for.
+   *
+   * `···` and not a gear, because a gear means settings and one of these three
+   * is not settings. It matches the terminal's own More, which has said `···`
+   * since it had four things to offer and room for three.
+   */
+  const [more, setMore] = useState(false);
+  const here = usePathname();
+
+  const moreButton = (
+    <HeaderButton label="More" side="right" onPress={() => setMore(true)}>
+      <Text style={{ color: C.text, fontSize: T.title }}>···</Text>
+    </HeaderButton>
+  );
+
+  const go = (to: "/now" | "/repos" | "/settings"): void => {
+    setMore(false);
+    router.push(to);
+  };
+
   const back = (
     <HeaderButton label="Back" side="left" onPress={() => router.back()}>
       <BackIcon color={C.text} />
@@ -63,6 +90,7 @@ export default function TabsLayout(): React.ReactNode {
   );
 
   return (
+    <>
     <Tabs
       tabBar={(props) => <TabBar {...props} />}
       screenOptions={{
@@ -73,17 +101,7 @@ export default function TabsLayout(): React.ReactNode {
       }}
     >
       {/* ── the bar ─────────────────────────────────────────────────────── */}
-      <Tabs.Screen
-        name="index"
-        options={{
-          title: "Inbox",
-          headerRight: () => (
-            <HeaderButton label="Settings" side="right" onPress={() => router.push("/settings")}>
-              <SettingsIcon color={C.text} />
-            </HeaderButton>
-          ),
-        }}
-      />
+      <Tabs.Screen name="index" options={{ title: "Inbox", headerRight: () => moreButton }} />
       {/* Pull requests and cards were one destination behind a segmented
           control, which was a saving made when the bar was full of screens
           that have since gone. They are two destinations now, and each keeps
@@ -94,16 +112,42 @@ export default function TabsLayout(): React.ReactNode {
         which is the Inbox — and the Inbox is now the only place any of them is
         opened from, so it is also the right answer.
       */}
-      <Tabs.Screen name="prs" options={{ title: "Pull requests", headerLeft: () => back }} />
+      <Tabs.Screen name="prs" options={{ title: "Pull requests", headerLeft: () => back, headerRight: () => moreButton }} />
       {/* The terminal draws its own header — it is the one screen that gives
           the pane every point it can, so the navigator's chrome would be
           spending 56 of them on a title. Its back control is in that header. */}
       <Tabs.Screen name="terminal" options={{ title: "Terminal", headerShown: false }} />
-      <Tabs.Screen name="issues" options={{ title: "Issues", headerLeft: () => back }} />
-      <Tabs.Screen name="tasks" options={{ title: "Cards", headerLeft: () => back }} />
-      <Tabs.Screen name="now" options={{ title: "Now", headerLeft: () => back }} />
-      <Tabs.Screen name="repos" options={{ title: "Source control", headerLeft: () => back }} />
-      <Tabs.Screen name="settings" options={{ title: "Settings", headerLeft: () => back }} />
+      <Tabs.Screen name="issues" options={{ title: "Issues", headerLeft: () => back, headerRight: () => moreButton }} />
+      <Tabs.Screen name="tasks" options={{ title: "Cards", headerLeft: () => back, headerRight: () => moreButton }} />
+      <Tabs.Screen name="now" options={{ title: "Now", headerLeft: () => back, headerRight: () => moreButton }} />
+      <Tabs.Screen name="repos" options={{ title: "Source control", headerLeft: () => back, headerRight: () => moreButton }} />
+      <Tabs.Screen name="settings" options={{ title: "Settings", headerLeft: () => back, headerRight: () => moreButton }} />
     </Tabs>
+
+    {/* The three, and nothing else. A More menu that grows into a second bar
+        is how a five-item bar becomes an eight-item one with extra steps —
+        anything that belongs to a SCREEN stays on that screen, the way the
+        terminal keeps its own. */}
+    <Sheet open={more} onClose={() => setMore(false)} title="More">
+      <SheetRow
+        label="Now"
+        sub="What every agent on the machine is doing"
+        on={here === "/now"}
+        onPress={() => go("/now")}
+      />
+      <SheetRow
+        label="Source control"
+        sub="The working tree — stage, commit, push"
+        on={here === "/repos"}
+        onPress={() => go("/repos")}
+      />
+      <SheetRow
+        label="Settings"
+        sub="This phone's pairing, appearance and alerts"
+        on={here === "/settings"}
+        onPress={() => go("/settings")}
+      />
+    </Sheet>
+    </>
   );
 }

--- a/mobile/app/(tabs)/index.tsx
+++ b/mobile/app/(tabs)/index.tsx
@@ -257,8 +257,8 @@ export default function InboxScreen(): React.ReactNode {
           {/*
             A title in the CONTENT, not only in the navigation bar.
 
-            The bar's own title is 17pt and shares its row with a gear; it says
-            which tab you are on and nothing else. A page has room to open with
+            The bar's own title is 17pt and shares its row with the More
+            control; it says which tab you are on and nothing else. A page has room to open with
             a sentence, and the sentence people arrive for is not "Inbox" — it
             is how much is waiting. So the heading answers that, and the count
             under it is the same one the tiles add up to, said in words for the


### PR DESCRIPTION
## What does this PR do?

Now, Source control and Settings are tabs the bar deliberately does not draw — and the only way to any of them was a gear on the Inbox. So reaching Settings from a pull request was: back to the Inbox, gear, and then find your way home again.

They are one **More** control on every header now, opening a sheet with the three.

`···` rather than a gear, because a gear means *settings* and one of these three is not settings. It matches the terminal's own More, which has said `···` since it had four things to offer and room for three.

The sheet holds those three and will hold no more. A More menu that grows is how a five-item bar becomes an eight-item one with extra steps; anything that belongs to a **screen** stays on that screen, the way the terminal keeps its own.

The terminal has no header of the navigator's to put this on — it draws its own, deliberately, to give the pane every point it can — and it already reaches the working tree from its own menu.

This is the last piece of the review rearrangement (#581 was the segments).

## How was it tested?

- `bun test` in `mobile/` — **799 pass, 41 skip, 0 fail**.
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on the touched files — clean, bar one unused import on the Inbox that predates this branch.
- The row for the screen you are already on is marked, using the router's own path rather than a guess.

Not exercised on a handset. Worth a look: the `···` sits where the gear used to on the Inbox, so muscle memory should survive, but Settings has moved one tap further from that screen and one tap closer from every other.