### PR TITLE
fix(phone): one read of a pull request, however many panes look at it

### DIFF
--- a/mobile/app/pr/[number].tsx
+++ b/mobile/app/pr/[number].tsx
@@ -30,6 +30,7 @@ import { ask } from "../../src/lib/api.ts";
 import { Md, outline } from "../../src/md/Md.tsx";
 import { useAgentglass } from "../../src/state/host-context.tsx";
 import { usePaletteTick } from "../../src/state/use-palette.ts";
+import { usePrDetail } from "../../src/state/pr-detail.ts";
 import { useTracksWork } from "../../src/state/use-tracks-work.ts";
 import { TaskChip } from "../../src/review/TaskChip.tsx";
 import { FilesPane } from "../../src/review/FilesPane.tsx";
@@ -194,8 +195,12 @@ export default function PrScreen(): React.ReactNode {
      stay available, because neither writes anything. */
   const mayWrite = host?.scope === "full";
 
-  const [detail, setDetail] = useState<PrDetail | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  /* One read for the whole review — the two panes below are looking at the
+     same pull request, and a write in either of them re-reads this. Before
+     that, resolving a thread left the count on this screen saying what it said
+     when you arrived. See state/pr-detail.ts. */
+  const { detail, error, reload: load } = usePrDetail(host, root ?? "", String(number ?? ""));
+
   const [handing, setHanding] = useState(false);
   const [allFiles, setAllFiles] = useState(false);
   /* The description folds after six blocks. Six is where this project's own
@@ -276,22 +281,6 @@ export default function PrScreen(): React.ReactNode {
   const [mergeBusy, setMergeBusy] = useState(false);
   const [mergeErr, setMergeErr] = useState<string | null>(null);
 
-  const load = useCallback(async (): Promise<void> => {
-    if (!host || !number || !root) return;
-    const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
-    const answer = await ask<{ ok: boolean; detail?: PrDetail; error?: string }>(
-      host, `/prs/detail?${query}`,
-    );
-    if (!answer.ok) { setError(answer.error); return; }
-    if (!answer.value.ok || !answer.value.detail) {
-      setError(answer.value.error || "That pull request could not be read.");
-      return;
-    }
-    setError(null);
-    setDetail(answer.value.detail);
-  }, [host, number, root]);
-
-  useEffect(() => { void load(); }, [load]);
 
   // Fetched beside the detail rather than after it: they are independent
   // questions, and the sheet is not opened in the first instant anyway.

--- a/mobile/src/review/FilesPane.tsx
+++ b/mobile/src/review/FilesPane.tsx
@@ -53,10 +53,10 @@ import {
 } from "react-native";
 import { useRouter } from "expo-router";
 import * as Haptics from "expo-haptics";
-import type { PrDetail } from "../../../shared/types.ts";
 import { ask } from "../lib/api.ts";
 import { useAgentglass } from "../state/host-context.tsx";
 import { usePaletteTick } from "../state/use-palette.ts";
+import { usePrDetail } from "../state/pr-detail.ts";
 import {
   commentableLine, fileLabel, parseDiff, type DiffFile, type DiffLine,
 } from "../model/diffLines.ts";
@@ -209,18 +209,14 @@ export function FilesPane({ number, root, path, bar = true }: {
    * both stale-while-revalidate, so the cost of asking here is one cached
    * answer, not one round trip to GitHub.
    */
-  const [detail, setDetail] = useState<PrDetail | null>(null);
-
-  const loadThreads = useCallback(async (): Promise<void> => {
-    if (!host || !number || !root) return;
-    const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
-    const answer = await ask<{ ok: boolean; detail?: PrDetail; error?: string }>(host, `/prs/detail?${query}`);
-    // Deliberately quiet. The diff is the reason to be here; a pull request
-    // whose detail cannot be read still shows its change, with no markers.
-    if (answer.ok && answer.value.ok && answer.value.detail) setDetail(answer.value.detail);
-  }, [host, number, root]);
-
-  useEffect(() => { void loadThreads(); }, [loadThreads]);
+  /*
+   * The conversations, from the same read the rest of the review uses.
+   *
+   * A shared one and not this pane's own: it is a segment beside the overview
+   * and the threads, all three want the same answer, and three copies of it
+   * disagree the moment one of them writes. See state/pr-detail.ts.
+   */
+  const { detail, reload: loadThreads } = usePrDetail(host, root, number);
 
   /*
    * After a write, both halves of the screen are re-read.

--- a/mobile/src/review/ThreadsPane.tsx
+++ b/mobile/src/review/ThreadsPane.tsx
@@ -24,12 +24,11 @@
  * stands on its own, and holding it back until some later verdict would be
  * holding an answer somebody is waiting for.
  */
-import { useCallback, useEffect, useMemo, useState } from "react";
+import { useMemo } from "react";
 import { ActivityIndicator, KeyboardAvoidingView, ScrollView } from "react-native";
-import type { PrDetail } from "../../../shared/types.ts";
-import { ask } from "../lib/api.ts";
 import { useAgentglass } from "../state/host-context.tsx";
 import { usePaletteTick } from "../state/use-palette.ts";
+import { usePrDetail } from "../state/pr-detail.ts";
 import { ordered } from "../model/threads.ts";
 import { ApplyConfirm } from "./ApplyConfirm.tsx";
 import { ThreadCard } from "./ThreadCard.tsx";
@@ -48,25 +47,12 @@ export function ThreadsPane({ number, root }: { number: string; root: string }):
   usePaletteTick(); // a scene repaints only if it asks — see use-palette.ts
   const { host } = useAgentglass();
 
-  const [detail, setDetail] = useState<PrDetail | null>(null);
-  const [error, setError] = useState<string | null>(null);
+  /* One read for the whole review — see state/pr-detail.ts. This pane is a
+     segment beside two others that want the same answer, and three copies of
+     it disagree the moment one of them writes. */
+  const { detail, error, reload } = usePrDetail(host, root, number);
 
-  const load = useCallback(async (): Promise<void> => {
-    if (!host || !number || !root) return;
-    const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
-    const answer = await ask<{ ok: boolean; detail?: PrDetail; error?: string }>(host, `/prs/detail?${query}`);
-    if (!answer.ok) { setError(answer.error); return; }
-    if (!answer.value.ok || !answer.value.detail) {
-      setError(answer.value.error || "That pull request could not be read.");
-      return;
-    }
-    setError(null);
-    setDetail(answer.value.detail);
-  }, [host, number, root]);
-
-  useEffect(() => { void load(); }, [load]);
-
-  const actions = useThreadActions({ host, root: root ?? "", number: number ?? "", reload: load });
+  const actions = useThreadActions({ host, root, number, reload });
 
   const threads = useMemo(() => ordered(detail?.threads ?? []), [detail]);
   const open = threads.filter((t) => !t.isResolved).length;

--- a/mobile/src/state/pr-detail.ts
+++ b/mobile/src/state/pr-detail.ts
@@ -1,0 +1,135 @@
+/*
+ * One pull request, read once, however many panes are looking at it.
+ *
+ * Three of them are now: the overview, the diff and the threads, and until
+ * this they each fetched `/prs/detail` for themselves. That was harmless while
+ * they were three screens — you were only ever on one — and stopped being
+ * harmless the moment they became segments of one, because all three can be
+ * mounted at the same time.
+ *
+ * The cost was the smaller half. The real one is that three copies of the same
+ * answer disagree: resolve a thread in the Threads pane, which re-reads after
+ * every write, and the Overview behind it still says "3 open" because nobody
+ * told it. A number that is wrong on the screen you came from reads as the
+ * write not having taken.
+ *
+ * So there is one copy per pull request, and a write anywhere re-reads it for
+ * everybody. A module-level store rather than context, for the reason
+ * card-edits.ts gives for its listeners: a pane is also a route, so the three
+ * share no ancestor short of the root, and a context at the root re-renders
+ * the app to change one count.
+ */
+import { useCallback, useEffect, useState } from "react";
+import type { PrDetail } from "../../../shared/types.ts";
+import { ask } from "../lib/api.ts";
+import type { Host } from "../lib/host.ts";
+
+interface Entry {
+  detail: PrDetail | null;
+  error: string | null;
+  /** The read in flight, so three panes mounting together make one request
+   *  rather than three — the same join the server does for `gh pr diff`. */
+  reading: Promise<void> | null;
+  listeners: Set<() => void>;
+}
+
+const store = new Map<string, Entry>();
+
+const keyOf = (root: string, number: string): string => `${root}#${number}`;
+
+function entryFor(key: string): Entry {
+  const found = store.get(key);
+  if (found) return found;
+  const made: Entry = { detail: null, error: null, reading: null, listeners: new Set() };
+  store.set(key, made);
+  return made;
+}
+
+function tell(entry: Entry): void {
+  for (const listen of entry.listeners) listen();
+}
+
+async function read(host: Host, root: string, number: string, entry: Entry): Promise<void> {
+  const query = `root=${encodeURIComponent(root)}&number=${encodeURIComponent(number)}`;
+  const answer = await ask<{ ok: boolean; detail?: PrDetail; error?: string }>(host, `/prs/detail?${query}`);
+  if (!answer.ok) { entry.error = answer.error; tell(entry); return; }
+  if (!answer.value.ok || !answer.value.detail) {
+    entry.error = answer.value.error || "That pull request could not be read.";
+    tell(entry);
+    return;
+  }
+  entry.error = null;
+  entry.detail = answer.value.detail;
+  tell(entry);
+}
+
+/**
+ * Read it, or join the read already in flight.
+ *
+ * The join is the point and not an optimisation: three panes mount together
+ * when a review opens, and without it that is three requests for one answer —
+ * the same join the server makes for `gh pr diff`, made on this side for the
+ * same reason.
+ *
+ * Exported so it can be tested without a renderer. There is none in this
+ * project, and "three callers, one request" is a fact about this function
+ * rather than about a screen.
+ */
+export async function readPrDetail(host: Host | null, root: string, number: string): Promise<void> {
+  if (!host || !root || !number) return;
+  const entry = entryFor(keyOf(root, number));
+  if (entry.reading) return entry.reading;
+  const run = read(host, root, number, entry).finally(() => { entry.reading = null; });
+  entry.reading = run;
+  return run;
+}
+
+/** What is held for one pull request, for a test that wants to look. */
+export function prDetailNow(root: string, number: string): PrDetail | null {
+  return store.get(keyOf(root, number))?.detail ?? null;
+}
+
+/**
+ * The detail, and the way to ask for it again.
+ *
+ * `reload` is what every write calls: it always goes to the server — never a
+ * cached answer — because what a thread looks like after a reply is GitHub's
+ * answer and not this app's guess, which is the rule `useThreadActions`
+ * already states.
+ *
+ * The first mount fetches; the second and third join the same promise. What is
+ * kept between visits is deliberate: coming back to a pull request shows what
+ * it said last time WHILE the fresh read is in flight, rather than an empty
+ * screen for a second.
+ */
+export function usePrDetail(host: Host | null, root: string, number: string): {
+  detail: PrDetail | null;
+  error: string | null;
+  reload: () => Promise<void>;
+} {
+  const key = keyOf(root, number);
+  const entry = entryFor(key);
+  const [, repaint] = useState(0);
+
+  useEffect(() => {
+    const listen = (): void => repaint((n) => n + 1);
+    entry.listeners.add(listen);
+    return () => { entry.listeners.delete(listen); };
+  }, [entry]);
+
+  const reload = useCallback(
+    async (): Promise<void> => readPrDetail(host, root, number),
+    [host, root, number],
+  );
+
+  useEffect(() => { void reload(); }, [reload]);
+
+  return { detail: entry.detail, error: entry.error, reload };
+}
+
+/** Drop what is held for one pull request. Only tests need this: the store is
+ *  a handful of objects and a phone that reviewed forty pull requests in a
+ *  session has bigger things in memory than forty titles. */
+export function forgetPrDetail(root: string, number: string): void {
+  store.delete(keyOf(root, number));
+}

--- a/mobile/test/pr-detail.test.ts
+++ b/mobile/test/pr-detail.test.ts
@@ -1,0 +1,118 @@
+/*
+ * One pull request, read once, however many panes are looking at it.
+ *
+ * Three of them are, since the review became one screen with three segments —
+ * the overview, the diff and the threads. Two things had to become true for
+ * that not to be a regression:
+ *
+ *   they make ONE request between them, not three;
+ *   and a write in any of them re-reads for all three, so the count on the
+ *   overview cannot still say "3 open" after you resolved one next door.
+ *
+ * `fetch` is stubbed rather than a server booted: the question is what this
+ * store does with an answer, not what the server answers.
+ */
+import { afterEach, beforeEach, describe, expect, test } from "bun:test";
+import { forgetPrDetail, prDetailNow, readPrDetail } from "../src/state/pr-detail.ts";
+import type { Host } from "../src/lib/host.ts";
+
+const host: Host = {
+  origin: "http://192.168.7.20:4000",
+  token: "a-device-token",
+  label: "Test phone",
+  scope: "full",
+  pairedAt: 0,
+};
+
+const realFetch = globalThis.fetch;
+let calls = 0;
+/** A gate every stubbed read waits behind, so a second and third caller arrive
+ *  while the first is still in flight — the only moment a join can be seen.
+ *  Opened for ALL of them, so a broken join fails with the wrong count rather
+ *  than hanging. */
+let gate: { wait: Promise<void>; open: () => void } | null = null;
+
+const answer = (title: string): Response =>
+  new Response(JSON.stringify({ ok: true, detail: { number: 12, title, threads: [] } }), {
+    status: 200, headers: { "content-type": "application/json" },
+  });
+
+beforeEach(() => {
+  calls = 0;
+  forgetPrDetail("/code/widget", "12");
+  // Typed like the stub in ask-refusals.test.ts: a bare async function is not
+  // `typeof fetch` — that type carries `preconnect` — and the parameters are
+  // what makes the cast honest rather than a silencer.
+  globalThis.fetch = ((_url: string | URL | Request, _init?: RequestInit) => {
+    calls++;
+    const n = calls;
+    return (gate ? gate.wait : Promise.resolve()).then(() => answer(`read ${n}`));
+  }) as typeof fetch;
+});
+
+afterEach(() => { globalThis.fetch = realFetch; gate = null; });
+
+/** A gate that starts shut. */
+function shut(): { wait: Promise<void>; open: () => void } {
+  let open = (): void => {};
+  const wait = new Promise<void>((go) => { open = go; });
+  return { wait, open };
+}
+
+describe("three panes, one request", () => {
+  test("callers that arrive while a read is in flight join it", async () => {
+    gate = shut();
+    const all = Promise.all([
+      readPrDetail(host, "/code/widget", "12"),
+      readPrDetail(host, "/code/widget", "12"),
+      readPrDetail(host, "/code/widget", "12"),
+    ]);
+    gate.open();
+    await all;
+    expect(calls).toBe(1);
+    expect(prDetailNow("/code/widget", "12")?.title).toBe("read 1");
+  });
+
+  test("and a later one is a fresh read, because a write must not see a cache", async () => {
+    // What a thread looks like after a reply is GitHub's answer and not this
+    // app's guess — the rule useThreadActions already states, which is worth
+    // nothing if the re-read it makes is served from memory.
+    gate = null;
+    await readPrDetail(host, "/code/widget", "12");
+    await readPrDetail(host, "/code/widget", "12");
+    expect(calls).toBe(2);
+    expect(prDetailNow("/code/widget", "12")?.title).toBe("read 2");
+  });
+});
+
+describe("two pull requests are two answers", () => {
+  test("nothing is shared between them", async () => {
+    gate = null;
+    await readPrDetail(host, "/code/widget", "12");
+    await readPrDetail(host, "/code/widget", "13");
+    expect(prDetailNow("/code/widget", "12")?.title).toBe("read 1");
+    expect(prDetailNow("/code/widget", "13")?.title).toBe("read 2");
+    forgetPrDetail("/code/widget", "13");
+  });
+
+  test("the same number in two checkouts is two things", async () => {
+    // A worktree per pull request is how this project works; #12 of one
+    // checkout is not #12 of another.
+    gate = null;
+    await readPrDetail(host, "/code/widget", "12");
+    await readPrDetail(host, "/code/other", "12");
+    expect(prDetailNow("/code/widget", "12")?.title).toBe("read 1");
+    expect(prDetailNow("/code/other", "12")?.title).toBe("read 2");
+    forgetPrDetail("/code/other", "12");
+  });
+});
+
+describe("nothing to read", () => {
+  test("no host, no root, no number: no request rather than a bad one", async () => {
+    gate = null;
+    await readPrDetail(null, "/code/widget", "12");
+    await readPrDetail(host, "", "12");
+    await readPrDetail(host, "/code/widget", "");
+    expect(calls).toBe(0);
+  });
+});


### PR DESCRIPTION
## What does this PR do?

Making the review one screen (#581) made three panes able to be mounted at once — and each of them was fetching `/prs/detail` for itself. That was harmless while they were three screens, because you were only ever on one.

The extra requests are the smaller half. The real problem is that **three copies of the same answer disagree**: resolve a thread in the Threads pane, which re-reads after every write, and the Overview behind it still says "3 open", because nobody told it. A number that is wrong on the screen you came from reads as the write not having taken.

So there is one copy per pull request now, and a write anywhere re-reads it for everybody. Three panes mounting together **join one request** rather than making three — the same join the server already makes for `gh pr diff`, made on this side for the same reason.

A module-level store rather than context, for the reason `card-edits.ts` gives for its listeners: a pane is also a route, so the three share no ancestor short of the root, and a context at the root re-renders the app to change one count.

## How was it tested?

- `bun test` in `mobile/` — **804 pass, 41 skip, 0 fail**, including 5 new ones against a stubbed `fetch` rather than a booted server:
  - three callers arriving together make **one** request;
  - a later one is a **fresh** read, because a write must not be answered from memory — the rule `useThreadActions` already states is worth nothing if the re-read it makes is cached;
  - two pull requests are two answers, and the same number in two checkouts is two things (a worktree per pull request is how this project works);
  - no host, no root or no number makes **no** request rather than a bad one.
- The join test was checked by deleting the join and watching it fail, so it is not passing for the wrong reason.
- `npm run typecheck` in `mobile/` (app and test configs) — clean. `bunx oxlint` on every touched file — clean.

Behaviour to look at on a handset: resolve a thread in the Threads segment and switch back to Overview — the open count should already have moved.