### PR TITLE
docs: twenty-five comments stop quoting somebody's own words

### DIFF
--- a/landing/index.html
+++ b/landing/index.html
@@ -542,9 +542,9 @@
 
   /* A guarded switch: you cannot arm by brushing past it.
      The guard has to physically COVER the switch for the metaphor to read.
-     Stacked as two separate boxes it was just two unexplained rectangles —
-     hence "no entiendo para qué es". Now it is a hinged lid on the thing it
-     protects, it says what it protects, and it says what happens if you throw it. */
+     Stacked as two separate boxes it was two unexplained rectangles nobody
+     could read a purpose into. Now it is a hinged lid on the thing it protects,
+     it says what it protects, and it says what happens if you throw it. */
   .ck-sw{display:flex; flex-direction:column; align-items:center; gap:10px;}
   .sw-cap{font-size:9px; letter-spacing:.22em; text-transform:uppercase; color:var(--primary); text-align:center;}
   .sw-stack{position:relative; width:172px; height:56px; perspective:420px;}

--- a/mobile/src/notifications/notify.ts
+++ b/mobile/src/notifications/notify.ts
@@ -16,8 +16,8 @@
  * release of SDK 53" as an UNCAUGHT error — a red box over whatever you were
  * looking at, on every cold start. This file is reached from the host store,
  * which is reached from the tab layout, so that is not "notifications are
- * off", it is expo-router failing to build a route. That is what "la app sigue
- * rota" was.
+ * off" — it is expo-router failing to build a route, and what it looks like
+ * from outside is an app that will not start.
  *
  * So it is required inside the functions, once, behind a try, and behind the
  * Expo Go check that stops it being attempted at all. A phone that cannot

--- a/mobile/src/terminal/terminal-html.ts
+++ b/mobile/src/terminal/terminal-html.ts
@@ -850,8 +850,8 @@ export function terminalDocument({ palette, columns }: TerminalDocOptions): stri
    *
    * ── why the rate is measured and not a constant ───────────────────────────
    * This shipped at one notch per three rows, because three rows is what a
-   * desktop wheel sends, and the complaint came back the same day: "el scroll
-   * con el dedo es pesimo, apenas se mueve unos pixeles". Three rows is true
+   * desktop wheel sends, and a drag of the whole screen then moved the pane a
+   * few pixels — unusable, the same day it shipped. Three rows is true
    * about a desktop and irrelevant here, because HOW FAR A NOTCH GOES IS NOT
    * OURS TO DECIDE. A notch is a request; the program on the other end picks
    * the distance. Measured on this machine, on the same pane, minutes apart:

--- a/mobile/test/fleet-shapes.test.ts
+++ b/mobile/test/fleet-shapes.test.ts
@@ -81,11 +81,26 @@ afterAll(async () => {
   if (dir) rmSync(dir, { recursive: true, force: true });
 });
 
+/**
+ * Longer than bun's five seconds, and for the same reason the boot above is.
+ *
+ * Every test below speaks to a real server over HTTP, and one of the routes —
+ * `/docker/overview` — probes for a tool that may not be installed, which is a
+ * process spawn rather than a lookup. Measured on ubuntu-latest: that test
+ * timed out at exactly 5000ms while the two after it then failed in
+ * milliseconds against a server that was no longer answering, so the whole
+ * file reads as three defects when it is one slow probe.
+ *
+ * The number is not a guess about the route. It is "long enough that a failure
+ * here means something is wrong, rather than that the runner was busy".
+ */
+const SLOW = 30_000;
+
 describe("what the Now screen reads", () => {
   test("gates come wrapped", async () => {
     const body = await get<{ gates: unknown }>("/gate/pending");
     expect(Array.isArray(body.gates)).toBe(true);
-  });
+  }, SLOW);
 
   test("sessions come BARE — the one that was got wrong", async () => {
     const body = await get<unknown>("/sessions?limit=100");
@@ -93,13 +108,13 @@ describe("what the Now screen reads", () => {
     // Stated as its own assertion so a future wrapper shows up as this line
     // rather than as an empty queue nobody can explain.
     expect((body as { sessions?: unknown }).sessions).toBeUndefined();
-  });
+  }, SLOW);
 
   test("containers come wrapped", async () => {
     const body = await get<{ containers: unknown; available: unknown }>("/docker/overview");
     expect(Array.isArray(body.containers)).toBe(true);
     expect(typeof body.available).toBe("boolean");
-  });
+  }, SLOW);
 
   test("and the queue builds from all three without throwing", async () => {
     /*
@@ -122,7 +137,7 @@ describe("what the Now screen reads", () => {
       now: Date.now(),
     });
     expect(Array.isArray(queue)).toBe(true);
-  });
+  }, SLOW);
 
   test("a theme is null before anybody picks one, rather than a guess", async () => {
     // The other route the app reads on every foreground. Null and a palette
@@ -130,5 +145,5 @@ describe("what the Now screen reads", () => {
     // following the computer or falling back to what it ships.
     const body = await get<{ theme: unknown }>("/theme/current");
     expect(body.theme).toBeNull();
-  });
+  }, SLOW);
 });

--- a/server/test/agent-sessions.test.ts
+++ b/server/test/agent-sessions.test.ts
@@ -1,11 +1,11 @@
 /*
  * The sessions a project has, wherever they ran.
  *
- * Asked for like this: "que este desplegable me abra directamente la tab o el
- * pane… muéstrame todas las sesiones que haya en todas las rutas del proyecto,
- * ya que puede que hayan sesiones en worktrees que no se muestren".
+ * Two things were asked of it: that picking a session opens its tab or pane
+ * directly, and that the list covers every path of the project — because
+ * sessions in a worktree were not being shown at all.
  *
- * That last clause is the whole feature. `/resume` lists the transcripts of the
+ * That second one is the whole feature. `/resume` lists the transcripts of the
  * directory the agent is running in, so a session from a worktree is invisible
  * from the main checkout — and those are the ones being looked for, because a
  * worktree is where the work was. This walks every checkout `git worktree list`

--- a/server/test/new-tab-starts-in-the-project.test.ts
+++ b/server/test/new-tab-starts-in-the-project.test.ts
@@ -1,10 +1,10 @@
 /*
  * A new tab opens in the project on screen.
  *
- * Reported with two screenshots: the panel's chip said the repository was
- * `~/code/orbit`, the prompt in the tab that had just been opened said
- * `~/code/agentglass-work`, and the ask was not subtle — "SIEMPRE SIEMPRE
- * SIEMPRE debe abrirse desde la raíz del proyecto seleccionado".
+ * Found with the two paths side by side: the panel's chip said the repository
+ * was `~/code/orbit`, and the prompt in the tab that had just been opened said
+ * `~/code/agentglass-work`. A new tab opens at the root of the project on
+ * screen, always — there is no second reading of that.
  *
  * `new-window` with no `-c` starts in the SESSION's directory, and the session
  * was created by the server, so its directory is wherever the server was

--- a/server/test/private-content.test.ts
+++ b/server/test/private-content.test.ts
@@ -74,17 +74,46 @@ describe("nothing private is in the tree", () => {
   test("a comment does not quote a message somebody sent", () => {
     /*
      * The heuristic is language. This codebase is written in English, and every
-     * one of these got in as a quoted Spanish sentence — so a Spanish function
-     * word between quotes is the shape of the thing, and it is nearly free of
-     * false positives: a real Spanish string in the product would be a
-     * translation file, and there is none.
+     * one of these got in as a quoted Spanish sentence — so a quoted run with
+     * three different Spanish function words in it is the shape of the thing.
      *
-     * Deliberately narrow. It is a tripwire for the mistake that was actually
-     * made, not a language detector; the rule it protects is written in
-     * CLAUDE.md and a person reading a failure here should go and read it.
+     * The first version of this rule looked for one word from a list of twelve
+     * and looked at raw source, and it found four of the twenty-three that were
+     * actually in the tree. Both halves were wrong:
+     *
+     *   A comment wraps. `"la app sigue\n * rota"` is one quote to a reader and
+     *   two lines to a regex, so the comment is FLATTENED before it is read.
+     *
+     *   One word is not a signal. "de" and "la" are in half the identifiers in
+     *   any codebase; three distinct ones inside one pair of quotes is not an
+     *   accident.
+     *
+     * Deliberately still a tripwire for the mistake that was actually made, and
+     * not a language detector — the rule it protects is written in CLAUDE.md,
+     * and somebody reading a failure here should go and read that.
      */
-    const SPANISH = /(?:"|«|`)[^"«`\n]{0,120}\b(?:cuando|porque|entonces|debería|deberia|tengo que|puedas|para que|movil|móvil|gracias|vale)\b[^"«`\n]{0,120}(?:"|»|`)/i;
-    expect(hits(SPANISH)).toEqual([]);
+    const SPANISH = /\b(?:la|el|los|las|un|una|que|de|del|en|es|no|si|al|lo|se|con|por|para|más|pero|como|esto|esta|este|sigue|roto|rota|puedo|puedes|hay|está|estoy|tengo|quiero|cuando|porque|entonces|donde|nada|todo|muy|bien|mal|vale|gracias|movil|móvil|pantalla|boton|botón|aqui|aquí|abajo|arriba|deberia|debería|solo|sólo|ni|ve|otra|hacer|desde|sin|sobre|entre|hasta|entonces)\b/gi;
+    const COMMENT = /\/\*[\s\S]*?\*\/|\/\/[^\n]*/g;
+    const QUOTED = /["“«]([^"”»]{8,260})["”»]/g;
+
+    const quoted = scanned.flatMap(({ path, text }) => {
+      const found: string[] = [];
+      for (const comment of text.match(COMMENT) ?? []) {
+        // Unwrapped: the leading `*` of each line goes, and so does the break.
+        const flat = comment.replace(/\s*\n\s*\*?\s*/g, " ");
+        for (const [, run] of flat.matchAll(QUOTED)) {
+          const words = new Set((run.match(SPANISH) ?? []).map((w) => w.toLowerCase()));
+          if (words.size >= 3) found.push(`${path}: ${run.slice(0, 60)}`);
+        }
+      }
+      return found;
+    });
+
+    expect(
+      quoted,
+      "a comment is quoting somebody's own words. Say what the defect WAS — "
+      + "who mentioned it, and in which language, is not documentation.",
+    ).toEqual([]);
   });
 
   test("and the rules it enforces are written down", () => {

--- a/server/test/reminders.test.ts
+++ b/server/test/reminders.test.ts
@@ -221,9 +221,9 @@ describe("delivery", () => {
        * This assertion used to read 1, with a comment saying a reminder is
        * news. It is not: everything else on this path is something that
        * HAPPENED and can be read whenever, while a reminder is a promise the
-       * user made to themselves at a particular minute. Reported exactly so —
-       * "es una alarma que yo he programado, tiene que ser más invasiva" — and
-       * both halves of the change are here: freedesktop keeps a CRITICAL
+       * user made to themselves at a particular minute. An alarm somebody set
+       * deliberately is meant to interrupt, and both halves of the change are
+       * here: freedesktop keeps a CRITICAL
        * notification on screen instead of expiring it after a few seconds, and
        * the mark is what lets the app raise its own alarm rather than adding
        * another grey row to the list behind the bell.

--- a/web/src/components/FileRail.tsx
+++ b/web/src/components/FileRail.tsx
@@ -174,8 +174,9 @@ export function FileRail({
    * The review note being written, and a way to write it.
    *
    * The rail used to carry the three verdicts and the Submit and no field, so
-   * everything except an approval bounced you to another tab — "si quiero hacer
-   * la review desde aquí no tengo input para meter texto, entonces es inútil".
+   * everything except an approval bounced you to another tab. A rail you can
+   * finish a review from except when you have something to say is a rail you
+   * leave every time.
    *
    * It is the SAME draft the Review tab holds, not a second one: two boxes with
    * two bodies is a way to lose the one you typed in the other.

--- a/web/src/components/PrFilterBar.tsx
+++ b/web/src/components/PrFilterBar.tsx
@@ -147,8 +147,8 @@ export function PrFilterBar({
           *
           * These pills are built from the pull requests that have been loaded,
           * so the bar used to appear a second or two after everything else and
-          * shove the board down as it landed — reported as "tarda en cargar,
-          * entonces como que salta". Drawn from the static facet table instead
+          * shove the board down as it landed, which reads as the board jumping
+          * under the cursor. Drawn from the static facet table instead
           * while there is nothing to count, dimmed and inert: same row, same
           * height, same place, filling in rather than arriving.
           */}

--- a/web/src/components/TriageBoard.tsx
+++ b/web/src/components/TriageBoard.tsx
@@ -831,9 +831,9 @@ export function TriageBoard({
                         * IT HOLDS SOMETHING, and then it draws no control
                         * rather than a dead one. At zero it folds like any
                         * other: an empty lane is asking nothing, and it was
-                        * still taking 268px of a board that does not fit five
-                        * columns — "no puedo plegar la primera columna", said
-                        * under a heading reading `0 NEEDS YOUR REVIEW`.
+                        * still taking 268px of a board that does not fit
+                        * five columns — a lane that cannot be folded under a
+                        * heading reading `0 NEEDS YOUR REVIEW`.
                         */}
                       {foldable(l.id, all.length) && (
                         <button onClick={() => toggleFold(l.id, all.length)}

--- a/web/src/components/git/Lists.tsx
+++ b/web/src/components/git/Lists.tsx
@@ -351,8 +351,8 @@ export function commitRows(
     title: <span className="truncate" style={{ fontFamily: "var(--font-sans)" }}>{l.subject}</span>,
     /* `clip`, and capped: this is the one chip in the app whose text is not a
        word but a list of branch names, and on a busy commit it is longer than
-       the subject it sits beside. Uncapped it ate the row and drew itself over
-       the date and author — reported as "se ve por encima del texto". */
+       the subject it sits beside. Uncapped it ate the row and drew itself
+       over the date and the author. */
     chips: l.refs
       ? <span className="chip-ref"><Chip tone="good" clip title={l.refs}>{l.refs}</Chip></span>
       : undefined,

--- a/web/src/components/git/ui.tsx
+++ b/web/src/components/git/ui.tsx
@@ -285,9 +285,8 @@ export function RowAction({ label, danger, disabled, onClick, title }: {
  *
  * It was the character `☐` at 11px — which renders as a seven-pixel outline
  * with no tick you can see when it is ON, in a list where the whole point is
- * knowing which rows you have selected. Reported as "el checkbox es ENANO, ni
- * se ve", and it was not a control at all: a `<span>` with an onClick, no role,
- * no keyboard, no target.
+ * knowing which rows you have selected. It was not a control at all either:
+ * a `<span>` with an onClick, no role, no keyboard, no target.
  *
  * Drawn now, at `ICON.sm` inside the app's own `HIT` square — the same
  * geometry every other icon-only control in this app has — with a real tick and

--- a/web/src/components/workspace/Chrome.tsx
+++ b/web/src/components/workspace/Chrome.tsx
@@ -5,8 +5,8 @@
  * headers written at five different times had drifted, and switching views made
  * the frame twitch. What it never fixed is what goes IN the bar, so the drift
  * moved one level down — a chip at 11.5px here, one at 10px there, a segmented
- * control with its own border and inner padding in a third. Reported, in the
- * author's words: "no hay homogeneidad… parece que estoy en otra app".
+ * control with its own border and inner padding in a third. The effect is
+ * that switching views reads as switching applications.
  *
  * Nothing here is invented. The numbers are the ones the panels already agree
  * on, counted across the six view files:
@@ -328,8 +328,7 @@ export function ScopeChip({ label, kind, trailing = "none", on, onClick, title, 
    * correct for a toolbar toggle, wrong here: the pull-request header turned
    * into two grey words with arrows after them, and grey text with punctuation
    * reads as a caption that happens to have an arrow, not as something you can
-   * press. Reported the moment it shipped: "usa ese chip que usas en los demás,
-   * así está en armonía y no parece otra cosa."
+   * press — and as the one header in the app that does not match the others.
    *
    * The fill and the hairline are the Git panel's, which is the header that had
    * this right — they are what say "this is a control".

--- a/web/src/components/workspace/ViewRail.tsx
+++ b/web/src/components/workspace/ViewRail.tsx
@@ -371,10 +371,9 @@ export function ViewRail({
           *
           * It used to be two. A drag raised a dashed bin of its own directly
           * ABOVE this button, so the moment you picked something up there were
-          * two dashed squares stacked in the corner of the rail: one to drop it
-          * into and one that opens the drawer it lands in. Reported as "es muy
-          * raro… ese botón debería ser el de agregar" — which it now is, in both
-          * directions.
+          * two dashed squares stacked in the corner of the rail: one to drop
+          * it into and one that opens the drawer it lands in. One button, in
+          * both directions, is what that should always have been.
           *
           * Shown while dragging even with nothing hidden yet, or the first view
           * you ever put away would have nowhere to be dropped.

--- a/web/src/lib/boardPrefs.ts
+++ b/web/src/lib/boardPrefs.ts
@@ -65,9 +65,8 @@ export function setFoldedLanes(ids: readonly string[]): void {
  * ONLY WHILE IT HOLDS SOMETHING, which the first version of this missed. The
  * argument above is entirely about a lane that is asking you for something: a
  * lane at ZERO is asking for nothing, and it was still taking 268 pixels of a
- * board that does not fit five columns on his screen, with a control that
- * refused. Reported looking straight at it: "no puedo plegar la primera
- * columna", under a heading reading `0 NEEDS YOUR REVIEW`.
+ * board that does not fit five columns, with a control that refused — a lane
+ * that cannot be folded under a heading reading `0 NEEDS YOUR REVIEW`.
  *
  * Both halves matter and they do not conflict. Empty, it folds like any other.
  * The moment something lands in it, `foldable` says no again — and because a

--- a/web/test/app-chord.test.ts
+++ b/web/test/app-chord.test.ts
@@ -4,9 +4,8 @@
  * It is the only binding in the app that reaches past a running shell — the
  * terminal is told to hand it over instead of writing it to the PTY. That makes
  * it the one most likely to collide with something already bound inside tmux,
- * readline or vim, and so the one that most needs to be movable. "Ante la duda
- * déjalo para poder editarlo en los settings" is exactly the right instinct and
- * this is the test of it.
+ * readline or vim, and so the one that most needs to be movable. When in doubt
+ * a binding stays editable in Settings, and this is the test of that.
  *
  * The first case here is a defect found while building it, not a hypothetical:
  * the chord encoder dropped Shift for letter keys, so Ctrl+Shift+P and Ctrl+P

--- a/web/test/board-fold.test.ts
+++ b/web/test/board-fold.test.ts
@@ -152,8 +152,8 @@ describe("the lane that cannot be folded", () => {
     /* The half the first version got wrong. The argument for never folding this
        lane is entirely about a lane that is asking you for something; at zero it
        asks nothing, and it was still taking 268px of a board that does not fit
-       five columns. Reported looking straight at it: "no puedo plegar la primera
-       columna", under a heading reading `0 NEEDS YOUR REVIEW`. */
+       five columns — a lane that cannot be folded under a heading reading
+       `0 NEEDS YOUR REVIEW`. */
     const empty = { mine: [pr(1)], review: [], total: 40 };
     /* Counted rather than matched on one attribute: `column()` cuts from this
        lane's marker to the next one's, and what distinguishes "offers a fold"

--- a/web/test/card-plan.test.ts
+++ b/web/test/card-plan.test.ts
@@ -23,8 +23,8 @@ describe("what a visit to the card would change", () => {
   });
 
   it("does not count a status the card is already in", () => {
-    // Reported: "esto no es nada, no deberíamos mandarlo". A card in Code
-    // Review being moved to Code Review is a no-op that dates the card.
+    // A card in Code Review being moved to Code Review is a write that
+    // changes nothing and dates the card, which is worse than not writing.
     expect(plan({ pick: "code review", statusNow: "code review" }).status).toBe("");
     expect(plan({ pick: "code review", statusNow: "in progress" }).status).toBe("code review");
   });

--- a/web/test/diff-scroll-paint.test.ts
+++ b/web/test/diff-scroll-paint.test.ts
@@ -76,8 +76,8 @@ describe("one width for the whole file", () => {
 /*
  * And the numbers stay while it scrolls.
  *
- * Reported straight after the paint fix: "los números de las líneas se deben
- * quedar, ¿no?". They were already written as sticky and had never once stuck,
+ * Found straight after the paint fix. They were already written as sticky and
+ * had never once stuck,
  * because `.agx-gutter{position:relative}` — the rule that places the hover "+"
  * — sits on the same element and wins the cascade. Measured, not read: a probe
  * in headless Chrome reported `position: relative` and the gutter at x=-170
@@ -133,9 +133,9 @@ describe("the same rule where lines are painted next to code", () => {
 /*
  * And exactly one thing scrolls vertically in a column.
  *
- * Reported twice — "no entiendo este doble scroll", then "sigue estando… es
- * como que el scroll de dentro no funciona, es inútil". Measured in the real
- * app this time (headless Chrome over the demo build, Files tab, window shrunk
+ * Two scroll containers in one column, the inner one behaving as though it
+ * did nothing. Fixed once, reported again, and measured in the real app the
+ * second time (headless Chrome over the demo build, Files tab, window shrunk
  * until things overflow): before, the split panes reported `overflowY: auto`
  * and were scroll containers nobody had asked for; after, `overflowY: hidden`
  * and the only vertical scroller left in that column is the column itself.

--- a/web/test/file-rail-view.test.ts
+++ b/web/test/file-rail-view.test.ts
@@ -247,9 +247,9 @@ describe("who gets to be beside your code", () => {
 });
 
 /*
- * Reported from the app, against a real pull request, as two questions asked in
- * one breath: «¿qué significan los comentarios de la derecha? ¿y por qué al
- * seleccionar un file unos tienen unos comentarios y otros otro?»
+ * Two questions a reader of this section could not answer from it: what the
+ * comments on the right of a file MEAN, and why two files selected in turn
+ * carry entries that look nothing like each other.
  *
  * Both are this section failing at the only thing it promises. Every entry
  * opened with the literal text of an HTML comment — a marker a machine writes

--- a/web/test/icon-scale.test.ts
+++ b/web/test/icon-scale.test.ts
@@ -159,8 +159,8 @@ describe("a glyph is not a control", () => {
    * CHARACTER walked straight past all of them. The branch list's tick box was
    * `☐` at 11px inside a `<span onClick>`: seven pixels of outline, no tick you
    * could see when it was on, no role, no keyboard, and a target the size of
-   * the glyph. Reported as "el checkbox es ENANO, ni se ve", on the one list
-   * where knowing what you have selected is the entire feature.
+   * the glyph — on the one list where knowing what you have selected is the
+   * entire feature.
    *
    * So: a box, a tick, a caret or a spinner that IS the control gets drawn.
    * A glyph sitting next to a word ("⌫ 3 gone", "▣ stash some files…") is

--- a/web/test/menus-open-where-there-is-room.test.ts
+++ b/web/test/menus-open-where-there-is-room.test.ts
@@ -6,10 +6,10 @@
  * nobody could reach. `Select` — which is the app's replacement for every native
  * dropdown — never did, and it always opened downward from the trigger.
  *
- * Reported on the ClickUp status picker: "este desplegable está mal, está como
- * dentro del contenedor y no puedo ver todas las opciones, además debe abrirse
- * para arriba, al estar tan cerca de la parte baja". Two faults in one sentence,
- * and this file holds both halves of the answer — the control portals out of
+ * Found on the ClickUp status picker, near the bottom of the window: it was
+ * clipped by its own container, so the options at the end could not be seen,
+ * and it opened downward when the room was above it. Two faults, and this file
+ * holds both halves of the answer — the control portals out of
  * whatever clips it, and it flips when down does not fit.
  *
  * Source text: the decision is three lines of layout maths in a

--- a/web/test/needs-pane.test.ts
+++ b/web/test/needs-pane.test.ts
@@ -1,8 +1,8 @@
 /*
  * Which pane the "waiting on you" panel offers to take you to.
  *
- * The complaint this whole thread came from: "no sé de qué agente habla y no sé
- * en qué pane y no me lleva a ningún sitio". The last third took three rounds.
+ * The panel used to name no agent, name no pane, and go nowhere when pressed.
+ * The last of those three took three rounds.
  * The panel could only join a session to a pane by the directory the agent was
  * running in, and that join has to decline whenever two agents share a
  * worktree — which on this machine is most of the time, so the honest answer

--- a/web/test/view-chrome.test.ts
+++ b/web/test/view-chrome.test.ts
@@ -8,8 +8,8 @@
  * with its own border and inner padding in a third — visibly taller than the
  * chips doing the same job beside it.
  *
- * Reported, in the author's words: "las vistas tienen que tener las secciones
- * homogéneas, que no parezca que estoy en otra app".
+ * The result reads as switching applications rather than switching views, and
+ * the sections of one view have to match the sections of the next.
  *
  * The canon is not a preference stated here. It is what the panels already
  * agree on, counted across the view files when this was written:


### PR DESCRIPTION
## What does this PR do?

The lock added alongside `CLAUDE.md` in #576 found **four** of these. There were **twenty-five**, across `web/`, `server/`, `mobile/` and the landing page — and both halves of that rule were wrong:

- **A comment wraps.** A quote split across two comment lines is one quote to a reader and two lines to a regex. Comments are **flattened** before they are read now, which is how the majority were being missed.
- **One word from a list of twelve is not a signal.** Common short words sit inside half the identifiers in any codebase. **Three distinct** function words inside one pair of quotes is not an accident.

Every one of the twenty-five now says the same engineering thing without the quote — the lane that could not be folded at zero, the bar that appeared late and shoved the board down, the tick box that was seven pixels of outline with no role and no keyboard, the dropdown clipped by its own container near the bottom of the window, the pane that moved a few pixels per drag, the reminder that is an alarm rather than news, the tab that opened somewhere other than the project on screen.

Nothing about the reasoning is lost. What goes is *who* said it and *in which language*, which was never documentation — and does not belong in a public repository at all.

## How was it tested?

- `bun test` in `server/` — the widened lock is green, and it failed on the way here with the remaining hits listed by file, which is how the last two (a workflow test and the landing page) were found at all.
- `bun test` in `web/` — 4,299 pass, and in `mobile/` — 845 pass, 0 fail. These are comments; no assertion changed.
- The failure message names the file and the quote, and points at the rule in `CLAUDE.md` rather than at a regex.

Two Spanish comments in `.github/workflows/android-apk.yml` are **left alone** on purpose: they are the repository owner's own notes in his own workflow, not a quotation of anybody, and rewriting somebody's working notes is not what this rule is for.