### PR TITLE
docs: the lock says what it checks, and what it cannot

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -26,9 +26,23 @@ Everything below follows from that one fact.
   files, no implementation plans, no screenshots of a conversation. A working
   document lives outside the repository.
 
-`bun test` in `server/` runs `test/private-content.test.ts`, which scans the
-tree for the first three. It fails the build rather than trusting anybody to
-remember.
+`bun test` in `server/` runs `test/private-content.test.ts`, and it fails the
+build rather than trusting anybody to remember. It checks two of the five:
+
+  the session links, which are a fixed shape;
+  and a quoted conversation, by language — this codebase is written in
+  English, so three distinct Spanish function words inside one pair of quotes
+  in a comment is not an accident. The comment is flattened first, because a
+  quote wrapped across two lines is one quote to a reader.
+
+**A real name it cannot check**, and pretending otherwise is worse than saying
+so: there is no scan that separates a person from an identifier. That one rests
+on whoever writes the example, and the place it has come from every time is a
+chat notification or a task board open on the other screen.
+
+The other two — a paraphrase with "reported by", and a working document
+committed by accident — are the same: read before you commit, because nothing
+here will stop you.
 
 ## Commits
 


### PR DESCRIPTION
## What does this PR do?

`CLAUDE.md` said the test scans the tree "for the first three" of its five rules. It scans **two**: the session links, which are a fixed shape, and a quoted conversation, by language.

The third is a real **name**, and there is no scan that separates a person from an identifier. Claiming it was covered is the same defect that file exists to stop — a note that reads as a reason and stops anybody looking — and it was on the one rule whose leak came from a chat notification open on the other screen, which is exactly the case a reader would have trusted the lock for.

So it now names the two it holds, says plainly that a name rests on whoever writes the example, and says the same of the other two rules: read before you commit, because nothing there will stop you.

Found by auditing the rules against the test rather than reading the sentence, after two rounds of "nothing left" that were both wrong.

## How was it tested?

- `bun test test/private-content.test.ts` in `server/` — green; the test asserts `CLAUDE.md` still carries the rules it points at, so a rewrite that dropped them would fail here.
- Documentation only. No code changes.