### PR TITLE
fix(traffic): a 401 says the token expired, and what that costs

### DIFF
--- a/scripts/traffic-snapshot.mjs
+++ b/scripts/traffic-snapshot.mjs
@@ -51,6 +51,32 @@ async function get(path) {
       authorization: `Bearer ${TOKEN}`,
     },
   });
+  if (r.status === 401) {
+    /*
+     * A different fault from the one below, with a different fix, and the
+     * number is the only thing that says which — so it says it in words.
+     *
+     * 401 is the credential itself: expired, revoked or regenerated. A
+     * fine-grained PAT expires, and the default when you mint one is thirty
+     * days, so this arrives about a month after somebody sets it up and works
+     * perfectly in between. 403 is a token that IS valid and is not allowed to
+     * read this, which is the case below.
+     *
+     * Worth spelling out because of what it costs. GitHub keeps fourteen days
+     * of traffic and rolls nothing up; this job exists to turn that window
+     * into a history. A run that fails is a day that cannot be recovered by
+     * anybody, including GitHub, and a token nobody notices has expired takes
+     * a fortnight of the record with it before the gap is visible.
+     */
+    console.error(
+      `traffic: 401 on /${path}. The token is not valid — expired, revoked or replaced.\n` +
+        "  A fine-grained PAT expires; thirty days is the default when you mint one.\n" +
+        "  Fix: mint a new one with Administration: read on this repo, save it as\n" +
+        "  the TRAFFIC_TOKEN secret, and re-run this workflow.\n" +
+        "  Every day this stays broken is a day of traffic nobody can get back.",
+    );
+    process.exit(1);
+  }
   if (r.status === 403 || r.status === 404) {
     // The one failure worth spelling out. Every traffic endpoint needs *push*
     // access, which the default Actions token does not always carry, and the


### PR DESCRIPTION
## What does this PR do?

**The snapshot job has failed every day since the end of August.** The `traffic-data` branch stops at `2026-08-26` and the last row in `views.csv` is the 24th — so a fortnight of the record is already unrecoverable, which is precisely what this job exists to prevent: GitHub keeps fourteen days of traffic and rolls nothing up.

The log said `traffic: 401 on /popular/referrers`, and that is the generic branch — every status but 403 and 404 prints the number and stops. But **401 and 403 are different faults with different fixes**, and the number is the only thing that distinguishes them:

- **401** — the credential itself: expired, revoked or replaced. A fine-grained PAT expires, and thirty days is the default when you mint one, so this arrives about a month after setup having worked perfectly in between.
- **403** — a valid credential that is not allowed to read this. That one already has its own sentence, and it is the wrong advice for a 401.

So 401 gets its own: what it means, the fix, and the reason not to leave it sitting — every day it stays broken is a day of traffic nobody can get back.

### The token itself is not fixable from here

This changes the message, not the secret. `TRAFFIC_TOKEN` needs a new fine-grained PAT with **Administration: read** on this repository.

**Not reproducible from a sandbox**: the proxy here replaces the `authorization` header with its own installation credential, so every request comes back `403 "Resource not accessible by integration"` and a deliberately invalid token still reads a public endpoint fine. The reasoning is the runner's own log, GitHub's documented statuses, and the dates above.

## How was it tested?

- `node --check` and `bunx oxlint` on the script — clean.
- The 403 path still fires with its original message, exercised by running the script against this sandbox's credential.
- The 401 path could not be exercised here for the reason above; it is one branch, and the message is the whole of it.